### PR TITLE
[pigeon] Moved exit command to bin/ from lib/

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.25
+
+* Moved exit command to bin/ from lib/
+
 ## 0.1.24
 
 * Moved logic from bin/ to lib/ to help customers wrap up the behavior.

--- a/packages/pigeon/bin/pigeon.dart
+++ b/packages/pigeon/bin/pigeon.dart
@@ -4,8 +4,8 @@
 
 // @dart = 2.2
 
-import 'package:pigeon/pigeon_cl.dart';
 import 'dart:io';
+import 'package:pigeon/pigeon_cl.dart';
 
 Future<void> main(List<String> args) async {
   exit(await runCommandLine(args));

--- a/packages/pigeon/bin/pigeon.dart
+++ b/packages/pigeon/bin/pigeon.dart
@@ -7,5 +7,5 @@
 import 'package:pigeon/pigeon_cl.dart';
 
 Future<void> main(List<String> args) async {
-  await runCommandLine(args);
+  exit(await runCommandLine(args));
 }

--- a/packages/pigeon/bin/pigeon.dart
+++ b/packages/pigeon/bin/pigeon.dart
@@ -5,6 +5,7 @@
 // @dart = 2.2
 
 import 'package:pigeon/pigeon_cl.dart';
+import 'dart:io';
 
 Future<void> main(List<String> args) async {
   exit(await runCommandLine(args));

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '0.2.0';
+const String pigeonVersion = '0.2.1';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/pigeon_cl.dart
+++ b/packages/pigeon/lib/pigeon_cl.dart
@@ -27,7 +27,7 @@ String _posixRelative(String input, {required String from}) {
 /// This is the main entrypoint for the command-line tool.  [args] are the
 /// commmand line arguments and there is an optional [packageConfig] to
 /// accomodate users that want to integrate pigeon with other build systems.
-Future<void> runCommandLine(List<String> args, {Uri? packageConfig}) async {
+Future<int> runCommandLine(List<String> args, {Uri? packageConfig}) async {
   final PigeonOptions opts = Pigeon.parseArgs(args);
   final Directory tempDir = Directory.systemTemp.createTempSync(
     'flutter_pigeon.',
@@ -71,5 +71,5 @@ void main(List<String> args, SendPort sendPort) async {
   });
   final int exitCode = await completer.future;
   tempDir.deleteSync(recursive: true);
-  exit(exitCode);
+  return exitCode;
 }

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pigeon
-version: 0.2.0 # This must match the version in lib/generator_tools.dart
+version: 0.2.1 # This must match the version in lib/generator_tools.dart
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 homepage: https://github.com/flutter/packages/tree/master/packages/pigeon
 dependencies:


### PR DESCRIPTION
Move exit command the bin/pigeon.dart. This way runCommandLine can be called without the program exiting. 

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
