### PR TITLE
[flutter_markdown] Fix horizontal sizing of lists in MarkdownBody

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.10+4
+
+* Fixes MarkdownBody - Lists expand horizontally instead of using only the space they need ([flutter/flutter#108976](https://github.com/flutter/flutter/issues/108976)).
+
 ## 0.6.10+3
 
 * Fixes shrinkWrap not taken into account with single child ([flutter/flutter#105299](https://github.com/flutter/flutter/issues/105299)).

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -106,6 +106,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     this.fitContent = false,
     this.onTapText,
     this.softLineBreak = false,
+    this.expandLists = true,
   });
 
   /// A delegate that controls how link and `pre` elements behave.
@@ -156,6 +157,9 @@ class MarkdownBuilder implements md.NodeVisitor {
   /// Default these spaces are removed in accordance with the Markdown
   /// specification on soft line breaks when lines of text are joined.
   final bool softLineBreak;
+
+  /// Whether lists should expand to use all available horizontal space.
+  final bool expandLists;
 
   final List<String> _listIndents = <String>[];
   final List<_BlockElement> _blocks = <_BlockElement>[];
@@ -391,6 +395,7 @@ class MarkdownBuilder implements md.NodeVisitor {
             bullet = _buildBullet(_listIndents.last);
           }
           child = Row(
+            mainAxisSize: expandLists ? MainAxisSize.max : MainAxisSize.min,
             textBaseline: listItemCrossAxisAlignment ==
                     MarkdownListItemCrossAxisAlignment.start
                 ? null
@@ -406,7 +411,10 @@ class MarkdownBuilder implements md.NodeVisitor {
                     styleSheet.listBulletPadding!.right,
                 child: bullet,
               ),
-              Expanded(child: child)
+              Flexible(
+                fit: expandLists ? FlexFit.tight : FlexFit.loose,
+                child: child,
+              )
             ],
           );
         }

--- a/packages/flutter_markdown/lib/src/widget.dart
+++ b/packages/flutter_markdown/lib/src/widget.dart
@@ -168,6 +168,7 @@ abstract class MarkdownWidget extends StatefulWidget {
     this.listItemCrossAxisAlignment =
         MarkdownListItemCrossAxisAlignment.baseline,
     this.softLineBreak = false,
+    this.expandLists = true,
   }) : super(key: key);
 
   /// The Markdown to display.
@@ -265,6 +266,9 @@ abstract class MarkdownWidget extends StatefulWidget {
   /// specification on soft line breaks when lines of text are joined.
   final bool softLineBreak;
 
+  /// Whether lists should expand to use all available horizontal space.
+  final bool expandLists;
+
   /// Subclasses should override this function to display the given children,
   /// which are the parsed representation of [data].
   @protected
@@ -336,6 +340,7 @@ class _MarkdownWidgetState extends State<MarkdownWidget>
       listItemCrossAxisAlignment: widget.listItemCrossAxisAlignment,
       onTapText: widget.onTapText,
       softLineBreak: widget.softLineBreak,
+      expandLists: widget.expandLists,
     );
 
     _children = builder.build(astNodes);
@@ -413,6 +418,7 @@ class MarkdownBody extends MarkdownWidget {
     this.shrinkWrap = true,
     bool fitContent = true,
     bool softLineBreak = false,
+    bool expandLists = true,
   }) : super(
           key: key,
           data: data,
@@ -434,6 +440,7 @@ class MarkdownBody extends MarkdownWidget {
           bulletBuilder: bulletBuilder,
           fitContent: fitContent,
           softLineBreak: softLineBreak,
+          expandLists: expandLists,
         );
 
   /// If [shrinkWrap] is `true`, [MarkdownBody] will take the minimum height

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.6.10+3
+version: 0.6.10+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/flutter_markdown/test/list_test.dart
+++ b/packages/flutter_markdown/test/list_test.dart
@@ -184,4 +184,52 @@ void defineTests() {
       },
     );
   });
+  
+  group('expandLists', () {
+    testWidgets(
+      'expandLists=true',
+      (WidgetTester tester) async {
+        const String data = '- Foo\n- Bar';
+
+        await tester.pumpWidget(
+          boilerplate(
+            Column(
+              children: const <Widget>[
+                MarkdownBody(expandLists: true, data: data),
+              ],
+            ),
+          ),
+        );
+
+        final double screenWidth = tester.allElements.first.size!.width;
+        final double markdownBodyWidth =
+            find.byType(MarkdownBody).evaluate().single.size!.width;
+
+        expect(markdownBodyWidth, equals(screenWidth));
+      },
+    );
+
+    testWidgets(
+      'expandLists=false',
+      (WidgetTester tester) async {
+        const String data = '- Foo\n- Bar';
+
+        await tester.pumpWidget(
+          boilerplate(
+            Column(
+              children: const <Widget>[
+                MarkdownBody(expandLists: false, data: data),
+              ],
+            ),
+          ),
+        );
+
+        final double screenWidth = tester.allElements.first.size!.width;
+        final double markdownBodyWidth =
+            find.byType(MarkdownBody).evaluate().single.size!.width;
+
+        expect(markdownBodyWidth, lessThan(screenWidth));
+      },
+    );
+  });
 }

--- a/packages/flutter_markdown/test/list_test.dart
+++ b/packages/flutter_markdown/test/list_test.dart
@@ -184,7 +184,7 @@ void defineTests() {
       },
     );
   });
-  
+
   group('expandLists', () {
     testWidgets(
       'expandLists=true',


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/108976

Adds an optional `bool expandLists` to control how lists in `MarkdownBody` are sized horizontally.

Before, only this behavior could be achieved when wrapping a `MarkdownBody` with a `ColoredBox` inside a `Column`:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/39117631/182873991-3d231ac5-b9e2-407e-a0f0-cfdc965b3bd9.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/39117631/182877135-3fdb4084-2900-4f76-9856-f23699afe4b6.png">


Now this behavior can be achieved as well by setting `expandLists` to `false`:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/39117631/182874456-b88c9ef1-527d-4aba-bd83-dbca037f770b.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/39117631/182876593-1a7ae426-dbcf-47dc-987e-3af1b07eec84.png">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
