### PR TITLE
[animations] optimize open container opacity usage

### DIFF
--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -389,9 +389,12 @@ class _HideableState extends State<_Hideable> {
     if (_placeholderSize != null) {
       return SizedBox.fromSize(size: _placeholderSize);
     }
-    return Opacity(
-      opacity: _visible ? 1.0 : 0.0,
+    return Visibility(
+      visible: _visible,
       child: widget.child,
+      maintainSize: true,
+      maintainState: true,
+      maintainAnimation: true,
     );
   }
 }
@@ -819,9 +822,9 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
                               child: (hideableKey.currentState?.isInTree ??
                                       false)
                                   ? null
-                                  : Opacity(
+                                  : FadeTransition(
                                       opacity: closedOpacityTween!
-                                          .evaluate(animation),
+                                          .animate(animation),
                                       child: Builder(
                                         key: closedBuilderKey,
                                         builder: (BuildContext context) {
@@ -841,8 +844,8 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
                             child: SizedBox(
                               width: _rectTween.end!.width,
                               height: _rectTween.end!.height,
-                              child: Opacity(
-                                opacity: openOpacityTween!.evaluate(animation),
+                              child: FadeTransition(
+                                opacity: openOpacityTween!.animate(animation),
                                 child: Builder(
                                   key: _openBuilderKey,
                                   builder: (BuildContext context) {

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -580,6 +580,7 @@ void main() {
     final NavigatorState navigator = tester.state(find.byType(Navigator));
     navigator.pop();
     await tester.pump();
+    await tester.pump();
 
     expect(find.text('Closed'), findsOneWidget);
     expect(find.text('Open'), findsOneWidget);
@@ -1854,11 +1855,11 @@ void _expectMaterialPropertiesHaveAdvanced({
 }
 
 double _getOpacity(WidgetTester tester, String label) {
-  final Opacity widget = tester.firstWidget(find.ancestor(
+  final FadeTransition widget = tester.firstWidget(find.ancestor(
     of: find.text(label),
-    matching: find.byType(Opacity),
+    matching: find.byType(FadeTransition),
   ));
-  return widget.opacity;
+  return widget.opacity.value;
 }
 
 class _TrackedData {


### PR DESCRIPTION
Replace Opacity with Visibility. On newer framework versions, visibility will be much faster as it does not create an opacity layer.
Replace manually animated opacity widgets with a FadeTransition. On newer framework versions, the opacity animated via fade transition has some performance enhancements for stable subtrees that do not apply to the regular opacity render object
