### PR TITLE
[xdg_directories] Migrate xdg_directories to nnbd

### DIFF
--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.0-nullsafety.0] - Migrated to null safety
+
+* Migrated to null safety.
+
 ## [0.1.2] - Reduce dependencies on external libraries.
 
 * Broaden dependencies to allow nullsafety version of process, meta, and path to be OK.

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -13,7 +13,7 @@ import 'package:process/process.dart';
 
 /// An override function used by the tests to override the environment variable
 /// lookups using [xdgEnvironmentOverride].
-typedef EnvironmentAccessor = String Function(String envVar);
+typedef EnvironmentAccessor = String? Function(String envVar);
 
 /// A testing setter that replaces the real environment lookups with an override.
 ///
@@ -21,7 +21,7 @@ typedef EnvironmentAccessor = String Function(String envVar);
 ///
 /// Only available to tests.
 @visibleForTesting
-set xdgEnvironmentOverride(EnvironmentAccessor override) {
+set xdgEnvironmentOverride(EnvironmentAccessor? override) {
   _xdgEnvironmentOverride = override;
   _getenv = _xdgEnvironmentOverride ?? _productionGetEnv;
 }
@@ -31,8 +31,8 @@ set xdgEnvironmentOverride(EnvironmentAccessor override) {
 ///
 /// Only available to tests.
 @visibleForTesting
-EnvironmentAccessor get xdgEnvironmentOverride => _xdgEnvironmentOverride;
-EnvironmentAccessor _xdgEnvironmentOverride;
+EnvironmentAccessor? get xdgEnvironmentOverride => _xdgEnvironmentOverride;
+EnvironmentAccessor? _xdgEnvironmentOverride;
 EnvironmentAccessor _productionGetEnv =
     (String value) => Platform.environment[value];
 EnvironmentAccessor _getenv = _productionGetEnv;
@@ -50,9 +50,9 @@ ProcessManager _processManager = const LocalProcessManager();
 
 List<Directory> _directoryListFromEnvironment(
     String envVar, List<Directory> fallback) {
-  assert(envVar != null);
-  assert(fallback != null);
-  final String value = _getenv(envVar);
+  ArgumentError.checkNotNull(envVar);
+  ArgumentError.checkNotNull(fallback);
+  final String? value = _getenv(envVar);
   if (value == null || value.isEmpty) {
     return fallback;
   }
@@ -63,13 +63,20 @@ List<Directory> _directoryListFromEnvironment(
   }).toList();
 }
 
-Directory _directoryFromEnvironment(String envVar, String fallback) {
-  assert(envVar != null);
-  final String value = _getenv(envVar);
+Directory? _directoryFromEnvironment(String envVar) {
+  ArgumentError.checkNotNull(envVar);
+  final String? value = _getenv(envVar);
   if (value == null || value.isEmpty) {
-    if (fallback == null) {
-      return null;
-    }
+    return null;
+  }
+  return Directory(value);
+}
+
+Directory _directoryFromEnvironmentWithFallback(
+    String envVar, String fallback) {
+  ArgumentError.checkNotNull(envVar);
+  final String? value = _getenv(envVar);
+  if (value == null || value.isEmpty) {
     return _getDirectory(fallback);
   }
   return Directory(value);
@@ -77,9 +84,9 @@ Directory _directoryFromEnvironment(String envVar, String fallback) {
 
 // Creates a Directory from a fallback path.
 Directory _getDirectory(String subdir) {
-  assert(subdir != null);
+  ArgumentError.checkNotNull(subdir);
   assert(subdir.isNotEmpty);
-  final String homeDir = _getenv('HOME');
+  final String? homeDir = _getenv('HOME');
   if (homeDir == null || homeDir.isEmpty) {
     throw StateError(
         'The "HOME" environment variable is not set. This package (and POSIX) '
@@ -94,7 +101,7 @@ Directory _getDirectory(String subdir) {
 ///
 /// Throws [StateError] if the HOME environment variable is not set.
 Directory get cacheHome =>
-    _directoryFromEnvironment('XDG_CACHE_HOME', '.cache');
+    _directoryFromEnvironmentWithFallback('XDG_CACHE_HOME', '.cache');
 
 /// The list of preference-ordered base directories relative to
 /// which configuration files should be searched. (Corresponds to
@@ -113,7 +120,7 @@ List<Directory> get configDirs {
 ///
 /// Throws [StateError] if the HOME environment variable is not set.
 Directory get configHome =>
-    _directoryFromEnvironment('XDG_CONFIG_HOME', '.config');
+    _directoryFromEnvironmentWithFallback('XDG_CONFIG_HOME', '.config');
 
 /// The list of preference-ordered base directories relative to
 /// which data files should be searched. (Corresponds to `$XDG_DATA_DIRS`).
@@ -131,14 +138,14 @@ List<Directory> get dataDirs {
 ///
 /// Throws [StateError] if the HOME environment variable is not set.
 Directory get dataHome =>
-    _directoryFromEnvironment('XDG_DATA_HOME', '.local/share');
+    _directoryFromEnvironmentWithFallback('XDG_DATA_HOME', '.local/share');
 
 /// The base directory relative to which user-specific runtime
 /// files and other file objects should be placed. (Corresponds to
 /// `$XDG_RUNTIME_DIR`).
 ///
 /// Throws [StateError] if the HOME environment variable is not set.
-Directory get runtimeDir => _directoryFromEnvironment('XDG_RUNTIME_DIR', null);
+Directory? get runtimeDir => _directoryFromEnvironment('XDG_RUNTIME_DIR');
 
 /// Gets the xdg user directory named by `dirName`.
 ///
@@ -147,7 +154,7 @@ Directory getUserDirectory(String dirName) {
   final ProcessResult result = _processManager.runSync(
     <String>['xdg-user-dir', dirName],
     includeParentEnvironment: true,
-    stdoutEncoding: Encoding.getByName('utf8'),
+    stdoutEncoding: Encoding.getByName('utf8') ?? systemEncoding,
   );
   final String path = utf8.decode(result.stdout).split('\n')[0];
   return Directory(path);
@@ -172,11 +179,11 @@ Set<String> getUserDirectoryNames() {
   final RegExp dirRegExp =
       RegExp(r'^\s*XDG_(?<dirname>[^=]*)_DIR\s*=\s*(?<dir>.*)\s*$');
   for (String line in contents) {
-    final RegExpMatch match = dirRegExp.firstMatch(line);
+    final RegExpMatch? match = dirRegExp.firstMatch(line);
     if (match == null) {
       continue;
     }
-    result.add(match.namedGroup('dirname'));
+    result.add(match.namedGroup('dirname')!);
   }
   return result;
 }

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -150,7 +150,7 @@ Directory? get runtimeDir => _directoryFromEnvironment('XDG_RUNTIME_DIR');
 /// Gets the xdg user directory named by `dirName`.
 ///
 /// Use [getUserDirectoryNames] to find out the list of available names.
-Directory getUserDirectory(String dirName) {
+Directory? getUserDirectory(String dirName) {
   final ProcessResult result = _processManager.runSync(
     <String>['xdg-user-dir', dirName],
     includeParentEnvironment: true,

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -1,16 +1,16 @@
 name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
-version: 0.1.2
+version: 0.2.0-nullsafety.0
 homepage: https://github.com/flutter/packages/tree/master/packages/xdg_directories
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  meta: ">=1.2.2 <2.0.0"
-  path: ">=1.6.4 <2.0.0"
-  process: ">=3.0.12 <5.0.0"
+  meta: ^1.3.0-nullsafety.6
+  path: ^1.8.0-nullsafety.3
+  process: ^4.0.0-nullsafety.4
 
 dev_dependencies:
-  mockito: ^4.1.1
-  test: ^1.15.3
+  mockito: ^5.0.0-nullsafety.1
+  test: ^1.16.0-nullsafety.13

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -14,7 +14,7 @@ import 'package:xdg_directories/xdg_directories.dart' as xdg;
 
 void main() {
   final Map<String, String> fakeEnv = <String, String>{};
-  Directory tmpDir;
+  late Directory tmpDir;
 
   String testPath(String subdir) => path.join(tmpDir.path, subdir);
 
@@ -29,11 +29,11 @@ void main() {
         '${testPath('usr/local/test_share')}:${testPath('usr/test_share')}';
     fakeEnv['XDG_DATA_HOME'] = testPath('.local/test_share');
     fakeEnv['XDG_RUNTIME_DIR'] = testPath('.local/test_runtime');
-    Directory(fakeEnv['XDG_CONFIG_HOME']).createSync(recursive: true);
-    Directory(fakeEnv['XDG_CACHE_HOME']).createSync(recursive: true);
-    Directory(fakeEnv['XDG_DATA_HOME']).createSync(recursive: true);
-    Directory(fakeEnv['XDG_RUNTIME_DIR']).createSync(recursive: true);
-    File(path.join(fakeEnv['XDG_CONFIG_HOME'], 'user-dirs.dirs'))
+    Directory(fakeEnv['XDG_CONFIG_HOME']!).createSync(recursive: true);
+    Directory(fakeEnv['XDG_CACHE_HOME']!).createSync(recursive: true);
+    Directory(fakeEnv['XDG_DATA_HOME']!).createSync(recursive: true);
+    Directory(fakeEnv['XDG_RUNTIME_DIR']!).createSync(recursive: true);
+    File(path.join(fakeEnv['XDG_CONFIG_HOME']!, 'user-dirs.dirs'))
         .writeAsStringSync(r'''
 XDG_DESKTOP_DIR="$HOME/Desktop"
 XDG_DOCUMENTS_DIR="$HOME/Documents"
@@ -48,9 +48,7 @@ XDG_VIDEOS_DIR="$HOME/Videos"
   });
 
   tearDown(() {
-    if (tmpDir != null) {
-      tmpDir.deleteSync(recursive: true);
-    }
+    tmpDir.deleteSync(recursive: true);
     // Stop overriding the environment accessor.
     xdg.xdgEnvironmentOverride = null;
   });
@@ -76,7 +74,7 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     expect(xdg.cacheHome.path, equals(testPath('.test_cache')));
     expect(xdg.configHome.path, equals(testPath('.test_config')));
     expect(xdg.dataHome.path, equals(testPath('.local/test_share')));
-    expect(xdg.runtimeDir.path, equals(testPath('.local/test_runtime')));
+    expect(xdg.runtimeDir!.path, equals(testPath('.local/test_runtime')));
 
     expectDirList(xdg.configDirs, <String>[testPath('etc/test_xdg')]);
     expectDirList(xdg.dataDirs, <String>[
@@ -122,13 +120,13 @@ class FakeProcessManager extends Fake implements ProcessManager {
   @override
   ProcessResult runSync(
     List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
     Encoding stdoutEncoding = systemEncoding,
     Encoding stderrEncoding = systemEncoding,
   }) {
-    return ProcessResult(0, 0, expected[command[1]].codeUnits, <int>[]);
+    return ProcessResult(0, 0, expected[command[1]]!.codeUnits, <int>[]);
   }
 }

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -98,7 +98,7 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     final Set<String> userDirs = xdg.getUserDirectoryNames();
     expect(userDirs, equals(expected.keys.toSet()));
     for (String key in userDirs) {
-      expect(xdg.getUserDirectory(key).path, equals(expected[key]),
+      expect(xdg.getUserDirectory(key)!.path, equals(expected[key]),
           reason: 'Path $key value not correct');
     }
     xdg.xdgProcessManager = const LocalProcessManager();

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -74,6 +74,7 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     expect(xdg.cacheHome.path, equals(testPath('.test_cache')));
     expect(xdg.configHome.path, equals(testPath('.test_config')));
     expect(xdg.dataHome.path, equals(testPath('.local/test_share')));
+    expect(xdg.runtimeDir, isNotNull);
     expect(xdg.runtimeDir!.path, equals(testPath('.local/test_runtime')));
 
     expectDirList(xdg.configDirs, <String>[testPath('etc/test_xdg')]);


### PR DESCRIPTION
This PR migrates `xdg_directories` package to null safety.

Fixes
* https://github.com/flutter/flutter/issues/71506
* https://github.com/flutter/flutter/issues/74836

Related PR
* https://github.com/flutter/packages/pull/250

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
