### PR TITLE
[ci] Cirrus pre-alignment with flutter/plugins, part 1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -143,6 +143,8 @@ task:
         # minimum Flutter/Dart version than the package itself.
         - ./script/tool_runner.sh remove-dev-dependencies
       analyze_script:
+        # Only analyze lib/; non-client code doesn't need to work on
+        # all supported legacy version.
         - ./script/tool_runner.sh analyze --lib-only --skip-if-not-supporting-flutter-version="$CHANNEL" --skip-if-not-supporting-dart-version="$DART_VERSION" --custom-analysis=script/configs/custom_analysis.yaml
     # Does a sanity check that packages pass analysis with the lowest possible
     # versions of all dependencies. This is to catch cases where we add use of

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,6 +92,31 @@ task:
       publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
       depends_on:
         - format+analyze
+    - name: format+analyze
+      always:
+        format_script: ./script/tool_runner.sh format --fail-on-change
+        license_script: $PLUGIN_TOOL_COMMAND license-check
+        pubspec_script: ./script/tool_runner.sh pubspec-check
+        readme_script:
+          - ./script/tool_runner.sh readme-check
+          # Re-run with --require-excerpts, skipping packages that still need
+          # to be converted. Once https://github.com/flutter/flutter/issues/102679
+          # has been fixed, this can be removed and there can just be a single
+          # run with --require-excerpts and no exclusions.
+          - ./script/tool_runner.sh readme-check --require-excerpts --exclude=script/configs/temp_exclude_excerpt.yaml
+        analyze_script:
+          - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
+        pathified_analyze_script:
+          # Run analysis with path-based dependencies to ensure that publishing
+          # the changes won't break analysis of other packages in the respository
+          # that depend on it.
+          - ./script/tool_runner.sh make-deps-path-based  --target-dependencies-with-non-breaking-updates
+          # This uses --run-on-dirty-packages rather than --packages-for-branch
+          # since only the packages changed by 'make-deps-path-based' need to be
+          # checked.
+          - $PLUGIN_TOOL_COMMAND analyze --run-on-dirty-packages --custom-analysis=script/configs/custom_analysis.yaml
+          # Restore the tree to a clean state
+          - git checkout .
 
 # Heavy-workload Linux tasks.
 # These use machines with more CPUs and memory, so will reduce parallelization
@@ -109,31 +134,6 @@ task:
     memory: 12G
   matrix:
     ### Platform-agnostic tasks ###
-    - name: format+analyze
-      always:
-        format_script: ./script/tool_runner.sh format --fail-on-change
-        license_script: $PLUGIN_TOOL_COMMAND license-check
-        analyze_script:
-          - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
-        pathified_analyze_script:
-          # Run analysis with path-based dependencies to ensure that publishing
-          # the changes won't break analysis of other packages in the respository
-          # that depend on it.
-          - ./script/tool_runner.sh make-deps-path-based  --target-dependencies-with-non-breaking-updates
-          # This uses --run-on-dirty-packages rather than --packages-for-branch
-          # since only the packages changed by 'make-deps-path-based' need to be
-          # checked.
-          - $PLUGIN_TOOL_COMMAND analyze --run-on-dirty-packages --custom-analysis=script/configs/custom_analysis.yaml
-          # Restore the tree to a clean state
-          - git checkout .
-        pubspec_script: ./script/tool_runner.sh pubspec-check
-        readme_script:
-          - ./script/tool_runner.sh readme-check
-          # Re-run with --require-excerpts, skipping packages that still need
-          # to be converted. Once https://github.com/flutter/flutter/issues/102679
-          # has been fixed, this can be removed and there can just be a single
-          # run with --require-excerpts and no exclusions.
-          - ./script/tool_runner.sh readme-check --require-excerpts --exclude=script/configs/temp_exclude_excerpt.yaml
     - name: readme_excerpts
       env:
         CIRRUS_CLONE_SUBMODULES: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@ gcp_credentials: ENCRYPTED[!f1177d1ddb5330ffaa9ea11c9c9e8e0c542185e895c36071f18c
 only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'main')
 env:
   CHANNEL: "master" # Default to master when not explicitly set by a task.
