### PR TITLE
[pigeon] fix async DartApi methods with void return

### DIFF
--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -148,7 +148,11 @@ void _writeFlutterApi(
                 call = 'api.${func.name}(input)';
               }
               if (returnType == 'void') {
-                indent.writeln('$call;');
+                if (isAsync) {
+                  indent.writeln('await $call;');
+                } else {
+                  indent.writeln('$call;');
+                }
                 indent.writeln(emptyReturnStatement);
               } else {
                 if (isAsync) {

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -194,7 +194,7 @@ xcodebuild \
   -scheme RunnerTests \
   -sdk iphonesimulator \
   -destination 'platform=iOS Simulator,name=iPhone 8' \
-  test | xcpretty
+  test
 popd
 
 ###############################################################################

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -310,7 +310,6 @@ void main() {
     expect(code, isNot(contains('._toMap()')));
   });
 
-
   test('gen one async Host Api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -284,6 +284,33 @@ void main() {
         code, contains('final Output output = await api.doSomething(input);'));
   });
 
+  test('gen one async Flutter Api with void return', () {
+    final Root root = Root(apis: <Api>[
+      Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
+        Method(
+          name: 'doSomething',
+          argType: 'Input',
+          returnType: 'void',
+          isAsynchronous: true,
+        )
+      ])
+    ], classes: <Class>[
+      Class(
+          name: 'Input',
+          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(
+          name: 'Output',
+          fields: <Field>[Field(name: 'output', dataType: 'String')])
+    ]);
+    final StringBuffer sink = StringBuffer();
+    generateDart(DartOptions(), root, sink);
+    final String code = sink.toString();
+    expect(code, isNot(matches('=.*doSomething')));
+    expect(code, contains('await api.doSomething('));
+    expect(code, isNot(contains('._toMap()')));
+  });
+
+
   test('gen one async Host Api', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[


### PR DESCRIPTION
Currently only DartApi methods that return any value work with `@async`. Void method do not generate `await` statement.

This PR fixes that issue.