### PR TITLE
[go_router] Remove assert so that ShellRoute allows child ShellRoute

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 5.0.0
 
+- Allows ShellRoute to have child ShellRoutes (flutter/flutter#111981)
+
+## 5.0.0
+
 - Fixes a bug where intermediate route redirect methods are not called.
 - GoRouter implements the RouterConfig interface, allowing you to call
   MaterialApp.router(routerConfig: _myGoRouter) instead of passing

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,4 @@
-## NEXT
-
-## 5.0.0
+## 5.0.1
 
 - Allows ShellRoute to have child ShellRoutes (flutter/flutter#111981)
 

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -439,8 +439,9 @@ class ShellRoute extends RouteBase {
         navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>(),
         super._() {
     for (final RouteBase route in routes) {
-      assert(route is GoRoute);
-      assert((route as GoRoute).parentNavigatorKey == null);
+      if (route is GoRoute) {
+        assert(route.parentNavigatorKey == null);
+      }
     }
   }
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 5.0.0
+version: 5.0.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/configuration_test.dart
+++ b/packages/go_router/test/configuration_test.dart
@@ -333,6 +333,46 @@ void main() {
         );
       },
     );
+    test('does not throw when ShellRoute is the child of another ShellRoute',
+        () {
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> shell =
+          GlobalKey<NavigatorState>(debugLabel: 'shell');
+      final GlobalKey<NavigatorState> shell2 =
+          GlobalKey<NavigatorState>(debugLabel: 'shell2');
+      RouteConfiguration(
+        routes: <RouteBase>[
+          ShellRoute(
+            builder: _mockShellBuilder,
+            routes: <RouteBase>[
+              ShellRoute(
+                builder: _mockShellBuilder,
+                routes: [
+                  GoRoute(
+                    path: '/a',
+                    builder: _mockScreenBuilder,
+                  ),
+                ],
+              ),
+              GoRoute(
+                path: '/b',
+                builder: _mockScreenBuilder,
+              ),
+            ],
+          ),
+          GoRoute(
+            path: '/c',
+            builder: _mockScreenBuilder,
+          ),
+        ],
+        redirectLimit: 10,
+        topRedirect: (BuildContext context, GoRouterState state) {
+          return null;
+        },
+        navigatorKey: root,
+      );
+    });
   });
 
   test(
@@ -389,35 +429,6 @@ void main() {
       );
     },
   );
-
-  test('throws when ShellRoute contains a ShellRoute', () {
-    final GlobalKey<NavigatorState> root =
-        GlobalKey<NavigatorState>(debugLabel: 'root');
-    expect(
-      () {
-        RouteConfiguration(
-          navigatorKey: root,
-          routes: <RouteBase>[
-            ShellRoute(routes: <RouteBase>[
-              ShellRoute(
-                routes: <RouteBase>[
-                  GoRoute(
-                    path: '/a',
-                    builder: _mockScreenBuilder,
-                  ),
-                ],
-              ),
-            ]),
-          ],
-          redirectLimit: 10,
-          topRedirect: (BuildContext context, GoRouterState state) {
-            return null;
-          },
-        );
-      },
-      throwsAssertionError,
-    );
-  });
 
   test('throws when ShellRoute contains a GoRoute with a parentNavigatorKey',
       () {

--- a/packages/go_router/test/configuration_test.dart
+++ b/packages/go_router/test/configuration_test.dart
@@ -344,7 +344,7 @@ void main() {
             routes: <RouteBase>[
               ShellRoute(
                 builder: _mockShellBuilder,
-                routes: [
+                routes: <GoRoute>[
                   GoRoute(
                     path: '/a',
                     builder: _mockScreenBuilder,

--- a/packages/go_router/test/configuration_test.dart
+++ b/packages/go_router/test/configuration_test.dart
@@ -337,10 +337,6 @@ void main() {
         () {
       final GlobalKey<NavigatorState> root =
           GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> shell =
-          GlobalKey<NavigatorState>(debugLabel: 'shell');
-      final GlobalKey<NavigatorState> shell2 =
-          GlobalKey<NavigatorState>(debugLabel: 'shell2');
       RouteConfiguration(
         routes: <RouteBase>[
           ShellRoute(


### PR DESCRIPTION
closes flutter/flutter#111981

See https://github.com/flutter/samples/pull/1437 for an example use-case.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.