### PR TITLE
[pigeon] reved pigeon, tweaked contributors changes before publish

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.22
+
+* Java code generator enhancements:
+  * Added linter tests to CI.
+  * Fixed some linter issues in the Java code.
+
 ## 0.1.21
 
 * Fixed decode method on generated Flutter classes that use null-safety and have

--- a/packages/pigeon/README.md
+++ b/packages/pigeon/README.md
@@ -68,6 +68,48 @@ channels supports
 
 Note: Generics for List and Map aren't supported yet.
 
+## Asynchronous Handlers
+
+By default Pigeon will generate synchronous handlers for messages.  If you want
+to be able to respond to a message asynchronously you can use the `@async`
+annotation as of version 0.1.20.
+
+Example:
+
+```dart
+class Value {
+  int number;
+}
+
+@HostApi()
+abstract class Api2Host {
+  @async
+  Value calculate(Value value);
+}
+```
+
+Generates:
+
+```objc
+// Objc
+@protocol Api2Host
+-(void)calculate:(nullable Value *)input 
+      completion:(void(^)(Value *_Nullable, FlutterError *_Nullable))completion;
+@end
+```
+
+```java
+// Java
+public interface Result<T> {
+   void success(T result);
+}
+
+/** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+public interface Api2Host {
+   void calculate(Value arg, Result<Value> result);
+}
+```
+
 ## Feedback
 
 File an issue in [flutter/flutter](https://github.com/flutter/flutter) with the

--- a/packages/pigeon/example/README.md
+++ b/packages/pigeon/example/README.md
@@ -120,7 +120,7 @@ A downloadable example of using Pigeon to create a Flutter Plugin with Swift and
 Kotlin can be found at
 [gaaclarke/flutter_plugin_example](https://github.com/gaaclarke/pigeon_plugin_example).
 
-## Swift Add-to-app Example
+## Swift / Kotlin Add-to-app Example
 
 A full example of using Pigeon for add-to-app with Swift on iOS can be found at
-[gaaclarke/GiantsA2A](https://github.com/gaaclarke/GiantsA2A).
+[samples/add_to_app/books](https://github.com/flutter/samples/tree/master/add_to_app/books).

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '0.1.21';
+const String pigeonVersion = '0.1.22';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -169,38 +169,18 @@ void _writeFlutterApi(Indent indent, Api api) {
         if (func.argType != 'void') {
           indent.writeln('Map<String, Object> inputMap = argInput.toMap();');
         }
-        indent.write('if (callback != null)');
-        indent.scoped('{', '}', () {
-          indent.write('channel.send($sendArgument, channelReply -> ');
-          indent.scoped('{', '});', () {
-            if (func.returnType == 'void') {
-              indent.writeln('callback.reply(null);');
-            } else {
-              indent.writeln('Map outputMap = (Map)channelReply;');
-              indent.writeln('@SuppressWarnings("ConstantConditions")');
-              indent.writeln(
-                  '${func.returnType} output = ${func.returnType}.fromMap(outputMap);');
-              indent.writeln('callback.reply(output);');
-            }
-          });
+        indent.write('channel.send($sendArgument, channelReply -> ');
+        indent.scoped('{', '});', () {
+          if (func.returnType == 'void') {
+            indent.writeln('callback.reply(null);');
+          } else {
+            indent.writeln('Map outputMap = (Map)channelReply;');
+            indent.writeln('@SuppressWarnings("ConstantConditions")');
+            indent.writeln(
+                '${func.returnType} output = ${func.returnType}.fromMap(outputMap);');
+            indent.writeln('callback.reply(output);');
+          }
         });
-        indent.write(' else ');
-        indent.scoped('{', '}', () {
-          indent.writeln('channel.send($sendArgument, null);');
-        });
-      });
-
-      if (func.argType == 'void') {
-        indent.write('public void ${func.name}() ');
-      } else {
-        indent.write('public void ${func.name}(${func.argType} argInput) ');
-      }
-      indent.scoped('{', '}', () {
-        if (func.argType == 'void') {
-          indent.writeln('${func.name}(null);');
-        } else {
-          indent.writeln('${func.name}(argInput, null);');
-        }
       });
     }
   });

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -15,7 +15,7 @@ const Map<String, String> _javaTypeForDartTypeMap = <String, String>{
   'Int64List': 'long[]',
   'Float64List': 'double[]',
   'List': 'List<Object>',
-  'Map': 'Map<String, Object>',
+  'Map': 'Map<Object, Object>',
 };
 
 /// Options that control how Java code will be generated.

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pigeon
-version: 0.1.21 # This must match the version in lib/generator_tools.dart
+version: 0.1.22 # This must match the version in lib/generator_tools.dart
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 homepage: https://github.com/flutter/packages/tree/master/packages/pigeon
 dependencies:

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -124,7 +124,7 @@ fi
 pub get
 dart analyze bin
 dart analyze lib
-pub run test test/
+dart --no-sound-null-safety test
 
 ###############################################################################
 # Execute without arguments test

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -257,7 +257,7 @@ void main() {
     generateJava(javaOptions, root, sink);
     final String code = sink.toString();
     expect(code, contains('public static class Foobar'));
-    expect(code, contains('private Map<String, Object> field1;'));
+    expect(code, contains('private Map<Object, Object> field1;'));
   });
 
   test('gen nested', () {


### PR DESCRIPTION
- updated run_tests.sh
- removed the ability to accept null callbacks in java code (unpublished change)
- switched Map's java type to `Map<Object, Object>`, it was previously `Map<String, Object>` in an unpublished PR.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
