### PR TITLE
Fix for RMS parsing

### DIFF
--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.5 (UNRELEASED)
+## 1.0.5
 
 - Fix JSON parsing issue when running in sound null-safety mode.
 

--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5 (UNRELEASED)
+
+- Fix JSON parsing issue when running in sound null-safety mode.
+
 ## 1.0.4
 
 - Fix un-await-ed Future in `SkiaPerfDestination.update`.

--- a/packages/metrics_center/lib/src/google_benchmark.dart
+++ b/packages/metrics_center/lib/src/google_benchmark.dart
@@ -66,7 +66,7 @@ void _parseAnItem(
 ) {
   final String name = item[kNameKey] as String;
   final Map<String, String> timeUnitMap = <String, String>{
-    kUnitKey: item[_kTimeUnitKey] as String
+    if (item.containsKey(_kTimeUnitKey)) kUnitKey: item[_kTimeUnitKey] as String
   };
   for (final String subResult in item.keys) {
     if (!_kNonNumericalValueSubResults.contains(subResult)) {

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -1,5 +1,5 @@
 name: metrics_center
-version: 1.0.5-dev
+version: 1.0.5
 description:
   Support multiple performance metrics sources/formats and destinations.
 repository: https://github.com/flutter/packages/tree/main/packages/metrics_center

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -1,5 +1,5 @@
 name: metrics_center
-version: 1.0.4
+version: 1.0.5-dev
 description:
   Support multiple performance metrics sources/formats and destinations.
 repository: https://github.com/flutter/packages/tree/main/packages/metrics_center

--- a/packages/metrics_center/test/example_google_benchmark.json
+++ b/packages/metrics_center/test/example_google_benchmark.json
@@ -78,6 +78,33 @@
             "real_coefficient": 6548,
             "big_o": "N",
             "time_unit": "ns"
+        },
+        {
+          "name": "ParagraphFixture/TextBigO_BigO",
+          "family_index": 5,
+          "per_family_instance_index": 0,
+          "run_name": "ParagraphFixture/TextBigO",
+          "run_type": "aggregate",
+          "repetitions": 1,
+          "threads": 1,
+          "aggregate_name": "BigO",
+          "aggregate_unit": "time",
+          "cpu_coefficient": 3.8,
+          "real_coefficient": 3.89,
+          "big_o": "N",
+          "time_unit": "ns"
+        },
+        {
+          "name": "ParagraphFixture/TextBigO_RMS",
+          "family_index": 5,
+          "per_family_instance_index": 0,
+          "run_name": "ParagraphFixture/TextBigO",
+          "run_type": "aggregate",
+          "repetitions": 1,
+          "threads": 1,
+          "aggregate_name": "RMS",
+          "aggregate_unit": "percentage",
+          "rms": 4.89
         }
     ]
 }

--- a/packages/metrics_center/test/google_benchmark_test.dart
+++ b/packages/metrics_center/test/google_benchmark_test.dart
@@ -13,10 +13,10 @@ void main() {
   test('GoogleBenchmarkParser parses example json.', () async {
     final List<MetricPoint> points =
         await GoogleBenchmarkParser.parse('test/example_google_benchmark.json');
-    expect(points.length, 6);
+    expect(points.length, 9);
     expectSetMatch(
       points.map((MetricPoint p) => p.value),
-      <int>[101, 101, 4460, 4460, 6548, 6548],
+      <double>[101, 101, 4460, 4460, 6548, 6548, 3.8, 3.89, 4.89],
     );
     expectSetMatch(
       points.map((MetricPoint p) => p.tags[kSubResultKey]),
@@ -25,6 +25,7 @@ void main() {
         'real_time',
         'cpu_coefficient',
         'real_coefficient',
+        'rms',
       ],
     );
     expectSetMatch(
@@ -33,6 +34,8 @@ void main() {
         'BM_PaintRecordInit',
         'SkParagraphFixture/ShortLayout',
         'SkParagraphFixture/TextBigO_BigO',
+        'ParagraphFixture/TextBigO_BigO',
+        'ParagraphFixture/TextBigO_RMS',
       ],
     );
     for (final MetricPoint p in points) {


### PR DESCRIPTION
The "unit" value can be null for RMS benchmark results.