### PR TITLE
[go_router_builder] Adds support for case insensitive enum parameters

### DIFF
--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.15
+
+* Adds support for case insensitive enum parameters in URL [#112371](https://github.com/flutter/flutter/issues/112371)
+
 ## 1.0.14
 
 * Bumps go_router version in example folder to v5.0.0

--- a/packages/go_router_builder/example/lib/all_types.g.dart
+++ b/packages/go_router_builder/example/lib/all_types.g.dart
@@ -302,6 +302,8 @@ bool _$boolConverter(String value) {
 }
 
 extension<T extends Enum> on Map<T, String> {
-  T _$fromName(String value) =>
-      entries.singleWhere((element) => element.value == value).key;
+  T _$fromName(String value) => entries
+      .singleWhere(
+          (element) => element.value.toLowerCase() == value.toLowerCase())
+      .key;
 }

--- a/packages/go_router_builder/example/lib/main.g.dart
+++ b/packages/go_router_builder/example/lib/main.g.dart
@@ -102,8 +102,10 @@ const _$PersonDetailsEnumMap = {
 };
 
 extension<T extends Enum> on Map<T, String> {
-  T _$fromName(String value) =>
-      entries.singleWhere((element) => element.value == value).key;
+  T _$fromName(String value) => entries
+      .singleWhere(
+          (element) => element.value.toLowerCase() == value.toLowerCase())
+      .key;
 }
 
 GoRoute get $loginRoute => GoRouteData.$route(

--- a/packages/go_router_builder/example/test/all_types_test.dart
+++ b/packages/go_router_builder/example/test/all_types_test.dart
@@ -5,6 +5,7 @@
 // import 'package:flutter/material.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:go_router_builder_example/all_types.dart';
 import 'package:go_router_builder_example/shared/data.dart';
 
@@ -87,6 +88,21 @@ void main() {
       requiredEnumField: PersonDetails.favoriteFood,
       enumField: PersonDetails.favoriteSport,
     ).go(scaffoldState.context);
+    await tester.pumpAndSettle();
+    expect(find.text('EnumRoute'), findsOneWidget);
+    expect(find.text('Param: PersonDetails.favoriteFood'), findsOneWidget);
+    expect(
+        find.text('Query param: PersonDetails.favoriteSport'), findsOneWidget);
+
+    final String enumRouteLocation = EnumRoute(
+      requiredEnumField: PersonDetails.favoriteFood,
+      enumField: PersonDetails.favoriteSport,
+    ).location;
+    final String capitalizedEnumRouteLocation = enumRouteLocation
+        .replaceFirst('food', 'FoOd')
+        .replaceAll('favorite', 'faVoRite')
+        .replaceAll('sport', 'SpOrT');
+    GoRouter.of(scaffoldState.context).go(capitalizedEnumRouteLocation);
     await tester.pumpAndSettle();
     expect(find.text('EnumRoute'), findsOneWidget);
     expect(find.text('Param: PersonDetails.favoriteFood'), findsOneWidget);

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -412,6 +412,8 @@ bool $boolConverterHelperName(String value) {
 
 const String _enumConverterHelper = '''
 extension<T extends Enum> on Map<T, String> {
-  T $enumExtensionHelperName(String value) =>
-      entries.singleWhere((element) => element.value == value).key;
+  T $enumExtensionHelperName(String value) => entries
+      .singleWhere(
+          (element) => element.value.toLowerCase() == value.toLowerCase())
+      .key;
 }''';

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 1.0.14
+version: 1.0.15
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 

--- a/packages/go_router_builder/test/test_inputs/_go_router_builder_test_input.dart
+++ b/packages/go_router_builder/test/test_inputs/_go_router_builder_test_input.dart
@@ -98,8 +98,10 @@ const _$EnumTestEnumMap = {
 };
 
 extension<T extends Enum> on Map<T, String> {
-  T _$fromName(String value) =>
-      entries.singleWhere((element) => element.value == value).key;
+  T _$fromName(String value) => entries
+      .singleWhere(
+          (element) => element.value.toLowerCase() == value.toLowerCase())
+      .key;
 }
 ''')
 @TypedGoRoute<EnumParam>(path: '/:y')


### PR DESCRIPTION
This PR aims at supporting case-insensitive parsing of enums in parameters when routing, since the rest of the URL is case-insensitive, so should the generated enums IMHO.

This fixes issue https://github.com/flutter/flutter/issues/112371

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
