### PR TITLE
[xdg_directories] Fix stdout encoding handling

### DIFF
--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.2.0-nullsafety.1] - Fix getUserDirectory
+
+* Fixes a regression due to the stdoutEncoding change
+  in the null-safety migration.
+
 ## [0.2.0-nullsafety.0] - Migrated to null safety
 
 * Migrated to null safety.

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -154,9 +154,9 @@ Directory? getUserDirectory(String dirName) {
   final ProcessResult result = _processManager.runSync(
     <String>['xdg-user-dir', dirName],
     includeParentEnvironment: true,
-    stdoutEncoding: Encoding.getByName('utf8') ?? systemEncoding,
+    stdoutEncoding: utf8,
   );
-  final String path = utf8.decode(result.stdout).split('\n')[0];
+  final String path = result.stdout.split('\n')[0];
   return Directory(path);
 }
 

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
-version: 0.2.0-nullsafety.0
+version: 0.2.0-nullsafety.1
 homepage: https://github.com/flutter/packages/tree/master/packages/xdg_directories
 
 environment:

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -128,6 +128,6 @@ class FakeProcessManager extends Fake implements ProcessManager {
     Encoding stdoutEncoding = systemEncoding,
     Encoding stderrEncoding = systemEncoding,
   }) {
-    return ProcessResult(0, 0, expected[command[1]]!.codeUnits, <int>[]);
+    return ProcessResult(0, 0, expected[command[1]]!, '');
   }
 }


### PR DESCRIPTION
The stdoutEncoding was originally specified as a by-name lookup of
"utf8"; this was actually equivalent to 'null', since that's not the
correct name. During the null safety migration, a fallback to
systemEncoding was added, causing it to always have an encoding. This
changed the type of result.stdout, so all calls gave a type error.

This fixes the issue by using 'utf8', the singleton encoder object,
rather than doing a name lookup, so the type will predicably be a
string, and adjusting the code reading it to expect a string.
