### PR TITLE
Fix SafeArea for shared-axis demo

### DIFF
--- a/packages/animations/example/lib/shared_axis_transition.dart
+++ b/packages/animations/example/lib/shared_axis_transition.dart
@@ -33,80 +33,82 @@ class _SharedAxisTransitionDemoState extends State<SharedAxisTransitionDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      resizeToAvoidBottomPadding: false,
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(title: const Text('Shared Axis Transition')),
-      body: Column(
-        children: <Widget>[
-          Expanded(
-            child: PageTransitionSwitcher(
-              duration: const Duration(milliseconds: 300),
-              reverse: _isLoggedIn,
-              transitionBuilder: (
-                Widget child,
-                Animation<double> animation,
-                Animation<double> secondaryAnimation,
-              ) {
-                return SharedAxisTransition(
-                  child: child,
-                  animation: animation,
-                  secondaryAnimation: secondaryAnimation,
-                  transitionType: _transitionType,
-                );
-              },
-              child: _isLoggedIn ? _CoursePage() : _SignInPage(),
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            Expanded(
+              child: PageTransitionSwitcher(
+                duration: const Duration(milliseconds: 300),
+                reverse: _isLoggedIn,
+                transitionBuilder: (
+                  Widget child,
+                  Animation<double> animation,
+                  Animation<double> secondaryAnimation,
+                ) {
+                  return SharedAxisTransition(
+                    child: child,
+                    animation: animation,
+                    secondaryAnimation: secondaryAnimation,
+                    transitionType: _transitionType,
+                  );
+                },
+                child: _isLoggedIn ? _CoursePage() : _SignInPage(),
+              ),
             ),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 15.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 15.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  FlatButton(
+                    onPressed: _isLoggedIn ? _toggleLoginStatus : null,
+                    textColor: Theme.of(context).colorScheme.primary,
+                    child: const Text('BACK'),
+                  ),
+                  RaisedButton(
+                    onPressed: _isLoggedIn ? null : _toggleLoginStatus,
+                    color: Theme.of(context).colorScheme.primary,
+                    textColor: Theme.of(context).colorScheme.onPrimary,
+                    disabledColor: Colors.black12,
+                    child: const Text('NEXT'),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(thickness: 2.0),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                FlatButton(
-                  onPressed: _isLoggedIn ? _toggleLoginStatus : null,
-                  textColor: Theme.of(context).colorScheme.primary,
-                  child: const Text('BACK'),
+                Radio<SharedAxisTransitionType>(
+                  value: SharedAxisTransitionType.horizontal,
+                  groupValue: _transitionType,
+                  onChanged: (SharedAxisTransitionType newValue) {
+                    _updateTransitionType(newValue);
+                  },
                 ),
-                RaisedButton(
-                  onPressed: _isLoggedIn ? null : _toggleLoginStatus,
-                  color: Theme.of(context).colorScheme.primary,
-                  textColor: Theme.of(context).colorScheme.onPrimary,
-                  disabledColor: Colors.black12,
-                  child: const Text('NEXT'),
+                const Text('X'),
+                Radio<SharedAxisTransitionType>(
+                  value: SharedAxisTransitionType.vertical,
+                  groupValue: _transitionType,
+                  onChanged: (SharedAxisTransitionType newValue) {
+                    _updateTransitionType(newValue);
+                  },
                 ),
+                const Text('Y'),
+                Radio<SharedAxisTransitionType>(
+                  value: SharedAxisTransitionType.scaled,
+                  groupValue: _transitionType,
+                  onChanged: (SharedAxisTransitionType newValue) {
+                    _updateTransitionType(newValue);
+                  },
+                ),
+                const Text('Z'),
               ],
             ),
-          ),
-          const Divider(thickness: 2.0),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Radio<SharedAxisTransitionType>(
-                value: SharedAxisTransitionType.horizontal,
-                groupValue: _transitionType,
-                onChanged: (SharedAxisTransitionType newValue) {
-                  _updateTransitionType(newValue);
-                },
-              ),
-              const Text('X'),
-              Radio<SharedAxisTransitionType>(
-                value: SharedAxisTransitionType.vertical,
-                groupValue: _transitionType,
-                onChanged: (SharedAxisTransitionType newValue) {
-                  _updateTransitionType(newValue);
-                },
-              ),
-              const Text('Y'),
-              Radio<SharedAxisTransitionType>(
-                value: SharedAxisTransitionType.scaled,
-                groupValue: _transitionType,
-                onChanged: (SharedAxisTransitionType newValue) {
-                  _updateTransitionType(newValue);
-                },
-              ),
-              const Text('Z'),
-            ],
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -182,7 +184,6 @@ class _SignInPage extends StatelessWidget {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final double maxHeight = constraints.maxHeight;
-        print(maxHeight);
         return Column(
           children: <Widget>[
             Padding(padding: EdgeInsets.symmetric(vertical: maxHeight / 20)),

--- a/packages/animations/test/fade_transition_test.dart
+++ b/packages/animations/test/fade_transition_test.dart
@@ -19,7 +19,7 @@ void main() {
               return Center(
                 child: RaisedButton(
                   onPressed: () {
-                    showModal(
+                    showModal<void>(
                       context: context,
                       configuration: FadeTransitionConfiguration(),
                       builder: (BuildContext context) {
@@ -51,7 +51,7 @@ void main() {
               return Center(
                 child: RaisedButton(
                   onPressed: () {
-                    showModal(
+                    showModal<void>(
                       context: context,
                       configuration: FadeTransitionConfiguration(),
                       builder: (BuildContext context) {
@@ -119,7 +119,7 @@ void main() {
               return Center(
                 child: RaisedButton(
                   onPressed: () {
-                    showModal(
+                    showModal<void>(
                       context: context,
                       configuration: FadeTransitionConfiguration(),
                       builder: (BuildContext context) {
@@ -184,7 +184,7 @@ void main() {
               return Center(
                 child: RaisedButton(
                   onPressed: () {
-                    showModal(
+                    showModal<void>(
                       context: context,
                       configuration: FadeTransitionConfiguration(),
                       builder: (BuildContext context) {
@@ -285,7 +285,7 @@ void main() {
                   children: <Widget>[
                     RaisedButton(
                       onPressed: () {
-                        showModal(
+                        showModal<void>(
                           context: context,
                           configuration: FadeTransitionConfiguration(),
                           builder: (BuildContext context) {

--- a/packages/animations/test/modal_test.dart
+++ b/packages/animations/test/modal_test.dart
@@ -18,7 +18,7 @@ void main() {
               return Center(
                 child: RaisedButton(
                   onPressed: () {
-                    showModal(
+                    showModal<void>(
                       context: context,
                       configuration: _TestModalConfiguration(),
                       builder: (BuildContext context) {
@@ -60,7 +60,7 @@ void main() {
               return Center(
                 child: RaisedButton(
                   onPressed: () {
-                    showModal(
+                    showModal<void>(
                       context: context,
                       configuration: _TestModalConfiguration(),
                       builder: (BuildContext context) {
@@ -110,7 +110,7 @@ void main() {
               return Center(
                 child: RaisedButton(
                   onPressed: () {
-                    showModal(
+                    showModal<void>(
                       context: context,
                       configuration: _TestModalConfiguration(),
                       builder: (BuildContext context) {
@@ -168,7 +168,7 @@ void main() {
                   children: <Widget>[
                     RaisedButton(
                       onPressed: () {
-                        showModal(
+                        showModal<void>(
                           context: context,
                           configuration: _TestModalConfiguration(),
                           builder: (BuildContext context) {


### PR DESCRIPTION
Without the SafeArea, the button options at the bottom of the shared axis transition demo appear underneath the bottom navigation bar for some devices.