### PR TITLE
[pointer_interceptor] Fix tests for flutter stable.

### DIFF
--- a/packages/pointer_interceptor/example/integration_test/widget_test.dart
+++ b/packages/pointer_interceptor/example/integration_test/widget_test.dart
@@ -76,6 +76,11 @@ void main() {
       app.main();
       await tester.pumpAndSettle();
 
+      if (!_newSemanticsAvailable()) {
+        print('Skipping test: Needs flutter > 2.10');
+        return;
+      }
+
       final html.Element element =
           _getHtmlElementAtCenter(clickableButtonFinder, tester);
 
@@ -89,6 +94,11 @@ void main() {
       app.main();
       await tester.pumpAndSettle();
 
+      if (!_newSemanticsAvailable()) {
+        print('Skipping test: Needs flutter > 2.10');
+        return;
+      }
+
       final html.Element element =
           _getHtmlElementAtCenter(clickableWrappedButtonFinder, tester);
 
@@ -101,6 +111,11 @@ void main() {
         (WidgetTester tester) async {
       app.main();
       await tester.pumpAndSettle();
+
+      if (!_newSemanticsAvailable()) {
+        print('Skipping test: Needs flutter > 2.10');
+        return;
+      }
 
       final html.Element element =
           _getHtmlElementAtCenter(nonClickableButtonFinder, tester);
@@ -148,4 +163,15 @@ html.Element _getHtmlElementAt(Offset point) {
   final html.ShadowRoot glassPaneShadow =
       html.document.querySelector('flt-glass-pane')!.shadowRoot!;
   return glassPaneShadow.elementFromPoint(point.dx.toInt(), point.dy.toInt())!;
+}
+
+// TODO(dit): Remove this after flutter master (2.13) lands into stable.
+// This detects that we can do new semantics assertions by looking at the 'id'
+// attribute on flt-semantics elements (it is now set in 2.13 and up).
+bool _newSemanticsAvailable() {
+  final html.ShadowRoot glassPaneShadow =
+      html.document.querySelector('flt-glass-pane')!.shadowRoot!;
+  final List<html.Element> elements = glassPaneShadow
+    .querySelectorAll('flt-semantics[id]');
+  return elements.isNotEmpty;
 }

--- a/packages/pointer_interceptor/example/integration_test/widget_test.dart
+++ b/packages/pointer_interceptor/example/integration_test/widget_test.dart
@@ -171,7 +171,7 @@ html.Element _getHtmlElementAt(Offset point) {
 bool _newSemanticsAvailable() {
   final html.ShadowRoot glassPaneShadow =
       html.document.querySelector('flt-glass-pane')!.shadowRoot!;
-  final List<html.Element> elements = glassPaneShadow
-    .querySelectorAll('flt-semantics[id]');
+  final List<html.Element> elements =
+      glassPaneShadow.querySelectorAll('flt-semantics[id]');
   return elements.isNotEmpty;
 }


### PR DESCRIPTION
There have been a few changes in the hit order + semantics implementations on the Flutter Web engine. Some tests were added, but those can only run on `master`, with the new semantics approach.

This change skips those tests unless the "new semantics" are available (runs in `master` but skips in `stable`).

Unblocks: https://github.com/flutter/packages/pull/1726

No CHANGELOG change: this code should be reverted in a few days. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
