### PR TITLE
[pigeon] unnamed arguments and nonnull typeArguments

### DIFF
--- a/packages/pigeon/lib/ast.dart
+++ b/packages/pigeon/lib/ast.dart
@@ -80,14 +80,14 @@ class TypeDeclaration {
   TypeDeclaration({
     required this.baseName,
     required this.isNullable,
-    this.typeArguments,
+    this.typeArguments = const <TypeDeclaration>[],
   });
 
   /// The base name of the [TypeDeclaration] (ex 'Foo' to 'Foo<Bar>?').
   final String baseName;
 
   /// The type arguments to the entity (ex 'Bar' to 'Foo<Bar>?').
-  final List<TypeDeclaration>? typeArguments;
+  final List<TypeDeclaration> typeArguments;
 
   /// True if the type is nullable.
   final bool isNullable;

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -94,16 +94,16 @@ void _writeCodec(Indent indent, String codecName, Api api) {
 
 /// Creates a Dart type where all type arguments are [Objects].
 String _makeGenericTypeArguments(TypeDeclaration type, String nullTag) {
-  return type.typeArguments != null
-      ? '${type.baseName}<${type.typeArguments!.map<String>((TypeDeclaration e) => 'Object$nullTag').join(', ')}>'
+  return type.typeArguments.isNotEmpty
+      ? '${type.baseName}<${type.typeArguments.map<String>((TypeDeclaration e) => 'Object$nullTag').join(', ')}>'
       : _addGenericTypes(type, nullTag);
 }
 
 /// Creates a `.cast<>` call for an type. Returns an empty string if the
 /// type has no type arguments.
 String _makeGenericCastCall(TypeDeclaration type, String nullTag) {
-  return type.typeArguments != null
-      ? '.cast<${_flattenTypeArguments(type.typeArguments!, nullTag)}>()'
+  return type.typeArguments.isNotEmpty
+      ? '.cast<${_flattenTypeArguments(type.typeArguments, nullTag)}>()'
       : '';
 }
 
@@ -293,23 +293,23 @@ void _writeFlutterApi(
 /// used in Dart code.
 String _flattenTypeArguments(List<TypeDeclaration> args, String nullTag) {
   return args
-      .map<String>((TypeDeclaration arg) => arg.typeArguments == null
+      .map<String>((TypeDeclaration arg) => arg.typeArguments.isEmpty
           ? '${arg.baseName}$nullTag'
-          : '${arg.baseName}<${_flattenTypeArguments(arg.typeArguments!, nullTag)}>$nullTag')
+          : '${arg.baseName}<${_flattenTypeArguments(arg.typeArguments, nullTag)}>$nullTag')
       .join(', ');
 }
 
 /// Creates the type declaration for use in Dart code from a [NamedType] making sure
 /// that type arguments are used for primitive generic types.
 String _addGenericTypes(TypeDeclaration type, String nullTag) {
-  final List<TypeDeclaration>? typeArguments = type.typeArguments;
+  final List<TypeDeclaration> typeArguments = type.typeArguments;
   switch (type.baseName) {
     case 'List':
-      return (typeArguments == null)
+      return (typeArguments.isEmpty)
           ? 'List<Object$nullTag>'
           : 'List<${_flattenTypeArguments(typeArguments, nullTag)}>';
     case 'Map':
-      return (typeArguments == null)
+      return (typeArguments.isEmpty)
           ? 'Map<Object$nullTag, Object$nullTag>'
           : 'Map<${_flattenTypeArguments(typeArguments, nullTag)}>';
     default:

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -412,7 +412,7 @@ pigeonMap['${field.name}'] != null
 pigeonMap['${field.name}'] != null
 \t\t? ${field.type.baseName}.values[pigeonMap['${field.name}']$unwrapOperator as int]
 \t\t: null''', leadingSpace: false, trailingNewline: false);
-            } else if (field.type.typeArguments != null) {
+            } else if (field.type.typeArguments.isNotEmpty) {
               final String genericType =
                   _makeGenericTypeArguments(field.type, nullTag);
               final String castCall = _makeGenericCastCall(field.type, nullTag);

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -305,10 +305,10 @@ String? _javaTypeForBuiltinDartType(TypeDeclaration type) {
   if (javaTypeForDartTypeMap.containsKey(type.baseName)) {
     return javaTypeForDartTypeMap[type.baseName];
   } else if (type.baseName == 'List') {
-    if (type.typeArguments == null) {
+    if (type.typeArguments.isEmpty) {
       return 'List<Object>';
     } else {
-      return 'List<${_flattenTypeArguments(type.typeArguments!)}>';
+      return 'List<${_flattenTypeArguments(type.typeArguments)}>';
     }
   } else {
     return null;

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -98,9 +98,9 @@ String? _objcTypePtrForPrimitiveDartType(String? classPrefix, NamedType field) {
 /// _objcTypeForDartType(null, 'int') => 'NSNumber'.
 String _objcTypeForDartType(String? classPrefix, TypeDeclaration field) {
   return _objcTypeForDartTypeMap.containsKey(field.baseName)
-      ? field.typeArguments == null
+      ? field.typeArguments.isEmpty
           ? _objcTypeForDartTypeMap[field.baseName]!
-          : '${_objcTypeForDartTypeMap[field.baseName]}<${_flattenTypeArguments(classPrefix, field.typeArguments!)}>'
+          : '${_objcTypeForDartTypeMap[field.baseName]}<${_flattenTypeArguments(classPrefix, field.typeArguments)}>'
       : _className(classPrefix, field.baseName);
 }
 

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -385,7 +385,7 @@ List<Error> _validateAst(Root root, String source) {
   for (final Class klass in root.classes) {
     for (final NamedType field in klass.fields) {
       if (field.type.typeArguments != null) {
-        for (final TypeDeclaration typeArgument in field.type.typeArguments!) {
+        for (final TypeDeclaration typeArgument in field.type.typeArguments) {
           if (!typeArgument.isNullable) {
             result.add(Error(
               message:
@@ -661,7 +661,7 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
     if (typeName != null) {
       final String argTypeBaseName = typeName.name.name;
       final bool isNullable = typeName.question != null;
-      final List<TypeDeclaration>? argTypeArguments =
+      final List<TypeDeclaration> argTypeArguments =
           typeAnnotationsToTypeArguments(typeName.typeArguments);
       return NamedType(
           type: TypeDeclaration(
@@ -731,13 +731,12 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
     return null;
   }
 
-  List<TypeDeclaration>? typeAnnotationsToTypeArguments(
+  List<TypeDeclaration> typeAnnotationsToTypeArguments(
       dart_ast.TypeArgumentList? typeArguments) {
-    List<TypeDeclaration>? result;
+    final List<TypeDeclaration> result = <TypeDeclaration>[];
     if (typeArguments != null) {
       for (final Object x in typeArguments.childEntities) {
         if (x is dart_ast.TypeName) {
-          result ??= <TypeDeclaration>[];
           result.add(TypeDeclaration(
               baseName: x.name.name,
               isNullable: x.question != null,

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -443,6 +443,14 @@ List<Error> _validateAst(Root root, String source) {
           lineNumber: _calculateLineNumberNullable(source, method.offset),
         ));
       }
+      for (final NamedType unnamedType in method.arguments
+          .where((NamedType element) => element.type.baseName.isEmpty)) {
+        result.add(Error(
+          message:
+              'Arguments must specify their type in method "${method.name}" in API: "${api.name}"',
+          lineNumber: _calculateLineNumberNullable(source, unnamedType.offset),
+        ));
+      }
     }
   }
 
@@ -648,20 +656,27 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
   }
 
   NamedType formalParameterToField(dart_ast.FormalParameter parameter) {
-    final dart_ast.TypeName typeName = parameter.childEntities.firstWhere(
-        (dart_ast_syntactic_entity.SyntacticEntity e) =>
-            e is dart_ast.TypeName) as dart_ast.TypeName;
-    final String argTypeBaseName = typeName.name.name;
-    final bool isNullable = typeName.question != null;
-    final List<TypeDeclaration>? argTypeArguments =
-        typeAnnotationsToTypeArguments(typeName.typeArguments);
-    return NamedType(
-        type: TypeDeclaration(
-            baseName: argTypeBaseName,
-            isNullable: isNullable,
-            typeArguments: argTypeArguments),
-        name: parameter.identifier?.name ?? '',
-        offset: null);
+    final dart_ast.TypeName? typeName =
+        getFirstChildOfType<dart_ast.TypeName>(parameter);
+    if (typeName != null) {
+      final String argTypeBaseName = typeName.name.name;
+      final bool isNullable = typeName.question != null;
+      final List<TypeDeclaration>? argTypeArguments =
+          typeAnnotationsToTypeArguments(typeName.typeArguments);
+      return NamedType(
+          type: TypeDeclaration(
+              baseName: argTypeBaseName,
+              isNullable: isNullable,
+              typeArguments: argTypeArguments),
+          name: parameter.identifier?.name ?? '',
+          offset: parameter.offset);
+    } else {
+      return NamedType(
+        name: '',
+        type: TypeDeclaration(baseName: '', isNullable: false),
+        offset: parameter.offset,
+      );
+    }
   }
 
   static T? getFirstChildOfType<T>(dart_ast.AstNode entity) {

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -14,7 +14,9 @@ void main() {
       fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'dataType1', isNullable: true, typeArguments: null),
+              baseName: 'dataType1',
+              isNullable: true,
+            ),
             name: 'field1',
             offset: null),
       ],
@@ -60,7 +62,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: 'input',
                 offset: null)
           ],
@@ -72,14 +76,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -98,7 +106,9 @@ void main() {
         fields: <NamedType>[
           NamedType(
               type: TypeDeclaration(
-                  baseName: 'String', isNullable: true, typeArguments: null),
+                baseName: 'String',
+                isNullable: true,
+              ),
               name: 'input',
               offset: null)
         ],
@@ -108,7 +118,9 @@ void main() {
         fields: <NamedType>[
           NamedType(
               type: TypeDeclaration(
-                  baseName: 'Input', isNullable: true, typeArguments: null),
+                baseName: 'Input',
+                isNullable: true,
+              ),
               name: 'nested',
               offset: null)
         ],
@@ -139,7 +151,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: 'input',
                 offset: null)
           ],
@@ -151,14 +165,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -179,7 +197,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -191,7 +211,9 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
@@ -211,7 +233,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -223,7 +247,9 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
@@ -252,7 +278,9 @@ void main() {
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ]),
@@ -272,9 +300,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'EnumClass',
-                    isNullable: false,
-                    typeArguments: null),
+                  baseName: 'EnumClass',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -286,7 +314,9 @@ void main() {
       Class(name: 'EnumClass', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Enum', isNullable: true, typeArguments: null),
+              baseName: 'Enum',
+              isNullable: true,
+            ),
             name: 'enum1',
             offset: null)
       ]),
@@ -316,9 +346,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'EnumClass',
-                    isNullable: false,
-                    typeArguments: null),
+                  baseName: 'EnumClass',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -330,7 +360,9 @@ void main() {
       Class(name: 'EnumClass', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Enum', isNullable: true, typeArguments: null),
+              baseName: 'Enum',
+              isNullable: true,
+            ),
             name: 'enum1',
             offset: null)
       ]),
@@ -368,7 +400,9 @@ void main() {
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ]),
@@ -391,9 +425,9 @@ void main() {
               arguments: <NamedType>[
                 NamedType(
                     type: TypeDeclaration(
-                        baseName: 'Input',
-                        isNullable: false,
-                        typeArguments: null),
+                      baseName: 'Input',
+                      isNullable: false,
+                    ),
                     name: '',
                     offset: null)
               ],
@@ -406,9 +440,9 @@ void main() {
               arguments: <NamedType>[
                 NamedType(
                     type: TypeDeclaration(
-                        baseName: 'Input',
-                        isNullable: false,
-                        typeArguments: null),
+                      baseName: 'Input',
+                      isNullable: false,
+                    ),
                     name: '',
                     offset: null)
               ],
@@ -420,14 +454,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -459,7 +497,9 @@ void main() {
       fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'dataType1', isNullable: true, typeArguments: null),
+              baseName: 'dataType1',
+              isNullable: true,
+            ),
             name: 'field1',
             offset: null),
       ],
@@ -483,7 +523,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -495,14 +537,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -524,7 +570,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -536,14 +584,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -564,7 +616,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -576,14 +630,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -609,7 +667,9 @@ void main() {
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ]),

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -13,7 +13,9 @@ void main() {
       fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'int', isNullable: true, typeArguments: null),
+              baseName: 'int',
+              isNullable: true,
+            ),
             name: 'field1',
             offset: null),
       ],
@@ -63,7 +65,9 @@ void main() {
       fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'int', isNullable: true, typeArguments: null),
+              baseName: 'int',
+              isNullable: true,
+            ),
             name: 'field1',
             offset: null)
       ],
@@ -90,7 +94,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -102,14 +108,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -128,42 +138,58 @@ void main() {
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'bool', isNullable: true, typeArguments: null),
+              baseName: 'bool',
+              isNullable: true,
+            ),
             name: 'aBool',
             offset: null),
         NamedType(
             type: TypeDeclaration(
-                baseName: 'int', isNullable: true, typeArguments: null),
+              baseName: 'int',
+              isNullable: true,
+            ),
             name: 'aInt',
             offset: null),
         NamedType(
             type: TypeDeclaration(
-                baseName: 'double', isNullable: true, typeArguments: null),
+              baseName: 'double',
+              isNullable: true,
+            ),
             name: 'aDouble',
             offset: null),
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'aString',
             offset: null),
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Uint8List', isNullable: true, typeArguments: null),
+              baseName: 'Uint8List',
+              isNullable: true,
+            ),
             name: 'aUint8List',
             offset: null),
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Int32List', isNullable: true, typeArguments: null),
+              baseName: 'Int32List',
+              isNullable: true,
+            ),
             name: 'aInt32List',
             offset: null),
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Int64List', isNullable: true, typeArguments: null),
+              baseName: 'Int64List',
+              isNullable: true,
+            ),
             name: 'aInt64List',
             offset: null),
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Float64List', isNullable: true, typeArguments: null),
+              baseName: 'Float64List',
+              isNullable: true,
+            ),
             name: 'aFloat64List',
             offset: null),
       ]),
@@ -191,7 +217,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -203,14 +231,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -231,7 +263,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -243,7 +277,9 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
@@ -264,7 +300,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -276,7 +314,9 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
@@ -303,7 +343,9 @@ void main() {
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ]),
@@ -330,7 +372,9 @@ void main() {
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ]),
@@ -348,7 +392,9 @@ void main() {
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'List', isNullable: true, typeArguments: null),
+              baseName: 'List',
+              isNullable: true,
+            ),
             name: 'field1',
             offset: null)
       ]),
@@ -366,7 +412,9 @@ void main() {
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Map', isNullable: true, typeArguments: null),
+              baseName: 'Map',
+              isNullable: true,
+            ),
             name: 'field1',
             offset: null)
       ]),
@@ -385,7 +433,9 @@ void main() {
       fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Nested', isNullable: true, typeArguments: null),
+              baseName: 'Nested',
+              isNullable: true,
+            ),
             name: 'nested',
             offset: null)
       ],
@@ -395,7 +445,9 @@ void main() {
       fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'int', isNullable: true, typeArguments: null),
+              baseName: 'int',
+              isNullable: true,
+            ),
             name: 'data',
             offset: null)
       ],
@@ -426,7 +478,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: 'arg',
                 offset: null)
           ],
@@ -438,14 +492,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -473,7 +531,9 @@ void main() {
           arguments: <NamedType>[
             NamedType(
                 type: TypeDeclaration(
-                    baseName: 'Input', isNullable: false, typeArguments: null),
+                  baseName: 'Input',
+                  isNullable: false,
+                ),
                 name: '',
                 offset: null)
           ],
@@ -485,14 +545,18 @@ void main() {
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+              baseName: 'String',
+              isNullable: true,
+            ),
             name: 'output',
             offset: null)
       ])
@@ -518,7 +582,9 @@ void main() {
       fields: <NamedType>[
         NamedType(
             type: TypeDeclaration(
-                baseName: 'Enum1', isNullable: true, typeArguments: null),
+              baseName: 'Enum1',
+              isNullable: true,
+            ),
             name: 'enum1',
             offset: null),
       ],

--- a/packages/pigeon/test/objc_generator_test.dart
+++ b/packages/pigeon/test/objc_generator_test.dart
@@ -11,8 +11,7 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'field1',
             offset: null)
       ]),
@@ -28,8 +27,7 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'field1',
             offset: null)
       ]),
@@ -85,13 +83,11 @@ void main() {
           name: 'Foobar',
           fields: <NamedType>[
             NamedType(
-                type: TypeDeclaration(
-                    baseName: 'String', isNullable: true, typeArguments: null),
+                type: TypeDeclaration(baseName: 'String', isNullable: true),
                 name: 'field1',
                 offset: null),
             NamedType(
-                type: TypeDeclaration(
-                    baseName: 'Enum1', isNullable: true, typeArguments: null),
+                type: TypeDeclaration(baseName: 'Enum1', isNullable: true),
                 name: 'enum1',
                 offset: null),
           ],
@@ -123,13 +119,11 @@ void main() {
           name: 'Foobar',
           fields: <NamedType>[
             NamedType(
-                type: TypeDeclaration(
-                    baseName: 'String', isNullable: true, typeArguments: null),
+                type: TypeDeclaration(baseName: 'String', isNullable: true),
                 name: 'field1',
                 offset: null),
             NamedType(
-                type: TypeDeclaration(
-                    baseName: 'Enum1', isNullable: true, typeArguments: null),
+                type: TypeDeclaration(baseName: 'Enum1', isNullable: true),
                 name: 'enum1',
                 offset: null),
           ],
@@ -158,10 +152,7 @@ void main() {
             name: 'doSomething',
             arguments: <NamedType>[
               NamedType(
-                  type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                  type: TypeDeclaration(baseName: 'Input', isNullable: false),
                   name: '',
                   offset: null)
             ],
@@ -170,15 +161,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ])
@@ -201,9 +190,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -212,15 +201,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ])
@@ -238,43 +225,35 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'bool', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'bool', isNullable: true),
             name: 'aBool',
             offset: null),
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'int', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'int', isNullable: true),
             name: 'aInt',
             offset: null),
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'double', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'double', isNullable: true),
             name: 'aDouble',
             offset: null),
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'aString',
             offset: null),
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Uint8List', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Uint8List', isNullable: true),
             name: 'aUint8List',
             offset: null),
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Int32List', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Int32List', isNullable: true),
             name: 'aInt32List',
             offset: null),
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Int64List', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Int64List', isNullable: true),
             name: 'aInt64List',
             offset: null),
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Float64List', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Float64List', isNullable: true),
             name: 'aFloat64List',
             offset: null),
       ]),
@@ -303,8 +282,7 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'bool', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'bool', isNullable: true),
             name: 'aBool',
             offset: null),
       ]),
@@ -321,15 +299,13 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Nested', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Input', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Input', isNullable: true),
             name: 'nested',
             offset: null)
       ])
@@ -345,15 +321,13 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Nested', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Input', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Input', isNullable: true),
             name: 'nested',
             offset: null)
       ])
@@ -369,8 +343,7 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'field1',
             offset: null)
       ]),
@@ -385,8 +358,7 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'field1',
             offset: null)
       ]),
@@ -405,9 +377,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -416,15 +388,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Nested', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Input', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Input', isNullable: true),
             name: 'nested',
             offset: null)
       ])
@@ -445,9 +415,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -456,15 +426,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Nested', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Input', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Input', isNullable: true),
             name: 'nested',
             offset: null)
       ])
@@ -485,9 +453,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -496,15 +464,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ])
@@ -528,9 +494,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -539,15 +505,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ])
@@ -567,9 +531,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -578,8 +542,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
@@ -599,9 +562,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -610,8 +573,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
@@ -633,9 +595,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -644,8 +606,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
@@ -665,9 +626,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -676,8 +637,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
@@ -701,8 +661,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -725,8 +684,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -749,8 +707,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -776,8 +733,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -797,8 +753,7 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'List', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'List', isNullable: true),
             name: 'field1',
             offset: null)
       ]),
@@ -814,8 +769,7 @@ void main() {
     final Root root = Root(apis: <Api>[], classes: <Class>[
       Class(name: 'Foobar', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'Map', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'Map', isNullable: true),
             name: 'field1',
             offset: null)
       ]),
@@ -835,9 +789,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -847,15 +801,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -878,9 +830,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -890,15 +842,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -925,8 +875,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -969,9 +918,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -981,15 +930,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -1012,9 +959,9 @@ void main() {
             arguments: <NamedType>[
               NamedType(
                   type: TypeDeclaration(
-                      baseName: 'Input',
-                      isNullable: false,
-                      typeArguments: null),
+                    baseName: 'Input',
+                    isNullable: false,
+                  ),
                   name: '',
                   offset: null)
             ],
@@ -1024,15 +971,13 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Input', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'input',
             offset: null)
       ]),
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),
@@ -1077,8 +1022,7 @@ void main() {
     ], classes: <Class>[
       Class(name: 'Output', fields: <NamedType>[
         NamedType(
-            type: TypeDeclaration(
-                baseName: 'String', isNullable: true, typeArguments: null),
+            type: TypeDeclaration(baseName: 'String', isNullable: true),
             name: 'output',
             offset: null)
       ]),

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -735,4 +735,18 @@ abstract class Api {
     // expect(results.root.apis[0].methods[0].name, equals('method'));
     // expect(results.root.apis[0].methods[0].arguments.length, 2);
   });
+
+  test('no type name argument', () {
+    const String code = '''
+@HostApi()
+abstract class Api {
+  void method(x);
+}
+''';
+    final ParseResults results = _parseSource(code);
+    expect(results.errors.length, 1);
+    expect(results.errors[0].lineNumber, 3);
+    expect(results.errors[0].message,
+        contains('Arguments must specify their type'));
+  });
 }

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -577,8 +577,8 @@ abstract class Api {
     final ParseResults parseResult = _parseSource(code);
     expect(parseResult.errors.length, equals(0));
     final NamedType field = parseResult.root.classes[0].fields[0];
-    expect(field.type.typeArguments!.length, 1);
-    expect(field.type.typeArguments![0].baseName, 'int');
+    expect(field.type.typeArguments.length, 1);
+    expect(field.type.typeArguments[0].baseName, 'int');
   });
 
   test('parse recursive generics', () {
@@ -595,9 +595,9 @@ abstract class Api {
     final ParseResults parseResult = _parseSource(code);
     expect(parseResult.errors.length, equals(0));
     final NamedType field = parseResult.root.classes[0].fields[0];
-    expect(field.type.typeArguments!.length, 1);
-    expect(field.type.typeArguments![0].baseName, 'List');
-    expect(field.type.typeArguments![0].typeArguments![0].baseName, 'int');
+    expect(field.type.typeArguments.length, 1);
+    expect(field.type.typeArguments[0].baseName, 'List');
+    expect(field.type.typeArguments[0].typeArguments[0].baseName, 'int');
   });
 
   test('error nonnull type argument', () {
@@ -668,11 +668,11 @@ abstract class Api {
     expect(parseResult.root.apis[0].methods[0].returnType.baseName, 'List');
     expect(
         parseResult
-            .root.apis[0].methods[0].returnType.typeArguments![0].baseName,
+            .root.apis[0].methods[0].returnType.typeArguments[0].baseName,
         'double');
     expect(
         parseResult
-            .root.apis[0].methods[0].returnType.typeArguments![0].isNullable,
+            .root.apis[0].methods[0].returnType.typeArguments[0].isNullable,
         isTrue);
   });
 
@@ -687,11 +687,11 @@ abstract class Api {
     expect(
         parseResult.root.apis[0].methods[0].arguments[0].type.baseName, 'List');
     expect(
-        parseResult.root.apis[0].methods[0].arguments[0].type.typeArguments![0]
+        parseResult.root.apis[0].methods[0].arguments[0].type.typeArguments[0]
             .baseName,
         'double');
     expect(
-        parseResult.root.apis[0].methods[0].arguments[0].type.typeArguments![0]
+        parseResult.root.apis[0].methods[0].arguments[0].type.typeArguments[0]
             .isNullable,
         isTrue);
   });
@@ -709,9 +709,9 @@ abstract class Api {
 ''';
     final ParseResults parseResult = _parseSource(code);
     final NamedType field = parseResult.root.classes[0].fields[0];
-    expect(field.type.typeArguments!.length, 2);
-    expect(field.type.typeArguments![0].baseName, 'String');
-    expect(field.type.typeArguments![1].baseName, 'int');
+    expect(field.type.typeArguments.length, 2);
+    expect(field.type.typeArguments[0].baseName, 'String');
+    expect(field.type.typeArguments[1].baseName, 'int');
   });
 
   test('two arguments', () {


### PR DESCRIPTION
1) Added a test to specifically test arguments that don't have types.
1) Refactored typeArguments to be nonnull

A followup to https://github.com/flutter/packages/pull/428

I tried to get a situation where an argument didn't have an identifier and found a different problem.  I'm not sure how to create that with dart since if you just provide one name it is assumed to be the name of the variable.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
