### PR TITLE
[pigeon] Minor Obj-C simplification

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 3.0.4
 
+* [objc] Simplified some code output, including avoiding Xcode warnings about
+  using `NSNumber*` directly as boolean value.
 * [tests] Moved test script to enable CI.
 
 ## 3.0.3

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -8,7 +8,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '3.0.3';
+const String pigeonVersion = '3.0.4';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -837,13 +837,13 @@ static NSDictionary<NSString *, id> *wrapResult(id result, FlutterError *error) 
 \tNSDictionary *errorDict = (NSDictionary *)[NSNull null];
 \tif (error) {
 \t\terrorDict = @{
-\t\t\t\t@"${Keys.errorCode}": (error.code ? error.code : [NSNull null]),
-\t\t\t\t@"${Keys.errorMessage}": (error.message ? error.message : [NSNull null]),
-\t\t\t\t@"${Keys.errorDetails}": (error.details ? error.details : [NSNull null]),
+\t\t\t\t@"${Keys.errorCode}": (error.code ?: [NSNull null]),
+\t\t\t\t@"${Keys.errorMessage}": (error.message ?: [NSNull null]),
+\t\t\t\t@"${Keys.errorDetails}": (error.details ?: [NSNull null]),
 \t\t\t\t};
 \t}
 \treturn @{
-\t\t\t@"${Keys.result}": (result ? result : [NSNull null]),
+\t\t\t@"${Keys.result}": (result ?: [NSNull null]),
 \t\t\t@"${Keys.error}": errorDict,
 \t\t\t};
 }''');
@@ -907,12 +907,13 @@ static id GetNullableObjectAtIndex(NSArray* array, NSInteger key) {
     void writeToMap() {
       indent.write('- (NSDictionary *)toMap ');
       indent.scoped('{', '}', () {
-        indent.write('return @{');
-        for (final NamedType field in klass.fields) {
-          indent.add(
-              '@"${field.name}" : ${_dictValue(classNames, enumNames, field)}');
-        }
-        indent.addln('};');
+        indent.write('return');
+        indent.scoped(' @{', '};', () {
+          for (final NamedType field in klass.fields) {
+            indent.writeln(
+                '@"${field.name}" : ${_dictValue(classNames, enumNames, field)},');
+          }
+        });
       });
     }
 

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -572,7 +572,7 @@ String _dictValue(
   } else if (enumNames.contains(field.type.baseName)) {
     return '@(self.${field.name})';
   } else {
-    return '(self.${field.name} ? self.${field.name} : [NSNull null])';
+    return '(self.${field.name} ?: [NSNull null])';
   }
 }
 
@@ -761,8 +761,7 @@ void _writeFlutterApiSource(Indent indent, ObjcOptions options, Api api) {
     if (func.arguments.isEmpty) {
       sendArgument = 'nil';
     } else {
-      String makeVarOrNSNullExpression(String x) =>
-          '($x == nil) ? [NSNull null] : $x';
+      String makeVarOrNSNullExpression(String x) => '$x ?: [NSNull null]';
       sendArgument = '@[${argNames.map(makeVarOrNSNullExpression).join(', ')}]';
     }
     indent.write(_makeObjcSignature(
@@ -908,12 +907,12 @@ static id GetNullableObjectAtIndex(NSArray* array, NSInteger key) {
     void writeToMap() {
       indent.write('- (NSDictionary *)toMap ');
       indent.scoped('{', '}', () {
-        indent.write('return [NSDictionary dictionaryWithObjectsAndKeys:');
+        indent.write('return @{');
         for (final NamedType field in klass.fields) {
-          indent.add(_dictValue(classNames, enumNames, field) +
-              ', @"${field.name}", ');
+          indent.add(
+              '@"${field.name}" : ${_dictValue(classNames, enumNames, field)}');
         }
-        indent.addln('nil];');
+        indent.addln('};');
       });
     }
 

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 3.0.3 # This must match the version in lib/generator_tools.dart
+version: 3.0.4 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/pigeon/test/objc_generator_test.dart
+++ b/packages/pigeon/test/objc_generator_test.dart
@@ -1507,7 +1507,7 @@ void main() {
       expect(
           code,
           contains(
-              '[channel sendMessage:@[(arg_x == nil) ? [NSNull null] : arg_x, (arg_y == nil) ? [NSNull null] : arg_y] reply:'));
+              '[channel sendMessage:@[arg_x ?: [NSNull null], arg_y ?: [NSNull null]] reply:'));
     }
   });
 


### PR DESCRIPTION
Minor changes to Obj-C output:
- Uses dictionary literals instead of `dictionaryWithObjectsAndKeys:`,
  which is shorter, easier to read, and more idiomatic.
- Uses `?:` operator to simplify some "or `NSNull` handling. In
  addition to being shorter, this version doesn't trigger Xcode warnings
  about using an `NSNumber*` as a bool.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
