### PR TITLE
Fixes accessibility/tappability of the FAB in the FadeScaleTransition example

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [1.0.1-dev] - TBD
 
+* Fix `FadeScaleTransition` example's `FloatingActionButton` being accessible
+and tappable when it is supposed to be hidden.
 * Add custom fillColor property to `SharedAxisTransition` and `SharedAxisPageTransitionsBuilder`.
 * Fix prefer_const_constructors lint in test and example.
 

--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -39,7 +39,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
     super.dispose();
   }
 
-  bool isAnimationRunningForwardsOrComplete() {
+  bool get _isAnimationRunningForwardsOrComplete {
     switch (_controller.status) {
       case AnimationStatus.forward:
       case AnimationStatus.completed:
@@ -98,7 +98,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                 const SizedBox(width: 10),
                 RaisedButton(
                   onPressed: () {
-                    if (isAnimationRunningForwardsOrComplete()) {
+                    if (_isAnimationRunningForwardsOrComplete) {
                       _controller.reverse();
                     } else {
                       _controller.forward();
@@ -106,7 +106,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                   },
                   color: Theme.of(context).colorScheme.primary,
                   textColor: Theme.of(context).colorScheme.onPrimary,
-                  child: isAnimationRunningForwardsOrComplete()
+                  child: _isAnimationRunningForwardsOrComplete
                       ? const Text('HIDE FAB')
                       : const Text('SHOW FAB'),
                 ),

--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -19,7 +19,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
   @override
   void initState() {
     _controller = AnimationController(
-      value: 1.0,
+      value: 0.0,
       duration: const Duration(milliseconds: 150),
       reverseDuration: const Duration(milliseconds: 75),
       vsync: this,

--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -24,8 +24,8 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
       reverseDuration: const Duration(milliseconds: 75),
       vsync: this,
     )..addListener(() {
-      setState(() {});
-    });
+        setState(() {});
+      });
     super.initState();
   }
 
@@ -35,7 +35,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
     super.dispose();
   }
 
-  bool isAnimationRunningForwardsOrComplete () {
+  bool isAnimationRunningForwardsOrComplete() {
     switch (_controller.status) {
       case AnimationStatus.forward:
       case AnimationStatus.completed:
@@ -96,7 +96,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                 const SizedBox(width: 10),
                 RaisedButton(
                   onPressed: () {
-                    if (isAnimationRunningForwardsOrComplete()){
+                    if (isAnimationRunningForwardsOrComplete()) {
                       _controller.reverse();
                     } else {
                       _controller.forward();
@@ -105,8 +105,8 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                   color: Theme.of(context).colorScheme.primary,
                   textColor: Theme.of(context).colorScheme.onPrimary,
                   child: isAnimationRunningForwardsOrComplete()
-                    ? const Text('HIDE FAB')
-                    : const Text('SHOW FAB'),
+                      ? const Text('HIDE FAB')
+                      : const Text('SHOW FAB'),
                 ),
               ],
             ),

--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -16,8 +16,6 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
     with SingleTickerProviderStateMixin {
   AnimationController _controller;
 
-  bool _showFab = true;
-
   @override
   void initState() {
     _controller = AnimationController(
@@ -25,7 +23,9 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
       duration: const Duration(milliseconds: 150),
       reverseDuration: const Duration(milliseconds: 75),
       vsync: this,
-    );
+    )..addListener(() {
+      setState(() {});
+    });
     super.initState();
   }
 
@@ -35,12 +35,25 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
     super.dispose();
   }
 
+  bool isAnimationRunningForwardsOrComplete () {
+    switch (_controller.status) {
+      case AnimationStatus.forward:
+      case AnimationStatus.completed:
+        return true;
+        break;
+      case AnimationStatus.reverse:
+      case AnimationStatus.dismissed:
+        return false;
+        break;
+    }
+    assert(true);
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Fade'),
-      ),
+      appBar: AppBar(title: const Text('Fade')),
       floatingActionButton: AnimatedBuilder(
         animation: _controller,
         builder: (BuildContext context, Widget child) {
@@ -49,9 +62,12 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
             child: child,
           );
         },
-        child: FloatingActionButton(
-          child: const Icon(Icons.add),
-          onPressed: () {},
+        child: Visibility(
+          visible: _controller.value != 0,
+          child: FloatingActionButton(
+            child: const Icon(Icons.add),
+            onPressed: () {},
+          ),
         ),
       ),
       bottomNavigationBar: Column(
@@ -80,23 +96,17 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                 const SizedBox(width: 10),
                 RaisedButton(
                   onPressed: () {
-                    if (_showFab) {
-                      setState(() {
-                        _showFab = false;
-                      });
+                    if (isAnimationRunningForwardsOrComplete()){
                       _controller.reverse();
                     } else {
-                      setState(() {
-                        _showFab = true;
-                      });
                       _controller.forward();
                     }
                   },
                   color: Theme.of(context).colorScheme.primary,
                   textColor: Theme.of(context).colorScheme.onPrimary,
-                  child: _showFab
-                      ? const Text('HIDE FAB')
-                      : const Text('SHOW FAB'),
+                  child: isAnimationRunningForwardsOrComplete()
+                    ? const Text('HIDE FAB')
+                    : const Text('SHOW FAB'),
                 ),
               ],
             ),

--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -23,8 +23,12 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
       duration: const Duration(milliseconds: 150),
       reverseDuration: const Duration(milliseconds: 75),
       vsync: this,
-    )..addListener(() {
-        setState(() {});
+    )..addStatusListener((AnimationStatus status) {
+        setState(() {
+          // setState needs to be called to trigger a rebuild because
+          // the 'HIDE FAB'/'SHOW FAB' button needs to be updated based
+          // the latest value of [_controller.value].
+        });
       });
     super.initState();
   }
@@ -40,13 +44,11 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
       case AnimationStatus.forward:
       case AnimationStatus.completed:
         return true;
-        break;
       case AnimationStatus.reverse:
       case AnimationStatus.dismissed:
         return false;
-        break;
     }
-    assert(true);
+    assert(false);
     return null;
   }
 
@@ -63,7 +65,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
           );
         },
         child: Visibility(
-          visible: _controller.value != 0,
+          visible: _controller.status != AnimationStatus.dismissed,
           child: FloatingActionButton(
             child: const Icon(Icons.add),
             onPressed: () {},

--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -27,7 +27,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
         setState(() {
           // setState needs to be called to trigger a rebuild because
           // the 'HIDE FAB'/'SHOW FAB' button needs to be updated based
-          // the latest value of [_controller.value].
+          // the latest value of [_controller.status].
         });
       });
     super.initState();


### PR DESCRIPTION
Before this PR, it is possible to tap on the FAB even though it's not supposed to be shown because `FadeScaleTransition` widget controls its opacity and size, but does not decide whether to keep or remove the widget from the widget tree. This change fixes the example to properly hide the FAB.

Fixes https://github.com/flutter/flutter/issues/51300

![fixed-fab-accessibility](https://user-images.githubusercontent.com/27032613/79024682-8bad5900-7b38-11ea-832c-967984803941.gif)
