### PR TITLE
[ci] Attempt to 'fail fast' CI tasks:

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,30 +53,7 @@ task:
     memory: 8G
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
-    - name: format+analyze
-      always:
-        format_script: ./script/tool_runner.sh format --fail-on-change
-        license_script: dart pub global run flutter_plugin_tools license-check
-        analyze_script: ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
-        pubspec_script: ./script/tool_runner.sh pubspec-check
-    # Does a sanity check that packages at least pass analysis on the N-1 and N-2
-    # versions of Flutter stable if the package claims to support that version.
-    # This is to minimize accidentally making changes that break old versions
-    # (which we don't commit to supporting, but don't want to actively break)
-    # without updating the constraints.
-    # Note: The versions below should be manually updated after a new stable
-    # version comes out.
-    - name: legacy-version-analyze
-      depends_on: format+analyze
-      env:
-        matrix:
-          CHANNEL: "2.5.3"
-          CHANNEL: "2.8.1"
-      analyze_script:
-        # Exclude:
-        # - flutter_lints: does not depend on flutter, is only constrained by
-        #   Dart SDK version.
-        - ./script/tool_runner.sh analyze --skip-if-not-supporting-flutter-version="$CHANNEL" --custom-analysis=script/configs/custom_analysis.yaml --exclude=flutter_lints
+    # Runs in parallel with format+analyze
     - name: publishable
       env:
         # TODO(stuartmorgan): Remove once the fix for https://github.com/dart-lang/pub/issues/3152
@@ -97,9 +74,35 @@ task:
         -   ./script/tool_runner.sh version-check --check-for-missing-changes --change-description-file="$CHANGE_DESC"
         - fi
       publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
+    - name: format+analyze
+      always:
+        format_script: ./script/tool_runner.sh format --fail-on-change
+        license_script: dart pub global run flutter_plugin_tools license-check
+        analyze_script: ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
+        pubspec_script: ./script/tool_runner.sh pubspec-check
+    # Does a sanity check that packages at least pass analysis on the N-1 and N-2
+    # versions of Flutter stable if the package claims to support that version.
+    # This is to minimize accidentally making changes that break old versions
+    # (which we don't commit to supporting, but don't want to actively break)
+    # without updating the constraints.
+    # Note: The versions below should be manually updated after a new stable
+    # version comes out.
+    - name: legacy-version-analyze
       depends_on:
         - format+analyze
+      env:
+        matrix:
+          CHANNEL: "2.5.3"
+          CHANNEL: "2.8.1"
+      analyze_script:
+        # Exclude:
+        # - flutter_lints: does not depend on flutter, is only constrained by
+        #   Dart SDK version.
+        - ./script/tool_runner.sh analyze --skip-if-not-supporting-flutter-version="$CHANNEL" --custom-analysis=script/configs/custom_analysis.yaml --exclude=flutter_lints
     - name: test
+      depends_on:
+        - format+analyze
+        - publishable
       env:
         matrix:
           CHANNEL: "master"
@@ -107,9 +110,9 @@ task:
       script:
         # We exclude flutter_image because its tests need a test server, so are run via custom_package_tests.
         - ./script/tool_runner.sh test --exclude=flutter_image
-      depends_on:
-        - format+analyze
     - name: linux-custom_package_tests
+      depends_on:
+        - test
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -126,6 +129,8 @@ task:
         -   ./script/tool_runner.sh custom-test --exclude=pigeon,flutter_image
         - fi
     - name: android-build+platform-tests
+      depends_on:
+        - test
       env:
         matrix:
           CHANNEL: "master"
@@ -135,9 +140,9 @@ task:
         # https://github.com/flutter/flutter/issues/89301
         - ./script/tool_runner.sh build-examples --apk --exclude=extension_google_sign_in_as_googleapis_auth
         - ./script/tool_runner.sh native-test --android --no-integration
-      depends_on:
-        - format+analyze
     - name: web_benchmarks_test
+      depends_on:
+        - test
       env:
         matrix:
           CHROMIUM_BUILD: "768968" # Chromium 84.0.4147.0
@@ -158,6 +163,8 @@ task:
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     - name: ios-build+platform-test
+      depends_on:
+        - test
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -166,6 +173,8 @@ task:
       build_script:
         - ./script/tool_runner.sh build-examples --ios
     - name: ios-custom_package_tests
+      depends_on:
+        - test
       env:
         PATH: $PATH:/usr/local/bin
         matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,6 +53,12 @@ task:
     memory: 8G
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
+    - name: format+analyze
+      always:
+        format_script: ./script/tool_runner.sh format --fail-on-change
+        license_script: dart pub global run flutter_plugin_tools license-check
+        analyze_script: ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
+        pubspec_script: ./script/tool_runner.sh pubspec-check
     # Runs in parallel with format+analyze
     - name: publishable
       env:
@@ -74,12 +80,6 @@ task:
         -   ./script/tool_runner.sh version-check --check-for-missing-changes --change-description-file="$CHANGE_DESC"
         - fi
       publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
-    - name: format+analyze
-      always:
-        format_script: ./script/tool_runner.sh format --fail-on-change
-        license_script: dart pub global run flutter_plugin_tools license-check
-        analyze_script: ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
-        pubspec_script: ./script/tool_runner.sh pubspec-check
     # Does a sanity check that packages at least pass analysis on the N-1 and N-2
     # versions of Flutter stable if the package claims to support that version.
     # This is to minimize accidentally making changes that break old versions


### PR DESCRIPTION
With the current setup, a package may fail CI because the `publishable` check fails, but by the time CI notices, expensive checks (like ios-specific ones) are already running. This reduces the availability of ios-specific resources for other checks that might have passed their cheap tests already.

Attempt to model the test execution flow from cheap (fast) -> expensive, so early failures don't incur in extra CI expenses:

The idea is:

* publishable
* analyze
  * legacy-analysis
  * test
    * android/ios/web tests

Fixes: N/A

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
