### PR TITLE
Use Cirrus compute credits in PRs for collaborators

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,6 @@
+use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+
 task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   container:
     dockerfile: .ci/Dockerfile
     cpu: 4
@@ -44,7 +45,6 @@ task:
         - dart testing/web_benchmarks_test.dart
 
 task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: build-ipas
   osx_instance:
     image: big-sur-xcode-12.4
@@ -63,7 +63,6 @@ task:
     - ./script/incremental_build.sh build-examples --ipa
 
 task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: local_tests
   osx_instance:
     image: big-sur-xcode-12.4


### PR DESCRIPTION
Always use Cirrus compute credits for flutter-hackers in PRs. The macOS tests were already doing this, change the Linux task to match.

@kf6gpe agreed this is fine for this particular low-traffic (~5 commits per month) repo.