### PR TITLE
[ci] Roll repo tooling to 0.9.2

### DIFF
--- a/.ci/scripts/prepare_tool.sh
+++ b/.ci/scripts/prepare_tool.sh
@@ -8,4 +8,4 @@ git fetch origin main
 
 # Pinned version of the plugin tools, to avoid breakage in this repository
 # when pushing updates from flutter/plugins.
-dart pub global activate flutter_plugin_tools 0.9.1
+dart pub global activate flutter_plugin_tools 0.9.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: dart pub global activate flutter_plugin_tools 0.9.1
+      run: dart pub global activate flutter_plugin_tools 0.9.2
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests

--- a/packages/standard_message_codec/CHANGELOG.md
+++ b/packages/standard_message_codec/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+3
+
+* Minor README updates.
+
 ## 0.0.1+2
 
 * Fixes lint warnings.

--- a/packages/standard_message_codec/README.md
+++ b/packages/standard_message_codec/README.md
@@ -1,3 +1,5 @@
+<?code-excerpt path-base="excerpts/packages/standard_message_codec_examples"?>
+
 An efficient and schemaless binary format used by the Flutter SDK.
 
 ## Features
@@ -43,7 +45,8 @@ or pure Dart applications.
 <?code-excerpt "readme_excerpts.dart (Encoding)"?>
 ```dart
 void main() {
-  final ByteData? data = const StandardMessageCodec().encodeMessage(<Object, Object>{
+  final ByteData? data =
+      const StandardMessageCodec().encodeMessage(<Object, Object>{
     'foo': true,
     3: 'fizz',
   });

--- a/packages/standard_message_codec/example/build.excerpt.yaml
+++ b/packages/standard_message_codec/example/build.excerpt.yaml
@@ -1,0 +1,16 @@
+targets:
+  $default:
+    sources:
+      include:
+        - lib/**
+        # Some default includes that aren't really used here but will prevent
+        # false-negative warnings:
+        - $package$
+        - lib/$lib$
+      exclude:
+        - '**/.*/**'
+        - '**/build/**'
+    builders:
+      code_excerpter|code_excerpter:
+        enabled: true
+        

--- a/packages/standard_message_codec/example/lib/readme_excerpts.dart
+++ b/packages/standard_message_codec/example/lib/readme_excerpts.dart
@@ -7,11 +7,10 @@
 
 // ignore_for_file: avoid_print
 
-// #docregion Encoding
 import 'dart:typed_data';
 import 'package:standard_message_codec/standard_message_codec.dart';
-// #enddocregion Encoding
 
+// #docregion Encoding
 void main() {
   final ByteData? data =
       const StandardMessageCodec().encodeMessage(<Object, Object>{
@@ -20,3 +19,4 @@ void main() {
   });
   print('The encoded message is $data');
 }
+// #enddocregion Encoding

--- a/packages/standard_message_codec/example/pubspec.yaml
+++ b/packages/standard_message_codec/example/pubspec.yaml
@@ -9,3 +9,6 @@ environment:
 dependencies:
   standard_message_codec:
     path: ../
+
+dev_dependencies:
+  build_runner: ^2.1.10

--- a/packages/standard_message_codec/pubspec.yaml
+++ b/packages/standard_message_codec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: standard_message_codec
 description: An efficient and schemaless binary encoding format for Flutter and Dart.
-version: 0.0.1+2
+version: 0.0.1+3
 repository: https://github.com/flutter/packages/tree/main/packages/standard_message_codec
 issue_tracker:  https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Astandard_message_codec
 


### PR DESCRIPTION
Updates the repo tooling to 0.9.2 to pick up improved validation of `code-excerpt` use.

Fixes `standard_message_codec` to actually set up and use `code-excerpt`, so that the improved checks pass.

Part of https://github.com/flutter/flutter/issues/109231

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
