### PR TITLE
[pigeon] Do not 'activate' flutter_plugin_tools

### DIFF
--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -292,7 +292,7 @@ run_ios_e2e_tests() {
 
 run_formatter() {
   cd ../..
-  pub global activate flutter_plugin_tools && pub global run flutter_plugin_tools format 2>/dev/null
+  dart pub global run flutter_plugin_tools format 2>/dev/null
 }
 
 run_android_unittests() {


### PR DESCRIPTION
Calling 'pub activate flutter_plugin_tools' changes the global state,
which is not something a specific package should be doing in a script
that runs on CI. This not only bypasses the pinning for this test, which
is currently causing out-of-band breakage, but also any test that runs
later.

Fixes https://github.com/flutter/flutter/issues/86675

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
