### PR TITLE
[animations] add onOpen callback

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0-nullsafety.1] - February 8, 2020
+
+* add onOpen callback
+
 ## [2.0.0-nullsafety.0] - November 16, 2020
 
 * Migrates to null safety.

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -200,7 +200,7 @@ class OpenContainer<T extends Object?> extends StatefulWidget {
   /// `null` will be returned by default.
   final ClosedCallback<T?>? onClosed;
 
-  /// Called when the container is opening.
+  /// Called when the container opens.
   final VoidCallback? onOpen;
 
   /// Called to obtain the child for the container in the closed state.

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -91,6 +91,7 @@ class OpenContainer<T extends Object?> extends StatefulWidget {
     ),
     this.openShape = const RoundedRectangleBorder(),
     this.onClosed,
+    this.onOpen,
     required this.closedBuilder,
     required this.openBuilder,
     this.tappable = true,
@@ -199,6 +200,9 @@ class OpenContainer<T extends Object?> extends StatefulWidget {
   /// `null` will be returned by default.
   final ClosedCallback<T?>? onClosed;
 
+  /// Called when the container is opening.
+  final VoidCallback? onOpen;
+
   /// Called to obtain the child for the container in the closed state.
   ///
   /// The [Widget] returned by this builder is faded out when the container
@@ -268,6 +272,7 @@ class _OpenContainerState<T> extends State<OpenContainer<T?>> {
   final GlobalKey _closedBuilderKey = GlobalKey();
 
   Future<void> openContainer() async {
+    widget.onOpen?.call();
     final Color middleColor =
         widget.middleColor ?? Theme.of(context).canvasColor;
     final T? data = await Navigator.of(

--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
-version: 2.0.0-nullsafety.0
+version: 2.0.0-nullsafety.1
 homepage: https://github.com/flutter/packages/tree/master/packages/animations
 
 environment:

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1485,41 +1485,41 @@ void main() {
   });
 
   testWidgets('onOpen callback is called when container opens',
-          (WidgetTester tester) async {
-        bool hasOpened = false;
-        final Widget openContainer = OpenContainer(
-          onOpen: () {
-            hasOpened = true;
-          },
-          closedBuilder: (BuildContext context, VoidCallback action) {
-            return GestureDetector(
-              onTap: action,
-              child: const Text('Closed'),
-            );
-          },
-          openBuilder: (BuildContext context, VoidCallback action) {
-            return GestureDetector(
-              onTap: action,
-              child: const Text('Open'),
-            );
-          },
+      (WidgetTester tester) async {
+    bool hasOpened = false;
+    final Widget openContainer = OpenContainer(
+      onOpen: () {
+        hasOpened = true;
+      },
+      closedBuilder: (BuildContext context, VoidCallback action) {
+        return GestureDetector(
+          onTap: action,
+          child: const Text('Closed'),
         );
-
-        await tester.pumpWidget(
-          _boilerplate(child: openContainer),
+      },
+      openBuilder: (BuildContext context, VoidCallback action) {
+        return GestureDetector(
+          onTap: action,
+          child: const Text('Open'),
         );
+      },
+    );
 
-        expect(find.text('Open'), findsNothing);
-        expect(find.text('Closed'), findsOneWidget);
-        expect(hasOpened, isFalse);
+    await tester.pumpWidget(
+      _boilerplate(child: openContainer),
+    );
 
-        await tester.tap(find.text('Closed'));
-        await tester.pumpAndSettle();
+    expect(find.text('Open'), findsNothing);
+    expect(find.text('Closed'), findsOneWidget);
+    expect(hasOpened, isFalse);
 
-        expect(find.text('Open'), findsOneWidget);
-        expect(find.text('Closed'), findsNothing);
-        expect(hasOpened, isTrue);
-      });
+    await tester.tap(find.text('Closed'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Open'), findsOneWidget);
+    expect(find.text('Closed'), findsNothing);
+    expect(hasOpened, isTrue);
+  });
 
   testWidgets('onClosed callback is called when container has closed',
       (WidgetTester tester) async {

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1484,6 +1484,43 @@ void main() {
     expect(find.text('Container has been removed'), findsOneWidget);
   });
 
+  testWidgets('onOpen callback is called when container opens',
+          (WidgetTester tester) async {
+        bool hasOpened = false;
+        final Widget openContainer = OpenContainer(
+          onOpen: () {
+            hasOpened = true;
+          },
+          closedBuilder: (BuildContext context, VoidCallback action) {
+            return GestureDetector(
+              onTap: action,
+              child: const Text('Closed'),
+            );
+          },
+          openBuilder: (BuildContext context, VoidCallback action) {
+            return GestureDetector(
+              onTap: action,
+              child: const Text('Open'),
+            );
+          },
+        );
+
+        await tester.pumpWidget(
+          _boilerplate(child: openContainer),
+        );
+
+        expect(find.text('Open'), findsNothing);
+        expect(find.text('Closed'), findsOneWidget);
+        expect(hasOpened, isFalse);
+
+        await tester.tap(find.text('Closed'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Open'), findsOneWidget);
+        expect(find.text('Closed'), findsNothing);
+        expect(hasOpened, isTrue);
+      });
+
   testWidgets('onClosed callback is called when container has closed',
       (WidgetTester tester) async {
     bool hasClosed = false;


### PR DESCRIPTION
This pr adds an onOpen callback to OpenContainer.

Fixes https://github.com/flutter/flutter/issues/74111

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
