### PR TITLE
[animations] adds alignment parameter to FadeScaleTransition

### DIFF
--- a/packages/animations/lib/src/fade_scale_transition.dart
+++ b/packages/animations/lib/src/fade_scale_transition.dart
@@ -63,6 +63,28 @@ import 'modal.dart';
 ///   }
 /// }
 /// ```
+///
+/// To modify scale alignment, `FadeScaleTransitionConfiguration` will
+/// need to be extended and this new configuration class will need to be used instead:
+/// ```dart
+/// class _ModifiedFadeScaleTransitionConfiguration extends FadeScaleTransitionConfiguration {
+///   const _ModifiedFadeScaleTransitionConfiguration();
+///
+///   @override
+///   Widget transitionBuilder(
+///     BuildContext context,
+///     Animation<double> animation,
+///     Animation<double> secondaryAnimation,
+///     Widget child,
+///   ) {
+///     return FadeScaleTransition(
+///       animation: animation,
+///       alignment: Alignment.topRight, // add this line
+///       child: child,
+///     );
+///   }
+/// }
+/// ```
 class FadeScaleTransitionConfiguration extends ModalConfiguration {
   /// Creates the Material fade transition configuration.
   ///

--- a/packages/animations/lib/src/fade_scale_transition.dart
+++ b/packages/animations/lib/src/fade_scale_transition.dart
@@ -123,6 +123,7 @@ class FadeScaleTransition extends StatelessWidget {
   const FadeScaleTransition({
     Key key,
     @required this.animation,
+    this.alignment = Alignment.center,
     this.child,
   })  : assert(animation != null),
         super(key: key);
@@ -134,6 +135,19 @@ class FadeScaleTransition extends StatelessWidget {
   ///  * [TransitionRoute.animate], which is the value given to this property
   ///    when it is used as a page transition.
   final Animation<double> animation;
+
+  /// The alignment of scale anchor point, relative to it's child.
+  ///
+  /// By default, the child scales from it's center when fading in. In a
+  /// variation on the default behavior, the scale anchor point can be
+  /// repositioned from the center of a child to another location within
+  /// the child.
+  ///
+  /// For example, when an overflow icon (the parent component) triggers a menu
+  /// (the child component), the menu's anchor point can be positioned at the
+  /// top right corner of the menu so that it appears to scale from the overflow
+  /// icon during a transition.
+  final Alignment alignment;
 
   /// The widget below this widget in the tree.
   ///
@@ -166,6 +180,7 @@ class FadeScaleTransition extends StatelessWidget {
           opacity: _fadeInTransition.animate(animation),
           child: ScaleTransition(
             scale: _scaleInTransition.animate(animation),
+            alignment: alignment,
             child: child,
           ),
         );

--- a/packages/animations/lib/src/fade_scale_transition.dart
+++ b/packages/animations/lib/src/fade_scale_transition.dart
@@ -120,12 +120,15 @@ class FadeScaleTransition extends StatelessWidget {
   ///
   /// [animation] is typically an [AnimationController] that drives the transition
   /// animation. [animation] cannot be null.
+  ///
+  /// The [alignment] defaults to [Alignment.center] and cannot be null.
   const FadeScaleTransition({
     Key key,
     @required this.animation,
     this.alignment = Alignment.center,
     this.child,
   })  : assert(animation != null),
+        assert(alignment != null),
         super(key: key);
 
   /// The animation that drives the [child]'s entrance and exit.

--- a/packages/animations/test/fade_scale_transition_test.dart
+++ b/packages/animations/test/fade_scale_transition_test.dart
@@ -71,8 +71,10 @@ void main() {
       // Opacity duration: First 30% of 150ms, linear transition
       double topFadeTransitionOpacity = _getOpacity(key, tester);
       double topScale = _getScale(key, tester);
+      Alignment topScaleAlignment = _getScaleAlignment(key, tester);
       expect(topFadeTransitionOpacity, 0.0);
       expect(topScale, 0.80);
+      expect(topScaleAlignment, Alignment.center);
 
       // 3/10 * 150ms = 45ms (total opacity animation duration)
       // 1/2 * 45ms = ~23ms elapsed for halfway point of opacity
@@ -83,6 +85,8 @@ void main() {
       topScale = _getScale(key, tester);
       expect(topScale, greaterThan(0.80));
       expect(topScale, lessThan(1.0));
+      topScaleAlignment = _getScaleAlignment(key, tester);
+      expect(topScaleAlignment, Alignment.center);
 
       // End of opacity animation
       await tester.pump(const Duration(milliseconds: 22));
@@ -91,17 +95,23 @@ void main() {
       topScale = _getScale(key, tester);
       expect(topScale, greaterThan(0.80));
       expect(topScale, lessThan(1.0));
+      topScaleAlignment = _getScaleAlignment(key, tester);
+      expect(topScaleAlignment, Alignment.center);
 
       // 100ms into the animation
       await tester.pump(const Duration(milliseconds: 55));
       topScale = _getScale(key, tester);
       expect(topScale, greaterThan(0.80));
       expect(topScale, lessThan(1.0));
+      topScaleAlignment = _getScaleAlignment(key, tester);
+      expect(topScaleAlignment, Alignment.center);
 
       // Get to the end of the animation
       await tester.pump(const Duration(milliseconds: 50));
       topScale = _getScale(key, tester);
       expect(topScale, 1.0);
+      topScaleAlignment = _getScaleAlignment(key, tester);
+      expect(topScaleAlignment, Alignment.center);
 
       await tester.pump();
       expect(find.byType(_FlutterLogoModal), findsOneWidget);
@@ -146,20 +156,26 @@ void main() {
       // No scale animations on exit transition.
       double topFadeTransitionOpacity = _getOpacity(key, tester);
       double topScale = _getScale(key, tester);
+      Alignment topScaleAlignment = _getScaleAlignment(key, tester);
       expect(topFadeTransitionOpacity, 1.0);
       expect(topScale, 1.0);
+      expect(topScaleAlignment, Alignment.center);
 
       await tester.pump(const Duration(milliseconds: 25));
       topFadeTransitionOpacity = _getOpacity(key, tester);
       topScale = _getScale(key, tester);
+      topScaleAlignment = _getScaleAlignment(key, tester);
       expect(topFadeTransitionOpacity, closeTo(0.66, 0.05));
       expect(topScale, 1.0);
+      expect(topScaleAlignment, Alignment.center);
 
       await tester.pump(const Duration(milliseconds: 25));
       topFadeTransitionOpacity = _getOpacity(key, tester);
       topScale = _getScale(key, tester);
+      topScaleAlignment = _getScaleAlignment(key, tester);
       expect(topFadeTransitionOpacity, closeTo(0.33, 0.05));
       expect(topScale, 1.0);
+      expect(topScaleAlignment, Alignment.center);
 
       // End of opacity animation
       await tester.pump(const Duration(milliseconds: 25));
@@ -167,6 +183,8 @@ void main() {
       expect(topFadeTransitionOpacity, 0.0);
       topScale = _getScale(key, tester);
       expect(topScale, 1.0);
+      topScaleAlignment = _getScaleAlignment(key, tester);
+      expect(topScaleAlignment, Alignment.center);
 
       await tester.pump(const Duration(milliseconds: 1));
       expect(find.byType(_FlutterLogoModal), findsNothing);
@@ -469,6 +487,15 @@ double _getScale(GlobalKey key, WidgetTester tester) {
     final ScaleTransition transition = widget;
     return a * transition.scale.value;
   });
+}
+
+Alignment _getScaleAlignment(GlobalKey key, WidgetTester tester) {
+  final Finder finder = find.ancestor(
+    of: find.byKey(key),
+    matching: find.byType(ScaleTransition),
+  );
+  final ScaleTransition transition = tester.widget(finder);
+  return transition.alignment;
 }
 
 class _FlutterLogoModal extends StatefulWidget {

--- a/packages/animations/test/fade_scale_transition_test.dart
+++ b/packages/animations/test/fade_scale_transition_test.dart
@@ -71,10 +71,8 @@ void main() {
       // Opacity duration: First 30% of 150ms, linear transition
       double topFadeTransitionOpacity = _getOpacity(key, tester);
       double topScale = _getScale(key, tester);
-      Alignment topScaleAlignment = _getScaleAlignment(key, tester);
       expect(topFadeTransitionOpacity, 0.0);
       expect(topScale, 0.80);
-      expect(topScaleAlignment, Alignment.center);
 
       // 3/10 * 150ms = 45ms (total opacity animation duration)
       // 1/2 * 45ms = ~23ms elapsed for halfway point of opacity
@@ -85,8 +83,6 @@ void main() {
       topScale = _getScale(key, tester);
       expect(topScale, greaterThan(0.80));
       expect(topScale, lessThan(1.0));
-      topScaleAlignment = _getScaleAlignment(key, tester);
-      expect(topScaleAlignment, Alignment.center);
 
       // End of opacity animation
       await tester.pump(const Duration(milliseconds: 22));
@@ -95,23 +91,17 @@ void main() {
       topScale = _getScale(key, tester);
       expect(topScale, greaterThan(0.80));
       expect(topScale, lessThan(1.0));
-      topScaleAlignment = _getScaleAlignment(key, tester);
-      expect(topScaleAlignment, Alignment.center);
 
       // 100ms into the animation
       await tester.pump(const Duration(milliseconds: 55));
       topScale = _getScale(key, tester);
       expect(topScale, greaterThan(0.80));
       expect(topScale, lessThan(1.0));
-      topScaleAlignment = _getScaleAlignment(key, tester);
-      expect(topScaleAlignment, Alignment.center);
 
       // Get to the end of the animation
       await tester.pump(const Duration(milliseconds: 50));
       topScale = _getScale(key, tester);
       expect(topScale, 1.0);
-      topScaleAlignment = _getScaleAlignment(key, tester);
-      expect(topScaleAlignment, Alignment.center);
 
       await tester.pump();
       expect(find.byType(_FlutterLogoModal), findsOneWidget);
@@ -156,26 +146,20 @@ void main() {
       // No scale animations on exit transition.
       double topFadeTransitionOpacity = _getOpacity(key, tester);
       double topScale = _getScale(key, tester);
-      Alignment topScaleAlignment = _getScaleAlignment(key, tester);
       expect(topFadeTransitionOpacity, 1.0);
       expect(topScale, 1.0);
-      expect(topScaleAlignment, Alignment.center);
 
       await tester.pump(const Duration(milliseconds: 25));
       topFadeTransitionOpacity = _getOpacity(key, tester);
       topScale = _getScale(key, tester);
-      topScaleAlignment = _getScaleAlignment(key, tester);
       expect(topFadeTransitionOpacity, closeTo(0.66, 0.05));
       expect(topScale, 1.0);
-      expect(topScaleAlignment, Alignment.center);
 
       await tester.pump(const Duration(milliseconds: 25));
       topFadeTransitionOpacity = _getOpacity(key, tester);
       topScale = _getScale(key, tester);
-      topScaleAlignment = _getScaleAlignment(key, tester);
       expect(topFadeTransitionOpacity, closeTo(0.33, 0.05));
       expect(topScale, 1.0);
-      expect(topScaleAlignment, Alignment.center);
 
       // End of opacity animation
       await tester.pump(const Duration(milliseconds: 25));
@@ -183,8 +167,6 @@ void main() {
       expect(topFadeTransitionOpacity, 0.0);
       topScale = _getScale(key, tester);
       expect(topScale, 1.0);
-      topScaleAlignment = _getScaleAlignment(key, tester);
-      expect(topScaleAlignment, Alignment.center);
 
       await tester.pump(const Duration(milliseconds: 1));
       expect(find.byType(_FlutterLogoModal), findsNothing);


### PR DESCRIPTION
Implements Fade scale anchor point variant as documented here: https://material.io/design/motion/the-motion-system.html#fade

An example which the menu scales from top right when fading in.
![menu](https://user-images.githubusercontent.com/26335640/89136220-23f6a000-d565-11ea-841d-4e7c4f0fea03.gif)
