### PR TITLE
[flutter_markdown] replace deprecated string constants with empty string

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Remove deprecated API usage in test files.
+
 ## 0.6.12
 
 * Markdown Lists now take into account `fitContent` instead of always expanding to the maximum horizontally ([flutter/flutter#108976](https://github.com/flutter/flutter/issues/108976)).

--- a/packages/flutter_markdown/test/list_test.dart
+++ b/packages/flutter_markdown/test/list_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:markdown/markdown.dart'
-    show indicatorForCheckedCheckBox, indicatorForUncheckedCheckBox;
 import 'utils.dart';
 
 void main() => defineTests();
@@ -131,9 +129,9 @@ void defineTests() {
 
         expectTextStrings(widgets, <String>[
           String.fromCharCode(Icons.check_box.codePoint),
-          '${indicatorForCheckedCheckBox}Item 1',
+          'Item 1',
           String.fromCharCode(Icons.check_box_outline_blank.codePoint),
-          '${indicatorForUncheckedCheckBox}Item 2',
+          'Item 2',
         ]);
       },
     );
@@ -179,9 +177,9 @@ void defineTests() {
 
         expectTextStrings(widgets, <String>[
           'true',
-          '${indicatorForCheckedCheckBox}Item 1',
+          'Item 1',
           'false',
-          '${indicatorForUncheckedCheckBox}Item 2',
+          'Item 2',
         ]);
       },
     );


### PR DESCRIPTION
Remove the usage of the deprecated constants based on the new check mark algorithm. This fix is suggested in https://github.com/dart-lang/markdown/pull/459#issuecomment-1253991751

This PR fixes the tree.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
