### PR TITLE
[animations] Fixes shadow when theme uses material3.

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -315,6 +315,8 @@ class _OpenContainerState<T> extends State<OpenContainer<T?>> {
           clipBehavior: widget.clipBehavior,
           color: widget.closedColor,
           elevation: widget.closedElevation,
+          // For compatibility during the M3 migration the default shadow needs to be passed.
+          shadowColor: Theme.of(context).useMaterial3 ? Theme.of(context).shadowColor : null,
           shape: widget.closedShape,
           child: Builder(
             key: _closedBuilderKey,

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -316,7 +316,9 @@ class _OpenContainerState<T> extends State<OpenContainer<T?>> {
           color: widget.closedColor,
           elevation: widget.closedElevation,
           // For compatibility during the M3 migration the default shadow needs to be passed.
-          shadowColor: Theme.of(context).useMaterial3 ? Theme.of(context).shadowColor : null,
+          shadowColor: Theme.of(context).useMaterial3
+              ? Theme.of(context).shadowColor
+              : null,
           shape: widget.closedShape,
           child: Builder(
             key: _closedBuilderKey,


### PR DESCRIPTION
This change makes elevation's shadow visible when using material3 theme.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
