### PR TITLE
[go_router_builder] Fixes incorrect separator at location path on Windows.

### DIFF
--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -5,7 +5,6 @@
 ## 1.0.2
 
 - Changes the parameter name of the auto-generated `go` method from `buildContext` to `context`.
-- Fixes integration tests. [#102799](https://github.com/flutter/flutter/issues/102799).
 
 ## 1.0.1
 

--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.0.2
 
+- Fixes incorrect separator at location path on Windows. [#102710](https://github.com/flutter/flutter/issues/102710)
 - Changes the parameter name of the auto-generated `go` method from `buildContext` to `context`.
+- Fixes integration tests. [#102799](https://github.com/flutter/flutter/issues/102799).
 
 ## 1.0.1
 

--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 1.0.2
+## 1.0.3
 
 - Fixes incorrect separator at location path on Windows. [#102710](https://github.com/flutter/flutter/issues/102710)
+
+## 1.0.2
+
 - Changes the parameter name of the auto-generated `go` method from `buildContext` to `context`.
 - Fixes integration tests. [#102799](https://github.com/flutter/flutter/issues/102799).
 

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -236,7 +236,7 @@ GoRoute get $_routeGetterName => ${_routeDefinition()};
       config = config._parent;
     }
 
-    return p.joinAll(pathSegments.reversed);
+    return p.url.joinAll(pathSegments.reversed);
   }
 
   String get _className => _routeDataClass.name;

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 1.0.2
+version: 1.0.3
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 


### PR DESCRIPTION
The `go_router_builder` is using `path.joinAll` to concat `route` and create `location`, but it uses backslash as path separators on Windows.
This PR will replace that with `path.url.joinAll`, which uses slash. The builder will be able to generate slash-separated location on Windows, same on the other platforms.

I didn't know how to write test in this case. The build runner will generate correct `main.g.dart` in example project on Windows.

This PR will fix flutter/flutter#102710.

No changes in `flutter/tests`

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
