### PR TITLE
[animations] add routeSettings and imageFilter options to showModal

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.0-nullsafety.0] - February 6, 2021
+
+* Add `routeSettings` and `filter` option to `showModal`.
+
 ## [2.0.0-nullsafety.0] - November 16, 2020
 
 * Migrates to null safety.

--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.1.0-nullsafety.0] - February 6, 2021
+## [2.0.0-nullsafety.1] - February 6, 2021
 
 * Add `routeSettings` and `filter` option to `showModal`.
 

--- a/packages/animations/lib/src/modal.dart
+++ b/packages/animations/lib/src/modal.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 
 import 'fade_scale_transition.dart';
@@ -51,6 +53,8 @@ Future<T?> showModal<T>({
   ModalConfiguration configuration = const FadeScaleTransitionConfiguration(),
   bool useRootNavigator = true,
   required WidgetBuilder builder,
+  RouteSettings? routeSettings,
+  ui.ImageFilter? filter,
 }) {
   String? barrierLabel = configuration.barrierLabel;
   // Avoid looking up [MaterialLocalizations.of(context).modalBarrierDismissLabel]
@@ -68,6 +72,8 @@ Future<T?> showModal<T>({
       transitionDuration: configuration.transitionDuration,
       reverseTransitionDuration: configuration.reverseTransitionDuration,
       builder: builder,
+      routeSettings: routeSettings,
+      filter: filter,
     ),
   );
 }
@@ -91,8 +97,11 @@ class _ModalRoute<T> extends PopupRoute<T> {
     required this.reverseTransitionDuration,
     required _ModalTransitionBuilder transitionBuilder,
     required this.builder,
-  })   : assert(!barrierDismissible || barrierLabel != null),
-        _transitionBuilder = transitionBuilder;
+    RouteSettings? routeSettings,
+    ui.ImageFilter? filter,
+  })  : assert(!barrierDismissible || barrierLabel != null),
+        _transitionBuilder = transitionBuilder,
+        super(filter: filter, settings: routeSettings);
 
   @override
   final Color? barrierColor;

--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
-version: 2.0.0-nullsafety.0
+version: 2.1.0-nullsafety.0
 homepage: https://github.com/flutter/packages/tree/master/packages/animations
 
 environment:

--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
-version: 2.1.0-nullsafety.0
+version: 2.0.0-nullsafety.1
 homepage: https://github.com/flutter/packages/tree/master/packages/animations
 
 environment:

--- a/packages/animations/test/modal_test.dart
+++ b/packages/animations/test/modal_test.dart
@@ -500,6 +500,7 @@ void main() {
       expect(modalRoute.settings, routeSettings);
     },
   );
+
   testWidgets(
     'showModal builds a new route with specified image filter',
     (WidgetTester tester) async {


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/75568

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
