### PR TITLE
Fix OpenContainer source(closed) widget staying hidden when the OpenContainer route is removed when the OpenContainer route is pushed from a different Route

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -620,16 +620,10 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
       _currentAnimationStatus = status;
       switch (status) {
         case AnimationStatus.dismissed:
-          if (hideableKey?.currentState != null) {
-            hideableKey.currentState
-              ..placeholderSize = null
-              ..isVisible = true;
-          }
+          _toggleHideable(hide: false);
           break;
         case AnimationStatus.completed:
-          hideableKey.currentState
-            ..placeholderSize = null
-            ..isVisible = false;
+          _toggleHideable(hide: true);
           break;
         case AnimationStatus.forward:
         case AnimationStatus.reverse:
@@ -647,6 +641,25 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
       delayForSourceRoute: true,
     );
     return super.didPop(result);
+  }
+
+  @override
+  void dispose() {
+    if (hideableKey?.currentState?.isVisible == false) {
+      // Route may be disposed without dismissing the animation if it is
+      // removed by the navigator.
+      SchedulerBinding.instance
+          .addPostFrameCallback((Duration d) => _toggleHideable(hide: false));
+    }
+    super.dispose();
+  }
+
+  void _toggleHideable({bool hide}) {
+    if (hideableKey?.currentState != null) {
+      hideableKey.currentState
+        ..placeholderSize = null
+        ..isVisible = !hide;
+    }
   }
 
   void _takeMeasurements({

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -646,7 +646,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
   @override
   void dispose() {
     if (hideableKey?.currentState?.isVisible == false) {
-      // Route may be disposed without dismissing the animation if it is
+      // This route may be disposed without dismissing its animation if it is
       // removed by the navigator.
       SchedulerBinding.instance
           .addPostFrameCallback((Duration d) => _toggleHideable(hide: false));

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1733,6 +1733,46 @@ void main() {
       expect(modalRoute.settings, routeSettings);
     },
   );
+
+  testWidgets(
+    'OpenContainer works when the route is removed',
+        (WidgetTester tester) async {
+
+      final Widget openContainer = OpenContainer(
+        closedBuilder: (BuildContext context, VoidCallback action) {
+          return GestureDetector(
+            onTap: action,
+            child: const Text('Closed'),
+          );
+        },
+        openBuilder: (BuildContext context, VoidCallback action) {
+          return GestureDetector(
+            onTap: action,
+            child: const Text('Open'),
+          );
+        },
+      );
+      await tester.pumpWidget(_boilerplate(child: openContainer));
+      expect(_getOpacity(tester, 'Closed'), 1.0);
+
+      // Open the container
+      await tester.tap(find.text('Closed'));
+      await tester.pumpAndSettle();
+
+      final Element container = tester.element(find.byType(OpenContainer, skipOffstage: false));
+      // Replace the open container route.
+      Navigator.pushReplacement<void, void>(
+        container,
+        MaterialPageRoute<void>(builder: (_) => const Placeholder())
+      );
+      await tester.pumpAndSettle();
+      // Go back to the main page and verify the closed builder is showed.
+      Navigator.pop(container);
+      await tester.pumpAndSettle();
+
+      expect(_getOpacity(tester, 'Closed'), 1.0);
+    },
+  );
 }
 
 Color _getScrimColor(WidgetTester tester) {

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1734,10 +1734,11 @@ void main() {
     },
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/72238.
   testWidgets(
-    'OpenContainer works when the route is removed',
-        (WidgetTester tester) async {
-
+    'OpenContainer\'s source widget is visible in closed container route if '
+    'open container route is pushed from not using the OpenContainer itself',
+    (WidgetTester tester) async {
       final Widget openContainer = OpenContainer(
         closedBuilder: (BuildContext context, VoidCallback action) {
           return GestureDetector(
@@ -1759,12 +1760,12 @@ void main() {
       await tester.tap(find.text('Closed'));
       await tester.pumpAndSettle();
 
-      final Element container = tester.element(find.byType(OpenContainer, skipOffstage: false));
-      // Replace the open container route.
-      Navigator.pushReplacement<void, void>(
-        container,
-        MaterialPageRoute<void>(builder: (_) => const Placeholder())
+      final Element container = tester.element(
+        find.byType(OpenContainer, skipOffstage: false),
       );
+      // Replace the open container route.
+      Navigator.pushReplacement<void, void>(container,
+          MaterialPageRoute<void>(builder: (_) => const Placeholder()));
       await tester.pumpAndSettle();
       // Go back to the main page and verify the closed builder is showed.
       Navigator.pop(container);


### PR DESCRIPTION
The open container hide itself based on animation status of the container route. however, if the route is removed due to pushreplacement or pushremoveuntil, its animation controller will be disposed without status changes. this will hide the open container forever. This pr fixes it. 


fixes https://github.com/flutter/flutter/issues/72238