### PR TITLE
Adds xdg_directories package to access Linux well known directories.

### DIFF
--- a/packages/xdg_directories/.gitignore
+++ b/packages/xdg_directories/.gitignore
@@ -1,0 +1,75 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+
+# Android related
+**/android/**/gradle-wrapper.jar
+**/android/.gradle
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/xcuserdata
+**/ios/.generated/
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
+
+# Exceptions to above rules.
+!**/ios/**/default.mode1v3
+!**/ios/**/default.mode2v3
+!**/ios/**/default.pbxuser
+!**/ios/**/default.perspectivev3
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/packages/xdg_directories/.metadata
+++ b/packages/xdg_directories/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: d8c0deb1b6c116be79ceeca005f893be34ab5df2
+  channel: master
+
+project_type: package

--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [0.0.1] - TODO: Add release date.
+
+* TODO: Describe initial release.

--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,3 +1,3 @@
-## [0.0.1] - TODO: Add release date.
+## [0.1.0] - Initial Release
 
-* TODO: Describe initial release.
+* Initial release includes all the features described in the README.md

--- a/packages/xdg_directories/LICENSE
+++ b/packages/xdg_directories/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2019 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/xdg_directories/LICENSE
+++ b/packages/xdg_directories/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Flutter Authors. All rights reserved.
+Copyright 2020 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/xdg_directories/README.md
+++ b/packages/xdg_directories/README.md
@@ -39,12 +39,12 @@ To use this package, the basic XDG values for the following are available via a 
    files and other file objects should be placed. (Corresponds to
    `$XDG_RUNTIME_DIR`).
 
- - `definedUserDirs` - The list of user directories defined in the `xdg`
-   configuration files.
+ - `getUserDirectoryNames()` - Returns a set of the names of user directories
+   defined in the `xdg` configuration files.
 
