### PR TITLE
[pigeon] support nested value in @FlutterApi for --java_out, just like what objc does.

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixed Dart compilation for later versions that support null safety, opting out
   of it for now.
+* Fixed nested types in the Java runtime.
 
 ## 0.1.6
 

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -178,6 +178,9 @@ String _castObject(Field field, List<Class> classes, String varName) {
       getHostDatatype(field, classes, _javaTypeForDartType);
   if (field.dataType == 'int') {
     return '($varName == null) ? null : (($varName instanceof Integer) ? (Integer)$varName : (${hostDatatype.datatype})$varName)';
+  } else if (!hostDatatype.isBuiltin &&
+      classes.map((Class x) => x.name).contains(field.dataType)) {
+    return '${hostDatatype.datatype}.fromMap((HashMap)$varName)';
   } else {
     return '(${hostDatatype.datatype})$varName';
   }

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -189,6 +189,8 @@ String _castObject(Field field, List<Class> classes, String varName) {
 /// Generates the ".java" file for the AST represented by [root] to [sink] with the
 /// provided [options].
 void generateJava(JavaOptions options, Root root, StringSink sink) {
+  final Set<String> rootClassNameSet =
+      root.classes.map((Class x) => x.name).toSet();
   final Indent indent = Indent(sink);
   indent.writeln('// $generatedCodeWarning');
   indent.writeln('// $seeAlsoWarning');
@@ -230,7 +232,16 @@ void generateJava(JavaOptions options, Root root, StringSink sink) {
           indent.writeln(
               'HashMap<String, Object> toMapResult = new HashMap<>();');
           for (Field field in klass.fields) {
-            indent.writeln('toMapResult.put("${field.name}", ${field.name});');
+            final HostDatatype hostDatatype =
+                getHostDatatype(field, root.classes, _javaTypeForDartType);
+            String toWriteValue = '';
+            if (!hostDatatype.isBuiltin &&
+                rootClassNameSet.contains(field.dataType)) {
+              toWriteValue = '${field.name}.toMap()';
+            } else {
+              toWriteValue = field.name;
+            }
+            indent.writeln('toMapResult.put("${field.name}", $toWriteValue);');
           }
           indent.writeln('return toMapResult;');
         });

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -239,11 +239,7 @@ void main() {
           ..dataType = 'Nested'
       ];
     final Class nestedClass = Class()
-<<<<<<< HEAD
       ..name = 'Nested'
-=======
-      ..name = "Nested"
->>>>>>> [pigeon] nested value test
       ..fields = <Field>[
         Field()
           ..name = 'data'

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -239,7 +239,7 @@ void main() {
           ..dataType = 'Nested'
       ];
     final Class nestedClass = Class()
-      ..name = "Nested"
+      ..name = 'Nested'
       ..fields = <Field>[
         Field()
           ..name = 'data'

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -229,4 +229,36 @@ void main() {
     expect(code, contains('public static class Foobar'));
     expect(code, contains('private HashMap field1;'));
   });
+
+  test('gen nested', () {
+    final Class klass = Class()
+      ..name = 'Outer'
+      ..fields = <Field>[
+        Field()
+          ..name = 'nested'
+          ..dataType = 'Nested'
+      ];
+    final Class nestedClass = Class()
+      ..name = "Nested"
+      ..fields = <Field>[
+        Field()
+          ..name = 'data'
+          ..dataType = 'int'
+      ];
+    final Root root = Root()
+      ..apis = <Api>[]
+      ..classes = <Class>[klass, nestedClass];
+    final StringBuffer sink = StringBuffer();
+    final JavaOptions javaOptions = JavaOptions();
+    javaOptions.className = 'Messages';
+    generateJava(javaOptions, root, sink);
+    final String code = sink.toString();
+    expect(code, contains('public class Messages'));
+    expect(code, contains('public static class Outer'));
+    expect(code, contains('public static class Nested'));
+    expect(code, contains('private Nested nested;'));
+    expect(
+        code, contains('Nested.fromMap((HashMap)nested);')); // outer fromMap
+    expect(code, contains('put("nested", nested.toMap());')); // outer toMap
+  });
 }

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -239,7 +239,11 @@ void main() {
           ..dataType = 'Nested'
       ];
     final Class nestedClass = Class()
+<<<<<<< HEAD
       ..name = 'Nested'
+=======
+      ..name = "Nested"
+>>>>>>> [pigeon] nested value test
       ..fields = <Field>[
         Field()
           ..name = 'data'

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -257,8 +257,7 @@ void main() {
     expect(code, contains('public static class Outer'));
     expect(code, contains('public static class Nested'));
     expect(code, contains('private Nested nested;'));
-    expect(
-        code, contains('Nested.fromMap((HashMap)nested);')); // outer fromMap
-    expect(code, contains('put("nested", nested.toMap());')); // outer toMap
+    expect(code, contains('Nested.fromMap((HashMap)nested);'));
+    expect(code, contains('put("nested", nested.toMap());'));
   });
 }


### PR DESCRIPTION
for class like
```dart
class Nested {}
class A{
  Nested nested;
}
```
The generated Java codes are like 
```
static A fromMap(HashMap map) {
  // ...
  Object nested = map.get("nested");
  fromMapresult.nested = (Nested)nested;
}
```
While map.get("nested") actually get a HashMap, and this cast will get a ClassCastException.
What we hope is
`fromMapresult.nested = Nested.fromMap((HashMap)nested);`,
and it's already done in objc_generator.dart