### PR TITLE
[ci] Update to Xcode 13 everywhere

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,13 @@ tool_setup_template: &TOOL_SETUP_TEMPLATE
   tool_setup_script:
     - .ci/scripts/prepare_tool.sh
 
+macos_template: &MACOS_TEMPLATE
+  # Only one macOS task can run in parallel without credits, so use them for
+  # PRs on macOS.
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+  osx_instance:
+    image: big-sur-xcode-13
+
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   upgrade_flutter_script:
     # Master uses a pinned, auto-rolled version to prevent out-of-band CI
@@ -129,38 +136,31 @@ task:
         - dart testing/web_benchmarks_test.dart
 
 task:
-  name: ios-build+platform-test
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  osx_instance:
-    image: big-sur-xcode-12.4
-  env:
-    PATH: $PATH:/usr/local/bin
-    matrix:
-      CHANNEL: "master"
-      CHANNEL: "stable"
+  << : *MACOS_TEMPLATE
   << : *FLUTTER_UPGRADE_TEMPLATE
-  build_script:
-    # Exclude rfw until the next Flutter stable release because it depends
-    # on features that have never shipped to stable. (The rfw package has
-    # never worked on stable so this is not going to break anyone.)
-    # When updating this, also look at the android tests above.
-    # When updating this, also update the `rfw/run_tests.sh` file.
-    - if [[ "$CHANNEL" == "master" ]]; then
-    -   ./script/tool_runner.sh build-examples --ios
-    - else
-    -   ./script/tool_runner.sh build-examples --ios --exclude=rfw
-    - fi
-
-task:
-  name: local_tests
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  osx_instance:
-    image: big-sur-xcode-13
-  env:
-    PATH: $PATH:/usr/local/bin
-    matrix:
-      CHANNEL: "master"
-      CHANNEL: "stable"
-  << : *FLUTTER_UPGRADE_TEMPLATE
-  local_tests_script:
-    - ./script/local_tests.sh
+  matrix:
+    - name: ios-build+platform-test
+      env:
+        PATH: $PATH:/usr/local/bin
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
+      build_script:
+        # Exclude rfw until the next Flutter stable release because it depends
+        # on features that have never shipped to stable. (The rfw package has
+        # never worked on stable so this is not going to break anyone.)
+        # When updating this, also look at the android tests above.
+        # When updating this, also update the `rfw/run_tests.sh` file.
+        - if [[ "$CHANNEL" == "master" ]]; then
+        -   ./script/tool_runner.sh build-examples --ios
+        - else
+        -   ./script/tool_runner.sh build-examples --ios --exclude=rfw
+        - fi
+    - name: local_tests
+      env:
+        PATH: $PATH:/usr/local/bin
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
+      local_tests_script:
+        - ./script/local_tests.sh


### PR DESCRIPTION
In the previous update PR I missed that there were two places that the macOS image was specified. This fixes that by combining them into a single task entry, and also extracts the macOS tempate, making the structure match flutter/plugins so that updating is consistent across repositories.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
