### PR TITLE
[pigeon] fixed: classes aren't generated when they are only referenced as type arguments

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+* [front-end] Fixed bug where classes only referenced as type arguments for
+  generics weren't being generated.
+
 ## 1.0.0
 
 * Started allowing primitive data types as arguments and return types.

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '1.0.0';
+const String pigeonVersion = '1.0.1';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -504,6 +504,13 @@ class _FindInitializer extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
   }
 }
 
+Iterable<String> _getReferencedTypes(TypeDeclaration type) sync* {
+  for (final TypeDeclaration typeArg in type.typeArguments) {
+    yield* _getReferencedTypes(typeArg);
+  }
+  yield type.baseName;
+}
+
 class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
   _RootBuilder(this.source);
 
@@ -539,9 +546,9 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
     for (final Api api in _apis) {
       for (final Method method in api.methods) {
         for (final NamedType field in method.arguments) {
-          referencedTypes.add(field.type.baseName);
+          referencedTypes.addAll(_getReferencedTypes(field.type));
         }
-        referencedTypes.add(method.returnType.baseName);
+        referencedTypes.addAll(_getReferencedTypes(method.returnType));
       }
     }
 

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/master/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 1.0.0 # This must match the version in lib/generator_tools.dart
+version: 1.0.1 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -804,4 +804,38 @@ abstract class Api {
     dartGenerator.generate(buffer, options, root);
     expect(buffer.toString(), startsWith('// Copyright 2013'));
   });
+
+  test('only class reference is type argument for return value', () {
+    const String code = '''
+class Foo {
+  int? foo;
+}
+
+@HostApi()
+abstract class Api {
+  List<Foo?> grabAll();
+}
+''';
+    final ParseResults results = _parseSource(code);
+    expect(results.errors.length, 0);
+    expect(results.root.classes.length, 1);
+    expect(results.root.classes[0].name, 'Foo');
+  });
+
+  test('only class reference is type argument for argument', () {
+    const String code = '''
+class Foo {
+  int? foo;
+}
+
+@HostApi()
+abstract class Api {
+  void storeAll(List<Foo?> foos);
+}
+''';
+    final ParseResults results = _parseSource(code);
+    expect(results.errors.length, 0);
+    expect(results.root.classes.length, 1);
+    expect(results.root.classes[0].name, 'Foo');
+  });
 }


### PR DESCRIPTION
fixes: https://github.com/flutter/flutter/issues/89404

This is particularly bad since this is exactly what happens in our examples tab.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
