### PR TITLE
[CI] Add labels to version check

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,7 +142,7 @@ task:
         -   ./script/tool_runner.sh version-check
         - else
         -   echo "$CIRRUS_CHANGE_MESSAGE" > "$CHANGE_DESC"
-        -   ./script/tool_runner.sh version-check --check-for-missing-changes --change-description-file="$CHANGE_DESC"
+        -   ./script/tool_runner.sh version-check --check-for-missing-changes --change-description-file="$CHANGE_DESC" --pr-labels="$CIRRUS_PR_LABELS"
         - fi
       publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
       depends_on:


### PR DESCRIPTION
Passes the labels to the version check change so that overrides work. I missed this when rolling the tooling to pick up the new label-based system.