### PR TITLE
Open container: fade through color tween

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -445,14 +445,20 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
           ],
         );
       case ContainerTransitionType.fadeThrough:
+        final Color averageColor = Color.fromARGB(
+          (closedColor.alpha + openColor.alpha) ~/ 2,
+          (closedColor.red + openColor.red) ~/ 2,
+          (closedColor.green + openColor.green) ~/ 2,
+          (closedColor.blue + openColor.blue) ~/ 2,
+        );
         return _FlippableTweenSequence<Color>(
           <TweenSequenceItem<Color>>[
             TweenSequenceItem<Color>(
-              tween: ColorTween(begin: closedColor, end: Colors.white),
+              tween: ColorTween(begin: closedColor, end: averageColor),
               weight: 1 / 5,
             ),
             TweenSequenceItem<Color>(
-              tween: ColorTween(begin: Colors.white, end: openColor),
+              tween: ColorTween(begin: averageColor, end: openColor),
               weight: 4 / 5,
             ),
           ],

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -277,8 +277,6 @@ class _OpenContainerState<T> extends State<OpenContainer<T>> {
   Future<void> openContainer() async {
     final Color middleColor =
         widget.middleColor ?? Theme.of(context).canvasColor;
-    print(widget.middleColor);
-    print(Theme.of(context).canvasColor);
     final T data = await Navigator.of(
       context,
       rootNavigator: widget.useRootNavigator,

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -83,6 +83,7 @@ class OpenContainer<T extends Object> extends StatefulWidget {
     Key key,
     this.closedColor = Colors.white,
     this.openColor = Colors.white,
+    this.middleColor,
     this.closedElevation = 1.0,
     this.openElevation = 4.0,
     this.closedShape = const RoundedRectangleBorder(
@@ -112,9 +113,9 @@ class OpenContainer<T extends Object> extends StatefulWidget {
   /// Background color of the container while it is closed.
   ///
   /// When the container is opened, it will first transition from this color
-  /// to [Colors.white] and then transition from there to [openColor] in one
+  /// to [middleColor] and then transition from there to [openColor] in one
   /// smooth animation. When the container is closed, it will transition back to
-  /// this color from [openColor] via [Colors.white].
+  /// this color from [openColor] via [middleColor].
   ///
   /// Defaults to [Colors.white].
   ///
@@ -126,9 +127,9 @@ class OpenContainer<T extends Object> extends StatefulWidget {
   /// Background color of the container while it is open.
   ///
   /// When the container is closed, it will first transition from [closedColor]
-  /// to [Colors.white] and then transition from there to this color in one
+  /// to [middleColor] and then transition from there to this color in one
   /// smooth animation. When the container is closed, it will transition back to
-  /// [closedColor] from this color via [Colors.white].
+  /// [closedColor] from this color via [middleColor].
   ///
   /// Defaults to [Colors.white].
   ///
@@ -136,6 +137,16 @@ class OpenContainer<T extends Object> extends StatefulWidget {
   ///
   ///  * [Material.color], which is used to implement this property.
   final Color openColor;
+
+  /// The color to use for the background color during the transition
+  /// with [ContainerTransitionType.fadeThrough].
+  ///
+  /// Defaults to [Theme]'s [ThemeData.canvasColor].
+  ///
+  /// See also:
+  ///
+  ///  * [Material.color], which is used to implement this property.
+  final Color middleColor;
 
   /// Elevation of the container while it is closed.
   ///
@@ -264,12 +275,17 @@ class _OpenContainerState<T> extends State<OpenContainer<T>> {
   final GlobalKey _closedBuilderKey = GlobalKey();
 
   Future<void> openContainer() async {
+    final Color middleColor =
+        widget.middleColor ?? Theme.of(context).canvasColor;
+    print(widget.middleColor);
+    print(Theme.of(context).canvasColor);
     final T data = await Navigator.of(
       context,
       rootNavigator: widget.useRootNavigator,
     ).push(_OpenContainerRoute<T>(
       closedColor: widget.closedColor,
       openColor: widget.openColor,
+      middleColor: middleColor,
       closedElevation: widget.closedElevation,
       openElevation: widget.openElevation,
       closedShape: widget.closedShape,
@@ -383,6 +399,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
   _OpenContainerRoute({
     @required this.closedColor,
     @required this.openColor,
+    @required this.middleColor,
     @required double closedElevation,
     @required this.openElevation,
     @required ShapeBorder closedShape,
@@ -417,6 +434,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
           transitionType: transitionType,
           closedColor: closedColor,
           openColor: openColor,
+          middleColor: middleColor,
         ),
         _closedOpacityTween = _getClosedOpacityTween(transitionType),
         _openOpacityTween = _getOpenOpacityTween(transitionType);
@@ -425,6 +443,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     @required ContainerTransitionType transitionType,
     @required Color closedColor,
     @required Color openColor,
+    @required Color middleColor,
   }) {
     switch (transitionType) {
       case ContainerTransitionType.fade:
@@ -445,20 +464,14 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
           ],
         );
       case ContainerTransitionType.fadeThrough:
-        final Color averageColor = Color.fromARGB(
-          (closedColor.alpha + openColor.alpha) ~/ 2,
-          (closedColor.red + openColor.red) ~/ 2,
-          (closedColor.green + openColor.green) ~/ 2,
-          (closedColor.blue + openColor.blue) ~/ 2,
-        );
         return _FlippableTweenSequence<Color>(
           <TweenSequenceItem<Color>>[
             TweenSequenceItem<Color>(
-              tween: ColorTween(begin: closedColor, end: averageColor),
+              tween: ColorTween(begin: closedColor, end: middleColor),
               weight: 1 / 5,
             ),
             TweenSequenceItem<Color>(
-              tween: ColorTween(begin: averageColor, end: openColor),
+              tween: ColorTween(begin: middleColor, end: openColor),
               weight: 4 / 5,
             ),
           ],
@@ -539,6 +552,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
 
   final Color closedColor;
   final Color openColor;
+  final Color middleColor;
   final double openElevation;
   final ShapeBorder openShape;
   final CloseContainerBuilder closedBuilder;

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -364,6 +364,7 @@ void main() {
         child: OpenContainer(
           closedColor: Colors.green,
           openColor: Colors.blue,
+          middleColor: Colors.red,
           closedElevation: 4.0,
           openElevation: 8.0,
           closedShape: shape,
@@ -461,7 +462,7 @@ void main() {
       biggerMaterial: dataMidpoint,
       tester: tester,
     );
-    expect(dataMidpoint.material.color, const Color(0xff36a2a1));
+    expect(dataMidpoint.material.color, Colors.red);
     expect(_getOpacity(tester, 'Open'), moreOrLessEquals(0.0));
     expect(_getOpacity(tester, 'Closed'), moreOrLessEquals(0.0));
 
@@ -538,6 +539,7 @@ void main() {
         child: OpenContainer(
           closedColor: Colors.green,
           openColor: Colors.blue,
+          middleColor: Colors.red,
           closedElevation: 4.0,
           openElevation: 8.0,
           closedShape: shape,
@@ -635,7 +637,7 @@ void main() {
       biggerMaterial: dataMidFadeOut,
       tester: tester,
     );
-    expect(dataMidpoint.material.color, const Color(0xff36a2a1));
+    expect(dataMidpoint.material.color, Colors.red);
     expect(_getOpacity(tester, 'Open'), moreOrLessEquals(0.0));
     expect(_getOpacity(tester, 'Closed'), moreOrLessEquals(0.0));
 

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -461,7 +461,7 @@ void main() {
       biggerMaterial: dataMidpoint,
       tester: tester,
     );
-    expect(dataMidpoint.material.color, isNot(dataMidFadeOut.material.color));
+    expect(dataMidpoint.material.color, const Color(0xff36a2a1));
     expect(_getOpacity(tester, 'Open'), moreOrLessEquals(0.0));
     expect(_getOpacity(tester, 'Closed'), moreOrLessEquals(0.0));
 
@@ -635,7 +635,7 @@ void main() {
       biggerMaterial: dataMidFadeOut,
       tester: tester,
     );
-    expect(dataMidpoint.material.color, isNot(dataMidFadeOut.material.color));
+    expect(dataMidpoint.material.color, const Color(0xff36a2a1));
     expect(_getOpacity(tester, 'Open'), moreOrLessEquals(0.0));
     expect(_getOpacity(tester, 'Closed'), moreOrLessEquals(0.0));
 


### PR DESCRIPTION
Right now, when we use `ContainerTransitionType.fadeThrough`, then animation goes through `openColor` -> `Colors.white` -> `closedColor` (and vise-versa).

It's looks fine, when we have light containers, but it makes pretty ugly blink if we use dark backgrounds.

With this PR i suggest to use average color between `openColor` and `closedColor` instead of `Colors.white`.

In the attached archive i put videos with old and new way.

[examples.zip](https://github.com/flutter/packages/files/5086622/opencontainer.zip)
