### PR TITLE
[pigeon] added macos swift support

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.3
+
+* [swift] Makes swift output work on macOS.
+
 ## 4.0.2
 
 * Fixes lint warnings.

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -9,7 +9,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '4.0.2';
+const String pigeonVersion = '4.0.3';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/swift_generator.dart
+++ b/packages/pigeon/lib/swift_generator.dart
@@ -421,7 +421,15 @@ void generateSwift(SwiftOptions options, Root root, StringSink sink) {
 
   void writeImports() {
     indent.writeln('import Foundation');
-    indent.writeln('import Flutter');
+    indent.format('''
+#if os(iOS)
+import Flutter
+#elseif os(macOS)
+import FlutterMacOS
+#else
+#error("Unsupported platform.")
+#endif
+''');
   }
 
   void writeEnum(Enum anEnum) {

--- a/packages/pigeon/platform_tests/macos_swift_unit_tests/macos/Classes/MacosSwiftUnitTestsPlugin.swift
+++ b/packages/pigeon/platform_tests/macos_swift_unit_tests/macos/Classes/MacosSwiftUnitTestsPlugin.swift
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import Cocoa
+import FlutterMacOS
+
+public class MyApi: Api {
+  public init() {}
+  func getPlatform() -> String {
+    return "macOS " + ProcessInfo.processInfo.operatingSystemVersionString
+  }
+}
+
+public class MacosSwiftUnitTestsPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    ApiSetup.setUp(binaryMessenger: registrar.messenger, api: MyApi())
+  }
+}

--- a/packages/pigeon/platform_tests/macos_swift_unit_tests/macos/Tests/MessagesTest.swift
+++ b/packages/pigeon/platform_tests/macos_swift_unit_tests/macos/Tests/MessagesTest.swift
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import XCTest
+import macos_swift_unit_tests
+
+class MessagesTest: XCTestCase {
+   func testMakeApi() {
+    let api = MyApi()
+    XCTAssertNotNil(api)
+   }
+}

--- a/packages/pigeon/platform_tests/macos_swift_unit_tests/macos/macos_swift_unit_tests.podspec
+++ b/packages/pigeon/platform_tests/macos_swift_unit_tests/macos/macos_swift_unit_tests.podspec
@@ -1,0 +1,29 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint macos_swift_unit_tests.podspec` to validate before publishing.
+#
+Pod::Spec.new do |s|
+  s.name             = 'macos_swift_unit_tests'
+  s.version          = '0.0.1'
+  s.summary          = 'Fake library that uses pigeon for macos for testing.'
+  s.description      = <<-DESC
+Fake library that uses pigeon for macos for testing.
+
+Use `pod lib lint` to run the tests.
+                       DESC
+  s.homepage         = 'http://example.com'
+  s.license          = { :type => 'Flutter', :file => '../../../LICENSE' }
+  s.author           = { 'Your Company' => 'email@example.com' }
+
+  s.source           = { :http => 'https://github.com/flutter/packages' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+
+  s.platform = :osx, '10.11'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.swift_version = '5.0'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/*.{swift}'
+  end
+end

--- a/packages/pigeon/platform_tests/macos_swift_unit_tests/pigeons/messages.dart
+++ b/packages/pigeon/platform_tests/macos_swift_unit_tests/pigeons/messages.dart
@@ -1,0 +1,10 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:pigeon/pigeon.dart';
+
+@HostApi()
+abstract class Api {
+  String getPlatform();
+}

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 4.0.2 # This must match the version in lib/generator_tools.dart
+version: 4.0.3 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -191,6 +191,10 @@ run_mock_handler_tests() {
   dart run tool/run_tests.dart -t mock_handler_tests
 }
 
+run_macos_swift_unittests() {
+  dart run tool/run_tests.dart -t mac_swift_unittests
+}
+
 run_dart_compilation_tests() {
   local temp_dir=$(mktmpdir)
   local flutter_project_dir=$temp_dir/project
@@ -311,6 +315,7 @@ should_run_flutter_unittests=true
 should_run_ios_e2e_tests=true
 should_run_ios_unittests=true
 should_run_mock_handler_tests=true
+should_run_macos_swift_unittests=true
 while getopts "t:l?h" opt; do
   case $opt in
   t)
@@ -321,6 +326,7 @@ while getopts "t:l?h" opt; do
     should_run_ios_e2e_tests=false
     should_run_ios_unittests=false
     should_run_mock_handler_tests=false
+    should_run_macos_swift_unittests=false
     case $OPTARG in
     android_unittests) should_run_android_unittests=true ;;
     dart_compilation_tests) should_run_dart_compilation_tests=true ;;
@@ -329,6 +335,7 @@ while getopts "t:l?h" opt; do
     ios_e2e_tests) should_run_ios_e2e_tests=true ;;
     ios_unittests) should_run_ios_unittests=true ;;
     mock_handler_tests) should_run_mock_handler_tests=true ;;
+    macos_swift_unittests) should_run_macos_swift_unittests=true ;;
     *)
       echo "unrecognized test: $OPTARG"
       exit 1
@@ -344,6 +351,7 @@ while getopts "t:l?h" opt; do
   ios_e2e_tests          - End-to-end objc tests run on iOS Simulator
   ios_unittests          - Unit tests on generated Objc code.
   mock_handler_tests     - Unit tests on generated Dart mock handler code.
+  macos_swift_unittests  - Unit tests on generated Swift code on macOS.
   "
     exit 1
     ;;
@@ -389,4 +397,7 @@ if [ "$should_run_ios_e2e_tests" = true ]; then
 fi
 if [ "$should_run_android_unittests" = true ]; then
   run_android_unittests
+fi
+if [ "$should_run_macos_swift_unittests" = true ]; then
+  run_macos_swift_unittests
 fi


### PR DESCRIPTION
1) Made swift output able to compiled on macos
1) Added a platform unit test that runs the generated swift code on macos to make sure that it compiles

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
