### PR TITLE
Remove asserts in popRoute

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.5
+
+- Fixes issue where asserts in popRoute were preventing the app from
+  exiting on Android.
+
 ## 5.0.4
 
 - Fixes a bug in ShellRoute example where NavigationBar might lose current index in a nested routes.

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -50,6 +50,8 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
 
   @override
   Future<bool> popRoute() async {
+
+
     // Iterate backwards through the RouteMatchList until seeing a GoRoute with
     // a non-null parentNavigatorKey or a ShellRoute with a non-null
     // parentNavigatorKey and pop from that Navigator instead of the root.
@@ -59,13 +61,12 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
       final RouteBase route = match.route;
 
       if (route is GoRoute && route.parentNavigatorKey != null) {
-        // It should not be possible for a GoRoute with parentNavigatorKey to be
-        // the only page, so maybePop should never return false in this case.
-        assert(await route.parentNavigatorKey!.currentState!.maybePop());
-        return true;
+        return route.parentNavigatorKey!.currentState!.maybePop();
       } else if (route is ShellRoute) {
-        assert(await route.navigatorKey.currentState!.maybePop());
-        return true;
+        final bool didPop = await route.navigatorKey.currentState!.maybePop();
+        if (didPop) {
+          return didPop;
+        }
       }
     }
 
