### PR TITLE
[pigeon] disable deprecated e2e tests

### DIFF
--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -275,8 +275,8 @@ run_ios_e2e_tests() {
   pushd $PWD
   cd e2e_tests/test_objc
   flutter build ios -t test_driver/e2e_test.dart --simulator
-  # TODO transition to integration_test. e2e has been deprecated and has stopped
-  # working.
+  # TODO(gaaclarke): Transition to integration_test. `e2e` has been deprecated
+  # and has stopped working.
   # cd ios
   # xcodebuild \
   #   -workspace Runner.xcworkspace \

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -275,13 +275,15 @@ run_ios_e2e_tests() {
   pushd $PWD
   cd e2e_tests/test_objc
   flutter build ios -t test_driver/e2e_test.dart --simulator
-  cd ios
-  xcodebuild \
-    -workspace Runner.xcworkspace \
-    -scheme RunnerTests \
-    -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone 8' \
-    test
+  # TODO transition to integration_test. e2e has been deprecated and has stopped
+  # working.
+  # cd ios
+  # xcodebuild \
+  #   -workspace Runner.xcworkspace \
+  #   -scheme RunnerTests \
+  #   -sdk iphonesimulator \
+  #   -destination 'platform=iOS Simulator,name=iPhone 8' \
+  #   test
   popd
 }
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/98555

These tests were hardly used.  We've shifted away from them in favor of unit tests on generated code.

No version change: Just a tweak to CI.
No CHANGELOG change: Just a tweak to CI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
