### PR TITLE
[animations] Fix Shared Axis

### DIFF
--- a/packages/animations/example/lib/shared_axis_transition.dart
+++ b/packages/animations/example/lib/shared_axis_transition.dart
@@ -41,7 +41,7 @@ class _SharedAxisTransitionDemoState extends State<SharedAxisTransitionDemo> {
             Expanded(
               child: PageTransitionSwitcher(
                 duration: const Duration(milliseconds: 300),
-                reverse: _isLoggedIn,
+                reverse: !_isLoggedIn,
                 transitionBuilder: (
                   Widget child,
                   Animation<double> animation,

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -438,7 +438,8 @@ class _EnterTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeInTransition.animate(animation),
           child: ScaleTransition(
-            scale: (!reverse ? _scaleUpTransition : _scaleDownTransition).animate(animation),
+            scale: (!reverse ? _scaleUpTransition : _scaleDownTransition)
+                .animate(animation),
             child: child,
           ),
         );
@@ -518,7 +519,8 @@ class _ExitTransition extends StatelessWidget {
           child: Container(
             color: Theme.of(context).canvasColor,
             child: ScaleTransition(
-              scale: (!reverse ? _scaleUpTransition : _scaleDownTransition).animate(animation),
+              scale: (!reverse ? _scaleUpTransition : _scaleDownTransition)
+                  .animate(animation),
               child: child,
             ),
           ),

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -341,6 +341,7 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
             return _ExitTransition(
               animation: _flip(widget.animation),
               transitionType: widget.transitionType,
+              reverse: true,
               child: child,
             );
         }
@@ -363,6 +364,7 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
               return _EnterTransition(
                 animation: _flip(widget.secondaryAnimation),
                 transitionType: widget.transitionType,
+                reverse: true,
                 child: child,
               );
           }
@@ -378,12 +380,14 @@ class _EnterTransition extends StatelessWidget {
   const _EnterTransition({
     this.animation,
     this.transitionType,
+    this.reverse = false,
     this.child,
   });
 
   final Animation<double> animation;
   final SharedAxisTransitionType transitionType;
   final Widget child;
+  final bool reverse;
 
   static Animatable<double> fadeInTransition = CurveTween(
     curve: decelerateEasing,
@@ -399,7 +403,7 @@ class _EnterTransition extends StatelessWidget {
     switch (transitionType) {
       case SharedAxisTransitionType.horizontal:
         final Animatable<Offset> slideInTransition = Tween<Offset>(
-          begin: const Offset(30, 0.0),
+          begin: Offset(!reverse ? 30.0 : -30.0, 0.0),
           end: Offset.zero,
         ).chain(CurveTween(curve: standardEasing));
 
@@ -413,7 +417,7 @@ class _EnterTransition extends StatelessWidget {
         break;
       case SharedAxisTransitionType.vertical:
         final Animatable<Offset> slideInTransition = Tween<Offset>(
-          begin: const Offset(0.0, 30),
+          begin: Offset(0.0, !reverse ? 30.0 : -30.0),
           end: Offset.zero,
         ).chain(CurveTween(curve: standardEasing));
 
@@ -443,12 +447,14 @@ class _ExitTransition extends StatelessWidget {
   const _ExitTransition({
     this.animation,
     this.transitionType,
+    this.reverse = false,
     this.child,
   });
 
   final Animation<double> animation;
   final SharedAxisTransitionType transitionType;
   final Widget child;
+  final bool reverse;
 
   static Animatable<double> fadeOutTransition = FlippedCurveTween(
     curve: accelerateEasing,
@@ -465,7 +471,7 @@ class _ExitTransition extends StatelessWidget {
       case SharedAxisTransitionType.horizontal:
         final Animatable<Offset> slideOutTransition = Tween<Offset>(
           begin: Offset.zero,
-          end: const Offset(30, 0.0),
+          end: Offset(!reverse ? -30.0 : 30.0, 0.0),
         ).chain(CurveTween(curve: standardEasing));
 
         return FadeTransition(
@@ -482,7 +488,7 @@ class _ExitTransition extends StatelessWidget {
       case SharedAxisTransitionType.vertical:
         final Animatable<Offset> slideOutTransition = Tween<Offset>(
           begin: Offset.zero,
-          end: const Offset(0.0, 30),
+          end: Offset(0.0, !reverse ? -30.0 : 30.0),
         ).chain(CurveTween(curve: standardEasing));
 
         return FadeTransition(

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -389,11 +389,16 @@ class _EnterTransition extends StatelessWidget {
   final Widget child;
   final bool reverse;
 
-  static Animatable<double> fadeInTransition = CurveTween(
+  static final Animatable<double> _fadeInTransition = CurveTween(
     curve: decelerateEasing,
   ).chain(CurveTween(curve: const Interval(0.3, 1.0)));
 
-  static Animatable<double> scaleInTransition = Tween<double>(
+  static final Animatable<double> _scaleDownTransition = Tween<double>(
+    begin: 1.10,
+    end: 1.00,
+  ).chain(CurveTween(curve: standardEasing));
+
+  static final Animatable<double> _scaleUpTransition = Tween<double>(
     begin: 0.80,
     end: 1.00,
   ).chain(CurveTween(curve: standardEasing));
@@ -408,7 +413,7 @@ class _EnterTransition extends StatelessWidget {
         ).chain(CurveTween(curve: standardEasing));
 
         return FadeTransition(
-          opacity: fadeInTransition.animate(animation),
+          opacity: _fadeInTransition.animate(animation),
           child: Transform.translate(
             offset: slideInTransition.evaluate(animation),
             child: child,
@@ -422,7 +427,7 @@ class _EnterTransition extends StatelessWidget {
         ).chain(CurveTween(curve: standardEasing));
 
         return FadeTransition(
-          opacity: fadeInTransition.animate(animation),
+          opacity: _fadeInTransition.animate(animation),
           child: Transform.translate(
             offset: slideInTransition.evaluate(animation),
             child: child,
@@ -431,9 +436,9 @@ class _EnterTransition extends StatelessWidget {
         break;
       case SharedAxisTransitionType.scaled:
         return FadeTransition(
-          opacity: fadeInTransition.animate(animation),
+          opacity: _fadeInTransition.animate(animation),
           child: ScaleTransition(
-            scale: scaleInTransition.animate(animation),
+            scale: (!reverse ? _scaleUpTransition : _scaleDownTransition).animate(animation),
             child: child,
           ),
         );
@@ -456,13 +461,18 @@ class _ExitTransition extends StatelessWidget {
   final Widget child;
   final bool reverse;
 
-  static Animatable<double> fadeOutTransition = FlippedCurveTween(
+  static final Animatable<double> _fadeOutTransition = FlippedCurveTween(
     curve: accelerateEasing,
   ).chain(CurveTween(curve: const Interval(0.0, 0.3)));
 
-  static Animatable<double> scaleOutTransition = Tween<double>(
+  static final Animatable<double> _scaleUpTransition = Tween<double>(
     begin: 1.00,
     end: 1.10,
+  ).chain(CurveTween(curve: standardEasing));
+
+  static final Animatable<double> _scaleDownTransition = Tween<double>(
+    begin: 1.00,
+    end: 0.80,
   ).chain(CurveTween(curve: standardEasing));
 
   @override
@@ -475,7 +485,7 @@ class _ExitTransition extends StatelessWidget {
         ).chain(CurveTween(curve: standardEasing));
 
         return FadeTransition(
-          opacity: fadeOutTransition.animate(animation),
+          opacity: _fadeOutTransition.animate(animation),
           child: Container(
             color: Theme.of(context).canvasColor,
             child: Transform.translate(
@@ -492,7 +502,7 @@ class _ExitTransition extends StatelessWidget {
         ).chain(CurveTween(curve: standardEasing));
 
         return FadeTransition(
-          opacity: fadeOutTransition.animate(animation),
+          opacity: _fadeOutTransition.animate(animation),
           child: Container(
             color: Theme.of(context).canvasColor,
             child: Transform.translate(
@@ -504,11 +514,11 @@ class _ExitTransition extends StatelessWidget {
         break;
       case SharedAxisTransitionType.scaled:
         return FadeTransition(
-          opacity: fadeOutTransition.animate(animation),
+          opacity: _fadeOutTransition.animate(animation),
           child: Container(
             color: Theme.of(context).canvasColor,
             child: ScaleTransition(
-              scale: scaleOutTransition.animate(animation),
+              scale: (!reverse ? _scaleUpTransition : _scaleDownTransition).animate(animation),
               child: child,
             ),
           ),

--- a/packages/animations/test/shared_axis_transition_test.dart
+++ b/packages/animations/test/shared_axis_transition_test.dart
@@ -139,7 +139,7 @@ void main() {
             tester,
             SharedAxisTransitionType.horizontal,
           ),
-          30.0,
+          -30.0,
         );
         expect(_getOpacity(bottomRoute, tester), 0.0);
         // Top route has no offset and is visible.
@@ -203,7 +203,7 @@ void main() {
           0.0,
         );
         expect(_getOpacity(topRoute, tester), 1.0);
-        // Bottom route is offset to the right and is not visible yet.
+        // Bottom route is offset to the left and is not visible yet.
         expect(find.text(bottomRoute), findsOneWidget);
         expect(
           _getTranslationOffset(
@@ -211,7 +211,7 @@ void main() {
             tester,
             SharedAxisTransitionType.horizontal,
           ),
-          30.0,
+          -30.0,
         );
         expect(_getOpacity(bottomRoute, tester), 0.0);
 
@@ -224,7 +224,7 @@ void main() {
         // Top route is now invisible
         expect(find.text(topRoute), findsOneWidget);
         expect(_getOpacity(topRoute, tester), 0.0);
-        // Bottom route is still invisible, but moving towards the left.
+        // Bottom route is still invisible, but moving towards the right.
         expect(find.text(bottomRoute), findsOneWidget);
         expect(_getOpacity(bottomRoute, tester),
             moreOrLessEquals(0, epsilon: 0.005));
@@ -233,8 +233,8 @@ void main() {
           tester,
           SharedAxisTransitionType.horizontal,
         );
-        expect(bottomOffset, greaterThan(0.0));
-        expect(bottomOffset, lessThan(30.0));
+        expect(bottomOffset, lessThan(0.0));
+        expect(bottomOffset, greaterThan(-30.0));
 
         // Jump to the middle of fading in
         await tester.pump(const Duration(milliseconds: 90));
@@ -250,8 +250,8 @@ void main() {
           tester,
           SharedAxisTransitionType.horizontal,
         );
-        expect(bottomOffset, greaterThan(0.0));
-        expect(bottomOffset, lessThan(30.0));
+        expect(bottomOffset, lessThan(0.0));
+        expect(bottomOffset, greaterThan(-30.0));
 
         // Jump to the end of the transition
         await tester.pump(const Duration(milliseconds: 120));
@@ -313,8 +313,8 @@ void main() {
           tester,
           SharedAxisTransitionType.horizontal,
         );
-        expect(halfwayBottomOffset, greaterThan(0.0));
-        expect(halfwayBottomOffset, lessThan(30.0));
+        expect(halfwayBottomOffset, lessThan(0.0));
+        expect(halfwayBottomOffset, greaterThan(-30.0));
 
         // Top route is fading/coming in.
         expect(find.text(topRoute), findsOneWidget);
@@ -364,7 +364,7 @@ void main() {
             tester,
             SharedAxisTransitionType.horizontal,
           ),
-          greaterThan(0.0),
+          lessThan(0.0),
         );
         expect(
           _getTranslationOffset(
@@ -372,7 +372,7 @@ void main() {
             tester,
             SharedAxisTransitionType.horizontal,
           ),
-          lessThan(30.0),
+          greaterThan(-30.0),
         );
         expect(
           _getTranslationOffset(
@@ -380,7 +380,7 @@ void main() {
             tester,
             SharedAxisTransitionType.horizontal,
           ),
-          lessThan(halfwayBottomOffset),
+          greaterThan(halfwayBottomOffset),
         );
         expect(_getOpacity(bottomRoute, tester), greaterThan(0.0));
         expect(_getOpacity(bottomRoute, tester), lessThan(1.0));
@@ -575,7 +575,7 @@ void main() {
           0.0,
         );
         expect(_getOpacity(bottomRoute, tester), 1.0);
-        // Top route is offset to the right by 30.0 pixels
+        // Top route is offset down by 30.0 pixels
         // and not visible yet.
         expect(find.text(topRoute), findsOneWidget);
         expect(
@@ -597,7 +597,7 @@ void main() {
         // Bottom route is now invisible
         expect(find.text(bottomRoute), findsOneWidget);
         expect(_getOpacity(bottomRoute, tester), 0.0);
-        // Top route is still invisible, but moving towards the left.
+        // Top route is still invisible, but moving up.
         expect(find.text(topRoute), findsOneWidget);
         expect(_getOpacity(topRoute, tester), 0.0);
         double topOffset = _getTranslationOffset(
@@ -636,7 +636,7 @@ void main() {
             tester,
             SharedAxisTransitionType.vertical,
           ),
-          30.0,
+          -30.0,
         );
         expect(_getOpacity(bottomRoute, tester), 0.0);
         // Top route has no offset and is visible.
@@ -700,7 +700,7 @@ void main() {
           0.0,
         );
         expect(_getOpacity(topRoute, tester), 1.0);
-        // Bottom route is offset to the right and is not visible yet.
+        // Bottom route is offset up and is not visible yet.
         expect(find.text(bottomRoute), findsOneWidget);
         expect(
           _getTranslationOffset(
@@ -708,7 +708,7 @@ void main() {
             tester,
             SharedAxisTransitionType.vertical,
           ),
-          30.0,
+          -30.0,
         );
         expect(_getOpacity(bottomRoute, tester), 0.0);
 
@@ -721,7 +721,7 @@ void main() {
         // Top route is now invisible
         expect(find.text(topRoute), findsOneWidget);
         expect(_getOpacity(topRoute, tester), 0.0);
-        // Bottom route is still invisible, but moving towards the left.
+        // Bottom route is still invisible, but moving down.
         expect(find.text(bottomRoute), findsOneWidget);
         expect(
           _getOpacity(bottomRoute, tester),
@@ -732,8 +732,8 @@ void main() {
           tester,
           SharedAxisTransitionType.vertical,
         );
-        expect(bottomOffset, greaterThan(0.0));
-        expect(bottomOffset, lessThan(30.0));
+        expect(bottomOffset, lessThan(0.0));
+        expect(bottomOffset, greaterThan(-30.0));
 
         // Jump to the middle of fading in
         await tester.pump(const Duration(milliseconds: 90));
@@ -749,12 +749,12 @@ void main() {
           tester,
           SharedAxisTransitionType.vertical,
         );
-        expect(bottomOffset, greaterThan(0.0));
-        expect(bottomOffset, lessThan(30.0));
+        expect(bottomOffset, lessThan(0.0));
+        expect(bottomOffset, greaterThan(-30.0));
 
         // Jump to the end of the transition
         await tester.pump(const Duration(milliseconds: 120));
-        // Top route is not visible and is offset to the right.
+        // Top route is not visible and is offset down.
         expect(find.text(topRoute), findsOneWidget);
         expect(
           _getTranslationOffset(
@@ -812,8 +812,8 @@ void main() {
           tester,
           SharedAxisTransitionType.vertical,
         );
-        expect(halfwayBottomOffset, greaterThan(0.0));
-        expect(halfwayBottomOffset, lessThan(30.0));
+        expect(halfwayBottomOffset, lessThan(0.0));
+        expect(halfwayBottomOffset, greaterThan(-30.0));
 
         // Top route is fading/coming in.
         expect(find.text(topRoute), findsOneWidget);
@@ -863,7 +863,7 @@ void main() {
             tester,
             SharedAxisTransitionType.vertical,
           ),
-          greaterThan(0.0),
+          lessThan(0.0),
         );
         expect(
           _getTranslationOffset(
@@ -871,7 +871,7 @@ void main() {
             tester,
             SharedAxisTransitionType.vertical,
           ),
-          lessThan(30.0),
+          greaterThan(-30.0),
         );
         expect(
           _getTranslationOffset(
@@ -879,7 +879,7 @@ void main() {
             tester,
             SharedAxisTransitionType.vertical,
           ),
-          lessThan(halfwayBottomOffset),
+          greaterThan(halfwayBottomOffset),
         );
         expect(_getOpacity(bottomRoute, tester), greaterThan(0.0));
         expect(_getOpacity(bottomRoute, tester), lessThan(1.0));

--- a/packages/animations/test/shared_axis_transition_test.dart
+++ b/packages/animations/test/shared_axis_transition_test.dart
@@ -1140,9 +1140,9 @@ void main() {
         expect(find.text(topRoute), findsOneWidget);
         expect(_getScale(topRoute, tester), 1.0);
         expect(_getOpacity(topRoute, tester), 1.0);
-        // Bottom route is at 80% of full size and not visible yet.
+        // Bottom route is at 110% of full size and not visible yet.
         expect(find.text(bottomRoute), findsOneWidget);
-        expect(_getScale(bottomRoute, tester), 0.8);
+        expect(_getScale(bottomRoute, tester), 1.1);
         expect(_getOpacity(bottomRoute, tester), 0.0);
 
         // Jump 3/10ths of the way through the transition, bottom route
@@ -1154,15 +1154,15 @@ void main() {
         // Bottom route is now invisible
         expect(find.text(topRoute), findsOneWidget);
         expect(_getOpacity(topRoute, tester), 0.0);
-        // Top route is still invisible, but scaling up.
+        // Top route is still invisible, but scaling down.
         expect(find.text(bottomRoute), findsOneWidget);
         expect(
           _getOpacity(bottomRoute, tester),
           moreOrLessEquals(0, epsilon: 0.005),
         );
         double bottomScale = _getScale(bottomRoute, tester);
-        expect(bottomScale, greaterThan(0.8));
-        expect(bottomScale, lessThan(1.0));
+        expect(bottomScale, greaterThan(1.0));
+        expect(bottomScale, lessThan(1.1));
 
         // Jump to the middle of fading in
         await tester.pump(const Duration(milliseconds: 90));
@@ -1174,14 +1174,14 @@ void main() {
         expect(_getOpacity(bottomRoute, tester), greaterThan(0));
         expect(_getOpacity(bottomRoute, tester), lessThan(1.0));
         bottomScale = _getScale(bottomRoute, tester);
-        expect(bottomScale, greaterThan(0.8));
-        expect(bottomScale, lessThan(1.0));
+        expect(bottomScale, greaterThan(1.0));
+        expect(bottomScale, lessThan(1.1));
 
         // Jump to the end of the transition
         await tester.pump(const Duration(milliseconds: 120));
         // Top route is not visible.
         expect(find.text(topRoute), findsOneWidget);
-        expect(_getScale(topRoute, tester), 1.1);
+        expect(_getScale(topRoute, tester), 0.8);
         expect(_getOpacity(topRoute, tester), 0.0);
         // Bottom route fully scaled in and visible.
         expect(find.text(bottomRoute), findsOneWidget);


### PR DESCRIPTION
According to the spec:

* horizontal Shared Axis transition should move old _and_ new route towards the left when played forward, and right when played in reverse.
* vertical Shared Axis transition should move old _and_ new route up when played forward and down when played backwards. 
* scaled Shared Axis transition should scale old _and_ new route up when played forward and down when played backwards.

Prior to this change, old and new routes were moving in opposite directions and there was no difference between playing the animation in reverse or forward.