### PR TITLE
Replace 'pub' with 'dart pub' in CI scripts

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,7 +83,7 @@ task:
       BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
   << : *FLUTTER_UPGRADE_TEMPLATE
   build_script:
-    - ./script/tool_runner.sh build-examples --ios
+    - ./script/tool_runner.sh build-examples --ipa
 
 task:
   name: local_tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,7 +83,7 @@ task:
       BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
   << : *FLUTTER_UPGRADE_TEMPLATE
   build_script:
-    - ./script/tool_runner.sh build-examples --ipa
+    - ./script/tool_runner.sh build-examples --ios
 
 task:
   name: local_tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ tool_setup_template: &TOOL_SETUP_TEMPLATE
     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
     # Pinned version of the plugin tools, to avoid breakage in this repository
     # when pushing updates from flutter/plugins.
-    - pub global activate flutter_plugin_tools 0.1.4
+    - dart pub global activate flutter_plugin_tools 0.3.0
 
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   upgrade_flutter_script:
@@ -31,7 +31,7 @@ task:
   matrix:
     - name: format+analyze
       format_script: ./script/tool_runner.sh format --fail-on-change --clang-format=clang-format-5.0
-      license_script: pub global run flutter_plugin_tools license-check
+      license_script: dart pub global run flutter_plugin_tools license-check
       analyze_script: ./script/tool_runner.sh analyze --custom-analysis=web_benchmarks/testing/test_app,flutter_lints/example
       pubspec_script: ./script/tool_runner.sh pubspec-check
     - name: publishable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: pub global activate flutter_plugin_tools 0.3.0
+      run: dart pub global activate flutter_plugin_tools 0.3.0
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests

--- a/script/tool_runner.sh
+++ b/script/tool_runner.sh
@@ -16,7 +16,7 @@ fi
 BRANCH_NAME="${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}"
 if [[ "${BRANCH_NAME}" == "master" ]]; then
   echo "Running for all packages"
-  (cd "$REPO_DIR" && pub global run flutter_plugin_tools "${ACTIONS[@]}" $BUILD_SHARDING)
+  (cd "$REPO_DIR" && dart pub global run flutter_plugin_tools "${ACTIONS[@]}" $BUILD_SHARDING)
 else
-  (cd "$REPO_DIR" && pub global run flutter_plugin_tools "${ACTIONS[@]}" --run-on-changed-packages $BUILD_SHARDING)
+  (cd "$REPO_DIR" && dart pub global run flutter_plugin_tools "${ACTIONS[@]}" --run-on-changed-packages $BUILD_SHARDING)
 fi


### PR DESCRIPTION
Bare use of 'pub' is deprecated.

Also updates the pinned repo tool version, since some uses of 'pub' have
been fixed there.

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
