### PR TITLE
[flutter_markdown] fix "Duplicate keys found" - use UniqueKey() instead of d of millisecondsSinceEpoch

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.5
+
+ * Fix unique Keys for RichText blocks
+
 ## 0.6.4
 
  * Fix merging of spans when first span is not a TextSpan

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -748,21 +748,21 @@ class MarkdownBuilder implements md.NodeVisitor {
 
   Widget _buildRichText(TextSpan? text, {TextAlign? textAlign, String? key}) {
     //Adding a unique key prevents the problem of using the same link handler for text spans with the same text
-    key = key ?? '${text.hashCode}${DateTime.now().millisecondsSinceEpoch}';
+    final Key k = key == null ? UniqueKey() : Key(key);
     if (selectable) {
       return SelectableText.rich(
         text!,
         textScaleFactor: styleSheet.textScaleFactor,
         textAlign: textAlign ?? TextAlign.start,
         onTap: onTapText,
-        key: Key(key),
+        key: k,
       );
     } else {
       return RichText(
         text: text!,
         textScaleFactor: styleSheet.textScaleFactor!,
         textAlign: textAlign ?? TextAlign.start,
-        key: Key(key),
+        key: k,
       );
     }
   }

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/master/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.6.4
+version: 0.6.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/flutter_markdown/test/link_test.dart
+++ b/packages/flutter_markdown/test/link_test.dart
@@ -138,6 +138,41 @@ void defineTests() {
         expect(keys.toSet().length, 2); // Unique
       },
     );
+    testWidgets(
+      'multiple inline links with same content should not throw an exception',
+      (WidgetTester tester) async {
+        //Arange
+        final Widget toBePumped = boilerplate(
+          Column(
+            children: <Widget>[
+              Expanded(
+                child: MarkdownBody(
+                  data:
+                      '''links: [![first](image.png)](https://link.com) [![second](image.png)](https://link.com) [![third](image.png)](https://link.com)''',
+                  onTapLink: (String text, String? href, String title) {},
+                ),
+              ),
+            ],
+          ),
+        );
+
+        //Act
+        await tester.pumpWidget(toBePumped);
+
+        //Assert
+        final Finder widgetFinder = find.byType(RichText, skipOffstage: false);
+        final List<Element> elements = widgetFinder.evaluate().toList();
+        final List<Widget> widgets =
+            elements.map((Element e) => e.widget).toList();
+
+        final List<String> keys = widgets
+            .where((Widget w) => w.key != null && w.key.toString().isNotEmpty)
+            .map((Widget w) => w.key.toString())
+            .toList();
+        expect(keys.length, 3); //all three links.
+        expect(keys.toSet().length, 3); // all three unique.
+      },
+    );
 
     testWidgets(
       // Example 493 from GFM.


### PR DESCRIPTION
Markdown widget throws `Duplicate keys found` error when embedded in an `Expanded` Widget. 

This PR uses a `UniqueKey` instead of a `Key` with `millisecondsSinceEpoch`

https://github.com/flutter/flutter/issues/87636

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
