### PR TITLE
Bump Cirrus osx_instance image version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,7 @@ task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: build-ipas
   osx_instance:
-    image: high-sierra-xcode-9.4.1
+    image: catalina-flutter
   env:
     PATH: $PATH:/usr/local/bin
     matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,6 @@
+use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+
 task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   container:
     dockerfile: .ci/Dockerfile
     cpu: 4
@@ -44,7 +45,6 @@ task:
         - dart testing/web_benchmarks_test.dart
 
 task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: build-ipas
   osx_instance:
     image: big-sur-xcode-12.4
@@ -63,7 +63,6 @@ task:
     - ./script/incremental_build.sh build-examples --ipa
 
 task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: local_tests
   osx_instance:
     image: big-sur-xcode-12.4

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   container:
     dockerfile: .ci/Dockerfile
     cpu: 4
@@ -7,8 +7,6 @@ task:
   upgrade_script:
     - flutter channel master
     - flutter upgrade
-    # TODO(goderbauer): Remove next two lines when https://github.com/flutter/flutter/issues/74772 is resolved.
-    - rm -rf /home/cirrus/sdks/flutter/bin/cache
     - flutter doctor
     - git fetch origin master
   activate_script: pub global activate flutter_plugin_tools
@@ -49,38 +47,33 @@ task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: build-ipas
   osx_instance:
-    image: catalina-flutter
+    image: big-sur-xcode-12.4
   env:
     PATH: $PATH:/usr/local/bin
     matrix:
       BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
       BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
   setup_script:
-    - pod repo update
-    - git clone https://github.com/flutter/flutter.git
-    - git fetch origin master
-    - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
+    - flutter channel master
+    - flutter upgrade
     - flutter doctor
+    - git fetch origin master
     - pub global activate flutter_plugin_tools
   build_script:
-    - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
     - ./script/incremental_build.sh build-examples --ipa
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: local_tests
   osx_instance:
-    image: catalina-flutter
+    image: big-sur-xcode-12.4
   env:
     PATH: $PATH:/usr/local/bin
     matrix:
       CHANNEL: "master"
       CHANNEL: "stable"
   setup_script:
-    - pod repo update
-    - git clone https://github.com/flutter/flutter.git
     - git fetch origin master
-    - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
     - pub global activate flutter_plugin_tools
     - brew install clang-format
   upgrade_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,5 @@
-use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-
 task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   container:
     dockerfile: .ci/Dockerfile
     cpu: 4
@@ -45,6 +44,7 @@ task:
         - dart testing/web_benchmarks_test.dart
 
 task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: build-ipas
   osx_instance:
     image: big-sur-xcode-12.4
@@ -63,6 +63,7 @@ task:
     - ./script/incremental_build.sh build-examples --ipa
 
 task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: local_tests
   osx_instance:
     image: big-sur-xcode-12.4


### PR DESCRIPTION
- `high-sierra-xcode-9.4.1` isn't a supported Cirrus image, and auto-upgrades to `catalina-xcode-12.2`.  Update `build-ipas` `osx_instance` to `big-sur-xcode-12.4`. See https://cirrus-ci.org/guide/macOS/ for supported images.
- Stop cloning `flutter` on images that already have `flutter`.


________
<img width="937" alt="Screen Shot 2021-03-02 at 6 16 46 PM" src="https://user-images.githubusercontent.com/682784/109742172-7479be80-7b83-11eb-8524-0e4a45b3a5fc.png">