### PR TITLE
Use process.start instead of process.run in ssh client.

### DIFF
--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -68,7 +68,9 @@ Future<void> main(List<String> args) async {
     ..addOption('identity-file',
         defaultsTo: '.ssh/pkey', help: 'The key to use when SSHing.')
     ..addOption('timeout-seconds',
-        defaultsTo: '120', help: 'Ssh command timeout in seconds.');
+        defaultsTo: '120', help: 'Ssh command timeout in seconds.')
+    ..addOption('log-file',
+        defaultsTo: '', help: 'The file to write stdout and stderr.');
   parser.addCommand('pave')
     ..addOption('public-key',
         abbr: 'p', help: 'The public key to add to authorized_keys.')
@@ -176,6 +178,7 @@ Future<OperationResult> ssh(
   const SshClient sshClient = SshClient();
   final String targetIp = await devFinder.getTargetAddress(deviceName);
   final String identityFile = args['identity-file'];
+  final String outputFile = args['log-file'];
   if (args['interactive']) {
     return await sshClient.interactive(
       targetIp,
@@ -186,7 +189,8 @@ Future<OperationResult> ssh(
       identityFilePath: identityFile,
       command: args['command'].split(' '),
       timeoutMs:
-          Duration(milliseconds: int.parse(args['timeout-seconds']) * 1000));
+          Duration(milliseconds: int.parse(args['timeout-seconds']) * 1000),
+      logFilePath: outputFile);
   stdout.writeln(
       '==================================== STDOUT ====================================');
   stdout.writeln(result.info);

--- a/packages/fuchsia_ctl/lib/src/logger.dart
+++ b/packages/fuchsia_ctl/lib/src/logger.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+/// Defines the available log levels.
+class LogLevel {
+  const LogLevel._(this._level, this.name);
+
+  final int _level;
+
+  /// String name for the log level.
+  final String name;
+
+  /// LogLevel for messages instended for debugging.
+  static const LogLevel debug = LogLevel._(0, 'DEBUG');
+
+  /// LogLevel for messages instended to provide information about the exection.
+  static const LogLevel info = LogLevel._(1, 'INFO');
+
+  /// LogLevel for messages instended to flag potential problems.
+  static const LogLevel warning = LogLevel._(2, 'WARN');
+
+  /// LogLevel for errors in the execution.
+  static const LogLevel error = LogLevel._(3, 'ERROR');
+}
+
+/// Abstract class for loggers.
+abstract class Logger {
+  /// Processes a debug message.
+  void debug(Object message);
+
+  /// Processes an info message.
+  void info(Object message);
+
+  /// Processes a warning message.
+  void warning(Object message);
+
+  /// Processes an error message.
+  void error(Object message);
+}
+
+/// Logger to print message to standard output.
+class PrintLogger implements Logger {
+  /// Creates a logger instance to print messages to standard output.
+  PrintLogger({
+    IOSink out,
+    this.level = LogLevel.info,
+  }) : out = out ?? stdout;
+
+  /// The [IOSink] to print to.
+  final IOSink out;
+
+  /// Available log levels.
+  final LogLevel level;
+
+  @override
+  void debug(Object message) => _log(LogLevel.debug, message);
+
+  @override
+  void info(Object message) => _log(LogLevel.info, message);
+
+  @override
+  void warning(Object message) => _log(LogLevel.warning, message);
+
+  @override
+  void error(Object message) => _log(LogLevel.error, message);
+
+  void _log(LogLevel level, Object message) {
+    if (level._level >= this.level._level)
+      out.writeln(toLogString('$message', level: level));
+  }
+}
+
+/// Transforms a [message] with [level] to a string that contains the DateTime,
+/// level and message.
+String toLogString(String message, {LogLevel level}) {
+  final StringBuffer buffer = StringBuffer();
+  buffer.write(DateTime.now().toIso8601String());
+  buffer.write(': ');
+  if (level != null) {
+    buffer.write(level.name);
+    buffer.write(' ');
+  }
+  buffer.write(message);
+  return buffer.toString();
+}

--- a/packages/fuchsia_ctl/lib/src/ssh_client.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_client.dart
@@ -107,7 +107,7 @@ class SshClient {
     // return the stdout in OperationResult.
     if (logFile == null) {
       fs = MemoryFileSystem();
-      logFile = fs.file('logs');
+      logFile = fs.file('logs')..openWrite();
     }
 
     final Logger logger = PrintLogger();

--- a/packages/fuchsia_ctl/lib/src/ssh_client.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_client.dart
@@ -32,8 +32,7 @@ class SshClient {
   final ProcessManager processManager;
 
   /// The default ssh timeout as [Duration] in milliseconds.
-  static const Duration defaultSshTimeoutMs =
-      Duration(milliseconds: 5 * 60 * 1000);
+  static const Duration defaultSshTimeoutMs = Duration(milliseconds: 5 * 60 * 1000);
 
   /// Creates a list of arguments to pass to ssh.
   ///
@@ -112,8 +111,7 @@ class SshClient {
     // If no file is passed to this method we create a memoryfile to keep to
     // return the stdout in OperationResult.
     if (logToFile) {
-      fileSystem.file(logFilePath).existsSync() ??
-          fileSystem.file(logFilePath).deleteSync();
+      fileSystem.file(logFilePath).existsSync() ?? fileSystem.file(logFilePath).deleteSync();
       fileSystem.file(logFilePath).createSync();
       final IOSink data = fileSystem.file(logFilePath).openWrite();
       logger = PrintLogger(out: data);
@@ -131,23 +129,21 @@ class SshClient {
         command: command,
       ),
     );
-    final StreamSubscription<String> stdoutSubscription = process.stdout
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((String log) {
+    final StreamSubscription<String> stdoutSubscription =
+        process.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((String log) {
       if (!logToFile) {
         logFile.writeln(log);
+      } else {
+        logger.info(log);
       }
-      logger.info(log);
     });
-    final StreamSubscription<String> stderrSubscription = process.stderr
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((String log) {
+    final StreamSubscription<String> stderrSubscription =
+        process.stderr.transform(utf8.decoder).transform(const LineSplitter()).listen((String log) {
       if (!logToFile) {
         logFile.writeln(log);
+      } else {
+        logger.warning(log);
       }
-      logger.warning(log);
     });
 
     // Wait for stdout and stderr to be fully processed because proc.exitCode
@@ -171,8 +167,6 @@ class SshClient {
       output = await fileSystem.file('logs').readAsString();
     }
 
-    return exitCode != 0
-        ? OperationResult.error('Failed', info: output)
-        : OperationResult.success(info: output);
+    return exitCode != 0 ? OperationResult.error('Failed', info: output) : OperationResult.success(info: output);
   }
 }

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   process: ^3.0.12
   retry: ^3.0.0+1
   uuid: ^2.0.2
+  pedantic: ^1.9.2
 
 dev_dependencies:
   test: ^1.6.9

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -20,5 +20,5 @@ dependencies:
   pedantic: ^1.9.2
 
 dev_dependencies:
-  test: ^1.6.9
   mockito: ^4.1.1
+  test: ^1.6.9

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -14,9 +14,9 @@ dependencies:
   file: ^5.0.10
   meta: ^1.1.7
   path: ^1.6.4
+  pedantic: ^1.9.2
   process: ^3.0.12
   retry: ^3.0.0+1
-  pedantic: ^1.9.2
   uuid: ^2.0.2
 
 dev_dependencies:

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
   path: ^1.6.4
   process: ^3.0.12
   retry: ^3.0.0+1
-  uuid: ^2.0.2
   pedantic: ^1.9.2
+  uuid: ^2.0.2
 
 dev_dependencies:
   mockito: ^4.1.1

--- a/packages/fuchsia_ctl/test/logger_test.dart
+++ b/packages/fuchsia_ctl/test/logger_test.dart
@@ -1,0 +1,9 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+void main() {
+  test('', () async {});
+}

--- a/packages/fuchsia_ctl/test/ssh_client_test.dart
+++ b/packages/fuchsia_ctl/test/ssh_client_test.dart
@@ -77,6 +77,7 @@ void main() {
           targetIp: targetIp,
           command: command,
         ));
+    expect(result.info, 'abc\ncdf\n');
     expect(result.success, true);
   });
 

--- a/packages/fuchsia_ctl/test/ssh_client_test.dart
+++ b/packages/fuchsia_ctl/test/ssh_client_test.dart
@@ -52,11 +52,7 @@ void main() {
     final MockProcessManager processManager = MockProcessManager();
 
     when(processManager.start(any)).thenAnswer((_) async {
-      return FakeProcess(0, <String>[''], <String>['']);
-    });
-
-    when(processManager.run(any)).thenAnswer((_) async {
-      return ProcessResult(0, 0, 'Good job', '');
+      return FakeProcess(0, <String>['abc'], <String>['cdf']);
     });
 
     final SshClient ssh = SshClient(processManager: processManager);

--- a/packages/fuchsia_ctl/test/ssh_client_test.dart
+++ b/packages/fuchsia_ctl/test/ssh_client_test.dart
@@ -51,6 +51,10 @@ void main() {
     const List<String> command = <String>['ls', '-al'];
     final MockProcessManager processManager = MockProcessManager();
 
+    when(processManager.start(any)).thenAnswer((_) async {
+      return FakeProcess(0, <String>[''], <String>['']);
+    });
+
     when(processManager.run(any)).thenAnswer((_) async {
       return ProcessResult(0, 0, 'Good job', '');
     });
@@ -64,7 +68,7 @@ void main() {
     );
 
     final List<String> capturedStartArgs =
-        verify(processManager.run(captureAny))
+        verify(processManager.start(captureAny))
             .captured
             .cast<List<String>>()
             .single;
@@ -92,9 +96,9 @@ void main() {
   test('sshCommand times out', () async {
     final MockProcessManager processManager = MockProcessManager();
 
-    when(processManager.run(any)).thenAnswer((_) async {
+    when(processManager.start(any)).thenAnswer((_) async {
       await Future<void>.delayed(const Duration(milliseconds: 3));
-      return ProcessResult(0, 0, 'Good job', '');
+      return FakeProcess(0, <String>[''], <String>['']);
     });
 
     final SshClient ssh = SshClient(processManager: processManager);


### PR DESCRIPTION
Ssh_client was hanging when it was collecting a lot of information on
stdout. This PR is printing the output as it is being collected instead
of saving it and printing it to the end.

Bug:
  https://github.com/flutter/flutter/issues/57273