### PR TITLE
[go_router] Fixes namedLocation to return URIs without trailing quest…

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,10 +1,11 @@
-## NEXT
+## 4.2.8
 
-- Cleans up examples
+- Fixes namedLocation to return URIs without trailing question marks if there are no query parameters.
+- Cleans up examples.
 
 ## 4.2.7
 
-- Update README
+- Updates README.
 
 ## 4.2.6
 

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -80,7 +80,10 @@ class RouteConfiguration {
         param.key: Uri.encodeComponent(param.value)
     };
     final String location = patternToPath(path, encodedParams);
-    return Uri(path: location, queryParameters: queryParams).toString();
+    return Uri(
+            path: location,
+            queryParameters: queryParams.isEmpty ? null : queryParams)
+        .toString();
   }
 
   @override

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 4.2.7
+version: 4.2.8
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/parser_test.dart
+++ b/packages/go_router/test/parser_test.dart
@@ -92,12 +92,26 @@ void main() {
       topRedirect: (_) => null,
     );
 
-    expect(configuration.namedLocation('lowercase'), '/abc?');
-    expect(configuration.namedLocation('LOWERCASE'), '/abc?');
-    expect(configuration.namedLocation('camelCase'), '/efg?');
-    expect(configuration.namedLocation('camelcase'), '/efg?');
-    expect(configuration.namedLocation('snake_case'), '/hij?');
-    expect(configuration.namedLocation('SNAKE_CASE'), '/hij?');
+    expect(configuration.namedLocation('lowercase'), '/abc');
+    expect(configuration.namedLocation('LOWERCASE'), '/abc');
+    expect(configuration.namedLocation('camelCase'), '/efg');
+    expect(configuration.namedLocation('camelcase'), '/efg');
+    expect(configuration.namedLocation('snake_case'), '/hij');
+    expect(configuration.namedLocation('SNAKE_CASE'), '/hij');
+
+    // With query parameters
+    expect(
+        configuration
+            .namedLocation('lowercase', queryParams: const <String, String>{}),
+        '/abc');
+    expect(
+        configuration.namedLocation('lowercase',
+            queryParams: const <String, String>{'q': '1'}),
+        '/abc?q=1');
+    expect(
+        configuration.namedLocation('lowercase',
+            queryParams: const <String, String>{'q': '1', 'g': '2'}),
+        '/abc?q=1&g=2');
   });
 
   test('GoRouteInformationParser returns error when unknown route', () async {


### PR DESCRIPTION
…ion marks if there are no query parameters.

fixes https://github.com/flutter/flutter/issues/106605

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
