### PR TITLE
[pigeon] moved command line logic from bin/ to lib/

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.24
 
 * Moved logic from bin/ to lib/ to help customers wrap up the behavior.
+* Added some more linter ignores for Dart.
 
 ## 0.1.23
 

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.24
+
+* Moved logic from bin/ to lib/ to help customers wrap up the behavior.
+
 ## 0.1.23
 
 * More Java linter and linter fixes.

--- a/packages/pigeon/bin/pigeon.dart
+++ b/packages/pigeon/bin/pigeon.dart
@@ -4,71 +4,8 @@
 
 // @dart = 2.2
 
-import 'dart:async';
-import 'dart:io';
-import 'dart:isolate';
-
-import 'package:path/path.dart' as path;
-import 'package:pigeon/pigeon_lib.dart';
-
-/// This creates a relative path from `from` to `input`, the output being a
-/// posix path on all platforms.
-String _posixRelative(String input, {String from}) {
-  final path.Context context = path.Context(style: path.Style.posix);
-  final String rawInputPath = input;
-  final String absInputPath = File(rawInputPath).absolute.path;
-  // By going through URI's we can make sure paths can go between drives in
-  // Windows.
-  final Uri inputUri = path.toUri(absInputPath);
-  final String posixAbsInputPath = context.fromUri(inputUri);
-  final Uri tempUri = path.toUri(from);
-  final String posixTempPath = context.fromUri(tempUri);
-  return context.relative(posixAbsInputPath, from: posixTempPath);
-}
+import 'package:pigeon/pigeon_cl.dart';
 
 Future<void> main(List<String> args) async {
-  final PigeonOptions opts = Pigeon.parseArgs(args);
-  final Directory tempDir = Directory.systemTemp.createTempSync(
-    'flutter_pigeon.',
-  );
-
-  String importLine = '';
-  if (opts.input != null) {
-    final String relInputPath = _posixRelative(opts.input, from: tempDir.path);
-    importLine = 'import \'$relInputPath\';\n';
-  }
-  final String code = """
-// @dart = 2.2
-$importLine
-import 'dart:io';
-import 'dart:isolate';
-import 'package:pigeon/pigeon_lib.dart';
-
-void main(List<String> args, SendPort sendPort) async {
-  sendPort.send(await Pigeon.run(args));
-}
-""";
-  final File tempFile = File(path.join(tempDir.path, '_pigeon_temp_.dart'));
-  await tempFile.writeAsString(code);
-  final ReceivePort receivePort = ReceivePort();
-  Isolate.spawnUri(
-    // Using Uri.file instead of Uri.parse in order to parse backslashes as
-    // path segment separator with Windows semantics.
-    Uri.file(tempFile.path),
-    args,
-    receivePort.sendPort,
-  );
-
-  final Completer<int> completer = Completer<int>();
-  receivePort.listen((dynamic message) {
-    try {
-      // ignore: avoid_as
-      completer.complete(message as int);
-    } catch (exception) {
-      completer.completeError(exception);
-    }
-  });
-  final int exitCode = await completer.future;
-  tempDir.deleteSync(recursive: true);
-  exit(exitCode);
+  await runCommandLine(args);
 }

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -197,7 +197,7 @@ void generateDart(DartOptions opt, Root root, StringSink sink) {
   indent.writeln('// $generatedCodeWarning');
   indent.writeln('// $seeAlsoWarning');
   indent.writeln(
-    '// ignore_for_file: public_member_api_docs, non_constant_identifier_names, avoid_as, unused_import, unnecessary_parenthesis, prefer_null_aware_operators',
+    '// ignore_for_file: public_member_api_docs, non_constant_identifier_names, avoid_as, unused_import, unnecessary_parenthesis, prefer_null_aware_operators, omit_local_variable_types',
   );
   indent.writeln('// @dart = ${opt.isNullSafe ? '2.12' : '2.8'}');
   indent.writeln('import \'dart:async\';');

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '0.1.23';
+const String pigeonVersion = '0.1.24';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/pigeon_cl.dart
+++ b/packages/pigeon/lib/pigeon_cl.dart
@@ -1,0 +1,75 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:path/path.dart' as path;
+import 'package:pigeon/pigeon_lib.dart';
+
+/// This creates a relative path from `from` to `input`, the output being a
+/// posix path on all platforms.
+String _posixRelative(String input, {String from}) {
+  final path.Context context = path.Context(style: path.Style.posix);
+  final String rawInputPath = input;
+  final String absInputPath = File(rawInputPath).absolute.path;
+  // By going through URI's we can make sure paths can go between drives in
+  // Windows.
+  final Uri inputUri = path.toUri(absInputPath);
+  final String posixAbsInputPath = context.fromUri(inputUri);
+  final Uri tempUri = path.toUri(from);
+  final String posixTempPath = context.fromUri(tempUri);
+  return context.relative(posixAbsInputPath, from: posixTempPath);
+}
+
+/// This is the main entrypoint for the command-line tool.  [args] are the
+/// commmand line arguments and there is an optional [packageConfig] to
+/// accomodate users that want to integrate pigeon with other build systems.
+Future<void> runCommandLine(List<String> args, {Uri packageConfig}) async {
+  final PigeonOptions opts = Pigeon.parseArgs(args);
+  final Directory tempDir = Directory.systemTemp.createTempSync(
+    'flutter_pigeon.',
+  );
+
+  String importLine = '';
+  if (opts.input != null) {
+    final String relInputPath = _posixRelative(opts.input, from: tempDir.path);
+    importLine = 'import \'$relInputPath\';\n';
+  }
+  final String code = """
+// @dart = 2.2
+$importLine
+import 'dart:io';
+import 'dart:isolate';
+import 'package:pigeon/pigeon_lib.dart';
+void main(List<String> args, SendPort sendPort) async {
+  sendPort.send(await Pigeon.run(args));
+}
+""";
+  final File tempFile = File(path.join(tempDir.path, '_pigeon_temp_.dart'));
+  await tempFile.writeAsString(code);
+  final ReceivePort receivePort = ReceivePort();
+  Isolate.spawnUri(
+    // Using Uri.file instead of Uri.parse in order to parse backslashes as
+    // path segment separator with Windows semantics.
+    Uri.file(tempFile.path),
+    args,
+    receivePort.sendPort,
+    packageConfig: packageConfig,
+  );
+
+  final Completer<int> completer = Completer<int>();
+  receivePort.listen((dynamic message) {
+    try {
+      // ignore: avoid_as
+      completer.complete(message as int);
+    } catch (exception) {
+      completer.completeError(exception);
+    }
+  });
+  final int exitCode = await completer.future;
+  tempDir.deleteSync(recursive: true);
+  exit(exitCode);
+}

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pigeon
-version: 0.1.23 # This must match the version in lib/generator_tools.dart
+version: 0.1.24 # This must match the version in lib/generator_tools.dart
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 homepage: https://github.com/flutter/packages/tree/master/packages/pigeon
 dependencies:


### PR DESCRIPTION
 This helps users wrap the command-line tools logic with their own logic.  I also added an ignore for omit_local_variable_types since different people's linter settings might not agree on it (Flutter wants them, Dart doesn't).

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
