### PR TITLE
[go_router] Keep params in nested routes

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.3
+
+- Fixed a bug where params disappear when pushing a nested route.
+
 ## 3.0.2
 
 - Moves source to flutter/packages.

--- a/packages/go_router/lib/src/go_router_delegate.dart
+++ b/packages/go_router/lib/src/go_router_delegate.dart
@@ -343,9 +343,9 @@ class GoRouterDelegate extends RouterDelegate<Uri>
         var previouslyMatchedParams = <String, String>{};
         for (final match in matches) {
           assert(
-              !previouslyMatchedParams.keys
-                  .any(match.encodedParams.containsKey),
-              'Duplicated parameter names');
+            !previouslyMatchedParams.keys.any(match.encodedParams.containsKey),
+            'Duplicated parameter names',
+          );
           match.encodedParams.addAll(previouslyMatchedParams);
           previouslyMatchedParams = match.encodedParams;
         }

--- a/packages/go_router/lib/src/go_router_delegate.dart
+++ b/packages/go_router/lib/src/go_router_delegate.dart
@@ -342,7 +342,9 @@ class GoRouterDelegate extends RouterDelegate<Uri>
         for (final match in matches) {
           // merge new params to keep params from previously matched paths, e.g.
           // /family/:fid/person/:pid provides fid and pid to person/:pid
-          params = {...params, ...match.decodedParams};
+          params = {...params, ...match.encodedParams};
+          // Add all the params to the next match
+          match.encodedParams.addAll(params);
         }
 
         // check top route for redirect
@@ -356,7 +358,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
               name: top.route.name,
               path: top.route.path,
               fullpath: top.fullpath,
-              params: params,
+              params: top.decodedParams,
               queryParams: top.queryParams,
               extra: extra,
             ),

--- a/packages/go_router/lib/src/go_router_delegate.dart
+++ b/packages/go_router/lib/src/go_router_delegate.dart
@@ -338,13 +338,16 @@ class GoRouterDelegate extends RouterDelegate<Uri>
         // get stack of route matches
         matches = _getLocRouteMatches(loc, extra: extra);
 
-        var params = <String, String>{};
+        // merge new params to keep params from previously matched paths, e.g.
+        // /family/:fid/person/:pid provides fid and pid to person/:pid
+        var previouslyMatchedParams = <String, String>{};
         for (final match in matches) {
-          // merge new params to keep params from previously matched paths, e.g.
-          // /family/:fid/person/:pid provides fid and pid to person/:pid
-          params = {...params, ...match.encodedParams};
-          // Add all the params to the next match
-          match.encodedParams.addAll(params);
+          assert(
+              !previouslyMatchedParams.keys
+                  .any(match.encodedParams.containsKey),
+              'Duplicated parameter names');
+          match.encodedParams.addAll(previouslyMatchedParams);
+          previouslyMatchedParams = match.encodedParams;
         }
 
         // check top route for redirect

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 3.0.2
+version: 3.0.3
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -1387,9 +1387,9 @@ void main() {
 
       expect(router.location, loc);
       expect(matches, hasLength(2));
-      expect(router.screenFor(matches.first).runtimeType, PersonScreen);
-      expect(matches.first.decodedParams['fid'], fid);
-      expect(matches.first.decodedParams['pid'], pid);
+      expect(router.screenFor(matches.last).runtimeType, PersonScreen);
+      expect(matches.last.decodedParams['fid'], fid);
+      expect(matches.last.decodedParams['pid'], pid);
     });
   });
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -1353,6 +1353,44 @@ void main() {
       expect(page2.fid, 'f2');
       expect(page2.pid, 'p1');
     });
+
+    test('keep param in nested route', () {
+      final routes = [
+        GoRoute(
+          path: '/',
+          builder: (builder, state) => const HomeScreen(),
+        ),
+        GoRoute(
+          path: '/family/:fid',
+          builder: (builder, state) => FamilyScreen(state.params['fid']!),
+          routes: [
+            GoRoute(
+              path: 'person/:pid',
+              builder: (context, state) {
+                final fid = state.params['fid']!;
+                final pid = state.params['pid']!;
+
+                return PersonScreen(fid, pid);
+              },
+            ),
+          ],
+        ),
+      ];
+
+      final router = _router(routes);
+      const fid = "f1";
+      const pid = "p2";
+      final loc = "/family/$fid/person/$pid";
+
+      router.push(loc);
+      final matches = router.routerDelegate.matches;
+
+      expect(router.location, loc);
+      expect(matches, hasLength(2));
+      expect(router.screenFor(matches.first).runtimeType, PersonScreen);
+      expect(matches.first.decodedParams['fid'], fid);
+      expect(matches.first.decodedParams['pid'], pid);
+    });
   });
 
   group('refresh listenable', () {


### PR DESCRIPTION
Fix for [#99110](https://github.com/flutter/flutter/issues/99110)

There is a sample in the issue which can be used to reproduce it in a real app. The button "Not working" does not work with the current main branch, but does work if you reference the feature branch.

Since this is my first contribution to this repo, I highly appreciate feedback of any kind.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