+  PLUGIN_TOOL_COMMAND: "dart pub global run flutter_plugin_tools"
 
 install_chrome_linux_template: &INSTALL_CHROME_LINUX
   env:
@@ -69,7 +70,7 @@ task:
     - name: format+analyze
       always:
         format_script: ./script/tool_runner.sh format --fail-on-change
-        license_script: dart pub global run flutter_plugin_tools license-check
+        license_script: $PLUGIN_TOOL_COMMAND license-check
         analyze_script:
           - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
         pathified_analyze_script:
@@ -80,7 +81,7 @@ task:
           # This uses --run-on-dirty-packages rather than --packages-for-branch
           # since only the packages changed by 'make-deps-path-based' need to be
           # checked.
-          - dart pub global run flutter_plugin_tools analyze --run-on-dirty-packages --custom-analysis=script/configs/custom_analysis.yaml
+          - $PLUGIN_TOOL_COMMAND analyze --run-on-dirty-packages --custom-analysis=script/configs/custom_analysis.yaml
           # Restore the tree to a clean state
           - git checkout .
         pubspec_script: ./script/tool_runner.sh pubspec-check
@@ -153,7 +154,7 @@ task:
         # the changes won't break tests of other packages in the respository
         # that depend on it.
         - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
-        - dart pub global run flutter_plugin_tools test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
+        - $PLUGIN_TOOL_COMMAND test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
       depends_on:
         - format+analyze
     - name: linux-custom_package_tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,42 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
     - flutter doctor -v
   << : *TOOL_SETUP_TEMPLATE
 
+# Light-workload Linux tasks.
+# These use default machines, with fewer CPUs, to reduce pressure on the
+# concurrency limits.
 task:
+  << : *FLUTTER_UPGRADE_TEMPLATE
+  gke_container:
+    dockerfile: .ci/Dockerfile
+    builder_image_name: docker-builder-linux # gce vm image
+    builder_image_project: flutter-cirrus
+    cluster_name: test-cluster
+    zone: us-central1-a
+    namespace: default
+  matrix:
+    ### Platform-agnostic tasks ###
+    - name: publishable
+      version_script:
+        # For pre-submit, pass the PR description to the script to allow for
+        # version check overrides.
+        # For post-submit, ignore missing version/CHANGELOG detection; the PR
+        # description isn't reliably part of the commit message, so using the
+        # same flags as for presubmit would likely result in false-positive
+        # post-submit failures.
+        - if [[ $CIRRUS_PR == "" ]]; then
+        -   ./script/tool_runner.sh version-check
+        - else
+        -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
+        - fi
+      publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
+      depends_on:
+        - format+analyze
+
+# Heavy-workload Linux tasks.
+# These use machines with more CPUs and memory, so will reduce parallelization
+# for non-credit runs.
+task:
+  << : *FLUTTER_UPGRADE_TEMPLATE
   gke_container:
     dockerfile: .ci/Dockerfile
     builder_image_name: docker-builder-linux # gce vm image
@@ -72,7 +107,6 @@ task:
     namespace: default
     cpu: 4
     memory: 12G
-  << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     ### Platform-agnostic tasks ###
     - name: format+analyze
@@ -134,22 +168,6 @@ task:
       depends_on: format+analyze
       analyze_script:
         - ./script/tool_runner.sh analyze --downgrade --custom-analysis=script/configs/custom_analysis.yaml
-    - name: publishable
-      version_script:
-        # For pre-submit, pass the PR description to the script to allow for
-        # version check overrides.
-        # For post-submit, ignore missing version/CHANGELOG detection; the PR
-        # description isn't reliably part of the commit message, so using the
-        # same flags as for presubmit would likely result in false-positive
-        # post-submit failures.
-        - if [[ $CIRRUS_PR == "" ]]; then
-        -   ./script/tool_runner.sh version-check
-        - else
-        -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
-        - fi
-      publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
-      depends_on:
-        - format+analyze
     - name: dart_unit_tests
       env:
         matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,6 +26,14 @@ macos_template: &MACOS_TEMPLATE
   # Only one macOS task can run in parallel without credits, so use them for
   # PRs on macOS.
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+
+macos_intel_template: &MACOS_INTEL_TEMPLATE
+  << : *MACOS_TEMPLATE
+  osx_instance:
+    image: big-sur-xcode-13
+
+macos_arm_template: &MACOS_ARM_TEMPLATE
+  << : *MACOS_TEMPLATE
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:14
 
