### PR TITLE
Bugfix/shared axis useless renders with keys

### DIFF
--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -343,6 +343,7 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
         switch (_effectiveAnimationStatus) {
           case AnimationStatus.forward:
             return _EnterTransition(
+              key: const Key('SharedAxisTransitionAnimation'),
               animation: widget.animation,
               transitionType: widget.transitionType,
               child: child,
@@ -351,6 +352,7 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
           case AnimationStatus.reverse:
           case AnimationStatus.completed:
             return _ExitTransition(
+              key: const Key('SharedAxisTransitionAnimation'),
               animation: _flip(widget.animation),
               transitionType: widget.transitionType,
               reverse: true,
@@ -367,6 +369,7 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
           switch (_effectiveSecondaryAnimationStatus) {
             case AnimationStatus.forward:
               return _ExitTransition(
+                key: const Key('SharedAxisTransitionAnimation'),
                 animation: widget.secondaryAnimation,
                 transitionType: widget.transitionType,
                 fillColor: widget.fillColor,
@@ -376,6 +379,7 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
             case AnimationStatus.reverse:
             case AnimationStatus.completed:
               return _EnterTransition(
+                key: const Key('SharedAxisTransitionAnimation'),
                 animation: _flip(widget.secondaryAnimation),
                 transitionType: widget.transitionType,
                 reverse: true,
@@ -392,11 +396,12 @@ class _SharedAxisTransitionState extends State<SharedAxisTransition> {
 
 class _EnterTransition extends StatelessWidget {
   const _EnterTransition({
+    Key key,
     this.animation,
     this.transitionType,
     this.reverse = false,
     this.child,
-  });
+  }) : super(key: key);
 
   final Animation<double> animation;
   final SharedAxisTransitionType transitionType;
@@ -465,12 +470,13 @@ class _EnterTransition extends StatelessWidget {
 
 class _ExitTransition extends StatelessWidget {
   const _ExitTransition({
+    Key key,
     this.animation,
     this.transitionType,
     this.reverse = false,
     this.fillColor,
     this.child,
-  });
+  }) : super(key: key);
 
   final Animation<double> animation;
   final SharedAxisTransitionType transitionType;
@@ -503,12 +509,9 @@ class _ExitTransition extends StatelessWidget {
 
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
-          child: Container(
-            color: fillColor ?? Theme.of(context).canvasColor,
-            child: Transform.translate(
-              offset: slideOutTransition.evaluate(animation),
-              child: child,
-            ),
+          child: Transform.translate(
+            offset: slideOutTransition.evaluate(animation),
+            child: child,
           ),
         );
         break;
@@ -520,25 +523,19 @@ class _ExitTransition extends StatelessWidget {
 
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
-          child: Container(
-            color: fillColor ?? Theme.of(context).canvasColor,
-            child: Transform.translate(
-              offset: slideOutTransition.evaluate(animation),
-              child: child,
-            ),
+          child: Transform.translate(
+            offset: slideOutTransition.evaluate(animation),
+            child: child,
           ),
         );
         break;
       case SharedAxisTransitionType.scaled:
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
-          child: Container(
-            color: fillColor ?? Theme.of(context).canvasColor,
-            child: ScaleTransition(
-              scale: (!reverse ? _scaleUpTransition : _scaleDownTransition)
-                  .animate(animation),
-              child: child,
-            ),
+          child: ScaleTransition(
+            scale: (!reverse ? _scaleUpTransition : _scaleDownTransition)
+                .animate(animation),
+            child: child,
           ),
         );
         break;

--- a/packages/animations/test/shared_axis_transition_test.dart
+++ b/packages/animations/test/shared_axis_transition_test.dart
@@ -204,14 +204,14 @@ void main() {
         );
 
         // builds twice due to the tree changes
-        expect(topState.rebuildCount, 2);
+        expect(topState.rebuildCount, 1);
 
         navigator.currentState.pop();
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 301));
 
         // adds up one more build on navigating back
-        expect(bottomState.rebuildCount, 2);
+        expect(bottomState.rebuildCount, 1);
         expect(find.text(topRoute), findsNothing);
         expect(find.text(bottomRoute), findsOneWidget);
       },
@@ -563,83 +563,83 @@ void main() {
       },
     );
 
-    testWidgets('default fill color', (WidgetTester tester) async {
-      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-      const String bottomRoute = '/';
-      const String topRoute = '/a';
+//    testWidgets('default fill color', (WidgetTester tester) async {
+//      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+//      const String bottomRoute = '/';
+//      const String topRoute = '/a';
+//
+//      // The default fill color should be derived from ThemeData.canvasColor.
+//      final Color defaultFillColor = ThemeData().canvasColor;
+//
+//      await tester.pumpWidget(
+//        _TestWidget(
+//          navigatorKey: navigator,
+//          transitionType: SharedAxisTransitionType.horizontal,
+//        ),
+//      );
+//
+//      expect(find.text(bottomRoute), findsOneWidget);
+//      Finder fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color,
+//          defaultFillColor);
+//
+//      navigator.currentState.pushNamed(topRoute);
+//      await tester.pump();
+//      await tester.pumpAndSettle();
+//
+//      fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/a')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color,
+//          defaultFillColor);
+//    });
 
-      // The default fill color should be derived from ThemeData.canvasColor.
-      final Color defaultFillColor = ThemeData().canvasColor;
-
-      await tester.pumpWidget(
-        _TestWidget(
-          navigatorKey: navigator,
-          transitionType: SharedAxisTransitionType.horizontal,
-        ),
-      );
-
-      expect(find.text(bottomRoute), findsOneWidget);
-      Finder fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color,
-          defaultFillColor);
-
-      navigator.currentState.pushNamed(topRoute);
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/a')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color,
-          defaultFillColor);
-    });
-
-    testWidgets('custom fill color', (WidgetTester tester) async {
-      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-      const String bottomRoute = '/';
-      const String topRoute = '/a';
-
-      await tester.pumpWidget(
-        _TestWidget(
-          navigatorKey: navigator,
-          fillColor: Colors.green,
-          transitionType: SharedAxisTransitionType.horizontal,
-        ),
-      );
-
-      expect(find.text(bottomRoute), findsOneWidget);
-      Finder fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-
-      navigator.currentState.pushNamed(topRoute);
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/a')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-    });
+//    testWidgets('custom fill color', (WidgetTester tester) async {
+//      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+//      const String bottomRoute = '/';
+//      const String topRoute = '/a';
+//
+//      await tester.pumpWidget(
+//        _TestWidget(
+//          navigatorKey: navigator,
+//          fillColor: Colors.green,
+//          transitionType: SharedAxisTransitionType.horizontal,
+//        ),
+//      );
+//
+//      expect(find.text(bottomRoute), findsOneWidget);
+//      Finder fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+//
+//      navigator.currentState.pushNamed(topRoute);
+//      await tester.pump();
+//      await tester.pumpAndSettle();
+//
+//      fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/a')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+//    });
   });
 
   group('SharedAxisTransitionType.vertical', () {
@@ -1140,83 +1140,83 @@ void main() {
       },
     );
 
-    testWidgets('default fill color', (WidgetTester tester) async {
-      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-      const String bottomRoute = '/';
-      const String topRoute = '/a';
+//    testWidgets('default fill color', (WidgetTester tester) async {
+//      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+//      const String bottomRoute = '/';
+//      const String topRoute = '/a';
+//
+//      // The default fill color should be derived from ThemeData.canvasColor.
+//      final Color defaultFillColor = ThemeData().canvasColor;
+//
+//      await tester.pumpWidget(
+//        _TestWidget(
+//          navigatorKey: navigator,
+//          transitionType: SharedAxisTransitionType.vertical,
+//        ),
+//      );
+//
+//      expect(find.text(bottomRoute), findsOneWidget);
+//      Finder fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color,
+//          defaultFillColor);
+//
+//      navigator.currentState.pushNamed(topRoute);
+//      await tester.pump();
+//      await tester.pumpAndSettle();
+//
+//      fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/a')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color,
+//          defaultFillColor);
+//    });
 
-      // The default fill color should be derived from ThemeData.canvasColor.
-      final Color defaultFillColor = ThemeData().canvasColor;
-
-      await tester.pumpWidget(
-        _TestWidget(
-          navigatorKey: navigator,
-          transitionType: SharedAxisTransitionType.vertical,
-        ),
-      );
-
-      expect(find.text(bottomRoute), findsOneWidget);
-      Finder fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color,
-          defaultFillColor);
-
-      navigator.currentState.pushNamed(topRoute);
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/a')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color,
-          defaultFillColor);
-    });
-
-    testWidgets('custom fill color', (WidgetTester tester) async {
-      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-      const String bottomRoute = '/';
-      const String topRoute = '/a';
-
-      await tester.pumpWidget(
-        _TestWidget(
-          navigatorKey: navigator,
-          fillColor: Colors.green,
-          transitionType: SharedAxisTransitionType.vertical,
-        ),
-      );
-
-      expect(find.text(bottomRoute), findsOneWidget);
-      Finder fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-
-      navigator.currentState.pushNamed(topRoute);
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/a')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-    });
+//    testWidgets('custom fill color', (WidgetTester tester) async {
+//      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+//      const String bottomRoute = '/';
+//      const String topRoute = '/a';
+//
+//      await tester.pumpWidget(
+//        _TestWidget(
+//          navigatorKey: navigator,
+//          fillColor: Colors.green,
+//          transitionType: SharedAxisTransitionType.vertical,
+//        ),
+//      );
+//
+//      expect(find.text(bottomRoute), findsOneWidget);
+//      Finder fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+//
+//      navigator.currentState.pushNamed(topRoute);
+//      await tester.pump();
+//      await tester.pumpAndSettle();
+//
+//      fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/a')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+//    });
   });
 
   group('SharedAxisTransitionType.scaled', () {
@@ -1610,83 +1610,83 @@ void main() {
       },
     );
 
-    testWidgets('default fill color', (WidgetTester tester) async {
-      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-      const String bottomRoute = '/';
-      const String topRoute = '/a';
+//    testWidgets('default fill color', (WidgetTester tester) async {
+//      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+//      const String bottomRoute = '/';
+//      const String topRoute = '/a';
+//
+//      // The default fill color should be derived from ThemeData.canvasColor.
+//      final Color defaultFillColor = ThemeData().canvasColor;
+//
+//      await tester.pumpWidget(
+//        _TestWidget(
+//          navigatorKey: navigator,
+//          transitionType: SharedAxisTransitionType.scaled,
+//        ),
+//      );
+//
+//      expect(find.text(bottomRoute), findsOneWidget);
+//      Finder fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color,
+//          defaultFillColor);
+//
+//      navigator.currentState.pushNamed(topRoute);
+//      await tester.pump();
+//      await tester.pumpAndSettle();
+//
+//      fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/a')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color,
+//          defaultFillColor);
+//    });
 
-      // The default fill color should be derived from ThemeData.canvasColor.
-      final Color defaultFillColor = ThemeData().canvasColor;
-
-      await tester.pumpWidget(
-        _TestWidget(
-          navigatorKey: navigator,
-          transitionType: SharedAxisTransitionType.scaled,
-        ),
-      );
-
-      expect(find.text(bottomRoute), findsOneWidget);
-      Finder fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color,
-          defaultFillColor);
-
-      navigator.currentState.pushNamed(topRoute);
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/a')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color,
-          defaultFillColor);
-    });
-
-    testWidgets('custom fill color', (WidgetTester tester) async {
-      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-      const String bottomRoute = '/';
-      const String topRoute = '/a';
-
-      await tester.pumpWidget(
-        _TestWidget(
-          navigatorKey: navigator,
-          fillColor: Colors.green,
-          transitionType: SharedAxisTransitionType.scaled,
-        ),
-      );
-
-      expect(find.text(bottomRoute), findsOneWidget);
-      Finder fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-
-      navigator.currentState.pushNamed(topRoute);
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      fillContainerFinder = find
-          .ancestor(
-            matching: find.byType(Container),
-            of: find.byKey(const ValueKey<String>('/a')),
-          )
-          .last;
-      expect(fillContainerFinder, findsOneWidget);
-      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
-    });
+//    testWidgets('custom fill color', (WidgetTester tester) async {
+//      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+//      const String bottomRoute = '/';
+//      const String topRoute = '/a';
+//
+//      await tester.pumpWidget(
+//        _TestWidget(
+//          navigatorKey: navigator,
+//          fillColor: Colors.green,
+//          transitionType: SharedAxisTransitionType.scaled,
+//        ),
+//      );
+//
+//      expect(find.text(bottomRoute), findsOneWidget);
+//      Finder fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+//
+//      navigator.currentState.pushNamed(topRoute);
+//      await tester.pump();
+//      await tester.pumpAndSettle();
+//
+//      fillContainerFinder = find
+//          .ancestor(
+//            matching: find.byType(Container),
+//            of: find.byKey(const ValueKey<String>('/a')),
+//          )
+//          .last;
+//      expect(fillContainerFinder, findsOneWidget);
+//      expect(tester.widget<Container>(fillContainerFinder).color, Colors.green);
+//    });
   });
 }
 

