### PR TITLE
[all] Update repo links to 'main'

### DIFF
--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
-repository: https://github.com/flutter/packages/tree/master/packages/animations
+repository: https://github.com/flutter/packages/tree/main/packages/animations
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+animations%22
 version: 2.0.2
 

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
-repository: https://github.com/flutter/packages/tree/master/packages/cross_file
+repository: https://github.com/flutter/packages/tree/main/packages/cross_file
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+cross_file%22
 version: 0.3.2
 

--- a/packages/css_colors/pubspec.yaml
+++ b/packages/css_colors/pubspec.yaml
@@ -1,6 +1,6 @@
 name: css_colors
 description: Defines constant dart:ui Color objects for CSS colors (for use in Flutter code).
-repository: https://github.com/flutter/packages/tree/master/packages/css_colors
+repository: https://github.com/flutter/packages/tree/main/packages/css_colors
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+css_colors%22
 version: 1.1.1
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/README.md
+++ b/packages/extension_google_sign_in_as_googleapis_auth/README.md
@@ -30,7 +30,7 @@ This package contains a modified version of Flutter's Google Sign In example app
 
 See it [here](https://github.com/flutter/packages/blob/master/packages/extension_google_sign_in_as_googleapis_auth/example/lib/main.dart).
 
-The original code (and its license) can be seen [here](https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in/example/lib/main.dart).
+The original code (and its license) can be seen [here](https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in/example/lib/main.dart).
 
 ## Testing
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
@@ -6,7 +6,7 @@
 
 name: extension_google_sign_in_as_googleapis_auth
 description: A bridge package between google_sign_in and googleapis_auth, to create Authenticated Clients from google_sign_in user credentials.
-repository: https://github.com/flutter/packages/tree/master/packages/extension_google_sign_in_as_googleapis_auth
+repository: https://github.com/flutter/packages/tree/main/packages/extension_google_sign_in_as_googleapis_auth
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+extension_google_sign_in_as_googleapis_auth%22
 version: 2.0.4
 

--- a/packages/flutter_image/pubspec.yaml
+++ b/packages/flutter_image/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_image
 description: >
   Image utilities for Flutter: improved network providers, effects, etc.
-repository: https://github.com/flutter/packages/tree/master/packages/flutter_image
+repository: https://github.com/flutter/packages/tree/main/packages/flutter_image
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_image%22
 version: 4.1.0
 

--- a/packages/flutter_lints/pubspec.yaml
+++ b/packages/flutter_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_lints
 description: Recommended lints for Flutter apps, packages, and plugins to encourage good coding practices.
-repository: https://github.com/flutter/packages/tree/master/packages/flutter_lints
+repository: https://github.com/flutter/packages/tree/main/packages/flutter_lints
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_lints%22
 version: 1.0.4
 

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_markdown
 description: A Markdown renderer for Flutter. Create rich text output,
   including text styles, tables, links, and more, from plain text data
   formatted with simple Markdown tags.
-repository: https://github.com/flutter/packages/tree/master/packages/flutter_markdown
+repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
 version: 0.6.9
 

--- a/packages/flutter_template_images/pubspec.yaml
+++ b/packages/flutter_template_images/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_template_images
 description: Image files for use in flutter_tools templates without adding binary files to flutter/flutter.
-repository: https://github.com/flutter/packages/tree/master/packages/flutter_template_images
+repository: https://github.com/flutter/packages/tree/main/packages/flutter_template_images
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_template_images%22
 version: 4.0.0
 

--- a/packages/fuchsia_ctl/pubspec.yaml
+++ b/packages/fuchsia_ctl/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   Fuchsia Device. This package is primarily intended for use in Flutter's
   continuous integration/testing infrastructure.
 publish_to: none
-repository: https://github.com/flutter/packages/tree/master/packages/fuchsia_ctl
+repository: https://github.com/flutter/packages/tree/main/packages/fuchsia_ctl
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+fuchsia_ctl%22
 version: 0.0.25
 

--- a/packages/imitation_game/pubspec.yaml
+++ b/packages/imitation_game/pubspec.yaml
@@ -1,6 +1,6 @@
 name: imitation_game
 description: Testing framework for comparing multiple frameworks' performance.
-repository: https://github.com/flutter/packages/tree/master/packages/imitation_game
+repository: https://github.com/flutter/packages/tree/main/packages/imitation_game
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+imitation_game%22
 version: 0.0.1
 

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -2,7 +2,7 @@ name: metrics_center
 version: 1.0.3
 description:
   Support multiple performance metrics sources/formats and destinations.
-repository: https://github.com/flutter/packages/tree/master/packages/metrics_center
+repository: https://github.com/flutter/packages/tree/main/packages/metrics_center
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+metrics_center%22
 
 environment:

--- a/packages/multicast_dns/pubspec.yaml
+++ b/packages/multicast_dns/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multicast_dns
 description: Dart package for performing mDNS queries (e.g. Bonjour, Avahi).
-repository: https://github.com/flutter/packages/tree/master/packages/multicast_dns
+repository: https://github.com/flutter/packages/tree/main/packages/multicast_dns
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+multicast_dns%22
 version: 0.3.2
 

--- a/packages/palette_generator/pubspec.yaml
+++ b/packages/palette_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: palette_generator
 description: Flutter package for generating palette colors from a source image.
-repository: https://github.com/flutter/packages/tree/master/packages/palette_generator
+repository: https://github.com/flutter/packages/tree/main/packages/palette_generator
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+palette_generator%22
 version: 0.3.2
 

--- a/packages/pigeon/example/README.md
+++ b/packages/pigeon/example/README.md
@@ -131,4 +131,4 @@ A full example of using Pigeon for add-to-app with Swift on iOS can be found at
 ## Video player plugin
 
 A full real-world example can also be found in the
-[video_player plugin](https://github.com/flutter/plugins/tree/master/packages/video_player).
+[video_player plugin](https://github.com/flutter/plugins/tree/main/packages/video_player).

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
-repository: https://github.com/flutter/packages/tree/master/packages/pigeon
+repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
 version: 1.0.15 # This must match the version in lib/generator_tools.dart
 

--- a/packages/pointer_interceptor/pubspec.yaml
+++ b/packages/pointer_interceptor/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pointer_interceptor
 description: A widget to prevent clicks from being swallowed by underlying HtmlElementViews on the web.
-repository: https://github.com/flutter/packages/tree/master/packages/pointer_interceptor
+repository: https://github.com/flutter/packages/tree/main/packages/pointer_interceptor
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pointer_interceptor%22
 version: 0.9.0+1
 

--- a/packages/rfw/pubspec.yaml
+++ b/packages/rfw/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw
 description: "Remote Flutter widgets: a library for rendering declarative widget description files at runtime."
-repository: https://github.com/flutter/packages/tree/master/packages/rfw
+repository: https://github.com/flutter/packages/tree/main/packages/rfw
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+rfw%22
 version: 1.0.2
 

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_benchmarks
 description: A benchmark harness for performance-testing Flutter apps in Chrome.
-repository: https://github.com/flutter/packages/tree/master/packages/web_benchmarks
+repository: https://github.com/flutter/packages/tree/main/packages/web_benchmarks
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+web_benchmarks%22
 version: 0.0.5
 

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
-repository: https://github.com/flutter/packages/tree/master/packages/xdg_directories
+repository: https://github.com/flutter/packages/tree/main/packages/xdg_directories
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+xdg_directories%22
 version: 0.2.0
 

--- a/third_party/packages/cupertino_icons/pubspec.yaml
+++ b/third_party/packages/cupertino_icons/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cupertino_icons
 
 description: Default icons asset for Cupertino widgets based on Apple styled icons
-repository: https://github.com/flutter/packages/tree/master/third_party/packages/cupertino_icons
+repository: https://github.com/flutter/packages/tree/main/third_party/packages/cupertino_icons
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+cupertino_icons%22
 version: 1.0.4
 


### PR DESCRIPTION
Replaces 'tree/master/...' with 'tree/main/...' in pubspec `repository`
and podspec `source` links, now that `main` is the default branch.

No version change: `master` is being mirrored for the foreseeable
future, so there's no urgency on this; updates can go out as plugins
are updated naturally.

No CHANGELOG change: This is a mechanical mass change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
