### PR TITLE
[palette_generator] Fix typos

### DIFF
--- a/packages/palette_generator/CHANGELOG.md
+++ b/packages/palette_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.3.2
 
+* Fix typos
 * Fix `unnecessary_import` lint errors.
 
 ## 0.3.1

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -19,7 +19,7 @@ import 'package:flutter/painting.dart';
 
 /// A description of an encoded image.
 ///
-/// Used in [PaletteGenerator.fromEncodedImage].
+/// Used in [PaletteGenerator.fromByteData].
 class EncodedImage {
   /// Creates a description of an encoded image.
   const EncodedImage(
@@ -98,12 +98,12 @@ class PaletteGenerator with Diagnosticable {
     _selectSwatches();
   }
 
-  // TODO(gspencergoog): remove `dart:ui` paragragh from [fromByteData] method when https://github.com/flutter/flutter/issues/10647 is resolved
+  // TODO(gspencergoog): remove `dart:ui` paragraph from [fromByteData] method when https://github.com/flutter/flutter/issues/10647 is resolved
 
   /// Create a [PaletteGenerator] asynchronously from encoded image [ByteData],
   /// width, and height. These parameters are packed in [EncodedImage].
   ///
-  /// The image encoding must be RGBA with 8-bit per channel, this corresponds to
+  /// The image encoding must be RGBA with 8 bits per channel, this corresponds to
   /// [ImageByteFormat.rawRgba] or [ImageByteFormat.rawStraightRgba].
   ///
   /// In contast with [fromImage] and [fromImageProvider] this method can be used
@@ -148,7 +148,7 @@ class PaletteGenerator with Diagnosticable {
       encodedImage.byteData.lengthInBytes ~/ 4 ==
           encodedImage.width * encodedImage.height,
       "Image byte data doesn't match the image size, or has invalid encoding. "
-      'The encoding must be RGBA with 8 bit per channel.',
+      'The encoding must be RGBA with 8 bits per channel.',
     );
 
     final _ColorCutQuantizer quantizer = _ColorCutQuantizer(

--- a/packages/palette_generator/pubspec.yaml
+++ b/packages/palette_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: palette_generator
 description: Flutter package for generating palette colors from a source image.
 repository: https://github.com/flutter/packages/tree/master/packages/palette_generator
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+palette_generator%22
-version: 0.3.1
+version: 0.3.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Fix some typos I didn't notice when doing https://github.com/flutter/packages/pull/450

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
