### PR TITLE
[flutter_markdown] Added option selectionControls

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0
+
+  * Adds option selectionControls
+
 ## 0.6.9
 
   * Leading spaces in a paragraph and in list items are now ignored according to [GFM #192](https://github.github.com/gfm/#example-192) and [GFM #236](https://github.github.com/gfm/#example-236).

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -106,6 +106,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     this.fitContent = false,
     this.onTapText,
     this.softLineBreak = false,
+    this.selectionControls,
   });
 
   /// A delegate that controls how link and `pre` elements behave.
@@ -115,6 +116,9 @@ class MarkdownBuilder implements md.NodeVisitor {
   ///
   /// Defaults to false.
   final bool selectable;
+
+  /// Optional delegate for building the text selection handles and toolbar.
+  final TextSelectionControls? selectionControls;
 
   /// Defines which [TextStyle] objects to use for each type of element.
   final MarkdownStyleSheet styleSheet;
@@ -827,6 +831,7 @@ class MarkdownBuilder implements md.NodeVisitor {
         textAlign: textAlign ?? TextAlign.start,
         onTap: onTapText,
         key: k,
+        selectionControls: selectionControls,
       );
     } else {
       return RichText(

--- a/packages/flutter_markdown/lib/src/widget.dart
+++ b/packages/flutter_markdown/lib/src/widget.dart
@@ -150,6 +150,7 @@ abstract class MarkdownWidget extends StatefulWidget {
     Key? key,
     required this.data,
     this.selectable = false,
+    this.selectionControls,
     this.styleSheet,
     this.styleSheetTheme = MarkdownStyleSheetBaseTheme.material,
     this.syntaxHighlighter,
@@ -177,6 +178,9 @@ abstract class MarkdownWidget extends StatefulWidget {
   ///
   /// Defaults to false.
   final bool selectable;
+
+  /// Optional delegate for building the text selection handles and toolbar.
+  final TextSelectionControls? selectionControls;
 
   /// The styles to use when displaying the Markdown.
   ///
@@ -325,6 +329,7 @@ class _MarkdownWidgetState extends State<MarkdownWidget>
     final MarkdownBuilder builder = MarkdownBuilder(
       delegate: this,
       selectable: widget.selectable,
+      selectionControls: widget.selectionControls,
       styleSheet: styleSheet,
       imageDirectory: widget.imageDirectory,
       imageBuilder: widget.imageBuilder,
@@ -392,6 +397,7 @@ class MarkdownBody extends MarkdownWidget {
     Key? key,
     required String data,
     bool selectable = false,
+    TextSelectionControls? selectionControls,
     MarkdownStyleSheet? styleSheet,
     MarkdownStyleSheetBaseTheme? styleSheetTheme,
     SyntaxHighlighter? syntaxHighlighter,
@@ -417,6 +423,7 @@ class MarkdownBody extends MarkdownWidget {
           key: key,
           data: data,
           selectable: selectable,
+          selectionControls: selectionControls,
           styleSheet: styleSheet,
           styleSheetTheme: styleSheetTheme,
           syntaxHighlighter: syntaxHighlighter,
@@ -468,6 +475,7 @@ class Markdown extends MarkdownWidget {
     Key? key,
     required String data,
     bool selectable = false,
+    TextSelectionControls? selectionControls,
     MarkdownStyleSheet? styleSheet,
     MarkdownStyleSheetBaseTheme? styleSheetTheme,
     SyntaxHighlighter? syntaxHighlighter,
@@ -495,6 +503,7 @@ class Markdown extends MarkdownWidget {
           key: key,
           data: data,
           selectable: selectable,
+          selectionControls: selectionControls,
           styleSheet: styleSheet,
           styleSheetTheme: styleSheetTheme,
           syntaxHighlighter: syntaxHighlighter,

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/master/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.6.9
+version: 0.7.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/flutter_markdown/test/all.dart
+++ b/packages/flutter_markdown/test/all.dart
@@ -19,6 +19,7 @@ import 'style_sheet_test.dart' as style_sheet_test;
 import 'table_test.dart' as table_test;
 import 'text_alignment_test.dart' as text_alignment_test;
 import 'text_scale_factor_test.dart' as text_scale_factor;
+import 'text_selection_controls_test.dart' as text_selection_controls_test;
 import 'text_test.dart' as text_test;
 import 'uri_test.dart' as uri_test;
 
@@ -39,5 +40,6 @@ void main() {
   text_test.defineTests();
   text_alignment_test.defineTests();
   text_scale_factor.defineTests();
+  text_selection_controls_test.defineTests();
   uri_test.defineTests();
 }

--- a/packages/flutter_markdown/test/text_selection_controls.dart
+++ b/packages/flutter_markdown/test/text_selection_controls.dart
@@ -1,0 +1,316 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+const double _handleSize = 22.0;
+
+// Padding between the toolbar and the anchor.
+const double _toolbarContentDistanceBelow = _handleSize - 2.0;
+const double _toolbarContentDistance = 8.0;
+
+/// Android Material styled text selection controls.
+class MaterialTextSelectionControls extends TextSelectionControls {
+  /// Returns the size of the Material handle.
+  @override
+  Size getHandleSize(double textLineHeight) =>
+      const Size(_handleSize, _handleSize);
+
+  /// Builder for material-style copy/paste text selection toolbar.
+  @override
+  Widget buildToolbar(
+    BuildContext context,
+    Rect globalEditableRegion,
+    double textLineHeight,
+    Offset selectionMidpoint,
+    List<TextSelectionPoint> endpoints,
+    TextSelectionDelegate delegate,
+    ClipboardStatusNotifier clipboardStatus,
+    Offset? lastSecondaryTapDownPosition,
+  ) {
+    return _TextSelectionControlsToolbar(
+      globalEditableRegion: globalEditableRegion,
+      textLineHeight: textLineHeight,
+      selectionMidpoint: selectionMidpoint,
+      endpoints: endpoints,
+      delegate: delegate,
+      clipboardStatus: clipboardStatus,
+      handleCut:
+          canCut(delegate) ? () => handleCut(delegate, clipboardStatus) : null,
+      handleCopy: canCopy(delegate)
+          ? () => handleCopy(delegate, clipboardStatus)
+          : null,
+      handlePaste: canPaste(delegate) ? () => handlePaste(delegate) : null,
+      handleSelectAll:
+          canSelectAll(delegate) ? () => handleSelectAll(delegate) : null,
+    );
+  }
+
+  /// Builder for material-style text selection handles.
+  @override
+  Widget buildHandle(
+      BuildContext context, TextSelectionHandleType type, double textHeight,
+      [VoidCallback? onTap, double? startGlyphHeight, double? endGlyphHeight]) {
+    final ThemeData theme = Theme.of(context);
+    final Color handleColor =
+        TextSelectionTheme.of(context).selectionHandleColor ??
+            theme.colorScheme.primary;
+    final Widget handle = SizedBox(
+      width: _handleSize,
+      height: _handleSize,
+      child: CustomPaint(
+        painter: _TextSelectionHandlePainter(
+          color: handleColor,
+        ),
+        child: GestureDetector(
+          onTap: onTap,
+          behavior: HitTestBehavior.translucent,
+        ),
+      ),
+    );
+
+    // [handle] is a circle, with a rectangle in the top left quadrant of that
+    // circle (an onion pointing to 10:30). We rotate [handle] to point
+    // straight up or up-right depending on the handle type.
+    switch (type) {
+      case TextSelectionHandleType.left: // points up-right
+        return Transform.rotate(
+          angle: math.pi / 2.0,
+          child: handle,
+        );
+      case TextSelectionHandleType.right: // points up-left
+        return handle;
+      case TextSelectionHandleType.collapsed: // points up
+        return Transform.rotate(
+          angle: math.pi / 4.0,
+          child: handle,
+        );
+    }
+  }
+
+  /// Gets anchor for material-style text selection handles.
+  ///
+  /// See [TextSelectionControls.getHandleAnchor].
+  @override
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight,
+      [double? startGlyphHeight, double? endGlyphHeight]) {
+    switch (type) {
+      case TextSelectionHandleType.left:
+        return const Offset(_handleSize, 0);
+      case TextSelectionHandleType.right:
+        return Offset.zero;
+      case TextSelectionHandleType.collapsed:
+        return const Offset(_handleSize / 2, -4);
+    }
+  }
+
+  @override
+  bool canSelectAll(TextSelectionDelegate delegate) {
+    // Android allows SelectAll when selection is not collapsed, unless
+    // everything has already been selected.
+    final TextEditingValue value = delegate.textEditingValue;
+    return delegate.selectAllEnabled &&
+        value.text.isNotEmpty &&
+        !(value.selection.start == 0 &&
+            value.selection.end == value.text.length);
+  }
+}
+
+// The label and callback for the available default text selection menu buttons.
+class _TextSelectionToolbarItemData {
+  const _TextSelectionToolbarItemData({
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+}
+
+// The highest level toolbar widget, built directly by buildToolbar.
+class _TextSelectionControlsToolbar extends StatefulWidget {
+  const _TextSelectionControlsToolbar({
+    Key? key,
+    required this.clipboardStatus,
+    required this.delegate,
+    required this.endpoints,
+    required this.globalEditableRegion,
+    required this.handleCut,
+    required this.handleCopy,
+    required this.handlePaste,
+    required this.handleSelectAll,
+    required this.selectionMidpoint,
+    required this.textLineHeight,
+  }) : super(key: key);
+
+  final ClipboardStatusNotifier clipboardStatus;
+  final TextSelectionDelegate delegate;
+  final List<TextSelectionPoint> endpoints;
+  final Rect globalEditableRegion;
+  final VoidCallback? handleCut;
+  final VoidCallback? handleCopy;
+  final VoidCallback? handlePaste;
+  final VoidCallback? handleSelectAll;
+  final Offset selectionMidpoint;
+  final double textLineHeight;
+
+  @override
+  _TextSelectionControlsToolbarState createState() =>
+      _TextSelectionControlsToolbarState();
+}
+
+class _TextSelectionControlsToolbarState
+    extends State<_TextSelectionControlsToolbar> with TickerProviderStateMixin {
+  void _onChangedClipboardStatus() {
+    setState(() {
+      // Inform the widget that the value of clipboardStatus has changed.
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widget.clipboardStatus.addListener(_onChangedClipboardStatus);
+    widget.clipboardStatus.update();
+  }
+
+  @override
+  void didUpdateWidget(_TextSelectionControlsToolbar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.clipboardStatus != oldWidget.clipboardStatus) {
+      widget.clipboardStatus.addListener(_onChangedClipboardStatus);
+      oldWidget.clipboardStatus.removeListener(_onChangedClipboardStatus);
+    }
+    widget.clipboardStatus.update();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    // When used in an Overlay, it can happen that this is disposed after its
+    // creator has already disposed _clipboardStatus.
+    if (!widget.clipboardStatus.disposed) {
+      widget.clipboardStatus.removeListener(_onChangedClipboardStatus);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // If there are no buttons to be shown, don't render anything.
+    if (widget.handleCut == null &&
+        widget.handleCopy == null &&
+        widget.handlePaste == null &&
+        widget.handleSelectAll == null) {
+      return const SizedBox.shrink();
+    }
+    // If the paste button is desired, don't render anything until the state of
+    // the clipboard is known, since it's used to determine if paste is shown.
+    if (widget.handlePaste != null &&
+        widget.clipboardStatus.value == ClipboardStatus.unknown) {
+      return const SizedBox.shrink();
+    }
+
+    // Calculate the positioning of the menu. It is placed above the selection
+    // if there is enough room, or otherwise below.
+    final TextSelectionPoint startTextSelectionPoint = widget.endpoints[0];
+    final TextSelectionPoint endTextSelectionPoint =
+        widget.endpoints.length > 1 ? widget.endpoints[1] : widget.endpoints[0];
+    final Offset anchorAbove = Offset(
+      widget.globalEditableRegion.left + widget.selectionMidpoint.dx,
+      widget.globalEditableRegion.top +
+          startTextSelectionPoint.point.dy -
+          widget.textLineHeight -
+          _toolbarContentDistance,
+    );
+    final Offset anchorBelow = Offset(
+      widget.globalEditableRegion.left + widget.selectionMidpoint.dx,
+      widget.globalEditableRegion.top +
+          endTextSelectionPoint.point.dy +
+          _toolbarContentDistanceBelow,
+    );
+
+    // Determine which buttons will appear so that the order and total number is
+    // known. A button's position in the menu can slightly affect its
+    // appearance.
+    final MaterialLocalizations localizations =
+        MaterialLocalizations.of(context);
+    final List<_TextSelectionToolbarItemData> itemDatas =
+        <_TextSelectionToolbarItemData>[
+      if (widget.handleCut != null)
+        _TextSelectionToolbarItemData(
+          label: localizations.cutButtonLabel,
+          onPressed: widget.handleCut!,
+        ),
+      if (widget.handleCopy != null)
+        _TextSelectionToolbarItemData(
+          label: localizations.copyButtonLabel,
+          onPressed: widget.handleCopy!,
+        ),
+      if (widget.handlePaste != null &&
+          widget.clipboardStatus.value == ClipboardStatus.pasteable)
+        _TextSelectionToolbarItemData(
+          label: localizations.pasteButtonLabel,
+          onPressed: widget.handlePaste!,
+        ),
+      if (widget.handleSelectAll != null)
+        _TextSelectionToolbarItemData(
+          label: localizations.selectAllButtonLabel,
+          onPressed: widget.handleSelectAll!,
+        ),
+    ];
+
+    // If there is no option available, build an empty widget.
+    if (itemDatas.isEmpty) {
+      return const SizedBox(width: 0.0, height: 0.0);
+    }
+
+    return TextSelectionToolbar(
+      anchorAbove: anchorAbove,
+      anchorBelow: anchorBelow,
+      children: itemDatas
+          .asMap()
+          .entries
+          .map((MapEntry<int, _TextSelectionToolbarItemData> entry) {
+        return TextSelectionToolbarTextButton(
+          padding: TextSelectionToolbarTextButton.getPadding(
+              entry.key, itemDatas.length),
+          onPressed: entry.value.onPressed,
+          child: Text(entry.value.label),
+        );
+      }).toList(),
+    );
+  }
+}
+
+/// Draws a single text selection handle which points up and to the left.
+class _TextSelectionHandlePainter extends CustomPainter {
+  _TextSelectionHandlePainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()..color = color;
+    final double radius = size.width / 2.0;
+    final Rect circle =
+        Rect.fromCircle(center: Offset(radius, radius), radius: radius);
+    final Rect point = Rect.fromLTWH(0.0, 0.0, radius, radius);
+    final Path path = Path()
+      ..addOval(circle)
+      ..addRect(point);
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_TextSelectionHandlePainter oldPainter) {
+    return color != oldPainter.color;
+  }
+}
+
+/// Text selection controls that follow the Material Design specification.
+final TextSelectionControls materialTextSelectionControls =
+    MaterialTextSelectionControls();

--- a/packages/flutter_markdown/test/text_selection_controls_test.dart
+++ b/packages/flutter_markdown/test/text_selection_controls_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'utils.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  group('Selection Controls', () {
+    testWidgets(
+      'header with line of text',
+      (WidgetTester tester) async {
+        const String data = 'Hello _World_!';
+        await tester.pumpWidget(
+          MaterialApp(
+            home: boilerplate(
+              Markdown(
+                data: data,
+                selectionControls: materialTextSelectionControls,
+                selectable: true,
+              ),
+            ),
+          ),
+        );
+
+        final Offset selectableTextStart =
+            tester.getTopLeft(find.byType(SelectableText).last);
+
+        await tester.longPressAt(selectableTextStart + const Offset(50.0, 5.0));
+        await tester.pump();
+
+        final EditableText editableTextWidget =
+            tester.widget(find.byType(EditableText).last);
+        final TextEditingController controller = editableTextWidget.controller;
+
+        expect(
+          controller.selection.textInside(controller.text),
+          'Hello',
+        );
+
+        // Collapsed toolbar shows 2 buttons: copy, select all
+        expect(find.byType(TextButton), findsNWidgets(2));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Added option selectionControls.

flutter_markdown uses SelectableText for markdown rendering. It has selectionControls parameter for creating a custom context menu.  This PR added this parameter to flutter_markdown and passes it to SelectableText widget.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
