### PR TITLE
[pigeon] fixed bug where the codec didn't contain all types when "Object" is used.

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.10
+
+* [front-end] Made sure that explicit use of Object actually creates the codec
+  that can represent custom classes.
+
 ## 1.0.9
 
 * [dart] Fixed cast exception that can happen with primitive data types with

--- a/packages/pigeon/lib/functional.dart
+++ b/packages/pigeon/lib/functional.dart
@@ -75,13 +75,3 @@ Iterable<T> repeat<T>(T item, int n) sync* {
     yield item;
   }
 }
-
-/// Returns true if any value from [values] evalutes to true for `func(value)`.
-bool any<T>(Iterable<T> values, bool Function(T) func) {
-  for (final T value in values) {
-    if (func(value)) {
-      return true;
-    }
-  }
-  return false;
-}

--- a/packages/pigeon/lib/functional.dart
+++ b/packages/pigeon/lib/functional.dart
@@ -75,3 +75,13 @@ Iterable<T> repeat<T>(T item, int n) sync* {
     yield item;
   }
 }
+
+/// Returns true if any value from [values] evalutes to true for `func(value)`.
+bool any<T>(Iterable<T> values, bool Function(T) func) {
+  for (final T value in values) {
+    if (func(value)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:mirrors';
 import 'ast.dart';
-import 'functional.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
 const String pigeonVersion = '1.0.10';
@@ -352,7 +351,8 @@ Map<TypeDeclaration, List<int>> getReferencedTypes(
   return references.map;
 }
 
-bool _canContainAnyType(TypeDeclaration type) {
+/// Returns true if the concrete type cannot be determined at compile-time.
+bool _isConcreteTypeAmbiguous(TypeDeclaration type) {
   return (type.baseName == 'List' && type.typeArguments.isEmpty) ||
       (type.baseName == 'Map' && type.typeArguments.isEmpty) ||
       type.baseName == 'Object';
@@ -365,7 +365,7 @@ Iterable<EnumeratedClass> getCodecClasses(Api api, Root root) sync* {
   final Map<TypeDeclaration, List<int>> referencedTypes =
       getReferencedTypes(<Api>[api], root.classes);
   final Iterable<String> allTypeNames =
-      any(referencedTypes.keys, _canContainAnyType)
+      referencedTypes.keys.any(_isConcreteTypeAmbiguous)
           ? root.classes.map((Class aClass) => aClass.name)
           : referencedTypes.keys.map((TypeDeclaration e) => e.baseName);
   final List<String> sortedNames = allTypeNames

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/master/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 1.0.9 # This must match the version in lib/generator_tools.dart
+version: 1.0.10 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/pigeon/test/generator_tools_test.dart
+++ b/packages/pigeon/test/generator_tools_test.dart
@@ -229,6 +229,46 @@ void main() {
         1);
   });
 
+  test('getCodecClasses: with Object', () {
+    final Root root = Root(apis: <Api>[
+      Api(
+        name: 'Api1',
+        location: ApiLocation.flutter,
+        methods: <Method>[
+          Method(
+            name: 'foo',
+            arguments: <NamedType>[
+              NamedType(
+                  name: 'x',
+                  type: const TypeDeclaration(
+                      isNullable: false,
+                      baseName: 'List',
+                      typeArguments: <TypeDeclaration>[
+                        TypeDeclaration(baseName: 'Object', isNullable: true)
+                      ])),
+            ],
+            returnType: const TypeDeclaration.voidDeclaration(),
+            isAsynchronous: false,
+          )
+        ],
+      ),
+    ], classes: <Class>[
+      Class(name: 'Foo', fields: <NamedType>[
+        NamedType(
+            name: 'bar',
+            type: const TypeDeclaration(baseName: 'int', isNullable: true)),
+      ]),
+    ], enums: <Enum>[]);
+    final List<EnumeratedClass> classes =
+        getCodecClasses(root.apis[0], root).toList();
+    expect(classes.length, 1);
+    expect(
+        classes
+            .where((EnumeratedClass element) => element.name == 'Foo')
+            .length,
+        1);
+  });
+
   test('getCodecClasses: unique entries', () {
     final Root root = Root(apis: <Api>[
       Api(


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/93063

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
