### PR TITLE
Standardize copyright author and year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 The Chromium Authors. All rights reserved.
+Copyright 2014 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/animations/AUTHORS
+++ b/packages/animations/AUTHORS
@@ -4,6 +4,5 @@
 #   Name/Organization <email address>
 
 Google Inc.
-The Chromium Authors
 Britannio Jarrett <britanniojarrett@gmail.com>
 Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/animations/LICENSE
+++ b/packages/animations/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/animations/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/animations/example/ios/Runner.xcodeproj/project.pbxproj
@@ -136,7 +136,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1020;
-				ORGANIZATIONNAME = "The Chromium Authors";
+				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;

--- a/packages/animations/example/lib/container_transition.dart
+++ b/packages/animations/example/lib/container_transition.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/example/lib/fade_through_transition.dart
+++ b/packages/animations/example/lib/fade_through_transition.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/example/lib/main.dart
+++ b/packages/animations/example/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/example/lib/shared_axis_transition.dart
+++ b/packages/animations/example/lib/shared_axis_transition.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/lib/animations.dart
+++ b/packages/animations/lib/animations.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/lib/src/fade_scale_transition.dart
+++ b/packages/animations/lib/src/fade_scale_transition.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/lib/src/fade_through_transition.dart
+++ b/packages/animations/lib/src/fade_through_transition.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/lib/src/modal.dart
+++ b/packages/animations/lib/src/modal.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/lib/src/page_transition_switcher.dart
+++ b/packages/animations/lib/src/page_transition_switcher.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/lib/src/shared_axis_transition.dart
+++ b/packages/animations/lib/src/shared_axis_transition.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/test/dual_transition_builder_test.dart
+++ b/packages/animations/test/dual_transition_builder_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/test/fade_scale_transition_test.dart
+++ b/packages/animations/test/fade_scale_transition_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/test/fade_through_transition_test.dart
+++ b/packages/animations/test/fade_through_transition_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/test/modal_test.dart
+++ b/packages/animations/test/modal_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/test/page_transition_switcher_test.dart
+++ b/packages/animations/test/page_transition_switcher_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/animations/test/shared_axis_transition_test.dart
+++ b/packages/animations/test/shared_axis_transition_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/AUTHORS
+++ b/packages/cross_file/AUTHORS
@@ -5,5 +5,3 @@
 
 Google Inc.
 The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/cross_file/LICENSE
+++ b/packages/cross_file/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/packages/cross_file/lib/cross_file.dart
+++ b/packages/cross_file/lib/cross_file.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/cross_file.dart
+++ b/packages/cross_file/lib/cross_file.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/types/base.dart
+++ b/packages/cross_file/lib/src/types/base.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/types/base.dart
+++ b/packages/cross_file/lib/src/types/base.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/types/html.dart
+++ b/packages/cross_file/lib/src/types/html.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/types/html.dart
+++ b/packages/cross_file/lib/src/types/html.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/types/interface.dart
+++ b/packages/cross_file/lib/src/types/interface.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/types/interface.dart
+++ b/packages/cross_file/lib/src/types/interface.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/types/io.dart
+++ b/packages/cross_file/lib/src/types/io.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/types/io.dart
+++ b/packages/cross_file/lib/src/types/io.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/web_helpers/web_helpers.dart
+++ b/packages/cross_file/lib/src/web_helpers/web_helpers.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/web_helpers/web_helpers.dart
+++ b/packages/cross_file/lib/src/web_helpers/web_helpers.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/x_file.dart
+++ b/packages/cross_file/lib/src/x_file.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/lib/src/x_file.dart
+++ b/packages/cross_file/lib/src/x_file.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/test/x_file_html_test.dart
+++ b/packages/cross_file/test/x_file_html_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cross_file/test/x_file_io_test.dart
+++ b/packages/cross_file/test/x_file_io_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/css_colors/AUTHORS
+++ b/packages/css_colors/AUTHORS
@@ -4,6 +4,3 @@
 #   Name/Organization <email address>
 
 Google Inc.
