### PR TITLE
[pigeon] fixed java generics for Maps

### DIFF
--- a/packages/pigeon/lib/functional.dart
+++ b/packages/pigeon/lib/functional.dart
@@ -68,3 +68,10 @@ Iterable<int> _count() sync* {
 
 /// All integers starting at zero.
 final Iterable<int> wholeNumbers = _count();
+
+/// Repeats an [item] [n] times.
+Iterable<T> repeat<T>(T item, int n) sync* {
+  for (int i = 0; i < n; ++i) {
+    yield item;
+  }
+}

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -318,6 +318,17 @@ String _flattenTypeArguments(List<TypeDeclaration> args) {
   return args.map<String>(_javaTypeForDartType).join(', ');
 }
 
+String _javaTypeForBuiltinGenericDartType(
+  TypeDeclaration type,
+  int numberTypeArguments,
+) {
+  if (type.typeArguments.isEmpty) {
+    return '${type.baseName}<${repeat('Object', numberTypeArguments).join(', ')}>';
+  } else {
+    return '${type.baseName}<${_flattenTypeArguments(type.typeArguments)}>';
+  }
+}
+
 String? _javaTypeForBuiltinDartType(TypeDeclaration type) {
   const Map<String, String> javaTypeForDartTypeMap = <String, String>{
     'bool': 'Boolean',
@@ -328,16 +339,13 @@ String? _javaTypeForBuiltinDartType(TypeDeclaration type) {
     'Int32List': 'int[]',
     'Int64List': 'long[]',
     'Float64List': 'double[]',
-    'Map': 'Map<Object, Object>',
   };
   if (javaTypeForDartTypeMap.containsKey(type.baseName)) {
     return javaTypeForDartTypeMap[type.baseName];
   } else if (type.baseName == 'List') {
-    if (type.typeArguments.isEmpty) {
-      return 'List<Object>';
-    } else {
-      return 'List<${_flattenTypeArguments(type.typeArguments)}>';
-    }
+    return _javaTypeForBuiltinGenericDartType(type, 1);
+  } else if (type.baseName == 'Map') {
+    return _javaTypeForBuiltinGenericDartType(type, 2);
   } else {
     return null;
   }

--- a/packages/pigeon/test/functional_test.dart
+++ b/packages/pigeon/test/functional_test.dart
@@ -69,4 +69,12 @@ void main() {
     expect(result[1], 1);
     expect(result[2], 2);
   });
+
+  test('repeat', () {
+    final List<int> result = repeat(123, 3).toList();
+    expect(result.length, 3);
+    expect(result[0], 123);
+    expect(result[1], 123);
+    expect(result[2], 123);
+  });
 }

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -653,6 +653,35 @@ void main() {
     expect(code, contains('List<Long> field1;'));
   });
 
+  test('generics - maps', () {
+    final Class klass = Class(
+      name: 'Foobar',
+      fields: <NamedType>[
+        NamedType(
+            type: TypeDeclaration(
+                baseName: 'Map',
+                isNullable: true,
+                typeArguments: <TypeDeclaration>[
+                  TypeDeclaration(baseName: 'String', isNullable: true),
+                  TypeDeclaration(baseName: 'String', isNullable: true),
+                ]),
+            name: 'field1',
+            offset: null),
+      ],
+    );
+    final Root root = Root(
+      apis: <Api>[],
+      classes: <Class>[klass],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const JavaOptions javaOptions = JavaOptions(className: 'Messages');
+    generateJava(javaOptions, root, sink);
+    final String code = sink.toString();
+    expect(code, contains('class Foobar'));
+    expect(code, contains('Map<String, String> field1;'));
+  });
+
   test('host generics argument', () {
     final Root root = Root(
       apis: <Api>[


### PR DESCRIPTION
Fixes oversight discovered while upgrading video_player to pigeon 1.0: https://github.com/flutter/plugins/pull/4277#issuecomment-907519320

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
