### PR TITLE
[pigeon] fixed nested classes type arguments can be omitted from the output

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.7
+
+* [front-end] Fixed bug where nested classes' type arguments aren't included in
+  the output (generated class and codec).
+
 ## 1.0.6
 
 * Updated example README for set up steps.
@@ -22,6 +27,7 @@
   explicitly.
 
 ## 1.0.1
+
 * [front-end] Fixed bug where classes only referenced as type arguments for
   generics weren't being generated.
 

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -55,21 +55,22 @@ class JavaOptions {
 
 String _getCodecName(Api api) => '${api.name}Codec';
 
-void _writeCodec(Indent indent, Api api) {
+void _writeCodec(Indent indent, Api api, Root root) {
   final String codecName = _getCodecName(api);
   indent.write('private static class $codecName extends StandardMessageCodec ');
   indent.scoped('{', '}', () {
     indent
         .writeln('public static final $codecName INSTANCE = new $codecName();');
     indent.writeln('private $codecName() {}');
-    if (getCodecClasses(api).isNotEmpty) {
+    if (getCodecClasses(api, root).isNotEmpty) {
       indent.writeln('@Override');
       indent.write(
           'protected Object readValueOfType(byte type, ByteBuffer buffer) ');
       indent.scoped('{', '}', () {
         indent.write('switch (type) ');
         indent.scoped('{', '}', () {
-          for (final EnumeratedClass customClass in getCodecClasses(api)) {
+          for (final EnumeratedClass customClass
+              in getCodecClasses(api, root)) {
             indent.write('case (byte)${customClass.enumeration}: ');
             indent.writeScoped('', '', () {
               indent.writeln(
@@ -86,7 +87,7 @@ void _writeCodec(Indent indent, Api api) {
       indent.write(
           'protected void writeValue(ByteArrayOutputStream stream, Object value) ');
       indent.writeScoped('{', '}', () {
-        for (final EnumeratedClass customClass in getCodecClasses(api)) {
+        for (final EnumeratedClass customClass in getCodecClasses(api, root)) {
           indent.write('if (value instanceof ${customClass.name}) ');
           indent.scoped('{', '} else ', () {
             indent.writeln('stream.write(${customClass.enumeration});');
@@ -517,7 +518,7 @@ void generateJava(JavaOptions options, Root root, StringSink sink) {
     }
 
     for (final Api api in root.apis) {
-      _writeCodec(indent, api);
+      _writeCodec(indent, api, root);
       indent.addln('');
       if (api.location == ApiLocation.host) {
         _writeHostApi(indent, api);

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -161,19 +161,20 @@ String _getCodecName(String? prefix, String className) =>
 String _getCodecGetterName(String? prefix, String className) =>
     '${_className(prefix, className)}GetCodec';
 
-void _writeCodec(Indent indent, String name, ObjcOptions options, Api api) {
+void _writeCodec(
+    Indent indent, String name, ObjcOptions options, Api api, Root root) {
   final String readerWriterName = '${name}ReaderWriter';
   final String readerName = '${name}Reader';
   final String writerName = '${name}Writer';
   indent.writeln('@interface $readerName : FlutterStandardReader');
   indent.writeln('@end');
   indent.writeln('@implementation $readerName');
-  if (getCodecClasses(api).isNotEmpty) {
+  if (getCodecClasses(api, root).isNotEmpty) {
     indent.writeln('- (nullable id)readValueOfType:(UInt8)type ');
     indent.scoped('{', '}', () {
       indent.write('switch (type) ');
       indent.scoped('{', '}', () {
-        for (final EnumeratedClass customClass in getCodecClasses(api)) {
+        for (final EnumeratedClass customClass in getCodecClasses(api, root)) {
           indent.write('case ${customClass.enumeration}: ');
           indent.writeScoped('', '', () {
             indent.writeln(
@@ -192,10 +193,10 @@ void _writeCodec(Indent indent, String name, ObjcOptions options, Api api) {
   indent.writeln('@interface $writerName : FlutterStandardWriter');
   indent.writeln('@end');
   indent.writeln('@implementation $writerName');
-  if (getCodecClasses(api).isNotEmpty) {
+  if (getCodecClasses(api, root).isNotEmpty) {
     indent.writeln('- (void)writeValue:(id)value ');
     indent.scoped('{', '}', () {
-      for (final EnumeratedClass customClass in getCodecClasses(api)) {
+      for (final EnumeratedClass customClass in getCodecClasses(api, root)) {
         indent.write(
             'if ([value isKindOfClass:[${_className(options.prefix, customClass.name)} class]]) ');
         indent.scoped('{', '} else ', () {
@@ -722,7 +723,7 @@ static NSDictionary<NSString *, id> *wrapResult(id result, FlutterError *error) 
 
   for (final Api api in root.apis) {
     final String codecName = _getCodecName(options.prefix, api.name);
-    _writeCodec(indent, codecName, options, api);
+    _writeCodec(indent, codecName, options, api, root);
     indent.addln('');
     if (api.location == ApiLocation.host) {
       _writeHostApiSource(indent, options, api);

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/master/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 1.0.6 # This must match the version in lib/generator_tools.dart
+version: 1.0.7 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/pigeon/test/generator_tools_test.dart
+++ b/packages/pigeon/test/generator_tools_test.dart
@@ -87,7 +87,9 @@ void main() {
         isAsynchronous: true,
       )
     ]);
-    final List<EnumeratedClass> classes = getCodecClasses(api).toList();
+    final Root root =
+        Root(classes: <Class>[], apis: <Api>[api], enums: <Enum>[]);
+    final List<EnumeratedClass> classes = getCodecClasses(api, root).toList();
     expect(classes.length, 2);
     expect(
         classes
@@ -123,7 +125,9 @@ void main() {
         isAsynchronous: true,
       )
     ]);
-    final List<EnumeratedClass> classes = getCodecClasses(api).toList();
+    final Root root =
+        Root(classes: <Class>[], apis: <Api>[api], enums: <Enum>[]);
+    final List<EnumeratedClass> classes = getCodecClasses(api, root).toList();
     expect(classes.length, 2);
     expect(
         classes
@@ -162,7 +166,55 @@ void main() {
         isAsynchronous: true,
       )
     ]);
-    final List<EnumeratedClass> classes = getCodecClasses(api).toList();
+    final Root root =
+        Root(classes: <Class>[], apis: <Api>[api], enums: <Enum>[]);
+    final List<EnumeratedClass> classes = getCodecClasses(api, root).toList();
+    expect(classes.length, 2);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Foo')
+            .length,
+        1);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Bar')
+            .length,
+        1);
+  });
+
+  test('getCodecClasses: nested type arguments', () {
+    final Root root = Root(apis: <Api>[
+      Api(name: 'Api', location: ApiLocation.flutter, methods: <Method>[
+        Method(
+          name: 'foo',
+          arguments: <NamedType>[
+            NamedType(
+                name: 'x',
+                type: TypeDeclaration(
+                    isNullable: false,
+                    baseName: 'List',
+                    typeArguments: <TypeDeclaration>[
+                      TypeDeclaration(baseName: 'Foo', isNullable: true)
+                    ])),
+          ],
+          returnType: TypeDeclaration.voidDeclaration(),
+          isAsynchronous: false,
+        )
+      ])
+    ], classes: <Class>[
+      Class(name: 'Foo', fields: <NamedType>[
+        NamedType(
+            name: 'bar',
+            type: TypeDeclaration(baseName: 'Bar', isNullable: true)),
+      ]),
+      Class(name: 'Bar', fields: <NamedType>[
+        NamedType(
+            name: 'value',
+            type: TypeDeclaration(baseName: 'int', isNullable: true))
+      ])
+    ], enums: <Enum>[]);
+    final List<EnumeratedClass> classes =
+        getCodecClasses(root.apis[0], root).toList();
     expect(classes.length, 2);
     expect(
         classes

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -175,6 +175,10 @@ class Input1 {
   String? input;
 }
 
+class Output1 {
+  int? output;
+}
+
 @HostApi()
 abstract class ApiTwoMethods {
   Output1 method1(Input1 input);
@@ -218,6 +222,10 @@ abstract class Api {
     const String code = '''
 class Input1 {
   String? input;
+}
+
+class Output1 {
+  int? output;
 }
 
 @FlutterApi()
@@ -868,5 +876,18 @@ abstract class Api {
             .where((Class element) => element.name == 'Bar')
             .length,
         1);
+  });
+
+  test('undeclared class in argument type argument', () {
+    const String code = '''
+@HostApi()
+abstract class Api {
+  void storeAll(List<Foo?> foos);
+}
+''';
+    final ParseResults results = _parseSource(code);
+    expect(results.errors.length, 1);
+    expect(results.errors[0].lineNumber, 3);
+    expect(results.errors[0].message, contains('Unknown type: Foo'));
   });
 }

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -838,4 +838,35 @@ abstract class Api {
     expect(results.root.classes.length, 1);
     expect(results.root.classes[0].name, 'Foo');
   });
+
+  test('recurse into type arguments', () {
+    const String code = '''
+class Foo {
+  int? foo;
+  List<Bar?> bars;
+}
+
+class Bar {
+  int? bar;
+}
+
+@HostApi()
+abstract class Api {
+  void storeAll(List<Foo?> foos);
+}
+''';
+    final ParseResults results = _parseSource(code);
+    expect(results.errors.length, 0);
+    expect(results.root.classes.length, 2);
+    expect(
+        results.root.classes
+            .where((Class element) => element.name == 'Foo')
+            .length,
+        1);
+    expect(
+        results.root.classes
+            .where((Class element) => element.name == 'Bar')
+            .length,
+        1);
+  });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/90150

I've also refactored the logic so that calculating which classes to output is shared with calculating the codec classes so we shouldn't run into a problem where one of them works and one doesn't (which we ran into last fix).

Fingers crossed, hopefully this is the last of these.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
