### PR TITLE
[ci] Roll repo tooling to 0.12.0

### DIFF
--- a/.ci/scripts/prepare_tool.sh
+++ b/.ci/scripts/prepare_tool.sh
@@ -8,4 +8,4 @@ git fetch origin main
 
 # Pinned version of the plugin tools, to avoid breakage in this repository
 # when pushing updates from flutter/plugins.
-dart pub global activate flutter_plugin_tools 0.9.2
+dart pub global activate flutter_plugin_tools 0.12.0

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -126,11 +126,6 @@ task:
       analyze_script:
         - ./script/tool_runner.sh analyze --downgrade --custom-analysis=script/configs/custom_analysis.yaml
     - name: publishable
-      env:
-        # TODO(stuartmorgan): Remove once the fix for https://github.com/dart-lang/pub/issues/3152
-        # rolls into Flutter master.
-        CHANNEL: stable
-        CHANGE_DESC: "/tmp/change-description.txt"
       version_script:
         # For pre-submit, pass the PR description to the script to allow for
         # version check overrides.
@@ -141,8 +136,7 @@ task:
         - if [[ $CIRRUS_PR == "" ]]; then
         -   ./script/tool_runner.sh version-check
         - else
-        -   echo "$CIRRUS_CHANGE_MESSAGE" > "$CHANGE_DESC"
-        -   ./script/tool_runner.sh version-check --check-for-missing-changes --change-description-file="$CHANGE_DESC" --pr-labels="$CIRRUS_PR_LABELS"
+        -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
         - fi
       publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
       depends_on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: dart pub global activate flutter_plugin_tools 0.9.2
+      run: dart pub global activate flutter_plugin_tools 0.12.0
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests
@@ -47,6 +47,6 @@ jobs:
       run: |
         git config --global user.name ${{ secrets.USER_NAME }}
         git config --global user.email ${{ secrets.USER_EMAIL }}
-        dart pub global run flutter_plugin_tools publish-plugin --all-changed --base-sha=HEAD~ --skip-confirmation --remote=origin
+        dart pub global run flutter_plugin_tools publish --all-changed --base-sha=HEAD~ --skip-confirmation --remote=origin
       env: {PUB_CREDENTIALS: "${{ secrets.PUB_CREDENTIALS }}"}
 


### PR DESCRIPTION
Picks up the change that makes post-submit only run tests for changed packages, rather than all packages, so that it matches pre-submit logic. (Repo-level changes continue to run for all packages as in presubmit.)

Part of https://github.com/flutter/flutter/issues/111885