### PR TITLE
[pigeon] Remove Dart version from generated code

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+* Removes `@dart = 2.12` from generated Dart code.
+
 ## 3.2.0
 
 * Adds experimental support for Swift generation.
@@ -41,7 +45,7 @@
 ## 3.0.4
 
 * [objc] Simplified some code output, including avoiding Xcode warnings about
-  using `NSNumber*` directly as boolean value.  
+  using `NSNumber*` directly as boolean value.
 * [tests] Moved test script to enable CI.
 
 ## 3.0.3

--- a/packages/pigeon/e2e_tests/test_objc/lib/main.dart
+++ b/packages/pigeon/e2e_tests/test_objc/lib/main.dart
@@ -21,7 +21,7 @@ void main() {
 /// Main widget for the tests.
 class MyApp extends StatelessWidget {
   /// Creates the main widget for the tests.
-  const MyApp({Key key}) : super(key: key);
+  const MyApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +36,7 @@ class MyApp extends StatelessWidget {
 }
 
 class _MyHomePage extends StatefulWidget {
-  const _MyHomePage({Key key, this.title}) : super(key: key);
+  const _MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -53,8 +53,8 @@ class _MyHomePageState extends State<_MyHomePage> {
     final MessageApi api = MessageApi();
     final MessageSearchReply reply = await api.search(request);
     setState(() {
-      _message = reply.result;
-      _state = reply.state;
+      _message = reply.result ?? '(null)';
+      _state = reply.state ?? MessageRequestState.failure;
     });
   }
 

--- a/packages/pigeon/e2e_tests/test_objc/pubspec.yaml
+++ b/packages/pigeon/e2e_tests/test_objc/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   # The following adds the Cupertino Icons font to your application.

--- a/packages/pigeon/e2e_tests/test_objc/pubspec.yaml
+++ b/packages/pigeon/e2e_tests/test_objc/pubspec.yaml
@@ -25,8 +25,9 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  e2e: ^0.4.0
   flutter_test:
+    sdk: flutter
+  integration_test:
     sdk: flutter
 
 # For information on the generic Dart part of this file, see the

--- a/packages/pigeon/e2e_tests/test_objc/test_driver/e2e_test.dart
+++ b/packages/pigeon/e2e_tests/test_objc/test_driver/e2e_test.dart
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
 import 'package:test_objc/dartle.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized();
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   testWidgets('simple call', (WidgetTester tester) async {
     final MessageSearchRequest request = MessageSearchRequest()
       ..query = 'Aaron';
@@ -31,7 +31,7 @@ void main() {
     final MessageSearchRequest request = MessageSearchRequest()
       ..query = 'error';
     final MessageApi api = MessageApi();
-    MessageSearchReply reply;
+    MessageSearchReply? reply;
     expect(() async {
       reply = await api.search(request);
     }, throwsException);

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -423,7 +423,6 @@ void generateDart(DartOptions opt, Root root, StringSink sink) {
     indent.writeln(
       '// ignore_for_file: public_member_api_docs, non_constant_identifier_names, avoid_as, unused_import, unnecessary_parenthesis, prefer_null_aware_operators, omit_local_variable_types, unused_shown_name',
     );
-    indent.writeln('// @dart = 2.12');
   }
 
   void writeEnums() {
@@ -607,7 +606,6 @@ void generateTestDart(
     '// ignore_for_file: public_member_api_docs, non_constant_identifier_names, avoid_as, unused_import, unnecessary_parenthesis',
   );
   indent.writeln('// ignore_for_file: avoid_relative_lib_imports');
-  indent.writeln('// @dart = 2.12');
   indent.writeln('import \'dart:async\';');
   indent.writeln(
     'import \'dart:typed_data\' show Uint8List, Int32List, Int64List, Float64List;',

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -9,7 +9,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '3.2.0';
+const String pigeonVersion = '3.2.1';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 3.2.0 # This must match the version in lib/generator_tools.dart
+version: 3.2.1 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Eliminated `@dart = 2.12` from the generated code since the ecosystem
has reached the point where code that's not explicitly annotated as an
earlier version is generally assumed to be 2.12+.

Fixes https://github.com/flutter/flutter/issues/106526

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
