### PR TITLE
[go_router] Fix parentNavigatorKey not working with multiple nested Routes in ShellRoute

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.6
+
+- Fixes `parentNavigatorKey` not working with multiple nested `GoRoute` in `ShellRoute`.
+
 ## 5.1.5
 
 - Adds migration guide for 5.1.2 to readme.

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.1.6
 
-- Fixes `parentNavigatorKey` not working with multiple nested `GoRoute` in `ShellRoute`.
+- Fixes crashes when multiple `GoRoute`s use the same `parentNavigatorKey` in a route subtree.
 
 ## 5.1.5
 

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -60,9 +60,9 @@ class RouteConfiguration {
               checkParentNavigatorKeys(
                 route.routes,
                 <GlobalKey<NavigatorState>>[
-                  // Once a parentNavigatorKey is used, only the navigator keys
-                  // above it can be used.
-                  ...allowedKeys.sublist(0, allowedKeys.indexOf(parentKey)),
+                  // Once a parentNavigatorKey is used, only that navigator key
+                  // or keys above it can be used.
+                  ...allowedKeys.sublist(0, allowedKeys.indexOf(parentKey) + 1),
                 ],
               );
             } else {

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 5.1.5
+version: 5.1.6
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/configuration_test.dart
+++ b/packages/go_router/test/configuration_test.dart
@@ -176,6 +176,55 @@ void main() {
     );
 
     test(
+      'Does not throw with multiple nested GoRoutes using parentNavigatorKey in ShellRoute',
+      () {
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
+        RouteConfiguration(
+          navigatorKey: root,
+          routes: <RouteBase>[
+            ShellRoute(
+              navigatorKey: shell,
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/',
+                  builder: _mockScreenBuilder,
+                  routes: <RouteBase>[
+                    GoRoute(
+                      path: 'a',
+                      builder: _mockScreenBuilder,
+                      parentNavigatorKey: root,
+                      routes: <RouteBase>[
+                        GoRoute(
+                          path: 'b',
+                          builder: _mockScreenBuilder,
+                          parentNavigatorKey: root,
+                          routes: <RouteBase>[
+                            GoRoute(
+                              path: 'c',
+                              builder: _mockScreenBuilder,
+                              parentNavigatorKey: root,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+          redirectLimit: 10,
+          topRedirect: (BuildContext context, GoRouterState state) {
+            return null;
+          },
+        );
+      },
+    );
+
+    test(
       'Throws when parentNavigatorKeys are overlapping',
       () {
         final GlobalKey<NavigatorState> root =
@@ -369,78 +418,50 @@ void main() {
         navigatorKey: root,
       );
     });
-  });
 
-  test(
-    'Does not throw with valid parentNavigatorKey configuration',
-    () {
-      final GlobalKey<NavigatorState> root =
-          GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> shell =
-          GlobalKey<NavigatorState>(debugLabel: 'shell');
-      final GlobalKey<NavigatorState> shell2 =
-          GlobalKey<NavigatorState>(debugLabel: 'shell2');
-      RouteConfiguration(
-        navigatorKey: root,
-        routes: <RouteBase>[
-          ShellRoute(
-            navigatorKey: shell,
-            routes: <RouteBase>[
-              GoRoute(
-                path: '/',
-                builder: _mockScreenBuilder,
-                routes: <RouteBase>[
-                  GoRoute(
-                    path: 'a',
-                    builder: _mockScreenBuilder,
-                    parentNavigatorKey: root,
-                    routes: <RouteBase>[
-                      ShellRoute(
-                        navigatorKey: shell2,
-                        routes: <RouteBase>[
-                          GoRoute(
-                            path: 'b',
-                            builder: _mockScreenBuilder,
-                            routes: <RouteBase>[
-                              GoRoute(
-                                path: 'b',
-                                builder: _mockScreenBuilder,
-                                parentNavigatorKey: shell2,
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ],
-        redirectLimit: 10,
-        topRedirect: (BuildContext context, GoRouterState state) {
-          return null;
-        },
-      );
-    },
-  );
-
-  test('throws when ShellRoute contains a GoRoute with a parentNavigatorKey',
+    test(
+      'Does not throw with valid parentNavigatorKey configuration',
       () {
-    final GlobalKey<NavigatorState> root =
-        GlobalKey<NavigatorState>(debugLabel: 'root');
-    expect(
-      () {
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
+        final GlobalKey<NavigatorState> shell2 =
+            GlobalKey<NavigatorState>(debugLabel: 'shell2');
         RouteConfiguration(
           navigatorKey: root,
           routes: <RouteBase>[
             ShellRoute(
+              navigatorKey: shell,
               routes: <RouteBase>[
                 GoRoute(
-                  path: '/a',
+                  path: '/',
                   builder: _mockScreenBuilder,
-                  parentNavigatorKey: root,
+                  routes: <RouteBase>[
+                    GoRoute(
+                      path: 'a',
+                      builder: _mockScreenBuilder,
+                      parentNavigatorKey: root,
+                      routes: <RouteBase>[
+                        ShellRoute(
+                          navigatorKey: shell2,
+                          routes: <RouteBase>[
+                            GoRoute(
+                              path: 'b',
+                              builder: _mockScreenBuilder,
+                              routes: <RouteBase>[
+                                GoRoute(
+                                  path: 'b',
+                                  builder: _mockScreenBuilder,
+                                  parentNavigatorKey: shell2,
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
               ],
             ),
@@ -451,8 +472,36 @@ void main() {
           },
         );
       },
-      throwsAssertionError,
     );
+
+    test('throws when ShellRoute contains a GoRoute with a parentNavigatorKey',
+        () {
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      expect(
+        () {
+          RouteConfiguration(
+            navigatorKey: root,
+            routes: <RouteBase>[
+              ShellRoute(
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/a',
+                    builder: _mockScreenBuilder,
+                    parentNavigatorKey: root,
+                  ),
+                ],
+              ),
+            ],
+            redirectLimit: 10,
+            topRedirect: (BuildContext context, GoRouterState state) {
+              return null;
+            },
+          );
+        },
+        throwsAssertionError,
+      );
+    });
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/111961

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
