### PR TITLE
Add needs-publishing auto-label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,9 @@
 'p: extension_google_sign_in_as_googleapis_auth':
   - packages/extension_google_sign_in_as_googleapis_auth/**/*
 
+'p: flutter_image':
+  - packages/flutter_image/**/*
+
 'p: flutter_markdown':
   - packages/flutter_markdown/**/*
 

--- a/.github/post_merge_labeler.yml
+++ b/.github/post_merge_labeler.yml
@@ -1,0 +1,2 @@
+'needs-publishing':
+  - ./**/pubspec.yaml

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -20,3 +20,12 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true
+
+  post_merge_label:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@9794b1493b6f1fa7b006c5f8635a19c76c98be95
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/post_merge_labeler.yml


### PR DESCRIPTION
Tags any PR submitted that changes a pubspec.yaml as (likely) needing
publishing, to easily find things that may have been missed. Matches the
current setup in flutter/plugins.

Also updates the package auto-labeling for the newly-imported
flutter_image package.

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
