### PR TITLE
Roll to version 0.6.0+1 of repo tooling

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ tool_setup_template: &TOOL_SETUP_TEMPLATE
     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
     # Pinned version of the plugin tools, to avoid breakage in this repository
     # when pushing updates from flutter/plugins.
-    - dart pub global activate flutter_plugin_tools 0.5.0
+    - dart pub global activate flutter_plugin_tools 0.6.0+1
 
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   upgrade_flutter_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,9 @@ task:
           BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
           BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
       script:
-        - ./script/tool_runner.sh build-examples --apk
+        # extension_google_sign_in_as_googleapis_auth is currently not building, see
+        # https://github.com/flutter/flutter/issues/89301
+        - ./script/tool_runner.sh build-examples --apk --exclude=extension_google_sign_in_as_googleapis_auth
         # Must come after apk build:
         - ./script/tool_runner.sh native-test --android --no-integration
       depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,9 +58,6 @@ task:
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
-        matrix:
-          BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
-          BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
       script:
         # extension_google_sign_in_as_googleapis_auth is currently not building, see
         # https://github.com/flutter/flutter/issues/89301
@@ -90,9 +87,6 @@ task:
     matrix:
       CHANNEL: "master"
       CHANNEL: "stable"
-    matrix:
-      BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
-      BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
   << : *FLUTTER_UPGRADE_TEMPLATE
   build_script:
     - ./script/tool_runner.sh build-examples --ios

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: dart pub global activate flutter_plugin_tools 0.5.0
+      run: dart pub global activate flutter_plugin_tools 0.6.0+1
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests

--- a/script/tool_runner.sh
+++ b/script/tool_runner.sh
@@ -7,12 +7,6 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
-ACTIONS=("$@")
-
-BRANCH_NAME="${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}"
-if [[ "${BRANCH_NAME}" == "master" ]]; then
-  echo "Running for all packages"
-  (cd "$REPO_DIR" && dart pub global run flutter_plugin_tools "${ACTIONS[@]}" $BUILD_SHARDING)
-else
-  (cd "$REPO_DIR" && dart pub global run flutter_plugin_tools "${ACTIONS[@]}" --run-on-changed-packages $BUILD_SHARDING)
-fi
+# The tool expects to be run from the repo root.
+cd "$REPO_DIR"
+dart pub global run flutter_plugin_tools "$@" --packages-for-branch $BUILD_SHARDING


### PR DESCRIPTION
Picks up 0.6.0+1 of the tool, which among other things fixes `build-examples` to run on non-plugin packages.

Related changes:
- Simplifies tool_runner.sh using new tool flag, to match the recent change to flutter/plugins.
- Disables sharding of the build+native test tasks; even with building now working again, it's clear there's not enough load to warrant the shards; each one has about 1 minute of setup, and then the build times per shard varied from 1-4 minutes. Using an extra machine to run in 1+1 and 1+4 minutes is not a win over just doing a single 1+5 minute run.

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
