### PR TITLE
[pigeon] Fix on Windows

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.10
+
+* Fixed bug that prevented running `pigeon` on Windows (introduced in `0.1.8`).
+
 ## 0.1.9
 
 * Fixed bug where executing pigeon without arguments would crash (introduced in 0.1.8).

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon.
-const String pigeonVersion = '0.1.9';
+const String pigeonVersion = '0.1.10';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pigeon
-version: 0.1.9
+version: 0.1.10
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 homepage: https://github.com/flutter/packages/tree/master/packages/pigeon
 dependencies:


### PR DESCRIPTION
Fixes pigeon on Windows.

This also still works on Unix systems due to the nature of [`Uri.file`](https://api.dart.dev/stable/2.10.0/dart-core/Uri/Uri.file.html):

> This path is interpreted using either Windows or non-Windows semantics.

>With non-Windows semantics the slash (/) is used to separate path segments in the input path.

>With Windows semantics, backslash (\) and forward-slash (/) are used to separate path segments in the input path, except if the path starts with \\?\ in which case only backslash (\) separates path segments in path.

---

Closes flutter/flutter#67227.