### PR TITLE
Updated obsolete button references

### DIFF
--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -81,7 +81,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                RaisedButton(
+                ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -90,12 +90,10 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                       },
                     );
                   },
-                  color: Theme.of(context).colorScheme.primary,
-                  textColor: Theme.of(context).colorScheme.onPrimary,
                   child: const Text('SHOW MODAL'),
                 ),
                 const SizedBox(width: 10),
-                RaisedButton(
+                ElevatedButton(
                   onPressed: () {
                     if (_isAnimationRunningForwardsOrComplete) {
                       _controller.reverse();
@@ -103,8 +101,6 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                       _controller.forward();
                     }
                   },
-                  color: Theme.of(context).colorScheme.primary,
-                  textColor: Theme.of(context).colorScheme.onPrimary,
                   child: _isAnimationRunningForwardsOrComplete
                       ? const Text('HIDE FAB')
                       : const Text('SHOW FAB'),
@@ -124,13 +120,13 @@ class _ExampleAlertDialog extends StatelessWidget {
     return AlertDialog(
       content: const Text('Alert Dialog'),
       actions: <Widget>[
-        FlatButton(
+        TextButton(
           onPressed: () {
             Navigator.of(context).pop();
           },
           child: const Text('CANCEL'),
         ),
-        FlatButton(
+        TextButton(
           onPressed: () {
             Navigator.of(context).pop();
           },

--- a/packages/animations/example/lib/shared_axis_transition.dart
+++ b/packages/animations/example/lib/shared_axis_transition.dart
@@ -62,16 +62,12 @@ class _SharedAxisTransitionDemoState extends State<SharedAxisTransitionDemo> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: <Widget>[
-                  FlatButton(
+                  TextButton(
                     onPressed: _isLoggedIn ? _toggleLoginStatus : null,
-                    textColor: Theme.of(context).colorScheme.primary,
                     child: const Text('BACK'),
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: _isLoggedIn ? null : _toggleLoginStatus,
-                    color: Theme.of(context).colorScheme.primary,
-                    textColor: Theme.of(context).colorScheme.onPrimary,
-                    disabledColor: Colors.black12,
                     child: const Text('NEXT'),
                   ),
                 ],
@@ -229,17 +225,15 @@ class _SignInPage extends StatelessWidget {
                 ),
                 Padding(
                   padding: const EdgeInsets.only(left: 10.0),
-                  child: FlatButton(
+                  child: TextButton(
                     onPressed: () {},
-                    textColor: Theme.of(context).colorScheme.primary,
                     child: const Text('FORGOT EMAIL?'),
                   ),
                 ),
                 Padding(
                   padding: const EdgeInsets.only(left: 10.0),
-                  child: FlatButton(
+                  child: TextButton(
                     onPressed: () {},
-                    textColor: Theme.of(context).colorScheme.primary,
                     child: const Text('CREATE ACCOUNT'),
                   ),
                 ),

--- a/packages/animations/lib/src/fade_scale_transition.dart
+++ b/packages/animations/lib/src/fade_scale_transition.dart
@@ -26,7 +26,7 @@ import 'modal.dart';
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
 ///       body: Center(
-///         child: RaisedButton(
+///         child: ElevatedButton(
 ///           onPressed: () {
 ///             showModal(
 ///               context: context,

--- a/packages/animations/lib/src/fade_through_transition.dart
+++ b/packages/animations/lib/src/fade_through_transition.dart
@@ -37,7 +37,7 @@ import 'dual_transition_builder.dart' as dual_transition_builder;
 ///       return Container(
 ///         color: Colors.red,
 ///         child: Center(
-///           child: MaterialButton(
+///           child: TextButton(
 ///             child: Text('Push route'),
 ///             onPressed: () {
 ///               Navigator.of(context).pushNamed('/a');
@@ -50,7 +50,7 @@ import 'dual_transition_builder.dart' as dual_transition_builder;
 ///       return Container(
 ///         color: Colors.blue,
 ///         child: Center(
-///           child: MaterialButton(
+///           child: TextButton(
 ///             child: Text('Pop route'),
 ///             onPressed: () {
 ///               Navigator.of(context).pop();

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -59,7 +59,7 @@ enum SharedAxisTransitionType {
 ///       return Container(
 ///         color: Colors.red,
 ///         child: Center(
-///           child: RaisedButton(
+///           child: ElevatedButton(
 ///             child: Text('Push route'),
 ///             onPressed: () {
 ///               Navigator.of(context).pushNamed('/a');
@@ -72,7 +72,7 @@ enum SharedAxisTransitionType {
 ///       return Container(
 ///         color: Colors.blue,
 ///         child: Center(
-///           child: RaisedButton(
+///           child: ElevatedButton(
 ///             child: Text('Pop route'),
 ///             onPressed: () {
 ///               Navigator.of(context).pop();

--- a/packages/animations/test/fade_scale_transition_test.dart
+++ b/packages/animations/test/fade_scale_transition_test.dart
@@ -17,7 +17,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -34,7 +34,7 @@ void main() {
           ),
         ),
       );
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
       expect(find.byType(_FlutterLogoModal), findsOneWidget);
     },
@@ -49,7 +49,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -66,7 +66,7 @@ void main() {
           ),
         ),
       );
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pump();
       // Opacity duration: First 30% of 150ms, linear transition
       double topFadeTransitionOpacity = _getOpacity(key, tester);
@@ -117,7 +117,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -135,7 +135,7 @@ void main() {
         ),
       );
       // Show the incoming modal and let it animate in fully.
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
       // Tap on modal barrier to start reverse animation.
@@ -182,7 +182,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -200,7 +200,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pump();
       // Opacity duration: First 30% of 150ms, linear transition
       double topFadeTransitionOpacity = _getOpacity(key, tester);
@@ -283,7 +283,7 @@ void main() {
               return Center(
                 child: Column(
                   children: <Widget>[
-                    RaisedButton(
+                    ElevatedButton(
                       onPressed: () {
                         showModal<void>(
                           context: context,
@@ -318,7 +318,7 @@ void main() {
       expect(bottomState.widget.name, 'bottom route');
 
       // Start the enter transition of the modal route.
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pump();
       await tester.pump();
 

--- a/packages/animations/test/modal_test.dart
+++ b/packages/animations/test/modal_test.dart
@@ -16,7 +16,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -33,7 +33,7 @@ void main() {
           ),
         ),
       );
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
       // New route containing _FlutterLogoModal is present.
@@ -58,7 +58,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -77,7 +77,7 @@ void main() {
       );
 
       // Start forwards animation
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pump();
 
       // Opacity duration: Linear transition throughout 300ms
@@ -108,7 +108,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -127,7 +127,7 @@ void main() {
       );
 
       // Start forwards animation
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
       expect(find.byType(_FlutterLogoModal), findsOneWidget);
 
@@ -162,7 +162,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -178,7 +178,7 @@ void main() {
           ),
         ),
       );
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
       // New route containing _FlutterLogoModal is present.
@@ -204,7 +204,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -222,7 +222,7 @@ void main() {
       );
 
       // Start forwards animation
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pump();
 
       // Opacity duration: First 30% of 150ms, linear transition
@@ -275,7 +275,7 @@ void main() {
           home: Scaffold(
             body: Builder(builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   onPressed: () {
                     showModal<void>(
                       context: context,
@@ -293,7 +293,7 @@ void main() {
       );
 
       // Start forwards animation
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
       expect(find.byType(_FlutterLogoModal), findsOneWidget);
 
@@ -345,7 +345,7 @@ void main() {
               return Center(
                 child: Column(
                   children: <Widget>[
-                    RaisedButton(
+                    ElevatedButton(
                       onPressed: () {
                         showModal<void>(
                           context: context,
@@ -379,7 +379,7 @@ void main() {
       expect(bottomState.widget.name, 'bottom route');
 
       // Start the enter transition of the modal route.
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
       await tester.pump();
       await tester.pump();
 

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1804,7 +1804,7 @@ class __RemoveOpenContainerExampleState
                 Column(
               children: <Widget>[
                 const Text('Closed'),
-                RaisedButton(
+                ElevatedButton(
                   onPressed: action,
                   child: const Text('Open the container'),
                 ),
@@ -1813,11 +1813,11 @@ class __RemoveOpenContainerExampleState
             openBuilder: (BuildContext context, VoidCallback action) => Column(
               children: <Widget>[
                 const Text('Open'),
-                RaisedButton(
+                ElevatedButton(
                   onPressed: action,
                   child: const Text('Close the container'),
                 ),
-                RaisedButton(
+                ElevatedButton(
                     onPressed: () {
                       setState(() {
                         removeOpenContainerWidget = true;


### PR DESCRIPTION
Replaced obsolete example references to RaisedButton, FlatButton, and MaterialButton per https://github.com/flutter/flutter/pull/59702.