### PR TITLE
[ci] Move remaining macOS tests to ARM

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,14 +25,6 @@ macos_template: &MACOS_TEMPLATE
   # Only one macOS task can run in parallel without credits, so use them for
   # PRs on macOS.
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-
-macos_intel_template: &MACOS_INTEL_TEMPLATE
-  << : *MACOS_TEMPLATE
-  osx_instance:
-    image: monterey-xcode-13.3
-
-macos_arm_template: &MACOS_ARM_TEMPLATE
-  << : *MACOS_TEMPLATE
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:13.4.1
 
@@ -240,7 +232,7 @@ task:
 
 task:
   << : *FLUTTER_UPGRADE_TEMPLATE
-  << : *MACOS_ARM_TEMPLATE
+  << : *MACOS_TEMPLATE
   matrix:
    ### iOS tasks ###
     - name: ios-platform_tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,7 +34,7 @@ macos_intel_template: &MACOS_INTEL_TEMPLATE
 macos_arm_template: &MACOS_ARM_TEMPLATE
   << : *MACOS_TEMPLATE
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode:13.4
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:13.4.1
 
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   upgrade_flutter_script:
@@ -240,10 +240,10 @@ task:
 
 task:
   << : *FLUTTER_UPGRADE_TEMPLATE
+  << : *MACOS_ARM_TEMPLATE
   matrix:
    ### iOS tasks ###
     - name: ios-platform_tests
-      << : *MACOS_ARM_TEMPLATE
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -258,7 +258,6 @@ task:
         - ./script/tool_runner.sh native-test --ios --ios-destination "platform=iOS Simulator,name=iPhone 13,OS=latest"
     - name: ios-custom_package_tests
       # Run on macOS x64 image with Java runtime installed.
-      << : *MACOS_INTEL_TEMPLATE
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -276,7 +275,6 @@ task:
         - fi
     ### macOS desktop tasks ###
     - name: macos-platform_tests
-      << : *MACOS_ARM_TEMPLATE
       env:
         matrix:
           CHANNEL: "master"


### PR DESCRIPTION
Updates to the new ARM image that contains Java, and switches to using
that for all macOS tests.

Fixes https://github.com/flutter/flutter/issues/109821