### PR TITLE
[cross_file] Improve dart:io saveTo

### DIFF
--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1+4
+
+* The `dart:io` implementation of `saveTo` now does a file copy for path-based
+  `XFile` instances, rather than reading the contents into memory.
+
 ## 0.3.1+3
 
 * Fix example in README

--- a/packages/cross_file/lib/src/types/io.dart
+++ b/packages/cross_file/lib/src/types/io.dart
@@ -13,6 +13,10 @@ import './base.dart';
 /// A CrossFile backed by a dart:io File.
 class XFile extends XFileBase {
   /// Construct a CrossFile object backed by a dart:io File.
+  ///
+  /// [bytes] is ignored; the parameter exists only to match the web version of
+  /// the constructor. To construct a dart:io XFile from bytes, use
+  /// [XFile.fromData].
   XFile(
     String path, {
     this.mimeType,
@@ -62,9 +66,12 @@ class XFile extends XFileBase {
 
   @override
   Future<void> saveTo(String path) async {
-    final File fileToSave = File(path);
-    await fileToSave.writeAsBytes(_bytes ?? (await readAsBytes()));
-    await fileToSave.create();
+    if (_bytes == null) {
+      await _file.copy(path);
+    } else {
+      final File fileToSave = File(path);
+      await fileToSave.writeAsBytes(_bytes!);
+    }
   }
 
   @override

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -2,7 +2,7 @@ name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 repository: https://github.com/flutter/packages/tree/master/packages/cross_file
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+cross_file%22
-version: 0.3.1+3
+version: 0.3.1+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Changes the `saveTo` method for the dart:io-based implementation to copy
path-based instances rather than read them into memory and writing them
out again. This makes it *much* more efficient, especially for large
files.

Also adjusts the unit tests to write to a temporary directory rather
than in-tree, since they are using the actual filesystem.

Fixes https://github.com/flutter/flutter/issues/83665

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
