### PR TITLE
[animations] Set FadeScaleTransitionConfiguration to configuration default value

### DIFF
--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -85,7 +85,6 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                   onPressed: () {
                     showModal<void>(
                       context: context,
-                      configuration: const FadeScaleTransitionConfiguration(),
                       builder: (BuildContext context) {
                         return _ExampleAlertDialog();
                       },

--- a/packages/animations/lib/src/modal.dart
+++ b/packages/animations/lib/src/modal.dart
@@ -29,6 +29,7 @@ typedef _ModalTransitionBuilder = Widget Function(
 /// modal route that will be displayed, such as the enter and exit
 /// transitions, the duration of the transitions, and modal barrier
 /// properties.
+/// By default, `configuration` is [FadeScaleTransitionConfiguration].
 ///
 /// The `useRootNavigator` argument is used to determine whether to push the
 /// modal to the [Navigator] furthest from or nearest to the given `context`.

--- a/packages/animations/lib/src/modal.dart
+++ b/packages/animations/lib/src/modal.dart
@@ -4,6 +4,8 @@
 
 import 'package:flutter/material.dart';
 
+import 'fade_scale_transition.dart';
+
 /// Signature for a function that creates a widget that builds a
 /// transition.
 ///
@@ -45,7 +47,7 @@ typedef _ModalTransitionBuilder = Widget Function(
 /// the modal's characteristics.
 Future<T> showModal<T>({
   @required BuildContext context,
-  @required ModalConfiguration configuration,
+  ModalConfiguration configuration = const FadeScaleTransitionConfiguration(),
   bool useRootNavigator = true,
   WidgetBuilder builder,
 }) {

--- a/packages/animations/lib/src/modal.dart
+++ b/packages/animations/lib/src/modal.dart
@@ -28,8 +28,8 @@ typedef _ModalTransitionBuilder = Widget Function(
 /// The `configuration` argument is used to determine characteristics of the
 /// modal route that will be displayed, such as the enter and exit
 /// transitions, the duration of the transitions, and modal barrier
-/// properties.
-/// By default, `configuration` is [FadeScaleTransitionConfiguration].
+/// properties. By default, `configuration` is
+/// [FadeScaleTransitionConfiguration].
 ///
 /// The `useRootNavigator` argument is used to determine whether to push the
 /// modal to the [Navigator] furthest from or nearest to the given `context`.


### PR DESCRIPTION
`showModal` works well with `configuration: const FadeScaleTransitionConfiguration()` for typical use cases.

#124 made it possible to set `FadeScaleTransitionConfiguration` to `configuration` default value.
With this change, `showModal` can be just as easy to handle as [showDialog](https://api.flutter.dev/flutter/material/showDialog.html).