### PR TITLE
[ci] Fix dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       - "stuartmorgan"
       - "ditman"
     labels:
-      - "ecosystem"
       - "waiting for tree to go green"
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -22,5 +21,4 @@ updates:
       - "godofredoc"
     labels:
       - "team"
-      - "ecosystem"
       - "team: infra"


### PR DESCRIPTION
There is no `ecosystem` label in this repository (nor a need for one).

I missed this in review.