### PR TITLE
Don't use 'flutter upgrade' on Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,9 +12,17 @@ tool_setup_template: &TOOL_SETUP_TEMPLATE
 
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   upgrade_flutter_script:
-    - flutter channel $CHANNEL
-    - flutter upgrade
-    - flutter doctor
+    # Ensure that the repository has all the branches.
+    - cd $FLUTTER_HOME
+    - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    - git fetch origin
+    # Switch to the requested branch.
+    - git checkout $CHANNEL
+    # Reset to upstream branch, rather than using pull, since the base image
+    # can sometimes be in a state where it has diverged from upstream (!).
+    - git reset --hard @{u}
+    # Run doctor to allow auditing of what version of Flutter the run is using.
+    - flutter doctor -v
   << : *TOOL_SETUP_TEMPLATE
 
 task:


### PR DESCRIPTION
This command isn't intended for CI use, and is also slower due to
downloading artifacts that will be immediately discarded.

Matches recent changes to flutter/plugins. See flutter/flutter#86037

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