-The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/css_colors/LICENSE
+++ b/packages/css_colors/LICENSE
@@ -1,4 +1,4 @@
-// Copyright 2017 Google, Inc. All rights reserved.
+// Copyright 2017 The Flutter Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/packages/css_colors/LICENSE
+++ b/packages/css_colors/LICENSE
@@ -1,4 +1,4 @@
-// Copyright 2017 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/packages/css_colors/lib/css_colors.dart
+++ b/packages/css_colors/lib/css_colors.dart
@@ -1,4 +1,4 @@
-// Copyright 2017 Google, Inc. All rights reserved.
+// Copyright 2017 The Flutter Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/packages/css_colors/lib/css_colors.dart
+++ b/packages/css_colors/lib/css_colors.dart
@@ -1,4 +1,4 @@
-// Copyright 2017 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/packages/extension_google_sign_in_as_googleapis_auth/AUTHORS
+++ b/packages/extension_google_sign_in_as_googleapis_auth/AUTHORS
@@ -5,5 +5,3 @@
 
 Google Inc.
 The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/extension_google_sign_in_as_googleapis_auth/LICENSE
+++ b/packages/extension_google_sign_in_as_googleapis_auth/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1Activity.java
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1Activity.java
@@ -1,4 +1,4 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
+// Copyright 2017 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1Activity.java
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1Activity.java
@@ -1,4 +1,4 @@
-// Copyright 2017 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner.xcodeproj/project.pbxproj
@@ -169,7 +169,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1100;
-				ORGANIZATIONNAME = "The Chromium Authors";
+				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/AppDelegate.h
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/AppDelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
+// Copyright 2017 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/AppDelegate.h
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/AppDelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2017 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/AppDelegate.m
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/AppDelegate.m
@@ -1,4 +1,4 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
+// Copyright 2017 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/AppDelegate.m
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/AppDelegate.m
@@ -1,4 +1,4 @@
-// Copyright 2017 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/main.m
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/main.m
@@ -1,4 +1,4 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
+// Copyright 2017 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/main.m
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/ios/Runner/main.m
@@ -1,4 +1,4 @@
-// Copyright 2017 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/lib/main.dart
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/lib/extension_google_sign_in_as_googleapis_auth.dart
+++ b/packages/extension_google_sign_in_as_googleapis_auth/lib/extension_google_sign_in_as_googleapis_auth.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors
+// Copyright 2013 The Flutter Authors
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file or at

--- a/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Flutter Authors
+# Copyright 2013 The Flutter Authors
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at

--- a/packages/extension_google_sign_in_as_googleapis_auth/test/extension_google_sign_in_as_googleapis_auth_test.dart
+++ b/packages/extension_google_sign_in_as_googleapis_auth/test/extension_google_sign_in_as_googleapis_auth_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors
+// Copyright 2013 The Flutter Authors
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file or at

--- a/packages/flutter_template_images/AUTHORS
+++ b/packages/flutter_template_images/AUTHORS
@@ -4,6 +4,3 @@
 #   Name/Organization <email address>
 
 Google Inc.
-The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/flutter_template_images/LICENSE
+++ b/packages/flutter_template_images/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/packages/fuchsia_ctl/AUTHORS
+++ b/packages/fuchsia_ctl/AUTHORS
@@ -5,5 +5,3 @@
 
 Google Inc.
 The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/fuchsia_ctl/LICENSE
