### PR TITLE
[go_router] Fix broken links in documentation

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 5.1.9
+
+- Fixes broken links in documentation.
+
 ## 5.1.8
 
 - Fixes a bug with `replace` where it was not generated a new `pageKey`.
 
 ## 5.1.7
 
-- Adds documentation using dartdoc topics
+- Adds documentation using dartdoc topics.
 
 ## 5.1.6
 

--- a/packages/go_router/README.md
+++ b/packages/go_router/README.md
@@ -34,7 +34,6 @@ See the API documentation for details on the following topics:
 - [Transition animations](https://pub.dev/documentation/go_router/latest/topics/Transition%20animations-topic.html)
 - [Type-safe routes](https://pub.dev/documentation/go_router/latest/topics/Type-safe%20routes-topic.html)
 - [Named routes](https://pub.dev/documentation/go_router/latest/topics/Named%20routes-topic.html)
-- [Logging](https://pub.dev/documentation/go_router/latest/topics/Logging-topic.html)
 - [Error handling](https://pub.dev/documentation/go_router/latest/topics/Error%20handling-topic.html)
 
 ## Migration guides

--- a/packages/go_router/doc/get-started.md
+++ b/packages/go_router/doc/get-started.md
@@ -35,4 +35,4 @@ For a complete sample, see the [Getting started sample][] in the example directo
 For more on how to configure GoRouter, see [Configuration].
 
 [Getting started sample]: https://github.com/flutter/packages/tree/main/packages/go_router/example/lib/main.dart
-[Configuration]: https://pub.dev/documentation/go_router/topics/Configuration-topic.html 
+[Configuration]: https://pub.dev/documentation/go_router/latest/topics/Configuration-topic.html 

--- a/packages/go_router/doc/redirection.md
+++ b/packages/go_router/doc/redirection.md
@@ -3,9 +3,9 @@ example, redirection can be used to display a sign-in screen if the user is not
 logged in.
 
 A redirect is a callback of the type
-[GoRouterRedirect](go_router/GoRouterRedirect.html). To change incoming location
-based on some application state, add a callback to either the GoRouter or
-GoRoute constructor:
+[GoRouterRedirect](https://pub.dev/documentation/go_router/latest/go_router/GoRouterRedirect.html).
+To change incoming location based on some application state, add a callback to
+either the GoRouter or GoRoute constructor:
 
 
 ```dart

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 5.1.8
+version: 5.1.9
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 


### PR DESCRIPTION
I found some issues using the [linkcheck](https://pub.dev/packages/linkcheck) package, this fixes broken links introduced in #2789.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
