### PR TITLE
Use correct path to typed routing library

### DIFF
--- a/packages/go_router_builder/lib/src/go_router_generator.dart
+++ b/packages/go_router_builder/lib/src/go_router_generator.dart
@@ -18,7 +18,7 @@ class GoRouterGenerator extends GeneratorForAnnotation<void> {
 
   @override
   TypeChecker get typeChecker => const TypeChecker.fromUrl(
-        'package:go_router/src/route_data.dart#TypedGoRoute',
+        'package:go_router/src/typed_routing.dart#TypedGoRoute',
       );
 
   @override
@@ -82,5 +82,5 @@ ${getters.map((String e) => "$e,").join('\n')}
 }
 
 const TypeChecker _goRouteDataChecker = TypeChecker.fromUrl(
-  'package:go_router/src/route_data.dart#GoRouteData',
+  'package:go_router/src/typed_routing.dart#GoRouteData',
 );


### PR DESCRIPTION
I'm not sure why the unit tests aren't catching this, but we changed the location of the GoRouteData and TypedRoute classes in https://github.com/flutter/packages/pull/2317 so these strings need to be updated to match.

Fixes flutter/flutter#108274