### PR TITLE
[ci] Roll repo tooling to 0.8.7

### DIFF
--- a/.ci/scripts/prepare_tool.sh
+++ b/.ci/scripts/prepare_tool.sh
@@ -8,4 +8,4 @@ git fetch origin main
 
 # Pinned version of the plugin tools, to avoid breakage in this repository
 # when pushing updates from flutter/plugins.
-dart pub global activate flutter_plugin_tools 0.8.5
+dart pub global activate flutter_plugin_tools 0.8.7

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,15 +104,15 @@ task:
     # version comes out.
     - name: legacy-version-analyze
       depends_on: format+analyze
-      env:
-        matrix:
+      matrix:
+        env:
           CHANNEL: "2.10.5"
+          DART_VERSION: "2.16.2"
+        env:
           CHANNEL: "2.8.1"
+          DART_VERSION: "2.15.1"
       analyze_script:
-        # Exclude:
-        # - flutter_lints: does not depend on flutter, is only constrained by
-        #   Dart SDK version.
-        - ./script/tool_runner.sh analyze --skip-if-not-supporting-flutter-version="$CHANNEL" --custom-analysis=script/configs/custom_analysis.yaml --exclude=flutter_lints
+        - ./script/tool_runner.sh analyze --skip-if-not-supporting-flutter-version="$CHANNEL" --skip-if-not-supporting-dart-version="$DART_VERSION" --custom-analysis=script/configs/custom_analysis.yaml
     - name: publishable
       env:
         # TODO(stuartmorgan): Remove once the fix for https://github.com/dart-lang/pub/issues/3152

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: dart pub global activate flutter_plugin_tools 0.8.5
+      run: dart pub global activate flutter_plugin_tools 0.8.7
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/README.md
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/README.md
@@ -1,8 +1,3 @@
 # extension_google_sign_in_example
 
 Demonstrates how to use the google_sign_in plugin with the `googleapis` package.
-
-## Getting Started
-
-For help getting started with Flutter, view our online
-[documentation](https://flutter.dev/).

--- a/packages/flutter_markdown/example/README.md
+++ b/packages/flutter_markdown/example/README.md
@@ -1,16 +1,3 @@
 # flutter_markdown_example
 
 Demonstrates how to use the flutter_markdown package.
-
-## Getting Started
-
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
-
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.


### PR DESCRIPTION
Picks up the new Dart-SDK-version-based filtering for legacy version testing, and updates the legacy tests to use that instead of excluding non-Flutter packages completely.

Fixes some README boilerplate found by the newer tooling.

No version change: example/README.md isn't published for these plugins.
No CHANGELOG change: Removing boilerplate from example readmes isn't worth noting.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