@@ -230,7 +238,7 @@ task:
 
 task:
   << : *FLUTTER_UPGRADE_TEMPLATE
-  << : *MACOS_TEMPLATE
+  << : *MACOS_ARM_TEMPLATE
   matrix:
     ### iOS tasks ###
     - name: ios-platform_tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,23 +76,10 @@ task:
     namespace: default
   matrix:
     ### Platform-agnostic tasks ###
-    - name: publishable
-      version_script:
-        # For pre-submit, pass the PR description to the script to allow for
-        # version check overrides.
-        # For post-submit, ignore missing version/CHANGELOG detection; the PR
-        # description isn't reliably part of the commit message, so using the
-        # same flags as for presubmit would likely result in false-positive
-        # post-submit failures.
-        - if [[ $CIRRUS_PR == "" ]]; then
-        -   ./script/tool_runner.sh version-check
-        - else
-        -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
-        - fi
-      publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
-      depends_on:
-        - format+analyze
-    - name: format+analyze
+    # Repository rules and best-practice enforcement.
+    # Only channel-agnostic tests should go here since it is only run once
+    # (on Flutter master).
+    - name: repo_checks
       always:
         format_script: ./script/tool_runner.sh format --fail-on-change
         license_script: $PLUGIN_TOOL_COMMAND license-check
@@ -104,10 +91,22 @@ task:
           # has been fixed, this can be removed and there can just be a single
           # run with --require-excerpts and no exclusions.
           - ./script/tool_runner.sh readme-check --require-excerpts --exclude=script/configs/temp_exclude_excerpt.yaml
-        analyze_script:
+        version_script:
+          # For pre-submit, pass the PR description to the script to allow for
+          # version check overrides.
+          # For post-submit, ignore missing version/CHANGELOG detection; the PR
+          # description isn't reliably part of the commit message, so using the
+          # same flags as for presubmit would likely result in false-positive
+          # post-submit failures.
+          - if [[ $CIRRUS_PR == "" ]]; then
+          -   ./script/tool_runner.sh version-check
+          - else
+          -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
+          - fi
+        publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
+    - name: analyze
+      analyze_script:
           - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
-      # This is not part of the 'always' since there's no reason to run
-      # pathified analysis unless analysis passed.
       pathified_analyze_script:
         # Run analysis with path-based dependencies to ensure that publishing
         # the changes won't break analysis of other packages in the respository
@@ -148,7 +147,7 @@ task:
     # Note: The versions below should be manually updated after a new stable
     # version comes out.
     - name: legacy-version-analyze
-      depends_on: format+analyze
+      depends_on: analyze
       matrix:
         env:
           CHANNEL: "3.0.5"
@@ -167,7 +166,7 @@ task:
     # new APIs but forget to update minimum versions of dependencies to where
     # those APIs are introduced.
     - name: downgraded_analyze
-      depends_on: format+analyze
+      depends_on: analyze
       analyze_script:
         - ./script/tool_runner.sh analyze --downgrade --custom-analysis=script/configs/custom_analysis.yaml
     - name: dart_unit_tests
@@ -183,8 +182,6 @@ task:
         # that depend on it.
         - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
         - $PLUGIN_TOOL_COMMAND test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
-      depends_on:
-        - format+analyze
     - name: linux-custom_package_tests
       env:
         PATH: $PATH:/usr/local/bin
@@ -217,8 +214,6 @@ task:
         - ./script/tool_runner.sh build-examples --apk --exclude=extension_google_sign_in_as_googleapis_auth
       native_unit_test_scipt:
         - ./script/tool_runner.sh native-test --android --no-integration
