### PR TITLE
[web_benchmarks] Update versions for upstream packages

### DIFF
--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+* Updated dependencies to allow broader versions for upstream packages.
+
 ## 0.0.3
 
 * Fixed benchmarks failing due to trace format change for begin frame.

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   meta: ">=1.0.0 <2.0.0"
   path: ">=1.7.0 <2.0.0"
   process: ">=3.0.13 <5.0.0"
-  shelf: ">=0.7.5 <1.0.0"
+  shelf: ">=0.7.5 <2.0.0"
   shelf_static: ">=0.2.8 <1.0.0"
   test: ">=1.15.0 <3.0.0"
   webkit_inspection_protocol: ">=0.7.3 <1.0.0"

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  logging: ">=0.11.4 <1.0.0"
+  logging: ">=0.11.4 <2.0.0"
   meta: ">=1.0.0 <2.0.0"
   path: ">=1.7.0 <2.0.0"
   process: ">=3.0.13 <5.0.0"

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_benchmarks
 description: A benchmark harness for performance-testing Flutter apps in Chrome.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/flutter/packages/tree/master/packages/web_benchmarks
 
 environment:


### PR DESCRIPTION
## Description
This PR updates versions for packages `logging` and `shelf`, dependencies of the `web_benchmarks` package, in order to resolve version conflicts during null-safe migration.

`logging` is updated not to resolve the Gallery version conflict (https://github.com/flutter/gallery/issues/433), but to avoid future conflicts.

## Issues
https://github.com/flutter/gallery/issues/433

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
    * No tests were added. This is only a version bump.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
    * No documentation needed.
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
