### PR TITLE
avoid deleting non-existant dir

### DIFF
--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -253,7 +253,10 @@ Future<OperationResult> test(
     }
     return testResult;
   } finally {
-    repo.deleteSync(recursive: true);
+    // We may not have created the repo if dev finder errored first.
+    if (repo.existsSync()) {
+      repo.deleteSync(recursive: true);
+    }
     if (server.serving) {
       await server.close();
     }


### PR DESCRIPTION
We added retry logic to the script that drives fuchsia_ctl in case dev_finder can't find the device because it's still coming up from booting.

However, in this case, we're assuming we need to delete a directory we may not have created.

This leads to an exception being thrown and the CI failing instead of retrying.

See e.g. https://chromium-swarm.appspot.com/task?id=49ef05ca90626010

/cc @godofredoc 