-      depends_on:
-        - format+analyze
     ### Web tasks ###
     - name: web-platform_tests
       env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -122,27 +122,6 @@ task:
         # Restore the tree to a clean state, to avoid accidental issues if
         # other script steps are added to this task.
         - git checkout .
-
-# Heavy-workload Linux tasks.
-# These use machines with more CPUs and memory, so will reduce parallelization
-# for non-credit runs.
-task:
-  << : *FLUTTER_UPGRADE_TEMPLATE
-  gke_container:
-    dockerfile: .ci/Dockerfile
-    builder_image_name: docker-builder-linux # gce vm image
-    builder_image_project: flutter-cirrus
-    cluster_name: test-cluster
-    zone: us-central1-a
-    namespace: default
-    cpu: 4
-    memory: 12G
-  matrix:
-    ### Platform-agnostic tasks ###
-    - name: readme_excerpts
-      env:
-        CIRRUS_CLONE_SUBMODULES: true
-      script: ./script/tool_runner.sh update-excerpts --fail-on-change
     # Does a sanity check that packages at least pass analysis on the N-1 and N-2
     # versions of Flutter stable if the package claims to support that version.
     # This is to minimize accidentally making changes that break old versions
@@ -173,6 +152,27 @@ task:
       depends_on: analyze
       analyze_script:
         - ./script/tool_runner.sh analyze --downgrade --custom-analysis=script/configs/custom_analysis.yaml
+    - name: readme_excerpts
+      env:
+        CIRRUS_CLONE_SUBMODULES: true
+      script: ./script/tool_runner.sh update-excerpts --fail-on-change
+
+# Heavy-workload Linux tasks.
+# These use machines with more CPUs and memory, so will reduce parallelization
+# for non-credit runs.
+task:
+  << : *FLUTTER_UPGRADE_TEMPLATE
+  gke_container:
+    dockerfile: .ci/Dockerfile
+    builder_image_name: docker-builder-linux # gce vm image
+    builder_image_project: flutter-cirrus
+    cluster_name: test-cluster
+    zone: us-central1-a
+    namespace: default
+    cpu: 4
+    memory: 12G
+  matrix:
+    ### Platform-agnostic tasks ###
     - name: dart_unit_tests
       env:
         matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -246,7 +246,6 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       build_script:
-        - flutter config --enable-linux-desktop
         - ./script/tool_runner.sh build-examples --linux
       native_test_script:
         - ./script/tool_runner.sh native-test --linux --no-integration
@@ -294,7 +293,6 @@ task:
           CHANNEL: "stable"
         PATH: $PATH:/usr/local/bin
       build_script:
-        - flutter config --enable-macos-desktop
         - ./script/tool_runner.sh build-examples --macos
       native_test_script:
         - ./script/tool_runner.sh native-test --macos

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,8 +118,9 @@ task:
         # This uses --run-on-dirty-packages rather than --packages-for-branch
         # since only the packages changed by 'make-deps-path-based' need to be
         # checked.
-        - $PLUGIN_TOOL_COMMAND analyze --run-on-dirty-packages --custom-analysis=script/configs/custom_analysis.yaml
-        # Restore the tree to a clean state
+        - $PLUGIN_TOOL_COMMAND analyze --run-on-dirty-packages --log-timing --custom-analysis=script/configs/custom_analysis.yaml
+        # Restore the tree to a clean state, to avoid accidental issues if
+        # other script steps are added to this task.
         - git checkout .
 
 # Heavy-workload Linux tasks.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -206,6 +206,8 @@ task:
   matrix:
     ### Android tasks ###
     - name: android-platform_tests
+      # Don't run full platform tests on both channels in pre-submit.
+      skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
       env:
         matrix:
           PACKAGE_SHARDING: "--shardIndex 0 --shardCount 2"
@@ -246,6 +248,8 @@ task:
         - dart testing/web_benchmarks_test.dart
     ### Linux desktop tasks ###
     - name: linux-platform_tests
