### PR TITLE
Prepare packages for binding.instance becoming non-nullable

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -628,7 +628,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     if (hideableKey.currentState?.isVisible == false) {
       // This route may be disposed without dismissing its animation if it is
       // removed by the navigator.
-      SchedulerBinding.instance!
+      _ambiguate(SchedulerBinding.instance)!
           .addPostFrameCallback((Duration d) => _toggleHideable(hide: false));
     }
     super.dispose();
@@ -662,7 +662,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     }
 
     if (delayForSourceRoute) {
-      SchedulerBinding.instance!
+      _ambiguate(SchedulerBinding.instance)!
           .addPostFrameCallback(takeMeasurementsInSourceRoute);
     } else {
       takeMeasurementsInSourceRoute();
@@ -901,3 +901,11 @@ class _FlippableTweenSequence<T> extends TweenSequence<T> {
     return _flipped;
   }
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` on the stable branch.
+// TODO(ianh): Remove this once the relevant APIs have shipped to stable.
+// See https://github.com/flutter/flutter/issues/64830
+T? _ambiguate<T>(T? value) => value;

--- a/packages/flutter_markdown/test/utils.dart
+++ b/packages/flutter_markdown/test/utils.dart
@@ -154,9 +154,13 @@ void expectLinkTap(MarkdownLink? actual, MarkdownLink expected) {
 }
 
 String dumpRenderView() {
-  return WidgetsBinding.instance!.renderViewElement!.toStringDeep().replaceAll(
-      RegExp(r'SliverChildListDelegate#\d+', multiLine: true),
-      'SliverChildListDelegate');
+  return _ambiguate(WidgetsBinding.instance)!
+      .renderViewElement!
+      .toStringDeep()
+      .replaceAll(
+        RegExp(r'SliverChildListDelegate#\d+', multiLine: true),
+        'SliverChildListDelegate',
+      );
 }
 
 /// Wraps a widget with a left-to-right [Directionality] for tests.
@@ -197,3 +201,11 @@ class TestAssetBundle extends CachingAssetBundle {
     }
   }
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` on the stable branch.
+// TODO(ianh): Remove this once the relevant APIs have shipped to stable.
+// See https://github.com/flutter/flutter/issues/64830
+T? _ambiguate<T>(T? value) => value;

--- a/packages/rfw/example/wasm/lib/main.dart
+++ b/packages/rfw/example/wasm/lib/main.dart
@@ -38,7 +38,7 @@ class _ExampleState extends State<Example> {
   @override
   void initState() {
     super.initState();
-    RendererBinding.instance!.deferFirstFrame();
+    _ambiguate(RendererBinding.instance)!.deferFirstFrame();
     _runtime.update(const LibraryName(<String>['core', 'widgets']), createCoreWidgets());
     _loadLogic();
   }
@@ -62,7 +62,7 @@ class _ExampleState extends State<Example> {
     _logic = WasmModule(await logicFile.readAsBytes()).builder().build();
     _dataFetcher = _logic.lookupFunction('value');
     _updateData();
-    setState(() { RendererBinding.instance!.allowFirstFrame(); });
+    setState(() { _ambiguate(RendererBinding.instance)!.allowFirstFrame(); });
   }
 
   void _updateData() {
@@ -78,7 +78,7 @@ class _ExampleState extends State<Example> {
 
   @override
   Widget build(BuildContext context) {
-    if (!RendererBinding.instance!.sendFramesToEngine)
+    if (!_ambiguate(RendererBinding.instance)!.sendFramesToEngine)
       return const SizedBox.shrink();
     return RemoteWidget(
       runtime: _runtime,
@@ -92,3 +92,11 @@ class _ExampleState extends State<Example> {
     );
   }
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` on the stable branch.
+// TODO(ianh): Remove this once the relevant APIs have shipped to stable.
+// See https://github.com/flutter/flutter/issues/64830
+T? _ambiguate<T>(T? value) => value;


### PR DESCRIPTION
This prepares this repo for flutter/flutter#64830 to land.

The _ambiguate hack is needed to allow this code to run both with the old API and the new API.

No version change: This is a trivial internal change that should have no practical impact and can be rolled into the next update.
No CHANGELOG change: Same.