### PR TITLE
Pin dockerfile dependencies.

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -2,7 +2,7 @@
 # The Flutter version is not important here, since the CI scripts update Flutter
 # before running. What matters is that the base image is pinned to minimize
 # unintended changes when modifying this file.
-FROM cirrusci/flutter:sha256:02607513bf0b3daf303ab54c495efc4dd5cabf889a201be75c88b1e9888e0f5d
+FROM cirrusci/flutter@sha256:02607513bf0b3daf303ab54c495efc4dd5cabf889a201be75c88b1e9888e0f5d
 
 RUN sudo apt-get update && \
     sudo apt-get upgrade --yes && \

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,8 +1,8 @@
-# Last updated 12/14/2021 (to rebuild the docker image, update this timestamp)
+# Last updated 02/03/2022 (to rebuild the docker image, update this timestamp)
 # The Flutter version is not important here, since the CI scripts update Flutter
 # before running. What matters is that the base image is pinned to minimize
 # unintended changes when modifying this file.
-FROM cirrusci/flutter:2.8.0
+FROM cirrusci/flutter:sha256:02607513bf0b3daf303ab54c495efc4dd5cabf889a201be75c88b1e9888e0f5d
 
 RUN sudo apt-get update && \
     sudo apt-get upgrade --yes && \

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,4 +1,4 @@
-# Last updated 02/03/2022 (to rebuild the docker image, update this timestamp)
+# Last updated 02/04/2022 (to rebuild the docker image, update this timestamp)
 # The Flutter version is not important here, since the CI scripts update Flutter
 # before running. What matters is that the base image is pinned to minimize
 # unintended changes when modifying this file.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
 task:
   gke_container:
     dockerfile: .ci/Dockerfile
-    builder_image_name: docker-builder # gce vm image
+    builder_image_name: docker-builder-linux # gce vm image
     builder_image_project: flutter-cirrus
     cluster_name: test-cluster
     zone: us-central1-a


### PR DESCRIPTION
Pinning all the dependencies is recommended as as good security
practice. Dependabot will be used to update the dependency as soon as a
new version becomes available in the channel. The new docker images will
be generated independently of the testing workflows giving advance
alerts of any potential breaking issues. Once the PR updating the
dependency lands the image will be cached already and ready to be used.

If the base image get updated frequently < 45 days this will solve the
problem with the images reaching EOL and failing to get regenerated.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
