### PR TITLE
[animations] Opacity widget's child should not be nullable

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -342,10 +342,10 @@ class _OpenContainerState<T> extends State<OpenContainer<T?>> {
 class _Hideable extends StatefulWidget {
   const _Hideable({
     Key? key,
-    this.child,
+    required this.child,
   }) : super(key: key);
 
-  final Widget? child;
+  final Widget child;
 
   @override
   State<_Hideable> createState() => _HideableState();


### PR DESCRIPTION
Update _Hideable widget child to be required because Opacity widget child also became required.

Fixes #91321
Depends on #91350

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.