### PR TITLE
Drop dependency on pkg:pedantic from 4 packages

### DIFF
--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -16,4 +16,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0

--- a/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
 
 false_secrets:
  - example/android/app/google-services.json

--- a/packages/fuchsia_ctl/pubspec.lock
+++ b/packages/fuchsia_ctl/pubspec.lock
@@ -212,7 +212,7 @@ packages:
     source: hosted
     version: "1.6.4"
   pedantic:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -21,5 +21,4 @@ dependencies:
 
 dev_dependencies:
   mockito: ^4.1.1
-  pedantic: 1.9.2
   test: ^1.15.5

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -20,5 +20,4 @@ dev_dependencies:
   build_runner: ^2.1.1
   fake_async: ^1.2.0
   mockito: ^5.0.14
-  pedantic: ^1.11.1
   test: ^1.17.11


### PR DESCRIPTION
Only in dev_dependencies
None of these seemed to be using it, anyway
