### PR TITLE
[pigeon] Suppress more warnings on the java side

### DIFF
--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -238,7 +238,7 @@ void generateJava(JavaOptions options, Root root, StringSink sink) {
   indent.addln('');
   assert(options.className != null);
   indent.writeln('/** Generated class from Pigeon. */');
-  indent.writeln('@SuppressWarnings("unused")');
+  indent.writeln('@SuppressWarnings({"rawtypes", "unused", "CodeBlock2Expr", "ConstantConditions"})');
   indent.write('public class ${options.className} ');
   indent.scoped('{', '}', () {
     for (Class klass in root.classes) {


### PR DESCRIPTION
At the moment, Pigeon will still generate code with a bunch of warnings which pollute IDE's warning lists. This should ignore all the extra warnings.