### PR TITLE
[palette_generator] Fix dynamic calls due to operator ==

### DIFF
--- a/packages/palette_generator/CHANGELOG.md
+++ b/packages/palette_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+* Avoid dynamic calls in equality checks.
+
 ## 0.3.2
 
 * Fix typos

--- a/packages/palette_generator/CHANGELOG.md
+++ b/packages/palette_generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.3
 
-* Avoid dynamic calls in equality checks.
+* Avoids dynamic calls in equality checks.
 
 ## 0.3.2
 

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -620,7 +620,8 @@ class PaletteTarget with Diagnosticable {
 
   @override
   bool operator ==(dynamic other) {
-    return minimumSaturation == other.minimumSaturation &&
+    return other is PaletteTarget &&
+        minimumSaturation == other.minimumSaturation &&
         targetSaturation == other.targetSaturation &&
         maximumSaturation == other.maximumSaturation &&
         minimumLightness == other.minimumLightness &&
@@ -857,7 +858,7 @@ class PaletteColor with Diagnosticable {
 
   @override
   bool operator ==(dynamic other) {
-    return color == other.color && population == other.population;
+    return other is PaletteColor && color == other.color && population == other.population;
   }
 }
 

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -858,7 +858,9 @@ class PaletteColor with Diagnosticable {
 
   @override
   bool operator ==(Object other) {
-    return other is PaletteColor && color == other.color && population == other.population;
+    return other is PaletteColor &&
+        color == other.color &&
+        population == other.population;
   }
 }
 

--- a/packages/palette_generator/lib/palette_generator.dart
+++ b/packages/palette_generator/lib/palette_generator.dart
@@ -619,7 +619,7 @@ class PaletteTarget with Diagnosticable {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is PaletteTarget &&
         minimumSaturation == other.minimumSaturation &&
         targetSaturation == other.targetSaturation &&
@@ -857,7 +857,7 @@ class PaletteColor with Diagnosticable {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is PaletteColor && color == other.color && population == other.population;
   }
 }

--- a/packages/palette_generator/pubspec.yaml
+++ b/packages/palette_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: palette_generator
 description: Flutter package for generating palette colors from a source image.
 repository: https://github.com/flutter/packages/tree/main/packages/palette_generator
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+palette_generator%22
-version: 0.3.2
+version: 0.3.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/palette_generator/test/palette_generator_test.dart
+++ b/packages/palette_generator/test/palette_generator_test.dart
@@ -402,6 +402,24 @@ Future<void> main() async {
     expect(palette.paletteColors[0].color,
         within<Color>(distance: 8, from: const Color(0xff0000ff)));
   });
+
+  test('PaletteColor == does not crash on invalid comparisons', () {
+    final PaletteColor paletteColorA = PaletteColor(const Color(0xFFFFFFFF), 1);
+    final PaletteColor paletteColorB = PaletteColor(const Color(0xFFFFFFFF), 1);
+    final Object object = Object();
+
+    expect(paletteColorA == paletteColorB, true);
+    expect(paletteColorA == object, false);
+  });
+
+  test('PaletteTarget == does not crash on invalid comparisons', () {
+    final PaletteTarget paletteTargetA = PaletteTarget();
+    final PaletteTarget paletteTargetB = PaletteTarget();
+    final Object object = Object();
+
+    expect(paletteTargetA == paletteTargetB, true);
+    expect(paletteTargetA == object, false);
+  });
 }
 
 Future<PaletteGenerator> _computeFromByteData(EncodedImage encodedImage) async {


### PR DESCRIPTION
Dynamic calls can cause symbols to be retained that otherwise could be tree shaken.

This change checks that 'other' is of the same type in the operator == before referencing its member variables.

Fixes: https://github.com/flutter/flutter/issues/98075