### PR TITLE
[pigeon] Made using enums in type arguments an error, added workaround

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 1.0.11
 
-* [ci] Started transitioning to a Dart test runner, added windows support.
-* [front-end] Started issuing an error if enums are used in type arguments.
-* [front-end] Passed through all enums, referenced or not so they can be used as
+* [ci] Starts transition to a Dart test runner, adds windows support.
+* [front-end] Starts issuing an error if enums are used in type arguments.
+* [front-end] Passes through all enums, referenced or not so they can be used as
   a work around for direct enum support.
 
 ## 1.0.10

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,6 +1,9 @@
-## NEXT
+## 1.0.11
 
 * [ci] Started transitioning to a Dart test runner, added windows support.
+* [front-end] Started issuing an error if enums are used in type arguments.
+* [front-end] Passed through all enums, referenced or not so they can be used as
+  a work around for direct enum support.
 
 ## 1.0.10
 

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '1.0.10';
+const String pigeonVersion = '1.0.11';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -423,6 +423,13 @@ List<Error> _validateAst(Root root, String source) {
               lineNumber: _calculateLineNumberNullable(source, field.offset),
             ));
           }
+          if (customEnums.contains(typeArgument.baseName)) {
+            result.add(Error(
+              message:
+                  'Enum types aren\'t supported in type arguments in "${field.name}" in class "${klass.name}".',
+              lineNumber: _calculateLineNumberNullable(source, field.offset),
+            ));
+          }
         }
       }
       if (!(validTypes.contains(field.type.baseName) ||
@@ -544,9 +551,6 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
         .removeWhere((Class x) => !referencedTypeNames.contains(x.name));
 
     final List<Enum> referencedEnums = List<Enum>.from(_enums);
-    referencedEnums.removeWhere(
-        (final Enum anEnum) => !referencedTypeNames.contains(anEnum.name));
-
     final Root completeRoot =
         Root(apis: _apis, classes: referencedClasses, enums: referencedEnums);
 

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/master/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 1.0.10 # This must match the version in lib/generator_tools.dart
+version: 1.0.11 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -901,4 +901,49 @@ abstract class Api {
     final ParseResults results = _parseSource(code);
     expect(results.errors.length, 0);
   });
+
+  test('Enum key not supported', () {
+    const String code = '''
+enum MessageKey {
+  title,
+  subtitle,
+  description,
+}
+
+class Message {
+  int? id;
+  Map<MessageKey?, String?>? additionalProperties;
+}
+
+@HostApi()
+abstract class HostApiBridge {
+  void sendMessage(Message message);
+}
+''';
+    final ParseResults results = _parseSource(code);
+    expect(results.errors.length, 1);
+  });
+
+  test('Export unreferenced enums', () {
+    const String code = '''
+enum MessageKey {
+  title,
+  subtitle,
+  description,
+}
+
+class Message {
+  int? id;
+  Map<int?, String?>? additionalProperties;
+}
+
+@HostApi()
+abstract class HostApiBridge {
+  void sendMessage(Message message);
+}
+''';
+    final ParseResults results = _parseSource(code);
+    expect(results.root.enums.length, 1);
+    expect(results.root.enums[0].name, 'MessageKey');
+  });
 }


### PR DESCRIPTION
There are a lot of features related to enum's we don't yet support.  Issuing an error in the front-end is better than a compilation error later.

As a workaround I started always generating enums in code whether they were referenced or not so users can use their integer values.

issues: 
 * https://github.com/flutter/flutter/issues/93525
 * https://github.com/flutter/flutter/issues/93464

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
