### PR TITLE
[metrics_center] Filter out host_name, load_avg and caches keys from context for MetricPoint generation

### DIFF
--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3
+
+- Filter out host_name, load_avg and caches keys from context
+  before adding to a MetricPoint object.
+
 ## 1.0.2
 
 - Updated the GoogleBenchmark parser to correctly parse new keys added

--- a/packages/metrics_center/lib/src/google_benchmark.dart
+++ b/packages/metrics_center/lib/src/google_benchmark.dart
@@ -28,6 +28,14 @@ const List<String> _kNonNumericalValueSubResults = <String>[
   'big_o',
 ];
 
+// Context has some keys such as 'host_name' which need to be ignored
+// so that we can group series together
+const List<String> _kContextIgnoreKeys = <String>[
+  'host_name',
+  'load_avg',
+  'caches',
+];
+
 // ignore: avoid_classes_with_only_static_members
 /// Parse the json result of https://github.com/google/benchmark.
 class GoogleBenchmarkParser {
@@ -39,9 +47,12 @@ class GoogleBenchmarkParser {
 
     final Map<String, dynamic> rawContext =
         jsonResult['context'] as Map<String, dynamic>;
-    final Map<String, String> context = rawContext.map<String, String>(
-      (String k, dynamic v) => MapEntry<String, String>(k, v.toString()),
-    );
+    Map<String, String> context = <String, String>{};
+    rawContext.forEach((String k, dynamic v) {
+      if (!_kContextIgnoreKeys.contains(k)) {
+        context[k] = v.toString();
+      }
+    });
     final List<MetricPoint> points = <MetricPoint>[];
     for (final dynamic item in jsonResult['benchmarks']) {
       _parseAnItem(item as Map<String, dynamic>, points, context);

--- a/packages/metrics_center/lib/src/google_benchmark.dart
+++ b/packages/metrics_center/lib/src/google_benchmark.dart
@@ -47,12 +47,10 @@ class GoogleBenchmarkParser {
 
     final Map<String, dynamic> rawContext =
         jsonResult['context'] as Map<String, dynamic>;
-    Map<String, String> context = <String, String>{};
-    rawContext.forEach((String k, dynamic v) {
-      if (!_kContextIgnoreKeys.contains(k)) {
-        context[k] = v.toString();
-      }
-    });
+    final Map<String, String> context = rawContext.map<String, String>(
+      (String k, dynamic v) => MapEntry<String, String>(k, v.toString()),
+    )..removeWhere((k, v) => _kContextIgnoreKeys.contains(k));
+
     final List<MetricPoint> points = <MetricPoint>[];
     for (final dynamic item in jsonResult['benchmarks']) {
       _parseAnItem(item as Map<String, dynamic>, points, context);

--- a/packages/metrics_center/lib/src/google_benchmark.dart
+++ b/packages/metrics_center/lib/src/google_benchmark.dart
@@ -49,7 +49,7 @@ class GoogleBenchmarkParser {
         jsonResult['context'] as Map<String, dynamic>;
     final Map<String, String> context = rawContext.map<String, String>(
       (String k, dynamic v) => MapEntry<String, String>(k, v.toString()),
-    )..removeWhere((k, v) => _kContextIgnoreKeys.contains(k));
+    )..removeWhere((String k, String v) => _kContextIgnoreKeys.contains(k));
 
     final List<MetricPoint> points = <MetricPoint>[];
     for (final dynamic item in jsonResult['benchmarks']) {

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -1,5 +1,5 @@
 name: metrics_center
-version: 1.0.2
+version: 1.0.3
 description:
   Support multiple performance metrics sources/formats and destinations.
 repository: https://github.com/flutter/packages/tree/master/packages/metrics_center

--- a/packages/metrics_center/test/google_benchmark_test.dart
+++ b/packages/metrics_center/test/google_benchmark_test.dart
@@ -35,5 +35,17 @@ void main() {
         'SkParagraphFixture/TextBigO_BigO',
       ],
     );
+    points.forEach((MetricPoint p) {
+      expect(p.tags.containsKey('host_name'), false);
+    });
+    points.forEach((MetricPoint p) {
+      expect(p.tags.containsKey('load_avg'), false);
+    });
+    points.forEach((MetricPoint p) {
+      expect(p.tags.containsKey('caches'), false);
+    });
+    points.forEach((MetricPoint p) {
+      expect(p.tags.containsKey('executable'), true);
+    });
   });
 }

--- a/packages/metrics_center/test/google_benchmark_test.dart
+++ b/packages/metrics_center/test/google_benchmark_test.dart
@@ -35,12 +35,11 @@ void main() {
         'SkParagraphFixture/TextBigO_BigO',
       ],
     );
-    for (MetricPoint p in points) {
+    for (final MetricPoint p in points) {
       expect(p.tags.containsKey('host_name'), false);
       expect(p.tags.containsKey('load_avg'), false);
       expect(p.tags.containsKey('caches'), false);
       expect(p.tags.containsKey('executable'), true);
     }
-    ;
   });
 }

--- a/packages/metrics_center/test/google_benchmark_test.dart
+++ b/packages/metrics_center/test/google_benchmark_test.dart
@@ -40,6 +40,7 @@ void main() {
       expect(p.tags.containsKey('load_avg'), false);
       expect(p.tags.containsKey('caches'), false);
       expect(p.tags.containsKey('executable'), true);
-    };
+    }
+    ;
   });
 }

--- a/packages/metrics_center/test/google_benchmark_test.dart
+++ b/packages/metrics_center/test/google_benchmark_test.dart
@@ -35,17 +35,11 @@ void main() {
         'SkParagraphFixture/TextBigO_BigO',
       ],
     );
-    points.forEach((MetricPoint p) {
+    for (MetricPoint p in points) {
       expect(p.tags.containsKey('host_name'), false);
-    });
-    points.forEach((MetricPoint p) {
       expect(p.tags.containsKey('load_avg'), false);
-    });
-    points.forEach((MetricPoint p) {
       expect(p.tags.containsKey('caches'), false);
-    });
-    points.forEach((MetricPoint p) {
       expect(p.tags.containsKey('executable'), true);
-    });
+    };
   });
 }


### PR DESCRIPTION
The new Google Benchmark library added a few additional keys to the `context` group which are not necessarily constant across benchmark runs. This was causing our benchmark runs to be reported as different series.

https://github.com/flutter/flutter/issues/93575

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.