### PR TITLE
Switch to autosubmit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       - "stuartmorgan"
       - "ditman"
     labels:
-      - "waiting for tree to go green"
+      - "autosubmit"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The `waiting for tree to go green` label is being deprecated, and `autosubmit` will be used instead.

https://github.com/flutter/flutter/issues/107431