### PR TITLE
[cupertino_icons] Update README to link to API docs

### DIFF
--- a/third_party/packages/cupertino_icons/CHANGELOG.md
+++ b/third_party/packages/cupertino_icons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.3+1
+* Update README to link to API docs.
+
 ## 1.0.3
 * Source moved to flutter/packages.
 

--- a/third_party/packages/cupertino_icons/CHANGELOG.md
+++ b/third_party/packages/cupertino_icons/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.3+1
+## 1.0.4
 * Update README to link to API docs.
 
 ## 1.0.3

--- a/third_party/packages/cupertino_icons/README.md
+++ b/third_party/packages/cupertino_icons/README.md
@@ -20,8 +20,7 @@ For issues, file directly in the [main Flutter repo](https://github.com/flutter/
 
 # Icons
 
-[![icon gallery preview](gallery_preview_1.0.0.png)](https://flutter.github.io/cupertino_icons)
+[![icon gallery preview](gallery_preview_1.0.0.png)](https://api.flutter.dev/flutter/cupertino/CupertinoIcons-class.html)
 
-For versions 1.0.0 and above (available only on Flutter SDK versions 1.22+), see the [Cupertino Icons Gallery](https://flutter.github.io/cupertino_icons).
-
-For versions 0.1.3 and below, see this [glyph map](https://raw.githubusercontent.com/flutter/cupertino_icons/master/map.png).
+For a list of all icons, see
+[`CupertinoIcons` class documentation constants](https://api.flutter.dev/flutter/cupertino/CupertinoIcons-class.html#constants).

--- a/third_party/packages/cupertino_icons/README.md
+++ b/third_party/packages/cupertino_icons/README.md
@@ -24,3 +24,5 @@ For issues, file directly in the [main Flutter repo](https://github.com/flutter/
 
 For a list of all icons, see
 [`CupertinoIcons` class documentation constants](https://api.flutter.dev/flutter/cupertino/CupertinoIcons-class.html#constants).
+
+For versions 0.1.3 and below, see this [glyph map](https://raw.githubusercontent.com/flutter/packages/master/third_party/packages/cupertino_icons/map.png).

--- a/third_party/packages/cupertino_icons/pubspec.yaml
+++ b/third_party/packages/cupertino_icons/pubspec.yaml
@@ -3,7 +3,7 @@ name: cupertino_icons
 description: Default icons asset for Cupertino widgets based on Apple styled icons
 repository: https://github.com/flutter/packages/tree/master/third_party/packages/cupertino_icons
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+cupertino_icons%22
-version: 1.0.3
+version: 1.0.3+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/third_party/packages/cupertino_icons/pubspec.yaml
+++ b/third_party/packages/cupertino_icons/pubspec.yaml
@@ -3,7 +3,7 @@ name: cupertino_icons
 description: Default icons asset for Cupertino widgets based on Apple styled icons
 repository: https://github.com/flutter/packages/tree/master/third_party/packages/cupertino_icons
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+cupertino_icons%22
-version: 1.0.3+1
+version: 1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
1. Update 0.1.3 glyph map from broken https://raw.githubusercontent.com/flutter/cupertino_icons/master/map.png to updated https://raw.githubusercontent.com/flutter/packages/master/third_party/packages/cupertino_icons/map.png.
2. Replace dead link https://flutter.github.io/cupertino_icons to instead link to the API docs.

Package README/pub documentation part of https://github.com/flutter/flutter/issues/88754.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
