### PR TITLE
[animations] Add fillColor property to shared axis transitions

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## TBD
-Update with every new PR. If there is a new release, add a TBD section
-on top of this one and add the release version and the date of release.
+Update this list with new features and bug fixes. If there is a new release,
+add a new TBD section on top of this one and replace the preexisting "TBD"
+with the release version and the date of release.
 
 * Add custom fillColor property to `SharedAxisTransition` and `SharedAxisPageTransitionsBuilder`.
 

--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,3 +1,9 @@
+## TBD
+Update with every new PR. If there is a new release, add a TBD section
+on top of this one and add the release version and the date of release.
+
+* Add custom fillColor property to `SharedAxisTransition` and `SharedAxisPageTransitionsBuilder`.
+
 ## [1.0.0+6] - April 9, 2020
 
 * Fix prefer_const_constructors lint in test and example.

--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,13 +1,12 @@
-## TBD
-Update this list with new features and bug fixes. If there is a new release,
-add a new TBD section on top of this one and replace the preexisting "TBD"
-with the release version and the date of release.
+## [1.0.1-dev] - TBD
 
 * Add custom fillColor property to `SharedAxisTransition` and `SharedAxisPageTransitionsBuilder`.
+
 
 ## [1.0.0+6] - April 9, 2020
 
 * Fix prefer_const_constructors lint in test and example.
+
 
 ## [1.0.0+5] - February 21, 2020
 

--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,10 +1,6 @@
 ## [1.0.1-dev] - TBD
 
 * Add custom fillColor property to `SharedAxisTransition` and `SharedAxisPageTransitionsBuilder`.
-
-
-## [1.0.0+6] - April 9, 2020
-
 * Fix prefer_const_constructors lint in test and example.
 
 

