### PR TITLE
[animations] Migrate scrim color tests

### DIFF
--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1827,12 +1827,14 @@ void main() {
 }
 
 Color _getScrimColor(WidgetTester tester) {
-  return tester.widget<ColoredBox>(
-    find.descendant(
-      of: find.byType(Container),
-      matching: find.byType(ColoredBox),
-    ),
-  ).color;
+  return tester
+      .widget<ColoredBox>(
+        find.descendant(
+          of: find.byType(Container),
+          matching: find.byType(ColoredBox),
+        ),
+      )
+      .color;
 }
 
 void _expectMaterialPropertiesHaveAdvanced({
@@ -1905,6 +1907,7 @@ class _SizableContainerState extends State<_SizableContainer> {
 
   double get size => _size;
   late double _size;
+
   set size(double value) {
     if (value == _size) {
       return;

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1907,7 +1907,6 @@ class _SizableContainerState extends State<_SizableContainer> {
 
   double get size => _size;
   late double _size;
-
   set size(double value) {
     if (value == _size) {
       return;

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1827,7 +1827,12 @@ void main() {
 }
 
 Color _getScrimColor(WidgetTester tester) {
-  return tester.widget<ColoredBox>(find.byType(ColoredBox)).color;
+  return tester.widget<ColoredBox>(
+    find.descendant(
+      of: find.byType(Container),
+      matching: find.byType(ColoredBox),
+    ),
+  ).color;
 }
 
 void _expectMaterialPropertiesHaveAdvanced({


### PR DESCRIPTION
This is a pre-migration to the PR flutter/flutter#82670 . Now the `ColoredBox` is founded by a more specific finder.

cc @shihaohong @goderbauer 

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.