### PR TITLE
[flutter_migrate] Custom merge

### DIFF
--- a/packages/flutter_migrate/lib/src/custom_merge.dart
+++ b/packages/flutter_migrate/lib/src/custom_merge.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_migrate/lib/src/custom_merge.dart
+++ b/packages/flutter_migrate/lib/src/custom_merge.dart
@@ -1,0 +1,119 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'base/file_system.dart';
+import 'base/logger.dart';
+import 'base/project.dart';
+import 'flutter_project_metadata.dart';
+import 'utils.dart';
+
+/// Handles the custom/manual merging of one file at `localPath`.
+///
+/// The `merge` method should be overridden to implement custom merging.
+abstract class CustomMerge {
+  CustomMerge({
+    required this.logger,
+    required this.localPath,
+  });
+
+  /// The local path (with the project root as the root directory) of the file to merge.
+  final String localPath;
+  final Logger logger;
+
+  /// Called to perform a custom three way merge between the current,
+  /// base, and target files.
+  MergeResult merge(File current, File base, File target);
+}
+
+/// Manually merges a flutter .metadata file.
+///
+/// See `FlutterProjectMetadata`.
+class MetadataCustomMerge extends CustomMerge {
+  MetadataCustomMerge({
+    required super.logger,
+  }) : super(localPath: '.metadata');
+
+  @override
+  MergeResult merge(File current, File base, File target) {
+    final FlutterProjectMetadata result = computeMerge(
+      FlutterProjectMetadata(current, logger),
+      FlutterProjectMetadata(base, logger),
+      FlutterProjectMetadata(target, logger),
+      logger,
+    );
+    return StringMergeResult.explicit(
+      mergedString: result.toString(),
+      hasConflict: false,
+      exitCode: 0,
+      localPath: localPath,
+    );
+  }
+
+  FlutterProjectMetadata computeMerge(
+      FlutterProjectMetadata current,
+      FlutterProjectMetadata base,
+      FlutterProjectMetadata target,
+      Logger logger) {
+    // Prefer to update the version revision and channel to latest version.
+    final String? versionRevision = target.versionRevision ??
+        current.versionRevision ??
+        base.versionRevision;
+    final String? versionChannel =
+        target.versionChannel ?? current.versionChannel ?? base.versionChannel;
+    // Prefer to leave the project type untouched as it is non-trivial to change project type.
+    final FlutterProjectType? projectType =
+        current.projectType ?? base.projectType ?? target.projectType;
+    final MigrateConfig migrateConfig = mergeMigrateConfig(
+      current.migrateConfig,
+      target.migrateConfig,
+    );
+    final FlutterProjectMetadata output = FlutterProjectMetadata.explicit(
+      file: current.file,
+      versionRevision: versionRevision,
+      versionChannel: versionChannel,
+      projectType: projectType,
+      migrateConfig: migrateConfig,
+      logger: logger,
+    );
+    return output;
+  }
+
+  MigrateConfig mergeMigrateConfig(
+      MigrateConfig current, MigrateConfig target) {
+    // Create the superset of current and target platforms with baseRevision updated to be that of target.
+    final Map<SupportedPlatform, MigratePlatformConfig> platformConfigs =
+        <SupportedPlatform, MigratePlatformConfig>{};
+    for (final MapEntry<SupportedPlatform, MigratePlatformConfig> entry
+        in current.platformConfigs.entries) {
+      if (target.platformConfigs.containsKey(entry.key)) {
+        platformConfigs[entry.key] = MigratePlatformConfig(
+            platform: entry.value.platform,
+            createRevision: entry.value.createRevision,
+            baseRevision: target.platformConfigs[entry.key]?.baseRevision);
+      } else {
+        platformConfigs[entry.key] = entry.value;
+      }
+    }
+    for (final MapEntry<SupportedPlatform, MigratePlatformConfig> entry
+        in target.platformConfigs.entries) {
+      if (!platformConfigs.containsKey(entry.key)) {
+        platformConfigs[entry.key] = entry.value;
+      }
+    }
+
+    // Ignore the base file list.
+    final List<String> unmanagedFiles =
+        List<String>.from(current.unmanagedFiles);
+    for (final String path in target.unmanagedFiles) {
+      if (!unmanagedFiles.contains(path) &&
+          !MigrateConfig.kDefaultUnmanagedFiles.contains(path)) {
+        unmanagedFiles.add(path);
+      }
+    }
+    return MigrateConfig(
+      platformConfigs: platformConfigs,
+      unmanagedFiles: unmanagedFiles,
+    );
+  }
+}