- - `getUserDir(String dirName)` - Gets the value of the user dir with the given
-   name. Requesting a user dir that doesn't exist returns `null`. The `dirName`
-   argument is case-insensitive. See [this
+ - `getUserDirectory(String dirName)` - Gets the value of the user dir with the
+   given name. Requesting a user dir that doesn't exist returns `null`. The
+   `dirName` argument is case-insensitive. See [this
    wiki](https://wiki.archlinux.org/index.php/XDG_user_directories) for more
    details and what values of `dirName` might be available.
 

--- a/packages/xdg_directories/README.md
+++ b/packages/xdg_directories/README.md
@@ -1,0 +1,50 @@
+# `xdg_directories`
+
+A Dart package for reading XDG directory configuration information on Linux.
+
+## Getting Started
+
+On Linux, `xdg` is a system developed by [freedesktop.org](freedesktop.org), a
+project to work on interoperability and shared base technology for free software
+desktop environments for Linux.
+
+This Dart package can be used to determine the directory configuration
+information defined by `xdg`, such as where the Documents or Desktop directories
+are. These are called "user directories" and are defined in configuration file
+in the user's home directory.
+
+See [this wiki](https://wiki.archlinux.org/index.php/XDG_Base_Directory) for
+more details of the XDG Base Directory implementation.
+
+To use this package, the basic XDG values for the following are available via a Dart API:
+
+ - `dataHome` - The single base directory relative to which user-specific data
+   files should be written. (Corresponds to `$XDG_DATA_HOME`).
+
+ - `configHome` - The a single base directory relative to which user-specific
+   configuration files should be written. (Corresponds to `$XDG_CONFIG_HOME`).
+
+ - `dataDirs` - The list of preference-ordered base directories relative to
+   which data files should be searched. (Corresponds to `$XDG_DATA_DIRS`).
+
+ - `configDirs` - The list of preference-ordered base directories relative to
+   which configuration files should be searched. (Corresponds to
+   `$XDG_CONFIG_DIRS`).
+
+ - `cacheHome` - The base directory relative to which user-specific
+   non-essential (cached) data should be written. (Corresponds to
+   `$XDG_CACHE_HOME`).
+
+ - `runtimeDir` - The base directory relative to which user-specific runtime
+   files and other file objects should be placed. (Corresponds to
+   `$XDG_RUNTIME_DIR`).
+
+ - `definedUserDirs` - The list of user directories defined in the `xdg`
+   configuration files.
+
+ - `getUserDir(String dirName)` - Gets the value of the user dir with the given
+   name. Requesting a user dir that doesn't exist returns `null`. The `dirName`
+   argument is case-insensitive. See [this
+   wiki](https://wiki.archlinux.org/index.php/XDG_user_directories) for more
+   details and what values of `dirName` might be available.
+

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -1,0 +1,143 @@
+library xdg_directories;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:path/path.dart' as path;
+import 'package:process/process.dart';
+
+typedef EnvironmentOverride = String Function(String envVar);
+
+@visibleForTesting
+set xdgEnvironmentOverride(EnvironmentOverride override) => _getenv = override ?? _productionGetEnv;
+EnvironmentOverride _productionGetEnv = (String value) => Platform.environment[value];
+EnvironmentOverride _getenv = _productionGetEnv;
+
+@visibleForTesting
+set xdgProcessManager(ProcessManager processManager) {
+  _processManager = processManager;
+}
+
+ProcessManager _processManager = const LocalProcessManager();
+
+List<Directory> _directoryListFromEnvironment(String envVar, String fallback) {
+  assert(envVar != null);
+  assert(fallback != null);
+  String value = _getenv(envVar);
+  if (value == null || value.isEmpty) {
+    value = fallback;
+  }
+  return value.split(':').where((String value) {
+    return value.isNotEmpty;
+  }).map<Directory>((String entry) {
+    return Directory(entry);
+  }).toList();
+}
+
+Directory _directoryFromEnvironment(String envVar, String fallback) {
+  assert(envVar != null);
+  final String value = _getenv(envVar);
+  if (value == null || value.isEmpty) {
+    if (fallback == null) {
+      return null;
+    }
+    return _getDefaultDir(fallback);
+  }
+  return Directory(value);
+}
+
+Directory _getDefaultDir(String suffix) {
+  assert(suffix != null);
+  assert(suffix.isNotEmpty);
+  final String homeDir = _getenv('HOME');
+  if (homeDir == null || homeDir.isEmpty) {
+    throw StateError('The "HOME" environment variable is not set. This package (and POSIX) '
+        'requires that HOME be set.');
+  }
+  return Directory(path.joinAll(<String>[homeDir, suffix]));
+}
+
+/// The base directory relative to which user-specific
+/// non-essential (cached) data should be written. (Corresponds to
+/// `$XDG_CACHE_HOME`).
+///
+/// Throws [StateError] if the HOME environment variable is not set.
+Directory get cacheHome => _directoryFromEnvironment('XDG_CACHE_HOME', '.cache');
+
+/// The list of preference-ordered base directories relative to
+/// which configuration files should be searched. (Corresponds to
+/// `$XDG_CONFIG_DIRS`).
+///
+/// Throws [StateError] if the HOME environment variable is not set.
+List<Directory> get configDirs => _directoryListFromEnvironment('XDG_CONFIG_DIRS', '/etc/xdg');
+
+/// The a single base directory relative to which user-specific
+/// configuration files should be written. (Corresponds to `$XDG_CONFIG_HOME`).
+///
+/// Throws [StateError] if the HOME environment variable is not set.
+Directory get configHome => _directoryFromEnvironment('XDG_CONFIG_HOME', '.config');
+
+/// The list of preference-ordered base directories relative to
+/// which data files should be searched. (Corresponds to `$XDG_DATA_DIRS`).
+///
+/// Throws [StateError] if the HOME environment variable is not set.
+List<Directory> get dataDirs => _directoryListFromEnvironment('XDG_DATA_DIRS', '/usr/local/share:/usr/share');
+
+/// The base directory relative to which user-specific data files should be
+/// written. (Corresponds to `$XDG_DATA_HOME`).
+///
+/// Throws [StateError] if the HOME environment variable is not set.
+Directory get dataHome => _directoryFromEnvironment('XDG_DATA_HOME', '.local/share');
+
+/// The base directory relative to which user-specific runtime
+/// files and other file objects should be placed. (Corresponds to
+/// `$XDG_RUNTIME_DIR`).
+///
+/// Throws [StateError] if the HOME environment variable is not set.
+Directory get runtimeDir => _directoryFromEnvironment('XDG_RUNTIME_DIR', null);
+
+Directory _getUserDir(String dirName) {
+  final ProcessResult result = _processManager.runSync(
+    <String>['xdg-user-dir', dirName],
+    // Copy these env vars from the override so that the tests can override them.
+    environment: <String, String>{
+      'HOME': _getenv('HOME'),
+      'XDG_CONFIG_HOME': _getenv('XDG_CONFIG_HOME'),
+    },
+    includeParentEnvironment: true,
+    stdoutEncoding: Encoding.getByName('utf8'),
+  );
+  final String path = utf8.decode(result.stdout).split('\n')[0];
+  return Directory(path);
+}
+
+/// The list of user directories defined in the `xdg`
+/// configuration files.
+///
+/// Reads the file [configHome]`/user-dirs.dirs` to get the information from it.
+///
+/// The map keys are the name of the configuration variable, with `XDG_`
+/// stripped from the beginning of the name, and `_DIR` stripped from the
+/// end. They are typically uppercase.
+///
+/// Throws [StateError] if the HOME environment variable is not set.
+Map<String, Directory> getUserDirs() {
+  final File configFile = File(path.join(configHome.path, 'user-dirs.dirs'));
+  List<String> contents;
+  try {
+    contents = configFile.readAsLinesSync();
+  } on FileSystemException catch (e) {
+    return const <String, Directory>{};
+  }
+  final Map<String, Directory> result = <String, Directory>{};
+  final RegExp dirRegExp = RegExp(r'^\s*XDG_(?<dirname>.*)_DIR\s*=\s*(?<dir>.*)\s*$');
+  for (String line in contents) {
+    final RegExpMatch match = dirRegExp.firstMatch(line);
+    if (match == null) {
+      continue;
+    }
+    result[match.namedGroup('dirname')] = _getUserDir(match.namedGroup('dirname'));
+  }
+  return result;
+}

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -32,7 +32,8 @@ set xdgEnvironmentOverride(EnvironmentAccessor override) {
 /// Only available to tests.
 EnvironmentAccessor get xdgEnvironmentOverride => _xdgEnvironmentOverride;
 EnvironmentAccessor _xdgEnvironmentOverride;
-EnvironmentAccessor _productionGetEnv = (String value) => Platform.environment[value];
+EnvironmentAccessor _productionGetEnv =
+    (String value) => Platform.environment[value];
 EnvironmentAccessor _getenv = _productionGetEnv;
 
 /// A testing function that replaces the process manager used to run xdg-user-path
@@ -46,7 +47,8 @@ set xdgProcessManager(ProcessManager processManager) {
 
 ProcessManager _processManager = const LocalProcessManager();
 
-List<Directory> _directoryListFromEnvironment(String envVar, List<Directory> fallback) {
+List<Directory> _directoryListFromEnvironment(
+    String envVar, List<Directory> fallback) {
   assert(envVar != null);
   assert(fallback != null);
   final String value = _getenv(envVar);
@@ -78,7 +80,8 @@ Directory _getDirectory(String subdir) {
   assert(subdir.isNotEmpty);
   final String homeDir = _getenv('HOME');
   if (homeDir == null || homeDir.isEmpty) {
-    throw StateError('The "HOME" environment variable is not set. This package (and POSIX) '
+    throw StateError(
+        'The "HOME" environment variable is not set. This package (and POSIX) '
         'requires that HOME be set.');
   }
   return Directory(path.joinAll(<String>[homeDir, subdir]));
@@ -89,7 +92,8 @@ Directory _getDirectory(String subdir) {
 /// `$XDG_CACHE_HOME`).
 ///
 /// Throws [StateError] if the HOME environment variable is not set.
-Directory get cacheHome => _directoryFromEnvironment('XDG_CACHE_HOME', '.cache');
+Directory get cacheHome =>
+    _directoryFromEnvironment('XDG_CACHE_HOME', '.cache');
 
 /// The list of preference-ordered base directories relative to
 /// which configuration files should be searched. (Corresponds to
@@ -107,7 +111,8 @@ List<Directory> get configDirs {
 /// configuration files should be written. (Corresponds to `$XDG_CONFIG_HOME`).
 ///
 /// Throws [StateError] if the HOME environment variable is not set.
-Directory get configHome => _directoryFromEnvironment('XDG_CONFIG_HOME', '.config');
+Directory get configHome =>
+    _directoryFromEnvironment('XDG_CONFIG_HOME', '.config');
 
 /// The list of preference-ordered base directories relative to
 /// which data files should be searched. (Corresponds to `$XDG_DATA_DIRS`).
@@ -124,7 +129,8 @@ List<Directory> get dataDirs {
 /// written. (Corresponds to `$XDG_DATA_HOME`).
 ///
 /// Throws [StateError] if the HOME environment variable is not set.
-Directory get dataHome => _directoryFromEnvironment('XDG_DATA_HOME', '.local/share');
+Directory get dataHome =>
+    _directoryFromEnvironment('XDG_DATA_HOME', '.local/share');
 
 /// The base directory relative to which user-specific runtime
 /// files and other file objects should be placed. (Corresponds to
@@ -162,7 +168,8 @@ Set<String> getUserDirectoryNames() {
     return const <String>{};
   }
   final Set<String> result = <String>{};
-  final RegExp dirRegExp = RegExp(r'^\s*XDG_(?<dirname>[^=]*)_DIR\s*=\s*(?<dir>.*)\s*$');
+  final RegExp dirRegExp =
+      RegExp(r'^\s*XDG_(?<dirname>[^=]*)_DIR\s*=\s*(?<dir>.*)\s*$');
   for (String line in contents) {
     final RegExpMatch match = dirRegExp.firstMatch(line);
     if (match == null) {

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -1,18 +1,18 @@
 name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
-version: 1.0.0
+version: 0.1.0
 homepage: https://github.com/flutter/packages/tree/master/packages/animations
 
 environment:
   sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
-  path: ">=1.6.4"
-  process: ">=3.0.12"
+  path: ^1.6.4
+  process: ^3.0.12
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ">=4.1.1"
+  mockito: ^4.1.1
   flutter_test:
     sdk: flutter

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -1,0 +1,21 @@
+name: xdg_directories
+description: A new Flutter package project.
+version: 0.0.1
+author:
+homepage:
+
+environment:
+  sdk: ">=2.3.0 <3.0.0"
+
+dependencies:
+  path: ">=1.6.4"
+  process: ">=3.0.12"
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+#  mockito: ">=4.1.1"
+  flutter_test:
+    sdk: flutter
+
+flutter:

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-#  mockito: ">=4.1.1"
+  mockito: ">=4.1.1"
   flutter_test:
     sdk: flutter
 

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -1,8 +1,7 @@
 name: xdg_directories
-description: A new Flutter package project.
-version: 0.0.1
-author:
-homepage:
+description: A Dart package for reading XDG directory configuration information on Linux.
+version: 1.0.0
+homepage: https://github.com/flutter/packages/tree/master/packages/animations
 
 environment:
   sdk: ">=2.3.0 <3.0.0"
@@ -17,5 +16,3 @@ dev_dependencies:
   mockito: ">=4.1.1"
   flutter_test:
     sdk: flutter
-
-flutter:

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -25,14 +25,16 @@ void main() {
     fakeEnv['XDG_CACHE_HOME'] = testPath('.test_cache');
     fakeEnv['XDG_CONFIG_DIRS'] = testPath('etc/test_xdg');
     fakeEnv['XDG_CONFIG_HOME'] = testPath('.test_config');
-    fakeEnv['XDG_DATA_DIRS'] = '${testPath('usr/local/test_share')}:${testPath('usr/test_share')}';
+    fakeEnv['XDG_DATA_DIRS'] =
+        '${testPath('usr/local/test_share')}:${testPath('usr/test_share')}';
     fakeEnv['XDG_DATA_HOME'] = testPath('.local/test_share');
     fakeEnv['XDG_RUNTIME_DIR'] = testPath('.local/test_runtime');
     Directory(fakeEnv['XDG_CONFIG_HOME']).createSync(recursive: true);
     Directory(fakeEnv['XDG_CACHE_HOME']).createSync(recursive: true);
     Directory(fakeEnv['XDG_DATA_HOME']).createSync(recursive: true);
     Directory(fakeEnv['XDG_RUNTIME_DIR']).createSync(recursive: true);
-    File(path.join(fakeEnv['XDG_CONFIG_HOME'], 'user-dirs.dirs')).writeAsStringSync(r'''
+    File(path.join(fakeEnv['XDG_CONFIG_HOME'], 'user-dirs.dirs'))
+        .writeAsStringSync(r'''
 XDG_DESKTOP_DIR="$HOME/Desktop"
 XDG_DOCUMENTS_DIR="$HOME/Documents"
 XDG_DOWNLOAD_DIR="$HOME/Downloads"
@@ -52,7 +54,8 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     xdg.xdgEnvironmentOverride = null;
   });
   void expectDirList(List<Directory> values, List<String> expected) {
-    final List<String> valueStr = values.map<String>((Directory directory) => directory.path).toList();
+    final List<String> valueStr =
+        values.map<String>((Directory directory) => directory.path).toList();
     expect(valueStr, orderedEquals(expected));
   }
 
@@ -94,7 +97,8 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     final Set<String> userDirs = xdg.getUserDirectoryNames();
     expect(userDirs, equals(expected.keys.toSet()));
     for (String key in userDirs) {
-      expect(xdg.getUserDirectory(key).path, equals(expected[key]), reason: 'Path $key value not correct');
+      expect(xdg.getUserDirectory(key).path, equals(expected[key]),
+          reason: 'Path $key value not correct');
     }
     xdg.xdgProcessManager = const LocalProcessManager();
   });

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -15,16 +15,19 @@ import 'package:xdg_directories/xdg_directories.dart' as xdg;
 void main() {
   final Map<String, String> fakeEnv = <String, String>{};
   Directory tmpDir;
+
+  String testPath(String subdir) => path.join(tmpDir.path, subdir);
+
   setUp(() {
     tmpDir = Directory.systemTemp.createTempSync('xdg_test');
     fakeEnv.clear();
     fakeEnv['HOME'] = tmpDir.path;
-    fakeEnv['XDG_CACHE_HOME'] = path.join(tmpDir.path, '.test_cache');
-    fakeEnv['XDG_CONFIG_DIRS'] = path.join(tmpDir.path, 'etc/test_xdg');
-    fakeEnv['XDG_CONFIG_HOME'] = path.join(tmpDir.path, '.test_config');
-    fakeEnv['XDG_DATA_DIRS'] = '${path.join(tmpDir.path, 'usr/local/test_share')}:${path.join(tmpDir.path, 'usr/test_share')}';
-    fakeEnv['XDG_DATA_HOME'] = path.join(tmpDir.path, '.local/test_share');
-    fakeEnv['XDG_RUNTIME_DIR'] = path.join(tmpDir.path, '.local/test_runtime');
+    fakeEnv['XDG_CACHE_HOME'] = testPath('.test_cache');
+    fakeEnv['XDG_CONFIG_DIRS'] = testPath('etc/test_xdg');
+    fakeEnv['XDG_CONFIG_HOME'] = testPath('.test_config');
+    fakeEnv['XDG_DATA_DIRS'] = '${testPath('usr/local/test_share')}:${testPath('usr/test_share')}';
+    fakeEnv['XDG_DATA_HOME'] = testPath('.local/test_share');
+    fakeEnv['XDG_RUNTIME_DIR'] = testPath('.local/test_runtime');
     Directory(fakeEnv['XDG_CONFIG_HOME']).createSync(recursive: true);
     Directory(fakeEnv['XDG_CACHE_HOME']).createSync(recursive: true);
     Directory(fakeEnv['XDG_DATA_HOME']).createSync(recursive: true);
@@ -56,36 +59,36 @@ XDG_VIDEOS_DIR="$HOME/Videos"
   test('Default fallback values work', () {
     fakeEnv.clear();
     fakeEnv['HOME'] = tmpDir.path;
-    expect(xdg.cacheHome.path, equals(path.join(tmpDir.path, '.cache')));
-    expect(xdg.configHome.path, equals(path.join(tmpDir.path, '.config')));
-    expect(xdg.dataHome.path, equals(path.join(tmpDir.path, '.local/share')));
+    expect(xdg.cacheHome.path, equals(testPath('.cache')));
+    expect(xdg.configHome.path, equals(testPath('.config')));
+    expect(xdg.dataHome.path, equals(testPath('.local/share')));
     expect(xdg.runtimeDir, isNull);
 
     expectDirList(xdg.configDirs, <String>['/etc/xdg']);
     expectDirList(xdg.dataDirs, <String>['/usr/local/share', '/usr/share']);
   });
   test('Values pull from environment', () {
-    expect(xdg.cacheHome.path, equals(path.join(tmpDir.path, '.test_cache')));
-    expect(xdg.configHome.path, equals(path.join(tmpDir.path, '.test_config')));
-    expect(xdg.dataHome.path, equals(path.join(tmpDir.path, '.local/test_share')));
-    expect(xdg.runtimeDir.path, equals(path.join(tmpDir.path, '.local/test_runtime')));
+    expect(xdg.cacheHome.path, equals(testPath('.test_cache')));
+    expect(xdg.configHome.path, equals(testPath('.test_config')));
+    expect(xdg.dataHome.path, equals(testPath('.local/test_share')));
+    expect(xdg.runtimeDir.path, equals(testPath('.local/test_runtime')));
 
-    expectDirList(xdg.configDirs, <String>[path.join(tmpDir.path, 'etc/test_xdg')]);
+    expectDirList(xdg.configDirs, <String>[testPath('etc/test_xdg')]);
     expectDirList(xdg.dataDirs, <String>[
-      path.join(tmpDir.path, 'usr/local/test_share'),
-      path.join(tmpDir.path, 'usr/test_share'),
+      testPath('usr/local/test_share'),
+      testPath('usr/test_share'),
     ]);
   });
   test('Can get userDirs', () {
     final Map<String, String> expected = <String, String>{
-      'DESKTOP': path.join(tmpDir.path, 'Desktop'),
-      'DOCUMENTS': path.join(tmpDir.path, 'Documents'),
-      'DOWNLOAD': path.join(tmpDir.path, 'Downloads'),
-      'MUSIC': path.join(tmpDir.path, 'Music'),
-      'PICTURES': path.join(tmpDir.path, 'Pictures'),
-      'PUBLICSHARE': path.join(tmpDir.path, 'Public'),
-      'TEMPLATES': path.join(tmpDir.path, 'Templates'),
-      'VIDEOS': path.join(tmpDir.path, 'Videos'),
+      'DESKTOP': testPath('Desktop'),
+      'DOCUMENTS': testPath('Documents'),
+      'DOWNLOAD': testPath('Downloads'),
+      'MUSIC': testPath('Music'),
+      'PICTURES': testPath('Pictures'),
+      'PUBLICSHARE': testPath('Public'),
+      'TEMPLATES': testPath('Templates'),
+      'VIDEOS': testPath('Videos'),
     };
     xdg.xdgProcessManager = FakeProcessManager(expected);
     final Set<String> userDirs = xdg.getUserDirectoryNames();
@@ -113,10 +116,10 @@ class FakeProcessManager extends Fake implements ProcessManager {
     List<dynamic> command, {
     String workingDirectory,
     Map<String, String> environment,
-    bool includeParentEnvironment: true,
-    bool runInShell: false,
-    Encoding stdoutEncoding: systemEncoding,
-    Encoding stderrEncoding: systemEncoding,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding stdoutEncoding = systemEncoding,
+    Encoding stderrEncoding = systemEncoding,
   }) {
     return ProcessResult(0, 0, expected[command[1]].codeUnits, <int>[]);
   }

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -1,0 +1,93 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+
+import 'package:xdg_directories/xdg_directories.dart' as xdg;
+
+void main() {
+  final Map<String, String> fakeEnv = <String, String>{};
+  Directory tmpDir;
+  setUp(() {
+    tmpDir = Directory.systemTemp.createTempSync('xdg_test');
+    fakeEnv.clear();
+    fakeEnv['HOME'] = tmpDir.path;
+    fakeEnv['XDG_CACHE_HOME'] = path.join(tmpDir.path, '.test_cache');
+    fakeEnv['XDG_CONFIG_DIRS'] = path.join(tmpDir.path, 'etc/test_xdg');
+    fakeEnv['XDG_CONFIG_HOME'] = path.join(tmpDir.path, '.test_config');
+    fakeEnv['XDG_DATA_DIRS'] = '${path.join(tmpDir.path, 'usr/local/test_share')}:${path.join(tmpDir.path, 'usr/test_share')}';
+    fakeEnv['XDG_DATA_HOME'] = path.join(tmpDir.path, '.local/test_share');
+    fakeEnv['XDG_RUNTIME_DIR'] = path.join(tmpDir.path, '.local/test_runtime');
+    Directory(fakeEnv['XDG_CONFIG_HOME']).createSync(recursive: true);
+    Directory(fakeEnv['XDG_CACHE_HOME']).createSync(recursive: true);
+    Directory(fakeEnv['XDG_DATA_HOME']).createSync(recursive: true);
+    Directory(fakeEnv['XDG_RUNTIME_DIR']).createSync(recursive: true);
+    File(path.join(fakeEnv['XDG_CONFIG_HOME'], 'user-dirs.dirs')).writeAsStringSync(r'''
+XDG_DESKTOP_DIR="$HOME/Desktop"
+XDG_DOCUMENTS_DIR="$HOME/Documents"
+XDG_DOWNLOAD_DIR="$HOME/Downloads"
+XDG_MUSIC_DIR="$HOME/Music"
+XDG_PICTURES_DIR="$HOME/Pictures"
+XDG_PUBLICSHARE_DIR="$HOME/Public"
+XDG_TEMPLATES_DIR="$HOME/Templates"
+XDG_VIDEOS_DIR="$HOME/Videos"
+''');
+    xdg.xdgEnvironmentOverride = (String key) => fakeEnv[key];
+  });
+  tearDown(() {
+    if (tmpDir != null) {
+      tmpDir.deleteSync(recursive: true);
+    }
+  });
+  void expectDirList(List<Directory> values, List<String> expected) {
+    final List<String> valueStr = values.map<String>((Directory directory) => directory.path).toList();
+    expect(valueStr, orderedEquals(expected));
+  }
+  test('Default fallback values work', () {
+    fakeEnv.clear();
+    fakeEnv['HOME'] = tmpDir.path;
+    expect(xdg.cacheHome.path, equals(path.join(tmpDir.path, '.cache')));
+    expect(xdg.configHome.path, equals(path.join(tmpDir.path, '.config')));
+    expect(xdg.dataHome.path, equals(path.join(tmpDir.path, '.local/share')));
+    expect(xdg.runtimeDir, isNull);
+
+    expectDirList(xdg.configDirs, <String>['/etc/xdg']);
+    expectDirList(xdg.dataDirs, <String>['/usr/local/share', '/usr/share']);
+  });
+  test('Values pull from environment', () {
+    expect(xdg.cacheHome.path, equals(path.join(tmpDir.path, '.test_cache')));
+    expect(xdg.configHome.path, equals(path.join(tmpDir.path, '.test_config')));
+    expect(xdg.dataHome.path, equals(path.join(tmpDir.path, '.local/test_share')));
+    expect(xdg.runtimeDir.path, equals(path.join(tmpDir.path, '.local/test_runtime')));
+
+    expectDirList(xdg.configDirs, <String>[path.join(tmpDir.path, 'etc/test_xdg')]);
+    expectDirList(xdg.dataDirs, <String>[
+      path.join(tmpDir.path, 'usr/local/test_share'),
+      path.join(tmpDir.path, 'usr/test_share'),
+    ]);
+  });
+  test('Can get userDirs', () {
+    final Map<String, String> expected = <String, String>{
+      'DESKTOP': path.join(tmpDir.path, 'Desktop'),
+      'DOCUMENTS': path.join(tmpDir.path, 'Documents'),
+      'DOWNLOAD': path.join(tmpDir.path, 'Downloads'),
+      'MUSIC': path.join(tmpDir.path, 'Music'),
+      'PICTURES': path.join(tmpDir.path, 'Pictures'),
+      'PUBLICSHARE': path.join(tmpDir.path, 'Public'),
+      'TEMPLATES': path.join(tmpDir.path, 'Templates'),
+      'VIDEOS': path.join(tmpDir.path, 'Videos'),
+    };
+    final Map<String, Directory> userDirs = xdg.getUserDirs();
+    expect(userDirs.keys.toSet(), equals(expected.keys.toSet()));
+    for (String key in userDirs.keys) {
+      expect(userDirs[key].path, equals(expected[key]), reason: 'Path $key value not correct');
+    }
+  });
+  test('Throws StateError when HOME not set', () {
+    fakeEnv.clear();
+    expect(() { xdg.configHome; }, throwsStateError);
+  });
+}


### PR DESCRIPTION
`xdg_directories` is a package that allows access to the directory values managed by xdg on Linux systems.

It makes it easier to write other packages that need to know where Linux directories like "Documents" and "Desktop" are.