### PR TITLE
[pigeon] removed the formatter from local_tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,7 +97,5 @@ task:
       CHANNEL: "master"
       CHANNEL: "stable"
   << : *FLUTTER_UPGRADE_TEMPLATE
-  clang_format_setup_script:
-    - brew install clang-format
-  build_script:
+  local_tests_script:
     - ./script/local_tests.sh

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -290,11 +290,6 @@ run_ios_e2e_tests() {
   popd
 }
 
-run_formatter() {
-  cd ../..
-  dart pub global run flutter_plugin_tools format 2>/dev/null
-}
-
 run_android_unittests() {
   pushd $PWD
   gen_android_unittests_code ./pigeons/all_datatypes.dart AllDatatypes

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -387,7 +387,7 @@ if [ "$should_run_android_unittests" = true ]; then
   get_java_linter_formatter
 fi
 test_running_without_arguments
-if [ "$should_run_dart_unittests" = true ] && [ ! "$CIRRUS_CI" = true ]; then
+if [ "$should_run_dart_unittests" = true ]; then
   run_dart_unittests
 fi
 if [ "$should_run_flutter_unittests" = true ]; then
@@ -407,7 +407,4 @@ if [ "$should_run_ios_e2e_tests" = true ]; then
 fi
 if [ "$should_run_android_unittests" = true ]; then
   run_android_unittests
-fi
-if [ "$should_run_formatter" = true ] && [ ! "$CIRRUS_CI" = true ]; then
-  run_formatter
 fi

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -319,7 +319,6 @@ should_run_android_unittests=true
 should_run_dart_compilation_tests=true
 should_run_dart_unittests=true
 should_run_flutter_unittests=true
-should_run_formatter=true
 should_run_ios_e2e_tests=true
 should_run_ios_unittests=true
 should_run_mock_handler_tests=true
@@ -330,7 +329,6 @@ while getopts "t:l?h" opt; do
     should_run_dart_compilation_tests=false
     should_run_dart_unittests=false
     should_run_flutter_unittests=false
-    should_run_formatter=false
     should_run_ios_e2e_tests=false
     should_run_ios_unittests=false
     should_run_mock_handler_tests=false

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -387,7 +387,7 @@ if [ "$should_run_android_unittests" = true ]; then
   get_java_linter_formatter
 fi
 test_running_without_arguments
-if [ "$should_run_dart_unittests" = true ]; then
+if [ "$should_run_dart_unittests" = true ] && [ ! "$CIRRUS_CI" = true ]; then
   run_dart_unittests
 fi
 if [ "$should_run_flutter_unittests" = true ]; then
@@ -408,6 +408,6 @@ fi
 if [ "$should_run_android_unittests" = true ]; then
   run_android_unittests
 fi
-if [ "$should_run_formatter" = true ]; then
+if [ "$should_run_formatter" = true ] && [ ! "$CIRRUS_CI" = true ]; then
   run_formatter
 fi


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/85172

* Removed clang-tidy step from the cirrus setup
* Removed the formatting step

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
