### PR TITLE
Temporarily make 'publishable' failures non-fatal

### DIFF
--- a/script/check_publish.sh
+++ b/script/check_publish.sh
@@ -23,12 +23,12 @@ function check_publish() {
     fi
   done
   if [[ "${#failures[@]}" != 0 ]]; then
-    error "FAIL: The following ${#failures[@]} package(s) failed the publishing check:"
+    error "WARNING: The following ${#failures[@]} package(s) failed the publishing check:"
     for failure in "${failures[@]}"; do
       error "$failure"
     done
   fi
-  return "${#failures[@]}"
+  return 0
 }
 
 # Sets CHANGED_PACKAGE_LIST


### PR DESCRIPTION
Allows publishing NNBD packages as stable previews rather than prereleases without CI being red. The step still runs, so it can be manually validated for other issues. Since this repository is low-traffic, and the cost of something slipping through here is minor (since it will be caught when actually trying to publish), it's not worth engineering a solution to ignore only the specific failure in this case.

This should be reverted once NNBD support is on stable.
