### PR TITLE
[flutter_markdown] Padding builder

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.6.8
+
   * Added option paddingBuilders
 
 ## 0.6.7

--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.8
+  * Added option paddingBuilders
+
 ## 0.6.7
 
  * Fix `unnecessary_import` lint errors.

--- a/packages/flutter_markdown/example/lib/demos/wrap_alignment_demo.dart
+++ b/packages/flutter_markdown/example/lib/demos/wrap_alignment_demo.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:markdown/markdown.dart' as md;
 import '../shared/dropdown_menu.dart';
 import '../shared/markdown_demo_widget.dart';
 import '../shared/markdown_extensions.dart';
@@ -127,6 +128,9 @@ class _WrapAlignmentDemoState extends State<WrapAlignmentDemo> {
                     blockquoteAlign: _wrapAlignment,
                     codeblockAlign: _wrapAlignment,
                   ),
+                  paddingBuilders: <String, MarkdownPaddingBuilder>{
+                    'p': CustomPaddingBuilder()
+                  },
                 ),
               ),
             ],
@@ -136,5 +140,30 @@ class _WrapAlignmentDemoState extends State<WrapAlignmentDemo> {
         }
       },
     );
+  }
+}
+
+class CustomPaddingBuilder extends MarkdownPaddingBuilder {
+  final EdgeInsets _padding = const EdgeInsets.only(left: 10.0);
+  bool paddingUse = true;
+
+  @override
+  void visitElementBefore(md.Element element) {
+    if (element.children!.length == 1 && element.children![0] is md.Element) {
+      final md.Element child = element.children![0] as md.Element;
+
+      paddingUse = child.tag != 'img';
+    } else {
+      paddingUse = true;
+    }
+  }
+
+  @override
+  EdgeInsets getPadding() {
+    if (paddingUse) {
+      return _padding;
+    } else {
+      return EdgeInsets.zero;
+    }
   }
 }

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -432,6 +432,11 @@ class MarkdownBuilder implements md.NodeVisitor {
     } else {
       final _InlineElement current = _inlines.removeLast();
       final _InlineElement parent = _inlines.last;
+      EdgeInsets padding = EdgeInsets.zero;
+
+      if (paddingBuilders.containsKey(tag)) {
+        padding = paddingBuilders[tag]!.getPadding();
+      }
 
       if (builders.containsKey(tag)) {
         final Widget? child =
@@ -441,10 +446,13 @@ class MarkdownBuilder implements md.NodeVisitor {
         }
       } else if (tag == 'img') {
         // create an image widget for this image
-        current.children.add(_buildImage(
-          element.attributes['src']!,
-          element.attributes['title'],
-          element.attributes['alt'],
+        current.children.add(_buildPadding(
+          padding,
+          _buildImage(
+            element.attributes['src']!,
+            element.attributes['title'],
+            element.attributes['alt'],
+          ),
         ));
       } else if (tag == 'br') {
         current.children.add(_buildRichText(const TextSpan(text: '\n')));
@@ -579,6 +587,14 @@ class MarkdownBuilder implements md.NodeVisitor {
         ),
       ),
     );
+  }
+
+  Widget _buildPadding(EdgeInsets padding, Widget child) {
+    if (padding == EdgeInsets.zero) {
+      return child;
+    }
+
+    return Padding(padding: padding, child: child);
   }
 
   void _addParentInlineIfNeeded(String? tag) {

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -101,6 +101,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     required this.checkboxBuilder,
     required this.bulletBuilder,
     required this.builders,
+    required this.paddingBuilders,
     required this.listItemCrossAxisAlignment,
     this.fitContent = false,
     this.onTapText,
@@ -132,6 +133,9 @@ class MarkdownBuilder implements md.NodeVisitor {
 
   /// Call when build a custom widget.
   final Map<String, MarkdownElementBuilder> builders;
+
+  /// Call when build a padding for widget.
+  final Map<String, MarkdownPaddingBuilder> paddingBuilders;
 
   /// Whether to allow the widget to fit the child content.
   final bool fitContent;
@@ -193,6 +197,10 @@ class MarkdownBuilder implements md.NodeVisitor {
 
     if (builders.containsKey(tag)) {
       builders[tag]!.visitElementBefore(element);
+    }
+
+    if (paddingBuilders.containsKey(tag)) {
+      paddingBuilders[tag]!.visitElementBefore(element);
     }
 
     int? start;
@@ -603,6 +611,10 @@ class MarkdownBuilder implements md.NodeVisitor {
       blockAlignment = _wrapAlignmentForBlockTag(_currentBlockTag);
       textAlign = _textAlignForBlockTag(_currentBlockTag);
       textPadding = _textPaddingForBlockTag(_currentBlockTag);
+
+      if (paddingBuilders.containsKey(_currentBlockTag)) {
+        textPadding = paddingBuilders[_currentBlockTag]!.getPadding();
+      }
     }
 
     final _InlineElement inline = _inlines.single;

--- a/packages/flutter_markdown/lib/src/widget.dart
+++ b/packages/flutter_markdown/lib/src/widget.dart
@@ -163,6 +163,7 @@ abstract class MarkdownWidget extends StatefulWidget {
     this.checkboxBuilder,
     this.bulletBuilder,
     this.builders = const <String, MarkdownElementBuilder>{},
+    this.paddingBuilders = const <String, MarkdownPaddingBuilder>{},
     this.fitContent = false,
     this.listItemCrossAxisAlignment =
         MarkdownListItemCrossAxisAlignment.baseline,
@@ -233,6 +234,19 @@ abstract class MarkdownWidget extends StatefulWidget {
   ///
   /// The `SubscriptBuilder` is a subclass of [MarkdownElementBuilder].
   final Map<String, MarkdownElementBuilder> builders;
+
+  /// Add padding for different tags and elements
+  ///
+  /// For example, we will add padding for `img` tag:
+  ///
+  /// ```dart
+  /// paddingBuilders: {
+  ///   'img': ImgPaddingBuilder(),
+  /// }
+  /// ```
+  ///
+  /// The `ImgPaddingBuilder` is a subclass of [MarkdownPaddingBuilder].
+  final Map<String, MarkdownPaddingBuilder> paddingBuilders;
 
   /// Whether to allow the widget to fit the child content.
   final bool fitContent;
@@ -317,6 +331,7 @@ class _MarkdownWidgetState extends State<MarkdownWidget>
       checkboxBuilder: widget.checkboxBuilder,
       bulletBuilder: widget.bulletBuilder,
       builders: widget.builders,
+      paddingBuilders: widget.paddingBuilders,
       fitContent: widget.fitContent,
       listItemCrossAxisAlignment: widget.listItemCrossAxisAlignment,
       onTapText: widget.onTapText,
@@ -391,6 +406,8 @@ class MarkdownBody extends MarkdownWidget {
     MarkdownBulletBuilder? bulletBuilder,
     Map<String, MarkdownElementBuilder> builders =
         const <String, MarkdownElementBuilder>{},
+    Map<String, MarkdownPaddingBuilder> paddingBuilders =
+        const <String, MarkdownPaddingBuilder>{},
     MarkdownListItemCrossAxisAlignment listItemCrossAxisAlignment =
         MarkdownListItemCrossAxisAlignment.baseline,
     this.shrinkWrap = true,
@@ -412,6 +429,7 @@ class MarkdownBody extends MarkdownWidget {
           imageBuilder: imageBuilder,
           checkboxBuilder: checkboxBuilder,
           builders: builders,
+          paddingBuilders: paddingBuilders,
           listItemCrossAxisAlignment: listItemCrossAxisAlignment,
           bulletBuilder: bulletBuilder,
           fitContent: fitContent,
@@ -464,6 +482,8 @@ class Markdown extends MarkdownWidget {
     MarkdownBulletBuilder? bulletBuilder,
     Map<String, MarkdownElementBuilder> builders =
         const <String, MarkdownElementBuilder>{},
+    Map<String, MarkdownPaddingBuilder> paddingBuilders =
+        const <String, MarkdownPaddingBuilder>{},
     MarkdownListItemCrossAxisAlignment listItemCrossAxisAlignment =
         MarkdownListItemCrossAxisAlignment.baseline,
     this.padding = const EdgeInsets.all(16.0),
@@ -487,6 +507,7 @@ class Markdown extends MarkdownWidget {
           imageBuilder: imageBuilder,
           checkboxBuilder: checkboxBuilder,
           builders: builders,
+          paddingBuilders: paddingBuilders,
           listItemCrossAxisAlignment: listItemCrossAxisAlignment,
           bulletBuilder: bulletBuilder,
           softLineBreak: softLineBreak,
@@ -540,4 +561,14 @@ class TaskListSyntax extends md.InlineSyntax {
     parser.addNode(el);
     return true;
   }
+}
+
+/// An interface for an padding builder for element.
+abstract class MarkdownPaddingBuilder {
+  /// Called when an Element has been reached, before its children have been
+  /// visited.
+  void visitElementBefore(md.Element element) {}
+
+  /// Called when a widget node has been rendering and need tag padding.
+  EdgeInsets getPadding() => EdgeInsets.zero;
 }

--- a/packages/flutter_markdown/lib/src/widget.dart
+++ b/packages/flutter_markdown/lib/src/widget.dart
@@ -235,7 +235,7 @@ abstract class MarkdownWidget extends StatefulWidget {
   /// The `SubscriptBuilder` is a subclass of [MarkdownElementBuilder].
   final Map<String, MarkdownElementBuilder> builders;
 
-  /// Add padding for different tags and elements
+  /// Add padding for different tags (use only for block elements and img)
   ///
   /// For example, we will add padding for `img` tag:
   ///

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/master/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.6.7
+version: 0.6.8
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/flutter_markdown/test/padding_test.dart
+++ b/packages/flutter_markdown/test/padding_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'utils.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  group('Padding builders', () {
+    testWidgets(
+      'use paddingBuilders for p',
+      (WidgetTester tester) async {
+        const double paddingX = 10.0;
+
+        await tester.pumpWidget(
+          boilerplate(
+            Markdown(
+                data: '**line 1**\n\n# H1\n![alt](/assets/images/logo.png)',
+                paddingBuilders: <String, MarkdownPaddingBuilder>{
+                  'p': CustomPaddingBuilder(paddingX * 1),
+                  'strong': CustomPaddingBuilder(paddingX * 2),
+                  'h1': CustomPaddingBuilder(paddingX * 3),
+                  'img': CustomPaddingBuilder(paddingX * 4),
+                }),
+          ),
+        );
+
+        final List<Padding> paddings =
+            tester.widgetList<Padding>(find.byType(Padding)).toList();
+
+        expect(paddings.length, 4);
+        expect(
+          paddings[0].padding.along(Axis.horizontal) == paddingX * 1 * 2,
+          true,
+        );
+        expect(
+          paddings[1].padding.along(Axis.horizontal) == paddingX * 3 * 2,
+          true,
+        );
+        expect(
+          paddings[2].padding.along(Axis.horizontal) == paddingX * 1 * 2,
+          true,
+        );
+        expect(
+          paddings[3].padding.along(Axis.horizontal) == paddingX * 4 * 2,
+          true,
+        );
+      },
+    );
+  });
+}
+
+class CustomPaddingBuilder extends MarkdownPaddingBuilder {
+  CustomPaddingBuilder(this.paddingX);
+
+  double paddingX;
+
+  @override
+  EdgeInsets getPadding() {
+    return EdgeInsets.symmetric(horizontal: paddingX);
+  }
+}

--- a/packages/flutter_markdown/test/padding_test.dart
+++ b/packages/flutter_markdown/test/padding_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';


### PR DESCRIPTION
This is PR will add new logic markdown padding render, if you need set image padding smaller than paragraph and other case

Add custom set padding for block element and img in flutter_markdown

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
