### PR TITLE
[pigeon] fixed cases where types can be missing from codecs

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.4
+
+* [front-end] Fixed bug where codecs weren't generating support for types that
+  only show up in type arguments.
+
 ## 1.0.3
 
 * [objc] Updated assert message for incomplete implementations of protocols.

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/master/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 1.0.3 # This must match the version in lib/generator_tools.dart
+version: 1.0.4 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/pigeon/test/generator_tools_test.dart
+++ b/packages/pigeon/test/generator_tools_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:pigeon/ast.dart';
 import 'package:pigeon/generator_tools.dart';
 import 'package:test/test.dart';
 
@@ -62,5 +63,116 @@ void main() {
       '3': '3',
     };
     expect(_equalMaps(expected, mergeMaps(source, modification)), isTrue);
+  });
+
+  test('get codec classes from argument type arguments', () {
+    final Api api =
+        Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
+      Method(
+        name: 'doSomething',
+        arguments: <NamedType>[
+          NamedType(
+            type: TypeDeclaration(
+              baseName: 'List',
+              isNullable: false,
+              typeArguments: <TypeDeclaration>[
+                TypeDeclaration(baseName: 'Input', isNullable: true)
+              ],
+            ),
+            name: '',
+            offset: null,
+          )
+        ],
+        returnType: TypeDeclaration(baseName: 'Output', isNullable: false),
+        isAsynchronous: true,
+      )
+    ]);
+    final List<EnumeratedClass> classes = getCodecClasses(api).toList();
+    expect(classes.length, 2);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Input')
+            .length,
+        1);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Output')
+            .length,
+        1);
+  });
+
+  test('get codec classes from return value type arguments', () {
+    final Api api =
+        Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
+      Method(
+        name: 'doSomething',
+        arguments: <NamedType>[
+          NamedType(
+            type: TypeDeclaration(baseName: 'Output', isNullable: false),
+            name: '',
+            offset: null,
+          )
+        ],
+        returnType: TypeDeclaration(
+          baseName: 'List',
+          isNullable: false,
+          typeArguments: <TypeDeclaration>[
+            TypeDeclaration(baseName: 'Input', isNullable: true)
+          ],
+        ),
+        isAsynchronous: true,
+      )
+    ]);
+    final List<EnumeratedClass> classes = getCodecClasses(api).toList();
+    expect(classes.length, 2);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Input')
+            .length,
+        1);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Output')
+            .length,
+        1);
+  });
+
+  test('get codec classes from all arguments', () {
+    final Api api =
+        Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
+      Method(
+        name: 'doSomething',
+        arguments: <NamedType>[
+          NamedType(
+            type: TypeDeclaration(baseName: 'Foo', isNullable: false),
+            name: '',
+            offset: null,
+          ),
+          NamedType(
+            type: TypeDeclaration(baseName: 'Bar', isNullable: false),
+            name: '',
+            offset: null,
+          ),
+        ],
+        returnType: TypeDeclaration(
+          baseName: 'List',
+          isNullable: false,
+          typeArguments: <TypeDeclaration>[TypeDeclaration.voidDeclaration()],
+        ),
+        isAsynchronous: true,
+      )
+    ]);
+    final List<EnumeratedClass> classes = getCodecClasses(api).toList();
+    expect(classes.length, 2);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Foo')
+            .length,
+        1);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Bar')
+            .length,
+        1);
   });
 }


### PR DESCRIPTION
Previously we fixed that classes are generated when referenced only from type arguments, we were still missing them from the codec though.  This fixes that.

fixes internal question 4652416327166722048

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
