### PR TITLE
exclude flutter_lints from legacy check

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,7 +71,7 @@ task:
           CHANNEL: "2.5.3"
           CHANNEL: "2.8.1"
       analyze_script:
-        - ./script/tool_runner.sh analyze --skip-if-not-supporting-flutter-version="$CHANNEL" --custom-analysis=script/configs/custom_analysis.yaml
+        - ./script/tool_runner.sh analyze --skip-if-not-supporting-flutter-version="$CHANNEL" --custom-analysis=script/configs/custom_analysis.yaml --exclude=flutter_lints
     - name: publishable
       env:
         # TODO(stuartmorgan): Remove once the fix for https://github.com/dart-lang/pub/issues/3152

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,6 +71,9 @@ task:
           CHANNEL: "2.5.3"
           CHANNEL: "2.8.1"
       analyze_script:
+        # Exclude:
+        # - flutter_lints: does not depend on flutter, is only constrained by
+        #   Dart SDK version.
         - ./script/tool_runner.sh analyze --skip-if-not-supporting-flutter-version="$CHANNEL" --custom-analysis=script/configs/custom_analysis.yaml --exclude=flutter_lints
     - name: publishable
       env:


### PR DESCRIPTION
`flutter_lints` is only constrained by the Dart SDK version.

This will be submitted on red to get the tree back to green.