@@ -116,10 +117,6 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
       final RouteBase route = match.route;
       if (route is GoRoute && route.parentNavigatorKey != null) {
         final bool canPop = route.parentNavigatorKey!.currentState!.canPop();
-        // Similar to popRoute, it should not be possible for a GoRoute with
-        // parentNavigatorKey to be the only page, so canPop should return true
-        // in this case.
-        assert(canPop);
         return canPop;
       } else if (route is ShellRoute) {
         final bool canPop = route.navigatorKey.currentState!.canPop();

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -50,8 +50,6 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
 
   @override
   Future<bool> popRoute() async {
-
-
     // Iterate backwards through the RouteMatchList until seeing a GoRoute with
     // a non-null parentNavigatorKey or a ShellRoute with a non-null
     // parentNavigatorKey and pop from that Navigator instead of the root.
@@ -61,7 +59,10 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
       final RouteBase route = match.route;
 
       if (route is GoRoute && route.parentNavigatorKey != null) {
-        return route.parentNavigatorKey!.currentState!.maybePop();
+        final bool didPop = await route.parentNavigatorKey!.currentState!.maybePop();
+        if (didPop) {
+          return didPop;
+        }
       } else if (route is ShellRoute) {
         final bool didPop = await route.navigatorKey.currentState!.maybePop();
         if (didPop) {

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -61,11 +61,15 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
       if (route is GoRoute && route.parentNavigatorKey != null) {
         final bool didPop =
             await route.parentNavigatorKey!.currentState!.maybePop();
+
+        // Continue if didPop was false.
         if (didPop) {
           return didPop;
         }
       } else if (route is ShellRoute) {
         final bool didPop = await route.navigatorKey.currentState!.maybePop();
+
+        // Continue if didPop was false.
         if (didPop) {
           return didPop;
         }
@@ -119,9 +123,15 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
       final RouteBase route = match.route;
       if (route is GoRoute && route.parentNavigatorKey != null) {
         final bool canPop = route.parentNavigatorKey!.currentState!.canPop();
-        return canPop;
+
+        // Continue if canPop is false.
+        if (canPop) {
+          return canPop;
+        }
       } else if (route is ShellRoute) {
         final bool canPop = route.navigatorKey.currentState!.canPop();
+
+        // Continue if canPop is false.
         if (canPop) {
           return canPop;
         }

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -59,7 +59,8 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
       final RouteBase route = match.route;
 
       if (route is GoRoute && route.parentNavigatorKey != null) {
-        final bool didPop = await route.parentNavigatorKey!.currentState!.maybePop();
+        final bool didPop =
+            await route.parentNavigatorKey!.currentState!.maybePop();
         if (didPop) {
           return didPop;
         }

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -437,7 +437,14 @@ class ShellRoute extends RouteBase {
     GlobalKey<NavigatorState>? navigatorKey,
   })  : assert(routes.isNotEmpty),
         navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>(),
-        super._();
+        super._() {
+    for (final RouteBase route in routes) {
+      if (route is GoRoute) {
+        assert(route.parentNavigatorKey == null ||
+            route.parentNavigatorKey == navigatorKey);
+      }
+    }
+  }
 
   /// The widget builder for a shell route.
   ///

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -437,13 +437,7 @@ class ShellRoute extends RouteBase {
     GlobalKey<NavigatorState>? navigatorKey,
   })  : assert(routes.isNotEmpty),
         navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>(),
-        super._() {
-    for (final RouteBase route in routes) {
-      if (route is GoRoute) {
-        assert(route.parentNavigatorKey == null);
-      }
-    }
-  }
+        super._();
 
   /// The widget builder for a shell route.
   ///

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 5.0.4
+version: 5.0.5
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -729,7 +729,8 @@ void main() {
     });
   });
 
-  testWidgets('Handles the Android back button when a second Shell has a GoRoute with parentNavigator key',
+  testWidgets(
+      'Handles the Android back button when a second Shell has a GoRoute with parentNavigator key',
       (WidgetTester tester) async {
     final List<MethodCall> log = <MethodCall>[];
     TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
@@ -748,15 +749,14 @@ void main() {
     final GlobalKey<NavigatorState> rootNavigatorKey =
         GlobalKey<NavigatorState>();
     final GlobalKey<NavigatorState> shellNavigatorKeyA =
-    GlobalKey<NavigatorState>();
+        GlobalKey<NavigatorState>();
     final GlobalKey<NavigatorState> shellNavigatorKeyB =
-    GlobalKey<NavigatorState>();
+        GlobalKey<NavigatorState>();
 
     final List<RouteBase> routes = <RouteBase>[
       ShellRoute(
         navigatorKey: shellNavigatorKeyA,
-        builder:
-            (BuildContext context, GoRouterState state, Widget child) {
+        builder: (BuildContext context, GoRouterState state, Widget child) {
           return Scaffold(
             appBar: AppBar(
               title: const Text('Shell'),

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -694,35 +694,32 @@ void main() {
               body: Text('Screen A'),
             );
           },
+        ),
+        ShellRoute(
+          builder: (BuildContext context, GoRouterState state, Widget child) {
+            return Scaffold(
+              appBar: AppBar(
+                title: const Text('Shell'),
+              ),
+              body: child,
+            );
+          },
           routes: <RouteBase>[
-            ShellRoute(
-              builder:
-                  (BuildContext context, GoRouterState state, Widget child) {
-                return Scaffold(
-                  appBar: AppBar(
-                    title: Text('Shell'),
-                  ),
-                  body: child,
+            GoRoute(
+              path: '/b',
+              builder: (BuildContext context, GoRouterState state) {
+                return const Scaffold(
+                  body: Text('Screen B'),
                 );
               },
-              routes: <RouteBase>[
-                GoRoute(
-                  path: 'b',
-                  builder: (BuildContext context, GoRouterState state) {
-                    return const Scaffold(
-                      body: Text('Screen B'),
-                    );
-                  },
-                ),
-              ],
             ),
           ],
         ),
       ];
 
       await createRouter(routes, tester,
-          initialLocation: '/a', navigatorKey: rootNavigatorKey);
-      expect(find.text('Screen A'), findsOneWidget);
+          initialLocation: '/b', navigatorKey: rootNavigatorKey);
+      expect(find.text('Screen B'), findsOneWidget);
 
       await tester.runAsync(() async {
         await verify(() => simulateAndroidBackButton(tester), <Object>[

--- a/packages/go_router/test/test_helpers.dart
+++ b/packages/go_router/test/test_helpers.dart
@@ -347,9 +347,9 @@ class DummyStatefulWidgetState extends State<DummyStatefulWidget> {
   Widget build(BuildContext context) => Container();
 }
 
-Future<void> simulateAndroidBackButton() async {
+Future<void> simulateAndroidBackButton(WidgetTester tester) async {
   final ByteData message =
       const JSONMethodCodec().encodeMethodCall(const MethodCall('popRoute'));
-  await ServicesBinding.instance.defaultBinaryMessenger
+  await tester.binding.defaultBinaryMessenger
       .handlePlatformMessage('flutter/navigation', message, (_) {});
 }


### PR DESCRIPTION
This removes the asserts in popRoute and canPop and were causing incorrect behavior when the Android back button is pressed and there are no routes to pop. popRoute should always return false if no navigators returned true from `maybePop`.

closes flutter/flutter#111861

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