--- a/packages/animations/example/lib/shared_axis_transition.dart
+++ b/packages/animations/example/lib/shared_axis_transition.dart
@@ -32,87 +32,82 @@ class _SharedAxisTransitionDemoState extends State<SharedAxisTransitionDemo> {
 
   @override
   Widget build(BuildContext context) {
-    return Theme(
-      data: Theme.of(context).copyWith(
-        backgroundColor: Colors.green,
-      ),
-      child: Scaffold(
-        resizeToAvoidBottomInset: false,
-        appBar: AppBar(title: const Text('Shared axis')),
-        body: Builder(
-          builder: (BuildContext context) => Column(
-            children: <Widget>[
-              Expanded(
-                child: PageTransitionSwitcher(
-                  duration: const Duration(milliseconds: 300),
-                  reverse: !_isLoggedIn,
-                  transitionBuilder: (
-                    Widget child,
-                    Animation<double> animation,
-                    Animation<double> secondaryAnimation,
-                  ) {
-                    return SharedAxisTransition(
-                      child: child,
-                      animation: animation,
-                      secondaryAnimation: secondaryAnimation,
-                      transitionType: _transitionType,
-                    );
-                  },
-                  child: _isLoggedIn ? _CoursePage() : _SignInPage(),
-                ),
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(title: const Text('Shared axis')),
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            Expanded(
+              child: PageTransitionSwitcher(
+                duration: const Duration(milliseconds: 300),
+                reverse: !_isLoggedIn,
+                transitionBuilder: (
+                  Widget child,
+                  Animation<double> animation,
+                  Animation<double> secondaryAnimation,
+                ) {
+                  return SharedAxisTransition(
+                    child: child,
+                    animation: animation,
+                    secondaryAnimation: secondaryAnimation,
+                    transitionType: _transitionType,
+                  );
+                },
+                child: _isLoggedIn ? _CoursePage() : _SignInPage(),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    FlatButton(
-                      onPressed: _isLoggedIn ? _toggleLoginStatus : null,
-                      textColor: Theme.of(context).colorScheme.primary,
-                      child: const Text('BACK'),
-                    ),
-                    RaisedButton(
-                      onPressed: _isLoggedIn ? null : _toggleLoginStatus,
-                      color: Theme.of(context).colorScheme.primary,
-                      textColor: Theme.of(context).colorScheme.onPrimary,
-                      disabledColor: Colors.black12,
-                      child: const Text('NEXT'),
-                    ),
-                  ],
-                ),
-              ),
-              const Divider(thickness: 2.0),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 15.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: <Widget>[
-                  Radio<SharedAxisTransitionType>(
-                    value: SharedAxisTransitionType.horizontal,
-                    groupValue: _transitionType,
-                    onChanged: (SharedAxisTransitionType newValue) {
-                      _updateTransitionType(newValue);
-                    },
+                  FlatButton(
+                    onPressed: _isLoggedIn ? _toggleLoginStatus : null,
+                    textColor: Theme.of(context).colorScheme.primary,
+                    child: const Text('BACK'),
                   ),
-                  const Text('X'),
-                  Radio<SharedAxisTransitionType>(
-                    value: SharedAxisTransitionType.vertical,
-                    groupValue: _transitionType,
-                    onChanged: (SharedAxisTransitionType newValue) {
-                      _updateTransitionType(newValue);
-                    },
+                  RaisedButton(
+                    onPressed: _isLoggedIn ? null : _toggleLoginStatus,
+                    color: Theme.of(context).colorScheme.primary,
+                    textColor: Theme.of(context).colorScheme.onPrimary,
+                    disabledColor: Colors.black12,
+                    child: const Text('NEXT'),
                   ),
-                  const Text('Y'),
-                  Radio<SharedAxisTransitionType>(
-                    value: SharedAxisTransitionType.scaled,
-                    groupValue: _transitionType,
-                    onChanged: (SharedAxisTransitionType newValue) {
-                      _updateTransitionType(newValue);
-                    },
-                  ),
-                  const Text('Z'),
                 ],
               ),
-            ],
-          ),
+            ),
+            const Divider(thickness: 2.0),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Radio<SharedAxisTransitionType>(
+                  value: SharedAxisTransitionType.horizontal,
+                  groupValue: _transitionType,
+                  onChanged: (SharedAxisTransitionType newValue) {
+                    _updateTransitionType(newValue);
+                  },
+                ),
+                const Text('X'),
+                Radio<SharedAxisTransitionType>(
+                  value: SharedAxisTransitionType.vertical,
+                  groupValue: _transitionType,
+                  onChanged: (SharedAxisTransitionType newValue) {
+                    _updateTransitionType(newValue);
+                  },
+                ),
+                const Text('Y'),
+                Radio<SharedAxisTransitionType>(
+                  value: SharedAxisTransitionType.scaled,
+                  groupValue: _transitionType,
+                  onChanged: (SharedAxisTransitionType newValue) {
+                    _updateTransitionType(newValue);
+                  },
+                ),
+                const Text('Z'),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/packages/animations/example/lib/shared_axis_transition.dart
+++ b/packages/animations/example/lib/shared_axis_transition.dart
@@ -32,82 +32,87 @@ class _SharedAxisTransitionDemoState extends State<SharedAxisTransitionDemo> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      resizeToAvoidBottomInset: false,
-      appBar: AppBar(title: const Text('Shared axis')),
-      body: SafeArea(
-        child: Column(
-          children: <Widget>[
-            Expanded(
-              child: PageTransitionSwitcher(
-                duration: const Duration(milliseconds: 300),
-                reverse: !_isLoggedIn,
-                transitionBuilder: (
-                  Widget child,
-                  Animation<double> animation,
-                  Animation<double> secondaryAnimation,
-                ) {
-                  return SharedAxisTransition(
-                    child: child,
-                    animation: animation,
-                    secondaryAnimation: secondaryAnimation,
-                    transitionType: _transitionType,
-                  );
-                },
-                child: _isLoggedIn ? _CoursePage() : _SignInPage(),
+    return Theme(
+      data: Theme.of(context).copyWith(
+        backgroundColor: Colors.green,
+      ),
+      child: Scaffold(
+        resizeToAvoidBottomInset: false,
+        appBar: AppBar(title: const Text('Shared axis')),
+        body: Builder(
+          builder: (BuildContext context) => Column(
+            children: <Widget>[
+              Expanded(
+                child: PageTransitionSwitcher(
+                  duration: const Duration(milliseconds: 300),
+                  reverse: !_isLoggedIn,
+                  transitionBuilder: (
+                    Widget child,
+                    Animation<double> animation,
+                    Animation<double> secondaryAnimation,
+                  ) {
+                    return SharedAxisTransition(
+                      child: child,
+                      animation: animation,
+                      secondaryAnimation: secondaryAnimation,
+                      transitionType: _transitionType,
+                    );
+                  },
+                  child: _isLoggedIn ? _CoursePage() : _SignInPage(),
+                ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 15.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    FlatButton(
+                      onPressed: _isLoggedIn ? _toggleLoginStatus : null,
+                      textColor: Theme.of(context).colorScheme.primary,
+                      child: const Text('BACK'),
+                    ),
+                    RaisedButton(
+                      onPressed: _isLoggedIn ? null : _toggleLoginStatus,
+                      color: Theme.of(context).colorScheme.primary,
+                      textColor: Theme.of(context).colorScheme.onPrimary,
+                      disabledColor: Colors.black12,
+                      child: const Text('NEXT'),
+                    ),
+                  ],
+                ),
+              ),
+              const Divider(thickness: 2.0),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
-                  FlatButton(
-                    onPressed: _isLoggedIn ? _toggleLoginStatus : null,
-                    textColor: Theme.of(context).colorScheme.primary,
-                    child: const Text('BACK'),
+                  Radio<SharedAxisTransitionType>(
+                    value: SharedAxisTransitionType.horizontal,
+                    groupValue: _transitionType,
+                    onChanged: (SharedAxisTransitionType newValue) {
+                      _updateTransitionType(newValue);
+                    },
                   ),
-                  RaisedButton(
-                    onPressed: _isLoggedIn ? null : _toggleLoginStatus,
-                    color: Theme.of(context).colorScheme.primary,
-                    textColor: Theme.of(context).colorScheme.onPrimary,
-                    disabledColor: Colors.black12,
-                    child: const Text('NEXT'),
+                  const Text('X'),
+                  Radio<SharedAxisTransitionType>(
+                    value: SharedAxisTransitionType.vertical,
+                    groupValue: _transitionType,
+                    onChanged: (SharedAxisTransitionType newValue) {
+                      _updateTransitionType(newValue);
+                    },
                   ),
+                  const Text('Y'),
+                  Radio<SharedAxisTransitionType>(
+                    value: SharedAxisTransitionType.scaled,
+                    groupValue: _transitionType,
+                    onChanged: (SharedAxisTransitionType newValue) {
+                      _updateTransitionType(newValue);
+                    },
+                  ),
+                  const Text('Z'),
                 ],
               ),
-            ),
-            const Divider(thickness: 2.0),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Radio<SharedAxisTransitionType>(
-                  value: SharedAxisTransitionType.horizontal,
-                  groupValue: _transitionType,
-                  onChanged: (SharedAxisTransitionType newValue) {
-                    _updateTransitionType(newValue);
-                  },
-                ),
-                const Text('X'),
-                Radio<SharedAxisTransitionType>(
-                  value: SharedAxisTransitionType.vertical,
-                  groupValue: _transitionType,
-                  onChanged: (SharedAxisTransitionType newValue) {
-                    _updateTransitionType(newValue);
-                  },
-                ),
-                const Text('Y'),
-                Radio<SharedAxisTransitionType>(
-                  value: SharedAxisTransitionType.scaled,
-                  groupValue: _transitionType,
-                  onChanged: (SharedAxisTransitionType newValue) {
-                    _updateTransitionType(newValue);
-                  },
-                ),
-                const Text('Z'),
-              ],
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -504,6 +504,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
+            color: fillColor,
             child: Transform.translate(
               offset: slideOutTransition.evaluate(animation),
               child: child,
@@ -520,6 +521,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
+            color: fillColor,
             child: Transform.translate(
               offset: slideOutTransition.evaluate(animation),
               child: child,
@@ -531,6 +533,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
+            color: fillColor,
             child: ScaleTransition(
               scale: (!reverse ? _scaleUpTransition : _scaleDownTransition)
                   .animate(animation),

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -80,10 +80,16 @@ class SharedAxisPageTransitionsBuilder extends PageTransitionsBuilder {
   /// Construct a [SharedAxisPageTransitionsBuilder].
   const SharedAxisPageTransitionsBuilder({
     this.transitionType,
+    this.fillColor,
   });
 
   /// Determines which [SharedAxisTransitionType] to build.
   final SharedAxisTransitionType transitionType;
+
+  /// The color to use for the background color during the transition.
+  ///
+  /// This defaults to the [Theme]'s [ThemeData.canvasColor].
+  final Color fillColor;
 
   @override
   Widget buildTransitions<T>(
@@ -97,6 +103,7 @@ class SharedAxisPageTransitionsBuilder extends PageTransitionsBuilder {
       animation: animation,
       secondaryAnimation: secondaryAnimation,
       transitionType: transitionType,
+      fillColor: fillColor,
       child: child,
     );
   }
@@ -186,6 +193,7 @@ class SharedAxisTransition extends StatefulWidget {
     @required this.animation,
     @required this.secondaryAnimation,
     @required this.transitionType,
+    this.fillColor,
     this.child,
   })  : assert(transitionType != null),
         super(key: key);
@@ -214,6 +222,11 @@ class SharedAxisTransition extends StatefulWidget {
   ///  * [SharedAxisTransitionType], which defines and describes all shared
   ///    axis transition types.
   final SharedAxisTransitionType transitionType;
+
+  /// The color to use for the background color during the transition.
+  ///
+  /// This defaults to the [Theme]'s [ThemeData.canvasColor].
+  final Color fillColor;
 
   /// The widget below this widget in the tree.
   ///
@@ -341,6 +354,7 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
               animation: _flip(widget.animation),
               transitionType: widget.transitionType,
               reverse: true,
+              fillColor: widget.fillColor,
               child: child,
             );
         }
@@ -355,6 +369,7 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
               return _ExitTransition(
                 animation: widget.secondaryAnimation,
                 transitionType: widget.transitionType,
+                fillColor: widget.fillColor,
                 child: child,
               );
             case AnimationStatus.dismissed:
@@ -453,13 +468,15 @@ class _ExitTransition extends StatelessWidget {
     this.animation,
     this.transitionType,
     this.reverse = false,
+    this.fillColor,
     this.child,
   });
 
   final Animation<double> animation;
   final SharedAxisTransitionType transitionType;
-  final Widget child;
   final bool reverse;
+  final Color fillColor;
+  final Widget child;
 
   static final Animatable<double> _fadeOutTransition = FlippedCurveTween(
     curve: accelerateEasing,
@@ -487,7 +504,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: Theme.of(context).canvasColor,
+            color: fillColor ?? Theme.of(context).canvasColor,
             child: Transform.translate(
               offset: slideOutTransition.evaluate(animation),
               child: child,
@@ -504,7 +521,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: Theme.of(context).canvasColor,
+            color: fillColor ?? Theme.of(context).canvasColor,
             child: Transform.translate(
               offset: slideOutTransition.evaluate(animation),
               child: child,
@@ -516,7 +533,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: Theme.of(context).canvasColor,
+            color: fillColor ?? Theme.of(context).canvasColor,
             child: ScaleTransition(
               scale: (!reverse ? _scaleUpTransition : _scaleDownTransition)
                   .animate(animation),

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -504,7 +504,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: fillColor,
+            color: fillColor ?? Theme.of(context).canvasColor,
             child: Transform.translate(
               offset: slideOutTransition.evaluate(animation),
               child: child,
@@ -521,7 +521,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: fillColor,
+            color: fillColor ?? Theme.of(context).canvasColor,
             child: Transform.translate(
               offset: slideOutTransition.evaluate(animation),
               child: child,
@@ -533,7 +533,7 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: fillColor,
+            color: fillColor ?? Theme.of(context).canvasColor,
             child: ScaleTransition(
               scale: (!reverse ? _scaleUpTransition : _scaleDownTransition)
                   .animate(animation),

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -504,7 +504,6 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: fillColor ?? Theme.of(context).canvasColor,
             child: Transform.translate(
               offset: slideOutTransition.evaluate(animation),
               child: child,
@@ -521,7 +520,6 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: fillColor ?? Theme.of(context).canvasColor,
             child: Transform.translate(
               offset: slideOutTransition.evaluate(animation),
               child: child,
@@ -533,7 +531,6 @@ class _ExitTransition extends StatelessWidget {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
           child: Container(
-            color: fillColor ?? Theme.of(context).canvasColor,
             child: ScaleTransition(
               scale: (!reverse ? _scaleUpTransition : _scaleDownTransition)
                   .animate(animation),

--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
-version: 1.0.0+6
+version: 1.0.1-dev
 homepage: https://github.com/flutter/packages/tree/master/packages/animations
 
 environment:

--- a/packages/animations/test/shared_axis_transition_test.dart
+++ b/packages/animations/test/shared_axis_transition_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
-import 'package:vector_math/vector_math_64.dart';
+import 'package:vector_math/vector_math_64.dart' hide Colors;
 
 void main() {
   group('SharedAxisTransitionType.horizontal', () {
@@ -504,6 +504,80 @@ void main() {
         );
         expect(find.byKey(const ValueKey<String>(topRoute)), findsNothing);
       },
+    );
+
+    testWidgets(
+      'default fill color',
+      (WidgetTester tester) async {
+        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+        const String bottomRoute = '/';
+        const String topRoute = '/a';
+
+        // The default fill color should be derived from ThemeData.canvasColor.
+        final Color defaultFillColor = ThemeData().canvasColor;
+
+        await tester.pumpWidget(
+          _TestWidget(
+            navigatorKey: navigator,
+            transitionType: SharedAxisTransitionType.horizontal,
+          ),
+        );
+
+        expect(find.text(bottomRoute), findsOneWidget);
+        Finder fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+
+        navigator.currentState.pushNamed(topRoute);
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/a')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+      }
+    );
+
+    testWidgets(
+      'custom fill color',
+      (WidgetTester tester) async {
+        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+        const String bottomRoute = '/';
+        const String topRoute = '/a';
+
+        await tester.pumpWidget(
+          _TestWidget(
+            navigatorKey: navigator,
+            fillColor: Colors.green,
+            transitionType: SharedAxisTransitionType.horizontal,
+          ),
+        );
+
+        expect(find.text(bottomRoute), findsOneWidget);
+        Finder fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+
+        navigator.currentState.pushNamed(topRoute);
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/a')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+      }
     );
   });
 
@@ -1004,6 +1078,80 @@ void main() {
         expect(find.byKey(const ValueKey<String>(topRoute)), findsNothing);
       },
     );
+
+    testWidgets(
+      'default fill color',
+      (WidgetTester tester) async {
+        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+        const String bottomRoute = '/';
+        const String topRoute = '/a';
+
+        // The default fill color should be derived from ThemeData.canvasColor.
+        final Color defaultFillColor = ThemeData().canvasColor;
+
+        await tester.pumpWidget(
+          _TestWidget(
+            navigatorKey: navigator,
+            transitionType: SharedAxisTransitionType.vertical,
+          ),
+        );
+
+        expect(find.text(bottomRoute), findsOneWidget);
+        Finder fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+
+        navigator.currentState.pushNamed(topRoute);
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/a')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+      }
+    );
+
+    testWidgets(
+      'custom fill color',
+      (WidgetTester tester) async {
+        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+        const String bottomRoute = '/';
+        const String topRoute = '/a';
+
+        await tester.pumpWidget(
+          _TestWidget(
+            navigatorKey: navigator,
+            fillColor: Colors.green,
+            transitionType: SharedAxisTransitionType.vertical,
+          ),
+        );
+
+        expect(find.text(bottomRoute), findsOneWidget);
+        Finder fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+
+        navigator.currentState.pushNamed(topRoute);
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/a')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+      }
+    );
   });
 
   group('SharedAxisTransitionType.scaled', () {
@@ -1396,6 +1544,80 @@ void main() {
         expect(find.byKey(const ValueKey<String>(topRoute)), findsNothing);
       },
     );
+
+    testWidgets(
+      'default fill color',
+      (WidgetTester tester) async {
+        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+        const String bottomRoute = '/';
+        const String topRoute = '/a';
+
+        // The default fill color should be derived from ThemeData.canvasColor.
+        final Color defaultFillColor = ThemeData().canvasColor;
+
+        await tester.pumpWidget(
+          _TestWidget(
+            navigatorKey: navigator,
+            transitionType: SharedAxisTransitionType.scaled,
+          ),
+        );
+
+        expect(find.text(bottomRoute), findsOneWidget);
+        Finder fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+
+        navigator.currentState.pushNamed(topRoute);
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/a')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+      }
+    );
+
+    testWidgets(
+      'custom fill color',
+      (WidgetTester tester) async {
+        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+        const String bottomRoute = '/';
+        const String topRoute = '/a';
+
+        await tester.pumpWidget(
+          _TestWidget(
+            navigatorKey: navigator,
+            fillColor: Colors.green,
+            transitionType: SharedAxisTransitionType.scaled,
+          ),
+        );
+
+        expect(find.text(bottomRoute), findsOneWidget);
+        Finder fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+
+        navigator.currentState.pushNamed(topRoute);
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        fillContainerFinder = find.ancestor(
+          matching: find.byType(Container),
+          of: find.byKey(const ValueKey<String>('/a')),
+        ).last;
+        expect(fillContainerFinder, findsOneWidget);
+        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+      }
+    );
   });
 }
 
@@ -1462,11 +1684,13 @@ class _TestWidget extends StatelessWidget {
     this.navigatorKey,
     this.contentBuilder,
     this.transitionType,
+    this.fillColor,
   });
 
   final Key navigatorKey;
   final _ContentBuilder contentBuilder;
   final SharedAxisTransitionType transitionType;
+  final Color fillColor;
 
   @override
   Widget build(BuildContext context) {
@@ -1477,6 +1701,7 @@ class _TestWidget extends StatelessWidget {
         pageTransitionsTheme: PageTransitionsTheme(
           builders: <TargetPlatform, PageTransitionsBuilder>{
             TargetPlatform.android: SharedAxisPageTransitionsBuilder(
+              fillColor: fillColor,
               transitionType: transitionType,
             ),
           },

--- a/packages/animations/test/shared_axis_transition_test.dart
+++ b/packages/animations/test/shared_axis_transition_test.dart
@@ -506,79 +506,83 @@ void main() {
       },
     );
 
-    testWidgets(
-      'default fill color',
-      (WidgetTester tester) async {
-        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-        const String bottomRoute = '/';
-        const String topRoute = '/a';
+    testWidgets('default fill color', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      const String bottomRoute = '/';
+      const String topRoute = '/a';
 
-        // The default fill color should be derived from ThemeData.canvasColor.
-        final Color defaultFillColor = ThemeData().canvasColor;
+      // The default fill color should be derived from ThemeData.canvasColor.
+      final Color defaultFillColor = ThemeData().canvasColor;
 
-        await tester.pumpWidget(
-          _TestWidget(
-            navigatorKey: navigator,
-            transitionType: SharedAxisTransitionType.horizontal,
-          ),
-        );
+      await tester.pumpWidget(
+        _TestWidget(
+          navigatorKey: navigator,
+          transitionType: SharedAxisTransitionType.horizontal,
+        ),
+      );
 
-        expect(find.text(bottomRoute), findsOneWidget);
-        Finder fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+      expect(find.text(bottomRoute), findsOneWidget);
+      Finder fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color,
+          defaultFillColor);
 
-        navigator.currentState.pushNamed(topRoute);
-        await tester.pump();
-        await tester.pumpAndSettle();
+      navigator.currentState.pushNamed(topRoute);
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/a')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
-      }
-    );
+      fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/a')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color,
+          defaultFillColor);
+    });
 
-    testWidgets(
-      'custom fill color',
-      (WidgetTester tester) async {
-        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-        const String bottomRoute = '/';
-        const String topRoute = '/a';
+    testWidgets('custom fill color', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      const String bottomRoute = '/';
+      const String topRoute = '/a';
 
-        await tester.pumpWidget(
-          _TestWidget(
-            navigatorKey: navigator,
-            fillColor: Colors.green,
-            transitionType: SharedAxisTransitionType.horizontal,
-          ),
-        );
+      await tester.pumpWidget(
+        _TestWidget(
+          navigatorKey: navigator,
+          fillColor: Colors.green,
+          transitionType: SharedAxisTransitionType.horizontal,
+        ),
+      );
 
-        expect(find.text(bottomRoute), findsOneWidget);
-        Finder fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+      expect(find.text(bottomRoute), findsOneWidget);
+      Finder fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
 
-        navigator.currentState.pushNamed(topRoute);
-        await tester.pump();
-        await tester.pumpAndSettle();
+      navigator.currentState.pushNamed(topRoute);
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/a')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-      }
-    );
+      fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/a')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+    });
   });
 
   group('SharedAxisTransitionType.vertical', () {
@@ -1079,79 +1083,83 @@ void main() {
       },
     );
 
-    testWidgets(
-      'default fill color',
-      (WidgetTester tester) async {
-        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-        const String bottomRoute = '/';
-        const String topRoute = '/a';
+    testWidgets('default fill color', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      const String bottomRoute = '/';
+      const String topRoute = '/a';
 
-        // The default fill color should be derived from ThemeData.canvasColor.
-        final Color defaultFillColor = ThemeData().canvasColor;
+      // The default fill color should be derived from ThemeData.canvasColor.
+      final Color defaultFillColor = ThemeData().canvasColor;
 
-        await tester.pumpWidget(
-          _TestWidget(
-            navigatorKey: navigator,
-            transitionType: SharedAxisTransitionType.vertical,
-          ),
-        );
+      await tester.pumpWidget(
+        _TestWidget(
+          navigatorKey: navigator,
+          transitionType: SharedAxisTransitionType.vertical,
+        ),
+      );
 
-        expect(find.text(bottomRoute), findsOneWidget);
-        Finder fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+      expect(find.text(bottomRoute), findsOneWidget);
+      Finder fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color,
+          defaultFillColor);
 
-        navigator.currentState.pushNamed(topRoute);
-        await tester.pump();
-        await tester.pumpAndSettle();
+      navigator.currentState.pushNamed(topRoute);
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/a')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
-      }
-    );
+      fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/a')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color,
+          defaultFillColor);
+    });
 
-    testWidgets(
-      'custom fill color',
-      (WidgetTester tester) async {
-        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-        const String bottomRoute = '/';
-        const String topRoute = '/a';
+    testWidgets('custom fill color', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      const String bottomRoute = '/';
+      const String topRoute = '/a';
 
-        await tester.pumpWidget(
-          _TestWidget(
-            navigatorKey: navigator,
-            fillColor: Colors.green,
-            transitionType: SharedAxisTransitionType.vertical,
-          ),
-        );
+      await tester.pumpWidget(
+        _TestWidget(
+          navigatorKey: navigator,
+          fillColor: Colors.green,
+          transitionType: SharedAxisTransitionType.vertical,
+        ),
+      );
 
-        expect(find.text(bottomRoute), findsOneWidget);
-        Finder fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+      expect(find.text(bottomRoute), findsOneWidget);
+      Finder fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
 
-        navigator.currentState.pushNamed(topRoute);
-        await tester.pump();
-        await tester.pumpAndSettle();
+      navigator.currentState.pushNamed(topRoute);
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/a')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-      }
-    );
+      fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/a')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+    });
   });
 
   group('SharedAxisTransitionType.scaled', () {
@@ -1545,79 +1553,83 @@ void main() {
       },
     );
 
-    testWidgets(
-      'default fill color',
-      (WidgetTester tester) async {
-        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-        const String bottomRoute = '/';
-        const String topRoute = '/a';
+    testWidgets('default fill color', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      const String bottomRoute = '/';
+      const String topRoute = '/a';
 
-        // The default fill color should be derived from ThemeData.canvasColor.
-        final Color defaultFillColor = ThemeData().canvasColor;
+      // The default fill color should be derived from ThemeData.canvasColor.
+      final Color defaultFillColor = ThemeData().canvasColor;
 
-        await tester.pumpWidget(
-          _TestWidget(
-            navigatorKey: navigator,
-            transitionType: SharedAxisTransitionType.scaled,
-          ),
-        );
+      await tester.pumpWidget(
+        _TestWidget(
+          navigatorKey: navigator,
+          transitionType: SharedAxisTransitionType.scaled,
+        ),
+      );
 
-        expect(find.text(bottomRoute), findsOneWidget);
-        Finder fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
+      expect(find.text(bottomRoute), findsOneWidget);
+      Finder fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color,
+          defaultFillColor);
 
-        navigator.currentState.pushNamed(topRoute);
-        await tester.pump();
-        await tester.pumpAndSettle();
+      navigator.currentState.pushNamed(topRoute);
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/a')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, defaultFillColor);
-      }
-    );
+      fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/a')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color,
+          defaultFillColor);
+    });
 
-    testWidgets(
-      'custom fill color',
-      (WidgetTester tester) async {
-        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-        const String bottomRoute = '/';
-        const String topRoute = '/a';
+    testWidgets('custom fill color', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      const String bottomRoute = '/';
+      const String topRoute = '/a';
 
-        await tester.pumpWidget(
-          _TestWidget(
-            navigatorKey: navigator,
-            fillColor: Colors.green,
-            transitionType: SharedAxisTransitionType.scaled,
-          ),
-        );
+      await tester.pumpWidget(
+        _TestWidget(
+          navigatorKey: navigator,
+          fillColor: Colors.green,
+          transitionType: SharedAxisTransitionType.scaled,
+        ),
+      );
 
-        expect(find.text(bottomRoute), findsOneWidget);
-        Finder fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+      expect(find.text(bottomRoute), findsOneWidget);
+      Finder fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
 
-        navigator.currentState.pushNamed(topRoute);
-        await tester.pump();
-        await tester.pumpAndSettle();
+      navigator.currentState.pushNamed(topRoute);
+      await tester.pump();
+      await tester.pumpAndSettle();
 
-        fillContainerFinder = find.ancestor(
-          matching: find.byType(Container),
-          of: find.byKey(const ValueKey<String>('/a')),
-        ).last;
-        expect(fillContainerFinder, findsOneWidget);
-        expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-      }
-    );
+      fillContainerFinder = find
+          .ancestor(
+            matching: find.byType(Container),
+            of: find.byKey(const ValueKey<String>('/a')),
+          )
+          .last;
+      expect(fillContainerFinder, findsOneWidget);
+      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+    });
   });
 }
 


### PR DESCRIPTION
Adds a `fillColor` property to `SharedAxisTransition` and `SharedAxisPageTransitionsBuilder`. This allows the developer to specify a background color that isn't `ThemeData.canvasColor`

Fixes https://github.com/flutter/flutter/issues/52328