### PR TITLE
[web_benchmarks] add ignore unnecessary_non_null_assertion for Scrollable.of

### DIFF
--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,7 +1,3 @@
-## NEXT
-
-* Fixes lint warnings in the test_app.
-
 ## 0.1.0+1
 
 * Fixes lint warnings.

--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Fixes lint warnings in the test_app.
+
 ## 0.1.0+1
 
 * Fixes lint warnings.

--- a/packages/web_benchmarks/testing/test_app/lib/benchmarks/runner.dart
+++ b/packages/web_benchmarks/testing/test_app/lib/benchmarks/runner.dart
@@ -39,6 +39,9 @@ class ScrollRecorder extends AppRecorder {
   @override
   Future<void> automate() async {
     final ScrollableState scrollable =
+        // TODO(cyanglaz): Fix the unnecessary non null assertion when https://github.com/flutter/flutter/commit/37b72342b0ce86fbfc238a9d43e524608b89af3a is on stable,
+        // https://github.com/flutter/flutter/issues/114434
+        //ignore: unnecessary_non_null_assertion
         Scrollable.of(find.byKey(textKey).evaluate().single)!;
     await scrollable.position.animateTo(
       30000,


### PR DESCRIPTION
https://github.com/flutter/flutter/commit/37b72342b0ce86fbfc238a9d43e524608b89af3a caused a lint warning for Scrollable.of, which stopped the flutter->package roll. To ensure the package is still compatible with stable, I added an `ignore` to suppress the warning.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
