### PR TITLE
[animations] Updated open_container.dart documentation. 

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+* Fixed documentation for `OpenContainer` class; replaced `openBuilder` with `closedBuilder`. 
+
 ## 2.0.1
 * Add links to the spec and codelab.
 

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -57,7 +57,7 @@ typedef ClosedCallback<S> = void Function(S data);
 /// container is closed again via the callback provided to [openBuilder] or via
 /// Android's back button, the animation is reversed: The container shrinks back
 /// to its original size while the widget returned by [openBuilder] is faded out
-/// and the widget returned by [openBuilder] is faded back in.
+/// and the widget returned by [closedBuilder] is faded back in.
 ///
 /// By default, the container is in the closed state. During the transition from
 /// closed to open and vice versa the widgets returned by the [openBuilder] and

--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -2,7 +2,7 @@ name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
 repository: https://github.com/flutter/packages/tree/master/packages/animations
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+animations%22
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Extension of [this pull request](https://github.com/flutter/packages/pull/497). 
Fixed minor mistake in the documentation for `OpenContainer` class. 

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
