### PR TITLE
[fuchsia_ctl] set correct exit code

### DIFF
--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.0.7
+
+- Set error code in wrapper script
+- Add more logging on failures
+
 ## 0.0.6
 
 - Use random port for PM serving.

--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.0.7
 
 - Set error code in wrapper script
-- Add more logging on failures
 
 ## 0.0.6
 

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -205,7 +205,6 @@ Future<OperationResult> test(
       result = await server.publishRepo(repo.path, farFile);
       if (!result.success) {
         stderr.writeln('Failed to publish repo at $repo with $farFiles.');
-        stderr.writeln(result.error);
         return result;
       }
       final String packageName =
@@ -222,7 +221,6 @@ Future<OperationResult> test(
       );
       if (!result.success) {
         stderr.writeln('amberctl get_up failed, aborting.');
-        stderr.writeln(result.error);
         return result;
       }
     }

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -205,6 +205,7 @@ Future<OperationResult> test(
       result = await server.publishRepo(repo.path, farFile);
       if (!result.success) {
         stderr.writeln('Failed to publish repo at $repo with $farFiles.');
+        stderr.writeln(result.error);
         return result;
       }
       final String packageName =
@@ -221,6 +222,7 @@ Future<OperationResult> test(
       );
       if (!result.success) {
         stderr.writeln('amberctl get_up failed, aborting.');
+        stderr.writeln(result.error);
         return result;
       }
     }

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
   continuous integration/testing infrastructure.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/packags/tree/master/packages/fuchsia_ctl
-version: 0.0.6
+version: 0.0.7
 
 environment:
   sdk: ">=2.4.0 <3.0.0"

--- a/packages/fuchsia_ctl/tool/fuchsia_ctl
+++ b/packages/fuchsia_ctl/tool/fuchsia_ctl
@@ -7,4 +7,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 
 pushd $DIR > /dev/null
 ./dartaotruntime main.aot "$@"
+retcode=$?
 popd > /dev/null
+
+exit $retcode

--- a/packages/fuchsia_ctl/tool/fuchsia_ctl
+++ b/packages/fuchsia_ctl/tool/fuchsia_ctl
@@ -3,11 +3,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 
 pushd $DIR > /dev/null
 ./dartaotruntime main.aot "$@"
-retcode=$?
 popd > /dev/null
-
-exit $retcode


### PR DESCRIPTION
The wrapper script was giving you the exit code from the `popd`.  Because I forgot `set -e`.  Again.