### PR TITLE
[animations] fix crash when opening container at edge

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -620,8 +620,8 @@ class _OpenContainerRoute extends ModalRoute<void> {
                               child: hideableKey.currentState.isInTree
                                   ? null
                                   : Opacity(
-                                      opacity:
-                                          closedOpacityTween.evaluate(animation),
+                                      opacity: closedOpacityTween
+                                          .evaluate(animation),
                                       child: Builder(
                                         key: closedBuilderKey,
                                         builder: (BuildContext context) {

--- a/packages/animations/lib/src/utils/curves.dart
+++ b/packages/animations/lib/src/utils/curves.dart
@@ -1,3 +1,7 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -942,8 +942,11 @@ void main() {
     expect(_getScrimColor(tester), Colors.transparent);
   });
 
-  testWidgets('Container partly offscreen can be opened without crash - vertical', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController(initialScrollOffset: 50);
+  testWidgets(
+      'Container partly offscreen can be opened without crash - vertical',
+      (WidgetTester tester) async {
+    final ScrollController controller =
+        ScrollController(initialScrollOffset: 50);
     await tester.pumpWidget(Center(
       child: SizedBox(
         height: 200,
@@ -1011,8 +1014,11 @@ void main() {
     expect(find.text('Open 2'), findsOneWidget);
   });
 
-  testWidgets('Container partly offscreen can be opened without crash - horizontal', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController(initialScrollOffset: 50);
+  testWidgets(
+      'Container partly offscreen can be opened without crash - horizontal',
+      (WidgetTester tester) async {
+    final ScrollController controller =
+        ScrollController(initialScrollOffset: 50);
     await tester.pumpWidget(Center(
       child: SizedBox(
         height: 200,

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:animations/src/open_container.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
If the container was only partially visible, `Padding` was getting a negative `padding` value, which caused a crash. This change removes the `Padding` widget in favor of a `Transform.translate` widget.

Suggested review setting: "[Hide whitespace changes](https://github.com/flutter/packages/pull/83/files?utf8=%E2%9C%93&diff=split&w=1)"