### PR TITLE
Use fuchsia package URL instead of pkgfs

### DIFF
--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.0.8
+
+- Use fuchsiapkg URLs to launch test target
+
 ## 0.0.7
 
 - Set error code in wrapper script

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -230,7 +230,7 @@ Future<OperationResult> test(
     final OperationResult testResult = await ssh.runCommand(
       targetIp,
       identityFilePath: identityFile,
-      command: <String>['pkgfs/packages/$target/0/bin/app'],
+      command: <String>['run', 'fuchsia-pkg://fuchsia.com/$target#meta/$target.cmx'],
     );
     stdout.writeln('Test results (passed: ${testResult.success}):');
     if (result.info != null) {

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -230,7 +230,10 @@ Future<OperationResult> test(
     final OperationResult testResult = await ssh.runCommand(
       targetIp,
       identityFilePath: identityFile,
-      command: <String>['run', 'fuchsia-pkg://fuchsia.com/$target#meta/$target.cmx'],
+      command: <String>[
+        'run',
+        'fuchsia-pkg://fuchsia.com/$target#meta/$target.cmx'
+      ],
     );
     stdout.writeln('Test results (passed: ${testResult.success}):');
     if (result.info != null) {

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
   continuous integration/testing infrastructure.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/packags/tree/master/packages/fuchsia_ctl
-version: 0.0.7
+version: 0.0.8
 
 environment:
   sdk: ">=2.4.0 <3.0.0"


### PR DESCRIPTION
I'm publishing this early to unbreak the build.  Apparently directly invoking the app executable no longer works.