### PR TITLE
Migrate SnackBar methods to ScaffoldMessenger

### DIFF
--- a/packages/animations/example/lib/container_transition.dart
+++ b/packages/animations/example/lib/container_transition.dart
@@ -49,11 +49,10 @@ class OpenContainerTransformDemo extends StatefulWidget {
 class _OpenContainerTransformDemoState
     extends State<OpenContainerTransformDemo> {
   ContainerTransitionType _transitionType = ContainerTransitionType.fade;
-  final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
 
   void _showMarkedAsDoneSnackbar(bool isMarkedAsDone) {
     if (isMarkedAsDone ?? false)
-      scaffoldKey.currentState.showSnackBar(const SnackBar(
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
         content: Text('Marked as done!'),
       ));
   }
@@ -111,7 +110,6 @@ class _OpenContainerTransformDemoState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      key: scaffoldKey,
       appBar: AppBar(
         title: const Text('Container transform'),
         actions: <Widget>[


### PR DESCRIPTION
cc/ @goderbauer contact for https://github.com/flutter/tests/blob/master/registry/flutter_packages.test

flutter/flutter#66504 introduced the ScaffoldMessenger widget, which allows for persistent SnackBars across Scaffolds, as well as easier management of asynchronous SnackBars. The original SnackBar methods in Scaffold are going to be deprecated. Test failures were identified in this repository in flutter/flutter#67947, so this PR is intended to migrate to the new API.

Full Migration Guide:
flutter/website#4527

References:
flutter/flutter#62921
flutter/flutter#57218