### PR TITLE
Catch FormatException in packet decoding.

### DIFF
--- a/packages/multicast_dns/lib/src/packet.dart
+++ b/packages/multicast_dns/lib/src/packet.dart
@@ -366,6 +366,9 @@ List<ResourceRecord> decodeMDnsResponse(List<int> packet) {
   } on MDnsDecodeException {
     // If decoding fails return null.
     return null;
+  } on FormatException {
+    // If decoding fails on a non-utf8 packet, return null.
+    return null;
   }
   return result;
 }


### PR DESCRIPTION
If a packet contains non-utf8 data, decoding will fail with a FormatException. Handle the exception similarly to an MDnsDecodeException.