### PR TITLE
[animations] Ignore deprecated use of BottomNavigationBarItem.title

### DIFF
--- a/packages/animations/example/lib/fade_through_transition.dart
+++ b/packages/animations/example/lib/fade_through_transition.dart
@@ -49,14 +49,17 @@ class _FadeThroughTransitionDemoState extends State<FadeThroughTransitionDemo> {
         items: const <BottomNavigationBarItem>[
           BottomNavigationBarItem(
             icon: Icon(Icons.photo_library),
+            // ignore: deprecated_member_use
             title: Text('Albums'),
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.photo),
+            // ignore: deprecated_member_use
             title: Text('Photos'),
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.search),
+            // ignore: deprecated_member_use
             title: Text('Search'),
           ),
         ],


### PR DESCRIPTION
This is to allow the following PR to submit: https://github.com/flutter/flutter/pull/59127

Right now it can not submit due to failed analyzer checks in the customer_testing stage.

See [flutter.dev/go/bottom-navigation-bar-title-deprecation](flutter.dev/go/bottom-navigation-bar-title-deprecation) for the full breaking change doc. 

Once this lands, then the above PR lands in flutter/flutter, the usages can be updated in this repo.