### PR TITLE
Download depot_tools automatically

### DIFF
--- a/packages/gauge/CHANGELOG.md
+++ b/packages/gauge/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+* Download depot_tools automatically.
+
 ## 0.1.3
 
 * More fixes from health suggestions.

--- a/packages/gauge/README.md
+++ b/packages/gauge/README.md
@@ -1,16 +1,17 @@
 Tools for gauging/measuring some performance metrics.
 
 Currently there's only one tool to measure iOS CPU/GPU usages for Flutter's CI
-tests.
+tests. It's only tested on Xcode 10 and it's known that Xcode 11 may not be
+compatible.
 
 # Install
 
-First install [depot_tools][1] (we used its `cipd`).
+First install Xcode 10 (https://developer.apple.com/download/more/),
+[dart](https://dart.dev/get-dart), and
+[git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+Make sure that `pub`, `git`, and `instruments` are on your path.
 
-Then install [dart](https://dart.dev/get-dart) and make sure that `pub` is on
-your path.
-
-Finally run:
+Then run:
 ```shell
 pub global activate gauge
 ```
@@ -18,7 +19,7 @@ pub global activate gauge
 # Run
 Connect an iPhone, run a Flutter app on it, and
 ```shell
-gauge ioscpugpu new
+pub global run gauge ioscpugpu new
 ```
 
 Sample output:
@@ -28,10 +29,8 @@ gpu: 12.4%, cpu: 22.525%
 
 For more information, try
 ```shell
-gauge help
-gauge help ioscpugpu
-gauge help ioscpugpu new
-gauge help ioscpugpu parse
+pub global run gauge help
+pub global run gauge help ioscpugpu
+pub global run gauge help ioscpugpu new
+pub global run gauge help ioscpugpu parse
 ```
-
-[1]: https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up

--- a/packages/gauge/pubspec.yaml
+++ b/packages/gauge/pubspec.yaml
@@ -6,7 +6,7 @@ description:
   tests.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/packages/tree/master/packages/gauge
-version: 0.1.3
+version: 0.1.4
 
 executables:
   gauge: gauge

--- a/packages/gauge/test/gauge_general_test.dart
+++ b/packages/gauge/test/gauge_general_test.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@TestOn('posix')
+
 import 'dart:io';
 
+import 'package:gauge/commands/base.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -52,6 +55,36 @@ void main() {
     expect(
       result.stdout.toString(),
       contains('Downloading resources from CIPD...'),
+    );
+    expect(
+      Directory('${BaseCommand.defaultResourcesRoot}/resources').existsSync(),
+      isTrue,
+    );
+  });
+
+  test('depot_tools is downloaded.', () {
+    final Directory depotToolsDir =
+        Directory('${BaseCommand.defaultResourcesRoot}/depot_tools');
+    if (depotToolsDir.existsSync()) {
+      depotToolsDir.deleteSync(recursive: true);
+    }
+    expect(
+      depotToolsDir.existsSync(),
+      isFalse,
+    );
+    Process.runSync(
+      'dart',
+      <String>[
+        '$gaugeRootPath/bin/gauge.dart',
+        'ioscpugpu',
+        'parse',
+        'non-existent-file',
+        '--verbose'
+      ],
+    );
+    expect(
+      depotToolsDir.existsSync(),
+      isTrue,
     );
   });
 }


### PR DESCRIPTION
This would fix the cipd-not-found issue and allow the reland of https://github.com/flutter/flutter/pull/41234