### PR TITLE
[pigeon] Use File.uri over manual URI construction

### DIFF
--- a/packages/pigeon/bin/pigeon.dart
+++ b/packages/pigeon/bin/pigeon.dart
@@ -51,9 +51,7 @@ void main(List<String> args, SendPort sendPort) async {
   await tempFile.writeAsString(code);
   final ReceivePort receivePort = ReceivePort();
   Isolate.spawnUri(
-    // Using Uri.file instead of Uri.parse in order to parse backslashes as
-    // path segment separator with Windows semantics.
-    Uri.file(tempFile.path),
+    tempFile.uri,
     args,
     receivePort.sendPort,
   );

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '0.1.21';
+const String pigeonVersion = '0.1.22';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pigeon
-version: 0.1.21 # This must match the version in lib/generator_tools.dart
+version: 0.1.22 # This must match the version in lib/generator_tools.dart
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 homepage: https://github.com/flutter/packages/tree/master/packages/pigeon
 dependencies:


### PR DESCRIPTION
The `uri` getter works correctly on Windows without the need for extra
attention needed to the details of the paths.