### PR TITLE
[animations] Null-safety changes due to FadeTransition migration

### DIFF
--- a/packages/animations/example/lib/fade_scale_transition.dart
+++ b/packages/animations/example/lib/fade_scale_transition.dart
@@ -62,7 +62,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
         builder: (BuildContext context, Widget? child) {
           return FadeScaleTransition(
             animation: _controller,
-            child: child,
+            child: child!,
           );
         },
         child: Visibility(

--- a/packages/animations/lib/src/fade_scale_transition.dart
+++ b/packages/animations/lib/src/fade_scale_transition.dart
@@ -117,7 +117,7 @@ class FadeScaleTransition extends StatelessWidget {
   const FadeScaleTransition({
     Key? key,
     required this.animation,
-    this.child,
+    required this.child,
   }) : super(key: key);
 
   /// The animation that drives the [child]'s entrance and exit.
@@ -132,7 +132,7 @@ class FadeScaleTransition extends StatelessWidget {
   ///
   /// This widget will transition in and out as driven by [animation] and
   /// [secondaryAnimation].
-  final Widget? child;
+  final Widget child;
 
   static final Animatable<double> _fadeInTransition = CurveTween(
     curve: const Interval(0.0, 0.3),
@@ -170,7 +170,7 @@ class FadeScaleTransition extends StatelessWidget {
       ) {
         return FadeTransition(
           opacity: _fadeOutTransition.animate(animation),
-          child: child,
+          child: child!,
         );
       },
       child: child,

--- a/packages/animations/lib/src/fade_through_transition.dart
+++ b/packages/animations/lib/src/fade_through_transition.dart
@@ -239,7 +239,7 @@ class _ZoomedFadeInFadeOut extends StatelessWidget {
         Widget? child,
       ) {
         return _FadeOut(
-          child: child,
+          child: child!,
           animation: animation,
         );
       },
@@ -299,11 +299,11 @@ class _ZoomedFadeIn extends StatelessWidget {
 
 class _FadeOut extends StatelessWidget {
   const _FadeOut({
-    this.child,
+    required this.child,
     required this.animation,
   });
 
-  final Widget? child;
+  final Widget child;
   final Animation<double> animation;
 
   static final CurveTween _outCurve = CurveTween(

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -342,10 +342,10 @@ class _OpenContainerState<T> extends State<OpenContainer<T?>> {
 class _Hideable extends StatefulWidget {
   const _Hideable({
     Key? key,
-    this.child,
+    required this.child,
   }) : super(key: key);
 
-  final Widget? child;
+  final Widget child;
 
   @override
   State<_Hideable> createState() => _HideableState();

--- a/packages/animations/test/dual_transition_builder_test.dart
+++ b/packages/animations/test/dual_transition_builder_test.dart
@@ -32,7 +32,7 @@ void main() {
         ) {
           return FadeTransition(
             opacity: Tween<double>(begin: 1.0, end: 0.0).animate(animation),
-            child: child,
+            child: child!,
           );
         },
         child: Container(
@@ -102,7 +102,7 @@ void main() {
           ) {
             return FadeTransition(
               opacity: Tween<double>(begin: 1.0, end: 0.0).animate(animation),
-              child: child,
+              child: child!,
             );
           },
           child: const _StatefulTestWidget(name: 'Foo'),
@@ -164,7 +164,7 @@ void main() {
         ) {
           return FadeTransition(
             opacity: Tween<double>(begin: 1.0, end: 0.0).animate(animation),
-            child: child,
+            child: child!,
           );
         },
         child: Container(
@@ -230,7 +230,7 @@ void main() {
         ) {
           return FadeTransition(
             opacity: Tween<double>(begin: 1.0, end: 0.0).animate(animation),
-            child: child,
+            child: child!,
           );
         },
         child: Container(


### PR DESCRIPTION
Null-safety changes due to FadeTransition migration

Fixes https://github.com/flutter/flutter/issues/91321
Depends on https://github.com/flutter/flutter/pull/91350

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
