### PR TITLE
Update the rules for the post-merge labeler

### DIFF
--- a/.github/post_merge_labeler.yml
+++ b/.github/post_merge_labeler.yml
@@ -1,2 +1,3 @@
 'needs-publishing':
-  - ./**/pubspec.yaml
+  - packages/**/pubspec.yaml
+  - third_party/packages/**/pubspec.yaml


### PR DESCRIPTION
The existing pattern isn't matching; this replaces it with more explicit rules that are more similar to what flutter/plugins is successfully using.

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
