### PR TITLE
Loosen dependencies so that nullsafety versions are acceptable.

### DIFF
--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.2] - Reduce dependencies on external libraries.
+
+* Broaden dependencies to allow nullsafety version of process, meta, and path to be OK.
+
 ## [0.1.1] - Reduce dependencies on external libraries.
 
 * Remove flutter, flutter_test from pubspec dependencies.

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -1,15 +1,15 @@
 name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/flutter/packages/tree/master/packages/xdg_directories
 
 environment:
   sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
-  meta: ^1.2.2
-  path: ^1.6.4
-  process: ^3.0.12
+  meta: ">=1.2.2 <2.0.0"
+  path: ">=1.6.4 <2.0.0"
+  process: ">=3.0.12 <5.0.0"
 
 dev_dependencies:
   test: ^1.15.3


### PR DESCRIPTION
The strict dependencies were making it impossible to use in the plugins repo when combined with the nullsafety version of the `process` package.