### PR TITLE
Revert "Bump ossf/scorecard-action from 2.0.0 to 2.0.3"

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972 # v1.0.3
+        uses: ossf/scorecard-action@13ec8c77e8a5dae7e0a0d47bde3e3004df15d34f # v1.0.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Reverts flutter/packages#2591

The fix didn't work reverting back to 1.1.2.

Bug: https://github.com/ossf/scorecard-action/issues/900
