### PR TITLE
[go_router] Fix a case-sensitive issue with name in version 4.0.0 or later

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+- Fixes a bug where calling namedLocation does not support case-insensitive way.
+
 ## 4.1.0
 
 - Adds `bool canPop()` to `GoRouterDelegate`, `GoRouter` and `GoRouterHelper`.

--- a/packages/go_router/lib/src/go_route_information_parser.dart
+++ b/packages/go_router/lib/src/go_route_information_parser.dart
@@ -94,8 +94,9 @@ class GoRouteInformationParser
           '${queryParams.isEmpty ? '' : ', queryParams: $queryParams'}');
       return true;
     }());
-    assert(_nameToPath.containsKey(name), 'unknown route name: $name');
-    final String path = _nameToPath[name]!;
+    final String keyName = name.toLowerCase();
+    assert(_nameToPath.containsKey(keyName), 'unknown route name: $name');
+    final String path = _nameToPath[keyName]!;
     assert(() {
       // Check that all required params are present.
       final List<String> paramNames = <String>[];

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 4.1.0
+version: 4.1.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_route_information_parser_test.dart
+++ b/packages/go_router/test/go_route_information_parser_test.dart
@@ -87,8 +87,11 @@ void main() {
     );
 
     expect(parser.namedLocation('lowercase'), '/abc?');
+    expect(parser.namedLocation('lowerCase'), '/abc?');
     expect(parser.namedLocation('camelCase'), '/efg?');
+    expect(parser.namedLocation('camelcase'), '/efg?');
     expect(parser.namedLocation('snake_case'), '/hij?');
+    expect(parser.namedLocation('snake_Case'), '/hij?');
   });
 
   test('GoRouteInformationParser returns error when unknown route', () async {

--- a/packages/go_router/test/go_route_information_parser_test.dart
+++ b/packages/go_router/test/go_route_information_parser_test.dart
@@ -87,11 +87,11 @@ void main() {
     );
 
     expect(parser.namedLocation('lowercase'), '/abc?');
-    expect(parser.namedLocation('lowerCase'), '/abc?');
+    expect(parser.namedLocation('LOWERCASE'), '/abc?');
     expect(parser.namedLocation('camelCase'), '/efg?');
     expect(parser.namedLocation('camelcase'), '/efg?');
     expect(parser.namedLocation('snake_case'), '/hij?');
-    expect(parser.namedLocation('snake_Case'), '/hij?');
+    expect(parser.namedLocation('SNAKE_CASE'), '/hij?');
   });
 
   test('GoRouteInformationParser returns error when unknown route', () async {

--- a/packages/go_router/test/go_route_information_parser_test.dart
+++ b/packages/go_router/test/go_route_information_parser_test.dart
@@ -56,6 +56,41 @@ void main() {
     expect(matches[1].route, routes[0].routes[0]);
   });
 
+  test('GoRouteInformationParser can retrieve route by name', () async {
+    final List<GoRoute> routes = <GoRoute>[
+      GoRoute(
+        path: '/',
+        builder: (_, __) => const Placeholder(),
+        routes: <GoRoute>[
+          GoRoute(
+            path: 'abc',
+            name: 'lowercase',
+            builder: (_, __) => const Placeholder(),
+          ),
+          GoRoute(
+            path: 'efg',
+            name: 'camelCase',
+            builder: (_, __) => const Placeholder(),
+          ),
+          GoRoute(
+            path: 'hij',
+            name: 'snake_case',
+            builder: (_, __) => const Placeholder(),
+          ),
+        ],
+      ),
+    ];
+    final GoRouteInformationParser parser = GoRouteInformationParser(
+      routes: routes,
+      redirectLimit: 100,
+      topRedirect: (_) => null,
+    );
+
+    expect(parser.namedLocation('lowercase'), '/abc?');
+    expect(parser.namedLocation('camelCase'), '/efg?');
+    expect(parser.namedLocation('snake_case'), '/hij?');
+  });
+
   test('GoRouteInformationParser returns error when unknown route', () async {
     final List<GoRoute> routes = <GoRoute>[
       GoRoute(


### PR DESCRIPTION
go_router's namedLocation method supports case-insensitive name.
However, this does not work in go_router 4.0 and later. This PR solves this problem.

https://gorouter.dev/named-routes#navigating-to-named-routes

> The namedLocation method will look up the route by name in a case-insensitive way, construct the URI for you and fill in the params as appropriate. 

Fixes https://github.com/flutter/flutter/issues/106163

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
