### PR TITLE
Fix bug when parsing `DartOptions.copyrightHeader` with `@ConfigurePigeon`

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.17
+
+* Fix error caused by parsing `copyrightHeaders` passed to options in `@ConfigurePigeon`.
+
 ## 1.0.16
 
 * Updates behavior of run\_tests.dart with no arguments.

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -20,9 +20,11 @@ class DartOptions {
   /// Creates a [DartOptions] from a Map representation where:
   /// `x = DartOptions.fromMap(x.toMap())`.
   static DartOptions fromMap(Map<String, Object> map) {
+    final Iterable<dynamic>? copyrightHeader =
+        map['copyrightHeader'] as Iterable<dynamic>?;
     return DartOptions(
       isNullSafe: map['isNullSafe'] as bool? ?? true,
-      copyrightHeader: map['copyrightHeader'] as Iterable<String>?,
+      copyrightHeader: copyrightHeader?.cast<String>(),
     );
   }
 

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '1.0.16';
+const String pigeonVersion = '1.0.17';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -28,10 +28,12 @@ class JavaOptions {
   /// Creates a [JavaOptions] from a Map representation where:
   /// `x = JavaOptions.fromMap(x.toMap())`.
   static JavaOptions fromMap(Map<String, Object> map) {
+    final Iterable<dynamic>? copyrightHeader =
+        map['copyrightHeader'] as Iterable<dynamic>?;
     return JavaOptions(
       className: map['className'] as String?,
       package: map['package'] as String?,
-      copyrightHeader: map['copyrightHeader'] as Iterable<String>?,
+      copyrightHeader: copyrightHeader?.cast<String>(),
     );
   }
 

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -29,10 +29,12 @@ class ObjcOptions {
   /// Creates a [ObjcOptions] from a Map representation where:
   /// `x = ObjcOptions.fromMap(x.toMap())`.
   static ObjcOptions fromMap(Map<String, Object> map) {
+    final Iterable<dynamic>? copyrightHeader =
+        map['copyrightHeader'] as Iterable<dynamic>?;
     return ObjcOptions(
       header: map['header'] as String?,
       prefix: map['prefix'] as String?,
-      copyrightHeader: map['copyrightHeader'] as Iterable<String>?,
+      copyrightHeader: copyrightHeader?.cast<String>(),
     );
   }
 

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -647,10 +647,9 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
           list.add(_expressionToMap(element));
         } else {
           _errors.add(Error(
-            message: 'expected Expression but found $expression',
+            message: 'expected Expression but found $element',
             lineNumber: _calculateLineNumber(source, element.offset),
           ));
-          break;
         }
       }
       return list;

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -640,6 +640,20 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
       return expression.value!;
     } else if (expression is dart_ast.BooleanLiteral) {
       return expression.value;
+    } else if (expression is dart_ast.ListLiteral) {
+      final List<dynamic> list = <dynamic>[];
+      for (final dart_ast.CollectionElement element in expression.elements) {
+        if (element is dart_ast.Expression) {
+          list.add(_expressionToMap(element));
+        } else {
+          _errors.add(Error(
+            message: 'expected Expression but found $expression',
+            lineNumber: _calculateLineNumber(source, element.offset),
+          ));
+          break;
+        }
+      }
+      return list;
     } else {
       _errors.add(Error(
         message:
@@ -1086,6 +1100,20 @@ options:
 
     final ParseResults parseResults =
         pigeon.parseFile(options.input!, sdkPath: sdkPath);
+
+    if (parseResults.errors.isNotEmpty) {
+      final List<Error> errors = <Error>[];
+      for (final Error err in parseResults.errors) {
+        errors.add(Error(
+            message: err.message,
+            filename: options.input,
+            lineNumber: err.lineNumber));
+      }
+
+      printErrors(errors);
+      return 1;
+    }
+
     if (parseResults.pigeonOptions != null) {
       options = PigeonOptions.fromMap(
           mergeMaps(options.toMap(), parseResults.pigeonOptions!));
@@ -1096,32 +1124,21 @@ options:
       return 1;
     }
 
-    final List<Error> errors = <Error>[];
     if (options.objcHeaderOut != null) {
       options = options.merge(PigeonOptions(
           objcOptions: options.objcOptions!.merge(
               ObjcOptions(header: path.basename(options.objcHeaderOut!)))));
     }
 
-    for (final Error err in parseResults.errors) {
-      errors.add(Error(
-          message: err.message,
-          filename: options.input,
-          lineNumber: err.lineNumber));
-    }
-    if (errors.isEmpty) {
-      for (final Generator generator in safeGenerators) {
-        final IOSink? sink = generator.shouldGenerate(options);
-        if (sink != null) {
-          generator.generate(sink, options, parseResults.root);
-          await sink.flush();
-        }
+    for (final Generator generator in safeGenerators) {
+      final IOSink? sink = generator.shouldGenerate(options);
+      if (sink != null) {
+        generator.generate(sink, options, parseResults.root);
+        await sink.flush();
       }
     }
 
-    printErrors(errors);
-
-    return errors.isNotEmpty ? 1 : 0;
+    return 0;
   }
 
   /// Print a list of errors to stderr.

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 1.0.16 # This must match the version in lib/generator_tools.dart
+version: 1.0.17 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -1004,4 +1004,49 @@ abstract class HostApiBridge {
     expect(results.root.enums.length, 1);
     expect(results.root.enums[0].name, 'MessageKey');
   });
+
+  test('@ConfigurePigeon JavaOptions.copyrightHeader', () {
+    const String code = '''
+@ConfigurePigeon(PigeonOptions(
+  javaOptions: JavaOptions(copyrightHeader: <String>['A', 'Header']),
+))
+class Message {
+  int? id;
+}
+''';
+
+    final ParseResults results = _parseSource(code);
+    final PigeonOptions options = PigeonOptions.fromMap(results.pigeonOptions!);
+    expect(options.javaOptions!.copyrightHeader, <String>['A', 'Header']);
+  });
+
+  test('@ConfigurePigeon DartOptions.copyrightHeader', () {
+    const String code = '''
+@ConfigurePigeon(PigeonOptions(
+  dartOptions: DartOptions(copyrightHeader: <String>['A', 'Header']),
+))
+class Message {
+  int? id;
+}
+''';
+
+    final ParseResults results = _parseSource(code);
+    final PigeonOptions options = PigeonOptions.fromMap(results.pigeonOptions!);
+    expect(options.dartOptions!.copyrightHeader, <String>['A', 'Header']);
+  });
+
+  test('@ConfigurePigeon ObjcOptions.copyrightHeader', () {
+    const String code = '''
+@ConfigurePigeon(PigeonOptions(
+  objcOptions: ObjcOptions(copyrightHeader: <String>['A', 'Header']),
+))
+class Message {
+  int? id;
+}
+''';
+
+    final ParseResults results = _parseSource(code);
+    final PigeonOptions options = PigeonOptions.fromMap(results.pigeonOptions!);
+    expect(options.objcOptions!.copyrightHeader, <String>['A', 'Header']);
+  });
 }


### PR DESCRIPTION
When using a `pigeon.dart` file that passes a copyrightHeader to `DartOptions/ObjcOptions/JavaOptions` a type error is thrown. For example, the following code leads to the error below it:

```dart
import 'package:pigeon/pigeon.dart';

@ConfigurePigeon(PigeonOptions(
  dartOptions: DartOptions(copyrightHeader: <String>[
    'Copyright 2013 The Flutter Authors. All rights reserved.',
    'Use of this source code is governed by a BSD-style license that can be',
    'found in the LICENSE file.',
  ]),
))

@HostApi()
class MyApi { }
```

```
Unhandled exception:
type 'int' is not a subtype of type 'Iterable<String>?' in type cast
#0      DartOptions.fromMap (package:pigeon/dart_generator.dart:25:47)
#1      PigeonOptions.fromMap (package:pigeon/pigeon_lib.dart:195:25)
#2      Pigeon.run (package:pigeon/pigeon_lib.dart:1090:31)
#3      runCommandLine (package:pigeon/pigeon_cl.dart:14:17)
#4      main (file:///Users/bmparr/.pub-cache/bin/bin/bin/hosted/pub.dartlang.org/pigeon-1.0.16/bin/pigeon.dart:12:14)
#5      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295:32)
#6      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
pub finished with exit code 255
```

This happens because [DartOptions.copyrightHeader](https://pub.dev/documentation/pigeon/latest/dart_generator/DartOptions/copyrightHeader.html) requires an `Iterable`, but this is not supported in [_expressionToMap](https://github.com/flutter/packages/blob/main/packages/pigeon/lib/pigeon_lib.dart#L621) (a helper method that uses analyzer to read an annotation). This method is missing support of a `ListLiteral`, so it ultimately sets the `copyrightHeader` value to a `0` in the [else statement](https://github.com/flutter/packages/blob/main/packages/pigeon/lib/pigeon_lib.dart#L649) of the method. When the `pigeonOptions` map is parsed in [DartOptions.fromMap](https://github.com/flutter/packages/blob/main/packages/pigeon/lib/dart_generator.dart#L22), the code attempts to pass a `0` to the `copyrightHeader` field. This causes the error shown above.

This indicates there are two bugs when parsing a `@ConfigurePigeon` annotation:
1. `DartOptions.copyrightHeader`, `JavaOptions.copyrightHeader`, `ObjcOptions.copyrightHeader` are not parsed correctly and the value is set to `0`.
2. Errors caused by parsing does't prevent constructing a `PigeonOptions` object: https://github.com/flutter/packages/blob/main/packages/pigeon/lib/pigeon_lib.dart#L1090.

This PR attempts to solve both of these bugs by:
1. Adding support for `ListLiteral`s parsed in an annotation.
2. Exiting the program and printing parsing errors before they are used to construct a `PigeonOptions` class.

As a side note, I think `json_serializable` could probably help with avoiding these type of errors. We could try using it for all of the `PigeonOptions` classes?

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
