### PR TITLE
[pigeon] fixed ConfigurePigeon overriding the dart_out parameter

### DIFF
--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -971,10 +971,21 @@ options:
         ];
     _executeConfigurePigeon(options);
 
-    if (options.input == null ||
-        (options.oneLanguage == false && options.dartOut == null)) {
+    if (options.input == null) {
       print(usage);
       return 0;
+    }
+
+    final ParseResults parseResults =
+        pigeon.parseFile(options.input!, sdkPath: sdkPath);
+    if (parseResults.pigeonOptions != null) {
+      options = PigeonOptions.fromMap(
+          mergeMaps(options.toMap(), parseResults.pigeonOptions!));
+    }
+
+    if (options.oneLanguage == false && options.dartOut == null) {
+      print(usage);
+      return 1;
     }
 
     final List<Error> errors = <Error>[];
@@ -984,12 +995,6 @@ options:
               ObjcOptions(header: path.basename(options.objcHeaderOut!)))));
     }
 
-    final ParseResults parseResults =
-        pigeon.parseFile(options.input!, sdkPath: sdkPath);
-    if (parseResults.pigeonOptions != null) {
-      options = PigeonOptions.fromMap(
-          mergeMaps(options.toMap(), parseResults.pigeonOptions!));
-    }
     for (final Error err in parseResults.errors) {
       errors.add(Error(
           message: err.message,

--- a/packages/pigeon/pigeons/configure_pigeon_dart_out.dart
+++ b/packages/pigeon/pigeons/configure_pigeon_dart_out.dart
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:pigeon/pigeon.dart';
+
+@ConfigurePigeon(PigeonOptions(dartOut: 'stdout', javaOut: 'stdout'))
+@HostApi()
+abstract class Api {
+  void ping();
+}

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -189,18 +189,18 @@ run_dart_unittests() {
   dart test
 }
 
-test_running_without_arguments() {
+test_command_line() {
+  # Test with no arguments.
   $run_pigeon 1>/dev/null
-}
-
-# Test one_language flag. With this flag specified, java_out can be generated
-# without dart_out.
-test_one_language_flag() {
+  # Test one_language flag. With this flag specified, java_out can be generated
+  # without dart_out.
   $run_pigeon \
     --input pigeons/message.dart \
     --one_language \
     --java_out stdout \
     | grep "public class Message">/dev/null
+  # Test dartOut in ConfigurePigeon overrides output.
+  $run_pigeon --input pigeons/configure_pigeon_dart_out.dart 1>/dev/null
 }
 
 run_flutter_unittests() {
@@ -315,8 +315,6 @@ run_ios_e2e_tests() {
 }
 
 run_android_unittests() {
-  test_one_language_flag
-
   pushd $PWD
   gen_android_unittests_code ./pigeons/all_datatypes.dart AllDatatypes
   gen_android_unittests_code ./pigeons/all_void.dart AllVoid
@@ -408,7 +406,7 @@ dart --snapshot-kind=kernel --snapshot=bin/pigeon.dart.dill bin/pigeon.dart
 if [ "$should_run_android_unittests" = true ]; then
   get_java_linter_formatter
 fi
-test_running_without_arguments
+test_command_line
 if [ "$should_run_dart_unittests" = true ]; then
   run_dart_unittests
 fi


### PR DESCRIPTION
Fixes a regression where dart_out couldn't be set with ConfigurePigeon.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
