### PR TITLE
[ci] Skip tests that aren't suppose to run on win

### DIFF
--- a/.ci/scripts/dart_unit_tests.sh
+++ b/.ci/scripts/dart_unit_tests.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Copyright 2013 The Flutter Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
-dart pub global run flutter_plugin_tools test --packages-for-branch \
-  --log-timing

--- a/.ci/scripts/dart_unit_tests_win32.sh
+++ b/.ci/scripts/dart_unit_tests_win32.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Exclude flutter_image because its tests need a test server, so are run via custom_package_tests.
+# Exclude xgd_directories because it is a Linux only package.
+dart pub global run flutter_plugin_tools test --exclude=flutter_image,fuchsia_ctl,xgd_directories \
+  --packages-for-branch --log-timing

--- a/.ci/scripts/dart_unit_tests_win32.sh
+++ b/.ci/scripts/dart_unit_tests_win32.sh
@@ -3,5 +3,5 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-dart pub global run flutter_plugin_tools test --exclude=../../script/configs/windows_unit_tests_exceptions.yaml \
+dart pub global run flutter_plugin_tools test --exclude=script/configs/windows_unit_tests_exceptions.yaml \
   --packages-for-branch --log-timing

--- a/.ci/scripts/dart_unit_tests_win32.sh
+++ b/.ci/scripts/dart_unit_tests_win32.sh
@@ -3,7 +3,5 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Exclude flutter_image because its tests need a test server, so are run via custom_package_tests.
-# Exclude xgd_directories because it is a Linux only package.
-dart pub global run flutter_plugin_tools test --exclude=flutter_image,fuchsia_ctl,xgd_directories \
+dart pub global run flutter_plugin_tools test --exclude=../../script/configs/windows_unit_tests_exceptions.yaml \
   --packages-for-branch --log-timing

--- a/.ci/targets/windows_dart_unit_tests.yaml
+++ b/.ci/targets/windows_dart_unit_tests.yaml
@@ -2,4 +2,4 @@ tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
   - name: custom package tests
-    script: .ci/scripts/dart_unit_tests.sh
+    script: .ci/scripts/dart_unit_tests_win32.sh

--- a/.ci/targets/windows_dart_unit_tests.yaml
+++ b/.ci/targets/windows_dart_unit_tests.yaml
@@ -1,5 +1,5 @@
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
-  - name: custom package tests
+  - name: dart unit tests
     script: .ci/scripts/dart_unit_tests_win32.sh

--- a/script/configs/windows_unit_tests_exceptions.yaml
+++ b/script/configs/windows_unit_tests_exceptions.yaml
@@ -1,0 +1,8 @@
+# Packages that are excluded from dart unit test on Windows.
+
+# Exclude flutter_image because its tests need a test server, so are run via custom_package_tests.
+- flutter_image
+# TODO(chunhtai): Remove fuchsia_ctl if possible https://github.com/flutter/flutter/issues/103991.
+- fuchsia_ctl
+# TODO(chunhtai): Remove xgd_directories https://github.com/flutter/flutter/issues/103992.
+- xgd_directories


### PR DESCRIPTION
Currently the ci is failing https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8814226430734410449/+/u/Run_package_tests/custom_package_tests/stdout

the failing packages are: flutter_image, xgd_directories, fuchsia_ctl.
First two can be safely skipped, not sure about fuchsia_ctl

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
