### PR TITLE
[animations] Handle DualTransitionBuilder name conflict with flutter/flutter

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - June 19, 2020
+
+* Hide implementation of `DualTransitionBuilder` as the widget has been implemented in the Flutter framework.
 
 ## [1.1.0] - June 2, 2020
 

--- a/packages/animations/lib/src/dual_transition_builder.dart
+++ b/packages/animations/lib/src/dual_transition_builder.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(shihaohong): Remove DualTransitionBuilder once flutter/flutter's `stable`
+// branch contains DualTransitionBuilder.
+
 import 'package:flutter/widgets.dart';
 
 /// Builder callback used by [DualTransitionBuilder].

--- a/packages/animations/lib/src/fade_scale_transition.dart
+++ b/packages/animations/lib/src/fade_scale_transition.dart
@@ -4,7 +4,9 @@
 
 import 'package:flutter/material.dart';
 
-import 'dual_transition_builder.dart';
+// TODO(shihaohong): Remove DualTransitionBuilder once flutter/flutter's `stable`
+// branch contains DualTransitionBuilder.
+import 'dual_transition_builder.dart' as dual_transition_builder;
 import 'modal.dart';
 import 'utils/curves.dart';
 
@@ -151,7 +153,7 @@ class FadeScaleTransition extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualTransitionBuilder(
+    return dual_transition_builder.DualTransitionBuilder(
       animation: animation,
       forwardBuilder: (
         BuildContext context,

--- a/packages/animations/lib/src/fade_through_transition.dart
+++ b/packages/animations/lib/src/fade_through_transition.dart
@@ -4,7 +4,9 @@
 
 import 'package:flutter/material.dart';
 
-import 'dual_transition_builder.dart';
+// TODO(shihaohong): Remove DualTransitionBuilder once flutter/flutter's `stable`
+// branch contains DualTransitionBuilder.
+import 'dual_transition_builder.dart' as dual_transition_builder;
 
 /// Used by [PageTransitionsTheme] to define a page route transition animation
 /// in which the outgoing page fades out, then the incoming page fades in and
@@ -223,7 +225,7 @@ class _ZoomedFadeInFadeOut extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualTransitionBuilder(
+    return dual_transition_builder.DualTransitionBuilder(
       animation: animation,
       forwardBuilder: (
         BuildContext context,

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -7,7 +7,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-import 'dual_transition_builder.dart';
+// TODO(shihaohong): Remove DualTransitionBuilder once flutter/flutter's `stable`
+// branch contains DualTransitionBuilder.
+import 'dual_transition_builder.dart' as dual_transition_builder;
 import 'utils/curves.dart';
 
 /// Determines which type of shared axis transition is used.
@@ -238,7 +240,7 @@ class SharedAxisTransition extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color color = fillColor ?? Theme.of(context).canvasColor;
-    return DualTransitionBuilder(
+    return dual_transition_builder.DualTransitionBuilder(
       animation: animation,
       forwardBuilder: (
         BuildContext context,
@@ -264,7 +266,7 @@ class SharedAxisTransition extends StatelessWidget {
           child: child,
         );
       },
-      child: DualTransitionBuilder(
+      child: dual_transition_builder.DualTransitionBuilder(
         animation: ReverseAnimation(secondaryAnimation),
         forwardBuilder: (
           BuildContext context,

--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/flutter/packages/tree/master/packages/animations
 
 environment:

--- a/packages/animations/test/dual_transition_builder_test.dart
+++ b/packages/animations/test/dual_transition_builder_test.dart
@@ -4,7 +4,8 @@
 
 // TODO(shihaohong): Remove DualTransitionBuilder once flutter/flutter's `stable`
 // branch contains DualTransitionBuilder.
-import 'package:animations/src/dual_transition_builder.dart' as dual_transition_builder;
+import 'package:animations/src/dual_transition_builder.dart'
+    as dual_transition_builder;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/animations/test/dual_transition_builder_test.dart
+++ b/packages/animations/test/dual_transition_builder_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:animations/src/dual_transition_builder.dart';
+// TODO(shihaohong): Remove DualTransitionBuilder once flutter/flutter's `stable`
+// branch contains DualTransitionBuilder.
+import 'package:animations/src/dual_transition_builder.dart' as dual_transition_builder;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
@@ -15,7 +17,7 @@ void main() {
     );
 
     await tester.pumpWidget(Center(
-      child: DualTransitionBuilder(
+      child: dual_transition_builder.DualTransitionBuilder(
         animation: controller,
         forwardBuilder: (
           BuildContext context,
@@ -85,7 +87,7 @@ void main() {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: Center(
-        child: DualTransitionBuilder(
+        child: dual_transition_builder.DualTransitionBuilder(
           animation: controller,
           forwardBuilder: (
             BuildContext context,
@@ -147,7 +149,7 @@ void main() {
       duration: const Duration(milliseconds: 300),
     );
     await tester.pumpWidget(Center(
-      child: DualTransitionBuilder(
+      child: dual_transition_builder.DualTransitionBuilder(
         animation: controller,
         forwardBuilder: (
           BuildContext context,
@@ -213,7 +215,7 @@ void main() {
       duration: const Duration(milliseconds: 300),
     );
     await tester.pumpWidget(Center(
-      child: DualTransitionBuilder(
+      child: dual_transition_builder.DualTransitionBuilder(
         animation: controller,
         forwardBuilder: (
           BuildContext context,


### PR DESCRIPTION
Require animations package to use internal version of DualTransitionBuilder to avoid conflicts with flutter/flutter's recently merged copy of DualTransitionBuilder: https://github.com/flutter/flutter/pull/58686. This will become an issue for developers using the animations package with versions of Flutter newer than https://github.com/flutter/flutter/commit/fe15d1e793cb509f0d616caf1eab19477262b804

Since it is used internally by the library and not exposed to our users, this should be okay. Once DualTransitionBuilder has made it into the stable version of Flutter, we can remove the animations package's copy of the widget altogether. Filed an issue to track in https://github.com/flutter/flutter/issues/59659