### PR TITLE
Increase dev_finder timeout to 5 mins.

### DIFF
--- a/packages/fuchsia_ctl/lib/src/dev_finder.dart
+++ b/packages/fuchsia_ctl/lib/src/dev_finder.dart
@@ -84,8 +84,8 @@ class DevFinder {
   /// default value is false.
   Future<String> getTargetAddress(
     String deviceName, {
-    int numTries = 60,
-    int sleepDelay = 2,
+    int numTries = 75,
+    int sleepDelay = 4,
     bool nullOk = false,
   }) {
     return _runDevFinderWithRetries(


### PR DESCRIPTION
We are decreasing the retry freq to 4 secs to avoid mdns packets
saturating the network.

https://github.com/flutter/flutter/issues/42241