### PR TITLE
Fix begin frame check

### DIFF
--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+* Fixed benchmarks failing due to trace format change for begin frame.
+
 ## 0.0.2
 
 * Improve console messages.

--- a/packages/web_benchmarks/lib/src/browser.dart
+++ b/packages/web_benchmarks/lib/src/browser.dart
@@ -95,14 +95,11 @@ class Chrome {
     final List<String> args = <String>[
       if (options.userDataDirectory != null)
         '--user-data-dir=${options.userDataDirectory}',
-      if (options.url != null)
-        options.url,
+      if (options.url != null) options.url,
       if (io.Platform.environment['CHROME_NO_SANDBOX'] == 'true')
         '--no-sandbox',
-      if (options.headless)
-        '--headless',
-      if (withDebugging)
-        '--remote-debugging-port=${options.debugPort}',
+      if (options.headless) '--headless',
+      if (withDebugging) '--remote-debugging-port=${options.debugPort}',
       '--window-size=${options.windowWidth},${options.windowHeight}',
       '--disable-extensions',
       '--disable-popup-blocking',

--- a/packages/web_benchmarks/lib/src/browser.dart
+++ b/packages/web_benchmarks/lib/src/browser.dart
@@ -95,11 +95,14 @@ class Chrome {
     final List<String> args = <String>[
       if (options.userDataDirectory != null)
         '--user-data-dir=${options.userDataDirectory}',
-      if (options.url != null) options.url,
+      if (options.url != null)
+        options.url,
       if (io.Platform.environment['CHROME_NO_SANDBOX'] == 'true')
         '--no-sandbox',
-      if (options.headless) '--headless',
-      if (withDebugging) '--remote-debugging-port=${options.debugPort}',
+      if (options.headless)
+        '--headless',
+      if (withDebugging)
+        '--remote-debugging-port=${options.debugPort}',
       '--window-size=${options.windowWidth},${options.windowHeight}',
       '--disable-extensions',
       '--disable-popup-blocking',
@@ -551,9 +554,10 @@ class BlinkTraceEvent {
   /// for compatibility.
   ///
   /// This event is a duration event that has its `tdur` populated.
-  bool get isBeginFrame => ph == 'X' &&
-      (name == 'WebViewImpl::beginFrame'
-          || name == 'WebFrameWidgetBase::BeginMainFrame');
+  bool get isBeginFrame =>
+      ph == 'X' &&
+      (name == 'WebViewImpl::beginFrame' ||
+          name == 'WebFrameWidgetBase::BeginMainFrame');
 
   /// An "update all lifecycle phases" event contains UI thread computations
   /// related to an animation frame that's outside the scripting phase.

--- a/packages/web_benchmarks/lib/src/browser.dart
+++ b/packages/web_benchmarks/lib/src/browser.dart
@@ -547,8 +547,13 @@ class BlinkTraceEvent {
   /// This event does not include non-UI thread scripting, such as web workers,
   /// service workers, and CSS Paint paintlets.
   ///
+  /// WebViewImpl::beginFrame was used in earlier versions of Chrome, kept
+  /// for compatibility.
+  ///
   /// This event is a duration event that has its `tdur` populated.
-  bool get isBeginFrame => ph == 'X' && name == 'WebViewImpl::beginFrame';
+  bool get isBeginFrame => ph == 'X' &&
+      (name == 'WebViewImpl::beginFrame'
+          || name == 'WebFrameWidgetBase::BeginMainFrame');
 
   /// An "update all lifecycle phases" event contains UI thread computations
   /// related to an animation frame that's outside the scripting phase.

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_benchmarks
 description: A benchmark harness for performance-testing Flutter apps in Chrome.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/flutter/packages/tree/master/packages/web_benchmarks
 
 environment:

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/packages/tree/master/packages/web_benchmark
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  flutter: ">=1.17.0"
 
 # Using +2 upper limit on some packages to allow null-safe versions
 dependencies:


### PR DESCRIPTION
Frame Event name has changed from WebViewImpl::beginFrame to WebFrameWidgetBase::BeginMainFrame causing BeginFrame events to be null.

Fixes: https://github.com/flutter/gallery/issues/411
Related issue https://github.com/flutter/flutter/issues/75652

testing/web_benchmarks_test.dart was failing before this PR, now passing.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
