### PR TITLE
[fuchsia_ctl] initial emulator support

### DIFF
--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -1,12 +1,12 @@
 # CHANGELOG
 
-## 0.0.22
+## 0.0.23
 
 - Added `emu` tool for spawning an emulator instance given a Fuchsia QEMU build,
   the Fuchsia SDK, and an Android emulator executable.
 - Fixed homepage link.
 
-## 0.0.18 - 0.0.21
+## 0.0.18 - 0.0.22
 
 - Add retries to paving operations.
 - Add timeouts to paving and ssh operations.

--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -1,14 +1,16 @@
 # CHANGELOG
 
+## 0.0.22
 
+- Added `emu` tool for spawning an emulator instance given a Fuchsia QEMU build,
+  the Fuchsia SDK, and an Android emulator executable.
+- Fixed homepage link.
 
 ## 0.0.18 - 0.0.21
 
 - Add retries to paving operations.
 - Add timeouts to paving and ssh operations.
 - Add arguments parameter to test command.
-
-
 
 ## 0.0.17
 

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -43,10 +43,12 @@ Future<void> main(List<String> args) async {
     ..addFlag('help', defaultsTo: false, help: 'Prints help.');
 
   parser.addCommand('emu')
-    ..addOption('workdir',
-        abbr: 'w', help: 'Working directory containing the image files')
+    ..addOption('image', help: 'Fuchsia image to run')
+    ..addOption('zbi', help: 'Bootloader image to sign and run')
+    ..addOption('qemu-kernel', help: 'QEMU kernel to run')
+    ..addOption('window-size', help: 'Emulator window size formatted "WxH"')
     ..addOption('aemu', help: 'AEMU executable path')
-    ..addOption('sdk-path',
+    ..addOption('sdk',
         help: 'Location to Fuchsia SDK containing tools and images')
     ..addOption('ssh-path', defaultsTo: '.fuchsia', help: 'Path to ssh keys')
     ..addFlag('headless', help: 'Run FEMU without graphical window');
@@ -146,14 +148,18 @@ Future<OperationResult> emulator(
 ) async {
   final Emulator emulator = Emulator(
     aemuPath: args['aemu'],
-    fuchsiaSdkPath: args['sdk-path'],
-    headless: args['headless'],
+    fuchsiaImagePath: args['image'],
+    fuchsiaSdkPath: args['sdk'],
+    qemuKernelPath: args['qemu-kernel'],
     sshPath: args['ssh-path'],
-    workDirectory: args['workdir'],
+    zbiPath: args['zbi'],
   );
-  emulator.start();
-
-  return OperationResult.success();
+  await emulator.prepareEnvironment();
+  
+  return emulator.start(
+    headless: args['headless'],
+    windowSize: args['window-size'],
+  );
 }
 
 @visibleForTesting

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -155,7 +155,7 @@ Future<OperationResult> emulator(
     zbiPath: args['zbi'],
   );
   await emulator.prepareEnvironment();
-  
+
   return emulator.start(
     headless: args['headless'],
     windowSize: args['window-size'],

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -42,6 +42,7 @@ Future<void> main(List<String> args) async {
         help: 'The path to the dev_finder executable.')
     ..addFlag('help', defaultsTo: false, help: 'Prints help.');
 
+  /// This is a blocking command and will run until exited.
   parser.addCommand('emu')
     ..addOption('image', help: 'Fuchsia image to run')
     ..addOption('zbi', help: 'Bootloader image to sign and run')
@@ -51,7 +52,6 @@ Future<void> main(List<String> args) async {
     ..addOption('sdk',
         help: 'Location to Fuchsia SDK containing tools and images')
     ..addOption('public-key',
-        abbr: 'p',
         defaultsTo: '.fuchsia/authorized_keys',
         help: 'Path to the authorized_keys to sign zbi image with')
     ..addFlag('headless', help: 'Run FEMU without graphical window');
@@ -154,7 +154,9 @@ Future<OperationResult> emulator(
     fuchsiaImagePath: args['image'],
     fuchsiaSdkPath: args['sdk'],
     qemuKernelPath: args['qemu-kernel'],
-    authorizedKeysPath: args['public-key'],
+    sshKeyManager: SystemSshKeyManager.defaultProvider(
+      publicKeyPath: args['public-key'],
+    ),
     zbiPath: args['zbi'],
   );
   await emulator.prepareEnvironment();

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -50,7 +50,10 @@ Future<void> main(List<String> args) async {
     ..addOption('aemu', help: 'AEMU executable path')
     ..addOption('sdk',
         help: 'Location to Fuchsia SDK containing tools and images')
-    ..addOption('ssh-path', defaultsTo: '.fuchsia', help: 'Path to ssh keys')
+    ..addOption('public-key',
+        abbr: 'p',
+        defaultsTo: '.fuchsia/authorized_keys',
+        help: 'Path to the authorized_keys to sign zbi image with')
     ..addFlag('headless', help: 'Run FEMU without graphical window');
 
   parser.addCommand('ssh')
@@ -151,7 +154,7 @@ Future<OperationResult> emulator(
     fuchsiaImagePath: args['image'],
     fuchsiaSdkPath: args['sdk'],
     qemuKernelPath: args['qemu-kernel'],
-    sshPath: args['ssh-path'],
+    authorizedKeysPath: args['public-key'],
     zbiPath: args['zbi'],
   );
   await emulator.prepareEnvironment();

--- a/packages/fuchsia_ctl/lib/fuchsia_ctl.dart
+++ b/packages/fuchsia_ctl/lib/fuchsia_ctl.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'src/amber_ctl.dart';
 export 'src/dev_finder.dart';
+export 'src/emulator.dart';
 export 'src/image_paver.dart';
 export 'src/operation_result.dart';
 export 'src/package_server.dart';
 export 'src/ssh_client.dart';
+export 'src/tar.dart';

--- a/packages/fuchsia_ctl/lib/fuchsia_ctl.dart
+++ b/packages/fuchsia_ctl/lib/fuchsia_ctl.dart
@@ -9,4 +9,5 @@ export 'src/image_paver.dart';
 export 'src/operation_result.dart';
 export 'src/package_server.dart';
 export 'src/ssh_client.dart';
+export 'src/ssh_key_manager.dart';
 export 'src/tar.dart';

--- a/packages/fuchsia_ctl/lib/src/amber_ctl.dart
+++ b/packages/fuchsia_ctl/lib/src/amber_ctl.dart
@@ -5,11 +5,9 @@
 import 'dart:io';
 
 import 'package:meta/meta.dart';
-import 'package:fuchsia_ctl/fuchsia_ctl.dart';
-import 'package:fuchsia_ctl/src/ssh_client.dart';
 import 'package:uuid/uuid.dart';
 
-import 'operation_result.dart';
+import 'package:fuchsia_ctl/fuchsia_ctl.dart';
 
 const SshClient _kSsh = SshClient();
 

--- a/packages/fuchsia_ctl/lib/src/command_line.dart
+++ b/packages/fuchsia_ctl/lib/src/command_line.dart
@@ -1,0 +1,81 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:process/process.dart';
+
+/// Class for common actions with processes on the command line.
+@immutable
+class CommandLine {
+  /// Create a new instance of [CommandLine].
+  const CommandLine(
+      {this.processManager = const LocalProcessManager(),
+      @visibleForTesting this.stdoutValue,
+      @visibleForTesting this.stderrValue});
+
+  /// The underlying [ProcessManager] to use for running on the current shell.
+  final ProcessManager processManager;
+
+  /// Mock value for use in tests.
+  final Stdout stdoutValue;
+
+  /// Mock value for use in tests.
+  final Stdout stderrValue;
+
+  /// Current shells stdout to use.
+  Stdout get shellStdout => stdoutValue ?? stdout;
+
+  /// Current shells stderr to use.
+  Stdout get shellStderr => stderrValue ?? stderr;
+
+  /// Run [command] and handle its stdio. Once [command] is complete, it will
+  /// output its stdio to the console.
+  ///
+  /// Use this for tasks where stdio does not need to be monitored.
+  ///
+  /// Throw [CommandLineException] if [command] returns a non-0 exit code.
+  Future<void> run(List<String> command) async {
+    shellStdout.writeln(command.join(' '));
+    final ProcessResult process = await processManager.run(command);
+    shellStdout.writeln(process.stdout);
+    shellStderr.writeln(process.stderr);
+
+    if (process.exitCode != 0) {
+      throw CommandLineException('${command.first} did not return exit code 0');
+    }
+  }
+
+  /// Start [command] and handle its stdio by streaming it to the existing
+  /// stdio. While [command] is running, its stdio is streamed to the shell.
+  ///
+  /// Use this for long running tasks where stdio should be monitored.
+  ///
+  /// Throw [CommandLineException] if [command] returns a non-0 exit code.
+  Future<Process> start(List<String> command) async {
+    shellStdout.writeln(command.join(' '));
+    final Process process = await processManager.start(command);
+    shellStdout.addStream(process.stdout);
+    shellStderr.addStream(process.stderr);
+
+    if (await process.exitCode != 0) {
+      throw CommandLineException('${command.first} did not return exit code 0');
+    }
+
+    return process;
+  }
+}
+
+/// Wraps exceptions thrown by [CommandLine].
+class CommandLineException implements Exception {
+  /// Creates a new [CommandLineException].
+  const CommandLineException(this.message);
+
+  /// The user-facing message to display.
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/packages/fuchsia_ctl/lib/src/dev_finder.dart
+++ b/packages/fuchsia_ctl/lib/src/dev_finder.dart
@@ -43,10 +43,15 @@ class DevFinder {
     }
     final List<String> command = <String>[
       devFinderPath,
-      if (deviceName != null) 'resolve' else 'list',
+      if (deviceName != null)
+        'resolve'
+      else
+        'list',
       '-device-limit', '1', //
-      if (local) '-local',
-      if (deviceName != null) deviceName,
+      if (local)
+        '-local',
+      if (deviceName != null)
+        deviceName,
     ];
 
     for (int i = 0; i < numTries; i++) {

--- a/packages/fuchsia_ctl/lib/src/dev_finder.dart
+++ b/packages/fuchsia_ctl/lib/src/dev_finder.dart
@@ -43,15 +43,10 @@ class DevFinder {
     }
     final List<String> command = <String>[
       devFinderPath,
-      if (deviceName != null)
-        'resolve'
-      else
-        'list',
+      if (deviceName != null) 'resolve' else 'list',
       '-device-limit', '1', //
-      if (local)
-        '-local',
-      if (deviceName != null)
-        deviceName,
+      if (local) '-local',
+      if (deviceName != null) deviceName,
     ];
 
     for (int i = 0; i < numTries; i++) {

--- a/packages/fuchsia_ctl/lib/src/emulator.dart
+++ b/packages/fuchsia_ctl/lib/src/emulator.dart
@@ -1,0 +1,202 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
+import 'package:process/process.dart';
+
+/// A wrapper for running Fuchsia images on AEMU.
+@immutable
+class Emulator {
+  /// Creates a new wrapper for the `emu` tool.
+  const Emulator({
+    @required this.aemuPath,
+    @required this.fuchsiaSdkPath,
+    this.headless = false,
+    this.processManager = const LocalProcessManager(),
+    this.sshPath = '.fuchsia',
+    @required this.workDirectory,
+  }) : assert(processManager != null);
+
+  /// The location of the extracted images. This directly will be used for
+  /// creating FEMU compatible assets.
+  final String workDirectory;
+
+  /// The path to the AEMU executable on disk.
+  final String aemuPath;
+
+  /// The path to the Fuchsia SDK that contains the tools.
+  final String fuchsiaSdkPath;
+
+  /// The path to the directory containing authorized_keys.
+  final String sshPath;
+
+  /// Whether to run AEMU with a graphical window or not.
+  /// 
+  /// Infrastructure will run FEMU in headless mode whereas local debugging
+  /// may use the graphical window.
+  final bool headless;
+
+  /// The QEMU kernel image to use. This is only including in Fuchsia QEMU images.
+  static const String _kernelImage = 'qemu-kernel.kernel';
+
+  /// Bootloader image in [workDirectory].
+  static const String _bootloaderImage = 'zircon-a.zbi';
+
+  /// [_bootloaderImage] that is accessible with SSH using [sshPath] keys.
+  static const String _signedBootloaderImage = 'fuchsia-ssh.zbi';
+
+  /// Fuchsia image in [workDirectory].
+  static const String _fuchsiaImage = 'storage-full.blk';
+
+  /// FVM extended version of [_fuchsiaImage] to have additional space for FEMU.
+  static const String _fvmImage = 'fvm.blk';
+
+  /// Location of `fvm` in [fuchsiaSdkPath].
+  static const String _fvmToolPath = 'sdk/tools/fvm';
+
+  /// Location of `zbi` in [fuchsiaSdkPath].
+  static const String _zbiToolPath = 'sdk/tools/zbi';
+
+  /// The [ProcessManager] to use for launching the `emu` tool.
+  final ProcessManager processManager;
+
+  /// 1. Verify [workdir] has necessary files to run a Fuchsia image on AEMU.
+  ///   a. image file
+  ///   b. zircon boot file
+  /// 2. Verify [qemuKernelPath] exists.
+  /// 3. Prepare
+  /// 4. Sign [zirconA] with given ssh keys to ensure access to the the guest
+  /// Fuchsia instance on the emulator.
+  Future<void> prepareEnvironment() async {
+    final String fuchsiaImagePath = path.join(workDirectory, _fuchsiaImage);
+    final String fvmImagePath = path.join(workDirectory, _fvmImage);
+    prepareFvmImage(fuchsiaImagePath, fvmImagePath);
+
+    final String zirconBootImagePath =
+        path.join(workDirectory, _bootloaderImage);
+    final String signedZirconBootImagePath =
+        path.join(workDirectory, _signedBootloaderImage);
+    prepareZirconBootImage(zirconBootImagePath, signedZirconBootImagePath);
+  }
+
+  @visibleForTesting
+  void prepareFvmImage(String fuchsiaImagePath, String fvmPath,
+      {String fvmExecutable}) {
+    fvmExecutable ??= path.join(fuchsiaSdkPath, _fvmToolPath);
+
+    /// Need to make the SDK storage-full.blk writable so that the copy is writable as well, otherwise [fvmTool] extend fails.
+    final ProcessResult chmodResult =
+        processManager.runSync(<String>['chmod', 'u+w', fuchsiaImagePath]);
+    if (chmodResult.exitCode != 0) {
+      throw EmulatorException(chmodResult.stderr);
+    }
+
+    final ProcessResult cpResult =
+        processManager.runSync(<String>['cp', fuchsiaImagePath, fvmPath]);
+    if (cpResult.exitCode != 0) {
+      throw EmulatorException(cpResult.stderr);
+    }
+
+    // Calculate new size by doubling the current size
+    final File fvmFile = File(fvmPath);
+    final int newSize = fvmFile.lengthSync() * 2;
+
+    // 2. Use [fvmExecutable] extend to copy image to make compatible with AEMU.
+    // Return path to this new fvm image?
+    final ProcessResult fvmResult = processManager.runSync(
+        <String>[fvmExecutable, fvmPath, 'extend', '--length', '$newSize']);
+    if (fvmResult.exitCode != 0) {
+      throw EmulatorException(
+          fvmResult.stderr); // ERROR HERE: Found invalid FVM container
+    }
+  }
+
+  @visibleForTesting
+  void prepareZirconBootImage(
+      String zirconBootImagePath, String signedZirconBootImagePath,
+      {String zbiExecutable, String authorizedKeysPath}) {
+    zbiExecutable ??= path.join(fuchsiaSdkPath, _zbiToolPath);
+    authorizedKeysPath ??= path.join(sshPath, 'authorized_keys');
+
+    /// The authorized keys file is not being found, but this runs locally :)
+    final ProcessResult zbiResult = processManager.runSync(<String>[
+      zbiExecutable,
+      '--compressed=zstd',
+      '-o',
+      signedZirconBootImagePath,
+      zirconBootImagePath,
+      '--entry',
+      '"data/ssh/authorized_keys=$authorizedKeysPath"'
+    ]);
+    if (zbiResult.exitCode != 0) {
+      throw EmulatorException(zbiResult.stderr);
+    }
+  }
+
+  /// Pass the given state to AEMU.
+  Future<void> start() async {
+    // prepareEnvironment();
+    final String fvmImagePath = path.join(workDirectory, _fvmImage);
+
+    /// Anything after -fuchsia flag will be passed to QEMU
+    final List<String> _aemuArgs = <String>[
+      '-feature', 'VirtioInput,RefCountPipe,KVM,GLDirectMem,Vulkan',
+      '-window-size', '1280x800', // TODO(chillers): Configurable
+      '-gpu', 'swiftshader_indirect',
+      headless ? '-no-window' : '',
+      '-fuchsia',
+    ];
+
+    final String qemuKernelPath = path.join(workDirectory, _kernelImage);
+    _aemuArgs.addAll(<String>['-kernel', qemuKernelPath]);
+
+    final String signedZirconBootImagePath =
+        path.join(workDirectory, _signedBootloaderImage);
+    _aemuArgs.addAll(<String>['-initrd', signedZirconBootImagePath]);
+
+    _aemuArgs.addAll(<String>[
+      '-m', '2048',
+      '-serial', 'stdio',
+      '-vga', 'none',
+      '-device', 'virtio-keyboard-pci',
+      '-device', 'virtio_input_multi_touch_pci_1',
+      '-smp', '4,threads=2',
+      '-machine', 'q35',
+      '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04',
+      '-enable-kvm', // configurable
+      '-cpu', 'host,migratable=no,+invtsc',
+      '-netdev', 'type=tap,ifname=qemu,script=no,downscript=no,id=net0',
+      '-device', 'e1000,netdev=net0,mac=52:54:00:63:5e:7a',
+      '-drive', 'file=$fvmImagePath,format=raw,if=none,id=vdisk',
+      '-device', 'virtio-blk-pci,drive=vdisk',
+      '-append',
+      '\'TERM=xterm-256color kernel.serial=legacy kernel.entropy-mixin=660486b6b20b4ace3fb5c81b0002abf5271289185c6a5620707606c55b377562 kernel.halt-on-panic=true\'' // configure entropy
+    ]);
+
+    // Insert the AEMU executable
+    _aemuArgs.insert(0, aemuPath);
+
+    stdout.writeln(_aemuArgs.join(' '));
+    final Process emuProcess = await processManager.start(_aemuArgs);
+    stdout.addStream(emuProcess.stdout);
+    stderr.addStream(emuProcess.stderr);
+
+    await emuProcess.exitCode;
+  }
+}
+
+/// Wraps exceptions thrown by [Emulator].
+class EmulatorException implements Exception {
+  /// Creates a new [EmulatorException].
+  const EmulatorException(this.message);
+
+  /// The user-facing message to display.
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/packages/fuchsia_ctl/lib/src/emulator.dart
+++ b/packages/fuchsia_ctl/lib/src/emulator.dart
@@ -22,11 +22,11 @@ class Emulator {
     this.fs = const LocalFileSystem(),
     this.cli = const CommandLine(),
     @required this.qemuKernelPath,
-    this.sshPath = '.fuchsia',
+    this.authorizedKeysPath = '.fuchsia/authorized_keys',
     @required this.zbiPath,
   })  : assert(cli != null),
         assert(fs != null),
-        assert(sshPath != null);
+        assert(authorizedKeysPath != null);
 
   /// The path to the AEMU executable on disk.
   final String aemuPath;
@@ -40,8 +40,8 @@ class Emulator {
   /// The QEMU kernel image to use. This is only bundled in Fuchsia QEMU images.
   final String qemuKernelPath;
 
-  /// The path to the directory containing authorized_keys.
-  final String sshPath;
+  /// The path to the authorized_keys to sign [zbiPath] with.
+  final String authorizedKeysPath;
 
   /// The Fuchsia bootloader image.
   final String zbiPath;
@@ -116,9 +116,8 @@ class Emulator {
   /// Signed [zbiPath] using [zbiExecutable] with [authorizedKeysPath] to
   /// create a bootloader image that is accessible from the host.
   Future<void> _signBootImage(String zbiPath, String signedZbiPath,
-      {String zbiExecutable, String authorizedKeysPath}) async {
+      {String zbiExecutable}) async {
     zbiExecutable ??= path.join(fuchsiaSdkPath, zbiToolPath);
-    authorizedKeysPath ??= path.join(sshPath, 'authorized_keys');
 
     /// Ensure `zbi` is able to find the ssh keys by giving the full path.
     final File authorizedKeysAbsolute = fs.file(authorizedKeysPath).absolute;

--- a/packages/fuchsia_ctl/lib/src/emulator.dart
+++ b/packages/fuchsia_ctl/lib/src/emulator.dart
@@ -139,7 +139,7 @@ class Emulator {
   ///
   /// If [headless] is true, AEMU will run without a graphical window. Infra
   /// will run AEMU in headless mode.
-  /// 
+  ///
   /// [windowSize] is what AEMU will set its window size to. Defaults to
   /// [defaultWindowSize]. Expected to be in the format of "WIDTHxHEIGHT".
   Future<OperationResult> start(
@@ -155,8 +155,7 @@ class Emulator {
       windowSize ?? defaultWindowSize,
       '-gpu',
       'swiftshader_indirect',
-      if (headless)
-        aemuHeadlessFlag,
+      if (headless) aemuHeadlessFlag,
     ];
 
     /// Anything after -fuchsia flag will be passed to QEMU
@@ -180,7 +179,7 @@ class Emulator {
       '-drive', 'file=$fvmImagePath,format=raw,if=none,id=vdisk',
       '-device', 'virtio-blk-pci,drive=vdisk',
       '-append',
-       // TODO(chillers): Generate entropy mixin.
+      // TODO(chillers): Generate entropy mixin.
       '\'TERM=xterm-256color kernel.serial=legacy kernel.entropy-mixin=660486b6b20b4ace3fb5c81b0002abf5271289185c6a5620707606c55b377562 kernel.halt-on-panic=true\'',
     ]);
 

--- a/packages/fuchsia_ctl/lib/src/emulator.dart
+++ b/packages/fuchsia_ctl/lib/src/emulator.dart
@@ -27,7 +27,7 @@ class Emulator {
     @required this.zbiPath,
   })  : assert(cli != null),
         assert(fs != null);
-  
+
   /// The path to the AEMU executable on disk.
   final String aemuPath;
 
@@ -122,7 +122,8 @@ class Emulator {
     await sshKeyManager.createKeys();
 
     /// Ensure `zbi` is able to find the ssh keys by giving the full path.
-    final File authorizedKeysAbsolute = fs.file('.ssh/authorized_keys').absolute;
+    final File authorizedKeysAbsolute =
+        fs.file('.ssh/authorized_keys').absolute;
 
     final List<String> zbiCommand = <String>[
       zbiExecutable,

--- a/packages/fuchsia_ctl/lib/src/emulator.dart
+++ b/packages/fuchsia_ctl/lib/src/emulator.dart
@@ -159,8 +159,7 @@ class Emulator {
       windowSize ?? defaultWindowSize,
       '-gpu',
       'swiftshader_indirect',
-      if (headless)
-        aemuHeadlessFlag,
+      if (headless) aemuHeadlessFlag,
 
       /// Anything after -fuchsia flag will be passed to QEMU
       '-fuchsia',

--- a/packages/fuchsia_ctl/lib/src/package_server.dart
+++ b/packages/fuchsia_ctl/lib/src/package_server.dart
@@ -8,10 +8,11 @@ import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-import 'package:fuchsia_ctl/fuchsia_ctl.dart';
 import 'package:process/process.dart';
 import 'package:path/path.dart' as path;
 import 'package:uuid/uuid.dart';
+
+import 'package:fuchsia_ctl/fuchsia_ctl.dart';
 
 /// A wrapper around the Fuchsia SDK `pm` tool.
 class PackageServer {

--- a/packages/fuchsia_ctl/lib/src/ssh_key_manager.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_key_manager.dart
@@ -51,7 +51,7 @@ class SystemSshKeyManager implements SshKeyManager {
   }) {
     return SystemSshKeyManager(
       processManager: processManager ?? const LocalProcessManager(),
-      fs: fs,
+      fs: fs ?? const LocalFileSystem(),
       pkeyPubPath: publicKeyPath,
     );
   }

--- a/packages/fuchsia_ctl/pubspec.lock
+++ b/packages/fuchsia_ctl/pubspec.lock
@@ -253,6 +253,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
+  retry:
+    dependency: "direct main"
+    description:
+      name: retry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0+1"
   shelf:
     dependency: transitive
     description:

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -3,8 +3,8 @@ description: >
   A Dart package for paving, serving packages to, and running commands on a
   Fuchsia Device. This package is primarily intended for use in Flutter's
   continuous integration/testing infrastructure.
-homepage: https://github.com/flutter/packags/tree/master/packages/fuchsia_ctl
-version: 0.0.21
+homepage: https://github.com/flutter/packages/tree/master/packages/fuchsia_ctl
+version: 0.0.22
 
 environment:
   sdk: ">=2.4.0 <3.0.0"

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   Fuchsia Device. This package is primarily intended for use in Flutter's
   continuous integration/testing infrastructure.
 homepage: https://github.com/flutter/packages/tree/master/packages/fuchsia_ctl
-version: 0.0.22
+version: 0.0.23
 
 environment:
   sdk: ">=2.4.0 <3.0.0"

--- a/packages/fuchsia_ctl/test/command_line_test.dart
+++ b/packages/fuchsia_ctl/test/command_line_test.dart
@@ -61,7 +61,7 @@ void main() {
       await cli.start(<String>['test']);
 
       verify(mockStdout.addStream(any)).called(1);
-      verify(mockStdout.addStream(any)).called(1);
+      verify(mockStderr.addStream(any)).called(1);
     });
 
     test('start throws on non-0 exit code', () async {

--- a/packages/fuchsia_ctl/test/command_line_test.dart
+++ b/packages/fuchsia_ctl/test/command_line_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
+import 'package:test/test.dart';
+
+import 'package:fuchsia_ctl/src/command_line.dart';
+
+import 'fakes.dart';
+
+void main() {
+  CommandLine cli;
+  MockProcessManager mockProcessManager;
+  MockStdout mockStdout;
+  MockStdout mockStderr;
+
+  group('CommandLine', () {
+    setUp(() {
+      mockStdout = MockStdout();
+      mockStderr = MockStdout();
+      mockProcessManager = MockProcessManager();
+      cli = CommandLine(
+          processManager: mockProcessManager,
+          stderrValue: mockStderr,
+          stdoutValue: mockStdout);
+    });
+
+    test('run writes to stdout', () async {
+      when(mockProcessManager.run(any))
+          .thenAnswer((_) async => ProcessResult(123, 0, 'stdout123', ''));
+
+      await cli.run(<String>['test']);
+
+      verify(mockStdout.writeln('stdout123')).called(1);
+    });
+
+    test('run writes to stderr', () async {
+      when(mockProcessManager.run(any))
+          .thenAnswer((_) async => ProcessResult(123, 0, '', 'stderrABC'));
+
+      await cli.run(<String>['test']);
+
+      verify(mockStderr.writeln('stderrABC')).called(1);
+    });
+
+    test('run throws on non-0 exit code', () async {
+      when(mockProcessManager.run(any))
+          .thenAnswer((_) async => ProcessResult(123, 1, '', 'stderrABC'));
+
+      expect(cli.run(<String>['test']), throwsA(isA<CommandLineException>()));
+    });
+
+    test('start adds streams', () async {
+      when(mockProcessManager.start(any))
+          .thenAnswer((_) async => FakeProcess(0, <String>[''], <String>['']));
+
+      await cli.start(<String>['test']);
+
+      verify(mockStdout.addStream(any)).called(1);
+      verify(mockStdout.addStream(any)).called(1);
+    });
+
+    test('start throws on non-0 exit code', () async {
+      when(mockProcessManager.start(any))
+          .thenAnswer((_) async => FakeProcess(1, <String>[''], <String>['']));
+
+      expect(cli.start(<String>['test']), throwsA(isA<CommandLineException>()));
+    });
+  });
+}
+
+class MockProcessManager extends Mock implements ProcessManager {}
+
+class MockStdout extends Mock implements Stdout {}

--- a/packages/fuchsia_ctl/test/emulator_test.dart
+++ b/packages/fuchsia_ctl/test/emulator_test.dart
@@ -79,8 +79,7 @@ void main() {
           .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
 
       await emulator.start();
-      verify(mockCli
-              .start(argThat(contains(emulator.defaultWindowSize))))
+      verify(mockCli.start(argThat(contains(emulator.defaultWindowSize))))
           .called(1);
     });
 
@@ -95,8 +94,7 @@ void main() {
 
       const String customWindowSize = '50x200';
       await emulator.start(windowSize: customWindowSize);
-      verify(mockCli.start(argThat(contains(customWindowSize))))
-          .called(1);
+      verify(mockCli.start(argThat(contains(customWindowSize)))).called(1);
     });
 
     test('start configures headless', () async {
@@ -109,8 +107,7 @@ void main() {
           .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
 
       await emulator.start(headless: true);
-      verify(mockCli
-              .start(argThat(contains(emulator.aemuHeadlessFlag))))
+      verify(mockCli.start(argThat(contains(emulator.aemuHeadlessFlag))))
           .called(1);
     });
   });

--- a/packages/fuchsia_ctl/test/emulator_test.dart
+++ b/packages/fuchsia_ctl/test/emulator_test.dart
@@ -1,0 +1,142 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:file/memory.dart';
+import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
+import 'package:test/test.dart';
+
+import 'package:fuchsia_ctl/fuchsia_ctl.dart';
+
+import 'fakes.dart';
+
+void main() {
+  const String aemuPath = '/emulator';
+  const String fuchsiaImagePath = '/fuchsia.blk';
+  const String fuchsiaSdkPath = '/fuchsia-sdk';
+  const String qemuKernelPath = '/qemu-kernel.kernel';
+  const String zbiPath = '/zircon-a.zbi';
+
+  Emulator emulator;
+  MockProcessManager mockProcessManager;
+  MemoryFileSystem fs;
+
+  setUp(() {
+    mockProcessManager = MockProcessManager();
+    fs = MemoryFileSystem(style: FileSystemStyle.posix);
+    fs.file(aemuPath).createSync();
+    fs.file(fuchsiaImagePath)
+      ..createSync()
+      ..writeAsString('fuchsia image content');
+    fs.file(fuchsiaSdkPath).createSync();
+    fs.file(qemuKernelPath).createSync();
+    fs.file(zbiPath).createSync();
+    emulator = Emulator(
+      aemuPath: aemuPath,
+      fs: fs,
+      fuchsiaImagePath: fuchsiaImagePath,
+      fuchsiaSdkPath: fuchsiaSdkPath,
+      processManager: mockProcessManager,
+      qemuKernelPath: qemuKernelPath,
+      zbiPath: zbiPath,
+    );
+  });
+
+  test('prepare environment runs as expected', () async {
+    when(mockProcessManager.run(any))
+        .thenAnswer((_) async => ProcessResult(123, 0, '', ''));
+    when(mockProcessManager
+            .run(argThat(contains('$fuchsiaSdkPath/${emulator.zbiToolPath}'))))
+        .thenAnswer((_) async {
+      fs.file(emulator.signedZbiPath).createSync();
+      return ProcessResult(123, 0, '', '');
+    });
+
+    await emulator.prepareEnvironment();
+
+    expect(fs.isFileSync(emulator.fvmImagePath), isTrue);
+    expect(fs.isFileSync(emulator.signedZbiPath), isTrue);
+  });
+
+  test('prepare environment throws on process run failure', () async {
+    when(mockProcessManager.run(any)).thenAnswer((_) async {
+      return ProcessResult(123, 1, '', 'error');
+    });
+
+    expect(emulator.prepareEnvironment(), throwsA(isA<EmulatorException>()));
+  });
+
+  test('prepare environment throws on file not existing', () async {
+    fs.file(fuchsiaImagePath).deleteSync();
+
+    expect(emulator.prepareEnvironment(), throwsA(isA<AssertionError>()));
+  });
+
+  test('start throws when prepare enviornment was not called', () async {
+    expect(emulator.start(), throwsA(isA<AssertionError>()));
+
+    verifyNever(mockProcessManager.start(any));
+  });
+
+  test('start uses default window size', () async {
+    emulator.fvmImagePath = '/fvm.blk';
+    emulator.signedZbiPath = '/fuchsia-ssh.zbi';
+    fs.file(emulator.fvmImagePath).createSync();
+    fs.file(emulator.signedZbiPath).createSync();
+
+    when(mockProcessManager.start(any))
+        .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
+
+    await emulator.start();
+    verify(mockProcessManager
+            .start(argThat(contains(emulator.defaultWindowSize))))
+        .called(1);
+  });
+
+  test('start configures window size', () async {
+    emulator.fvmImagePath = '/fvm.blk';
+    emulator.signedZbiPath = '/fuchsia-ssh.zbi';
+    fs.file(emulator.fvmImagePath).createSync();
+    fs.file(emulator.signedZbiPath).createSync();
+
+    when(mockProcessManager.start(any))
+        .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
+
+    const String customWindowSize = '50x200';
+    await emulator.start(windowSize: customWindowSize);
+    verify(mockProcessManager.start(argThat(contains(customWindowSize))))
+        .called(1);
+  });
+
+  test('start configures headless', () async {
+    emulator.fvmImagePath = '/fvm.blk';
+    emulator.signedZbiPath = '/fuchsia-ssh.zbi';
+    fs.file(emulator.fvmImagePath).createSync();
+    fs.file(emulator.signedZbiPath).createSync();
+
+    when(mockProcessManager.start(any))
+        .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
+
+    await emulator.start(headless: true);
+    verify(mockProcessManager
+            .start(argThat(contains(emulator.aemuHeadlessFlag))))
+        .called(1);
+  });
+
+  test('start throws when emulator returns non-0 exit code', () async {
+    emulator.fvmImagePath = '/fvm.blk';
+    emulator.signedZbiPath = '/fuchsia-ssh.zbi';
+    fs.file(emulator.fvmImagePath).createSync();
+    fs.file(emulator.signedZbiPath).createSync();
+
+    when(mockProcessManager.start(any))
+        .thenAnswer((_) async => FakeProcess(1, <String>[], <String>[]));
+
+    expect(emulator.start(), throwsA(isA<EmulatorException>()));
+  });
+}
+
+class MockProcessManager extends Mock implements ProcessManager {}

--- a/packages/fuchsia_ctl/test/emulator_test.dart
+++ b/packages/fuchsia_ctl/test/emulator_test.dart
@@ -2,14 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:file/memory.dart';
 import 'package:mockito/mockito.dart';
-import 'package:process/process.dart';
 import 'package:test/test.dart';
 
 import 'package:fuchsia_ctl/fuchsia_ctl.dart';
+import 'package:fuchsia_ctl/src/command_line.dart';
 
 import 'fakes.dart';
 
@@ -21,122 +19,102 @@ void main() {
   const String zbiPath = '/zircon-a.zbi';
 
   Emulator emulator;
-  MockProcessManager mockProcessManager;
+  MockCommandLine mockCli;
   MemoryFileSystem fs;
 
-  setUp(() {
-    mockProcessManager = MockProcessManager();
-    fs = MemoryFileSystem(style: FileSystemStyle.posix);
-    fs.file(aemuPath).createSync();
-    fs.file(fuchsiaImagePath)
-      ..createSync()
-      ..writeAsString('fuchsia image content');
-    fs.file(fuchsiaSdkPath).createSync();
-    fs.file(qemuKernelPath).createSync();
-    fs.file(zbiPath).createSync();
-    emulator = Emulator(
-      aemuPath: aemuPath,
-      fs: fs,
-      fuchsiaImagePath: fuchsiaImagePath,
-      fuchsiaSdkPath: fuchsiaSdkPath,
-      processManager: mockProcessManager,
-      qemuKernelPath: qemuKernelPath,
-      zbiPath: zbiPath,
-    );
-  });
+  group('Emulator', () {
+    setUp(() {
+      mockCli = MockCommandLine();
+      fs = MemoryFileSystem(style: FileSystemStyle.posix);
+      fs.file(aemuPath).createSync();
+      fs.file(fuchsiaImagePath)
+        ..createSync()
+        ..writeAsString('fuchsia image content');
+      fs.file(fuchsiaSdkPath).createSync();
+      fs.file(qemuKernelPath).createSync();
+      fs.file(zbiPath).createSync();
+      emulator = Emulator(
+        aemuPath: aemuPath,
+        fs: fs,
+        fuchsiaImagePath: fuchsiaImagePath,
+        fuchsiaSdkPath: fuchsiaSdkPath,
+        cli: mockCli,
+        qemuKernelPath: qemuKernelPath,
+        zbiPath: zbiPath,
+      );
+    });
 
-  test('prepare environment runs as expected', () async {
-    when(mockProcessManager.run(any))
-        .thenAnswer((_) async => ProcessResult(123, 0, '', ''));
-    when(mockProcessManager
-            .run(argThat(contains('$fuchsiaSdkPath/${emulator.zbiToolPath}'))))
-        .thenAnswer((_) async {
+    test('prepare environment runs as expected', () async {
+      when(mockCli.run(
+              argThat(contains('$fuchsiaSdkPath/${emulator.zbiToolPath}'))))
+          .thenAnswer((_) async {
+        fs.file(emulator.signedZbiPath).createSync();
+      });
+
+      await emulator.prepareEnvironment();
+
+      expect(fs.isFileSync(emulator.fvmImagePath), isTrue);
+      expect(fs.isFileSync(emulator.signedZbiPath), isTrue);
+    });
+
+    test('prepare environment throws on file not existing', () async {
+      fs.file(fuchsiaImagePath).deleteSync();
+
+      expect(emulator.prepareEnvironment(), throwsA(isA<AssertionError>()));
+    });
+
+    test('start throws when prepare enviornment was not called', () async {
+      expect(emulator.start(), throwsA(isA<AssertionError>()));
+
+      verifyNever(mockCli.start(any));
+    });
+
+    test('start uses default window size', () async {
+      emulator.fvmImagePath = '/fvm.blk';
+      emulator.signedZbiPath = '/fuchsia-ssh.zbi';
+      fs.file(emulator.fvmImagePath).createSync();
       fs.file(emulator.signedZbiPath).createSync();
-      return ProcessResult(123, 0, '', '');
+
+      when(mockCli.start(any))
+          .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
+
+      await emulator.start();
+      verify(mockCli
+              .start(argThat(contains(emulator.defaultWindowSize))))
+          .called(1);
     });
 
-    await emulator.prepareEnvironment();
+    test('start configures window size', () async {
+      emulator.fvmImagePath = '/fvm.blk';
+      emulator.signedZbiPath = '/fuchsia-ssh.zbi';
+      fs.file(emulator.fvmImagePath).createSync();
+      fs.file(emulator.signedZbiPath).createSync();
 
-    expect(fs.isFileSync(emulator.fvmImagePath), isTrue);
-    expect(fs.isFileSync(emulator.signedZbiPath), isTrue);
-  });
+      when(mockCli.start(any))
+          .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
 
-  test('prepare environment throws on process run failure', () async {
-    when(mockProcessManager.run(any)).thenAnswer((_) async {
-      return ProcessResult(123, 1, '', 'error');
+      const String customWindowSize = '50x200';
+      await emulator.start(windowSize: customWindowSize);
+      verify(mockCli.start(argThat(contains(customWindowSize))))
+          .called(1);
     });
 
-    expect(emulator.prepareEnvironment(), throwsA(isA<EmulatorException>()));
-  });
+    test('start configures headless', () async {
+      emulator.fvmImagePath = '/fvm.blk';
+      emulator.signedZbiPath = '/fuchsia-ssh.zbi';
+      fs.file(emulator.fvmImagePath).createSync();
+      fs.file(emulator.signedZbiPath).createSync();
 
-  test('prepare environment throws on file not existing', () async {
-    fs.file(fuchsiaImagePath).deleteSync();
+      when(mockCli.start(any))
+          .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
 
-    expect(emulator.prepareEnvironment(), throwsA(isA<AssertionError>()));
-  });
-
-  test('start throws when prepare enviornment was not called', () async {
-    expect(emulator.start(), throwsA(isA<AssertionError>()));
-
-    verifyNever(mockProcessManager.start(any));
-  });
-
-  test('start uses default window size', () async {
-    emulator.fvmImagePath = '/fvm.blk';
-    emulator.signedZbiPath = '/fuchsia-ssh.zbi';
-    fs.file(emulator.fvmImagePath).createSync();
-    fs.file(emulator.signedZbiPath).createSync();
-
-    when(mockProcessManager.start(any))
-        .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
-
-    await emulator.start();
-    verify(mockProcessManager
-            .start(argThat(contains(emulator.defaultWindowSize))))
-        .called(1);
-  });
-
-  test('start configures window size', () async {
-    emulator.fvmImagePath = '/fvm.blk';
-    emulator.signedZbiPath = '/fuchsia-ssh.zbi';
-    fs.file(emulator.fvmImagePath).createSync();
-    fs.file(emulator.signedZbiPath).createSync();
-
-    when(mockProcessManager.start(any))
-        .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
-
-    const String customWindowSize = '50x200';
-    await emulator.start(windowSize: customWindowSize);
-    verify(mockProcessManager.start(argThat(contains(customWindowSize))))
-        .called(1);
-  });
-
-  test('start configures headless', () async {
-    emulator.fvmImagePath = '/fvm.blk';
-    emulator.signedZbiPath = '/fuchsia-ssh.zbi';
-    fs.file(emulator.fvmImagePath).createSync();
-    fs.file(emulator.signedZbiPath).createSync();
-
-    when(mockProcessManager.start(any))
-        .thenAnswer((_) async => FakeProcess(0, <String>[], <String>[]));
-
-    await emulator.start(headless: true);
-    verify(mockProcessManager
-            .start(argThat(contains(emulator.aemuHeadlessFlag))))
-        .called(1);
-  });
-
-  test('start throws when emulator returns non-0 exit code', () async {
-    emulator.fvmImagePath = '/fvm.blk';
-    emulator.signedZbiPath = '/fuchsia-ssh.zbi';
-    fs.file(emulator.fvmImagePath).createSync();
-    fs.file(emulator.signedZbiPath).createSync();
-
-    when(mockProcessManager.start(any))
-        .thenAnswer((_) async => FakeProcess(1, <String>[], <String>[]));
-
-    expect(emulator.start(), throwsA(isA<EmulatorException>()));
+      await emulator.start(headless: true);
+      verify(mockCli
+              .start(argThat(contains(emulator.aemuHeadlessFlag))))
+          .called(1);
+    });
   });
 }
 
-class MockProcessManager extends Mock implements ProcessManager {}
+// ignore: must_be_immutable
+class MockCommandLine extends Mock implements CommandLine {}

--- a/packages/fuchsia_ctl/test/emulator_test.dart
+++ b/packages/fuchsia_ctl/test/emulator_test.dart
@@ -7,7 +7,6 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'package:fuchsia_ctl/fuchsia_ctl.dart';
-import 'package:fuchsia_ctl/src/command_line.dart';
 
 import 'fakes.dart';
 
@@ -40,6 +39,7 @@ void main() {
         fuchsiaSdkPath: fuchsiaSdkPath,
         cli: mockCli,
         qemuKernelPath: qemuKernelPath,
+        sshKeyManager: MockSshKeyManager(),
         zbiPath: zbiPath,
       );
     });
@@ -115,6 +115,3 @@ void main() {
     });
   });
 }
-
-// ignore: must_be_immutable
-class MockCommandLine extends Mock implements CommandLine {}

--- a/packages/fuchsia_ctl/test/fakes.dart
+++ b/packages/fuchsia_ctl/test/fakes.dart
@@ -2,6 +2,11 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:mockito/mockito.dart';
+
+import 'package:fuchsia_ctl/fuchsia_ctl.dart';
+import 'package:fuchsia_ctl/src/command_line.dart';
+
 class FakeProcess implements Process {
   FakeProcess(this._exitCode, this._stdout, this._stderr);
 
@@ -73,3 +78,8 @@ class FakeIOSink implements IOSink {
   @override
   void writeln([Object obj = '']) {}
 }
+
+// ignore: must_be_immutable
+class MockCommandLine extends Mock implements CommandLine {}
+
+class MockSshKeyManager extends Mock implements SshKeyManager {}


### PR DESCRIPTION
Initial wrapper script to provide `fx emu` functionality in infra. This is the minimum to get a Fuchsia image to run on FEMU.

Given a Fuchsia QEMU image build, it sets up the images to be compatible with FEMU. Then it wraps the Android emulator to run FEMU.

# Future work

- Return emulator ip
- Configurable hardware acceleration + other options needed for infra
- Extend test option to be able to run tests on an emulator instance