### PR TITLE
Update flutter_plugin_tools to 0.5.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,6 +58,9 @@ task:
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
+        matrix:
+          BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
+          BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
       script:
         - ./script/tool_runner.sh build-examples --apk
         # Must come after apk build:
@@ -85,6 +88,9 @@ task:
     matrix:
       CHANNEL: "master"
       CHANNEL: "stable"
+    matrix:
+      BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
+      BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
   << : *FLUTTER_UPGRADE_TEMPLATE
   build_script:
     - ./script/tool_runner.sh build-examples --ios

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,9 +58,6 @@ task:
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
-        matrix:
-          BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
-          BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
       script:
         - ./script/tool_runner.sh build-examples --apk
         # Must come after apk build:
@@ -88,9 +85,6 @@ task:
     matrix:
       CHANNEL: "master"
       CHANNEL: "stable"
-    matrix:
-      BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
-      BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
   << : *FLUTTER_UPGRADE_TEMPLATE
   build_script:
     - ./script/tool_runner.sh build-examples --ios

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ tool_setup_template: &TOOL_SETUP_TEMPLATE
     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
     # Pinned version of the plugin tools, to avoid breakage in this repository
     # when pushing updates from flutter/plugins.
-    - dart pub global activate flutter_plugin_tools 0.3.0
+    - dart pub global activate flutter_plugin_tools 0.5.0
 
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   upgrade_flutter_script:
@@ -63,7 +63,8 @@ task:
           BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
       script:
         - ./script/tool_runner.sh build-examples --apk
-        - ./script/tool_runner.sh java-test  # must come after apk build
+        # Must come after apk build:
+        - ./script/tool_runner.sh native-test --android --no-integration
       depends_on:
         - format+analyze
     - name: web_benchmarks_test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,7 +53,7 @@ task:
       script: ./script/tool_runner.sh test --exclude=flutter_image
       depends_on:
         - format+analyze
-    - name: build-apks+java-test
+    - name: android-build+platform-tests
       env:
         matrix:
           CHANNEL: "master"
@@ -79,7 +79,7 @@ task:
         - dart testing/web_benchmarks_test.dart
 
 task:
-  name: build-ipas
+  name: ios-build+platform-test
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
     image: big-sur-xcode-12.4
@@ -93,7 +93,7 @@ task:
       BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
   << : *FLUTTER_UPGRADE_TEMPLATE
   build_script:
-    - ./script/tool_runner.sh build-examples --ipa
+    - ./script/tool_runner.sh build-examples --ios
 
 task:
   name: local_tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: dart pub global activate flutter_plugin_tools 0.3.0
+      run: dart pub global activate flutter_plugin_tools 0.5.0
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests

--- a/script/tool_runner.sh
+++ b/script/tool_runner.sh
@@ -7,11 +7,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Set some default actions if run without arguments.
 ACTIONS=("$@")
-if [[ "${#ACTIONS[@]}" == 0 ]]; then
-  ACTIONS=("test" "analyze" "java-test")
-fi
 
 BRANCH_NAME="${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}"
 if [[ "${BRANCH_NAME}" == "master" ]]; then


### PR DESCRIPTION
Rolls to the latest release of flutter_plugin_tools, updating calls for breaking changes to flags.

Other minor changes:
- Removes the default set of actions from `tool_runner.sh` since it's never used, and the set of things it runs is a very obsolete subset at this point; it's better to require people to choose specific actions.
- Renames some tasks to match recent renaming in flutter/plugins.

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
