### PR TITLE
[flutter_markdown] Do not modify children of an Element after construction

### DIFF
--- a/packages/flutter_markdown/test/custom_syntax_test.dart
+++ b/packages/flutter_markdown/test/custom_syntax_test.dart
@@ -160,9 +160,9 @@ class WikilinkSyntax extends md.InlineSyntax {
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {
-    final md.Element el = md.Element.withTag('wikilink');
-    el.attributes['href'] = match[1]!.replaceAll(' ', '_');
-    el.children!.add(md.Element.text('span', match[1]!));
+    final String link =  match[1]!;
+    final md.Element el = md.Element('wikilink', [md.Element.text('span', link)])
+      ..attributes['href'] = link.replaceAll(' ', '_');
 
     parser.addNode(el);
     return true;

--- a/packages/flutter_markdown/test/custom_syntax_test.dart
+++ b/packages/flutter_markdown/test/custom_syntax_test.dart
@@ -161,8 +161,9 @@ class WikilinkSyntax extends md.InlineSyntax {
   @override
   bool onMatch(md.InlineParser parser, Match match) {
     final String link =  match[1]!;
-    final md.Element el = md.Element('wikilink', <md.Element>[md.Element.text('span', link)])
-      ..attributes['href'] = link.replaceAll(' ', '_');
+    final md.Element el =
+        md.Element('wikilink', <md.Element>[md.Element.text('span', link)])
+          ..attributes['href'] = link.replaceAll(' ', '_');
 
     parser.addNode(el);
     return true;

--- a/packages/flutter_markdown/test/custom_syntax_test.dart
+++ b/packages/flutter_markdown/test/custom_syntax_test.dart
@@ -161,7 +161,7 @@ class WikilinkSyntax extends md.InlineSyntax {
   @override
   bool onMatch(md.InlineParser parser, Match match) {
     final String link =  match[1]!;
-    final md.Element el = md.Element('wikilink', [md.Element.text('span', link)])
+    final md.Element el = md.Element('wikilink', <md.Element>[md.Element.text('span', link)])
       ..attributes['href'] = link.replaceAll(' ', '_');
 
     parser.addNode(el);

--- a/packages/flutter_markdown/test/custom_syntax_test.dart
+++ b/packages/flutter_markdown/test/custom_syntax_test.dart
@@ -160,7 +160,7 @@ class WikilinkSyntax extends md.InlineSyntax {
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {
-    final String link =  match[1]!;
+    final String link = match[1]!;
     final md.Element el =
         md.Element('wikilink', <md.Element>[md.Element.text('span', link)])
           ..attributes['href'] = link.replaceAll(' ', '_');


### PR DESCRIPTION
The children list of an Element became unmodifiable in https://github.com/dart-lang/markdown/pull/463, so this just changes flutter_markdown to not modify the children, in a test.

Fixes https://github.com/dart-lang/markdown/issues/480



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
