### PR TITLE
[go_router] If there is more than one route to match, use the first match.

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 3.1.1
 
-- Removed assertion `too many routes for location`
-- Fixes (https://github.com/flutter/flutter/issues/99833)
+- Uses first match if there is more than one route to match. [ [#99833](https://github.com/flutter/flutter/issues/99833)
 
 ## 3.1.0
 

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.1
+
+- Removed assertion `too many routes for location`
+- Fixes (https://github.com/flutter/flutter/issues/99833)
+
 ## 3.1.0
 
 - Added `GoRouteData` and `TypedGoRoute` to support `package:go_router_builder`.

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.1
 
-- Uses first match if there is more than one route to match. [ [#99833](https://github.com/flutter/flutter/issues/99833)
+- Uses first match if there are more than one route to match. [ [#99833](https://github.com/flutter/flutter/issues/99833)
 
 ## 3.1.0
 

--- a/packages/go_router/lib/src/go_route.dart
+++ b/packages/go_router/lib/src/go_route.dart
@@ -184,8 +184,8 @@ class GoRoute {
   ///   ],
   /// );
   /// ```
-  /// In the above example, if family route is matched, it will be used.
-  /// else username route will be used.
+  /// In the above example, if /family route is matched, it will be used.
+  /// else /:username route will be used.
   final List<GoRoute> routes;
 
   /// An optional redirect function for this route.

--- a/packages/go_router/lib/src/go_route.dart
+++ b/packages/go_router/lib/src/go_route.dart
@@ -162,6 +162,30 @@ class GoRoute {
   ///   ],
   /// );
   ///
+  /// If there are multiple routes that match the location, the first match is used.
+  /// To make predefined routes to take precedence over dynamic routes eg. '/:id'
+  /// consider adding the dynamic route at the end of the routes
+  /// For example:
+  /// ```
+  /// final GoRouter _router = GoRouter(
+  ///   routes: <GoRoute>[
+  ///     GoRoute(
+  ///       path: '/',
+  ///       redirect: (_) => '/family/${Families.data[0].id}',
+  ///     ),
+  ///     GoRoute(
+  ///       path: '/family',
+  ///       pageBuilder: (BuildContext context, GoRouterState state) => ...,
+  ///     ),
+  ///     GoRoute(
+  ///       path: '/:username',
+  ///       pageBuilder: (BuildContext context, GoRouterState state) => ...,
+  ///     ),
+  ///   ],
+  /// );
+  /// ```
+  /// In the above example, if family route is matched, it will be used.
+  /// else username route will be used.
   final List<GoRoute> routes;
 
   /// An optional redirect function for this route.

--- a/packages/go_router/lib/src/go_router_delegate.dart
+++ b/packages/go_router/lib/src/go_router_delegate.dart
@@ -442,9 +442,9 @@ class GoRouterDelegate extends RouterDelegate<Uri>
 
     assert(matchStacks.isNotEmpty, 'no routes for location: $location');
 
-    /// If there are multiple routes that match the location, returning the first one.
-    /// So if you want Predefined routes to take precedence over dynamic routes eg. '/:id'
-    /// you need to add the dynamic route at the end of the routes
+    // If there are multiple routes that match the location, returning the first one.
+    // To make predefined routes to take precedence over dynamic routes eg. '/:id'
+    // consider adding the dynamic route at the end of the routes
 
     return matchStacks.first;
   }

--- a/packages/go_router/lib/src/go_router_delegate.dart
+++ b/packages/go_router/lib/src/go_router_delegate.dart
@@ -42,8 +42,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   }) : assert(() {
           // check top-level route paths are valid
           for (final GoRoute route in routes) {
-            assert(route.path.startsWith('/'),
-                'top-level path must start with "/": ${route.path}');
+            assert(route.path.startsWith('/'), 'top-level path must start with "/": ${route.path}');
           }
           return true;
         }()) {
@@ -175,8 +174,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   /// Pop the top page off the GoRouter's page stack.
   void pop() {
     _matches.remove(_matches.last);
-    assert(_matches.isNotEmpty,
-        'have popped the last page off of the stack; there are no pages left to show');
+    assert(_matches.isNotEmpty, 'have popped the last page off of the stack; there are no pages left to show');
     notifyListeners();
   }
 
@@ -188,8 +186,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   }
 
   /// Get the current location, e.g. /family/f2/person/p1
-  String get location =>
-      _addQueryParams(_matches.last.subloc, _matches.last.queryParams);
+  String get location => _addQueryParams(_matches.last.subloc, _matches.last.queryParams);
 
   /// For internal use; visible for testing only.
   @visibleForTesting
@@ -241,8 +238,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   }
 
   void _go(String location, {Object? extra}) {
-    final List<GoRouteMatch> matches =
-        _getLocRouteMatchesWithRedirects(location, extra: extra);
+    final List<GoRouteMatch> matches = _getLocRouteMatchesWithRedirects(location, extra: extra);
     assert(matches.isNotEmpty);
 
     // replace the stack of matches w/ the new ones
@@ -252,8 +248,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   }
 
   void _push(String location, {Object? extra}) {
-    final List<GoRouteMatch> matches =
-        _getLocRouteMatchesWithRedirects(location, extra: extra);
+    final List<GoRouteMatch> matches = _getLocRouteMatchesWithRedirects(location, extra: extra);
     assert(matches.isNotEmpty);
     final GoRouteMatch top = matches.last;
 
@@ -295,18 +290,8 @@ class GoRouterDelegate extends RouterDelegate<Uri>
 
         assert(Uri.tryParse(redir) != null, 'invalid redirect: $redir');
 
-        assert(
-            !redirects.contains(redir),
-            'redirect loop detected: ${<String>[
-              ...redirects,
-              redir
-            ].join(' => ')}');
-        assert(
-            redirects.length < redirectLimit,
-            'too many redirects: ${<String>[
-              ...redirects,
-              redir
-            ].join(' => ')}');
+        assert(!redirects.contains(redir), 'redirect loop detected: ${<String>[...redirects, redir].join(' => ')}');
+        assert(redirects.length < redirectLimit, 'too many redirects: ${<String>[...redirects, redir].join(' => ')}');
 
         redirects.add(redir);
         log.info('redirecting to $redir');
@@ -400,8 +385,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
           error: error,
           route: GoRoute(
             path: location,
-            pageBuilder: (BuildContext context, GoRouterState state) =>
-                _errorPageBuilder(
+            pageBuilder: (BuildContext context, GoRouterState state) => _errorPageBuilder(
               context,
               GoRouterState(
                 this,
@@ -441,30 +425,31 @@ class GoRouterDelegate extends RouterDelegate<Uri>
     ).toList();
 
     assert(matchStacks.isNotEmpty, 'no routes for location: $location');
-    assert(() {
-      if (matchStacks.length > 1) {
-        final StringBuffer sb = StringBuffer()
-          ..writeln('too many routes for location: $location');
+    // Fixes https://github.com/flutter/flutter/issues/99833
+    // assert(() {
+    //   if (matchStacks.length > 1) {
+    //     final StringBuffer sb = StringBuffer()
+    //       ..writeln('too many routes for location: $location');
 
-        for (final List<GoRouteMatch> stack in matchStacks) {
-          sb.writeln(
-              '\t${stack.map((GoRouteMatch m) => m.route.path).join(' => ')}');
-        }
+    //     for (final List<GoRouteMatch> stack in matchStacks) {
+    //       sb.writeln(
+    //           '\t${stack.map((GoRouteMatch m) => m.route.path).join(' => ')}');
+    //     }
 
-        assert(false, sb.toString());
-      }
+    //     assert(false, sb.toString());
+    //   }
 
-      assert(matchStacks.length == 1);
-      final GoRouteMatch match = matchStacks.first.last;
-      final String loc1 = _addQueryParams(match.subloc, match.queryParams);
-      final Uri uri2 = Uri.parse(location);
-      final String loc2 = _addQueryParams(uri2.path, uri2.queryParameters);
+    //   assert(matchStacks.length == 1);
+    //   final GoRouteMatch match = matchStacks.first.last;
+    //   final String loc1 = _addQueryParams(match.subloc, match.queryParams);
+    //   final Uri uri2 = Uri.parse(location);
+    //   final String loc2 = _addQueryParams(uri2.path, uri2.queryParameters);
 
-      // NOTE: match the lower case, since subloc is canonicalized to match the
-      // path case whereas the location can be any case
-      assert(loc1.toLowerCase() == loc2.toLowerCase(), '$loc1 != $loc2');
-      return true;
-    }());
+    //   // NOTE: match the lower case, since subloc is canonicalized to match the
+    //   // path case whereas the location can be any case
+    //   assert(loc1.toLowerCase() == loc2.toLowerCase(), '$loc1 != $loc2');
+    //   return true;
+    // }());
 
     return matchStacks.first;
   }
@@ -552,15 +537,13 @@ class GoRouterDelegate extends RouterDelegate<Uri>
       }
 
       // otherwise recurse
-      final String childRestLoc =
-          loc.substring(match.subloc.length + (match.subloc == '/' ? 0 : 1));
+      final String childRestLoc = loc.substring(match.subloc.length + (match.subloc == '/' ? 0 : 1));
       assert(loc.startsWith(match.subloc));
       assert(restLoc.isNotEmpty);
 
       // if there's no sub-route matches, then we don't have a match for this
       // location
-      final List<List<GoRouteMatch>> subRouteMatchStacks =
-          _getLocRouteMatchStacks(
+      final List<List<GoRouteMatch>> subRouteMatchStacks = _getLocRouteMatchStacks(
         loc: loc,
         restLoc: childRestLoc,
         parentSubloc: match.subloc,
@@ -785,18 +768,15 @@ class GoRouterDelegate extends RouterDelegate<Uri>
       if (elem != null && isMaterialApp(elem)) {
         log.info('MaterialApp found');
         _pageBuilderForAppType = pageBuilderForMaterialApp;
-        _errorBuilderForAppType = (BuildContext c, GoRouterState s) =>
-            GoRouterMaterialErrorScreen(s.error);
+        _errorBuilderForAppType = (BuildContext c, GoRouterState s) => GoRouterMaterialErrorScreen(s.error);
       } else if (elem != null && isCupertinoApp(elem)) {
         log.info('CupertinoApp found');
         _pageBuilderForAppType = pageBuilderForCupertinoApp;
-        _errorBuilderForAppType = (BuildContext c, GoRouterState s) =>
-            GoRouterCupertinoErrorScreen(s.error);
+        _errorBuilderForAppType = (BuildContext c, GoRouterState s) => GoRouterCupertinoErrorScreen(s.error);
       } else {
         log.info('WidgetsApp assumed');
         _pageBuilderForAppType = pageBuilderForWidgetApp;
-        _errorBuilderForAppType =
-            (BuildContext c, GoRouterState s) => GoRouterErrorScreen(s.error);
+        _errorBuilderForAppType = (BuildContext c, GoRouterState s) => GoRouterErrorScreen(s.error);
       }
     }
 
@@ -888,9 +868,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
     // /profile/ => /profile
     // / => /
     // /login?from=/ => login?from=/
-    canon = canon.endsWith('/') && canon != '/' && !canon.contains('?')
-        ? canon.substring(0, canon.length - 1)
-        : canon;
+    canon = canon.endsWith('/') && canon != '/' && !canon.contains('?') ? canon.substring(0, canon.length - 1) : canon;
 
     // /login/?from=/ => /login?from=/
     // /?from=/ => /?from=/
@@ -902,7 +880,6 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   static String _addQueryParams(String loc, Map<String, String> queryParams) {
     final Uri uri = Uri.parse(loc);
     assert(uri.queryParameters.isEmpty);
-    return _canonicalUri(
-        Uri(path: uri.path, queryParameters: queryParams).toString());
+    return _canonicalUri(Uri(path: uri.path, queryParameters: queryParams).toString());
   }
 }

--- a/packages/go_router/lib/src/go_router_delegate.dart
+++ b/packages/go_router/lib/src/go_router_delegate.dart
@@ -42,7 +42,8 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   }) : assert(() {
           // check top-level route paths are valid
           for (final GoRoute route in routes) {
-            assert(route.path.startsWith('/'), 'top-level path must start with "/": ${route.path}');
+            assert(route.path.startsWith('/'),
+                'top-level path must start with "/": ${route.path}');
           }
           return true;
         }()) {
@@ -174,7 +175,8 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   /// Pop the top page off the GoRouter's page stack.
   void pop() {
     _matches.remove(_matches.last);
-    assert(_matches.isNotEmpty, 'have popped the last page off of the stack; there are no pages left to show');
+    assert(_matches.isNotEmpty,
+        'have popped the last page off of the stack; there are no pages left to show');
     notifyListeners();
   }
 
@@ -186,7 +188,8 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   }
 
   /// Get the current location, e.g. /family/f2/person/p1
-  String get location => _addQueryParams(_matches.last.subloc, _matches.last.queryParams);
+  String get location =>
+      _addQueryParams(_matches.last.subloc, _matches.last.queryParams);
 
   /// For internal use; visible for testing only.
   @visibleForTesting
@@ -238,7 +241,8 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   }
 
   void _go(String location, {Object? extra}) {
-    final List<GoRouteMatch> matches = _getLocRouteMatchesWithRedirects(location, extra: extra);
+    final List<GoRouteMatch> matches =
+        _getLocRouteMatchesWithRedirects(location, extra: extra);
     assert(matches.isNotEmpty);
 
     // replace the stack of matches w/ the new ones
@@ -248,7 +252,8 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   }
 
   void _push(String location, {Object? extra}) {
-    final List<GoRouteMatch> matches = _getLocRouteMatchesWithRedirects(location, extra: extra);
+    final List<GoRouteMatch> matches =
+        _getLocRouteMatchesWithRedirects(location, extra: extra);
     assert(matches.isNotEmpty);
     final GoRouteMatch top = matches.last;
 
@@ -290,8 +295,18 @@ class GoRouterDelegate extends RouterDelegate<Uri>
 
         assert(Uri.tryParse(redir) != null, 'invalid redirect: $redir');
 
-        assert(!redirects.contains(redir), 'redirect loop detected: ${<String>[...redirects, redir].join(' => ')}');
-        assert(redirects.length < redirectLimit, 'too many redirects: ${<String>[...redirects, redir].join(' => ')}');
+        assert(
+            !redirects.contains(redir),
+            'redirect loop detected: ${<String>[
+              ...redirects,
+              redir
+            ].join(' => ')}');
+        assert(
+            redirects.length < redirectLimit,
+            'too many redirects: ${<String>[
+              ...redirects,
+              redir
+            ].join(' => ')}');
 
         redirects.add(redir);
         log.info('redirecting to $redir');
@@ -385,7 +400,8 @@ class GoRouterDelegate extends RouterDelegate<Uri>
           error: error,
           route: GoRoute(
             path: location,
-            pageBuilder: (BuildContext context, GoRouterState state) => _errorPageBuilder(
+            pageBuilder: (BuildContext context, GoRouterState state) =>
+                _errorPageBuilder(
               context,
               GoRouterState(
                 this,
@@ -425,31 +441,10 @@ class GoRouterDelegate extends RouterDelegate<Uri>
     ).toList();
 
     assert(matchStacks.isNotEmpty, 'no routes for location: $location');
-    // Fixes https://github.com/flutter/flutter/issues/99833
-    // assert(() {
-    //   if (matchStacks.length > 1) {
-    //     final StringBuffer sb = StringBuffer()
-    //       ..writeln('too many routes for location: $location');
 
-    //     for (final List<GoRouteMatch> stack in matchStacks) {
-    //       sb.writeln(
-    //           '\t${stack.map((GoRouteMatch m) => m.route.path).join(' => ')}');
-    //     }
-
-    //     assert(false, sb.toString());
-    //   }
-
-    //   assert(matchStacks.length == 1);
-    //   final GoRouteMatch match = matchStacks.first.last;
-    //   final String loc1 = _addQueryParams(match.subloc, match.queryParams);
-    //   final Uri uri2 = Uri.parse(location);
-    //   final String loc2 = _addQueryParams(uri2.path, uri2.queryParameters);
-
-    //   // NOTE: match the lower case, since subloc is canonicalized to match the
-    //   // path case whereas the location can be any case
-    //   assert(loc1.toLowerCase() == loc2.toLowerCase(), '$loc1 != $loc2');
-    //   return true;
-    // }());
+    /// If there are multiple routes that match the location, returning the first one.
+    /// So if you want Predefined routes to take precedence over dynamic routes eg. '/:id'
+    /// you need to add the dynamic route at the end of the routes
 
     return matchStacks.first;
   }
@@ -537,13 +532,15 @@ class GoRouterDelegate extends RouterDelegate<Uri>
       }
 
       // otherwise recurse
-      final String childRestLoc = loc.substring(match.subloc.length + (match.subloc == '/' ? 0 : 1));
+      final String childRestLoc =
+          loc.substring(match.subloc.length + (match.subloc == '/' ? 0 : 1));
       assert(loc.startsWith(match.subloc));
       assert(restLoc.isNotEmpty);
 
       // if there's no sub-route matches, then we don't have a match for this
       // location
-      final List<List<GoRouteMatch>> subRouteMatchStacks = _getLocRouteMatchStacks(
+      final List<List<GoRouteMatch>> subRouteMatchStacks =
+          _getLocRouteMatchStacks(
         loc: loc,
         restLoc: childRestLoc,
         parentSubloc: match.subloc,
@@ -768,15 +765,18 @@ class GoRouterDelegate extends RouterDelegate<Uri>
       if (elem != null && isMaterialApp(elem)) {
         log.info('MaterialApp found');
         _pageBuilderForAppType = pageBuilderForMaterialApp;
-        _errorBuilderForAppType = (BuildContext c, GoRouterState s) => GoRouterMaterialErrorScreen(s.error);
+        _errorBuilderForAppType = (BuildContext c, GoRouterState s) =>
+            GoRouterMaterialErrorScreen(s.error);
       } else if (elem != null && isCupertinoApp(elem)) {
         log.info('CupertinoApp found');
         _pageBuilderForAppType = pageBuilderForCupertinoApp;
-        _errorBuilderForAppType = (BuildContext c, GoRouterState s) => GoRouterCupertinoErrorScreen(s.error);
+        _errorBuilderForAppType = (BuildContext c, GoRouterState s) =>
+            GoRouterCupertinoErrorScreen(s.error);
       } else {
         log.info('WidgetsApp assumed');
         _pageBuilderForAppType = pageBuilderForWidgetApp;
-        _errorBuilderForAppType = (BuildContext c, GoRouterState s) => GoRouterErrorScreen(s.error);
+        _errorBuilderForAppType =
+            (BuildContext c, GoRouterState s) => GoRouterErrorScreen(s.error);
       }
     }
 
@@ -868,7 +868,9 @@ class GoRouterDelegate extends RouterDelegate<Uri>
     // /profile/ => /profile
     // / => /
     // /login?from=/ => login?from=/
-    canon = canon.endsWith('/') && canon != '/' && !canon.contains('?') ? canon.substring(0, canon.length - 1) : canon;
+    canon = canon.endsWith('/') && canon != '/' && !canon.contains('?')
+        ? canon.substring(0, canon.length - 1)
+        : canon;
 
     // /login/?from=/ => /login?from=/
     // /?from=/ => /?from=/
@@ -880,6 +882,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   static String _addQueryParams(String loc, Map<String, String> queryParams) {
     final Uri uri = Uri.parse(loc);
     assert(uri.queryParameters.isEmpty);
-    return _canonicalUri(Uri(path: uri.path, queryParameters: queryParams).toString());
+    return _canonicalUri(
+        Uri(path: uri.path, queryParameters: queryParams).toString());
   }
 }

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 3.1.0
+version: 3.1.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -275,23 +275,32 @@ void main() {
       }
     });
 
-    test('match too many sub-routes', () {
+    test('return first matching route if too many subroutes', () {
       final List<GoRoute> routes = <GoRoute>[
         GoRoute(
           path: '/',
-          builder: _dummy,
+          builder: (BuildContext context, GoRouterState state) =>
+              const HomeScreen(),
           routes: <GoRoute>[
             GoRoute(
               path: 'foo/bar',
-              builder: _dummy,
+              builder: (BuildContext context, GoRouterState state) =>
+                  const FamilyScreen(''),
+            ),
+            GoRoute(
+              path: 'bar',
+              builder: (BuildContext context, GoRouterState state) =>
+                  const Page1Screen(),
             ),
             GoRoute(
               path: 'foo',
-              builder: _dummy,
+              builder: (BuildContext context, GoRouterState state) =>
+                  const Page2Screen(),
               routes: <GoRoute>[
                 GoRoute(
                   path: 'bar',
-                  builder: _dummy,
+                  builder: (BuildContext context, GoRouterState state) =>
+                      const LoginScreen(),
                 ),
               ],
             ),
@@ -300,10 +309,20 @@ void main() {
       ];
 
       final GoRouter router = _router(routes);
+      router.go('/bar');
+      List<GoRouteMatch> matches = router.routerDelegate.matches;
+      expect(matches, hasLength(2));
+      expect(router.screenFor(matches[1]).runtimeType, Page1Screen);
+
       router.go('/foo/bar');
-      final List<GoRouteMatch> matches = router.routerDelegate.matches;
-      expect(matches, hasLength(1));
-      expect(router.screenFor(matches.first).runtimeType, ErrorScreen);
+      matches = router.routerDelegate.matches;
+      expect(matches, hasLength(2));
+      expect(router.screenFor(matches[1]).runtimeType, FamilyScreen);
+
+      router.go('/foo');
+      matches = router.routerDelegate.matches;
+      expect(matches, hasLength(2));
+      expect(router.screenFor(matches[1]).runtimeType, Page2Screen);
     });
 
     test('router state', () {

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -39,7 +39,7 @@ void main() {
       expect(router.screenFor(matches.first).runtimeType, HomeScreen);
     });
 
-    test('match too many routes', () {
+    test('If there is more than one route to match, use the first match', () {
       final List<GoRoute> routes = <GoRoute>[
         GoRoute(path: '/', builder: _dummy),
         GoRoute(path: '/', builder: _dummy),
@@ -50,7 +50,7 @@ void main() {
       final List<GoRouteMatch> matches = router.routerDelegate.matches;
       expect(matches, hasLength(1));
       expect(matches.first.fullpath, '/');
-      expect(router.screenFor(matches.first).runtimeType, ErrorScreen);
+      expect(router.screenFor(matches.first).runtimeType, DummyScreen);
     });
 
     test('empty path', () {
@@ -424,17 +424,19 @@ void main() {
       expect(router.screenFor(matches.first).runtimeType, FamilyScreen);
     });
 
-    test('match too many routes, ignoring case', () {
+    test('If there is more than one route to match, use the first match.', () {
       final List<GoRoute> routes = <GoRoute>[
+        GoRoute(path: '/', builder: _dummy),
         GoRoute(path: '/page1', builder: _dummy),
-        GoRoute(path: '/PaGe1', builder: _dummy),
+        GoRoute(path: '/page1', builder: _dummy),
+        GoRoute(path: '/:ok', builder: _dummy),
       ];
 
       final GoRouter router = _router(routes);
-      router.go('/PAGE1');
+      router.go('/user');
       final List<GoRouteMatch> matches = router.routerDelegate.matches;
       expect(matches, hasLength(1));
-      expect(router.screenFor(matches.first).runtimeType, ErrorScreen);
+      expect(router.screenFor(matches.first).runtimeType, DummyScreen);
     });
   });
 


### PR DESCRIPTION
Use case
If there is more than one route to match, use the first match.

The following was implemented using go_router.

  ```
final _router = GoRouter(
    routes: [
      GoRoute(
        path: '/home',
        builder: (_, __) => const HomePage(),
        routes: [
          GoRoute(
            path: 'create',
            builder: (_, __) => const CreatePage(),
          ),
          GoRoute(
            path: ':id',
            builder: (_, __) => const DetailPage(),
          ),
      ),
    ],
    urlPathStrategy: UrlPathStrategy.path,
  );
```
I expected the following behavior.

/home/create -> CreatePage
/home/xxxx   -> DetailPage ("xxxx" is some string, but exclude "create")
But I opened /home/create, go_router displayed following error.

Exception: too many routes for location: /home/create
/home => create
/home => :id
go_router uses path_to_regexp internally.
Therefore, perhaps specifying a regular expression could solve this problem. However, we felt that this would not be concise and would be a hassle for the developer.

Fixes : https://github.com/flutter/flutter/issues/99833



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

