### PR TITLE
Use Diagnosticable instead of DiagnosticableMixin

### DIFF
--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -59,7 +59,7 @@ import 'package:flutter/painting.dart';
 ///   * [PaletteTarget], to be able to create your own target color types.
 ///   * [PaletteFilter], a function signature for filtering the allowed colors
 ///     in the palette.
-class PaletteGenerator with DiagnosticableMixin {
+class PaletteGenerator with Diagnosticable {
   /// Create a [PaletteGenerator] from a set of paletteColors and targets.
   ///
   /// The usual way to create a [PaletteGenerator] is to use the asynchronous
@@ -369,7 +369,7 @@ class PaletteGenerator with DiagnosticableMixin {
 /// See also:
 ///
 ///   * [PaletteGenerator], a class for selecting color palettes from images.
-class PaletteTarget with DiagnosticableMixin {
+class PaletteTarget with Diagnosticable {
   /// Creates a [PaletteTarget] for custom palette selection.
   ///
   /// None of the arguments can be null.
@@ -597,7 +597,7 @@ typedef _ContrastCalculator = double Function(Color a, Color b, int alpha);
 /// See also:
 ///
 ///   * [PaletteGenerator], a class for selecting color palettes from images.
-class PaletteColor with DiagnosticableMixin {
+class PaletteColor with Diagnosticable {
   /// Generate a [PaletteColor].
   ///
   /// The `color` and `population` parameters must not be null.


### PR DESCRIPTION
Now that Diagnosticable in Flutter's stable release is a mixin, use that instead, since DiagnosticableMixin will be going away. The two mixin classes are identical, so there should be no change in functionality.

In anticipation of https://github.com/flutter/flutter/issues/50498