### PR TITLE
[pigeon] added support for builtin java datatypes

### DIFF
--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -82,3 +82,37 @@ class Indent {
 String makeChannelName(Api api, Method func) {
   return 'dev.flutter.dartle.${api.name}.${func.name}';
 }
+
+/// Represents the mapping of a Dart datatype to a Host datatype.
+class HostDatatype {
+  /// Parametric constructor for HostDatatype.
+  HostDatatype({this.datatype, this.isBuiltin});
+
+  /// The [String] that can be printed into host code to represent the type.
+  final String datatype;
+
+  /// `true` if the host datatype is something builtin.
+  final bool isBuiltin;
+}
+
+/// Calculates the [HostDatatype] for the provided [Field].  It will check the
+/// field against the [classes] to check if it is a builtin type.
+/// [builtinResolver] will return the host datatype for the Dart datatype for
+/// builtin types.  [customResolver] can modify the datatype of custom types.
+HostDatatype getHostDatatype(
+    Field field,
+    List<Class> classes,
+    String Function(String) builtinResolver,
+    String Function(String) customResolver) {
+  final String datatype = builtinResolver(field.dataType);
+  if (datatype == null) {
+    if (classes.map((Class x) => x.name).contains(field.dataType)) {
+      return HostDatatype(
+          datatype: customResolver(field.dataType), isBuiltin: false);
+    } else {
+      return null;
+    }
+  } else {
+    return HostDatatype(datatype: datatype, isBuiltin: true);
+  }
+}

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -96,9 +96,9 @@ class HostDatatype {
 }
 
 /// Calculates the [HostDatatype] for the provided [Field].  It will check the
-/// field against the [classes] to check if it is a builtin type.
-/// [builtinResolver] will return the host datatype for the Dart datatype for
-/// builtin types.  [customResolver] can modify the datatype of custom types.
+/// field against the `classes` to check if it is a builtin type.
+/// `builtinResolver` will return the host datatype for the Dart datatype for
+/// builtin types.  `customResolver` can modify the datatype of custom types.
 HostDatatype getHostDatatype(
     Field field,
     List<Class> classes,

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -81,15 +81,16 @@ void generateObjcHeader(ObjcOptions options, Root root, StringSink sink) {
     indent.writeln(
         '@interface ${_className(options.prefix, klass.name)} : NSObject ');
     for (Field field in klass.fields) {
-      String propertyType = _propertyTypeForDartType(field.dataType);
-      String objcType = _objcTypeForDartType(field.dataType);
-      if (objcType == null &&
-          root.classes.map((Class x) => x.name).contains(field.dataType)) {
-        propertyType = 'strong';
-        objcType = '${_className(options.prefix, field.dataType)} *';
-      }
+      final HostDatatype hostDatatype = getHostDatatype(
+          field,
+          root.classes,
+          _objcTypeForDartType,
+          (String x) => '${_className(options.prefix, x)} *');
+      final String propertyType = hostDatatype.isBuiltin
+          ? _propertyTypeForDartType(field.dataType)
+          : 'strong';
       indent.writeln(
-          '@property(nonatomic, $propertyType) $objcType ${field.name};');
+          '@property(nonatomic, $propertyType) ${hostDatatype.datatype} ${field.name};');
     }
     indent.writeln('@end');
     indent.writeln('');

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -48,6 +48,7 @@ test_pigeon_android() {
 }
 
 pub run test test/
+test_pigeon_android ./pigeons/host2flutter.dart
 test_pigeon_android ./pigeons/message.dart
 test_pigeon_ios ./pigeons/message.dart
 test_pigeon_ios ./pigeons/host2flutter.dart

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -25,7 +25,7 @@ void main() {
     final String code = sink.toString();
     expect(code, contains('public class Messages'));
     expect(code, contains('public static class Foobar'));
-    expect(code, contains('private int field1;'));
+    expect(code, contains('private Long field1;'));
   });
 
   test('package', () {
@@ -69,5 +69,34 @@ void main() {
     final String code = sink.toString();
     expect(code, contains('public interface Api'));
     expect(code, matches('Output.*doSomething.*Input'));
+  });
+
+  test('all the simple datatypes header', () {
+    final Root root = Root(apis: <Api>[], classes: <Class>[
+      Class(name: 'Foobar', fields: <Field>[
+        Field(name: 'aBool', dataType: 'bool'),
+        Field(name: 'aInt', dataType: 'int'),
+        Field(name: 'aDouble', dataType: 'double'),
+        Field(name: 'aString', dataType: 'String'),
+        Field(name: 'aUint8List', dataType: 'Uint8List'),
+        Field(name: 'aInt32List', dataType: 'Int32List'),
+        Field(name: 'aInt64List', dataType: 'Int64List'),
+        Field(name: 'aFloat64List', dataType: 'Float64List'),
+      ]),
+    ]);
+
+    final StringBuffer sink = StringBuffer();
+    final JavaOptions javaOptions = JavaOptions();
+    javaOptions.className = 'Messages';
+    generateJava(javaOptions, root, sink);
+    final String code = sink.toString();
+    expect(code, contains('private Boolean aBool;'));
+    expect(code, contains('private Long aInt;'));
+    expect(code, contains('private Double aDouble;'));
+    expect(code, contains('private String aString;'));
+    expect(code, contains('private byte[] aUint8List;'));
+    expect(code, contains('private int[] aInt32List;'));
+    expect(code, contains('private long[] aInt64List;'));
+    expect(code, contains('private double[] aFloat64List;'));
   });
 }


### PR DESCRIPTION
depends on: https://github.com/flutter/packages/pull/96

Now things like ints and data buffers can be used in classes, not just Strings.