### PR TITLE
[fuchsia] Refactor usage of amberctl to its own class

### DIFF
--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.0.9
+
+- Refactor usages of `amberctl` to its own class.
+
 ## 0.0.8
 
 - Use fuchsiapkg URLs to launch test target

--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG
 
-## 0.0.9
+## 0.0.16
 
 - Refactor usages of `amberctl` to its own class.
+
+## 0.0.9 - 0.0.15
+
+- Various improvements including support for Fuchsia tests.
 
 ## 0.0.8
 

--- a/packages/fuchsia_ctl/lib/src/amber_ctl.dart
+++ b/packages/fuchsia_ctl/lib/src/amber_ctl.dart
@@ -1,0 +1,104 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:fuchsia_ctl/fuchsia_ctl.dart';
+import 'package:fuchsia_ctl/src/ssh_client.dart';
+import 'package:uuid/uuid.dart';
+
+import 'operation_result.dart';
+
+const SshClient _kSsh = SshClient();
+
+/// Wrapper for amberctl utility for commands executed on the target device.
+@immutable
+class AmberCtl {
+  /// Creates a new [AmberCtl] with the specified [targetIp] and [identityFile].
+  const AmberCtl(
+    this._targetIp,
+    this._identityFile,
+  );
+
+  final String _identityFile;
+  final String _targetIp;
+
+  /// Adds a new package update source for the target device.
+  ///
+  /// * [port] is what "pm serve" is bound to.
+  /// * Returns the name of the package update source that is randomly generated.
+  Future<String> addSrc(int port) async {
+    final String uuid = Uuid().v4();
+    final String localIp = await _getLocalIp(_targetIp);
+    final OperationResult result = await _kSsh.runCommand(
+      _targetIp,
+      identityFilePath: _identityFile,
+      command: <String>[
+        'amberctl',
+        'add_src',
+        '-f',
+        'http://[$localIp]:$port/config.json',
+        '-n',
+        uuid,
+      ],
+    );
+
+    if (!result.success) {
+      throw AmberCtlException('"add_src" failed, aborting.', result);
+    } else {
+      stdout.writeln('Successfully added an update'
+          ' source on port $port with name $uuid.');
+      return uuid;
+    }
+  }
+
+  /// Adds a package with the given [packageName] to the device.
+  Future<void> addPackage(String packageName) async {
+    stdout.writeln('Adding $packageName...');
+    final OperationResult result = await _kSsh.runCommand(
+      _targetIp,
+      identityFilePath: _identityFile,
+      command: <String>[
+        'amberctl',
+        'get_up',
+        '-n',
+        packageName,
+      ],
+    );
+
+    if (!result.success) {
+      throw AmberCtlException('"get_up" failed, aborting.', result);
+    }
+  }
+
+  Future<String> _getLocalIp(String targetIp) async {
+    final OperationResult result = await _kSsh.runCommand(targetIp,
+        identityFilePath: _identityFile,
+        command: <String>['echo \$SSH_CONNECTION']);
+
+    if (!result.success) {
+      throw AmberCtlException('Failed to get local address, aborting.', result);
+    } else {
+      return result.info.split(' ')[0].replaceAll('%', '%25');
+    }
+  }
+}
+
+/// Wraps exceptions thrown by amberctl utility.
+@immutable
+class AmberCtlException implements Exception {
+  /// Creates a new [AmberCtlException] using the specified [cause] and [result].
+  const AmberCtlException(this.cause, this.result);
+
+  /// Represents the human-readable cause for the amberctl error.
+  final String cause;
+
+  /// Contains the result of the executed target command.
+  final OperationResult result;
+
+  @override
+  String toString() =>
+      '$runtimeType, cause: "$cause", underlying exception: $result.';
+}

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   Fuchsia Device. This package is primarily intended for use in Flutter's
   continuous integration/testing infrastructure.
 homepage: https://github.com/flutter/packags/tree/master/packages/fuchsia_ctl
-version: 0.0.8
+version: 0.0.9
 
 environment:
   sdk: ">=2.4.0 <3.0.0"

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   Fuchsia Device. This package is primarily intended for use in Flutter's
   continuous integration/testing infrastructure.
 homepage: https://github.com/flutter/packags/tree/master/packages/fuchsia_ctl
-version: 0.0.9
+version: 0.0.16
 
 environment:
   sdk: ">=2.4.0 <3.0.0"


### PR DESCRIPTION
This is one part of a multi part change that will
enable us to run flutter driver and dart tests on the
connected fuchsia devices.