### PR TITLE
Update compileSdkVersion for Android examples

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,8 @@
-# Last updated 10/22/2020 (to rebuild the docker image, update this timestamp)
-FROM cirrusci/flutter:stable-web
+# Last updated 11/23/2021 (to rebuild the docker image, update this timestamp)
+# The Flutter version is not important here, since the CI scripts update Flutter
+# before running. What matters is that the base image is pinned to minimize
+# unintended changes when modifying this file.
+FROM cirrusci/flutter:2.2.2
 
 RUN sudo apt-get update && \
     sudo apt-get upgrade --yes && \
@@ -7,14 +10,15 @@ RUN sudo apt-get update && \
     sudo apt-get clean --yes
 
 # This must occur after the install of gpg-agent
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
-    sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" && \
-    sudo apt-get update && \
-    sudo apt-get install --yes --allow-unauthenticated clang-format-5.0 && \
-    sudo apt-get clean --yes
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+
+# Install formatter.
+RUN apt-get install -y clang-format
 
 RUN yes | sdkmanager \
     "platforms;android-27" \
     "build-tools;27.0.3" \
     "extras;google;m2repository" \
     "extras;android;m2repository"
+
+RUN yes | sdkmanager --licenses

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -15,6 +15,9 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 # Install formatter.
 RUN apt-get install -y clang-format
 
+# Needed for web_benchmarks
+RUN sudo apt-get install -y libgbm-dev
+
 RUN yes | sdkmanager \
     "platforms;android-27" \
     "build-tools;27.0.3" \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ task:
   matrix:
     - name: format+analyze
       always:
-        format_script: ./script/tool_runner.sh format --fail-on-change --clang-format=clang-format-5.0
+        format_script: ./script/tool_runner.sh format --fail-on-change
         license_script: dart pub global run flutter_plugin_tools license-check
         analyze_script: ./script/tool_runner.sh analyze --custom-analysis=web_benchmarks/testing/test_app,flutter_lints/example,rfw/example
         pubspec_script: ./script/tool_runner.sh pubspec-check

--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates example compileSdkVersion to 31.
+
 ## 2.0.2
 * Fixed documentation for `OpenContainer` class; replaced `openBuilder` with `closedBuilder`. 
 

--- a/packages/animations/example/android/app/build.gradle
+++ b/packages/animations/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/animations/example/android/app/src/main/kotlin/dev/flutter/packages/animations/example/MainActivity.kt
+++ b/packages/animations/example/android/app/src/main/kotlin/dev/flutter/packages/animations/example/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package dev.flutter.packages.animations.example
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/animations/example/android/build.gradle
+++ b/packages/animations/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         jcenter()

