### PR TITLE
[ci] Give the LUCI Windows targets unique names

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -29,7 +29,7 @@ platform_properties:
       os: Windows
 
 targets:
-  - name: Windows win32-platform_tests master
+  - name: Windows win32-platform_tests master - packages
     bringup: true
     recipe: packages/packages
     timeout: 30
@@ -43,7 +43,7 @@ targets:
         ]
     scheduler: luci
 
-  - name: Windows win32-platform_tests stable
+  - name: Windows win32-platform_tests stable - packages
     bringup: true
     recipe: packages/packages
     timeout: 30


### PR DESCRIPTION
Names must be globally unique; the current names conflict with flutter/plugins targets

Should fix https://github.com/flutter/flutter/issues/91048

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
