### PR TITLE
Add a link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Additional resources specific to the packages repository:
   which covers the setup process for this repository.
 - [Packages repository structure](https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure),
   to get an overview of how this repository is laid out.
+- [Contributing to Plugins and Packages](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages),
+  for more information about how to make PRs for this repository.
 
 ## Notes
 


### PR DESCRIPTION
The "Contributing to Plugins and Packages" wiki page consolidates a lot of information specific to contributing to flutter/plugins and flutter/packages, but I forgot to link to it here when I added it to flutter/plugins.