### PR TITLE
[pointer_interceptor] Shadow dom tweaks

### DIFF
--- a/packages/pointer_interceptor/CHANGELOG.md
+++ b/packages/pointer_interceptor/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.1
+## 0.9.0+1
 
 * Change sizing of HtmlElementView so it works well when slotted.
 

--- a/packages/pointer_interceptor/CHANGELOG.md
+++ b/packages/pointer_interceptor/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+* Change sizing of HtmlElementView so it works well when slotted.
+
 ## 0.9.0
 
 * Migrates to null safety.

--- a/packages/pointer_interceptor/example/integration_test/widget_test.dart
+++ b/packages/pointer_interceptor/example/integration_test/widget_test.dart
@@ -21,18 +21,24 @@ void main() {
         find.byKey(const Key('clickable-button'));
 
     testWidgets(
-        'on wrapped elements, the browser hits the interceptor (and not the background-html-view)',
+        'on wrapped elements, the browser does not hit the background-html-view',
         (WidgetTester tester) async {
       app.main();
       await tester.pumpAndSettle();
 
       final html.Element? element =
           _getHtmlElementFromFinder(clickableButtonFinder, tester);
-      expect(element?.tagName.toLowerCase(), 'flt-platform-view');
 
-      final html.Element? platformViewRoot =
-          element?.shadowRoot?.getElementById('background-html-view');
-      expect(platformViewRoot, isNull);
+      if (html.document.querySelector('flt-glass-pane')?.shadowRoot != null) {
+        // In flutter master...
+        expect(element?.id, isNot('background-html-view'));
+      } else {
+        // In previous versions (--web-renderer=html only)...
+        expect(element?.tagName.toLowerCase(), 'flt-platform-view');
+        final html.Element? platformViewRoot =
+            element?.shadowRoot?.getElementById('background-html-view');
+        expect(platformViewRoot, isNull);
+      }
     });
 
     testWidgets(
@@ -43,11 +49,17 @@ void main() {
 
       final html.Element? element =
           _getHtmlElementFromFinder(nonClickableButtonFinder, tester);
-      expect(element?.tagName.toLowerCase(), 'flt-platform-view');
 
-      final html.Element? platformViewRoot =
-          element?.shadowRoot?.getElementById('background-html-view');
-      expect(platformViewRoot, isNotNull);
+      if (html.document.querySelector('flt-glass-pane')?.shadowRoot != null) {
+        // In flutter master...
+        expect(element?.id, 'background-html-view');
+      } else {
+        // In previous versions (--web-renderer=html only)...
+        expect(element?.tagName.toLowerCase(), 'flt-platform-view');
+        final html.Element? platformViewRoot =
+            element?.shadowRoot?.getElementById('background-html-view');
+        expect(platformViewRoot, isNotNull);
+      }
     });
   });
 }

--- a/packages/pointer_interceptor/example/lib/main.dart
+++ b/packages/pointer_interceptor/example/lib/main.dart
@@ -42,6 +42,11 @@ html.Element htmlElement = html.DivElement()
 //       ..style.border = 'none';
 
 void main() {
+  ui.platformViewRegistry.registerViewFactory(
+    _htmlElementViewType,
+    (int viewId) => htmlElement,
+  );
+
   runApp(const MyApp());
 }
 
@@ -52,13 +57,6 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    ui.platformViewRegistry.registerViewFactory(_htmlElementViewType,
-        (int viewId) {
-      final html.Element wrapper = html.DivElement();
-      wrapper.append(htmlElement);
-      return wrapper;
-    });
-
     return const MaterialApp(
       title: 'Stopping Clicks with some DOM',
       home: MyHomePage(),

--- a/packages/pointer_interceptor/lib/src/web.dart
+++ b/packages/pointer_interceptor/lib/src/web.dart
@@ -22,11 +22,8 @@ void _registerFactory({bool debug = false}) {
   final String viewType = _getViewType(debug: debug);
   ui.platformViewRegistry.registerViewFactory(viewType, (int viewId) {
     final html.Element htmlElement = html.DivElement()
-      ..style.top = '0'
-      ..style.right = '0'
-      ..style.bottom = '0'
-      ..style.left = '0'
-      ..style.position = 'relative';
+      ..style.width = '100%'
+      ..style.height = '100%';
     if (debug) {
       htmlElement.style.backgroundColor = 'rgba(255, 0, 0, .5)';
     }

--- a/packages/pointer_interceptor/pubspec.yaml
+++ b/packages/pointer_interceptor/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pointer_interceptor
 description: A widget to prevent clicks from being swallowed by underlying HtmlElementViews on the web.
 repository: https://github.com/flutter/packages
-version: 0.9.0
+version: 0.9.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/pointer_interceptor/pubspec.yaml
+++ b/packages/pointer_interceptor/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pointer_interceptor
 description: A widget to prevent clicks from being swallowed by underlying HtmlElementViews on the web.
 repository: https://github.com/flutter/packages
-version: 0.9.1
+version: 0.9.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Change the pointer_interceptor so that it works better with the new `slots` way of embedding HtmlElementViews in flutter web master.

Related to: https://github.com/flutter/flutter/issues/80524

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