+      # Don't run full platform tests on both channels in pre-submit.
+      skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
       env:
         matrix:
           CHANNEL: "master"
@@ -261,6 +265,8 @@ task:
   matrix:
     ### iOS tasks ###
     - name: ios-platform_tests
+      # Don't run full platform tests on both channels in pre-submit.
+      skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -292,6 +298,8 @@ task:
         - fi
     ### macOS desktop tasks ###
     - name: macos-platform_tests
+      # Don't run full platform tests on both channels in pre-submit.
+      skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
       env:
         matrix:
           CHANNEL: "master"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,10 +111,10 @@ task:
       analyze_script:
         - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
       pathified_analyze_script:
-        # Run analysis with path-based dependencies to ensure that publishing
+        # Re-run analysis with path-based dependencies to ensure that publishing
         # the changes won't break analysis of other packages in the respository
         # that depend on it.
-        - ./script/tool_runner.sh make-deps-path-based  --target-dependencies-with-non-breaking-updates
+        - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
         # This uses --run-on-dirty-packages rather than --packages-for-branch
         # since only the packages changed by 'make-deps-path-based' need to be
         # checked.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -106,17 +106,19 @@ task:
           - ./script/tool_runner.sh readme-check --require-excerpts --exclude=script/configs/temp_exclude_excerpt.yaml
         analyze_script:
           - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
-        pathified_analyze_script:
-          # Run analysis with path-based dependencies to ensure that publishing
-          # the changes won't break analysis of other packages in the respository
-          # that depend on it.
-          - ./script/tool_runner.sh make-deps-path-based  --target-dependencies-with-non-breaking-updates
-          # This uses --run-on-dirty-packages rather than --packages-for-branch
-          # since only the packages changed by 'make-deps-path-based' need to be
-          # checked.
-          - $PLUGIN_TOOL_COMMAND analyze --run-on-dirty-packages --custom-analysis=script/configs/custom_analysis.yaml
-          # Restore the tree to a clean state
-          - git checkout .
+      # This is not part of the 'always' since there's no reason to run
+      # pathified analysis unless analysis passed.
+      pathified_analyze_script:
+        # Run analysis with path-based dependencies to ensure that publishing
+        # the changes won't break analysis of other packages in the respository
+        # that depend on it.
+        - ./script/tool_runner.sh make-deps-path-based  --target-dependencies-with-non-breaking-updates
+        # This uses --run-on-dirty-packages rather than --packages-for-branch
+        # since only the packages changed by 'make-deps-path-based' need to be
+        # checked.
+        - $PLUGIN_TOOL_COMMAND analyze --run-on-dirty-packages --custom-analysis=script/configs/custom_analysis.yaml
+        # Restore the tree to a clean state
+        - git checkout .
 
 # Heavy-workload Linux tasks.
 # These use machines with more CPUs and memory, so will reduce parallelization

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,14 +92,13 @@ task:
           # run with --require-excerpts and no exclusions.
           - ./script/tool_runner.sh readme-check --require-excerpts --exclude=script/configs/temp_exclude_excerpt.yaml
         version_script:
-          # For pre-submit, pass the PR description to the script to allow for
-          # version check overrides.
-          # For post-submit, ignore missing version/CHANGELOG detection; the PR
-          # description isn't reliably part of the commit message, so using the
-          # same flags as for presubmit would likely result in false-positive
-          # post-submit failures.
+          # For pre-submit, pass the PR labels to the script to allow for
+          # check overrides.
+          # For post-submit, ignore platform version breaking version changes
+          # and missing version/CHANGELOG detection since the labels aren't
+          # available outside of the context of the PR.
           - if [[ $CIRRUS_PR == "" ]]; then
-          -   ./script/tool_runner.sh version-check
+          -   ./script/tool_runner.sh version-check --ignore-platform-interface-breaks
           - else
           -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
           - fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,6 +103,19 @@ task:
           -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
           - fi
         publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