+++ b/packages/fuchsia_ctl/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 The Chromium Authors. All rights reserved.
+Copyright 2014 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/fuchsia_ctl/LICENSE
+++ b/packages/fuchsia_ctl/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/fuchsia_ctl/bin/main.dart
+++ b/packages/fuchsia_ctl/bin/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/fuchsia_ctl.dart
+++ b/packages/fuchsia_ctl/lib/fuchsia_ctl.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/amber_ctl.dart
+++ b/packages/fuchsia_ctl/lib/src/amber_ctl.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/command_line.dart
+++ b/packages/fuchsia_ctl/lib/src/command_line.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/dev_finder.dart
+++ b/packages/fuchsia_ctl/lib/src/dev_finder.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/emulator.dart
+++ b/packages/fuchsia_ctl/lib/src/emulator.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/image_paver.dart
+++ b/packages/fuchsia_ctl/lib/src/image_paver.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/operation_result.dart
+++ b/packages/fuchsia_ctl/lib/src/operation_result.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/package_server.dart
+++ b/packages/fuchsia_ctl/lib/src/package_server.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/ssh_client.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/ssh_key_manager.dart
+++ b/packages/fuchsia_ctl/lib/src/ssh_key_manager.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/lib/src/tar.dart
+++ b/packages/fuchsia_ctl/lib/src/tar.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_ctl/test/command_line_test.dart
+++ b/packages/fuchsia_ctl/test/command_line_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // @dart = 2.4

--- a/packages/fuchsia_ctl/test/dev_finder_test.dart
+++ b/packages/fuchsia_ctl/test/dev_finder_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // @dart = 2.4

--- a/packages/fuchsia_ctl/test/emulator_test.dart
+++ b/packages/fuchsia_ctl/test/emulator_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // @dart = 2.4

--- a/packages/fuchsia_ctl/test/image_paver_test.dart
+++ b/packages/fuchsia_ctl/test/image_paver_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // @dart = 2.4

--- a/packages/fuchsia_ctl/test/logger_test.dart
+++ b/packages/fuchsia_ctl/test/logger_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // @dart = 2.4

--- a/packages/fuchsia_ctl/test/package_server_test.dart
+++ b/packages/fuchsia_ctl/test/package_server_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // @dart = 2.4

--- a/packages/fuchsia_ctl/test/ssh_client_test.dart
+++ b/packages/fuchsia_ctl/test/ssh_client_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // @dart = 2.4

--- a/packages/fuchsia_ctl/test/tar_test.dart
+++ b/packages/fuchsia_ctl/test/tar_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // @dart = 2.4

--- a/packages/fuchsia_ctl/tool/build.sh
+++ b/packages/fuchsia_ctl/tool/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019 The Flutter Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/packages/imitation_game/AUTHORS
+++ b/packages/imitation_game/AUTHORS
@@ -5,5 +5,3 @@
 
 Google Inc.
 The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/imitation_game/LICENSE
+++ b/packages/imitation_game/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/imitation_game/LICENSE
+++ b/packages/imitation_game/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Chromium Authors. All rights reserved.
+Copyright 2019 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/imitation_game/imitation_tests/smiley/flutter/smiley/lib/main.dart
+++ b/packages/imitation_game/imitation_tests/smiley/flutter/smiley/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/AppDelegate.h
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/AppDelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/AppDelegate.m
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/AppDelegate.m
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/SceneDelegate.h
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/SceneDelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/SceneDelegate.m
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/SceneDelegate.m
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/ViewController.h
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/ViewController.h
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/ViewController.m
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/ViewController.m
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/main.m
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/main.m
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/AUTHORS
+++ b/packages/metrics_center/AUTHORS
@@ -4,6 +4,3 @@
 #   Name/Organization <email address>
 
 Google Inc.
