### PR TITLE
Use Flutter stable for testing, format, and analysis

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
     cpu: 4
     memory: 8G
   upgrade_script:
-    - flutter channel master
+    - flutter channel stable
     - flutter upgrade
     - git fetch origin master
   activate_script: pub global activate flutter_plugin_tools


### PR DESCRIPTION
The analyisis (and other) runs on `flutter channel master` which causes problems:

- #103 
- #106 

Both of these are failing in CI checks, even though they would not fail on `stable`. This also means that something like the `animations` example *does not even work* on `stable` because it uses members from `master`. Still, the checks did not complain.