### PR TITLE
[animations] Add ability to use root Navigator with an OpenContainer

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -71,6 +71,7 @@ class OpenContainer extends StatefulWidget {
     this.tappable = true,
     this.transitionDuration = const Duration(milliseconds: 300),
     this.transitionType = ContainerTransitionType.fade,
+    this.useRootNavigator = false,
   })  : assert(closedColor != null),
         assert(openColor != null),
         assert(closedElevation != null),
@@ -81,6 +82,7 @@ class OpenContainer extends StatefulWidget {
         assert(openBuilder != null),
         assert(tappable != null),
         assert(transitionType != null),
+        assert(useRootNavigator != null),
         super(key: key);
 
   /// Background color of the container while it is closed.
@@ -203,6 +205,14 @@ class OpenContainer extends StatefulWidget {
   /// Defaults to [ContainerTransitionType.fade].
   final ContainerTransitionType transitionType;
 
+  /// The [useRootNavigator] argument is used to determine whether to push the
+  /// route for [openBuilder] to the Navigator furthest from or nearest to
+  /// the given context.
+  ///
+  /// By default, [useRootNavigator] is false and the route created will push
+  /// to the nearest navigator.
+  final bool useRootNavigator;
+
   @override
   _OpenContainerState createState() => _OpenContainerState();
 }
@@ -221,7 +231,8 @@ class _OpenContainerState extends State<OpenContainer> {
   final GlobalKey _closedBuilderKey = GlobalKey();
 
   void openContainer() {
-    Navigator.of(context).push(_OpenContainerRoute(
+    Navigator.of(context, rootNavigator: widget.useRootNavigator)
+        .push(_OpenContainerRoute(
       closedColor: widget.closedColor,
       openColor: widget.openColor,
       closedElevation: widget.closedElevation,

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1110,6 +1110,7 @@ void main() {
         ),
       ),
     ));
+
     await tester.tap(find.text('Closed'));
     await tester.pumpAndSettle();
 
@@ -1447,6 +1448,75 @@ void main() {
 
     expect(find.text('Closed 2'), findsNothing);
     expect(find.text('Open 2'), findsOneWidget);
+  });
+
+  Widget _createRootNavigatorTest({
+    @required Key appKey,
+    @required Key nestedNavigatorKey,
+    @required bool useRootNavigator,
+  }) =>
+      MaterialApp(
+        key: appKey,
+        // a nested navigator
+        home: Navigator(
+            key: nestedNavigatorKey,
+            onGenerateRoute: (RouteSettings route) =>
+                MaterialPageRoute<dynamic>(
+                    settings: route,
+                    builder: (BuildContext context) => Container(
+                        child: OpenContainer(
+                            useRootNavigator: useRootNavigator,
+                            closedBuilder: (BuildContext context, _) =>
+                                const Text('Closed'),
+                            openBuilder: (BuildContext context, _) =>
+                                const Text('Opened'))))),
+      );
+
+  testWidgets(
+      'Verify that "useRootNavigator: false" uses the correct navigator',
+      (WidgetTester tester) async {
+    const Key appKey = Key('App');
+    const Key nestedNavigatorKey = Key('Nested Navigator');
+
+    await tester.pumpWidget(_createRootNavigatorTest(
+        appKey: appKey,
+        nestedNavigatorKey: nestedNavigatorKey,
+        useRootNavigator: false));
+
+    await tester.tap(find.text('Closed'));
+    await tester.pumpAndSettle();
+
+    expect(
+        find.descendant(of: find.byKey(appKey), matching: find.text('Opened')),
+        findsOneWidget);
+
+    expect(
+        find.descendant(
+            of: find.byKey(nestedNavigatorKey), matching: find.text('Opened')),
+        findsOneWidget);
+  });
+
+  testWidgets('Verify that "useRootNavigator: true" uses the correct navigator',
+      (WidgetTester tester) async {
+    const Key appKey = Key('App');
+    const Key nestedNavigatorKey = Key('Nested Navigator');
+
+    await tester.pumpWidget(_createRootNavigatorTest(
+        appKey: appKey,
+        nestedNavigatorKey: nestedNavigatorKey,
+        useRootNavigator: true));
+
+    await tester.tap(find.text('Closed'));
+    await tester.pumpAndSettle();
+
+    expect(
+        find.descendant(of: find.byKey(appKey), matching: find.text('Opened')),
+        findsOneWidget);
+
+    expect(
+        find.descendant(
+            of: find.byKey(nestedNavigatorKey), matching: find.text('Opened')),
+        findsNothing);
   });
 }
 

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1492,7 +1492,7 @@ void main() {
     expect(find.text('Closed'), findsOneWidget);
     expect(hasClosed, isTrue);
   });
-  
+
   Widget _createRootNavigatorTest({
     @required Key appKey,
     @required Key nestedNavigatorKey,

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1454,23 +1454,28 @@ void main() {
     @required Key appKey,
     @required Key nestedNavigatorKey,
     @required bool useRootNavigator,
-  }) =>
-      MaterialApp(
+  }) {
+    return MaterialApp(
         key: appKey,
         // a nested navigator
         home: Navigator(
             key: nestedNavigatorKey,
-            onGenerateRoute: (RouteSettings route) =>
-                MaterialPageRoute<dynamic>(
-                    settings: route,
-                    builder: (BuildContext context) => Container(
+            onGenerateRoute: (RouteSettings route) {
+              return MaterialPageRoute<dynamic>(
+                  settings: route,
+                  builder: (BuildContext context) {
+                    return Container(
                         child: OpenContainer(
                             useRootNavigator: useRootNavigator,
-                            closedBuilder: (BuildContext context, _) =>
-                                const Text('Closed'),
-                            openBuilder: (BuildContext context, _) =>
-                                const Text('Opened'))))),
-      );
+                            closedBuilder: (BuildContext context, _) {
+                              return const Text('Closed');
+                            },
+                            openBuilder: (BuildContext context, _) {
+                              return const Text('Opened');
+                            }));
+                  });
+            }));
+  }
 
   testWidgets(
       'Verify that "useRootNavigator: false" uses the correct navigator',


### PR DESCRIPTION
Right now, OpenContainer uses the first Navigator it finds in the Widget hierarchy. This pull request adds the ability to use the root Navigator, which is important for being able to use OpenContainer with nested Navigators (for example, when using tabs with their own Navigators).

Fixes https://github.com/flutter/flutter/issues/52614.