### PR TITLE
[dart_ui_web_shim] Introduce package.

### DIFF
--- a/packages/dart_ui_web_shim/CHANGELOG.md
+++ b/packages/dart_ui_web_shim/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.1.0
+
+* Extracted to a stand-alone package from `package:pointer_interceptor` and other samples in flutter/plugins.
+* Added tests.

--- a/packages/dart_ui_web_shim/LICENSE
+++ b/packages/dart_ui_web_shim/LICENSE
@@ -1,0 +1,25 @@
+Copyright 2013 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/dart_ui_web_shim/README.md
+++ b/packages/dart_ui_web_shim/README.md
@@ -1,0 +1,74 @@
+`dart_ui_web_shim` is a package that helps use `dart:ui` in Flutter Web apps,
+without triggering failures in dart analyzer.
+
+## What is the problem?
+
+Some Flutter Web-only APIs are currently exposed through a slightly modified version
+of `dart:ui` for web.
+
+flutter analyzer doesn't like that those APIs exist in some versions of `dart:ui`
+and not others (because of type safety), so some methods in dart:ui are flagged
+as non-existent by the analyzer, like `ui.platformViewRegistry.registerViewFactory`.
+
+Unfortunately some of the methods exposed in that fashion are essential for web
+apps (to access Asset URLs, or to register Platform Views).
+
+## How does this work?
+
+This package works by offering a "shim" version of `dart:ui` that contains the web
+methods, and with conditional exports, exposes them to your app:
+
+* In mobile: it exposes noop versions of the methods (see `dart_ui_fake.dart`)
+* In web: it exposes the actual version of the methods (see `dart_ui_real.dart`)
+
+> **Note that similarly to `dart:html`, this package can only be used in source files for the web platform!**
+
+In your app, when you normally did something like:
+
+```dart
+import 'dart:ui' as ui;
+
+...
+
+// ignore: undefined_prefixed_name
+ui.platformViewRegistry.registerViewFactory('foo', (int viewId) {
+    return html.DivElement();
+});
+
+// or
+
+// ignore: undefined_prefixed_name
+final String assetUrl = ui.webOnlyAssetManager.getAssetUrl('some-asset.png');
+
+```
+
+Now you can do:
+
+```dart
+import 'package:dart_ui_web_shim/ui.dart' as ui;
+
+...
+
+ui.platformViewRegistry.registerViewFactory('foo', (int viewId) {
+    return html.DivElement();
+});
+
+// or
+
+final String assetUrl = ui.webOnlyAssetManager.getAssetUrl('some-asset.png');
+```
+
+Without the need to `ignore: undefined_prefixed_name`.
+
+## I need method `ui.xxx.yyy` added to the shim
+
+Please, [file an issue](https://github.com/flutter/flutter/issues/new/choose), or
+send a Pull Request!
+
+In any case, make sure to add `[dart_ui_web_shim]` in the title or description,
+so it can be appropriately handled.
+
+## Cleanup
+
+Monitor this issue: [flutter/flutter#55000](https://github.com/flutter/flutter/issues/55000).
+Once it's resolved, this package will be marked as "Discontinued".

--- a/packages/dart_ui_web_shim/example/README.md
+++ b/packages/dart_ui_web_shim/example/README.md
@@ -1,0 +1,9 @@
+# Testing
+
+This package uses `package:integration_test` to run its tests in a web browser.
+
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
+in the Flutter wiki for instructions to setup and run the tests in this package.
+
+Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
+for more info.

--- a/packages/dart_ui_web_shim/example/assets/file.txt
+++ b/packages/dart_ui_web_shim/example/assets/file.txt
@@ -1,0 +1,1 @@
+integration_test passes with this content!

--- a/packages/dart_ui_web_shim/example/integration_test/dart_ui_web_shim_test.dart
+++ b/packages/dart_ui_web_shim/example/integration_test/dart_ui_web_shim_test.dart
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+
+import 'package:dart_ui_web_shim/ui.dart' as ui;
+
+import 'package:dart_ui_web_shim_integration_tests/main.dart' as app;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+const String expectedContents = 'Contents defined in test!';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('platformViewRegistry', () {
+    testWidgets('registerViewFactory works', (WidgetTester tester) async {
+      ui.platformViewRegistry.registerViewFactory(app.viewId, (int id) {
+        return html.DivElement()
+          ..id = 'test-passed'
+          ..innerText = expectedContents
+          ..style.width = '100%'
+          ..style.height = '100%';
+      });
+
+      app.main();
+      await tester.pumpAndSettle();
+
+      // Expect that the DOM contains a div with id = #test-passed
+      final html.Element? element = html.document.querySelector('#test-passed');
+
+      expect(element, isNotNull);
+      expect(element!.innerText, expectedContents);
+    });
+  });
+
+  group('webOnlyAssetManager', () {
+    testWidgets('assetURL is valid in web', (WidgetTester tester) async {
+      app.main();
+      await tester.pumpAndSettle();
+
+      final String result = ui.webOnlyAssetManager.getAssetUrl('file.txt');
+
+      expect(result, 'assets/file.txt');
+    });
+  });
+}

--- a/packages/dart_ui_web_shim/example/lib/main.dart
+++ b/packages/dart_ui_web_shim/example/lib/main.dart
@@ -45,7 +45,7 @@ class _MyAppState extends State<MyApp> {
           children: const <Widget>[
             SizedBox(
               child: HtmlElementView(
-                viewType: 'defined-in-tests',
+                viewType: viewId,
               ),
               width: 320,
               height: 240,

--- a/packages/dart_ui_web_shim/example/lib/main.dart
+++ b/packages/dart_ui_web_shim/example/lib/main.dart
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+
+import 'package:dart_ui_web_shim/ui.dart' as ui;
+import 'package:flutter/material.dart';
+
+/// The viewId for the HtmlElementView rendered in this app.
+/// This is overriden by the integration_tests before main runs so they can
+/// control what ends up injected in the DOM.
+@visibleForTesting
+const String viewId = 'defined-in-tests';
+
+void main() {
+  // Take a look at the integration_test. We define this here, but the tests
+  // define something else *before* this runs!
+  ui.platformViewRegistry.registerViewFactory(viewId, (int viewId) {
+    return html.DivElement()
+      ..id = 'test-failed'
+      ..innerText = 'Content defined in main!'
+      ..style.width = '100%'
+      ..style.height = '100%';
+  });
+  runApp(MyApp(key: UniqueKey()));
+}
+
+/// App for testing
+class MyApp extends StatefulWidget {
+  /// Constructs our app for testing with a key.
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  _MyAppState createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: const <Widget>[
+            SizedBox(
+              child: HtmlElementView(
+                viewType: 'defined-in-tests',
+              ),
+              width: 320,
+              height: 240,
+            ),
+            Text('Testing... Look at the console output for results!'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/dart_ui_web_shim/example/pubspec.yaml
+++ b/packages/dart_ui_web_shim/example/pubspec.yaml
@@ -1,0 +1,25 @@
+name: dart_ui_web_shim_integration_tests
+publish_to: none
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.2.0"
+
+dependencies:
+  dart_ui_web_shim:
+    path: ../
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
+  js: ^0.6.3
+
+flutter:
+  assets:
+    - assets/file.txt

--- a/packages/dart_ui_web_shim/example/run_test.sh
+++ b/packages/dart_ui_web_shim/example/run_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if pgrep -lf chromedriver > /dev/null; then
+  echo "chromedriver is running."
+
+  if [ $# -eq 0 ]; then
+    echo "No target specified, running all tests..."
+    find integration_test/ -iname *_test.dart | xargs -n1 -i -t flutter drive -d web-server --web-port=7357 --browser-name=chrome --driver=test_driver/integration_test.dart --target='{}'
+  else
+    echo "Running test target: $1..."
+    set -x
+    flutter drive -d web-server --web-port=7357 --browser-name=chrome --driver=test_driver/integration_test.dart --target=$1
+  fi
+
+  else
+    echo "chromedriver is not running."
+    echo "Please, check the README.md for instructions on how to use run_test.sh"
+fi
+

--- a/packages/dart_ui_web_shim/example/test_driver/integration_test.dart
+++ b/packages/dart_ui_web_shim/example/test_driver/integration_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/packages/dart_ui_web_shim/example/web/index.html
+++ b/packages/dart_ui_web_shim/example/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<!-- Copyright 2013 The Flutter Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file. -->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>example</title>
+</head>
+<body>
+  <script src="main.dart.js" type="application/javascript"></script>
+</body>
+</html>

--- a/packages/dart_ui_web_shim/lib/dart_ui_web_shim.dart
+++ b/packages/dart_ui_web_shim/lib/dart_ui_web_shim.dart
@@ -1,0 +1,10 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// This file shims dart:ui in web-only scenarios, getting rid of the need to
+/// suppress analyzer warnings.
+
+// TODO(dit): flutter/flutter#55000 Remove this package once web-only dart:ui
+// APIs are exposed from a dedicated place.
+export 'src/dart_ui_fake.dart' if (dart.library.html) 'src/dart_ui_real.dart';

--- a/packages/dart_ui_web_shim/lib/src/dart_ui_fake.dart
+++ b/packages/dart_ui_web_shim/lib/src/dart_ui_fake.dart
@@ -5,9 +5,11 @@
 // Fake interface for the logic that this package needs from (web-only) dart:ui.
 // This is conditionally exported so the analyzer sees these methods as available.
 
+// ignore_for_file: avoid_classes_with_only_static_members
+// ignore_for_file: camel_case_types
+
 /// Shim for web_ui engine.PlatformViewRegistry
 /// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/ui.dart#L62
-// ignore: camel_case_types, avoid_classes_with_only_static_members
 class platformViewRegistry {
   /// Shim for registerViewFactory
   /// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/ui.dart#L72
@@ -20,7 +22,6 @@ class platformViewRegistry {
 
 /// Shim for web_ui engine.AssetManager.
 /// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/assets.dart#L12
-// ignore: camel_case_types, avoid_classes_with_only_static_members
 class webOnlyAssetManager {
   /// Shim for getAssetUrl.
   /// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/assets.dart#L45

--- a/packages/dart_ui_web_shim/lib/src/dart_ui_fake.dart
+++ b/packages/dart_ui_web_shim/lib/src/dart_ui_fake.dart
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Fake interface for the logic that this package needs from (web-only) dart:ui.
+// This is conditionally exported so the analyzer sees these methods as available.
+
+/// Shim for web_ui engine.PlatformViewRegistry
+/// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/ui.dart#L62
+// ignore: camel_case_types, avoid_classes_with_only_static_members
+class platformViewRegistry {
+  /// Shim for registerViewFactory
+  /// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/ui.dart#L72
+  static bool registerViewFactory(
+    String viewTypeId,
+    dynamic Function(int viewId) viewFactory,
+  ) =>
+      false;
+}
+
+/// Shim for web_ui engine.AssetManager.
+/// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/assets.dart#L12
+// ignore: camel_case_types, avoid_classes_with_only_static_members
+class webOnlyAssetManager {
+  /// Shim for getAssetUrl.
+  /// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/assets.dart#L45
+  static String getAssetUrl(String asset) => '';
+}
+
+/// Signature of callbacks that have no arguments and return no data.
+typedef VoidCallback = void Function();

--- a/packages/dart_ui_web_shim/lib/src/dart_ui_real.dart
+++ b/packages/dart_ui_web_shim/lib/src/dart_ui_real.dart
@@ -1,0 +1,5 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'dart:ui';

--- a/packages/dart_ui_web_shim/lib/ui.dart
+++ b/packages/dart_ui_web_shim/lib/ui.dart
@@ -1,0 +1,8 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file exists as a convenience when importing, as packages must contain
+// a file with the same name as the package as their main entrypoint.
+
+export 'dart_ui_web_shim.dart';

--- a/packages/dart_ui_web_shim/pubspec.yaml
+++ b/packages/dart_ui_web_shim/pubspec.yaml
@@ -1,0 +1,17 @@
+name: dart_ui_web_shim
+description: A shim so dart analyze doesn't complain about web-only parts of the dart:ui package.
+repository: https://github.com/flutter/packages/tree/master/packages/dart_ui_web_shim
+issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+dart_ui_web_shim%22
+version: 0.1.0
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter

--- a/packages/dart_ui_web_shim/test/dart_ui_web_shim_test.dart
+++ b/packages/dart_ui_web_shim/test/dart_ui_web_shim_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:dart_ui_web_shim/ui.dart' as ui;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('platformViewRegistry', () {
+    test('registerViewFactory always returns false in the VM', () {
+      final bool result =
+          ui.platformViewRegistry.registerViewFactory('key', (int id) {});
+      expect(result, isFalse);
+    });
+  });
+
+  group('webOnlyAssetManager', () {
+    test('asset always returns empty string in the VM', () {
+      final String result = ui.webOnlyAssetManager.getAssetUrl('anything');
+      expect(result, '');
+    });
+  });
+
+  test('Tell the user where to find more tests', () {
+    print('---');
+    print('This package also uses integration_test for its web tests.');
+    print('See `example/README.md` for more info.');
+    print('---');
+  });
+}


### PR DESCRIPTION
* Package the `dart:ui` web shim so it can be used in multiple places without having multiple copies of the source code (there are at least 4 copies of this shim code between flutter/packages and flutter/plugins).
* Add tests to the shim, that was untested earlier.

## Issues

* Fixes https://github.com/flutter/flutter/issues/41563  (workaround until the code is exposed from a different package than dart:ui)

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
