### PR TITLE
Fix tree by setting SDK bounds for palette_generator example

### DIFF
--- a/packages/palette_generator/example/pubspec.yaml
+++ b/packages/palette_generator/example/pubspec.yaml
@@ -3,6 +3,8 @@ description: A simple example of how to use the PaletteGenerator to load the pal
 
 version: 0.1.0
 
+publish_to: none
+
 dependencies:
   cupertino_icons: ^0.1.2
   flutter:
@@ -19,4 +21,5 @@ flutter:
   assets:
    - assets/landscape.png
 
-
+environment:
+  sdk: ">=2.2.0 <3.0.0"


### PR DESCRIPTION
Without the constraints it will be analyzed in null-safe mode, but the code has not been migrated yet.

Failure: https://cirrus-ci.com/task/5483229580886016