### PR TITLE
[animations] Test fix for: flutter/flutter 112610 `AutomatedTestWidgetsFlutterBinding.pump` should match engine frame precision

### DIFF
--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -255,7 +255,6 @@ void main() {
       expect(dataTransitionStart.radius, dataOpen.radius);
       expect(dataTransitionStart.rect, dataOpen.rect);
       expect(_getOpacity(tester, 'Open'), 1.0);
-      await tester.pump(const Duration(microseconds: 1)); // 300 * 1/5 = 60
 
       // Jump to start of fade out: 1/5 of 300.
       await tester.pump(const Duration(milliseconds: 60)); // 300 * 1/5 = 60


### PR DESCRIPTION
The 'Container closes - Fade (by default)' test included a pump with a `Duration` that had microsecond precision. This was effectively a no-op since the AutomatedTestWidgetsFlutterBinding only had millisecond precision. Once the binding was updated to microsecond precision, the rest of the test was off by a microsecond which caused an invalid test failure.

Related to [flutter/flutter 112610](https://github.com/flutter/flutter/issues/112610).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
