### PR TITLE
[ci] Migrate Cirrus tests to Apple Silicon

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ macos_template: &MACOS_TEMPLATE
 macos_intel_template: &MACOS_INTEL_TEMPLATE
   << : *MACOS_TEMPLATE
   osx_instance:
-    image: big-sur-xcode-13
+    image: monterey-xcode-13.3
 
 macos_arm_template: &MACOS_ARM_TEMPLATE
   << : *MACOS_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,14 @@ macos_template: &MACOS_TEMPLATE
   # Only one macOS task can run in parallel without credits, so use them for
   # PRs on macOS.
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  # Run tasks on Apple Silicon.
+
+macos_intel_template: &MACOS_INTEL_TEMPLATE
+  << : *MACOS_TEMPLATE
+  osx_instance:
+    image: big-sur-xcode-13
+
+macos_arm_template: &MACOS_ARM_TEMPLATE
+  << : *MACOS_TEMPLATE
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:13.4
 
@@ -232,11 +239,11 @@ task:
         - ./script/tool_runner.sh native-test --linux --no-integration
 
 task:
-  << : *MACOS_TEMPLATE
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
    ### iOS tasks ###
     - name: ios-platform_tests
+      << : *MACOS_ARM_TEMPLATE
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -250,6 +257,8 @@ task:
       native_test_script:
         - ./script/tool_runner.sh native-test --ios --ios-destination "platform=iOS Simulator,name=iPhone 13,OS=latest"
     - name: ios-custom_package_tests
+      # Run on macOS x64 image with Java runtime installed.
+      << : *MACOS_INTEL_TEMPLATE
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -267,6 +276,7 @@ task:
         - fi
     ### macOS desktop tasks ###
     - name: macos-platform_tests
+      << : *MACOS_ARM_TEMPLATE
       env:
         matrix:
           CHANNEL: "master"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,8 +25,9 @@ macos_template: &MACOS_TEMPLATE
   # Only one macOS task can run in parallel without credits, so use them for
   # PRs on macOS.
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  osx_instance:
-    image: big-sur-xcode-13
+  # Run tasks on Apple Silicon.
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:13.4
 
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   upgrade_flutter_script:
@@ -243,11 +244,11 @@ task:
           CHANNEL: "stable"
       create_simulator_script:
         - xcrun simctl list
-        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-15-0 | xargs xcrun simctl boot
+        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-13 com.apple.CoreSimulator.SimRuntime.iOS-15-5 | xargs xcrun simctl boot
       build_script:
         - ./script/tool_runner.sh build-examples --ios
       native_test_script:
-        - ./script/tool_runner.sh native-test --ios --ios-destination "platform=iOS Simulator,name=iPhone 11,OS=latest"
+        - ./script/tool_runner.sh native-test --ios --ios-destination "platform=iOS Simulator,name=iPhone 13,OS=latest"
     - name: ios-custom_package_tests
       env:
         PATH: $PATH:/usr/local/bin


### PR DESCRIPTION
Run `ios-platform_tests` and `macos-platform_tests` on Apple Silicon Macs.  Keep `ios-custom_package_tests` on Intel for now until Java installation https://github.com/flutter/flutter/issues/109821 can be resolved.
Upgrade to macOS 12 Monterey and latest available Xcode 13.

Apple Silicon image options at https://github.com/cirruslabs/macos-image-templates/pkgs/container/macos-monterey-xcode

Fixes https://github.com/flutter/flutter/issues/109819
See also plugin version of this at https://github.com/flutter/plugins/pull/5794

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
