### PR TITLE
[ci.yaml] roller presubmit builder, master->main

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4,8 +4,9 @@
 # for every commit.
 #
 # More information at:
-#  * https://github.com/flutter/cocoon/blob/master/CI_YAML.md
+#  * https://github.com/flutter/cocoon/blob/main/CI_YAML.md
 enabled_branches:
+  - main
   - master
 
 platform_properties:
@@ -25,6 +26,5 @@ targets:
 
   - name: Linux ci_yaml packages roller
     bringup: true
-    presubmit: false
     recipe: infra/ci_yaml
     scheduler: luci


### PR DESCRIPTION
This starts some master->main migration (support running on both master and main)
Point to Cocoon documentation on main
Add presubmit builder for ci.yaml roller (once it has rolled we can remove bringup: true and add it as blocking)

## Pre-launch Checklist

- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
