### PR TITLE
[ci] Split android-platform_tests in 2 shards

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -183,8 +183,8 @@ task:
     - name: android-platform_tests
       env:
         matrix:
-          PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
-          PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
+          BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
+          BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -183,9 +183,8 @@ task:
     - name: android-platform_tests
       env:
         matrix:
-          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 3"
-          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 3"
-          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 3"
+          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 2"
+          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -183,6 +183,9 @@ task:
     - name: android-platform_tests
       env:
         matrix:
+          PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
+          PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
+        matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
       build_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -183,8 +183,9 @@ task:
     - name: android-platform_tests
       env:
         matrix:
-          BUILD_SHARDING: "--shardIndex 0 --shardCount 2"
-          BUILD_SHARDING: "--shardIndex 1 --shardCount 2"
+          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 3"
+          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 3"
+          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 3"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"

--- a/script/tool_runner.sh
+++ b/script/tool_runner.sh
@@ -8,8 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 # The tool expects to be run from the repo root.
+# PACKAGE_SHARDING is (optionally) set from Cirrus. See .cirrus.yml
 cd "$REPO_DIR"
 dart pub global run flutter_plugin_tools "$@" \
   --packages-for-branch \
   --log-timing \
-  $BUILD_SHARDING
+  $PACKAGE_SHARDING

--- a/script/tool_runner.sh
+++ b/script/tool_runner.sh
@@ -9,5 +9,7 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 # The tool expects to be run from the repo root.
 cd "$REPO_DIR"
-dart pub global run flutter_plugin_tools "$@" --packages-for-branch \
-  --log-timing $BUILD_SHARDING
+dart pub global run flutter_plugin_tools "$@" \
+  --packages-for-branch \
+  --log-timing \
+  $BUILD_SHARDING


### PR DESCRIPTION
The `android-platform_tests` task has started OOM'ing.

After increasing its memory limit to `12G`, it passed, but the current max utilization is at 11.44GB.

This PR splits the `android-platform_tests` in 3 shards, to see if memory utilization goes down further without having to request a beefier instance.

Also, make the environment variable consistent with flutter/plugins (in [this PR](https://github.com/flutter/plugins/pull/6374))

Fixes https://github.com/flutter/flutter/issues/111126

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
