### PR TITLE
[adaptive_scaffold] Fix typo seconary -> secondary

### DIFF
--- a/packages/adaptive_scaffold/lib/src/adaptive_scaffold.dart
+++ b/packages/adaptive_scaffold/lib/src/adaptive_scaffold.dart
@@ -157,7 +157,7 @@ class AdaptiveScaffold extends StatefulWidget {
   /// The default displayed secondaryBody.
   final WidgetBuilder? secondaryBody;
 
-  /// Widget to be displayed in the seconaryBody slot at the smallest
+  /// Widget to be displayed in the secondaryBody slot at the smallest
   /// breakpoint.
   ///
   /// If nothing is entered for this property, then the default [secondaryBody]


### PR DESCRIPTION
Fixing a typo in the docs.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.