### PR TITLE
Allow LegacyFlutterDestination to specify project

### DIFF
--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.6
+- Allow `datastoreFromCredentialsJson` to specify project id.
+
 # 0.0.5
 
 - `FlutterDestination` writes into both Skia perf GCS and the legacy datastore.

--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.7
+- Expose constants that were missing since 0.0.4+1.
+
 # 0.0.6
 - Allow `datastoreFromCredentialsJson` to specify project id.
 

--- a/packages/metrics_center/lib/metrics_center.dart
+++ b/packages/metrics_center/lib/metrics_center.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 export 'src/common.dart';
+export 'src/constants.dart';
 export 'src/flutter.dart';
 export 'src/google_benchmark.dart';
 export 'src/skiaperf.dart';

--- a/packages/metrics_center/lib/src/flutter.dart
+++ b/packages/metrics_center/lib/src/flutter.dart
@@ -40,8 +40,11 @@ class FlutterDestination extends MetricDestination {
   static Future<FlutterDestination> makeFromCredentialsJson(
       Map<String, dynamic> json,
       {bool isTesting = false}) async {
+    // Specify the project id for LegacyFlutterDestination as we may get a
+    // service account json from another GCP project.
     final LegacyFlutterDestination legacyDestination =
-        LegacyFlutterDestination(await datastoreFromCredentialsJson(json));
+        await LegacyFlutterDestination.makeFromCredentialsJson(json,
+            projectId: 'flutter-cirrus');
     final SkiaPerfDestination skiaPerfDestination =
         await SkiaPerfDestination.makeFromGcpCredentials(json,
             isTesting: isTesting);

--- a/packages/metrics_center/lib/src/legacy_datastore.dart
+++ b/packages/metrics_center/lib/src/legacy_datastore.dart
@@ -18,11 +18,15 @@ import 'common.dart';
 import 'constants.dart';
 
 /// Creates a [DatastoreDB] connection from JSON service account credentials.
-Future<DatastoreDB> datastoreFromCredentialsJson(
-    Map<String, dynamic> json) async {
+///
+/// We allow specifying a project id as we may use the service account from one
+/// project to write into the datastore of another project.
+Future<DatastoreDB> datastoreFromCredentialsJson(Map<String, dynamic> json,
+    {String projectId}) async {
   final AutoRefreshingAuthClient client = await clientViaServiceAccount(
       ServiceAccountCredentials.fromJson(json), DatastoreImpl.SCOPES);
-  return DatastoreDB(DatastoreImpl(client, json[kProjectId] as String));
+  return DatastoreDB(
+      DatastoreImpl(client, projectId ?? json[kProjectId] as String));
 }
 
 /// Creates a [DatastoreDB] from an auth token.

--- a/packages/metrics_center/lib/src/legacy_flutter.dart
+++ b/packages/metrics_center/lib/src/legacy_flutter.dart
@@ -61,8 +61,11 @@ class LegacyFlutterDestination extends MetricDestination {
 
   /// Creates this destination from a service account credentials JSON file.
   static Future<LegacyFlutterDestination> makeFromCredentialsJson(
-      Map<String, dynamic> json) async {
-    return LegacyFlutterDestination(await datastoreFromCredentialsJson(json));
+    Map<String, dynamic> json, {
+    String projectId,
+  }) async {
+    return LegacyFlutterDestination(
+        await datastoreFromCredentialsJson(json, projectId: projectId));
   }
 
   /// Creates this destination to authorize with an OAuth access token.

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -1,5 +1,5 @@
 name: metrics_center
-version: 0.0.6
+version: 0.0.7
 description:
   Support multiple performance metrics sources/formats and destinations.
 homepage:

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -1,5 +1,5 @@
 name: metrics_center
-version: 0.0.5
+version: 0.0.6
 description:
   Support multiple performance metrics sources/formats and destinations.
 homepage:

--- a/packages/metrics_center/test/legacy_flutter_test.dart
+++ b/packages/metrics_center/test/legacy_flutter_test.dart
@@ -25,6 +25,15 @@ void main() {
 
   test(
       'LegacyFlutterDestination integration test: '
+      'can specify datastore project id.', () async {
+    final LegacyFlutterDestination dst =
+        await LegacyFlutterDestination.makeFromCredentialsJson(credentialsJson,
+            projectId: 'flutter-test-262600');
+    await dst.update(<MetricPoint>[MetricPoint(1.0, const <String, String>{})]);
+  }, skip: credentialsJson == null);
+
+  test(
+      'LegacyFlutterDestination integration test: '
       'can update with an access token.', () async {
     final AutoRefreshingAuthClient client = await clientViaServiceAccount(
       ServiceAccountCredentials.fromJson(credentialsJson),


### PR DESCRIPTION
So we may use the service account from one project to write into the
datastore of another project.

Eventually, we'll remove all datastore related code and
LegacyFlutterDestination so this will only be a temporary solution
during our transition.
