### PR TITLE
Remove unused dart:async import

### DIFF
--- a/packages/palette_generator/CHANGELOG.md
+++ b/packages/palette_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4+1
+
+* Removed a `dart:async` import that isn't required for \>=Dart 2.1.
+
 ## 0.2.4
 
 * Fix PaletteGenerator.fromImageProvider region not scaled to fit image size.

--- a/packages/palette_generator/pubspec.yaml
+++ b/packages/palette_generator/pubspec.yaml
@@ -1,7 +1,7 @@
 name: palette_generator
 description: Flutter package for generating palette colors from a source image.
 homepage: https://github.com/flutter/packages/tree/master/packages/palette_generator
-version: 0.2.4
+version: 0.2.4+1
 
 dependencies:
   flutter:

--- a/packages/palette_generator/test/palette_generator_test.dart
+++ b/packages/palette_generator/test/palette_generator_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui show Image, Codec, FrameInfo, instantiateImageCodec;


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core