-The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/metrics_center/LICENSE
+++ b/packages/metrics_center/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/packages/metrics_center/lib/metrics_center.dart
+++ b/packages/metrics_center/lib/metrics_center.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/lib/src/common.dart
+++ b/packages/metrics_center/lib/src/common.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/lib/src/constants.dart
+++ b/packages/metrics_center/lib/src/constants.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/lib/src/flutter.dart
+++ b/packages/metrics_center/lib/src/flutter.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/lib/src/gcs_lock.dart
+++ b/packages/metrics_center/lib/src/gcs_lock.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/lib/src/google_benchmark.dart
+++ b/packages/metrics_center/lib/src/google_benchmark.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/lib/src/skiaperf.dart
+++ b/packages/metrics_center/lib/src/skiaperf.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/test/common.dart
+++ b/packages/metrics_center/test/common.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/test/flutter_test.dart
+++ b/packages/metrics_center/test/flutter_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/test/gcs_lock_test.dart
+++ b/packages/metrics_center/test/gcs_lock_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/test/google_benchmark_test.dart
+++ b/packages/metrics_center/test/google_benchmark_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/test/skiaperf_test.dart
+++ b/packages/metrics_center/test/skiaperf_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/metrics_center/test/utility.dart
+++ b/packages/metrics_center/test/utility.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/multicast_dns/AUTHORS
+++ b/packages/multicast_dns/AUTHORS
@@ -4,6 +4,4 @@
 #   Name/Organization <email address>
 
 Google Inc.
-The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>
+The Dartino project authors

--- a/packages/multicast_dns/LICENSE
+++ b/packages/multicast_dns/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/multicast_dns/example/main.dart
+++ b/packages/multicast_dns/example/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. Please see the AUTHORS file
+// Copyright 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/example/main.dart
+++ b/packages/multicast_dns/example/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2018, the Flutter project authors. Please see the AUTHORS file
+// Copyright 2018 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/example/mdns_resolve.dart
+++ b/packages/multicast_dns/example/mdns_resolve.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/example/mdns_resolve.dart
+++ b/packages/multicast_dns/example/mdns_resolve.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/example/mdns_sd.dart
+++ b/packages/multicast_dns/example/mdns_sd.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/example/mdns_sd.dart
+++ b/packages/multicast_dns/example/mdns_sd.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/multicast_dns.dart
+++ b/packages/multicast_dns/lib/multicast_dns.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/multicast_dns.dart
+++ b/packages/multicast_dns/lib/multicast_dns.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/constants.dart
+++ b/packages/multicast_dns/lib/src/constants.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/constants.dart
+++ b/packages/multicast_dns/lib/src/constants.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/lookup_resolver.dart
+++ b/packages/multicast_dns/lib/src/lookup_resolver.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/lookup_resolver.dart
+++ b/packages/multicast_dns/lib/src/lookup_resolver.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/native_protocol_client.dart
+++ b/packages/multicast_dns/lib/src/native_protocol_client.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/native_protocol_client.dart
+++ b/packages/multicast_dns/lib/src/native_protocol_client.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/packet.dart
+++ b/packages/multicast_dns/lib/src/packet.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/packet.dart
+++ b/packages/multicast_dns/lib/src/packet.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors.  Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/lib/src/resource_record.dart
+++ b/packages/multicast_dns/lib/src/resource_record.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/multicast_dns/test/client_test.dart
+++ b/packages/multicast_dns/test/client_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/test/client_test.dart
+++ b/packages/multicast_dns/test/client_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/test/decode_test.dart
+++ b/packages/multicast_dns/test/decode_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/test/decode_test.dart
+++ b/packages/multicast_dns/test/decode_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/test/lookup_resolver_test.dart
+++ b/packages/multicast_dns/test/lookup_resolver_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/test/lookup_resolver_test.dart
+++ b/packages/multicast_dns/test/lookup_resolver_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/test/resource_record_cache_test.dart
+++ b/packages/multicast_dns/test/resource_record_cache_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/test/resource_record_cache_test.dart
+++ b/packages/multicast_dns/test/resource_record_cache_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/tool/packet_gen.dart
+++ b/packages/multicast_dns/tool/packet_gen.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
+// Copyright (c) 2013 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/multicast_dns/tool/packet_gen.dart
+++ b/packages/multicast_dns/tool/packet_gen.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dartino project authors. Please see the AUTHORS file
+// Copyright (c) 2015 The Flutter Authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/palette_generator/AUTHORS
+++ b/packages/palette_generator/AUTHORS
@@ -5,5 +5,3 @@
 
 Google Inc.
 The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/palette_generator/LICENSE
