### PR TITLE
Adds BrowserState to support  parameter in web platform.

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 4.3.0
 
 - Cleans up examples
+- Adds BrowserState to support `extra` parameter in web platform.
 
 ## 4.2.7
 

--- a/packages/go_router/example/README.md
+++ b/packages/go_router/example/README.md
@@ -25,6 +25,11 @@ An example to demonstrate how to navigate using named locations instead of URLs.
 
 An example to demonstrate how to use redirect to handle a sign-in flow.
 
+## [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_parameter.dart)
+`flutter run lib/extra_parameter.dart`
+
+An example to demonstrate how to use extra parameter when navigate between locations.
+
 ## [books app](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/books)
 `flutter run lib/books/main.dart`
 

--- a/packages/go_router/example/README.md
+++ b/packages/go_router/example/README.md
@@ -28,7 +28,7 @@ An example to demonstrate how to use redirect to handle a sign-in flow.
 ## [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_parameter.dart)
 `flutter run lib/extra_parameter.dart`
 
-An example to demonstrate how to use extra parameter when navigate between locations.
+An example to demonstrate how to use extra parameter when navigating between locations.
 
 ## [books app](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/books)
 `flutter run lib/books/main.dart`

--- a/packages/go_router/example/lib/extra_param.dart
+++ b/packages/go_router/example/lib/extra_param.dart
@@ -7,6 +7,11 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+// This scenario demonstrates how to use the extra parameter.
+//
+// The example uses the extra parameter to send addition `fid` along with the
+// URL. The BrowserState is used for supporting web platform.
+
 final Map<String, dynamic> _families = const JsonDecoder().convert('''
 {
   "f1": {
@@ -68,8 +73,8 @@ class App extends StatelessWidget {
             name: 'family',
             path: 'family',
             builder: (BuildContext context, GoRouterState state) {
-              final Map<String, Object> params =
-                  state.extra! as Map<String, String>;
+              final dynamic params = const JsonDecoder()
+                  .convert((state.extra! as BrowserState).jsonString);
               final String fid = params['fid']! as String;
               return FamilyScreen(fid: fid);
             },
@@ -93,8 +98,12 @@ class HomeScreen extends StatelessWidget {
             for (final String fid in _families.keys)
               ListTile(
                 title: Text(_families[fid]['name']),
-                onTap: () => context
-                    .goNamed('family', extra: <String, String>{'fid': fid}),
+                onTap: () {
+                  final BrowserState state = BrowserState(
+                      jsonString: const JsonEncoder()
+                          .convert(<String, String>{'fid': fid}));
+                  context.goNamed('family', extra: state);
+                },
               )
           ],
         ),

--- a/packages/go_router/example/lib/extra_param.dart
+++ b/packages/go_router/example/lib/extra_param.dart
@@ -74,7 +74,7 @@ class App extends StatelessWidget {
             path: 'family',
             builder: (BuildContext context, GoRouterState state) {
               final dynamic params = const JsonDecoder()
-                  .convert((state.extra! as BrowserState).jsonString);
+                  .convert((state.extra! as BrowserState).data);
               final String fid = params['fid']! as String;
               return FamilyScreen(fid: fid);
             },
@@ -100,7 +100,7 @@ class HomeScreen extends StatelessWidget {
                 title: Text(_families[fid]['name']),
                 onTap: () {
                   final BrowserState state = BrowserState(
-                      jsonString: const JsonEncoder()
+                      data: const JsonEncoder()
                           .convert(<String, String>{'fid': fid}));
                   context.goNamed('family', extra: state);
                 },

--- a/packages/go_router/lib/go_router.dart
+++ b/packages/go_router/lib/go_router.dart
@@ -7,6 +7,7 @@
 library go_router;
 
 export 'src/configuration.dart' show GoRouterState, GoRoute;
+export 'src/information_provider.dart' show BrowserState;
 export 'src/misc/extensions.dart';
 export 'src/misc/inherited_router.dart';
 export 'src/misc/refresh_stream.dart';

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -31,6 +31,7 @@ import 'parser.dart';
 ///   }
 /// )
 /// {@end-tool}
+/// ```
 class BrowserState {
   /// Creates an [BrowserState] with a JSON encoded string.
   const BrowserState({required this.jsonString});

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -14,8 +14,8 @@ import 'parser.dart';
 /// using the browser's Back button.
 ///
 /// {@tool snippet}
-/// To create a [BrowserState] with the data, the data must be encoded through
-/// JSON codec.
+/// To create a [BrowserState] with the data, the data must be a string. One
+/// can use JSON codec to encode complex objects to strings.
 ///
 /// ```dart
 /// ElevatedButton(
@@ -33,11 +33,11 @@ import 'parser.dart';
 /// {@end-tool}
 /// ```
 class BrowserState {
-  /// Creates an [BrowserState] with a JSON encoded string.
-  const BrowserState({required this.jsonString});
+  /// Creates an [BrowserState] with a data string.
+  const BrowserState({required this.data});
 
-  /// A JSON encoded string for the data.
-  final String jsonString;
+  /// The data in string format.
+  final String data;
 }
 
 /// The [RouteInformationProvider] created by go_router.
@@ -69,7 +69,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
     Object? effectiveState;
     if (routeInformation.state != null &&
         routeInformation.state is BrowserState) {
-      effectiveState = (routeInformation.state! as BrowserState).jsonString;
+      effectiveState = (routeInformation.state! as BrowserState).data;
     }
     SystemNavigator.routeInformationUpdated(
       location: routeInformation.location!,
@@ -140,7 +140,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
     Object? effectiveState;
     if (routeInformation.state != null && routeInformation.state is String) {
       effectiveState =
-          BrowserState(jsonString: routeInformation.state! as String);
+          BrowserState(data: routeInformation.state! as String);
     }
     _platformReportsNewRouteInformation(RouteInformation(
       location: routeInformation.location,

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -6,12 +6,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'parser.dart';
 
-/// A data class that can be serialized and stored into browser history entry.
+/// A data class that can be serialized and stored in the browser's history.
 ///
 /// Passing an instance of this class into the `extra` parameter makes the
-/// browser store to memorize data in this instance when handling browser
-/// backward and forward button, e.g pressing backward button in a browser will
-/// send back the BrowserState that associated with the URL.
+/// browser store its data along with its associated URL. The browser will
+/// send restore the BrowserState if the user navigates back to the URL
+/// using the browser's Back button.
 ///
 /// {@tool snippet}
 /// To create a [BrowserState] with the data, the data must be encoded through

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -155,7 +155,7 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
   ///
   /// The `extra` provides a different way to send additional data that is not
   /// part of the location string. If the application is targeting web platform,
-  /// consider use [BrowserState] hold the data. See
+  /// consider use [BrowserState] to hold the data. See
   /// [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_param.dart)
   /// for a runnable example.
   void go(String location, {Object? extra}) {

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -152,6 +152,12 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
 
   /// Navigate to a URI location w/ optional query parameters, e.g.
   /// `/family/f2/person/p1?color=blue`
+  ///
+  /// The `extra` provides a different way to send additional data that is not
+  /// part of the location string. If the application is targeting web platform,
+  /// consider use [BrowserState] hold the data. See
+  /// [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_param.dart)
+  /// for a runnable example.
   void go(String location, {Object? extra}) {
     assert(() {
       log.info('going to $location');
@@ -164,6 +170,12 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
   /// Navigate to a named route w/ optional parameters, e.g.
   /// `name='person', params={'fid': 'f2', 'pid': 'p1'}`
   /// Navigate to the named route.
+  ///
+  /// The `extra` provides a different way to send additional data that is not
+  /// part of the location string. If the application is targeting web platform,
+  /// consider use [BrowserState] hold the data. See
+  /// [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_param.dart)
+  /// for a runnable example.
   void goNamed(
     String name, {
     Map<String, String> params = const <String, String>{},
@@ -177,6 +189,12 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
 
   /// Push a URI location onto the page stack w/ optional query parameters, e.g.
   /// `/family/f2/person/p1?color=blue`
+  ///
+  /// The `extra` provides a different way to send additional data that is not
+  /// part of the location string. If the application is targeting web platform,
+  /// consider use [BrowserState] hold the data. See
+  /// [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_param.dart)
+  /// for a runnable example.
   void push(String location, {Object? extra}) {
     assert(() {
       log.info('pushing $location');
@@ -192,6 +210,12 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
 
   /// Push a named route onto the page stack w/ optional parameters, e.g.
   /// `name='person', params={'fid': 'f2', 'pid': 'p1'}`
+  ///
+  /// The `extra` provides a different way to send additional data that is not
+  /// part of the location string. If the application is targeting web platform,
+  /// consider use [BrowserState] hold the data. See
+  /// [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_param.dart)
+  /// for a runnable example.
   void pushNamed(
     String name, {
     Map<String, String> params = const <String, String>{},
@@ -205,6 +229,13 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
 
   /// Replaces the top-most page of the page stack with the given URL location
   /// w/ optional query parameters, e.g. `/family/f2/person/p1?color=blue`.
+  ///
+  ///
+  /// The `extra` provides a different way to send additional data that is not
+  /// part of the location string. If the application is targeting web platform,
+  /// consider use [BrowserState] hold the data. See
+  /// [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_param.dart)
+  /// for a runnable example.
   ///
   /// See also:
   /// * [go] which navigates to the location.
@@ -222,6 +253,12 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
   /// Replaces the top-most page of the page stack with the named route w/
   /// optional parameters, e.g. `name='person', params={'fid': 'f2', 'pid':
   /// 'p1'}`.
+  ///
+  /// The `extra` provides a different way to send additional data that is not
+  /// part of the location string. If the application is targeting web platform,
+  /// consider use [BrowserState] hold the data. See
+  /// [Extra parameter](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_param.dart)
+  /// for a runnable example.
   ///
   /// See also:
   /// * [goNamed] which navigates a named route.

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 4.2.7
+version: 4.3.0
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/information_provider_test.dart
+++ b/packages/go_router/test/information_provider_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/src/information_provider.dart';
@@ -13,18 +16,107 @@ void main() {
   group('GoRouteInformationProvider', () {
     testWidgets('notifies its listeners when set by the app',
         (WidgetTester tester) async {
-      late final GoRouteInformationProvider provider =
+      final GoRouteInformationProvider provider =
           GoRouteInformationProvider(initialRouteInformation: initialRoute);
       provider.addListener(expectAsync0(() {}));
       provider.value = newRoute;
+      provider.dispose();
     });
 
     testWidgets('notifies its listeners when set by the platform',
         (WidgetTester tester) async {
-      late final GoRouteInformationProvider provider =
+      final GoRouteInformationProvider provider =
           GoRouteInformationProvider(initialRouteInformation: initialRoute);
       provider.addListener(expectAsync0(() {}));
       provider.didPushRouteInformation(newRoute);
+      provider.dispose();
+    });
+
+    testWidgets('updates route information', (WidgetTester tester) async {
+      final List<MethodCall> log = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.navigation,
+              (MethodCall methodCall) async {
+        log.add(methodCall);
+        return null;
+      });
+      late final GoRouteInformationProvider provider =
+          GoRouteInformationProvider(
+              initialRouteInformation: const RouteInformation(location: '/'));
+
+      log.clear();
+      final String jsonString1 =
+          const JsonEncoder().convert(<String, String>{'1': '2'});
+      provider.routerReportsNewRouteInformation(RouteInformation(
+          location: '/a', state: BrowserState(jsonString: jsonString1)));
+      // Implicit reporting pushes new history entry if the location changes.
+      expect(log, <Object>[
+        isMethodCall('selectMultiEntryHistory', arguments: null),
+        isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{
+          'location': '/a',
+          'state': jsonString1,
+          'replace': false
+        }),
+      ]);
+      log.clear();
+      final String jsonString2 =
+          const JsonEncoder().convert(<String, String>{'2': '3'});
+      provider.routerReportsNewRouteInformation(RouteInformation(
+          location: '/a', state: BrowserState(jsonString: jsonString2)));
+      // Since the location is the same, the provider sends replaces message.
+      expect(log, <Object>[
+        isMethodCall('selectMultiEntryHistory', arguments: null),
+        isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{
+          'location': '/a',
+          'state': jsonString2,
+          'replace': true
+        }),
+      ]);
+
+      log.clear();
+      provider.routerReportsNewRouteInformation(
+          const RouteInformation(location: '/a', state: false),
+          type: RouteInformationReportingType.neglect);
+      // If the state is not a BrowserState, GoRouteInformationProvider will not report.
+      expect(log, <Object>[
+        isMethodCall('selectMultiEntryHistory', arguments: null),
+        isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{
+          'location': '/a',
+          'state': null,
+          'replace': true
+        }),
+      ]);
+    });
+
+    testWidgets('can convert browser state', (WidgetTester tester) async {
+      final GoRouteInformationProvider provider = GoRouteInformationProvider(
+        initialRouteInformation: const RouteInformation(
+          location: 'initial',
+        ),
+      );
+      RouteInformation? notifiedInformation;
+      provider.addListener(() {
+        notifiedInformation = provider.value;
+      });
+
+      final String jsonString =
+          const JsonEncoder().convert(<String, String>{'1': '2'});
+      const String newLocation = 'testRouteName';
+      // Pushes through the `pushRouteInformation` in the navigation method channel.
+      final Map<String, dynamic> testRouteInformation = <String, dynamic>{
+        'location': newLocation,
+        'state': jsonString,
+      };
+      final ByteData routerMessage = const JSONMethodCodec().encodeMethodCall(
+        MethodCall('pushRouteInformation', testRouteInformation),
+      );
+      await tester.binding.defaultBinaryMessenger
+          .handlePlatformMessage('flutter/navigation', routerMessage, (_) {});
+      expect(notifiedInformation, isNotNull);
+      expect(notifiedInformation!.location, newLocation);
+      expect(notifiedInformation!.state, isA<BrowserState>());
+      expect(
+          (notifiedInformation!.state! as BrowserState).jsonString, jsonString);
     });
   });
 }

--- a/packages/go_router/test/information_provider_test.dart
+++ b/packages/go_router/test/information_provider_test.dart
@@ -48,7 +48,7 @@ void main() {
       final String jsonString1 =
           const JsonEncoder().convert(<String, String>{'1': '2'});
       provider.routerReportsNewRouteInformation(RouteInformation(
-          location: '/a', state: BrowserState(jsonString: jsonString1)));
+          location: '/a', state: BrowserState(data: jsonString1)));
       // Implicit reporting pushes new history entry if the location changes.
       expect(log, <Object>[
         isMethodCall('selectMultiEntryHistory', arguments: null),
@@ -62,7 +62,7 @@ void main() {
       final String jsonString2 =
           const JsonEncoder().convert(<String, String>{'2': '3'});
       provider.routerReportsNewRouteInformation(RouteInformation(
-          location: '/a', state: BrowserState(jsonString: jsonString2)));
+          location: '/a', state: BrowserState(data: jsonString2)));
       // Since the location is the same, the provider sends replaces message.
       expect(log, <Object>[
         isMethodCall('selectMultiEntryHistory', arguments: null),
@@ -116,7 +116,7 @@ void main() {
       expect(notifiedInformation!.location, newLocation);
       expect(notifiedInformation!.state, isA<BrowserState>());
       expect(
-          (notifiedInformation!.state! as BrowserState).jsonString, jsonString);
+          (notifiedInformation!.state! as BrowserState).data, jsonString);
     });
   });
 }


### PR DESCRIPTION
Previously the extra parameter is not stored in browser session. When the browser backward and forward, it only sends url to the GoRouter without extra parameter. It may crash if the the page expecting a extra parameter to build. This pr fixes it by introducing a new class BrowserState. If GoRouter sees this BrwoserState in the extra parameter, it will send it over to the browser so that the backward and forward can sends the same BrowserState back for the page.

fixes https://github.com/flutter/flutter/issues/109404

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
