### PR TITLE
[pigeon] added a test to assert circular references

### DIFF
--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -378,6 +378,33 @@ void main() {
     }
   }
 
+  test('test circular references', () {
+    final Pigeon dartle = Pigeon.setup();
+    _withTempFile('compilationError.dart', (File file) {
+      file.writeAsStringSync('''
+class Foo {
+  Bar? bar;
+}
+
+class Bar {
+  Foo? foo;
+}
+
+@HostApi()
+abstract class NotificationsHostApi {
+  void doit(Foo foo);
+}  
+''');
+      final ParseResults results =
+          dartle.parseFile(file.path, ignoresInvalidImports: true);
+      expect(results.errors.length, 0);
+      expect(results.root.classes.length, 2);
+      final Class foo = results.root.classes.firstWhere((Class aClass) => aClass.name == 'Foo');
+      expect(foo.fields.length, 1);
+      expect(foo.fields[0].dataType, 'Bar');
+    });
+  });
+
   test('test compilation error', () {
     final Pigeon dartle = Pigeon.setup();
     _withTempFile('compilationError.dart', (File file) {


### PR DESCRIPTION
This issue was fixed in the analyzer rewrite, but didn't get an explicit test for it until now.

fixes https://github.com/flutter/flutter/issues/76196

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
