### PR TITLE
[Pigeon] Add one_language flag to pigeon

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [front-end] Added more errors for incorrect usage of Pigeon (previously they were just ignored).
 * Moved Pigeon to using a custom codec which allows collection types to contain custom classes.
 * Started allowing primitive data types as arguments and return types.
+* Added one_language flag for allowing pigeon to generate for one platform.
 
 ## 0.3.0
 

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [front-end] Added more errors for incorrect usage of Pigeon (previously they were just ignored).
 * Moved Pigeon to using a custom codec which allows collection types to contain custom classes.
 * Started allowing primitive data types as arguments and return types.
-* Added one_language flag for allowing pigeon to generate for one platform.
+* Added one_language flag for allowing Pigeon to only generate code for one platform.
 
 ## 0.3.0
 

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -811,7 +811,7 @@ options:
   static final ArgParser _argParser = ArgParser()
     ..addOption('input', help: 'REQUIRED: Path to pigeon file.')
     ..addOption('dart_out',
-        help: 'Path to generated Dart source file (.dart).'
+        help: 'Path to generated Dart source file (.dart). '
             'Required if one_language is not specified.')
     ..addOption('dart_test_out',
         help: 'Path to generated library for Dart tests, when using '

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -115,7 +115,8 @@ class PigeonOptions {
       this.javaOut,
       this.javaOptions,
       this.dartOptions,
-      this.copyrightHeader});
+      this.copyrightHeader,
+      this.oneLanguage});
 
   /// Path to the file which will be processed.
   final String? input;
@@ -147,6 +148,9 @@ class PigeonOptions {
   /// Path to a copyright header that will get prepended to generated code.
   final String? copyrightHeader;
 
+  /// If Pigeon allows generating code for one language.
+  final bool? oneLanguage;
+
   /// Creates a [PigeonOptions] from a Map representation where:
   /// `x = PigeonOptions.fromMap(x.toMap())`.
   static PigeonOptions fromMap(Map<String, Object> map) {
@@ -167,6 +171,7 @@ class PigeonOptions {
           ? DartOptions.fromMap((map['dartOptions'] as Map<String, Object>?)!)
           : null,
       copyrightHeader: map['copyrightHeader'] as String?,
+      oneLanguage: map['oneLanguage'] as bool?,
     );
   }
 
@@ -806,7 +811,8 @@ options:
   static final ArgParser _argParser = ArgParser()
     ..addOption('input', help: 'REQUIRED: Path to pigeon file.')
     ..addOption('dart_out',
-        help: 'REQUIRED: Path to generated Dart source file (.dart).')
+        help: 'Path to generated Dart source file (.dart).'
+            'Required if one_language is not specified.')
     ..addOption('dart_test_out',
         help: 'Path to generated library for Dart tests, when using '
             '@HostApi(dartHostTestHandler:).')
@@ -824,7 +830,10 @@ options:
         help: 'Prefix for generated Objective-C classes and protocols.')
     ..addOption('copyright_header',
         help:
-            'Path to file with copyright header to be prepended to generated code.');
+            'Path to file with copyright header to be prepended to generated code.')
+    ..addFlag('one_language',
+        help: 'Allow Pigeon to only generate code for one language.',
+        defaultsTo: false);
 
   /// Convert command-line arguments to [PigeonOptions].
   static PigeonOptions parseArgs(List<String> args) {
@@ -851,6 +860,7 @@ options:
         isNullSafe: results['dart_null_safety'],
       ),
       copyrightHeader: results['copyright_header'],
+      oneLanguage: results['one_language'],
     );
     return opts;
   }
@@ -891,7 +901,8 @@ options:
         ];
     _executeConfigurePigeon(options);
 
-    if (options.input == null || options.dartOut == null) {
+    if (options.input == null ||
+        (options.oneLanguage == false && options.dartOut == null)) {
       print(usage);
       return 0;
     }

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -294,6 +294,17 @@ run_ios_e2e_tests() {
 }
 
 run_android_unittests() {
+  # Test one_language flag. With this flag specified, java_out can be generated
+  # without dart_out.
+  if ! $run_pigeon \
+    --input pigeons/message.dart \
+    --one_language \
+    --java_out stdout \
+    | grep "public class Message"; then 
+    echo "one_language flag failed"
+    exit 1
+  fi
+
   pushd $PWD
   gen_android_unittests_code ./pigeons/all_datatypes.dart AllDatatypes
   gen_android_unittests_code ./pigeons/all_void.dart AllVoid

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -193,6 +193,16 @@ test_running_without_arguments() {
   $run_pigeon 1>/dev/null
 }
 
+# Test one_language flag. With this flag specified, java_out can be generated
+# without dart_out.
+test_one_language_flag() {
+  $run_pigeon \
+    --input pigeons/message.dart \
+    --one_language \
+    --java_out stdout \
+    | grep "public class Message">/dev/null
+}
+
 run_flutter_unittests() {
   pushd $PWD
   $run_pigeon \
@@ -294,16 +304,7 @@ run_ios_e2e_tests() {
 }
 
 run_android_unittests() {
-  # Test one_language flag. With this flag specified, java_out can be generated
-  # without dart_out.
-  if ! $run_pigeon \
-    --input pigeons/message.dart \
-    --one_language \
-    --java_out stdout \
-    | grep "public class Message"; then 
-    echo "one_language flag failed"
-    exit 1
-  fi
+  test_one_language_flag
 
   pushd $PWD
   gen_android_unittests_code ./pigeons/all_datatypes.dart AllDatatypes

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -70,6 +70,12 @@ void main() {
     expect(opts.objcSourceOut, equals('foo.m'));
   });
 
+  test('parse args - one_language', () {
+    final PigeonOptions opts =
+        Pigeon.parseArgs(<String>['--one_language']);
+    expect(opts.oneLanguage, isTrue);
+  });
+
   test('simple parse api', () {
     const String code = '''
 class Input1 {

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -71,8 +71,7 @@ void main() {
   });
 
   test('parse args - one_language', () {
-    final PigeonOptions opts =
-        Pigeon.parseArgs(<String>['--one_language']);
+    final PigeonOptions opts = Pigeon.parseArgs(<String>['--one_language']);
     expect(opts.oneLanguage, isTrue);
   });
 


### PR DESCRIPTION
one_language flag allows pigeon to only generate for one platform.

*List which issues are fixed by this PR. You must list at least one issue.*
This is an internal request. No issue to link.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
