### PR TITLE
Fix typo in pigeon's CHANGELOG.md

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ## 0.1.11
 
-* Added flag to generate null safety annotated Dart code `--dart-null-safety`.
+* Added flag to generate null safety annotated Dart code `--dart_null_safety`.
 * Made it so Dart API setup methods can take null.
 
 ## 0.1.10+1


### PR DESCRIPTION
`--dart-null-safety` doesn't exist. It is instead `--dart_null_safety`