### PR TITLE
print test results to stdout/stderr

### DIFF
--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.0.4
+
+- Fix issue where tests results were not printing.

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -224,12 +224,19 @@ Future<OperationResult> test(
       }
     }
 
-    stdout.writeln('Test results:');
-    return await ssh.runCommand(
+    final OperationResult testResult = await ssh.runCommand(
       targetIp,
       identityFilePath: identityFile,
       command: <String>['pkgfs/packages/$target/0/bin/app'],
     );
+    stdout.writeln('Test results (passed: ${testResult.success}):');
+    if (result.info != null) {
+      stdout.writeln(testResult.info);
+    }
+    if (result.error != null) {
+      stderr.writeln(testResult.error);
+    }
+    return testResult;
   } finally {
     repo.deleteSync(recursive: true);
     await server.close();

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -146,7 +146,7 @@ Future<OperationResult> pm(
   switch (args.command.name) {
     case 'serve':
       await server.serveRepo(args['repo']);
-      await Future<void>.delayed(Duration(seconds: 15));
+      await Future<void>.delayed(const Duration(seconds: 15));
       return await server.close();
     case 'newRepo':
       return await server.newRepo(args['repo']);

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
   continuous integration/testing infrastructure.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/packags/tree/master/packages/fuchsia_ctl
-version: 0.0.1
+version: 0.0.4
 
 environment:
   sdk: ">=2.4.0 <3.0.0"


### PR DESCRIPTION
Missed this in a refactor during the last trip.  Currently test results aren't being printed, which is inconvenient.