### PR TITLE
[flutter_markdown] Standardize license/copyright

### DIFF
--- a/packages/flutter_markdown/AUTHORS
+++ b/packages/flutter_markdown/AUTHORS
@@ -5,4 +5,4 @@
 
 Google Inc.
 The Chromium Authors
-Quiverware LLC
+Quiverware LLC <mjordan@quiverware.com>

--- a/packages/flutter_markdown/AUTHORS
+++ b/packages/flutter_markdown/AUTHORS
@@ -1,0 +1,8 @@
+# Below is a list of people and organizations that have contributed
+# to the Flutter project. Names should be added to the list like so:
+#
+#   Name/Organization <email address>
+
+Google Inc.
+The Chromium Authors
+Quiverware LLC

--- a/packages/flutter_markdown/LICENSE
+++ b/packages/flutter_markdown/LICENSE
@@ -1,27 +1,25 @@
-// Copyright 2017 Google, Inc. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//    * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//    * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Copyright 2013 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/flutter_markdown/example/lib/demos/basic_markdown_demo.dart
+++ b/packages/flutter_markdown/example/lib/demos/basic_markdown_demo.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/demos/centered_header_demo.dart
+++ b/packages/flutter_markdown/example/lib/demos/centered_header_demo.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/demos/extended_emoji_demo.dart
+++ b/packages/flutter_markdown/example/lib/demos/extended_emoji_demo.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/demos/original_demo.dart
+++ b/packages/flutter_markdown/example/lib/demos/original_demo.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/demos/subscript_syntax_demo.dart
+++ b/packages/flutter_markdown/example/lib/demos/subscript_syntax_demo.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/demos/wrap_alignment_demo.dart
+++ b/packages/flutter_markdown/example/lib/demos/wrap_alignment_demo.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/main.dart
+++ b/packages/flutter_markdown/example/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 ///

--- a/packages/flutter_markdown/example/lib/screens/demo_card.dart
+++ b/packages/flutter_markdown/example/lib/screens/demo_card.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/screens/demo_screen.dart
+++ b/packages/flutter_markdown/example/lib/screens/demo_screen.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/screens/home_screen.dart
+++ b/packages/flutter_markdown/example/lib/screens/home_screen.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/shared/dropdown_menu.dart
+++ b/packages/flutter_markdown/example/lib/shared/dropdown_menu.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/shared/markdown_demo_widget.dart
+++ b/packages/flutter_markdown/example/lib/shared/markdown_demo_widget.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/example/lib/shared/markdown_extensions.dart
+++ b/packages/flutter_markdown/example/lib/shared/markdown_extensions.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/lib/flutter_markdown.dart
+++ b/packages/flutter_markdown/lib/flutter_markdown.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/lib/src/_functions_io.dart
+++ b/packages/flutter_markdown/lib/src/_functions_io.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/lib/src/_functions_web.dart
+++ b/packages/flutter_markdown/lib/src/_functions_web.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/lib/src/style_sheet.dart
+++ b/packages/flutter_markdown/lib/src/style_sheet.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/lib/src/widget.dart
+++ b/packages/flutter_markdown/lib/src/widget.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/all.dart
+++ b/packages/flutter_markdown/test/all.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/blockquote_test.dart
+++ b/packages/flutter_markdown/test/blockquote_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/custom_syntax_test.dart
+++ b/packages/flutter_markdown/test/custom_syntax_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/emphasis_test.dart
+++ b/packages/flutter_markdown/test/emphasis_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/header_test.dart
+++ b/packages/flutter_markdown/test/header_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/horizontal_rule_test.dart
+++ b/packages/flutter_markdown/test/horizontal_rule_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/html_test.dart
+++ b/packages/flutter_markdown/test/html_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/image_test.dart
+++ b/packages/flutter_markdown/test/image_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/image_test_mocks.dart
+++ b/packages/flutter_markdown/test/image_test_mocks.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/line_break_test.dart
+++ b/packages/flutter_markdown/test/line_break_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/link_test.dart
+++ b/packages/flutter_markdown/test/link_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/list_test.dart
+++ b/packages/flutter_markdown/test/list_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/scrollable_test.dart
+++ b/packages/flutter_markdown/test/scrollable_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/style_sheet_test.dart
+++ b/packages/flutter_markdown/test/style_sheet_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/table_test.dart
+++ b/packages/flutter_markdown/test/table_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/text_alignment_test.dart
+++ b/packages/flutter_markdown/test/text_alignment_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/text_scale_factor_test.dart
+++ b/packages/flutter_markdown/test/text_scale_factor_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/text_test.dart
+++ b/packages/flutter_markdown/test/text_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/uri_test.dart
+++ b/packages/flutter_markdown/test/uri_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_markdown/test/utils.dart
+++ b/packages/flutter_markdown/test/utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Quiverware LLC. Open source contribution. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
This applies the recent license standardization to the newly-imported
flutter_markdown to align it with the rest of the respository:
- Standardizes year as 2013
- Standardizes author as "The Flutter Authors", moving other authors
  to the AUTHORS file
- Uses the exact same text format for the copyright line as in other
  files

Note that the files that currently list "Quiverware" are not third-party
code, but code that was submitted to flutter/flutter_markdown through
the standard PR process with a signed CLA; the reviews just didn't catch
that it was using a non-standard author line.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
