### PR TITLE
Several improvements to fuchsia_ctl.

### DIFF
--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -39,7 +39,8 @@ Future<void> main(List<String> args) async {
             'If not specified, the first discoverable device will be used.')
     ..addOption('dev-finder-path',
         defaultsTo: './dev_finder',
-        help: 'The path to the dev_finder executable.');
+        help: 'The path to the dev_finder executable.')
+    ..addFlag('help', defaultsTo: false, help: 'Prints help.');
   parser.addCommand('ssh')
     ..addFlag('interactive',
         abbr: 'i',
@@ -68,9 +69,8 @@ Future<void> main(List<String> args) async {
             'publish, or serve.')
     ..addCommand('serve')
     ..addCommand('newRepo');
-  pmSubCommand
-      .addCommand('publishRepo')
-      .addMultiOption('far', abbr: 'f', help: 'The .far files to publish.');
+  pmSubCommand.addCommand('publishRepo')
+    ..addMultiOption('far', abbr: 'f', help: 'The .far files to publish.');
 
   parser.addCommand('push-packages')
     ..addOption('pm-path',
@@ -104,6 +104,7 @@ Future<void> main(List<String> args) async {
     stderr.writeln(parser.usage);
     exit(-1);
   }
+
   final AsyncResult command = commands[results.command.name];
   if (command == null) {
     stderr.writeln('Unkown command ${results.command.name}.');

--- a/packages/fuchsia_ctl/lib/src/image_paver.dart
+++ b/packages/fuchsia_ctl/lib/src/image_paver.dart
@@ -62,7 +62,7 @@ class ImagePaver {
           'an unexpected device.');
     }
     final SshKeyManager sshKeyManager = sshKeyManagerProvider(
-        processManager: processManager, pubKeyPath: pubKeyPath);
+        processManager: processManager, pubKeyPath: pubKeyPath, fs: fs);
     final String uuid = Uuid().v4();
     final Directory imageDirectory = fs.directory('image_$uuid');
     if (verbose) {

--- a/packages/fuchsia_ctl/lib/src/ssh_client.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_client.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -9,6 +10,9 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import 'operation_result.dart';
+
+/// The default timeout in milliseconds for the ssh command.
+const int defaultSshTimeoutMs = 5 * 1000;
 
 /// A client for running SSH based commands on a Fuchsia device.
 @immutable
@@ -84,23 +88,24 @@ class SshClient {
   /// [DevFinder] class.
   ///
   /// All arguments must not be null.
-  Future<OperationResult> runCommand(
-    String targetIp, {
-    @required String identityFilePath,
-    @required List<String> command,
-  }) async {
+  Future<OperationResult> runCommand(String targetIp,
+      {@required String identityFilePath,
+      @required List<String> command,
+      int timeoutMs = defaultSshTimeoutMs}) async {
     assert(targetIp != null);
     assert(identityFilePath != null);
     assert(command != null);
 
     return OperationResult.fromProcessResult(
-      await processManager.run(
-        getSshArguments(
-          identityFilePath: identityFilePath,
-          targetIp: targetIp,
-          command: command,
-        ),
-      ),
+      await processManager
+          .run(
+            getSshArguments(
+              identityFilePath: identityFilePath,
+              targetIp: targetIp,
+              command: command,
+            ),
+          )
+          .timeout(Duration(milliseconds: timeoutMs)),
     );
   }
 }

--- a/packages/fuchsia_ctl/lib/src/ssh_client.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_client.dart
@@ -12,7 +12,7 @@ import 'package:process/process.dart';
 import 'operation_result.dart';
 
 /// The default timeout in milliseconds for the ssh command.
-const int defaultSshTimeoutMs = 5 * 1000;
+const int defaultSshTimeoutMs = 5 * 60 * 1000;
 
 /// A client for running SSH based commands on a Fuchsia device.
 @immutable

--- a/packages/fuchsia_ctl/lib/src/ssh_client.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_client.dart
@@ -11,9 +11,6 @@ import 'package:process/process.dart';
 
 import 'operation_result.dart';
 
-/// The default timeout in milliseconds for the ssh command.
-const int defaultSshTimeoutMs = 5 * 60 * 1000;
-
 /// A client for running SSH based commands on a Fuchsia device.
 @immutable
 class SshClient {
@@ -28,6 +25,10 @@ class SshClient {
 
   /// The [ProcessManager] to use for spawning `ssh`.
   final ProcessManager processManager;
+
+  /// The default ssh timeout as [Duration] in milliseconds.
+  static const Duration defaultSshTimeoutMs =
+      Duration(milliseconds: 5 * 60 * 1000);
 
   /// Creates a list of arguments to pass to ssh.
   ///
@@ -91,7 +92,7 @@ class SshClient {
   Future<OperationResult> runCommand(String targetIp,
       {@required String identityFilePath,
       @required List<String> command,
-      int timeoutMs = defaultSshTimeoutMs}) async {
+      Duration timeoutMs = defaultSshTimeoutMs}) async {
     assert(targetIp != null);
     assert(identityFilePath != null);
     assert(command != null);
@@ -105,7 +106,7 @@ class SshClient {
               command: command,
             ),
           )
-          .timeout(Duration(milliseconds: timeoutMs)),
+          .timeout(timeoutMs),
     );
   }
 }

--- a/packages/fuchsia_ctl/lib/src/ssh_key_manager.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_key_manager.dart
@@ -12,16 +12,21 @@ import 'package:process/process.dart';
 import 'operation_result.dart';
 
 /// Function signature for a [SshKeyManager] provider.
-typedef SshKeyManagerProvider = SshKeyManager Function(
-    {ProcessManager processManager, FileSystem fs, String pubKeyPath});
+typedef SshKeyManagerProvider = SshKeyManager Function({
+  ProcessManager processManager,
+  FileSystem fs,
+  String publicKeyPath,
+});
 
 /// A wrapper for managing SSH key generation.
 ///
 /// Implemented by [SystemSshKeyManager].
 abstract class SshKeyManager {
   /// Create SSH key material suitable for paving and accessing a Fuchsia image.
-  Future<OperationResult> createKeys(
-      {String destinationPath = '.ssh', bool force = false});
+  Future<OperationResult> createKeys({
+    String destinationPath = '.ssh',
+    bool force = false,
+  });
 }
 
 /// A class that delegates creating SSH keys to the system `ssh-keygen`.
@@ -39,12 +44,16 @@ class SystemSshKeyManager implements SshKeyManager {
         assert(fs != null);
 
   /// Creates a static provider that returns a SystemSshKeyManager.
-  static SshKeyManager defaultProvider(
-      {ProcessManager processManager, FileSystem fs, String pubKeyPath}) {
+  static SshKeyManager defaultProvider({
+    ProcessManager processManager,
+    FileSystem fs,
+    String publicKeyPath,
+  }) {
     return SystemSshKeyManager(
-        processManager: processManager ?? const LocalProcessManager(),
-        fs: fs,
-        pkeyPubPath: pubKeyPath);
+      processManager: processManager ?? const LocalProcessManager(),
+      fs: fs,
+      pkeyPubPath: publicKeyPath,
+    );
   }
 
   /// The [ProcessManager] implementation to use when spawning ssh-keygen.

--- a/packages/fuchsia_ctl/test/image_paver_test.dart
+++ b/packages/fuchsia_ctl/test/image_paver_test.dart
@@ -24,10 +24,18 @@ void main() {
   final MemoryFileSystem fs = MemoryFileSystem(style: FileSystemStyle.posix);
   FakeTar tar;
   MockProcessManager processManager;
+  SshKeyManagerProvider sshKeyManagerProvider;
 
   setUp(() {
     processManager = MockProcessManager();
     sshKeyManager = const FakeSshKeyManager(true);
+    sshKeyManagerProvider = ({
+      ProcessManager processManager,
+      FileSystem fs,
+      String publicKeyPath,
+    }) {
+      return sshKeyManager;
+    };
   });
 
   test('Tar fails', () async {
@@ -38,11 +46,7 @@ void main() {
 
     final ImagePaver paver = ImagePaver(
       tar: tar,
-      sshKeyManagerProvider: (
-              {ProcessManager processManager,
-              FileSystem fs,
-              String pubKeyPath}) =>
-          sshKeyManager,
+      sshKeyManagerProvider: sshKeyManagerProvider,
       fs: fs,
       processManager: processManager,
     );
@@ -50,7 +54,6 @@ void main() {
     final OperationResult result = await paver.pave(
       'generic-x64.tgz',
       deviceName,
-      null,
       verbose: false,
     );
 
@@ -68,11 +71,7 @@ void main() {
 
     final ImagePaver paver = ImagePaver(
       tar: tar,
-      sshKeyManagerProvider: (
-              {ProcessManager processManager,
-              FileSystem fs,
-              String pubKeyPath}) =>
-          sshKeyManager,
+      sshKeyManagerProvider: sshKeyManagerProvider,
       fs: fs,
       processManager: processManager,
     );
@@ -80,7 +79,6 @@ void main() {
     final OperationResult result = await paver.pave(
       'generic-x64.tgz',
       deviceName,
-      null,
       verbose: false,
     );
 
@@ -99,18 +97,18 @@ void main() {
 
     final ImagePaver paver = ImagePaver(
       tar: tar,
-      sshKeyManagerProvider: (
-              {ProcessManager processManager,
-              FileSystem fs,
-              String pubKeyPath}) =>
-          sshKeyManager,
+      sshKeyManagerProvider: sshKeyManagerProvider,
       fs: fs,
       processManager: processManager,
     );
 
     expect(
-        paver.pave('generic-x64.tgz', deviceName, null,
-            verbose: false, timeoutMs: 1),
+        paver.pave(
+          'generic-x64.tgz',
+          deviceName,
+          verbose: false,
+          timeoutMs: const Duration(milliseconds: 1),
+        ),
         throwsA(const TypeMatcher<TimeoutException>()));
   });
 
@@ -122,11 +120,7 @@ void main() {
 
     final ImagePaver paver = ImagePaver(
       tar: tar,
-      sshKeyManagerProvider: (
-              {ProcessManager processManager,
-              FileSystem fs,
-              String pubKeyPath}) =>
-          sshKeyManager,
+      sshKeyManagerProvider: sshKeyManagerProvider,
       fs: fs,
       processManager: processManager,
     );
@@ -134,7 +128,6 @@ void main() {
     final OperationResult result = await paver.pave(
       'generic-x64.tgz',
       deviceName,
-      null,
       verbose: false,
     );
 

--- a/packages/fuchsia_ctl/test/ssh_client_test.dart
+++ b/packages/fuchsia_ctl/test/ssh_client_test.dart
@@ -99,10 +99,12 @@ void main() {
 
     final SshClient ssh = SshClient(processManager: processManager);
     expect(
-        ssh.runCommand(targetIp,
-            identityFilePath: identityFilePath,
-            command: const <String>['ls', '-al'],
-            timeoutMs: 1),
+        ssh.runCommand(
+          targetIp,
+          identityFilePath: identityFilePath,
+          command: const <String>['ls', '-al'],
+          timeoutMs: const Duration(milliseconds: 1),
+        ),
         throwsA(const TypeMatcher<TimeoutException>()));
   });
 }

--- a/packages/fuchsia_ctl/test/ssh_key_manager_test.dart
+++ b/packages/fuchsia_ctl/test/ssh_key_manager_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:file/file.dart';
+import 'package:path/path.dart' as path;
+import 'package:file/memory.dart';
+import 'package:fuchsia_ctl/src/ssh_key_manager.dart';
+import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SystemSshKeyManager', () {
+    MemoryFileSystem fs;
+    final MockProcessManager processManager = MockProcessManager();
+
+    setUp(() async {
+      fs = MemoryFileSystem();
+    });
+    test('CreateAuthorizedKeys', () async {
+      const SystemSshKeyManager systemSshKeyManager = SystemSshKeyManager();
+      final File authorizedKeys = fs.file('authorized_keys');
+      final File pkeyPub = fs.file('key.pub');
+      pkeyPub.writeAsString('ssh-rsa AAAA== abc@cde.com');
+      systemSshKeyManager.createAuthorizedKeys(authorizedKeys, pkeyPub);
+      final String result = await authorizedKeys.readAsString();
+      expect(result, equals('ssh-rsa AAAA==\n'));
+    });
+
+    test('KeysNotGenerated_PubKeyPassed', () async {
+      final File pkeyPub = fs.file('key.pub');
+      pkeyPub.writeAsString('ssh-rsa AAAA== abc@cde.com');
+      final SystemSshKeyManager systemSshKeyManager = SystemSshKeyManager(
+          processManager: processManager, fs: fs, pkeyPubPath: pkeyPub.path);
+      await systemSshKeyManager.createKeys();
+      final File authorizedKeys = fs.file(path.join('.ssh', 'authorized_keys'));
+      final String result = await authorizedKeys.readAsString();
+      expect(result, equals('ssh-rsa AAAA==\n'));
+      verifyNever(processManager.run(any));
+    });
+
+    test('KeysGenerated', () async {
+      when(processManager.run(any)).thenAnswer((_) async {
+        final File pkeyPub = fs.file(path.join('.ssh', 'pkey.pub'));
+        pkeyPub.writeAsString('ssh-rsa AAAA== abc@cde.com');
+        final File pkey = fs.file(path.join('.ssh', 'pkey'));
+        pkey.create();
+        return ProcessResult(0, 0, 'Good job', '');
+      });
+      final SystemSshKeyManager systemSshKeyManager =
+          SystemSshKeyManager(processManager: processManager, fs: fs);
+      await systemSshKeyManager.createKeys();
+      final File authorizedKeys = fs.file(path.join('.ssh', 'authorized_keys'));
+      expect(await authorizedKeys.exists(), isTrue);
+      final File pkey = fs.file(path.join('.ssh', 'pkey'));
+      expect(await pkey.exists(), isTrue);
+      final File pkeyPub = fs.file(path.join('.ssh', 'pkey.pub'));
+      expect(await pkeyPub.exists(), isTrue);
+    });
+  });
+}
+
+class MockProcessManager extends Mock implements ProcessManager {}


### PR DESCRIPTION
* Adds timeouts for paving process.
* Adds timeouts to ssh commands and tests.
* Support to generate authorized_keys with existing pub key.
* Add flags to pass public key to pave subcommand.

https://github.com/flutter/flutter/issues/54416