### PR TITLE
[animations] Fixed useRootNavigator to use correct Navigator size

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -4,6 +4,7 @@
 and tappable when it is supposed to be hidden.
 * Add custom fillColor property to `SharedAxisTransition` and `SharedAxisPageTransitionsBuilder`.
 * Fix prefer_const_constructors lint in test and example.
+* Add option `useRootNavigator` to `OpenContainer`.
 
 
 ## [1.0.0+5] - February 21, 2020

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -249,7 +249,7 @@ class _OpenContainerState extends State<OpenContainer> {
             closedBuilderKey: _closedBuilderKey,
             transitionDuration: widget.transitionDuration,
             transitionType: widget.transitionType,
-            useRootNavigator: widget.useRootNavigator));
+            useRootNavigator: widget.useRootNavigator,));
     if (widget.onClosed != null) {
       widget.onClosed();
     }

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -235,21 +235,21 @@ class _OpenContainerState extends State<OpenContainer> {
   final GlobalKey _closedBuilderKey = GlobalKey();
 
   Future<void> openContainer() async {
-    await Navigator.of(context, rootNavigator: widget.useRootNavigator)
-        .push(_OpenContainerRoute(
-      closedColor: widget.closedColor,
-      openColor: widget.openColor,
-      closedElevation: widget.closedElevation,
-      openElevation: widget.openElevation,
-      closedShape: widget.closedShape,
-      openShape: widget.openShape,
-      closedBuilder: widget.closedBuilder,
-      openBuilder: widget.openBuilder,
-      hideableKey: _hideableKey,
-      closedBuilderKey: _closedBuilderKey,
-      transitionDuration: widget.transitionDuration,
-      transitionType: widget.transitionType,
-    ));
+    await Navigator.of(context, rootNavigator: widget.useRootNavigator).push(
+        _OpenContainerRoute(
+            closedColor: widget.closedColor,
+            openColor: widget.openColor,
+            closedElevation: widget.closedElevation,
+            openElevation: widget.openElevation,
+            closedShape: widget.closedShape,
+            openShape: widget.openShape,
+            closedBuilder: widget.closedBuilder,
+            openBuilder: widget.openBuilder,
+            hideableKey: _hideableKey,
+            closedBuilderKey: _closedBuilderKey,
+            transitionDuration: widget.transitionDuration,
+            transitionType: widget.transitionType,
+            useRootNavigator: widget.useRootNavigator));
     if (widget.onClosed != null) {
       widget.onClosed();
     }
@@ -361,6 +361,7 @@ class _OpenContainerRoute extends ModalRoute<void> {
     @required this.closedBuilderKey,
     @required this.transitionDuration,
     @required this.transitionType,
+    @required this.useRootNavigator,
   })  : assert(closedColor != null),
         assert(openColor != null),
         assert(closedElevation != null),
@@ -371,6 +372,7 @@ class _OpenContainerRoute extends ModalRoute<void> {
         assert(hideableKey != null),
         assert(closedBuilderKey != null),
         assert(transitionType != null),
+        assert(useRootNavigator != null),
         _elevationTween = Tween<double>(
           begin: closedElevation,
           end: openElevation,
@@ -514,6 +516,8 @@ class _OpenContainerRoute extends ModalRoute<void> {
   final Duration transitionDuration;
   final ContainerTransitionType transitionType;
 
+  final bool useRootNavigator;
+
   final Tween<double> _elevationTween;
   final ShapeBorderTween _shapeTween;
   final _FlippableTweenSequence<double> _closedOpacityTween;
@@ -593,7 +597,9 @@ class _OpenContainerRoute extends ModalRoute<void> {
     bool delayForSourceRoute = false,
   }) {
     final RenderBox navigator =
-        Navigator.of(navigatorContext).context.findRenderObject();
+        Navigator.of(navigatorContext, rootNavigator: useRootNavigator)
+            .context
+            .findRenderObject();
     final Size navSize = _getSize(navigator);
     _rectTween.end = Offset.zero & navSize;
 

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -597,7 +597,7 @@ class _OpenContainerRoute extends ModalRoute<void> {
     bool delayForSourceRoute = false,
   }) {
     final RenderBox navigator =
-        Navigator.of(navigatorContext, rootNavigator: useRootNavigator)
+        Navigator.of(navigatorContext, rootNavigator: useRootNavigator,)
             .context
             .findRenderObject();
     final Size navSize = _getSize(navigator);

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -235,21 +235,24 @@ class _OpenContainerState extends State<OpenContainer> {
   final GlobalKey _closedBuilderKey = GlobalKey();
 
   Future<void> openContainer() async {
-    await Navigator.of(context, rootNavigator: widget.useRootNavigator).push(
-        _OpenContainerRoute(
-            closedColor: widget.closedColor,
-            openColor: widget.openColor,
-            closedElevation: widget.closedElevation,
-            openElevation: widget.openElevation,
-            closedShape: widget.closedShape,
-            openShape: widget.openShape,
-            closedBuilder: widget.closedBuilder,
-            openBuilder: widget.openBuilder,
-            hideableKey: _hideableKey,
-            closedBuilderKey: _closedBuilderKey,
-            transitionDuration: widget.transitionDuration,
-            transitionType: widget.transitionType,
-            useRootNavigator: widget.useRootNavigator,));
+    await Navigator.of(
+      context,
+      rootNavigator: widget.useRootNavigator,
+    ).push(_OpenContainerRoute(
+      closedColor: widget.closedColor,
+      openColor: widget.openColor,
+      closedElevation: widget.closedElevation,
+      openElevation: widget.openElevation,
+      closedShape: widget.closedShape,
+      openShape: widget.openShape,
+      closedBuilder: widget.closedBuilder,
+      openBuilder: widget.openBuilder,
+      hideableKey: _hideableKey,
+      closedBuilderKey: _closedBuilderKey,
+      transitionDuration: widget.transitionDuration,
+      transitionType: widget.transitionType,
+      useRootNavigator: widget.useRootNavigator,
+    ));
     if (widget.onClosed != null) {
       widget.onClosed();
     }
@@ -596,10 +599,10 @@ class _OpenContainerRoute extends ModalRoute<void> {
     BuildContext navigatorContext,
     bool delayForSourceRoute = false,
   }) {
-    final RenderBox navigator =
-        Navigator.of(navigatorContext, rootNavigator: useRootNavigator,)
-            .context
-            .findRenderObject();
+    final RenderBox navigator = Navigator.of(
+      navigatorContext,
+      rootNavigator: useRootNavigator,
+    ).context.findRenderObject();
     final Size navSize = _getSize(navigator);
     _rectTween.end = Offset.zero & navSize;
 

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1530,26 +1530,37 @@ void main() {
     @required Key nestedNavigatorKey,
     @required bool useRootNavigator,
   }) {
-    return MaterialApp(
-        key: appKey,
-        // a nested navigator
-        home: Navigator(
-            key: nestedNavigatorKey,
-            onGenerateRoute: (RouteSettings route) {
-              return MaterialPageRoute<dynamic>(
-                  settings: route,
-                  builder: (BuildContext context) {
-                    return Container(
-                        child: OpenContainer(
-                            useRootNavigator: useRootNavigator,
-                            closedBuilder: (BuildContext context, _) {
-                              return const Text('Closed');
-                            },
-                            openBuilder: (BuildContext context, _) {
-                              return const Text('Opened');
-                            }));
-                  });
-            }));
+    return Center(
+      child: SizedBox(
+        width: 100,
+        height: 100,
+        child: MaterialApp(
+            key: appKey,
+            // a nested navigator
+            home: Center(
+              child: SizedBox(
+                width: 50,
+                height: 50,
+                child: Navigator(
+                    key: nestedNavigatorKey,
+                    onGenerateRoute: (RouteSettings route) {
+                      return MaterialPageRoute<dynamic>(
+                          settings: route,
+                          builder: (BuildContext context) {
+                            return OpenContainer(
+                                useRootNavigator: useRootNavigator,
+                                closedBuilder: (BuildContext context, _) {
+                                  return const Text('Closed');
+                                },
+                                openBuilder: (BuildContext context, _) {
+                                  return const Text('Opened');
+                                });
+                          });
+                    }),
+              ),
+            )),
+      ),
+    );
   }
 
   testWidgets(
@@ -1597,6 +1608,40 @@ void main() {
         find.descendant(
             of: find.byKey(nestedNavigatorKey), matching: find.text('Opened')),
         findsNothing);
+  });
+
+  testWidgets('Verify correct opened size  when "useRootNavigator: false"',
+      (WidgetTester tester) async {
+    const Key appKey = Key('App');
+    const Key nestedNavigatorKey = Key('Nested Navigator');
+
+    await tester.pumpWidget(_createRootNavigatorTest(
+        appKey: appKey,
+        nestedNavigatorKey: nestedNavigatorKey,
+        useRootNavigator: false));
+
+    await tester.tap(find.text('Closed'));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.text('Opened')),
+        equals(tester.getSize(find.byKey(nestedNavigatorKey))));
+  });
+
+  testWidgets('Verify correct opened size  when "useRootNavigator: true"',
+      (WidgetTester tester) async {
+    const Key appKey = Key('App');
+    const Key nestedNavigatorKey = Key('Nested Navigator');
+
+    await tester.pumpWidget(_createRootNavigatorTest(
+        appKey: appKey,
+        nestedNavigatorKey: nestedNavigatorKey,
+        useRootNavigator: true));
+
+    await tester.tap(find.text('Closed'));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.text('Opened')),
+        equals(tester.getSize(find.byKey(appKey))));
   });
 }
 

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1535,30 +1535,34 @@ void main() {
         width: 100,
         height: 100,
         child: MaterialApp(
-            key: appKey,
-            // a nested navigator
-            home: Center(
-              child: SizedBox(
-                width: 50,
-                height: 50,
-                child: Navigator(
-                    key: nestedNavigatorKey,
-                    onGenerateRoute: (RouteSettings route) {
-                      return MaterialPageRoute<dynamic>(
-                          settings: route,
-                          builder: (BuildContext context) {
-                            return OpenContainer(
-                                useRootNavigator: useRootNavigator,
-                                closedBuilder: (BuildContext context, _) {
-                                  return const Text('Closed');
-                                },
-                                openBuilder: (BuildContext context, _) {
-                                  return const Text('Opened');
-                                });
-                          });
-                    }),
+          key: appKey,
+          // a nested navigator
+          home: Center(
+            child: SizedBox(
+              width: 50,
+              height: 50,
+              child: Navigator(
+                key: nestedNavigatorKey,
+                onGenerateRoute: (RouteSettings route) {
+                  return MaterialPageRoute<dynamic>(
+                    settings: route,
+                    builder: (BuildContext context) {
+                      return OpenContainer(
+                        useRootNavigator: useRootNavigator,
+                        closedBuilder: (BuildContext context, _) {
+                          return const Text('Closed');
+                        },
+                        openBuilder: (BuildContext context, _) {
+                          return const Text('Opened');
+                        },
+                      );
+                    },
+                  );
+                },
               ),
-            )),
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
This is a small bug fix to https://github.com/flutter/packages/pull/125. 

Although https://github.com/flutter/packages/pull/125 pushed the opened container to the correct route, `_OpenContainerRoute` was still using the closest nesting navigator size for the ending tween size, thus in some cases incorrectly visually scaling the `OpenContainer`. This PR fixes that, and includes two new tests to verify that final container sizes are correct whether `useRootNavigator` is true or false.