+    - name: dart_unit_tests
+      env:
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
+      unit_test_script:
+        - ./script/tool_runner.sh test --exclude=script/configs/dart_unit_tests_exceptions.yaml
+      pathified_unit_test_script:
+        # Run tests with path-based dependencies to ensure that publishing
+        # the changes won't break tests of other packages in the respository
+        # that depend on it.
+        - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
+        - $PLUGIN_TOOL_COMMAND test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
     - name: analyze
       env:
         matrix:
@@ -158,36 +171,6 @@ task:
       env:
         CIRRUS_CLONE_SUBMODULES: true
       script: ./script/tool_runner.sh update-excerpts --fail-on-change
-
-# Heavy-workload Linux tasks.
-# These use machines with more CPUs and memory, so will reduce parallelization
-# for non-credit runs.
-task:
-  << : *FLUTTER_UPGRADE_TEMPLATE
-  gke_container:
-    dockerfile: .ci/Dockerfile
-    builder_image_name: docker-builder-linux # gce vm image
-    builder_image_project: flutter-cirrus
-    cluster_name: test-cluster
-    zone: us-central1-a
-    namespace: default
-    cpu: 4
-    memory: 12G
-  matrix:
-    ### Platform-agnostic tasks ###
-    - name: dart_unit_tests
-      env:
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      unit_test_script:
-        - ./script/tool_runner.sh test --exclude=script/configs/dart_unit_tests_exceptions.yaml
-      pathified_unit_test_script:
-        # Run tests with path-based dependencies to ensure that publishing
-        # the changes won't break tests of other packages in the respository
-        # that depend on it.
-        - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
-        - $PLUGIN_TOOL_COMMAND test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
     - name: linux-custom_package_tests
       env:
         PATH: $PATH:/usr/local/bin
@@ -205,6 +188,22 @@ task:
         - else
         -   ./script/tool_runner.sh custom-test --exclude=pigeon,flutter_image
         - fi
+
+# Heavy-workload Linux tasks.
+# These use machines with more CPUs and memory, so will reduce parallelization
+# for non-credit runs.
+task:
+  << : *FLUTTER_UPGRADE_TEMPLATE
+  gke_container:
+    dockerfile: .ci/Dockerfile
+    builder_image_name: docker-builder-linux # gce vm image
+    builder_image_project: flutter-cirrus
+    cluster_name: test-cluster
+    zone: us-central1-a
+    namespace: default
+    cpu: 4
+    memory: 12G
+  matrix:
     ### Android tasks ###
     - name: android-platform_tests
       env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -146,7 +146,7 @@ task:
     # without updating the constraints.
     # Note: The versions below should be manually updated after a new stable
     # version comes out.
-    - name: legacy-version-analyze
+    - name: legacy_version_analyze
       depends_on: analyze
       matrix:
         env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,8 +104,12 @@ task:
           - fi
         publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
     - name: analyze
+      env:
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
       analyze_script:
-          - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
+        - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
       pathified_analyze_script:
         # Run analysis with path-based dependencies to ensure that publishing
         # the changes won't break analysis of other packages in the respository

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -77,7 +77,7 @@ linter:
     # - cascade_invocations # doesn't match the typical style of this repo
     - cast_nullable_to_non_nullable
     # - close_sinks # not reliable enough
-    - combinators_ordering
+    # - combinators_ordering # DIFFERENT FROM FLUTTER/FLUTTER: This isn't available on stable yet.
     # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
     - conditional_uri_does_not_exist
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204


### PR DESCRIPTION
Updates .cirrus.yaml to better match flutter/plugins, as a step toward eventually merging the repsositories. Changes include:
- Separating out light workload and heavy workload Linux tasks with different machine specs.
- Enabling analyze on `stable` in addition to `master`, which was missing only as an oversight.
- Skips platform tests on `stable`, as we now do in the plugins repo.
- Separates format and other repo-level, channel-agnostic checks from analyze (mostly to support the above).
- Combines some very cheap steps that don't need to be separate, to reduce machine/setup overhead.
- Cleans up some desktop enabling steps that are no longer necessary.
- Minor flag and comment adjustment to match across repos to aid with diffing.

Since analysis now runs on stable, one analysis option that's not on stable yet had to be commented out.