### PR TITLE
Pin ci.yaml dependencies.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -33,7 +33,7 @@ targets:
       version_file: flutter_master.version
       dependencies: >
         [
-          {"dependency": "vs_build"}
+          {"dependency": "vs_build", "version": "version:vs2019"}
         ]
 
   - name: Windows dart_unit_tests master - packages
@@ -46,7 +46,7 @@ targets:
       version_file: flutter_master.version
       dependencies: >
         [
-          {"dependency": "vs_build"}
+          {"dependency": "vs_build", "version": "version:vs2019"}
         ]
 
   - name: Windows win32-platform_tests master - packages
@@ -59,7 +59,7 @@ targets:
       version_file: flutter_master.version
       dependencies: >
         [
-          {"dependency": "vs_build"}
+          {"dependency": "vs_build", "version": "version:vs2019"}
         ]
 
   - name: Windows win32-platform_tests stable - packages
@@ -71,7 +71,7 @@ targets:
       channel: stable
       dependencies: >
         [
-          {"dependency": "vs_build"}
+          {"dependency": "vs_build", "version": "version:vs2019"}
         ]
 
   - name: Linux fuchsia_ctl

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -17,7 +17,7 @@ platform_properties:
     properties:
       dependencies: >
         [
-          {"dependency": "certs"}
+          {"dependency": "certs", "version": "version:9563bb"}
         ]
       device_type: none
       os: Windows


### PR DESCRIPTION
## Description of The Issue Being Addressed
The builder config is fragile when dependencies are not pinned to specific versions. Any upstream changes may cause breakage. We should create a test to validate all .ci.yaml dependencies are pinned. This also requires that we pin specific versions for all dependencies.

## Issues Addressed
https://github.com/flutter/flutter/issues/101712

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
