### PR TITLE
[pigeon] switched to using isolates instead of subprocesses to run pigeon_lib

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.8
+
+* Started spawning pigeon_lib in an isolate instead of a subprocess.  The
+  subprocess could have lead to errors if the dart version on $PATH didn't match
+  the one that comes with flutter.
+
 ## 0.1.7
 
 * Fixed Dart compilation for later versions that support null safety, opting out

--- a/packages/pigeon/bin/pigeon.dart
+++ b/packages/pigeon/bin/pigeon.dart
@@ -14,7 +14,7 @@ Future<void> main(List<String> args) async {
   final String rawInputPath = opts.input;
   final Directory tempDir = Directory.systemTemp.createTempSync();
   final String absInputPath = File(rawInputPath).absolute.path;
-  final String relInputPath = path.relative(absInputPath, from:tempDir.path);
+  final String relInputPath = path.relative(absInputPath, from: tempDir.path);
 
   final String importLine =
       (opts.input != null) ? 'import \'$relInputPath\';\n' : '';
@@ -27,8 +27,7 @@ void main(List<String> args, SendPort sendPort) async {
   sendPort.send(await Pigeon.run(args));
 }
 """;
-  final String tempFilename =
-      path.join(tempDir.path, '_pigeon_temp_.dart');
+  final String tempFilename = path.join(tempDir.path, '_pigeon_temp_.dart');
   await File(tempFilename).writeAsString(code);
   final ReceivePort receivePort = ReceivePort();
   Isolate.spawnUri(Uri.parse(tempFilename), args, receivePort.sendPort);

--- a/packages/pigeon/bin/pigeon.dart
+++ b/packages/pigeon/bin/pigeon.dart
@@ -23,7 +23,8 @@ void main(List<String> args, SendPort sendPort) async {
 }
 """;
   // TODO(aaclarke): Start using a system temp file.
-  final String tempFilename = path.join(Directory.current.path, '_pigeon_temp_.dart');
+  final String tempFilename =
+      path.join(Directory.current.path, '_pigeon_temp_.dart');
   final File tempFile = await File(tempFilename).writeAsString(code);
   final ReceivePort receivePort = ReceivePort();
   Isolate.spawnUri(Uri.parse(tempFilename), args, receivePort.sendPort);

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon.
-const String pigeonVersion = '0.1.7';
+const String pigeonVersion = '0.1.8';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pigeon
-version: 0.1.7
+version: 0.1.8
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 homepage: https://github.com/flutter/packages/tree/master/packages/pigeon
 dependencies:


### PR DESCRIPTION
Started spawning pigeon_lib in an isolate instead of a subprocess.  The subprocess could have lead to errors if the dart version on $PATH didn't match the one that comes with Flutter when running through `flutter pub run`.