### PR TITLE
Ensure that initialLocation doesn't take precedence over deep-links

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 4.0.2
+
+- Fixes a bug where initialLocation took precedence over deep-links
+
 ## 4.0.1
 
-- Fix a bug where calling setLogging(false) does not clear listeners
+- Fixes a bug where calling setLogging(false) does not clear listeners.
 
 ## 4.0.0
 

--- a/packages/go_router/lib/src/go_router.dart
+++ b/packages/go_router/lib/src/go_router.dart
@@ -46,9 +46,6 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
     setLogging(enabled: debugLogDiagnostics);
     WidgetsFlutterBinding.ensureInitialized();
 
-    final String _effectiveInitialLocation = initialLocation ??
-        // ignore: unnecessary_non_null_assertion
-        WidgetsBinding.instance.platformDispatcher.defaultRouteName;
     routeInformationParser = GoRouteInformationParser(
       routes: routes,
       topRedirect: redirect ?? (_) => null,
@@ -56,8 +53,8 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
       debugRequireGoRouteInformationProvider: true,
     );
     routeInformationProvider = GoRouteInformationProvider(
-        initialRouteInformation:
-            RouteInformation(location: _effectiveInitialLocation),
+        initialRouteInformation: RouteInformation(
+            location: _effectiveInitialLocation(initialLocation)),
         refreshListenable: refreshListenable);
 
     routerDelegate = GoRouterDelegate(
@@ -212,5 +209,17 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
     routeInformationProvider.dispose();
     routerDelegate.dispose();
     super.dispose();
+  }
+
+  String _effectiveInitialLocation(String? initialLocation) {
+    final String platformDefault =
+        WidgetsBinding.instance.platformDispatcher.defaultRouteName;
+    if (initialLocation == null) {
+      return platformDefault;
+    } else if (platformDefault == '/') {
+      return initialLocation;
+    } else {
+      return platformDefault;
+    }
   }
 }

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 4.0.1
+version: 4.0.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -1212,6 +1212,37 @@ void main() {
       );
       expect(router.location, '/');
     });
+
+    testWidgets(
+        'does not take precedence over platformDispatcher.defaultRouteName',
+        (WidgetTester tester) async {
+      TestWidgetsFlutterBinding
+          .instance.platformDispatcher.defaultRouteNameTestValue = '/dummy';
+
+      final List<GoRoute> routes = <GoRoute>[
+        GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) =>
+              const HomeScreen(),
+          routes: <GoRoute>[
+            GoRoute(
+              path: 'dummy',
+              builder: (BuildContext context, GoRouterState state) =>
+                  const DummyScreen(),
+            ),
+          ],
+        ),
+      ];
+
+      final GoRouter router = await _router(
+        routes,
+        tester,
+        initialLocation: '/',
+      );
+      expect(router.routeInformationProvider.value.location, '/dummy');
+      TestWidgetsFlutterBinding
+          .instance.platformDispatcher.defaultRouteNameTestValue = '/';
+    });
   });
 
   group('params', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/106204

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
