### PR TITLE
[pigeon] added more errors for improper usage

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [front-end] Added a more explicit error if generic fields are used.
 * [front-end] Added a more explicit error for static fields.
+* [front-end] Added more errors for incorrect usage of Pigeon (previously they were just ignored).
 
 ## 0.3.0
 

--- a/packages/pigeon/lib/ast.dart
+++ b/packages/pigeon/lib/ast.dart
@@ -21,8 +21,9 @@ class Method extends Node {
     required this.name,
     required this.returnType,
     required this.argType,
-    required this.isArgNullable,
+    this.isArgNullable = false,
     this.isAsynchronous = false,
+    this.isReturnNullable = false,
     this.offset,
   });
 
@@ -31,6 +32,9 @@ class Method extends Node {
 
   /// The data-type of the return value.
   String returnType;
+
+  /// True if the method can return a null value.
+  bool isReturnNullable;
 
   /// The data-type of the argument.
   String argType;

--- a/packages/pigeon/lib/ast.dart
+++ b/packages/pigeon/lib/ast.dart
@@ -21,7 +21,9 @@ class Method extends Node {
     required this.name,
     required this.returnType,
     required this.argType,
+    required this.isArgNullable,
     this.isAsynchronous = false,
+    this.offset,
   });
 
   /// The name of the method.
