### PR TITLE
_OpenContainerRoute extends PageRoute

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -393,7 +393,7 @@ class _HideableState extends State<_Hideable> {
   }
 }
 
-class _OpenContainerRoute<T> extends ModalRoute<T> {
+class _OpenContainerRoute<T> extends PageRoute<T> {
   _OpenContainerRoute({
     @required this.closedColor,
     @required this.openColor,


### PR DESCRIPTION
Change _OpenContainerRoute to extends PageRoute.
When extending ModalRoute the hero animations are not working, because hero checks for PageRoute.

Issue: #flutter/flutter#51337