--- a/packages/animations/example/android/build.gradle
+++ b/packages/animations/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/animations/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/animations/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
+++ b/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates example compileSdkVersion to 31.
+
 ## 2.0.4
 
 * Update example with the latest changes from `google_sign_in`, so it builds again on Android. [#89301](https://github.com/flutter/flutter/issues/89301).

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/build.gradle
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.google.gms.google-services'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates example compileSdkVersion to 31.
+
 ## 0.6.8
 
   * Added option paddingBuilders

--- a/packages/flutter_markdown/example/android/app/build.gradle
+++ b/packages/flutter_markdown/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/flutter_markdown/example/android/app/src/main/kotlin/io/flutter/packages/flutter_markdown_example/MainActivity.kt
+++ b/packages/flutter_markdown/example/android/app/src/main/kotlin/io/flutter/packages/flutter_markdown_example/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package io.flutter.packages.flutter_markdown_example
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/flutter_markdown/example/android/build.gradle
+++ b/packages/flutter_markdown/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         jcenter()

--- a/packages/flutter_markdown/example/android/build.gradle
+++ b/packages/flutter_markdown/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/flutter_markdown/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/flutter_markdown/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/packages/imitation_game/imitation_tests/smiley/android/app/src/androidTest/java/dev/flutter/imitation_game/smiley/ExampleInstrumentedTest.kt
+++ b/packages/imitation_game/imitation_tests/smiley/android/app/src/androidTest/java/dev/flutter/imitation_game/smiley/ExampleInstrumentedTest.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package dev.flutter.imitation_game.smiley
 
 import androidx.test.platform.app.InstrumentationRegistry

--- a/packages/imitation_game/imitation_tests/smiley/android/app/src/main/java/dev/flutter/imitation_game/smiley/MainActivity.kt
+++ b/packages/imitation_game/imitation_tests/smiley/android/app/src/main/java/dev/flutter/imitation_game/smiley/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package dev.flutter.imitation_game.smiley
 
 import androidx.appcompat.app.AppCompatActivity

--- a/packages/imitation_game/imitation_tests/smiley/flutter/smiley/android/app/src/main/kotlin/com/example/smiley/MainActivity.kt
+++ b/packages/imitation_game/imitation_tests/smiley/flutter/smiley/android/app/src/main/kotlin/com/example/smiley/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package com.example.smiley
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/AppDelegate.h
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/AppDelegate.h
@@ -4,6 +4,6 @@
 
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : UIResponder<UIApplicationDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @end

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/SceneDelegate.h
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/SceneDelegate.h
@@ -4,7 +4,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface SceneDelegate : UIResponder<UIWindowSceneDelegate>
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
 
 @property(strong, nonatomic) UIWindow* window;
 

--- a/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/ViewController.m
+++ b/packages/imitation_game/imitation_tests/smiley/uikit/smiley/smiley/ViewController.m
@@ -35,8 +35,9 @@ static NSString *loadIpAddress() {
 #else
   NSString *ipPath = [[NSBundle mainBundle] pathForResource:@"ip" ofType:@"txt"];
   NSError *err;
-  NSString *ipAddress =
-      [NSString stringWithContentsOfFile:ipPath encoding:NSUTF8StringEncoding error:&err];
+  NSString *ipAddress = [NSString stringWithContentsOfFile:ipPath
+                                                  encoding:NSUTF8StringEncoding
+                                                     error:&err];
   assert(err == nil);
   return
       [ipAddress stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];

--- a/packages/palette_generator/example/android/app/src/main/kotlin/io/flutter/packages/palettegenerator/example/MainActivity.kt
+++ b/packages/palette_generator/example/android/app/src/main/kotlin/io/flutter/packages/palettegenerator/example/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package io.flutter.packages.palettegenerator.imagecolors
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/pigeon/e2e_tests/test_objc/android/app/src/main/kotlin/com/example/test_objc/MainActivity.kt
+++ b/packages/pigeon/e2e_tests/test_objc/android/app/src/main/kotlin/com/example/test_objc/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package com.example.test_objc
 
 import androidx.annotation.NonNull;

--- a/packages/pigeon/e2e_tests/test_objc/ios/Runner/MyApi.h
+++ b/packages/pigeon/e2e_tests/test_objc/ios/Runner/MyApi.h
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Implementation of the Pigeon generated interface Api.
-@interface MyApi : NSObject<ACApi>
+@interface MyApi : NSObject <ACApi>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/pigeon/e2e_tests/test_objc/ios/Runner/MyNestedApi.h
+++ b/packages/pigeon/e2e_tests/test_objc/ios/Runner/MyNestedApi.h
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Implementation of the Pigeon generated interface NestedApi.
-@interface MyNestedApi : NSObject<ACNestedApi>
+@interface MyNestedApi : NSObject <ACNestedApi>
 - (ACSearchReply *)search:(ACNested *)input error:(FlutterError *_Nullable *_Nonnull)error;
 @end
 

--- a/packages/pigeon/platform_tests/android_unit_tests/android/app/src/main/kotlin/com/example/android_unit_tests/MainActivity.kt
+++ b/packages/pigeon/platform_tests/android_unit_tests/android/app/src/main/kotlin/com/example/android_unit_tests/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package com.example.android_unit_tests
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/AllDatatypesTest.m
+++ b/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/AllDatatypesTest.m
@@ -52,8 +52,8 @@
   everything.aFloatArray = [FlutterStandardTypedData
       typedDataWithFloat64:[@"12345678" dataUsingEncoding:NSUTF8StringEncoding]];
   everything.aList = @[ @(1), @(2) ];
-  everything.aMap = @{ @"hello" : @(1234) };
-  everything.mapWithObject = @{ @"hello" : @(1234), @"goodbye" : @"world" };
+  everything.aMap = @{@"hello" : @(1234)};
+  everything.mapWithObject = @{@"hello" : @(1234), @"goodbye" : @"world"};
   EchoBinaryMessenger* binaryMessenger =
       [[EchoBinaryMessenger alloc] initWithCodec:FlutterEverythingGetCodec()];
   FlutterEverything* api = [[FlutterEverything alloc] initWithBinaryMessenger:binaryMessenger];

--- a/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/AsyncHandlersTest.m
+++ b/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/AsyncHandlersTest.m
@@ -13,7 +13,7 @@
 @end
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-@interface MockBinaryMessenger : NSObject<FlutterBinaryMessenger>
+@interface MockBinaryMessenger : NSObject <FlutterBinaryMessenger>
 @property(nonatomic, copy) NSNumber *result;
 @property(nonatomic, retain) NSObject<FlutterMessageCodec> *codec;
 @property(nonatomic, retain) NSMutableDictionary<NSString *, FlutterBinaryMessageHandler> *handlers;
@@ -58,7 +58,7 @@
 @end
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-@interface MockApi2Host : NSObject<Api2Host>
+@interface MockApi2Host : NSObject <Api2Host>
 @property(nonatomic, copy) NSNumber *output;
 @property(nonatomic, retain) FlutterError *voidVoidError;
 @end

--- a/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/EchoMessenger.h
+++ b/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/EchoMessenger.h
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A FlutterBinaryMessenger who replies with the first argument sent to it.
-@interface EchoBinaryMessenger : NSObject<FlutterBinaryMessenger>
+@interface EchoBinaryMessenger : NSObject <FlutterBinaryMessenger>
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithCodec:(NSObject<FlutterMessageCodec>*)codec;
 @end

--- a/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/HandlerBinaryMessenger.h
+++ b/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/HandlerBinaryMessenger.h
@@ -11,7 +11,7 @@ typedef id _Nullable (^HandlerBinaryMessengerHandler)(NSArray *_Nonnull args);
 
 /// A FlutterBinaryMessenger that calls a supplied method when a call is
 /// invoked.
-@interface HandlerBinaryMessenger : NSObject<FlutterBinaryMessenger>
+@interface HandlerBinaryMessenger : NSObject <FlutterBinaryMessenger>
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithCodec:(NSObject<FlutterMessageCodec> *)codec
                       handler:(HandlerBinaryMessengerHandler)handler;

--- a/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/PrimitiveTest.m
+++ b/packages/pigeon/platform_tests/ios_unit_tests/ios/RunnerTests/PrimitiveTest.m
@@ -88,7 +88,7 @@
       [[EchoBinaryMessenger alloc] initWithCodec:PrimitiveFlutterApiGetCodec()];
   PrimitiveFlutterApi* api = [[PrimitiveFlutterApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation* expectation = [self expectationWithDescription:@"callback"];
-  NSDictionary* arg = @{ @"hello" : @1 };
+  NSDictionary* arg = @{@"hello" : @1};
   [api aMapValue:arg
       completion:^(NSDictionary* _Nonnull result, NSError* _Nullable err) {
         XCTAssertEqualObjects(arg, result);

--- a/packages/pigeon/platform_tests/windows_unit_tests/windows/test/pigeon_test.cpp
+++ b/packages/pigeon/platform_tests/windows_unit_tests/windows/test/pigeon_test.cpp
@@ -17,12 +17,12 @@ namespace test {
 
 namespace {
 
+using flutter::EncodableMap;
+using flutter::EncodableValue;
 using ::testing::DoAll;
 using ::testing::Pointee;
 using ::testing::Return;
 using ::testing::SetArgPointee;
-using flutter::EncodableMap;
-using flutter::EncodableValue;
 
 class MockMethodResult : public flutter::MethodResult<> {
  public:

--- a/packages/pigeon/platform_tests/windows_unit_tests/windows/windows_unit_tests_plugin.cpp
+++ b/packages/pigeon/platform_tests/windows_unit_tests/windows/windows_unit_tests_plugin.cpp
@@ -21,10 +21,10 @@ void WindowsUnitTestsPlugin::RegisterWithRegistrar(
 
   auto plugin = std::make_unique<WindowsUnitTestsPlugin>();
 
-  channel->SetMethodCallHandler([plugin_pointer = plugin.get()](
-      const auto &call, auto result) {
-    plugin_pointer->HandleMethodCall(call, std::move(result));
-  });
+  channel->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto &call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
 
   registrar->AddPlugin(std::move(plugin));
 }

--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -1,12 +1,8 @@
 ## NEXT
 
-* Updates example compileSdkVersion to 31.
-
-## NEXT
-
 * Transition internal testing from a command line lcov tool to a
   Dart tool. No effect on consumers.
-* Updates example compileSdkVersion to 31.
+* Updates all examples' compileSdkVersion to 31.
 
 ## 1.0.2
 

--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## NEXT
 
+* Updates example compileSdkVersion to 31.
+
+## NEXT
+
 * Transition internal testing from a command line lcov tool to a
   Dart tool. No effect on consumers.
+* Updates example compileSdkVersion to 31.
 
 ## 1.0.2
 

--- a/packages/rfw/example/hello/android/app/build.gradle
+++ b/packages/rfw/example/hello/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/rfw/example/hello/android/app/src/main/kotlin/dev/flutter/rfw/examples/hello/MainActivity.kt
+++ b/packages/rfw/example/hello/android/app/src/main/kotlin/dev/flutter/rfw/examples/hello/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package dev.flutter.rfw.examples.hello
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/rfw/example/hello/android/build.gradle
+++ b/packages/rfw/example/hello/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         mavenCentral()

--- a/packages/rfw/example/hello/android/build.gradle
+++ b/packages/rfw/example/hello/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/rfw/example/hello/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/rfw/example/hello/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/packages/rfw/example/local/android/app/build.gradle
+++ b/packages/rfw/example/local/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/rfw/example/local/android/app/src/main/kotlin/dev/flutter/rfw/examples/local/MainActivity.kt
+++ b/packages/rfw/example/local/android/app/src/main/kotlin/dev/flutter/rfw/examples/local/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package dev.flutter.rfw.examples.local
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/rfw/example/local/android/build.gradle
+++ b/packages/rfw/example/local/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         mavenCentral()

--- a/packages/rfw/example/local/android/build.gradle
+++ b/packages/rfw/example/local/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/rfw/example/local/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/rfw/example/local/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/packages/rfw/example/remote/android/app/build.gradle
+++ b/packages/rfw/example/remote/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/rfw/example/remote/android/app/src/main/kotlin/dev/flutter/rfw/examples/remote/MainActivity.kt
+++ b/packages/rfw/example/remote/android/app/src/main/kotlin/dev/flutter/rfw/examples/remote/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package dev.flutter.rfw.examples.remote
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/rfw/example/remote/android/build.gradle
+++ b/packages/rfw/example/remote/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         mavenCentral()

--- a/packages/rfw/example/remote/android/build.gradle
+++ b/packages/rfw/example/remote/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/rfw/example/remote/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/rfw/example/remote/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/packages/rfw/example/wasm/android/app/build.gradle
+++ b/packages/rfw/example/wasm/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/rfw/example/wasm/android/app/src/main/kotlin/dev/flutter/rfw/examples/wasm/MainActivity.kt
+++ b/packages/rfw/example/wasm/android/app/src/main/kotlin/dev/flutter/rfw/examples/wasm/MainActivity.kt
@@ -1,3 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 package dev.flutter.rfw.examples.wasm
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/rfw/example/wasm/android/build.gradle
+++ b/packages/rfw/example/wasm/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         mavenCentral()

--- a/packages/rfw/example/wasm/android/build.gradle
+++ b/packages/rfw/example/wasm/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/rfw/example/wasm/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/rfw/example/wasm/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Flutter master now requires that Android applications use
compileSdkVersion 31 in order to build.

This required updating the Kotlin and gradle versions as well.

And that in turn requires Java 11, which means the outdated
Dockerfile needs to be updated. This updates to use the same
base image (and formatter) that flutter/plugins now uses.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
