### PR TITLE
[flutter_adaptive_scaffold] Prevent duplicate keys in `AnimatedSwitcher`

### DIFF
--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.7
+
+* Patch duplicate key error in SlotLayout.
+
 ## 0.0.6
 
 * Change type of `appBar` parameter from `AppBar?` to `PreferredSizeWidget?`

--- a/packages/flutter_adaptive_scaffold/lib/src/slot_layout.dart
+++ b/packages/flutter_adaptive_scaffold/lib/src/slot_layout.dart
@@ -100,7 +100,8 @@ class _SlotLayoutState extends State<SlotLayout>
         layoutBuilder: (Widget? currentChild, List<Widget> previousChildren) {
           final Stack elements = Stack(
             children: <Widget>[
-              if (hasAnimation) ...previousChildren,
+              if (hasAnimation && previousChildren.isNotEmpty)
+                previousChildren.first,
               if (currentChild != null) currentChild,
             ],
           );

--- a/packages/flutter_adaptive_scaffold/pubspec.yaml
+++ b/packages/flutter_adaptive_scaffold/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 0.0.6
+version: 0.0.7
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_adaptive_scaffold%22
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold
 

--- a/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
@@ -152,7 +152,7 @@ void main() {
     expect(end, findsNothing);
 
     // Jumping back between two layouts before allowing an animation to complete.
-    // Produces a chain widgets in AnimatedSwitcher that contains duplicate
+    // Produces a chain of widgets in AnimatedSwitcher that includes duplicate
     // widgets with the same global key.
     for (int i = 0; i < 2; i++) {
       // Resize between the two slot layouts, but do not pump the animation

--- a/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
@@ -142,6 +142,33 @@ void main() {
     expect(begin, findsNothing);
     expect(end, findsOneWidget);
   });
+
+  testWidgets('AnimatedSwitcher does not spawn duplicate keys on rapid resize',
+      (WidgetTester tester) async {
+    // Populate the smaller slot layout and let the animation settle.
+    await tester.pumpWidget(slot(300));
+    await tester.pumpAndSettle();
+    expect(begin, findsOneWidget);
+    expect(end, findsNothing);
+
+    // Jumping back between two layouts before allowing an animation to complete.
+    // Produces a chain widgets in AnimatedSwitcher that contains duplicate
+    // widgets with the same global key.
+    for (int i = 0; i < 2; i++) {
+      // Resize between the two slot layouts, but do not pump the animation
+      // until completion.
+      await tester.pumpWidget(slot(500));
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(begin, findsOneWidget);
+      expect(end, findsOneWidget);
+
+      await tester.pumpWidget(slot(300));
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(begin, findsOneWidget);
+      expect(end, findsOneWidget);
+    }
+  });
+
   testWidgets('slot layout can tolerate rapid changes in breakpoints',
       (WidgetTester tester) async {
     await tester.pumpWidget(slot(300));

--- a/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
@@ -167,7 +167,9 @@ void main() {
       expect(begin, findsOneWidget);
       expect(end, findsOneWidget);
     }
-  });
+    // TODO(gspencergoog): Remove skip when AnimatedSwitcher fix rolls into stable.
+    // https://github.com/flutter/flutter/pull/107476
+  }, skip: true);
 
   testWidgets('slot layout can tolerate rapid changes in breakpoints',
       (WidgetTester tester) async {
@@ -186,7 +188,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(begin, findsOneWidget);
     expect(end, findsNothing);
-    // TODO(gspencergoog): Remove skip when AnimatedSwitcher fix rolls into stable.
+    // TODO(a-wallen): Remove skip when AnimatedSwitcher fix rolls into stable.
     // https://github.com/flutter/flutter/pull/107476
   }, skip: true);
 
@@ -243,7 +245,7 @@ void main() {
     expect(tester.getTopLeft(secondaryTestBreakpoint), const Offset(200, 10));
     expect(
         tester.getBottomRight(secondaryTestBreakpoint), const Offset(390, 790));
-    // TODO(gspencergoog): Remove skip when AnimatedSwitcher fix rolls into stable.
+    // TODO(a-wallen): Remove skip when AnimatedSwitcher fix rolls into stable.
     // https://github.com/flutter/flutter/pull/107476
   }, skip: true);
 
@@ -264,7 +266,7 @@ void main() {
     expect(tester.getTopLeft(secondaryTestBreakpoint), const Offset(200, 10));
     expect(
         tester.getBottomRight(secondaryTestBreakpoint), const Offset(390, 790));
-    // TODO(gspencergoog): Remove skip when AnimatedSwitcher fix rolls into stable.
+    // TODO(a-wallen): Remove skip when AnimatedSwitcher fix rolls into stable.
     // https://github.com/flutter/flutter/pull/107476
   }, skip: true);
 }


### PR DESCRIPTION
When rapidly resizing a window, the `AnimatedSwitcher` widget in `SlotLayout` would append all remaining widgets to a stack's children if animations were enabled. However, `AnimatedSwitcher`'s previous children can also contain the current widget. Just take the first of the previous children.

###### Fixes https://github.com/flutter/flutter/issues/113333

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
