### PR TITLE
Better error messages in web_benchmarks

### DIFF
--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Improve console messages.
+
 ## 0.0.1 - Initial release.
 
 * Provide a benchmark server (host-side) and a benchmark client (browser-side).

--- a/packages/web_benchmarks/lib/client.dart
+++ b/packages/web_benchmarks/lib/client.dart
@@ -9,6 +9,7 @@ import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
 
+import 'src/common.dart';
 import 'src/recorder.dart';
 export 'src/recorder.dart';
 
@@ -278,7 +279,7 @@ class LocalBenchmarkServerClient {
     // 404 is expected in the following cases:
     // - The benchmark is ran using plain `flutter run`, which does not provide "next-benchmark" handler.
     // - We ran all benchmarks and the benchmark is telling us there are no more benchmarks to run.
-    if (request.status == 404) {
+    if (request.responseText == kEndOfBenchmarks || request.status == 404) {
       isInManualMode = true;
       return kManualFallback;
     }

--- a/packages/web_benchmarks/lib/client.dart
+++ b/packages/web_benchmarks/lib/client.dart
@@ -276,9 +276,8 @@ class LocalBenchmarkServerClient {
       sendData: json.encode(_benchmarks.keys.toList()),
     );
 
-    // 404 is expected in the following cases:
-    // - The benchmark is ran using plain `flutter run`, which does not provide "next-benchmark" handler.
-    // - We ran all benchmarks and the benchmark is telling us there are no more benchmarks to run.
+    // `kEndOfBenchmarks` is expected when the benchmark server is telling us there are no more benchmarks to run.
+    // 404 is expected when the benchmark is run using plain `flutter run`, which does not provide "next-benchmark" handler.
     if (request.responseText == kEndOfBenchmarks || request.status == 404) {
       isInManualMode = true;
       return kManualFallback;

--- a/packages/web_benchmarks/lib/src/common.dart
+++ b/packages/web_benchmarks/lib/src/common.dart
@@ -10,3 +10,7 @@ library web_benchmarks.common;
 
 /// The number of samples we use to collect statistics from.
 const int kMeasuredSampleCount = 100;
+
+/// A special value returned by the `/next-benchmark` HTTP POST request when
+/// all benchmarks have run and there are no more benchmarks to run.
+const String kEndOfBenchmarks = '__end_of_benchmarks__';

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_benchmarks
 description: A benchmark harness for performance-testing Flutter apps in Chrome.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/flutter/packages/tree/master/packages/web_benchmarks
 
 environment:


### PR DESCRIPTION
Reorder request handlers such that static files go first. Only print a warning about unrecognized URLs after all handlers returned 404. Do not use HTTP 404 to signal "end of benchmarks" (to avoid printing the warning).

This makes the output from successful runs much less noisy.