### PR TITLE
Implement RouteConfig interface introduced in Flutter 3.3

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 5.0.0
 
 - Fixes a bug where intermediate route redirect methods are not called.
+- GoRouter implements the RouterConfig interface, allowing you to call
+  MaterialApp.router(routerConfig: _myGoRouter) instead of passing
+  the RouterDelegate, RouteInformationParser, and RouteInformationProvider
+  fields.
 - **BREAKING CHANGE**
   - Redesigns redirection API, adds asynchronous feature, and adds build context to redirect.
   - Removes GoRouterRefreshStream

--- a/packages/go_router/README.md
+++ b/packages/go_router/README.md
@@ -24,9 +24,7 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
-      routeInformationProvider: _router.routeInformationProvider,
-      routeInformationParser: _router.routeInformationParser,
-      routerDelegate: _router.routerDelegate,
+      routerConfig: _router,
       title: 'GoRouter Example',
     );
   }
@@ -100,9 +98,7 @@ final GoRouter _router = GoRouter(
 );
 
 MaterialApp.router(
-  routeInformationProvider: _router.routeInformationProvider,
-  routeInformationParser: _router.routeInformationParser,
-  routerDelegate: _router.routerDelegate,
+  routerConfig: _router,
 );
 ```
 

--- a/packages/go_router/example/lib/main.dart
+++ b/packages/go_router/example/lib/main.dart
@@ -26,9 +26,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/lib/named_routes.dart
+++ b/packages/go_router/example/lib/named_routes.dart
@@ -61,9 +61,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
         debugShowCheckedModeBanner: false,
       );

--- a/packages/go_router/example/lib/others/error_screen.dart
+++ b/packages/go_router/example/lib/others/error_screen.dart
@@ -17,9 +17,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/lib/others/extra_param.dart
+++ b/packages/go_router/example/lib/others/extra_param.dart
@@ -53,9 +53,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/lib/others/init_loc.dart
+++ b/packages/go_router/example/lib/others/init_loc.dart
@@ -17,9 +17,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/lib/others/nav_observer.dart
+++ b/packages/go_router/example/lib/others/nav_observer.dart
@@ -18,9 +18,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/lib/others/push.dart
+++ b/packages/go_router/example/lib/others/push.dart
@@ -17,9 +17,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/lib/others/router_neglect.dart
+++ b/packages/go_router/example/lib/others/router_neglect.dart
@@ -17,9 +17,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/lib/others/state_restoration.dart
+++ b/packages/go_router/example/lib/others/state_restoration.dart
@@ -32,9 +32,7 @@ class _AppState extends State<App> with RestorationMixin {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: App.title,
         restorationScopeId: 'app',
       );

--- a/packages/go_router/example/lib/others/transitions.dart
+++ b/packages/go_router/example/lib/others/transitions.dart
@@ -17,9 +17,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/lib/path_and_query_parameters.dart
+++ b/packages/go_router/example/lib/path_and_query_parameters.dart
@@ -62,9 +62,7 @@ class App extends StatelessWidget {
   // add the login info into the tree as app state that can change over time
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
         debugShowCheckedModeBanner: false,
       );

--- a/packages/go_router/example/lib/redirection.dart
+++ b/packages/go_router/example/lib/redirection.dart
@@ -51,9 +51,7 @@ class App extends StatelessWidget {
   Widget build(BuildContext context) => ChangeNotifierProvider<LoginInfo>.value(
         value: _loginInfo,
         child: MaterialApp.router(
-          routeInformationProvider: _router.routeInformationProvider,
-          routeInformationParser: _router.routeInformationParser,
-          routerDelegate: _router.routerDelegate,
+          routerConfig: _router,
           title: title,
           debugShowCheckedModeBanner: false,
         ),

--- a/packages/go_router/example/lib/sub_routes.dart
+++ b/packages/go_router/example/lib/sub_routes.dart
@@ -29,9 +29,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routeInformationProvider: _router.routeInformationProvider,
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
         title: title,
       );
 

--- a/packages/go_router/example/pubspec.yaml
+++ b/packages/go_router/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=3.3.0-0.5.pre"
+  flutter: ">=3.1.0-0.0.pre.2106"
 
 dependencies:
   adaptive_dialog: ^1.2.0

--- a/packages/go_router/example/pubspec.yaml
+++ b/packages/go_router/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.3.0-0.5.pre"
 
 dependencies:
   adaptive_dialog: ^1.2.0

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -59,7 +59,7 @@ class GoRouter extends ChangeNotifier
     List<NavigatorObserver>? observers,
     bool debugLogDiagnostics = false,
     String? restorationScopeId,
-    this.backButtonDispatcher,
+    BackButtonDispatcher? backButtonDispatcher,
   }) {
     setLogging(enabled: debugLogDiagnostics);
     WidgetsFlutterBinding.ensureInitialized();
@@ -99,6 +99,10 @@ class GoRouter extends ChangeNotifier
         child: nav,
       ),
     );
+
+    this.backButtonDispatcher =
+        backButtonDispatcher ?? RootBackButtonDispatcher();
+
     assert(() {
       log.info('setting initial location $initialLocation');
       return true;
@@ -111,7 +115,7 @@ class GoRouter extends ChangeNotifier
   late final GoRouteInformationProvider _routeInformationProvider;
 
   @override
-  final BackButtonDispatcher? backButtonDispatcher;
+  late final BackButtonDispatcher? backButtonDispatcher;
 
   /// The router delegate. Provide this to the MaterialApp or CupertinoApp's
   /// `.router()` constructor

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -59,8 +59,7 @@ class GoRouter extends ChangeNotifier
     List<NavigatorObserver>? observers,
     bool debugLogDiagnostics = false,
     String? restorationScopeId,
-    BackButtonDispatcher? backButtonDispatcher,
-  }) {
+  }) : backButtonDispatcher = RootBackButtonDispatcher() {
     setLogging(enabled: debugLogDiagnostics);
     WidgetsFlutterBinding.ensureInitialized();
 
@@ -100,9 +99,6 @@ class GoRouter extends ChangeNotifier
       ),
     );
 
-    this.backButtonDispatcher =
-        backButtonDispatcher ?? RootBackButtonDispatcher();
-
     assert(() {
       log.info('setting initial location $initialLocation');
       return true;
@@ -115,7 +111,7 @@ class GoRouter extends ChangeNotifier
   late final GoRouteInformationProvider _routeInformationProvider;
 
   @override
-  late final BackButtonDispatcher? backButtonDispatcher;
+  final BackButtonDispatcher backButtonDispatcher;
 
   /// The router delegate. Provide this to the MaterialApp or CupertinoApp's
   /// `.router()` constructor
@@ -319,5 +315,4 @@ class GoRouter extends ChangeNotifier
       return platformDefault;
     }
   }
-
 }

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -8,6 +8,7 @@ import 'configuration.dart';
 import 'delegate.dart';
 import 'information_provider.dart';
 import 'logging.dart';
+import 'match.dart';
 import 'matching.dart';
 import 'misc/inherited_router.dart';
 import 'parser.dart';
@@ -37,7 +38,9 @@ import 'typedefs.dart';
 ///  * [GoRoute], which provides APIs to define the routing table.
 ///  * [examples](https://github.com/flutter/packages/tree/main/packages/go_router/example),
 ///    which contains examples for different routing scenarios.
-class GoRouter extends ChangeNotifier with NavigatorObserver {
+class GoRouter extends ChangeNotifier
+    with NavigatorObserver
+    implements RouterConfig<RouteMatchList> {
   /// Default constructor to configure a GoRouter with a routes builder
   /// and an error page builder.
   ///
@@ -56,6 +59,7 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
     List<NavigatorObserver>? observers,
     bool debugLogDiagnostics = false,
     String? restorationScopeId,
+    this.backButtonDispatcher,
   }) {
     setLogging(enabled: debugLogDiagnostics);
     WidgetsFlutterBinding.ensureInitialized();
@@ -105,6 +109,9 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
   late final GoRouteInformationParser _routeInformationParser;
   late final GoRouterDelegate _routerDelegate;
   late final GoRouteInformationProvider _routeInformationProvider;
+
+  @override
+  final BackButtonDispatcher? backButtonDispatcher;
 
   /// The router delegate. Provide this to the MaterialApp or CupertinoApp's
   /// `.router()` constructor
@@ -308,4 +315,5 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
       return platformDefault;
     }
   }
+
 }

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -8,7 +8,6 @@ import 'configuration.dart';
 import 'delegate.dart';
 import 'information_provider.dart';
 import 'logging.dart';
-import 'match.dart';
 import 'matching.dart';
 import 'misc/inherited_router.dart';
 import 'parser.dart';
@@ -115,13 +114,16 @@ class GoRouter extends ChangeNotifier
 
   /// The router delegate. Provide this to the MaterialApp or CupertinoApp's
   /// `.router()` constructor
+  @override
   GoRouterDelegate get routerDelegate => _routerDelegate;
 
   /// The route information provider used by [GoRouter].
+  @override
   GoRouteInformationProvider get routeInformationProvider =>
       _routeInformationProvider;
 
   /// The route information parser used by [GoRouter].
+  @override
   GoRouteInformationParser get routeInformationParser =>
       _routeInformationParser;
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.3.0-0.5.pre"
+  flutter: ">=3.1.0-0.0.pre.2106"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.1.0-0.0.pre.2106"
+  flutter: ">=3.3.0-0.5.pre"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/go_router/test/custom_transition_page_test.dart
+++ b/packages/go_router/test/custom_transition_page_test.dart
@@ -24,9 +24,7 @@ void main() {
     );
     await tester.pumpWidget(
       MaterialApp.router(
-        routeInformationProvider: router.routeInformationProvider,
-        routeInformationParser: router.routeInformationParser,
-        routerDelegate: router.routerDelegate,
+        routerConfig: router,
         title: 'GoRouter Example',
       ),
     );

--- a/packages/go_router/test/delegate_test.dart
+++ b/packages/go_router/test/delegate_test.dart
@@ -25,9 +25,8 @@ Future<GoRouter> createGoRouter(
     refreshListenable: refreshListenable,
   );
   await tester.pumpWidget(MaterialApp.router(
-      routeInformationProvider: router.routeInformationProvider,
-      routeInformationParser: router.routeInformationParser,
-      routerDelegate: router.routerDelegate));
+    routerConfig: router,
+  ));
   return router;
 }
 
@@ -125,9 +124,7 @@ void main() {
         );
         await tester.pumpWidget(
           MaterialApp.router(
-            routeInformationProvider: goRouter.routeInformationProvider,
-            routeInformationParser: goRouter.routeInformationParser,
-            routerDelegate: goRouter.routerDelegate,
+            routerConfig: goRouter,
           ),
         );
 
@@ -177,9 +174,7 @@ void main() {
         );
         await tester.pumpWidget(
           MaterialApp.router(
-            routeInformationProvider: goRouter.routeInformationProvider,
-            routeInformationParser: goRouter.routeInformationParser,
-            routerDelegate: goRouter.routerDelegate,
+            routerConfig: goRouter,
           ),
         );
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -1836,9 +1836,7 @@ void main() {
           GoRouterNamedLocationSpy(routes: routes);
       await tester.pumpWidget(
         MaterialApp.router(
-          routeInformationProvider: router.routeInformationProvider,
-          routeInformationParser: router.routeInformationParser,
-          routerDelegate: router.routerDelegate,
+          routerConfig: router,
           title: 'GoRouter Example',
         ),
       );
@@ -1856,9 +1854,7 @@ void main() {
       final GoRouterGoSpy router = GoRouterGoSpy(routes: routes);
       await tester.pumpWidget(
         MaterialApp.router(
-          routeInformationProvider: router.routeInformationProvider,
-          routeInformationParser: router.routeInformationParser,
-          routerDelegate: router.routerDelegate,
+          routerConfig: router,
           title: 'GoRouter Example',
         ),
       );
@@ -1875,9 +1871,7 @@ void main() {
       final GoRouterGoNamedSpy router = GoRouterGoNamedSpy(routes: routes);
       await tester.pumpWidget(
         MaterialApp.router(
-          routeInformationProvider: router.routeInformationProvider,
-          routeInformationParser: router.routeInformationParser,
-          routerDelegate: router.routerDelegate,
+          routerConfig: router,
           title: 'GoRouter Example',
         ),
       );
@@ -1898,9 +1892,7 @@ void main() {
       final GoRouterPushSpy router = GoRouterPushSpy(routes: routes);
       await tester.pumpWidget(
         MaterialApp.router(
-          routeInformationProvider: router.routeInformationProvider,
-          routeInformationParser: router.routeInformationParser,
-          routerDelegate: router.routerDelegate,
+          routerConfig: router,
           title: 'GoRouter Example',
         ),
       );
@@ -1917,9 +1909,7 @@ void main() {
       final GoRouterPushNamedSpy router = GoRouterPushNamedSpy(routes: routes);
       await tester.pumpWidget(
         MaterialApp.router(
-          routeInformationProvider: router.routeInformationProvider,
-          routeInformationParser: router.routeInformationParser,
-          routerDelegate: router.routerDelegate,
+          routerConfig: router,
           title: 'GoRouter Example',
         ),
       );
@@ -1939,9 +1929,7 @@ void main() {
       final GoRouterPopSpy router = GoRouterPopSpy(routes: routes);
       await tester.pumpWidget(
         MaterialApp.router(
-          routeInformationProvider: router.routeInformationProvider,
-          routeInformationParser: router.routeInformationParser,
-          routerDelegate: router.routerDelegate,
+          routerConfig: router,
           title: 'GoRouter Example',
         ),
       );

--- a/packages/go_router/test/helpers/error_screen_helpers.dart
+++ b/packages/go_router/test/helpers/error_screen_helpers.dart
@@ -51,18 +51,14 @@ WidgetTesterCallback testClickingTheButtonRedirectsToRoot({
 
 Widget materialAppRouterBuilder(GoRouter router) {
   return MaterialApp.router(
-    routeInformationProvider: router.routeInformationProvider,
-    routeInformationParser: router.routeInformationParser,
-    routerDelegate: router.routerDelegate,
+    routerConfig: router,
     title: 'GoRouter Example',
   );
 }
 
 Widget cupertinoAppRouterBuilder(GoRouter router) {
   return CupertinoApp.router(
-    routeInformationProvider: router.routeInformationProvider,
-    routeInformationParser: router.routeInformationParser,
-    routerDelegate: router.routerDelegate,
+    routerConfig: router,
     title: 'GoRouter Example',
   );
 }

--- a/packages/go_router/test/inherited_test.dart
+++ b/packages/go_router/test/inherited_test.dart
@@ -137,5 +137,5 @@ class MockGoRouter extends GoRouter {
   }
 
   @override
-  BackButtonDispatcher? get backButtonDispatcher => throw UnimplementedError();
+  BackButtonDispatcher get backButtonDispatcher => RootBackButtonDispatcher();
 }

--- a/packages/go_router/test/inherited_test.dart
+++ b/packages/go_router/test/inherited_test.dart
@@ -137,6 +137,5 @@ class MockGoRouter extends GoRouter {
   }
 
   @override
-  // TODO: implement backButtonDispatcher
   BackButtonDispatcher? get backButtonDispatcher => throw UnimplementedError();
 }

--- a/packages/go_router/test/inherited_test.dart
+++ b/packages/go_router/test/inherited_test.dart
@@ -135,4 +135,8 @@ class MockGoRouter extends GoRouter {
       Object? extra}) {
     latestPushedName = name;
   }
+
+  @override
+  // TODO: implement backButtonDispatcher
+  BackButtonDispatcher? get backButtonDispatcher => throw UnimplementedError();
 }

--- a/packages/go_router/test/parser_test.dart
+++ b/packages/go_router/test/parser_test.dart
@@ -24,9 +24,7 @@ void main() {
       redirect: redirect,
     );
     await tester.pumpWidget(MaterialApp.router(
-      routeInformationProvider: router.routeInformationProvider,
-      routeInformationParser: router.routeInformationParser,
-      routerDelegate: router.routerDelegate,
+      routerConfig: router,
     ));
     return router.routeInformationParser;
   }

--- a/packages/go_router/test/test_helpers.dart
+++ b/packages/go_router/test/test_helpers.dart
@@ -22,9 +22,8 @@ Future<GoRouter> createGoRouter(WidgetTester tester) async {
     ],
   );
   await tester.pumpWidget(MaterialApp.router(
-      routeInformationProvider: goRouter.routeInformationProvider,
-      routeInformationParser: goRouter.routeInformationParser,
-      routerDelegate: goRouter.routerDelegate));
+    routerConfig: goRouter,
+  ));
   return goRouter;
 }
 
@@ -153,9 +152,7 @@ Future<GoRouter> createRouter(
   );
   await tester.pumpWidget(
     MaterialApp.router(
-      routeInformationProvider: goRouter.routeInformationProvider,
-      routeInformationParser: goRouter.routeInformationParser,
-      routerDelegate: goRouter.routerDelegate,
+      routerConfig: goRouter,
     ),
   );
   return goRouter;
@@ -163,6 +160,7 @@ Future<GoRouter> createRouter(
 
 class TestErrorScreen extends DummyScreen {
   const TestErrorScreen(this.ex, {super.key});
+
   final Exception ex;
 }
 
@@ -184,16 +182,19 @@ class LoginScreen extends DummyScreen {
 
 class FamilyScreen extends DummyScreen {
   const FamilyScreen(this.fid, {super.key});
+
   final String fid;
 }
 
 class FamiliesScreen extends DummyScreen {
   const FamiliesScreen({required this.selectedFid, super.key});
+
   final String selectedFid;
 }
 
 class PersonScreen extends DummyScreen {
   const PersonScreen(this.fid, this.pid, {super.key});
+
   final String fid;
   final String pid;
 }


### PR DESCRIPTION
This makes `GoRouter` implement the [RouterConfig](https://master-api.flutter.dev/flutter/widgets/RouterConfig-class.html) type added in Flutter 3.3.