--- a/packages/flutter_migrate/test/custom_merge_test.dart
+++ b/packages/flutter_migrate/test/custom_merge_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_migrate/test/custom_merge_test.dart
+++ b/packages/flutter_migrate/test/custom_merge_test.dart
@@ -1,0 +1,279 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+
+import 'package:flutter_migrate/src/base/file_system.dart';
+import 'package:flutter_migrate/src/base/logger.dart';
+import 'package:flutter_migrate/src/custom_merge.dart';
+import 'package:flutter_migrate/src/utils.dart';
+
+import 'src/common.dart';
+
+void main() {
+  late FileSystem fileSystem;
+  late BufferLogger logger;
+
+  setUpAll(() {
+    fileSystem = MemoryFileSystem.test();
+    logger = BufferLogger.test();
+  });
+
+  group('.metadata merge', () {
+    late MetadataCustomMerge merger;
+
+    setUp(() {
+      merger = MetadataCustomMerge(logger: logger);
+    });
+
+    testWithoutContext('merges empty', () async {
+      const String current = '';
+      const String base = '';
+      const String target = '';
+      final File currentFile = fileSystem.file('.metadata_current');
+      final File baseFile = fileSystem.file('.metadata_base');
+      final File targetFile = fileSystem.file('.metadata_target');
+
+      currentFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(current, flush: true);
+      baseFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(base, flush: true);
+      targetFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(target, flush: true);
+
+      final StringMergeResult result =
+          merger.merge(currentFile, baseFile, targetFile) as StringMergeResult;
+      expect(
+          result.mergedString,
+          '''
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled.
+
+version:
+  revision: null
+  channel: null
+
+project_type: '''
+          '''
+
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'
+''');
+    });
+
+    testWithoutContext('merge adds migration section', () async {
+      const String current = '''
+# my own comment
+version:
+  revision: abcdefg12345
+  channel: stable
+project_type: app
+      ''';
+      const String base = '''
+version:
+  revision: abcdefg12345base
+  channel: stable
+project_type: app
+migration:
+  platforms:
+    - platform: root
+      create_revision: somecreaterevision
+      base_revision: somebaserevision
+    - platform: android
+      create_revision: somecreaterevision
+      base_revision: somebaserevision
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'
+      ''';
+      const String target = '''
+version:
+  revision: abcdefg12345target
+  channel: stable
+project_type: app
+migration:
+  platforms:
+    - platform: root
+      create_revision: somecreaterevision
+      base_revision: somebaserevision
+    - platform: android
+      create_revision: somecreaterevision
+      base_revision: somebaserevision
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'
+      ''';
+      final File currentFile = fileSystem.file('.metadata_current');
+      final File baseFile = fileSystem.file('.metadata_base');
+      final File targetFile = fileSystem.file('.metadata_target');
+
+      currentFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(current, flush: true);
+      baseFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(base, flush: true);
+      targetFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(target, flush: true);
+
+      final StringMergeResult result =
+          merger.merge(currentFile, baseFile, targetFile) as StringMergeResult;
+      expect(result.mergedString, '''
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled.
+
+version:
+  revision: abcdefg12345target
+  channel: stable
+
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: somecreaterevision
+      base_revision: somebaserevision
+    - platform: android
+      create_revision: somecreaterevision
+      base_revision: somebaserevision
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'
+''');
+    });
+
+    testWithoutContext('merge handles standard migration flow', () async {
+      const String current = '''
+# my own comment
+version:
+  revision: abcdefg12345current
+  channel: stable
+project_type: app
+migration:
+  platforms:
+    - platform: root
+      create_revision: somecreaterevisioncurrent
+      base_revision: somebaserevisioncurrent
+    - platform: android
+      create_revision: somecreaterevisioncurrent
+      base_revision: somebaserevisioncurrent
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'new/file.dart'
+      ''';
+      const String base = '''
+version:
+  revision: abcdefg12345base
+  channel: stable
+project_type: app
+migration:
+  platforms:
+    - platform: root
+      create_revision: somecreaterevisionbase
+      base_revision: somebaserevisionbase
+    - platform: android
+      create_revision: somecreaterevisionbase
+      base_revision: somebaserevisionbase
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'
+      ''';
+      const String target = '''
+version:
+  revision: abcdefg12345target
+  channel: stable
+project_type: app
+migration:
+  platforms:
+    - platform: root
+      create_revision: somecreaterevisiontarget
+      base_revision: somebaserevisiontarget
+    - platform: android
+      create_revision: somecreaterevisiontarget
+      base_revision: somebaserevisiontarget
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'
+    - 'extra/file'
+      ''';
+      final File currentFile = fileSystem.file('.metadata_current');
+      final File baseFile = fileSystem.file('.metadata_base');
+      final File targetFile = fileSystem.file('.metadata_target');
+
+      currentFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(current, flush: true);
+      baseFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(base, flush: true);
+      targetFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync(target, flush: true);
+
+      final StringMergeResult result =
+          merger.merge(currentFile, baseFile, targetFile) as StringMergeResult;
+      expect(result.mergedString, '''
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled.
+
+version:
+  revision: abcdefg12345target
+  channel: stable
+
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: somecreaterevisioncurrent
+      base_revision: somebaserevisiontarget
+    - platform: android
+      create_revision: somecreaterevisioncurrent
+      base_revision: somebaserevisiontarget
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'new/file.dart'
+    - 'extra/file'
+''');
+    });
+  });
+}

--- a/packages/flutter_migrate/test/custom_merge_test.dart
+++ b/packages/flutter_migrate/test/custom_merge_test.dart
@@ -103,7 +103,7 @@ migration:
   unmanaged_files:
     - 'lib/main.dart'
     - 'ios/Runner.xcodeproj/project.pbxproj'
-      ''';
+''';
       const String target = '''
 version:
   revision: abcdefg12345target
@@ -120,7 +120,7 @@ migration:
   unmanaged_files:
     - 'lib/main.dart'
     - 'ios/Runner.xcodeproj/project.pbxproj'
-      ''';
+''';
       final File currentFile = fileSystem.file('.metadata_current');
       final File baseFile = fileSystem.file('.metadata_base');
       final File targetFile = fileSystem.file('.metadata_target');
@@ -224,7 +224,7 @@ migration:
     - 'lib/main.dart'
     - 'ios/Runner.xcodeproj/project.pbxproj'
     - 'extra/file'
-      ''';
+''';
       final File currentFile = fileSystem.file('.metadata_current');
       final File baseFile = fileSystem.file('.metadata_base');
       final File targetFile = fileSystem.file('.metadata_target');


### PR DESCRIPTION
Adds `custom_merge.dart`, which defines a simple api to specify how to merge a specific file in a unique way with knowledge of the contents. We currently are only custom merging the `.metadata` file as it is core to tracking migrations, but this can be expanded to also merge files like `pubspec.yaml` and more