--- a/packages/animations/test/shared_axis_transition_test.dart
+++ b/packages/animations/test/shared_axis_transition_test.dart
@@ -161,6 +161,63 @@ void main() {
     );
 
     testWidgets(
+      'Child render count',
+      (WidgetTester tester) async {
+        final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+        const String bottomRoute = '/';
+        const String topRoute = '/a';
+
+        await tester.pumpWidget(
+          _TestWidget(
+            navigatorKey: navigator,
+            contentBuilder: (RouteSettings settings) {
+              return _StatefulTestWidget(
+                key: ValueKey<String>(settings.name),
+                name: settings.name,
+              );
+            },
+            transitionType: SharedAxisTransitionType.horizontal,
+          ),
+        );
+
+        final _StatefulTestWidgetState bottomState = tester.state(
+          find.byKey(const ValueKey<String>(bottomRoute)),
+        );
+
+        // builds once on start
+        expect(bottomState.rebuildCount, 1);
+        expect(find.text(bottomRoute), findsOneWidget);
+        expect(find.text(topRoute), findsNothing);
+
+        navigator.currentState.push<dynamic>(
+          MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) => const _StatefulTestWidget(
+                    key: ValueKey<String>(topRoute),
+                    name: topRoute,
+                  )),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final _StatefulTestWidgetState topState = tester.state(
+          find.byKey(const ValueKey<String>(topRoute)),
+        );
+
+        // builds twice due to the tree changes
+        expect(topState.rebuildCount, 2);
+
+        navigator.currentState.pop();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 301));
+
+        // adds up one more build on navigating back
+        expect(bottomState.rebuildCount, 2);
+        expect(find.text(topRoute), findsNothing);
+        expect(find.text(bottomRoute), findsOneWidget);
+      },
+    );
+
+    testWidgets(
       'SharedAxisTransition runs in reverse',
       (WidgetTester tester) async {
         final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
@@ -1748,8 +1805,11 @@ class _StatefulTestWidget extends StatefulWidget {
 }
 
 class _StatefulTestWidgetState extends State<_StatefulTestWidget> {
+  int rebuildCount = 0;
+
   @override
   Widget build(BuildContext context) {
+    rebuildCount += 1;
     return Text(widget.name);
   }
 }


### PR DESCRIPTION
@shihaohong @goderbauer 

I tried to fix the rebuild issue with adding key's and removing container but without any success
This PR is just a demos how the test fails.
https://github.com/flutter/packages/pull/149/files#diff-ca7f59dbfd46169f7fa7e5467a016f1aR164

I commented out the tests related to the fill color as far as I removed the `Container`)