### PR TITLE
Flush logger IOSink.

### DIFF
--- a/packages/fuchsia_ctl/CHANGELOG.md
+++ b/packages/fuchsia_ctl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## version:0.0.27
+
+- Flush the content of iosink when writing output to a file.
+
 ## version:0.0.26
 
 - Replace amberctl with pkgctl.

--- a/packages/fuchsia_ctl/lib/src/logger.dart
+++ b/packages/fuchsia_ctl/lib/src/logger.dart
@@ -108,6 +108,12 @@ class PrintLogger implements Logger {
       out.writeln('$message');
     }
   }
+
+  /// Flushes the IOSink to ensure all the data is written. This is specially
+  /// useful when writing to a file.
+  Future<void> flush() async {
+    await out.flush();
+  }
 }
 
 /// Transforms a [message] with [level] to a string that contains the DateTime,

--- a/packages/fuchsia_ctl/lib/src/ssh_client.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_client.dart
@@ -146,6 +146,9 @@ class SshClient {
       stdoutSubscription.asFuture<void>(),
       stderrSubscription.asFuture<void>(),
     ]);
+
+    await logger.flush();
+
     // The streams as futures have already completed, so waiting for the
     // potentially async stream cancellation to complete likely has no benefit.
     stdoutSubscription.cancel();

--- a/packages/fuchsia_ctl/test/logger_test.dart
+++ b/packages/fuchsia_ctl/test/logger_test.dart
@@ -18,7 +18,7 @@ void main() {
     logger.info('cdf');
     logger.warning('gh');
     logger.error('jk');
-    await data.flush();
+    await logger.flush();
     final String content = fs.file('log.txt').readAsStringSync();
     expect(content, contains('ERROR jk'));
     expect(content, contains('INFO cdf'));
@@ -48,7 +48,7 @@ void main() {
     logger.info('cdf');
     logger.warning('gh');
     logger.error('jk');
-    await data.flush();
+    await logger.flush();
     final String content = fs.file('log.txt').readAsStringSync();
     expect(content, contains('ERROR jk'));
     expect(content, contains('INFO cdf'));


### PR DESCRIPTION
If we are writing to a file sometimes the content is incomplete because
not all the output has been written to the file.

Bug:
  https://github.com/flutter/flutter/issues/67942