### PR TITLE
[flutter_markdown] fix for latest pkg:markdown part 2

### DIFF
--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.6.13
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.6.13
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: '>=3.0.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_markdown/test/link_test.dart
+++ b/packages/flutter_markdown/test/link_test.dart
@@ -6,11 +6,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:markdown/markdown.dart' as md show version;
-import 'utils.dart';
 
-// TODO(Zhiguang): delete this once the min version of pkg:markdown is updated
-final bool _newMarkdown = md.version.compareTo('6.0.1') > 0;
+import 'utils.dart';
 
 void main() => defineTests();
 
@@ -632,7 +629,7 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!_newMarkdown) {
+        if (!newMarkdown) {
           // For pkg:markdown <= v6.0.1
           expectLinkTap(linkTapResults, const MarkdownLink('link', 'foo\bar'));
         } else {
@@ -659,7 +656,7 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!_newMarkdown) {
+        if (!newMarkdown) {
           // For pkg:markdown <= v6.0.1
           expectLinkTap(
               linkTapResults, const MarkdownLink('link', 'foo%20b&auml;'));
@@ -776,7 +773,7 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!_newMarkdown) {
+        if (!newMarkdown) {
           // For pkg:markdown <= v6.0.1
           expectLinkTap(linkTapResults,
               const MarkdownLink('link', '/url', 'title %22&quot;'));
@@ -805,7 +802,7 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!_newMarkdown) {
+        if (!newMarkdown) {
           // For pkg:markdown <= v6.0.1
           expectLinkTap(linkTapResults,
               const MarkdownLink('link', '/url\u{C2A0}%22title%22'));
@@ -856,7 +853,7 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!_newMarkdown) {
+        if (!newMarkdown) {
           // For pkg:markdown <= v6.0.1
           expectLinkTap(linkTapResults,
               const MarkdownLink('link', '/url', 'title %22and%22 title'));

--- a/packages/flutter_markdown/test/link_test.dart
+++ b/packages/flutter_markdown/test/link_test.dart
@@ -6,7 +6,11 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown/markdown.dart' as md show version;
 import 'utils.dart';
+
+// TODO(Zhiguang): delete this once the min version of pkg:markdown is updated
+final bool _newMarkdown = md.version.compareTo('6.0.1') > 0;
 
 void main() => defineTests();
 
@@ -628,7 +632,13 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        expectLinkTap(linkTapResults, const MarkdownLink('link', 'foo\bar'));
+        if (!_newMarkdown) {
+          // For pkg:markdown <= v6.0.1
+          expectLinkTap(linkTapResults, const MarkdownLink('link', 'foo\bar'));
+        } else {
+          // For pkg:markdown > v6.0.1
+          expectLinkTap(linkTapResults, const MarkdownLink('link', 'foo%08ar'));
+        }
       },
     );
 
@@ -649,8 +659,15 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        expectLinkTap(
-            linkTapResults, const MarkdownLink('link', 'foo%20b&auml;'));
+        if (!_newMarkdown) {
+          // For pkg:markdown <= v6.0.1
+          expectLinkTap(
+              linkTapResults, const MarkdownLink('link', 'foo%20b&auml;'));
+        } else {
+          // For pkg:markdown > v6.0.1
+          expectLinkTap(
+              linkTapResults, const MarkdownLink('link', 'foo%20b%C3%A4'));
+        }
       },
     );
 
@@ -759,8 +776,15 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        expectLinkTap(linkTapResults,
-            const MarkdownLink('link', '/url', 'title %22&quot;'));
+        if (!_newMarkdown) {
+          // For pkg:markdown <= v6.0.1
+          expectLinkTap(linkTapResults,
+              const MarkdownLink('link', '/url', 'title %22&quot;'));
+        } else {
+          // For pkg:markdown > v6.0.1
+          expectLinkTap(linkTapResults,
+              const MarkdownLink('link', '/url', 'title &quot;&quot;'));
+        }
       },
     );
 
@@ -781,8 +805,15 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        expectLinkTap(linkTapResults,
-            const MarkdownLink('link', '/url\u{C2A0}%22title%22'));
+        if (!_newMarkdown) {
+          // For pkg:markdown <= v6.0.1
+          expectLinkTap(linkTapResults,
+              const MarkdownLink('link', '/url\u{C2A0}%22title%22'));
+        } else {
+          // For pkg:markdown > v6.0.1
+          expectLinkTap(linkTapResults,
+              const MarkdownLink('link', '/url%EC%8A%A0%22title%22'));
+        }
       },
     );
 
@@ -825,8 +856,17 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        expectLinkTap(linkTapResults,
-            const MarkdownLink('link', '/url', 'title %22and%22 title'));
+        if (!_newMarkdown) {
+          // For pkg:markdown <= v6.0.1
+          expectLinkTap(linkTapResults,
+              const MarkdownLink('link', '/url', 'title %22and%22 title'));
+        } else {
+          // For pkg:markdown > v6.0.1
+          expectLinkTap(
+            linkTapResults,
+            const MarkdownLink('link', '/url', 'title &quot;and&quot; title'),
+          );
+        }
       },
     );
 

--- a/packages/flutter_markdown/test/table_test.dart
+++ b/packages/flutter_markdown/test/table_test.dart
@@ -5,12 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:markdown/markdown.dart' as md show version;
 
 import 'utils.dart';
-
-// TODO(kevmoo): delete this once the min version of pkg:markdown is updated
-final bool _newMarkdown = md.version.compareTo('6.0.1') > 0;
 
 void main() => defineTests();
 
@@ -395,7 +391,7 @@ void defineTests() {
 
           expectTableSize(3, 2);
 
-          if (!_newMarkdown) {
+          if (!newMarkdown) {
             // For pkg:markdown <= v6.0.1
             expect(find.byType(RichText), findsNWidgets(6));
             final List<String?> text = find
@@ -464,7 +460,7 @@ void defineTests() {
               .toList();
           expect(text[0], '| abc | def | | --- | | bar |');
         },
-        skip: !_newMarkdown,
+        skip: !newMarkdown,
       );
 
       testWidgets(
@@ -489,7 +485,7 @@ void defineTests() {
 
           expectTableSize(3, 2);
 
-          if (!_newMarkdown) {
+          if (!newMarkdown) {
             // For pkg:markdown <= v6.0.1
             expect(find.byType(RichText), findsNWidgets(5));
             final List<String?> cellText = find

--- a/packages/flutter_markdown/test/utils.dart
+++ b/packages/flutter_markdown/test/utils.dart
@@ -9,6 +9,10 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown/markdown.dart' as md show version;
+
+// TODO(Zhiguang): delete this once the min version of pkg:markdown is updated
+final bool newMarkdown = md.version.compareTo('6.0.1') > 0;
 
 final TextTheme textTheme = Typography.material2018()
     .black


### PR DESCRIPTION
The same reason as this PR: https://github.com/flutter/packages/pull/2777

CC @srawlins @kevmoo