### PR TITLE
[pigeon] made copyright headers work for dart test output

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -7,6 +7,7 @@
   code for one platform.
 * [command-line] Added the optional sdkPath parameter for specifying Dart SDK
   path.
+* [dart] Fixed copyright headers for Dart test output.
 * [front-end] Added more errors for incorrect usage of Pigeon (previously they
   were just ignored).
 * [generators] Moved Pigeon to using a custom codec which allows collection

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -483,6 +483,9 @@ void generateTestDart(
   String mainDartFile,
 ) {
   final Indent indent = Indent(sink);
+  if (opt.copyrightHeader != null) {
+    addLines(indent, opt.copyrightHeader!, linePrefix: '// ');
+  }
   indent.writeln('// $generatedCodeWarning');
   indent.writeln('// $seeAlsoWarning');
   indent.writeln(

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -274,6 +274,14 @@ abstract class Generator {
   void generate(StringSink sink, PigeonOptions options, Root root);
 }
 
+DartOptions _dartOptionsWithCopyrightHeader(
+    DartOptions? dartOptions, String? copyrightHeader) {
+  dartOptions = dartOptions ?? const DartOptions();
+  return dartOptions.merge(DartOptions(
+      copyrightHeader:
+          copyrightHeader != null ? _lineReader(copyrightHeader) : null));
+}
+
 /// A [Generator] that generates Dart source code.
 class DartGenerator implements Generator {
   /// Constructor for [DartGenerator].
@@ -281,11 +289,8 @@ class DartGenerator implements Generator {
 
   @override
   void generate(StringSink sink, PigeonOptions options, Root root) {
-    final DartOptions dartOptions = options.dartOptions ?? const DartOptions();
-    final DartOptions dartOptionsWithHeader = dartOptions.merge(DartOptions(
-        copyrightHeader: options.copyrightHeader != null
-            ? _lineReader(options.copyrightHeader!)
-            : null));
+    final DartOptions dartOptionsWithHeader = _dartOptionsWithCopyrightHeader(
+        options.dartOptions, options.copyrightHeader);
     generateDart(dartOptionsWithHeader, root, sink);
   }
 
@@ -304,8 +309,10 @@ class DartTestGenerator implements Generator {
       _posixify(options.dartOut!),
       from: _posixify(path.dirname(options.dartTestOut!)),
     );
+    final DartOptions dartOptionsWithHeader = _dartOptionsWithCopyrightHeader(
+        options.dartOptions, options.copyrightHeader);
     generateTestDart(
-      options.dartOptions ?? const DartOptions(),
+      dartOptionsWithHeader,
       root,
       sink,
       mainPath,

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -791,4 +791,17 @@ abstract class Api {
     expect(results.root.apis[0].methods.length, equals(1));
     expect(results.root.apis[0].methods[0].objcSelector, equals('foobar'));
   });
+
+  test('dart test has copyright', () {
+    final Root root = Root(apis: <Api>[], classes: <Class>[], enums: <Enum>[]);
+    const PigeonOptions options = PigeonOptions(
+      copyrightHeader: './copyright_header.txt',
+      dartTestOut: 'stdout',
+      dartOut: 'stdout',
+    );
+    const DartTestGenerator dartGenerator = DartTestGenerator();
+    final StringBuffer buffer = StringBuffer();
+    dartGenerator.generate(buffer, options, root);
+    expect(buffer.toString(), startsWith('// Copyright 2013'));
+  });
 }


### PR DESCRIPTION
Previously this just worked for Java, Dart and ObjC generators.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
