### PR TITLE
Use Isolate to Quantize

### DIFF
--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -186,7 +186,7 @@ class PaletteGenerator extends Diagnosticable {
       (ImageInfo info, bool synchronouscall) {
         imageCompleter.complete(info.image);
       },
-      onError: (dynamic error,StackTrace stackTrace) {
+      onError: (dynamic error, StackTrace stackTrace) {
         imageCompleter.completeError(error);
       },
     );
@@ -1114,7 +1114,7 @@ class _ColorCutQuantizer {
       });
   }
 
-  static List<PaletteColor> _quantizefromByte(Map<String,dynamic> map) {
+  static List<PaletteColor> _quantizefromByte(Map<String, dynamic> map) {
     ByteData bd = map['byteData'];
     int maxColors = map['maxColors'];
     int width = map['width'];

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -223,6 +223,7 @@ class PaletteGenerator extends Diagnosticable {
   /// By default, this contains the entire list of predefined targets in
   /// [PaletteTarget.baseTargets].
   final List<PaletteTarget> targets;
+
   /// Returns a list of colors in the [paletteColors], sorted from most
   /// dominant to least dominant color.
   Iterable<Color> get colors sync* {

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -182,11 +182,11 @@ class PaletteGenerator extends Diagnosticable {
       ImageConfiguration(size: size, devicePixelRatio: 1.0),
     );
     final Completer<ui.Image> imageCompleter = Completer<ui.Image>();
-    var imageListener = ImageStreamListener(
+    final ImageStreamListener imageListener = ImageStreamListener(
       (ImageInfo info, bool synchronouscall) {
         imageCompleter.complete(info.image);
       },
-      onError: (error, stackTrace) {
+      onError: (dynamic error,StackTrace stackTrace) {
         imageCompleter.completeError(error);
       },
     );
@@ -1114,7 +1114,7 @@ class _ColorCutQuantizer {
       });
   }
 
-  static List<PaletteColor> _quantizefromByte(Map map) {
+  static List<PaletteColor> _quantizefromByte(Map<String,dynamic> map) {
     ByteData bd = map['byteData'];
     int maxColors = map['maxColors'];
     int width = map['width'];

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -1121,7 +1121,6 @@ class _ColorCutQuantizer {
     Rect region = map['region'];
     List<PaletteFilter> filters = map['filters'];
     List<PaletteColor> _paletteColors = map['paletteColors'];
-
     final ByteData imageData = bd;
     final Iterable<Color> pixels =
         _getImagePixels(imageData, width, height, region);


### PR DESCRIPTION
Current computation method is very heavy on older devices.
This shifts computation to an isolate using compute.
this is only done is filters are null, since i could not find a way to pass filters/functions as message to isolate