### PR TITLE
[pigeon] Move test script to tool/

### DIFF
--- a/.ci/scripts/prepare_tool.sh
+++ b/.ci/scripts/prepare_tool.sh
@@ -8,4 +8,4 @@ git fetch origin master
 
 # Pinned version of the plugin tools, to avoid breakage in this repository
 # when pushing updates from flutter/plugins.
-dart pub global activate flutter_plugin_tools 0.8.2
+dart pub global activate flutter_plugin_tools 0.8.2+1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: dart pub global activate flutter_plugin_tools 0.8.2
+      run: dart pub global activate flutter_plugin_tools 0.8.2+1
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* [tests] Moved test script to enable CI.
+
 ## 3.0.3
 
 * Adds ability for generators to do AST validation.  This can help generators

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -172,7 +172,7 @@ get_java_linter_formatter() {
 }
 
 run_dart_unittests() {
-  dart run pigeon:run_tests -t dart_unittests
+  dart run tool/run_tests.dart -t dart_unittests
 }
 
 test_command_line() {
@@ -192,11 +192,11 @@ test_command_line() {
 }
 
 run_flutter_unittests() {
-  dart run pigeon:run_tests -t flutter_unittests
+  dart run tool/run_tests.dart -t flutter_unittests
 }
 
 run_mock_handler_tests() {
-  dart run pigeon:run_tests -t mock_handler_tests
+  dart run tool/run_tests.dart -t mock_handler_tests
 }
 
 run_dart_compilation_tests() {

--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -5,7 +5,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// Script for executing the Pigeon tests
 ///
-/// usage: pub run pigeon:run_tests
+/// usage: dart run tool/run_tests.dart
 ////////////////////////////////////////////////////////////////////////////////
 import 'dart:io' show File, Process, Platform, exit, stderr, stdout;
 import 'package:args/args.dart';
@@ -299,7 +299,7 @@ Future<void> main(List<String> args) async {
   } else if (argResults.wasParsed('help')) {
     print('''
 Pigeon run_tests
-usage: pub run pigeon:run_tests [-l | -t <test name>]
+usage: dart run tool/run_tests.dart [-l | -t <test name>]
 
 ${parser.usage}''');
     exit(0);


### PR DESCRIPTION
Per standard Dart package conventions, bin/ is only for client-facing
scripts; scripts for use by package maintainers, such as test scripts,
should be in tool/.

This is where the repository tooling expects to find run_tests.dart, so
this will re-enable Windows Pigeon tests (which were accidentally
dropped when switching to driving those tests via the repo tooling).

Also rolls the repo tool version to pick up a `custom-test` fix.

No version change: Does not affect package clients.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