@@ -33,8 +35,14 @@ class Method extends Node {
   /// The data-type of the argument.
   String argType;
 
+  /// True if the argument has a null tag `?`.
+  bool isArgNullable;
+
   /// Whether the receiver of this method is expected to return synchronously or not.
   bool isAsynchronous;
+
+  /// The offset in the source file where the field appears.
+  int? offset;
 
   @override
   String toString() {
@@ -76,6 +84,8 @@ class Field extends Node {
   Field({
     required this.name,
     required this.dataType,
+    required this.isNullable,
+    this.typeArguments,
     this.offset,
   });
 
@@ -87,6 +97,12 @@ class Field extends Node {
 
   /// The offset in the source file where the field appears.
   int? offset;
+
+  /// True if the datatype is nullable (ex `int?`).
+  bool isNullable;
+
+  /// Type parameters used for generics.
+  List<Field>? typeArguments;
 
   @override
   String toString() {

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -391,7 +391,7 @@ List<Error> _validateAst(Root root, String source) {
   final List<String> customEnums = root.enums.map((Enum x) => x.name).toList();
   for (final Class klass in root.classes) {
     for (final Field field in klass.fields) {
-      if (field.dataType.contains('<')) {
+      if (field.typeArguments != null) {
         result.add(Error(
           message:
               'Unsupported datatype:"${field.dataType}" in class "${klass.name}". Generic fields aren\'t yet supported (https://github.com/flutter/flutter/issues/63468).',
@@ -410,6 +410,13 @@ List<Error> _validateAst(Root root, String source) {
   }
   for (final Api api in root.apis) {
     for (final Method method in api.methods) {
+      if (method.isArgNullable) {
+        result.add(Error(
+          message:
+              'Nullable argument types aren\'t supported for Pigeon methods: "${method.argType}" in API: "${api.name}" method: "${method.name}',
+          lineNumber: _calculateLineNumberNullable(source, method.offset),
+        ));
+      }
       if (_validTypes.contains(method.argType)) {
         result.add(Error(
             message:
@@ -483,30 +490,11 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
       }
     }
 
-    final List<Class> classesWithNullTagStripped = _classes.map((Class aClass) {
-      return Class(
-          name: aClass.name,
-          fields: aClass.fields.map((Field field) {
-            String datatype = field.dataType;
-            if (datatype.endsWith('?')) {
-              datatype = datatype.substring(0, datatype.length - 1);
-            } else {
-              // TODO(aaclarke): Provide an error when not using a nullable type.
-              // _errors.add(Error(
-              //     message:
-              //         'Field ${aClass.name}.${field.name} must be nullable.'));
-            }
-            return Field(
-                name: field.name, dataType: datatype, offset: field.offset);
-          }).toList());
-    }).toList();
-
     final List<String> classesToCheck = List<String>.from(referencedTypes);
     while (classesToCheck.isNotEmpty) {
       final String next = classesToCheck.last;
       classesToCheck.removeLast();
-      final Class aClass = classesWithNullTagStripped.firstWhere(
-          (Class x) => x.name == next,
+      final Class aClass = _classes.firstWhere((Class x) => x.name == next,
           orElse: () => Class(name: '', fields: <Field>[]));
       for (final Field field in aClass.fields) {
         if (!referencedTypes.contains(field.dataType) &&
@@ -521,8 +509,7 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
         ? (Class x) => !referencedTypes.contains(x.name)
         : (Class x) =>
             !referencedTypes.contains(x.name) && !typeFilter.contains(x.name);
-    final List<Class> referencedClasses =
-        List<Class>.from(classesWithNullTagStripped);
+    final List<Class> referencedClasses = List<Class>.from(_classes);
     referencedClasses.removeWhere(classRemover);
 
     final List<Enum> referencedEnums = List<Enum>.from(_enums);
@@ -657,6 +644,7 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
   Object? visitMethodDeclaration(dart_ast.MethodDeclaration node) {
     final dart_ast.FormalParameterList parameters = node.parameters!;
     late String argType;
+    bool isNullable = false;
     if (parameters.parameters.isEmpty) {
       argType = 'void';
     } else {
@@ -666,6 +654,7 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
           // ignore: always_specify_types
           .firstWhere((e) => e is dart_ast.TypeName) as dart_ast.TypeName;
       argType = typeName.name.name;
+      isNullable = typeName.question != null;
     }
     final bool isAsynchronous = _hasMetadata(node.metadata, 'async');
     if (_currentApi != null) {
@@ -673,7 +662,9 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
           name: node.name.name,
           returnType: node.returnType.toString(),
           argType: argType,
-          isAsynchronous: isAsynchronous));
+          isArgNullable: isNullable,
+          isAsynchronous: isAsynchronous,
+          offset: node.offset));
     } else if (_currentClass != null) {
       _errors.add(Error(
           message:
@@ -713,9 +704,25 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
                   'Initialization isn\'t supported for fields in Pigeon data classes ("$node"), just use nullable types with no initializer (example "int? x;").',
               lineNumber: _calculateLineNumber(source, node.offset)));
         } else {
+          final dart_ast.TypeArgumentList? typeArguments = type.typeArguments;
           _currentClass!.fields.add(Field(
             name: node.fields.variables[0].name.name,
-            dataType: type.toString(),
+            dataType: type.name.name,
+            isNullable: type.question != null,
+            // TODO(aaclarke): This probably has to be recursive at some point.
+            // ignore: prefer_null_aware_operators
+            typeArguments: typeArguments == null
+                ? null
+                : typeArguments.arguments
+                    .map((dart_ast.TypeAnnotation e) => Field(
+                          name: '',
+                          dataType: (e.childEntities.first
+                                  as dart_ast.SimpleIdentifier)
+                              .name,
+                          isNullable: e.question != null,
+                          offset: e.offset,
+                        ))
+                    .toList(),
             offset: node.offset,
           ));
         }

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -426,13 +426,17 @@ List<Error> _validateAst(Root root, String source) {
       }
       if (_validTypes.contains(method.argType)) {
         result.add(Error(
-            message:
-                'Unsupported argument type: "${method.argType}" in API: "${api.name}" method: "${method.name}'));
+          message:
+              'Primitive argument types aren\'t yet supported (https://github.com/flutter/flutter/issues/66467): "${method.argType}" in API: "${api.name}" method: "${method.name}',
+          lineNumber: _calculateLineNumberNullable(source, method.offset),
+        ));
       }
       if (_validTypes.contains(method.returnType)) {
         result.add(Error(
-            message:
-                'Unsupported return type: "${method.returnType}" in API: "${api.name}" method: "${method.name}'));
+          message:
+              'Primitive return types aren\'t yet supported (https://github.com/flutter/flutter/issues/66467): "${method.returnType}" in API: "${api.name}" method: "${method.name}',
+          lineNumber: _calculateLineNumberNullable(source, method.offset),
+        ));
       }
     }
   }

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -410,6 +410,13 @@ List<Error> _validateAst(Root root, String source) {
   }
   for (final Api api in root.apis) {
     for (final Method method in api.methods) {
+      if (method.isReturnNullable) {
+        result.add(Error(
+          message:
+              'Nullable return types types aren\'t supported for Pigeon methods: "${method.argType}" in API: "${api.name}" method: "${method.name}',
+          lineNumber: _calculateLineNumberNullable(source, method.offset),
+        ));
+      }
       if (method.isArgNullable) {
         result.add(Error(
           message:
@@ -662,6 +669,7 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
           name: node.name.name,
           returnType: node.returnType.toString(),
           argType: argType,
+          isReturnNullable: node.returnType!.question != null,
           isArgNullable: isNullable,
           isAsynchronous: isAsynchronous,
           offset: node.offset));

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -15,6 +15,7 @@ void main() {
         Field(
           name: 'field1',
           dataType: 'dataType1',
+          isNullable: true,
         ),
       ],
     );
@@ -57,17 +58,26 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -80,11 +90,23 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(
         name: 'Input',
-        fields: <Field>[Field(name: 'input', dataType: 'String')],
+        fields: <Field>[
+          Field(
+            name: 'input',
+            dataType: 'String',
+            isNullable: true,
+          )
+        ],
       ),
       Class(
         name: 'Nested',
-        fields: <Field>[Field(name: 'nested', dataType: 'Input')],
+        fields: <Field>[
+          Field(
+            name: 'nested',
+            dataType: 'Input',
+            isNullable: true,
+          )
+        ],
       )
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
@@ -110,17 +132,26 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -135,14 +166,19 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'void',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -157,14 +193,19 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'void',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -183,14 +224,19 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'void',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -205,14 +251,19 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'EnumClass',
+          isArgNullable: false,
           returnType: 'EnumClass',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'EnumClass',
-          fields: <Field>[Field(name: 'enum1', dataType: 'Enum')]),
+      Class(name: 'EnumClass', fields: <Field>[
+        Field(
+          name: 'enum1',
+          dataType: 'Enum',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[
       Enum(
         name: 'Enum',
@@ -237,14 +288,19 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'EnumClass',
+          isArgNullable: false,
           returnType: 'EnumClass',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'EnumClass',
-          fields: <Field>[Field(name: 'enum1', dataType: 'Enum')]),
+      Class(name: 'EnumClass', fields: <Field>[
+        Field(
+          name: 'enum1',
+          dataType: 'Enum',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[
       Enum(
         name: 'Enum',
@@ -271,14 +327,19 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'void',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -296,23 +357,33 @@ void main() {
             Method(
               name: 'doSomething',
               argType: 'Input',
+              isArgNullable: false,
               returnType: 'Output',
               isAsynchronous: false,
             ),
             Method(
               name: 'voidReturner',
               argType: 'Input',
+              isArgNullable: false,
               returnType: 'void',
               isAsynchronous: false,
             )
           ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer mainCodeSink = StringBuffer();
     final StringBuffer testCodeSink = StringBuffer();
@@ -342,6 +413,7 @@ void main() {
         Field(
           name: 'field1',
           dataType: 'dataType1',
+          isNullable: true,
         ),
       ],
     );
@@ -362,17 +434,26 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: true,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -389,17 +470,26 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'void',
           isAsynchronous: true,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -415,17 +505,26 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: true,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);
@@ -440,14 +539,19 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'void',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: true,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateDart(const DartOptions(isNullSafe: false), root, sink);

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -14,6 +14,7 @@ void main() {
         Field(
           name: 'field1',
           dataType: 'int',
+          isNullable: true,
         ),
       ],
     );
@@ -63,6 +64,7 @@ void main() {
         Field(
           name: 'field1',
           dataType: 'int',
+          isNullable: true,
         )
       ],
     );
@@ -86,17 +88,18 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: true,
           returnType: 'Output',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(name: 'input', dataType: 'String', isNullable: true)
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(name: 'output', dataType: 'String', isNullable: true)
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -110,14 +113,14 @@ void main() {
   test('all the simple datatypes header', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <Field>[
-        Field(name: 'aBool', dataType: 'bool'),
-        Field(name: 'aInt', dataType: 'int'),
-        Field(name: 'aDouble', dataType: 'double'),
-        Field(name: 'aString', dataType: 'String'),
-        Field(name: 'aUint8List', dataType: 'Uint8List'),
-        Field(name: 'aInt32List', dataType: 'Int32List'),
-        Field(name: 'aInt64List', dataType: 'Int64List'),
-        Field(name: 'aFloat64List', dataType: 'Float64List'),
+        Field(name: 'aBool', dataType: 'bool', isNullable: true),
+        Field(name: 'aInt', dataType: 'int', isNullable: true),
+        Field(name: 'aDouble', dataType: 'double', isNullable: true),
+        Field(name: 'aString', dataType: 'String', isNullable: true),
+        Field(name: 'aUint8List', dataType: 'Uint8List', isNullable: true),
+        Field(name: 'aInt32List', dataType: 'Int32List', isNullable: true),
+        Field(name: 'aInt64List', dataType: 'Int64List', isNullable: true),
+        Field(name: 'aFloat64List', dataType: 'Float64List', isNullable: true),
       ]),
     ], enums: <Enum>[]);
 
@@ -141,17 +144,18 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(name: 'input', dataType: 'String', isNullable: true)
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(name: 'output', dataType: 'String', isNullable: true)
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -167,14 +171,15 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'void',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(name: 'input', dataType: 'String', isNullable: true)
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -190,14 +195,15 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'void',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(name: 'input', dataType: 'String', isNullable: true)
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -214,14 +220,15 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'void',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(name: 'output', dataType: 'String', isNullable: true)
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -237,14 +244,15 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'void',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: false,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(name: 'output', dataType: 'String', isNullable: true)
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -256,9 +264,9 @@ void main() {
 
   test('gen list', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Foobar',
-          fields: <Field>[Field(name: 'field1', dataType: 'List')]),
+      Class(name: 'Foobar', fields: <Field>[
+        Field(name: 'field1', dataType: 'List', isNullable: true)
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -270,9 +278,9 @@ void main() {
 
   test('gen map', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Foobar',
-          fields: <Field>[Field(name: 'field1', dataType: 'Map')]),
+      Class(name: 'Foobar', fields: <Field>[
+        Field(name: 'field1', dataType: 'Map', isNullable: true)
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -289,6 +297,7 @@ void main() {
         Field(
           name: 'nested',
           dataType: 'Nested',
+          isNullable: true,
         )
       ],
     );
@@ -298,6 +307,7 @@ void main() {
         Field(
           name: 'data',
           dataType: 'int',
+          isNullable: true,
         )
       ],
     );
@@ -324,17 +334,18 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: true,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(name: 'input', dataType: 'String', isNullable: true)
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(name: 'output', dataType: 'String', isNullable: true)
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -357,17 +368,18 @@ void main() {
         Method(
           name: 'doSomething',
           argType: 'Input',
+          isArgNullable: false,
           returnType: 'Output',
           isAsynchronous: true,
         )
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(name: 'input', dataType: 'String', isNullable: true)
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(name: 'output', dataType: 'String', isNullable: true)
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     const JavaOptions javaOptions = JavaOptions(className: 'Messages');
@@ -391,6 +403,7 @@ void main() {
         Field(
           name: 'enum1',
           dataType: 'Enum1',
+          isNullable: true,
         ),
       ],
     );

--- a/packages/pigeon/test/objc_generator_test.dart
+++ b/packages/pigeon/test/objc_generator_test.dart
@@ -9,9 +9,13 @@ import 'package:test/test.dart';
 void main() {
   test('gen one class header', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Foobar',
-          fields: <Field>[Field(name: 'field1', dataType: 'String')]),
+      Class(name: 'Foobar', fields: <Field>[
+        Field(
+          name: 'field1',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(const ObjcOptions(), root, sink);
@@ -22,9 +26,13 @@ void main() {
 
   test('gen one class source', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Foobar',
-          fields: <Field>[Field(name: 'field1', dataType: 'String')]),
+      Class(name: 'Foobar', fields: <Field>[
+        Field(
+          name: 'field1',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(const ObjcOptions(header: 'foo.h'), root, sink);
@@ -76,8 +84,16 @@ void main() {
         Class(
           name: 'Foobar',
           fields: <Field>[
-            Field(name: 'field1', dataType: 'String'),
-            Field(name: 'enum1', dataType: 'Enum1'),
+            Field(
+              name: 'field1',
+              dataType: 'String',
+              isNullable: true,
+            ),
+            Field(
+              name: 'enum1',
+              dataType: 'Enum1',
+              isNullable: true,
+            ),
           ],
         ),
       ],
@@ -102,15 +118,27 @@ void main() {
   test('gen one api header', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Output')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'Output')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(const ObjcOptions(), root, sink);
@@ -125,15 +153,27 @@ void main() {
   test('gen one api source', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Output')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'Output')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(const ObjcOptions(header: 'foo.h'), root, sink);
@@ -147,14 +187,46 @@ void main() {
   test('all the simple datatypes header', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <Field>[
-        Field(name: 'aBool', dataType: 'bool'),
-        Field(name: 'aInt', dataType: 'int'),
-        Field(name: 'aDouble', dataType: 'double'),
-        Field(name: 'aString', dataType: 'String'),
-        Field(name: 'aUint8List', dataType: 'Uint8List'),
-        Field(name: 'aInt32List', dataType: 'Int32List'),
-        Field(name: 'aInt64List', dataType: 'Int64List'),
-        Field(name: 'aFloat64List', dataType: 'Float64List'),
+        Field(
+          name: 'aBool',
+          dataType: 'bool',
+          isNullable: true,
+        ),
+        Field(
+          name: 'aInt',
+          dataType: 'int',
+          isNullable: true,
+        ),
+        Field(
+          name: 'aDouble',
+          dataType: 'double',
+          isNullable: true,
+        ),
+        Field(
+          name: 'aString',
+          dataType: 'String',
+          isNullable: true,
+        ),
+        Field(
+          name: 'aUint8List',
+          dataType: 'Uint8List',
+          isNullable: true,
+        ),
+        Field(
+          name: 'aInt32List',
+          dataType: 'Int32List',
+          isNullable: true,
+        ),
+        Field(
+          name: 'aInt64List',
+          dataType: 'Int64List',
+          isNullable: true,
+        ),
+        Field(
+          name: 'aFloat64List',
+          dataType: 'Float64List',
+          isNullable: true,
+        ),
       ]),
     ], enums: <Enum>[]);
 
@@ -180,7 +252,11 @@ void main() {
   test('bool source', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <Field>[
-        Field(name: 'aBool', dataType: 'bool'),
+        Field(
+          name: 'aBool',
+          dataType: 'bool',
+          isNullable: true,
+        ),
       ]),
     ], enums: <Enum>[]);
 
@@ -193,12 +269,20 @@ void main() {
 
   test('nested class header', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Nested',
-          fields: <Field>[Field(name: 'nested', dataType: 'Input')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Nested', fields: <Field>[
+        Field(
+          name: 'nested',
+          dataType: 'Input',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(const ObjcOptions(header: 'foo.h'), root, sink);
@@ -209,12 +293,20 @@ void main() {
 
   test('nested class source', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Nested',
-          fields: <Field>[Field(name: 'nested', dataType: 'Input')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Nested', fields: <Field>[
+        Field(
+          name: 'nested',
+          dataType: 'Input',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(const ObjcOptions(header: 'foo.h'), root, sink);
@@ -225,9 +317,13 @@ void main() {
 
   test('prefix class header', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Foobar',
-          fields: <Field>[Field(name: 'field1', dataType: 'String')]),
+      Class(name: 'Foobar', fields: <Field>[
+        Field(
+          name: 'field1',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(const ObjcOptions(prefix: 'ABC'), root, sink);
@@ -237,9 +333,13 @@ void main() {
 
   test('prefix class source', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Foobar',
-          fields: <Field>[Field(name: 'field1', dataType: 'String')]),
+      Class(name: 'Foobar', fields: <Field>[
+        Field(
+          name: 'field1',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(const ObjcOptions(prefix: 'ABC'), root, sink);
@@ -250,15 +350,27 @@ void main() {
   test('prefix nested class header', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Nested')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'Nested')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Nested',
-          fields: <Field>[Field(name: 'nested', dataType: 'Input')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Nested', fields: <Field>[
+        Field(
+          name: 'nested',
+          dataType: 'Input',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(const ObjcOptions(prefix: 'ABC'), root, sink);
@@ -271,15 +383,27 @@ void main() {
   test('prefix nested class source', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Nested')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'Nested')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Nested',
-          fields: <Field>[Field(name: 'nested', dataType: 'Input')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Nested', fields: <Field>[
+        Field(
+          name: 'nested',
+          dataType: 'Input',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(const ObjcOptions(prefix: 'ABC'), root, sink);
@@ -292,15 +416,27 @@ void main() {
   test('gen flutter api header', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Output')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'Output')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(const ObjcOptions(header: 'foo.h'), root, sink);
@@ -316,15 +452,27 @@ void main() {
   test('gen flutter api source', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'Output')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'Output')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')])
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ])
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(const ObjcOptions(header: 'foo.h'), root, sink);
@@ -336,12 +484,20 @@ void main() {
   test('gen host void header', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'void')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'void')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(
@@ -353,12 +509,20 @@ void main() {
   test('gen host void source', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'void')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'void')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(
@@ -372,12 +536,20 @@ void main() {
   test('gen flutter void return header', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'void')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'void')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(
@@ -389,12 +561,20 @@ void main() {
   test('gen flutter void return source', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'Input', returnType: 'void')
+        Method(
+            name: 'doSomething',
+            argType: 'Input',
+            isArgNullable: false,
+            returnType: 'void')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(
@@ -407,12 +587,20 @@ void main() {
   test('gen host void arg header', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'void', returnType: 'Output')
+        Method(
+            name: 'doSomething',
+            argType: 'void',
+            isArgNullable: false,
+            returnType: 'Output')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(
@@ -424,12 +612,20 @@ void main() {
   test('gen host void arg source', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.host, methods: <Method>[
-        Method(name: 'doSomething', argType: 'void', returnType: 'Output')
+        Method(
+            name: 'doSomething',
+            argType: 'void',
+            isArgNullable: false,
+            returnType: 'Output')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(
@@ -441,12 +637,20 @@ void main() {
   test('gen flutter void arg header', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'void', returnType: 'Output')
+        Method(
+            name: 'doSomething',
+            argType: 'void',
+            isArgNullable: false,
+            returnType: 'Output')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(
@@ -461,12 +665,20 @@ void main() {
   test('gen flutter void arg header', () {
     final Root root = Root(apis: <Api>[
       Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
-        Method(name: 'doSomething', argType: 'void', returnType: 'Output')
+        Method(
+            name: 'doSomething',
+            argType: 'void',
+            isArgNullable: false,
+            returnType: 'Output')
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(
@@ -481,9 +693,13 @@ void main() {
 
   test('gen list', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Foobar',
-          fields: <Field>[Field(name: 'field1', dataType: 'List')]),
+      Class(name: 'Foobar', fields: <Field>[
+        Field(
+          name: 'field1',
+          dataType: 'List',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(const ObjcOptions(), root, sink);
@@ -494,9 +710,13 @@ void main() {
 
   test('gen map', () {
     final Root root = Root(apis: <Api>[], classes: <Class>[
-      Class(
-          name: 'Foobar',
-          fields: <Field>[Field(name: 'field1', dataType: 'Map')]),
+      Class(name: 'Foobar', fields: <Field>[
+        Field(
+          name: 'field1',
+          dataType: 'Map',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(const ObjcOptions(), root, sink);
@@ -511,16 +731,25 @@ void main() {
         Method(
             name: 'doSomething',
             argType: 'Input',
+            isArgNullable: false,
             returnType: 'void',
             isAsynchronous: true)
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(
@@ -538,16 +767,25 @@ void main() {
         Method(
             name: 'doSomething',
             argType: 'Input',
+            isArgNullable: false,
             returnType: 'Output',
             isAsynchronous: true)
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(
@@ -565,13 +803,18 @@ void main() {
         Method(
             name: 'doSomething',
             argType: 'void',
+            isArgNullable: false,
             returnType: 'Output',
             isAsynchronous: true)
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcHeader(
@@ -589,6 +832,7 @@ void main() {
         Method(
             name: 'doSomething',
             argType: 'void',
+            isArgNullable: false,
             returnType: 'void',
             isAsynchronous: true)
       ])
@@ -609,16 +853,25 @@ void main() {
         Method(
             name: 'doSomething',
             argType: 'Input',
+            isArgNullable: false,
             returnType: 'Output',
             isAsynchronous: true)
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(
@@ -636,16 +889,25 @@ void main() {
         Method(
             name: 'doSomething',
             argType: 'Input',
+            isArgNullable: false,
             returnType: 'void',
             isAsynchronous: true)
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Input',
-          fields: <Field>[Field(name: 'input', dataType: 'String')]),
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Input', fields: <Field>[
+        Field(
+          name: 'input',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(
@@ -663,6 +925,7 @@ void main() {
         Method(
             name: 'doSomething',
             argType: 'void',
+            isArgNullable: false,
             returnType: 'void',
             isAsynchronous: true)
       ])
@@ -681,13 +944,18 @@ void main() {
         Method(
             name: 'doSomething',
             argType: 'void',
+            isArgNullable: false,
             returnType: 'Output',
             isAsynchronous: true)
       ])
     ], classes: <Class>[
-      Class(
-          name: 'Output',
-          fields: <Field>[Field(name: 'output', dataType: 'String')]),
+      Class(name: 'Output', fields: <Field>[
+        Field(
+          name: 'output',
+          dataType: 'String',
+          isNullable: true,
+        )
+      ]),
     ], enums: <Enum>[]);
     final StringBuffer sink = StringBuffer();
     generateObjcSource(

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -524,6 +524,26 @@ abstract class Api {
     });
   });
 
+  test('nullable api return', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+class Foo {
+  int? x;
+}
+
+@HostApi()
+abstract class Api {
+  Foo? doit(Foo foo);
+}
+''');
+      final ParseResults results = dartle.parseFile(file.path);
+      expect(results.errors.length, 1);
+      expect(results.errors[0].lineNumber, 7);
+      expect(results.errors[0].message, contains('Nullable'));
+    });
+  });
+
   test('test invalid import', () {
     final Pigeon dartle = Pigeon.setup();
     _withTempFile('compilationError.dart', (File file) {

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -184,10 +184,12 @@ void main() {
     expect(input?.fields.length, equals(1));
     expect(input?.fields[0].name, equals('input'));
     expect(input?.fields[0].dataType, equals('String'));
+    expect(input?.fields[0].isNullable, isTrue);
 
     expect(output?.fields.length, equals(1));
     expect(output?.fields[0].name, equals('output'));
     expect(output?.fields[0].dataType, equals('String'));
+    expect(output?.fields[0].isNullable, isTrue);
   });
 
   test('invalid datatype', () {
@@ -208,6 +210,7 @@ void main() {
     expect(results.root.classes[0].name, equals('ClassWithEnum'));
     expect(results.root.classes[0].fields.length, equals(1));
     expect(results.root.classes[0].fields[0].dataType, equals('Enum1'));
+    expect(results.root.classes[0].fields[0].isNullable, isTrue);
     expect(results.root.classes[0].fields[0].name, equals('enum1'));
   });
 
@@ -232,6 +235,7 @@ void main() {
         results.root.classes.firstWhere((Class x) => x.name == 'Nested');
     expect(nested.fields.length, equals(1));
     expect(nested.fields[0].dataType, equals('Input1'));
+    expect(nested.fields[0].isNullable, isTrue);
   });
 
   test('flutter api', () {
@@ -497,6 +501,26 @@ abstract class Api {
       expect(results.errors.length, 1);
       expect(results.errors[0].lineNumber, 3);
       expect(results.errors[0].message, contains('Constructor'));
+    });
+  });
+
+  test('nullable api arguments', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+class Foo {
+  int? x;
+}
+
+@HostApi()
+abstract class Api {
+  Foo doit(Foo? foo);
+}
+''');
+      final ParseResults results = dartle.parseFile(file.path);
+      expect(results.errors.length, 1);
+      expect(results.errors[0].lineNumber, 7);
+      expect(results.errors[0].message, contains('Nullable'));
     });
   });
 

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -544,6 +544,39 @@ abstract class Api {
     });
   });
 
+  test('primitive arguments', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+@HostApi()
+abstract class Api {
+  void doit(int foo);
+}
+''');
+      final ParseResults results = dartle.parseFile(file.path);
+      expect(results.errors.length, 1);
+      expect(results.errors[0].lineNumber, 3);
+      expect(results.errors[0].message, contains('Primitive'));
+    });
+  });
+
+  test('primitive return', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+@HostApi()
+abstract class Api {
+  int doit();
+}
+''');
+      final ParseResults results = dartle.parseFile(file.path);
+      expect(results.errors.length, 1);
+      expect(results.errors[0].lineNumber, 3);
+      expect(results.errors[0].message, contains('Primitive'));
+    });
+  });
+
+
   test('test invalid import', () {
     final Pigeon dartle = Pigeon.setup();
     _withTempFile('compilationError.dart', (File file) {

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -576,7 +576,6 @@ abstract class Api {
     });
   });
 
-
   test('test invalid import', () {
     final Pigeon dartle = Pigeon.setup();
     _withTempFile('compilationError.dart', (File file) {

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -417,6 +417,89 @@ abstract class NotificationsHostApi {
     });
   });
 
+  test('test method in data class error', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+class Foo {
+  int? x;
+  int? foo() { return x; }
+}
+
+@HostApi()
+abstract class Api {
+  Foo doit(Foo foo);
+}
+''');
+      final ParseResults results = dartle.parseFile(file.path);
+      expect(results.errors.length, 1);
+      expect(results.errors[0].lineNumber, 3);
+      expect(results.errors[0].message, contains('Method'));
+    });
+  });
+
+  test('test field initialization', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+class Foo {
+  int? x = 123;  
+}
+
+@HostApi()
+abstract class Api {
+  Foo doit(Foo foo);
+}
+''');
+      final ParseResults results = dartle.parseFile(file.path);
+      expect(results.errors.length, 1);
+      expect(results.errors[0].lineNumber, 2);
+      expect(results.errors[0].message, contains('Initialization'));
+    });
+  });
+
+  test('test field in api error', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+class Foo {
+  int? x;
+}
+
+@HostApi()
+abstract class Api {
+  int? x;
+  Foo doit(Foo foo);
+}
+''');
+      final ParseResults results = dartle.parseFile(file.path);
+      expect(results.errors.length, 1);
+      expect(results.errors[0].lineNumber, 7);
+      expect(results.errors[0].message, contains('Field'));
+    });
+  });
+
+  test('constructor in data class', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+class Foo {
+  int? x;
+  Foo(this.x);
+}
+
+@HostApi()
+abstract class Api {
+  Foo doit(Foo foo);
+}
+''');
+      final ParseResults results = dartle.parseFile(file.path);
+      expect(results.errors.length, 1);
+      expect(results.errors[0].lineNumber, 3);
+      expect(results.errors[0].message, contains('Constructor'));
+    });
+  });
+
   test('test invalid import', () {
     final Pigeon dartle = Pigeon.setup();
     _withTempFile('compilationError.dart', (File file) {


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/85355

added errors for:
- Using methods in data classes
-  Constructors in data classes
-  Using fields in APIs
-  Initializing data class fields
- Using nullable arguments in apis
- Using nullable return types in apis


## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
