### PR TITLE
Migrate animations and palette_generator fully to v2 Android embedding

### DIFF
--- a/packages/animations/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/animations/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/packages/animations/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/animations/example/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="dev.flutter.packages.animations.example">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="example"

--- a/packages/animations/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/animations/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="dev.flutter.packages.animations.example">
     <application
-        android:name="${applicationName}"
         android:label="example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/packages/animations/example/android/app/src/main/kotlin/dev/flutter/packages/animations/example/MainActivity.kt
+++ b/packages/animations/example/android/app/src/main/kotlin/dev/flutter/packages/animations/example/MainActivity.kt
@@ -1,12 +1,7 @@
 package dev.flutter.packages.animations.example
 
-import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugins.GeneratedPluginRegistrant
 
 class MainActivity: FlutterActivity() {
-    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-        GeneratedPluginRegistrant.registerWith(flutterEngine);
-    }
+
 }

--- a/packages/imitation_game/imitation_tests/smiley/flutter/smiley/android/app/src/main/AndroidManifest.xml
+++ b/packages/imitation_game/imitation_tests/smiley/flutter/smiley/android/app/src/main/AndroidManifest.xml
@@ -1,12 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.smiley">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="smiley"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/packages/palette_generator/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/palette_generator/example/android/app/src/main/AndroidManifest.xml
@@ -7,13 +7,8 @@
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="image_colors"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -35,5 +30,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/packages/palette_generator/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/palette_generator/example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-        android:name="${applicationName}"
         android:label="image_colors"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/packages/palette_generator/example/android/app/src/main/java/io/flutter/packages/palettegenerator/imagecolors/MainActivity.java
+++ b/packages/palette_generator/example/android/app/src/main/java/io/flutter/packages/palettegenerator/imagecolors/MainActivity.java
@@ -4,14 +4,8 @@
 
 package io.flutter.packages.palettegenerator.imagecolors;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
+
 }

--- a/packages/palette_generator/example/android/app/src/main/java/io/flutter/packages/palettegenerator/imagecolors/MainActivity.java
+++ b/packages/palette_generator/example/android/app/src/main/java/io/flutter/packages/palettegenerator/imagecolors/MainActivity.java
@@ -6,6 +6,4 @@ package io.flutter.packages.palettegenerator.imagecolors;
 
 import io.flutter.embedding.android.FlutterActivity;
 
-public class MainActivity extends FlutterActivity {
-
-}
+public class MainActivity extends FlutterActivity {}

--- a/packages/palette_generator/example/android/app/src/main/kotlin/io/flutter/packages/palettegenerator/example/MainActivity.kt
+++ b/packages/palette_generator/example/android/app/src/main/kotlin/io/flutter/packages/palettegenerator/example/MainActivity.kt
@@ -1,12 +1,7 @@
 package io.flutter.packages.palettegenerator.imagecolors
 
-import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugins.GeneratedPluginRegistrant
 
 class MainActivity: FlutterActivity() {
-    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-        GeneratedPluginRegistrant.registerWith(flutterEngine);
-    }
+
 }

--- a/packages/pigeon/e2e_tests/test_objc/android/app/src/main/AndroidManifest.xml
+++ b/packages/pigeon/e2e_tests/test_objc/android/app/src/main/AndroidManifest.xml
@@ -1,12 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.test_objc">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="test_objc"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
Once https://github.com/flutter/flutter/pull/93386 lands, usage of the v1 embedding will cause builds to fail. This removes vestiges of the v1 embedding.