### PR TITLE
[ci] Increase Linux bot memory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,7 @@ task:
     zone: us-central1-a
     namespace: default
     cpu: 4
-    memory: 8G
+    memory: 12G
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     ### Platform-agnostic tasks ###


### PR DESCRIPTION
Increases the memory spec from 8GB to 12GB (matching flutter/plugins)
since it looks like we may have been right at the edge of our memory
limit and just tipped over.

Speculative fix for tree redness.