### PR TITLE
[animations] Remove unnecessary override

### DIFF
--- a/packages/animations/lib/src/modal.dart
+++ b/packages/animations/lib/src/modal.dart
@@ -106,7 +106,7 @@ class _ModalRoute<T> extends PopupRoute<T> {
   @override
   final Duration transitionDuration;
 
-  @override
+  // TODO(creativecreatorormaybenot): Add override when 1.15.3 makes it to stable.
   final Duration reverseTransitionDuration;
 
   /// The primary contents of the modal.


### PR DESCRIPTION
`reverseTransitionDuration` in `TransitionRoute` is only [added in `v1.15.3`](https://github.com/flutter/flutter/commit/51e24a3561ee4f50a2b4ddeb36b1f7ea59d768d2) and Flutter `stable` is at `v1.12.13+hotfix.8`.

Thus, the `@override` annotation should not exist currently (analyzer is complaining).