### PR TITLE
[go_router] improve 'books' example : keep tab state when navigate to book detail page

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.7
+ - Improve 'books' example : keep tab state when navigate to book detail page
 ## 3.0.6
 
 - Exports inherited_go_router.dart file.

--- a/packages/go_router/example/lib/books/main.dart
+++ b/packages/go_router/example/lib/books/main.dart
@@ -62,9 +62,10 @@ class Bookstore extends StatelessWidget {
         redirect: (_) => '/books/popular',
       ),
       GoRoute(
-        path: '/book/:bookId',
-        redirect: (GoRouterState state) =>
-            '/books/all/${state.params['bookId']}',
+        path: '/book/:kind/:bookId',
+        redirect: (GoRouterState state) {
+          return '/books/${state.params['kind']}/${state.params['bookId']}';
+        },
       ),
       GoRoute(
         path: '/books/:kind(new|all|popular)',

--- a/packages/go_router/example/lib/books/src/screens/books.dart
+++ b/packages/go_router/example/lib/books/src/screens/books.dart
@@ -83,22 +83,33 @@ class _BooksScreenState extends State<BooksScreen>
           children: <Widget>[
             BookList(
               books: libraryInstance.popularBooks,
-              onTap: _handleBookTapped,
+              onTap: (Book book) {
+                _handleBookTapped(kind: widget.kind, book: book);
+              },
             ),
             BookList(
               books: libraryInstance.newBooks,
-              onTap: _handleBookTapped,
+              onTap: (Book book) {
+                _handleBookTapped(kind: widget.kind, book: book);
+              },
             ),
             BookList(
               books: libraryInstance.allBooks,
-              onTap: _handleBookTapped,
+              onTap: (Book book) {
+                _handleBookTapped(kind: widget.kind, book: book);
+              },
             ),
           ],
         ),
       );
 
-  void _handleBookTapped(Book book) {
-    context.go('/book/${book.id}');
+  void _handleBookTapped({
+    required String kind,
+    required Book book,
+  }) {
+    context.go(
+      '/book/$kind/${book.id}',
+    );
   }
 
   void _handleTabTapped(int index) {

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 3.0.6
+version: 3.0.7
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 


### PR DESCRIPTION
In the [original book example](https://github.com/flutter/packages/tree/main/packages/go_router/example/lib/books), when the user navigates from the tab page  to the details page and returns, the tab status will lost.

before:

1.  The first page is login page (`/signin`), just click login go to books page `/books/popular`
2. There are three tabs on the "Books" page, `popular`, `new` and `all`, default tab is `popular`, so path is `/books/popular`.
3. Click first book in the list to enter the details page.
4. Now path is `/books/all/0` instead of `/books/popular/0`, Now the tag status has been lost.
5. back to books page, the tab is `all` instead of `popular`

after:
1.  The first page is login page (`/signin`), just click login go to books page `/books/popular`
2. There are three tabs on the "Books" page, `popular`, `new` and `all`, default tab is `popular`, so path is `/books/popular`.
3. Click first book in the list to enter the details page.
4. Now is `/books/popular/0`
5. back to books page,  the tab is `popular`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
