### PR TITLE
Add master to main mirroring for packages repo.

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,25 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Mirror master to main branches in the packages repository.
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  mirror_job:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'flutter/packages' }}
+    name: Mirror main branch to master branch
+    steps:
+      - name: Mirror action step
+        id: mirror
+        uses: google/mirror-branch-action@c6b07e441a7ffc5ae15860c1d0a8107a3a151db8
+        with:
+          github-token: ${{ secrets.FLUTTERGITHUBBOT_TOKEN }}
+          source: 'master'
+          dest: 'main'


### PR DESCRIPTION
This is to prepare the repository for master branch migration to main.

Bug: https://github.com/flutter/flutter/issues/90476

## Pre-launch Checklist

- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the `#hackers-new` channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
