### PR TITLE
[flutter_adaptive_scaffold] Changed type of `appBar` parameter from `AppBar?` to `PreferredSizeWidget?`

### DIFF
--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+* Change type of `appBar` parameter from `AppBar` to `PreferredSizeWidget`
+
 ## 0.0.5
 
 * Calls onDestinationChanged callback in bottom nav bar.

--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.6
 
-* Change type of `appBar` parameter from `AppBar` to `PreferredSizeWidget`
+* Change type of `appBar` parameter from `AppBar?` to `PreferredSizeWidget?`
 
 ## 0.0.5
 

--- a/packages/flutter_adaptive_scaffold/example/lib/adaptive_scaffold_demo.dart
+++ b/packages/flutter_adaptive_scaffold/example/lib/adaptive_scaffold_demo.dart
@@ -50,7 +50,6 @@ class MyHomePage extends StatelessWidget {
         child: AdaptiveScaffold(
             // An option to override the default breakpoints used for small, medium,
             // and large.
-            appBar: AppBar(title: const Text('Adaptive Scaffold Example')),
             smallBreakpoint: const WidthPlatformBreakpoint(end: 700),
             mediumBreakpoint:
                 const WidthPlatformBreakpoint(begin: 700, end: 1000),

--- a/packages/flutter_adaptive_scaffold/example/lib/adaptive_scaffold_demo.dart
+++ b/packages/flutter_adaptive_scaffold/example/lib/adaptive_scaffold_demo.dart
@@ -50,6 +50,7 @@ class MyHomePage extends StatelessWidget {
         child: AdaptiveScaffold(
             // An option to override the default breakpoints used for small, medium,
             // and large.
+            appBar: AppBar(title: const Text('Adaptive Scaffold Example')),
             smallBreakpoint: const WidthPlatformBreakpoint(end: 700),
             mediumBreakpoint:
                 const WidthPlatformBreakpoint(begin: 700, end: 1000),

--- a/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
+++ b/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
@@ -217,7 +217,7 @@ class AdaptiveScaffold extends StatefulWidget {
 
   /// Option to override the default [AppBar] when using drawer in desktop
   /// small.
-  final AppBar? appBar;
+  final PreferredSizeWidget? appBar;
 
   /// Callback function for when the index of a [NavigationRail] changes.
   final Function(int)? onSelectedIndexChange;

--- a/packages/flutter_adaptive_scaffold/pubspec.yaml
+++ b/packages/flutter_adaptive_scaffold/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 0.0.5
+version: 0.0.6
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_adaptive_scaffold%22
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold
 

--- a/packages/flutter_adaptive_scaffold/pubspec.yaml
+++ b/packages/flutter_adaptive_scaffold/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 0.0.5
+version: 0.1.0
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_adaptive_scaffold%22
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold
 

--- a/packages/flutter_adaptive_scaffold/pubspec.yaml
+++ b/packages/flutter_adaptive_scaffold/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 0.1.0
+version: 0.0.5
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_adaptive_scaffold%22
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold
 

--- a/packages/flutter_adaptive_scaffold/test/adaptive_scaffold_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_scaffold_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:flutter_adaptive_scaffold/src/adaptive_scaffold.dart';
 import 'package:flutter_adaptive_scaffold/src/breakpoints.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -130,7 +129,7 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/111008
   testWidgets(
-    'appBar parameter should be a PreferredSizeWidget',
+    'appBar parameter should have the type PreferredSizeWidget',
     (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: MediaQuery(

--- a/packages/flutter_adaptive_scaffold/test/adaptive_scaffold_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_scaffold_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:flutter_adaptive_scaffold/src/adaptive_scaffold.dart';
 import 'package:flutter_adaptive_scaffold/src/breakpoints.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -127,6 +128,30 @@ void main() {
     expect(tester.getBottomRight(sBody), const Offset(800, 800));
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/111008
+  testWidgets(
+    'appBar parameter should be a PreferredSizeWidget',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(size: Size(500, 800)),
+          child: AdaptiveScaffold(
+            drawerBreakpoint: TestBreakpoint0(),
+            internalAnimations: false,
+            destinations: const <NavigationDestination>[
+              NavigationDestination(icon: Icon(Icons.inbox), label: 'Inbox'),
+              NavigationDestination(
+                  icon: Icon(Icons.video_call), label: 'Video'),
+            ],
+            appBar: const PreferredSizeWidgetImpl(),
+          ),
+        ),
+      ));
+
+      expect(find.byType(PreferredSizeWidgetImpl), findsOneWidget);
+    },
+  );
+
   // The goal of this test is to run through each of the navigation elements
   // and test whether tapping on that element will update the selected index
   // globally
@@ -168,6 +193,22 @@ void main() {
       expect(selectedIndex, state.index);
     });
   });
+}
+
+/// An empty widget that implements [PreferredSizeWidget] to ensure that
+/// [PreferredSizeWidget] is used as [AdaptiveScaffold.appBar] parameter instead
+/// of [AppBar].
+class PreferredSizeWidgetImpl extends StatelessWidget
+    implements PreferredSizeWidget {
+  const PreferredSizeWidgetImpl({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+
+  @override
+  Size get preferredSize => const Size(200, 200);
 }
 
 class TestBreakpoint0 extends Breakpoint {


### PR DESCRIPTION
Rebased https://github.com/flutter/packages/pull/2617 and updated versions as fit.

`appBar` parameter takes `AppBar?` instead of `PreferredSize?.` When developers migrate from Scaffold to AdaptiveScaffold, it won't be as seamless as it could be since these two apis don't match.

Fixes https://github.com/flutter/flutter/issues/111008

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
