### PR TITLE
[palette_generator]Fix PaletteGenerator.fromImageProvider region not scaled to fit image size.

### DIFF
--- a/packages/palette_generator/CHANGELOG.md
+++ b/packages/palette_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+* Fix PaletteGenerator.fromImageProvider region not scaled to fit image size.
+
 ## 0.2.3
 
 * Bumped minimum Flutter version to 1.15.21 to pick up Diagnosticable as a mixin and remove DiagnosticableMixin.

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -202,13 +202,16 @@ class PaletteGenerator with Diagnosticable {
     }
     stream.addListener(listener);
     final ui.Image image = await imageCompleter.future;
-    final double scale = image.width / size.width;
-    final ui.Rect newRegion = Rect.fromLTRB(
-      region.left * scale,
-      region.top * scale,
-      region.right * scale,
-      region.bottom * scale,
-    );
+    ui.Rect newRegion = region;
+    if (size != null && region != null) {
+      final double scale = image.width / size.width;
+      newRegion = Rect.fromLTRB(
+        region.left * scale,
+        region.top * scale,
+        region.right * scale,
+        region.bottom * scale,
+      );
+    }
     return PaletteGenerator.fromImage(
       image,
       region: newRegion,

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -201,9 +201,17 @@ class PaletteGenerator with Diagnosticable {
       });
     }
     stream.addListener(listener);
+    final ui.Image image = await imageCompleter.future;
+    final double scale = image.width / size.width;
+    final ui.Rect newRegion = Rect.fromLTRB(
+      region.left * scale,
+      region.top * scale,
+      region.right * scale,
+      region.bottom * scale,
+    );
     return PaletteGenerator.fromImage(
-      await imageCompleter.future,
-      region: region,
+      image,
+      region: newRegion,
       maximumColorCount: maximumColorCount,
       filters: filters,
       targets: targets,

--- a/packages/palette_generator/pubspec.yaml
+++ b/packages/palette_generator/pubspec.yaml
@@ -1,7 +1,7 @@
 name: palette_generator
 description: Flutter package for generating palette colors from a source image.
 homepage: https://github.com/flutter/packages/tree/master/packages/palette_generator
-version: 0.2.3
+version: 0.2.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
ui.Image.size is pixel size of Image, but the param `size` is the dp size of the widget, and `region` is same the dp size. 
```
static Future<PaletteGenerator> fromImageProvider(
    ImageProvider imageProvider, {
    Size size,
    Rect region,
    int maximumColorCount,
    List<PaletteFilter> filters,
    List<PaletteTarget> targets,
    Duration timeout = const Duration(seconds: 15),
  }) 
```