### PR TITLE
[ci] Add a builder for local_tests.sh on Windows

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -29,6 +29,16 @@ platform_properties:
       os: Windows
 
 targets:
+  - name: Windows local_tests master - packages
+    bringup: true
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      add_recipes_cq: "true"
+      target_file: windows_local_tests.yaml
+      channel: master
+    scheduler: luci
+
   - name: Windows win32-platform_tests master - packages
     recipe: packages/packages
     timeout: 30

--- a/.ci/scripts/local_tests.sh
+++ b/.ci/scripts/local_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# TODO(stuartmorgan): Call scripts/local_tests.sh here as part of updating
+# that script to work on Windows.

--- a/.ci/targets/windows_local_tests.yaml
+++ b/.ci/targets/windows_local_tests.yaml
@@ -1,0 +1,5 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  - name: local tests
+    script: .ci/scripts/local_tests.sh


### PR DESCRIPTION
This creates a builder that will be used to run local_tests.sh on
Windows. It doesn't call it yet because the script doesn't yet work on
Windows; having the builder in place in advance will allow testing those
changes in CI before landing them.

Part of https://github.com/flutter/flutter/issues/91061

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
