### PR TITLE
[flutter_lints] Fix readme

### DIFF
--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Small update to readme
+
 ## 1.0.3
 
 * More small updates to readme

--- a/packages/flutter_lints/README.md
+++ b/packages/flutter_lints/README.md
@@ -14,7 +14,7 @@ their UI. Alternatively, the analyzer can be invoked manually by running
 ## Usage
 
 Flutter apps, packages, and plugins created with `flutter create` starting with
-Flutter version 2.xx are already set up to use the lints defined in this
+Flutter version 2.3.0 are already set up to use the lints defined in this
 package. Entities created before that version can use these lints by following
 these instructions:
 

--- a/packages/flutter_lints/pubspec.yaml
+++ b/packages/flutter_lints/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_lints
 description: Recommended lints for Flutter apps, packages, and plugins to encourage good coding practices.
 repository: https://github.com/flutter/packages/tree/master/packages/flutter_lints
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_lints%22
-version: 1.0.3
+version: 1.0.4
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
The readme says that `flutter create` with version `2.xx` adds flutter_lints to the project.
This seems like every version since 2 includes flutter_lints.

But the latest stable (2.2.2) doesn't include it.
The beta channel (2.3.0-24.1.pre) includes it.

Changing the readme to `2.3.0` seems like a good option.

Closes https://github.com/flutter/flutter/issues/85378

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
