### PR TITLE
Update CI for nnbd branch

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
-# Last updated 10/22/2020 (to rebuild the docker image, update this timestamp)
-FROM cirrusci/flutter:stable-web
+# Last updated 11/26/2020 (to rebuild the docker image, update this timestamp)
+FROM cirrusci/flutter:dev
 
 RUN sudo apt-get update && \
     sudo apt-get upgrade --yes && \
@@ -9,6 +9,7 @@ RUN sudo apt-get update && \
 # This must occur after the install of gpg-agent
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
     sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" && \
+    sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ xenial main" && \
     sudo apt-get update && \
     sudo apt-get install --yes --allow-unauthenticated clang-format-5.0 && \
     sudo apt-get clean --yes

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,9 +5,9 @@ task:
     cpu: 4
     memory: 8G
   upgrade_script:
-    - flutter channel master
+    - flutter channel dev
     - flutter upgrade
-    - git fetch origin master
+    - git fetch origin nnbd
   activate_script: pub global activate flutter_plugin_tools
   matrix:
     - name: analyze
@@ -31,16 +31,18 @@ task:
         - ./script/incremental_build.sh java-test  # must come after apk build
       depends_on:
         - analyze
-    - name: web_benchmarks_test
-      script:
-        - ./script/install_chromium.sh
-        - export CHROME_EXECUTABLE=$(pwd)/.chromium/chrome-linux/chrome
-        - flutter config --enable-web
-        - cd packages/web_benchmarks/testing/test_app
-        - flutter packages get
-        - cd ../..
-        - flutter packages get
-        - dart testing/web_benchmarks_test.dart
+    # TODO(shihaohong): Skip because new builds do not contain Chromium:
+    # https://github.com/cirruslabs/docker-images-flutter/issues/66
+    # - name: web_benchmarks_test
+    #   script:
+    #     - ./script/install_chromium.sh
+    #     - export CHROME_EXECUTABLE=$(pwd)/.chromium/chrome-linux/chrome
+    #     - flutter config --enable-web
+    #     - cd packages/web_benchmarks/testing/test_app
+    #     - flutter packages get
+    #     - cd ../..
+    #     - flutter packages get
+    #     - dart testing/web_benchmarks_test.dart
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'


### PR DESCRIPTION
This PR makes the following changes to unblock the `animations` package migration to NNBD (https://github.com/flutter/packages/pull/245):
1) Updates the version of flutter for our Docker image to use the `dev` branch. This is necessary because NNBD is not in `flutter/stable` yet. I chose `dev` over `beta` because it'll contain more recent updates to the NNBD migration efforts in `flutter/flutter`.
2) Update `upgrade_script` in `cirrus.yml` to use the flutter `dev` channel, as well as `fetch` from the `flutter/packages:nnbd` branch instead of master.
3) Comment out running `web_benchmark_tests` from `cirrus.yml`. Unfortunately, Docker web builds are blocked because of a problem with installing Chromium: https://github.com/cirruslabs/docker-images-flutter/issues/66
4) Adds the following deb repository in the CI Dockerfile: `http://archive.ubuntu.com/ubuntu/ xenial main`. 

Without 4), there is a dependency issue [as seen in this test run](https://cirrus-ci.com/task/4587489782398976?command=build#L743):
```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
 clang-format-5.0 : Depends: libllvm5.0 (= 1:5.0.2~svn328729-1~exp1~20180509124008.99) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - &&     sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" &&     sudo apt-get update &&     sudo apt-get install --yes --allow-unauthenticated clang-format-5.0 &&     sudo apt-get clean --yes' returned a non-zero code: 100
``` 

When just modifying the Dockerfile to use `sudo apt-get install --yes --allow-unauthenticated clang-format-5.0 libllvm5.0`, it still results in the following issue:
```
Package libffi6 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
E: Package libffi6 has no installation candidate
```

So, I added an archived Ubuntu repository that contains the `libffi6` package to resolve this dependency problem.
