### PR TITLE
[go_router_builder] Changes the parameter name of the auto-generated go method from buildContext to context

### DIFF
--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,7 +1,3 @@
-## NEXT
-
-- Fixes integration tests. [#102799](https://github.com/flutter/flutter/issues/102799).
-
 ## 1.0.2
 
 - Changes the parameter name of the auto-generated `go` method from `buildContext` to `context`.

--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Fixes integration tests. [#102799](https://github.com/flutter/flutter/issues/102799).
 
+## 1.0.2
+
+- Changes the parameter name of the auto-generated `go` method from `buildContext` to `context`.
+
 ## 1.0.1
 
 - Documentation fixes. [#102713](https://github.com/flutter/flutter/issues/102713).

--- a/packages/go_router_builder/example/lib/all_types.g.dart
+++ b/packages/go_router_builder/example/lib/all_types.g.dart
@@ -64,7 +64,7 @@ extension $AllTypesRouteExtension on AllTypesRoute {
         },
       );
 
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
+  void go(BuildContext context) => context.go(location, extra: this);
 }
 
 const _$PersonDetailsEnumMap = {

--- a/packages/go_router_builder/example/lib/main.g.dart
+++ b/packages/go_router_builder/example/lib/main.g.dart
@@ -43,7 +43,7 @@ extension $HomeRouteExtension on HomeRoute {
         '/',
       );
 
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
+  void go(BuildContext context) => context.go(location, extra: this);
 }
 
 extension $FamilyRouteExtension on FamilyRoute {
@@ -55,7 +55,7 @@ extension $FamilyRouteExtension on FamilyRoute {
         '/family/${Uri.encodeComponent(fid)}',
       );
 
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
+  void go(BuildContext context) => context.go(location, extra: this);
 }
 
 extension $PersonRouteExtension on PersonRoute {
@@ -68,7 +68,7 @@ extension $PersonRouteExtension on PersonRoute {
         '/family/${Uri.encodeComponent(fid)}/person/${Uri.encodeComponent(pid.toString())}',
       );
 
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
+  void go(BuildContext context) => context.go(location, extra: this);
 }
 
 extension $PersonDetailsRouteExtension on PersonDetailsRoute {
@@ -84,7 +84,7 @@ extension $PersonDetailsRouteExtension on PersonDetailsRoute {
         '/family/${Uri.encodeComponent(fid)}/person/${Uri.encodeComponent(pid.toString())}/details/${Uri.encodeComponent(_$PersonDetailsEnumMap[details]!)}',
       );
 
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
+  void go(BuildContext context) => context.go(location, extra: this);
 }
 
 const _$PersonDetailsEnumMap = {
@@ -115,5 +115,5 @@ extension $LoginRouteExtension on LoginRoute {
         },
       );
 
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
+  void go(BuildContext context) => context.go(location, extra: this);
 }

--- a/packages/go_router_builder/example/lib/simple_example.g.dart
+++ b/packages/go_router_builder/example/lib/simple_example.g.dart
@@ -30,7 +30,7 @@ extension $HomeRouteExtension on HomeRoute {
         '/',
       );
 
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
+  void go(BuildContext context) => context.go(location, extra: this);
 }
 
 extension $FamilyRouteExtension on FamilyRoute {
@@ -42,5 +42,5 @@ extension $FamilyRouteExtension on FamilyRoute {
         '/family/${Uri.encodeComponent(familyId)}',
       );
 
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
+  void go(BuildContext context) => context.go(location, extra: this);
 }

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -136,11 +136,11 @@ class RouteConfig {
   String _extensionDefinition() => '''
 extension $_extensionName on $_className {
   static $_className _fromState(GoRouterState state) $_newFromState
-  
+
   String get location => GoRouteData.\$location($_locationArgs,$_locationQueryParams);
-  
-  void go(BuildContext buildContext) => buildContext.go(location, extra: this);
-} 
+
+  void go(BuildContext context) => context.go(location, extra: this);
+}
 ''';
 
   /// Returns this [RouteConfig] and all child [RouteConfig] instances.

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 


### PR DESCRIPTION
Changes the parameter name of the auto-generated `go` method from `buildContext` to `context`.

`buildContext` is redundant, and `context` is more popular and concise.
It is also more convenient when writing code if it is completed as`context` instead of `buildContext`.

https://user-images.githubusercontent.com/1255062/165443867-78fadb83-b2f4-4353-9e30-159165ef6c0e.mov

*List which issues are fixed by this PR. You must list at least one issue.*

- https://github.com/flutter/flutter/issues/99127

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
