### PR TITLE
Update shell_route.dart

### DIFF
--- a/packages/go_router/example/lib/shell_route.dart
+++ b/packages/go_router/example/lib/shell_route.dart
@@ -131,10 +131,10 @@ class ScaffoldWithNavBar extends StatelessWidget {
   static int _calculateSelectedIndex(BuildContext context) {
     final GoRouter route = GoRouter.of(context);
     final String location = route.location;
-    if (location == '/a') {
+    if (location.contains('/a')) {
       return 0;
     }
-    if (location == '/b') {
+    if (location.contains('/b')) {
       return 1;
     }
     return 0;


### PR DESCRIPTION
*If you went to comment out line 73, you could see that the validations for the bottom navigation bar were not working as expected when being in a nested route. Using the equal operator in _calculateSelectedIndex did not give the correct output. On the contrary, by using 'contains' we can check if we are indeed in a specific parent route and get the correct output.*

*_calculateSelectedIndex was not giving the correct output when being in a nested route.*
