### PR TITLE
Fix a problem with the completer not unregistering the listener.

### DIFF
--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -185,6 +185,7 @@ class PaletteGenerator extends Diagnosticable {
     Timer loadFailureTimeout;
     void imageListener(ImageInfo info, bool synchronousCall) {
       loadFailureTimeout?.cancel();
+      stream.removeListener(imageListener);
       imageCompleter.complete(info.image);
     }
 


### PR DESCRIPTION
This fixes a bug found by @afnx and reported in flutter/flutter#22754