+++ b/packages/palette_generator/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 The Chromium Authors. All rights reserved.
+Copyright 2014 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/palette_generator/LICENSE
+++ b/packages/palette_generator/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/palette_generator/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/palette_generator/example/ios/Runner.xcodeproj/project.pbxproj
@@ -157,7 +157,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0910;
-				ORGANIZATIONNAME = "The Chromium Authors";
+				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;

--- a/packages/palette_generator/example/lib/main.dart
+++ b/packages/palette_generator/example/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/palette_generator/example/lib/main.dart
+++ b/packages/palette_generator/example/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/palette_generator/test/palette_generator_test.dart
+++ b/packages/palette_generator/test/palette_generator_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/palette_generator/test/palette_generator_test.dart
+++ b/packages/palette_generator/test/palette_generator_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/AUTHORS
+++ b/packages/pigeon/AUTHORS
@@ -5,5 +5,3 @@
 
 Google Inc.
 The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/pigeon/LICENSE
+++ b/packages/pigeon/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/pigeon/LICENSE
+++ b/packages/pigeon/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Chromium Authors. All rights reserved.
+Copyright 2019 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/pigeon/bin/pigeon.dart
+++ b/packages/pigeon/bin/pigeon.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/lib/ast.dart
+++ b/packages/pigeon/lib/ast.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/lib/pigeon_cl.dart
+++ b/packages/pigeon/lib/pigeon_cl.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/mock_handler_tester/test/widget_test.dart
+++ b/packages/pigeon/mock_handler_tester/test/widget_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/all_datatypes.dart
+++ b/packages/pigeon/pigeons/all_datatypes.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/android_unittests.dart
+++ b/packages/pigeon/pigeons/android_unittests.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/async_handlers.dart
+++ b/packages/pigeon/pigeons/async_handlers.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/flutter_unittests.dart
+++ b/packages/pigeon/pigeons/flutter_unittests.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/host2flutter.dart
+++ b/packages/pigeon/pigeons/host2flutter.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/list.dart
+++ b/packages/pigeon/pigeons/list.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/message.dart
+++ b/packages/pigeon/pigeons/message.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/void_arg_flutter.dart
+++ b/packages/pigeon/pigeons/void_arg_flutter.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/void_arg_host.dart
+++ b/packages/pigeon/pigeons/void_arg_host.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/voidflutter.dart
+++ b/packages/pigeon/pigeons/voidflutter.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/pigeons/voidhost.dart
+++ b/packages/pigeon/pigeons/voidhost.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/platform_tests/android_unit_tests/lib/main.dart
+++ b/packages/pigeon/platform_tests/android_unit_tests/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/platform_tests/flutter_null_safe_unit_tests/test/null_safe_test.dart
+++ b/packages/pigeon/platform_tests/flutter_null_safe_unit_tests/test/null_safe_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/platform_tests/ios_unit_tests/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/pigeon/platform_tests/ios_unit_tests/ios/Runner.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1020;
-				ORGANIZATIONNAME = "The Chromium Authors";
+				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					0D50127123FF75B100CD5B95 = {
 						CreatedOnToolsVersion = 11.3;

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/test/objc_generator_test.dart
+++ b/packages/pigeon/test/objc_generator_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pigeon/test/version_test.dart
+++ b/packages/pigeon/test/version_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/AUTHORS
+++ b/packages/pointer_interceptor/AUTHORS
@@ -5,5 +5,3 @@
 
 Google Inc.
 The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/pointer_interceptor/LICENSE
+++ b/packages/pointer_interceptor/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/pointer_interceptor/example/integration_test/widget_test.dart
+++ b/packages/pointer_interceptor/example/integration_test/widget_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/example/lib/main.dart
+++ b/packages/pointer_interceptor/example/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/example/lib/src/shim/dart_ui.dart
+++ b/packages/pointer_interceptor/example/lib/src/shim/dart_ui.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/example/lib/src/shim/dart_ui_fake.dart
+++ b/packages/pointer_interceptor/example/lib/src/shim/dart_ui_fake.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/example/lib/src/shim/dart_ui_real.dart
+++ b/packages/pointer_interceptor/example/lib/src/shim/dart_ui_real.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/example/test_driver/integration_test.dart
+++ b/packages/pointer_interceptor/example/test_driver/integration_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/example/test_driver/integration_test.dart
+++ b/packages/pointer_interceptor/example/test_driver/integration_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/lib/pointer_interceptor.dart
+++ b/packages/pointer_interceptor/lib/pointer_interceptor.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/lib/src/mobile.dart
+++ b/packages/pointer_interceptor/lib/src/mobile.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/lib/src/shim/dart_ui.dart
+++ b/packages/pointer_interceptor/lib/src/shim/dart_ui.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/lib/src/shim/dart_ui_fake.dart
+++ b/packages/pointer_interceptor/lib/src/shim/dart_ui_fake.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/lib/src/shim/dart_ui_real.dart
+++ b/packages/pointer_interceptor/lib/src/shim/dart_ui_real.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/pointer_interceptor/lib/src/web.dart
+++ b/packages/pointer_interceptor/lib/src/web.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/AUTHORS
+++ b/packages/web_benchmarks/AUTHORS
@@ -5,5 +5,3 @@
 
 Google Inc.
 The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/web_benchmarks/LICENSE
+++ b/packages/web_benchmarks/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/web_benchmarks/LICENSE
+++ b/packages/web_benchmarks/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Chromium Authors. All rights reserved.
+Copyright 2019 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/web_benchmarks/lib/client.dart
+++ b/packages/web_benchmarks/lib/client.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/lib/server.dart
+++ b/packages/web_benchmarks/lib/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/lib/src/benchmark_result.dart
+++ b/packages/web_benchmarks/lib/src/benchmark_result.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/lib/src/browser.dart
+++ b/packages/web_benchmarks/lib/src/browser.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/lib/src/common.dart
+++ b/packages/web_benchmarks/lib/src/common.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/lib/src/recorder.dart
+++ b/packages/web_benchmarks/lib/src/recorder.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/lib/src/runner.dart
+++ b/packages/web_benchmarks/lib/src/runner.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/testing/test_app/lib/aboutpage.dart
+++ b/packages/web_benchmarks/testing/test_app/lib/aboutpage.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/testing/test_app/lib/benchmarks/runner.dart
+++ b/packages/web_benchmarks/testing/test_app/lib/benchmarks/runner.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/testing/test_app/lib/homepage.dart
+++ b/packages/web_benchmarks/testing/test_app/lib/homepage.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/testing/test_app/lib/main.dart
+++ b/packages/web_benchmarks/testing/test_app/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/web_benchmarks/testing/web_benchmarks_test.dart
+++ b/packages/web_benchmarks/testing/web_benchmarks_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/xdg_directories/AUTHORS
+++ b/packages/xdg_directories/AUTHORS
@@ -4,6 +4,3 @@
 #   Name/Organization <email address>
 
 Google Inc.
-The Chromium Authors
-Britannio Jarrett <britanniojarrett@gmail.com>
-Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/packages/xdg_directories/LICENSE
+++ b/packages/xdg_directories/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020 The Flutter Authors. All rights reserved.
+Copyright 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
Standardize copyright author ("The Flutter Authors") and year (2013), as was previously done in flutter/plugins.
Adds per-package AUTHORS files to ensure that published packages contain the authorship information referred to in the boilerplate (again, as in flutter/plugins).

First preparatory step in enabling the automated license format check in this repository.

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
