### PR TITLE
Allow tests to override GCP project id.

### DIFF
--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.8
+- Allow tests to override LegacyFlutterDestination GCP project id.
+
 # 0.0.7
 - Expose constants that were missing since 0.0.4+1.
 

--- a/packages/metrics_center/lib/src/flutter.dart
+++ b/packages/metrics_center/lib/src/flutter.dart
@@ -42,9 +42,15 @@ class FlutterDestination extends MetricDestination {
       {bool isTesting = false}) async {
     // Specify the project id for LegacyFlutterDestination as we may get a
     // service account json from another GCP project.
+    //
+    // When we're testing, let projectId be null so we'll still use the test
+    // project specified by the credentials json.
+    //
+    // This is completed, but fortunately we'll be able to remove all this
+    // once the migration is fully done.
     final LegacyFlutterDestination legacyDestination =
         await LegacyFlutterDestination.makeFromCredentialsJson(json,
-            projectId: 'flutter-cirrus');
+            projectId: isTesting ? null : 'flutter-cirrus');
     final SkiaPerfDestination skiaPerfDestination =
         await SkiaPerfDestination.makeFromGcpCredentials(json,
             isTesting: isTesting);


### PR DESCRIPTION
This is needed by https://github.com/flutter/engine/pull/24022