### PR TITLE
[animations] Add ink splash effect on tap

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -309,21 +309,21 @@ class _OpenContainerState<T> extends State<OpenContainer<T?>> {
   Widget build(BuildContext context) {
     return _Hideable(
       key: _hideableKey,
-      child: GestureDetector(
-        onTap: widget.tappable ? openContainer : null,
-        child: Material(
+      child:  Material(
           clipBehavior: widget.clipBehavior,
           color: widget.closedColor,
           elevation: widget.closedElevation,
           shape: widget.closedShape,
-          child: Builder(
-            key: _closedBuilderKey,
-            builder: (BuildContext context) {
-              return widget.closedBuilder(context, openContainer);
-            },
+          child: InkWell(
+            onTap: widget.tappable ? openContainer : null,
+            child: Builder(
+              key: _closedBuilderKey,
+              builder: (BuildContext context) {
+                return widget.closedBuilder(context, openContainer);
+              },
+            ),
           ),
         ),
-      ),
     );
   }
 }


### PR DESCRIPTION
This PR adds ink splash effect to collapsed OpenContainer by replacing `GestureDetector` with `InkWell` widget.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
