### PR TITLE
Pigeon : Support for asynchronous methods/Functions

### DIFF
--- a/packages/pigeon/lib/ast.dart
+++ b/packages/pigeon/lib/ast.dart
@@ -28,7 +28,7 @@ class Method extends Node {
   /// The data-type of the argument.
   String argType;
 
-  /// Whether the method is asynchronous or not
+  /// Whether the receiver of this method is expected to return synchronously or not.
   bool isAsynchronous;
 }
 

--- a/packages/pigeon/lib/ast.dart
+++ b/packages/pigeon/lib/ast.dart
@@ -17,7 +17,7 @@ class Node {}
 /// Represents a method on an [Api].
 class Method extends Node {
   /// Parametric constructor for [Method].
-  Method({this.name, this.returnType, this.argType});
+  Method({this.name, this.returnType, this.argType, this.isAsynchronous});
 
   /// The name of the method.
   String name;
@@ -27,6 +27,9 @@ class Method extends Node {
 
   /// The data-type of the argument.
   String argType;
+
+  /// Whether the method is asynchronous or not
+  bool isAsynchronous;
 }
 
 /// Represents a collection of [Method]s that are hosted ona given [location].

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -96,12 +96,12 @@ void _writeFlutterApi(Indent indent, Api api,
             final String argType = func.argType;
             final String returnType = func.returnType;
             final bool isAsync = func.isAsynchronous;
-            indent.writeln(
-                'final Map<dynamic, dynamic> mapMessage = message as Map<dynamic, dynamic>;');
             String call;
             if (argType == 'void') {
               call = 'api.${func.name}()';
             } else {
+              indent.writeln(
+                  'final Map<dynamic, dynamic> mapMessage = message as Map<dynamic, dynamic>;');
               indent.writeln(
                   'final $argType input = $argType._fromMap(mapMessage);');
               call = 'api.${func.name}(input)';

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -67,10 +67,11 @@ void _writeFlutterApi(Indent indent, Api api,
   indent.scoped('{', '}', () {
     for (Method func in api.methods) {
       final bool isAsync = func.isAsynchronous;
-      final String argSignature = func.argType == 'void'
-          ? ''
-          : isAsync ? 'Future<${func.argType}> arg' : '${func.argType} arg';
-      indent.writeln('${func.returnType} ${func.name}($argSignature);');
+      final String returnType =
+          isAsync ? 'Future<${func.returnType}>' : '${func.returnType}';
+      final String argSignature =
+          func.argType == 'void' ? '' : '${func.argType} arg';
+      indent.writeln('$returnType ${func.name}($argSignature);');
     }
     indent.write('static void setup(${api.name} api) ');
     indent.scoped('{', '}', () {

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -144,6 +144,8 @@ void generateDart(Root root, StringSink sink) {
   indent.writeln('// @dart = 2.8');
   indent.writeln('import \'dart:async\';');
   indent.writeln('import \'package:flutter/services.dart\';');
+  indent.writeln(
+      'import \'dart:typed_data\' show Uint8List, Int32List, Int64List, Float64List;');
   indent.writeln('');
 
   for (Class klass in root.classes) {

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -52,7 +52,7 @@ void _writeHostApi(Indent indent, Api api) {
       if (method.isAsynchronous) {
         argSignature.add('Result<${method.returnType}> result');
       }
-      indent.writeln('$returnType ${method.name}(${argSignature.join(',')});');
+      indent.writeln('$returnType ${method.name}(${argSignature.join(', ')});');
     }
     indent.addln('');
     indent.writeln(
@@ -90,14 +90,14 @@ void _writeHostApi(Indent indent, Api api) {
                 }
                 if (method.isAsynchronous) {
                   methodArgument.add(
-                    'result -> {'
-                    'wrapped.put("${Keys.result}", result.toMap());'
-                    'reply.reply(wrapped);'
+                    'result -> { '
+                    'wrapped.put("${Keys.result}", result.toMap()); '
+                    'reply.reply(wrapped); '
                     '}',
                   );
                 }
                 final String call =
-                    'api.${method.name}(${methodArgument.join(',')})';
+                    'api.${method.name}(${methodArgument.join(', ')})';
                 if (method.isAsynchronous) {
                   indent.writeln('$call;');
                 } else if (method.returnType == 'void') {

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -29,14 +29,30 @@ class JavaOptions {
 
 void _writeHostApi(Indent indent, Api api) {
   assert(api.location == ApiLocation.host);
+
+  if (api.methods.any((Method it) => it.isAsynchronous)) {
+    indent.write('public interface Result<T> ');
+    indent.scoped('{', '}', () {
+      indent.writeln('void success(T result);');
+    });
+    indent.addln('');
+  }
+
   indent.writeln(
       '/** Generated interface from Pigeon that represents a handler of messages from Flutter.*/');
   indent.write('public interface ${api.name} ');
   indent.scoped('{', '}', () {
     for (Method method in api.methods) {
-      final String argSignature =
-          method.argType == 'void' ? '' : '${method.argType} arg';
-      indent.writeln('${method.returnType} ${method.name}($argSignature);');
+      final String returnType =
+          method.isAsynchronous ? 'void' : method.returnType;
+      final List<String> argSignature = <String>[];
+      if (method.argType != 'void') {
+        argSignature.add('${method.argType} arg');
+      }
+      if (method.isAsynchronous) {
+        argSignature.add('Result<${method.returnType}> result');
+      }
+      indent.writeln('$returnType ${method.name}(${argSignature.join(',')});');
     }
     indent.addln('');
     indent.writeln(
@@ -65,17 +81,26 @@ void _writeHostApi(Indent indent, Api api) {
                   'HashMap<String, HashMap> wrapped = new HashMap<>();');
               indent.write('try ');
               indent.scoped('{', '}', () {
-                String methodArgument;
-                if (argType == 'void') {
-                  methodArgument = '';
-                } else {
+                final List<String> methodArgument = <String>[];
+                if (argType != 'void') {
                   indent.writeln('@SuppressWarnings("ConstantConditions")');
                   indent.writeln(
                       '$argType input = $argType.fromMap((HashMap)message);');
-                  methodArgument = 'input';
+                  methodArgument.add('input');
                 }
-                final String call = 'api.${method.name}($methodArgument)';
-                if (method.returnType == 'void') {
+                if (method.isAsynchronous) {
+                  methodArgument.add(
+                    'result -> {'
+                    'wrapped.put("${Keys.result}", result.toMap());'
+                    'reply.reply(wrapped);'
+                    '}',
+                  );
+                }
+                final String call =
+                    'api.${method.name}(${methodArgument.join(',')})';
+                if (method.isAsynchronous) {
+                  indent.writeln('$call;');
+                } else if (method.returnType == 'void') {
                   indent.writeln('$call;');
                   indent.writeln('wrapped.put("${Keys.result}", null);');
                 } else {
@@ -88,8 +113,13 @@ void _writeHostApi(Indent indent, Api api) {
               indent.scoped('{', '}', () {
                 indent.writeln(
                     'wrapped.put("${Keys.error}", wrapError(exception));');
+                if (method.isAsynchronous) {
+                  indent.writeln('reply.reply(wrapped);');
+                }
               });
-              indent.writeln('reply.reply(wrapped);');
+              if (!method.isAsynchronous) {
+                indent.writeln('reply.reply(wrapped);');
+              }
             });
           });
           indent.scoped(null, '}', () {

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -231,8 +231,10 @@ class Pigeon {
       final List<Method> functions = <Method>[];
       for (DeclarationMirror declaration in apiMirror.declarations.values) {
         if (declaration is MethodMirror && !declaration.isConstructor) {
-          final bool isAsynchronous = declaration.metadata
-              .any((InstanceMirror it) => '${it.type.simpleName}' == '');
+          final bool isAsynchronous =
+              declaration.metadata.any((InstanceMirror it) {
+            return MirrorSystem.getName(it.type.simpleName) == '${async.runtimeType}';
+          });
           functions.add(Method()
             ..name = MirrorSystem.getName(declaration.simpleName)
             ..argType = declaration.parameters.isEmpty

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -27,6 +27,13 @@ const List<String> _validTypes = <String>[
   'Map',
 ];
 
+class _Asynchronous {
+  const _Asynchronous();
+}
+
+/// Metadata to annotate a Api method as asynchronous
+const _Asynchronous async = _Asynchronous();
+
 /// Metadata to annotate a Pigeon API implemented by the host-platform.
 ///
 /// The abstract class with this annotation groups a collection of Dart↔host
@@ -224,6 +231,8 @@ class Pigeon {
       final List<Method> functions = <Method>[];
       for (DeclarationMirror declaration in apiMirror.declarations.values) {
         if (declaration is MethodMirror && !declaration.isConstructor) {
+          final bool isAsynchronous = declaration.metadata
+              .any((InstanceMirror it) => '${it.type.simpleName}' == '');
           functions.add(Method()
             ..name = MirrorSystem.getName(declaration.simpleName)
             ..argType = declaration.parameters.isEmpty
@@ -231,7 +240,8 @@ class Pigeon {
                 : MirrorSystem.getName(
                     declaration.parameters[0].type.simpleName)
             ..returnType =
-                MirrorSystem.getName(declaration.returnType.simpleName));
+                MirrorSystem.getName(declaration.returnType.simpleName)
+            ..isAsynchronous = isAsynchronous);
         }
       }
       final HostApi hostApi = _getHostApi(apiMirror);

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -233,7 +233,8 @@ class Pigeon {
         if (declaration is MethodMirror && !declaration.isConstructor) {
           final bool isAsynchronous =
               declaration.metadata.any((InstanceMirror it) {
-            return MirrorSystem.getName(it.type.simpleName) == '${async.runtimeType}';
+            return MirrorSystem.getName(it.type.simpleName) ==
+                '${async.runtimeType}';
           });
           functions.add(Method()
             ..name = MirrorSystem.getName(declaration.simpleName)

--- a/packages/pigeon/pigeons/async_handlers.dart
+++ b/packages/pigeon/pigeons/async_handlers.dart
@@ -1,0 +1,21 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:pigeon/pigeon.dart';
+
+class Value {
+  int number;
+}
+
+@HostApi()
+abstract class Api2Host {
+  @async
+  Value calculate(Value value);
+}
+
+@FlutterApi()
+abstract class Api2Flutter {
+  @async
+  Value calculate(Value value);
+}

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -91,6 +91,7 @@ test_pigeon_android ./pigeons/void_arg_host.dart
 test_pigeon_android ./pigeons/void_arg_flutter.dart
 test_pigeon_android ./pigeons/list.dart
 test_pigeon_android ./pigeons/all_datatypes.dart
+test_pigeon_android ./pigeons/async_handlers.dart
 test_pigeon_ios ./pigeons/message.dart
 test_pigeon_ios ./pigeons/host2flutter.dart
 test_pigeon_ios ./pigeons/voidhost.dart
@@ -99,6 +100,8 @@ test_pigeon_ios ./pigeons/void_arg_host.dart
 test_pigeon_ios ./pigeons/void_arg_flutter.dart
 test_pigeon_ios ./pigeons/list.dart
 test_pigeon_ios ./pigeons/all_datatypes.dart
+# Not implemented yet.
+# test_pigeon_ios ./pigeons/async_handlers.dart
 
 ###############################################################################
 # Mock handler flutter tests.

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -237,4 +237,77 @@ void main() {
     final String code = sink.toString();
     expect(code, contains('// @dart = 2.8'));
   });
+
+  test('gen one async Flutter Api', () {
+    final Root root = Root(apis: <Api>[
+      Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'Output',
+          isAsynchronous: true,
+        )
+      ])
+    ], classes: <Class>[
+      Class(
+          name: 'Input',
+          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(
+          name: 'Output',
+          fields: <Field>[Field(name: 'output', dataType: 'String')])
+    ]);
+    final StringBuffer sink = StringBuffer();
+    generateDart(root, sink);
+    final String code = sink.toString();
+    expect(code, contains('abstract class Api'));
+    expect(code, contains('Future<Output> doSomething(Input arg);'));
+    expect(
+        code, contains('final Output output = await api.doSomething(input);'));
+  });
+
+  test('gen one async Host Api', () {
+    final Root root = Root(apis: <Api>[
+      Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'Output',
+          isAsynchronous: true,
+        )
+      ])
+    ], classes: <Class>[
+      Class(
+          name: 'Input',
+          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(
+          name: 'Output',
+          fields: <Field>[Field(name: 'output', dataType: 'String')])
+    ]);
+    final StringBuffer sink = StringBuffer();
+    generateDart(root, sink);
+    final String code = sink.toString();
+    expect(code, contains('class Api'));
+    expect(code, matches('Output.*doSomething.*Input'));
+  });
+
+  test('async host void argument', () {
+    final Root root = Root(apis: <Api>[
+      Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
+        Method(
+          name: 'doSomething',
+          argType: 'void',
+          returnType: 'Output',
+          isAsynchronous: true,
+        )
+      ])
+    ], classes: <Class>[
+      Class(
+          name: 'Output',
+          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+    ]);
+    final StringBuffer sink = StringBuffer();
+    generateDart(root, sink);
+    final String code = sink.toString();
+    expect(code, matches('channel\.send[(]null[)]'));
+  });
 }

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:pigeon/ast.dart';
+import 'package:pigeon/dart_generator.dart';
 import 'package:pigeon/generator_tools.dart';
 import 'package:test/test.dart';
-import 'package:pigeon/dart_generator.dart';
-import 'package:pigeon/ast.dart';
 
 void main() {
   test('gen one class', () {
@@ -29,7 +29,12 @@ void main() {
   test('gen one host api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Output')
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'Output',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -69,7 +74,12 @@ void main() {
   test('flutterapi', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Output')
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'Output',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -89,7 +99,12 @@ void main() {
   test('host void', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'void')
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'void',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -106,7 +121,12 @@ void main() {
   test('flutter void return', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'void')
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'void',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -124,7 +144,12 @@ void main() {
   test('flutter void argument', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'void', returnType: 'Output')
+        Method(
+          name: 'doSomething',
+          argType: 'void',
+          returnType: 'Output',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -141,7 +166,12 @@ void main() {
   test('host void argument', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'void', returnType: 'Output')
+        Method(
+          name: 'doSomething',
+          argType: 'void',
+          returnType: 'Output',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -161,8 +191,18 @@ void main() {
           location: ApiLocation.host,
           dartHostTestHandler: 'ApiMock',
           methods: <Method>[
-            Method(name: 'doSomething', argType: 'Input', returnType: 'Output'),
-            Method(name: 'voidReturner', argType: 'Input', returnType: 'void')
+            Method(
+              name: 'doSomething',
+              argType: 'Input',
+              returnType: 'Output',
+              isAsynchronous: false,
+            ),
+            Method(
+              name: 'voidReturner',
+              argType: 'Input',
+              returnType: 'void',
+              isAsynchronous: false,
+            )
           ])
     ], classes: <Class>[
       Class(

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -317,11 +317,11 @@ void main() {
     expect(code, contains('public interface Api'));
     expect(code, contains('public interface Result<T> {'));
     expect(
-        code, contains('void doSomething(Input arg,Result<Output> result);'));
+        code, contains('void doSomething(Input arg, Result<Output> result);'));
     expect(
         code,
         contains(
-            'api.doSomething(input,result -> {wrapped.put("result", result.toMap());reply.reply(wrapped);});'));
+            'api.doSomething(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });'));
     expect(code, contains('channel.setMessageHandler(null)'));
   });
 

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
-import 'package:pigeon/java_generator.dart';
 import 'package:pigeon/ast.dart';
+import 'package:pigeon/java_generator.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('gen one class', () {
@@ -52,7 +52,12 @@ void main() {
   test('gen one host api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Output')
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'Output',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -104,7 +109,12 @@ void main() {
   test('gen one flutter api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Output')
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'Output',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -126,7 +136,12 @@ void main() {
   test('gen host void api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'void')
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'void',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -145,7 +160,12 @@ void main() {
   test('gen flutter void return api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'void')
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'void',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -165,7 +185,12 @@ void main() {
   test('gen host void argument api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'void', returnType: 'Output')
+        Method(
+          name: 'doSomething',
+          argType: 'void',
+          returnType: 'Output',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(
@@ -184,7 +209,12 @@ void main() {
   test('gen flutter void argument api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'void', returnType: 'Output')
+        Method(
+          name: 'doSomething',
+          argType: 'void',
+          returnType: 'Output',
+          isAsynchronous: false,
+        )
       ])
     ], classes: <Class>[
       Class(

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -290,4 +290,65 @@ void main() {
     expect(code, contains('Nested.fromMap((HashMap)nested);'));
     expect(code, contains('put("nested", nested.toMap());'));
   });
+
+  test('gen one async Host Api', () {
+    final Root root = Root(apis: <Api>[
+      Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'Output',
+          isAsynchronous: true,
+        )
+      ])
+    ], classes: <Class>[
+      Class(
+          name: 'Input',
+          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(
+          name: 'Output',
+          fields: <Field>[Field(name: 'output', dataType: 'String')])
+    ]);
+    final StringBuffer sink = StringBuffer();
+    final JavaOptions javaOptions = JavaOptions();
+    javaOptions.className = 'Messages';
+    generateJava(javaOptions, root, sink);
+    final String code = sink.toString();
+    expect(code, contains('public interface Api'));
+    expect(code, contains('public interface Result<T> {'));
+    expect(
+        code, contains('void doSomething(Input arg,Result<Output> result);'));
+    expect(
+        code,
+        contains(
+            'api.doSomething(input,result -> {wrapped.put("result", result.toMap());reply.reply(wrapped);});'));
+    expect(code, contains('channel.setMessageHandler(null)'));
+  });
+
+  test('gen one async Flutter Api', () {
+    final Root root = Root(apis: <Api>[
+      Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'Output',
+          isAsynchronous: true,
+        )
+      ])
+    ], classes: <Class>[
+      Class(
+          name: 'Input',
+          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(
+          name: 'Output',
+          fields: <Field>[Field(name: 'output', dataType: 'String')])
+    ]);
+    final StringBuffer sink = StringBuffer();
+    final JavaOptions javaOptions = JavaOptions();
+    javaOptions.className = 'Messages';
+    generateJava(javaOptions, root, sink);
+    final String code = sink.toString();
+    expect(code, contains('public static class Api'));
+    expect(code, matches('doSomething.*Input.*Output'));
+  });
 }


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/64810

`Usage:` Just add an `async` annotation above methods to make them asynchronous.

```dart
@FlutterApi()
abstract class TestFlutterApi {
  @async
  UserResult getUser();
}
```
This code here generates 

```java
abstract class TestFlutterApi {
  Future<UserResult> getUser();
  static void setup(TestFlutterApi api) {
    {
      const BasicMessageChannel<dynamic> channel =
          BasicMessageChannel<dynamic>('dev.flutter.pigeon.TestFlutterApi.getUser', StandardMessageCodec());
      channel.setMessageHandler((dynamic message) async {
        final UserResult output = await api.getUser();
        return output._toMap();
      });
    }
  }
}
```