### PR TITLE
Fix an error in calculating titleTextColor and bodyTextColor for PaletteColor.

### DIFF
--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -685,8 +685,8 @@ class PaletteColor extends Diagnosticable {
       // background
       foreground = Color.alphaBlend(foreground, background);
     }
-    final double lightness1 = HSLColor.fromColor(foreground).lightness + 0.05;
-    final double lightness2 = HSLColor.fromColor(background).lightness + 0.05;
+    final double lightness1 = foreground.computeLuminance() + 0.05;
+    final double lightness2 = background.computeLuminance() + 0.05;
     return math.max(lightness1, lightness2) / math.min(lightness1, lightness2);
   }
 

--- a/packages/palette_generator/test/palette_generator_test.dart
+++ b/packages/palette_generator/test/palette_generator_test.dart
@@ -95,9 +95,9 @@ Future<void> main() async {
     expect(palette.dominantColor.color,
         within<Color>(distance: 8, from: const Color(0xff0000ff)));
     expect(palette.dominantColor.titleTextColor,
-        within<Color>(distance: 8, from: const Color(0xbc000000)));
+        within<Color>(distance: 8, from: const Color(0x8affffff)));
     expect(palette.dominantColor.bodyTextColor,
-        within<Color>(distance: 8, from: const Color(0xda000000)));
+        within<Color>(distance: 8, from: const Color(0xb2ffffff)));
   });
 
   test('PaletteGenerator works with regions', () async {


### PR DESCRIPTION
Fix luminance calculation by using relative luminance instead of lightness in HSLColor.

This results in a incorrect calculation of titleTextColor and bodyTextColor for PaletteColor.

This fixes https://github.com/flutter/flutter/issues/31592