### PR TITLE
Fix integration_test dependency

### DIFF
--- a/packages/pointer_interceptor/example/pubspec.yaml
+++ b/packages/pointer_interceptor/example/pubspec.yaml
@@ -17,7 +17,8 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  integration_test: ^1.0.1
+  integration_test:
+    sdk: flutter
 
 # The following section is specific to Flutter.
 flutter:


### PR DESCRIPTION
This should fix the "submit-queue" CI test which now times out during
analyze.
