### PR TITLE
[pigeon] doc comments always start with ' '

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.6
+
+* Fixes bug with parsing documentation comments that start with '/'.
+
 ## 4.2.5
 
 * [dart] Fixes enum parameter handling in Dart test API class.

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -9,7 +9,7 @@ import 'dart:mirrors';
 import 'ast.dart';
 
 /// The current version of pigeon. This must match the version in pubspec.yaml.
-const String pigeonVersion = '4.2.5';
+const String pigeonVersion = '4.2.6';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {
@@ -474,7 +474,10 @@ void addDocumentationComments(
       indent.writeln(commentSpec.openCommentToken);
       currentLineOpenToken = commentSpec.blockContinuationToken;
     }
-    for (final String line in allComments) {
+    for (String line in allComments) {
+      if (line.isNotEmpty && line[0] != ' ') {
+        line = ' $line';
+      }
       indent.writeln(
         '$currentLineOpenToken$line',
       );

--- a/packages/pigeon/pigeons/message.dart
+++ b/packages/pigeon/pigeons/message.dart
@@ -20,6 +20,10 @@ import 'package:pigeon/pigeon.dart';
 /// This comment is to test enum documentation comments.
 ///
 /// This comment also tests multiple line comments.
+///
+///////////////////////////
+/// This comment also tests comments that start with '/'
+///////////////////////////
 enum MessageRequestState {
   pending,
   success,

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/android/src/main/.gitignore
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/android/src/main/.gitignore
@@ -2,4 +2,4 @@
 # changes on generated files. This will need a way to avoid unnecessary churn,
 # such as a flag to suppress version stamp generation.
 *.java
-!AlternateLanguageTestPlugin.kt
+!AlternateLanguageTestPlugin.java

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 4.2.5 # This must match the version in lib/generator_tools.dart
+version: 4.2.6 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/pigeon/test/cpp_generator_test.dart
+++ b/packages/pigeon/test/cpp_generator_test.dart
@@ -1062,6 +1062,9 @@ void main() {
     ];
     int count = 0;
 
+    final List<String> unspacedComments = <String>['////////'];
+    int unspacedCount = 0;
+
     final Root root = Root(
       apis: <Api>[
         Api(
@@ -1107,7 +1110,10 @@ void main() {
       enums: <Enum>[
         Enum(
           name: 'enum',
-          documentationComments: <String>[comments[count++]],
+          documentationComments: <String>[
+            comments[count++],
+            unspacedComments[unspacedCount++]
+          ],
           members: <String>[
             'one',
             'two',
@@ -1121,6 +1127,7 @@ void main() {
     for (final String comment in comments) {
       expect(code, contains('//$comment'));
     }
+    expect(code, contains('// ///'));
   });
 
   test('doesnt create codecs if no custom datatypes', () {

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -1174,6 +1174,10 @@ name: foobar
       ' enum comment',
     ];
     int count = 0;
+
+    final List<String> unspacedComments = <String>['////////'];
+    int unspacedCount = 0;
+
     final Root root = Root(
       apis: <Api>[
         Api(
@@ -1219,7 +1223,10 @@ name: foobar
       enums: <Enum>[
         Enum(
           name: 'enum',
-          documentationComments: <String>[comments[count++]],
+          documentationComments: <String>[
+            comments[count++],
+            unspacedComments[unspacedCount++]
+          ],
           members: <String>[
             'one',
             'two',
@@ -1233,6 +1240,7 @@ name: foobar
     for (final String comment in comments) {
       expect(code, contains('///$comment'));
     }
+    expect(code, contains('/// ///'));
   });
 
   test('doesnt create codecs if no custom datatypes', () {

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -6,6 +6,7 @@ import 'package:pigeon/ast.dart';
 import 'package:pigeon/java_generator.dart';
 import 'package:pigeon/pigeon.dart';
 import 'package:test/test.dart';
+import 'package:pigeon/generator_tools.dart';
 
 void main() {
   test('gen one class', () {
@@ -1139,6 +1140,9 @@ void main() {
     ];
     int count = 0;
 
+    final List<String> unspacedComments = <String>['////////'];
+    int unspacedCount = 0;
+
     final Root root = Root(
       apis: <Api>[
         Api(
@@ -1185,7 +1189,10 @@ void main() {
       enums: <Enum>[
         Enum(
           name: 'enum',
-          documentationComments: <String>[comments[count++]],
+          documentationComments: <String>[
+            comments[count++],
+            unspacedComments[unspacedCount++]
+          ],
           members: <String>[
             'one',
             'two',
@@ -1204,6 +1211,7 @@ void main() {
               .hasMatch(code),
           true);
     }
+    expect(code, isNot(contains('*//')));
   });
 
   test('doesnt create codecs if no custom datatypes', () {

--- a/packages/pigeon/test/java_generator_test.dart
+++ b/packages/pigeon/test/java_generator_test.dart
@@ -6,7 +6,6 @@ import 'package:pigeon/ast.dart';
 import 'package:pigeon/java_generator.dart';
 import 'package:pigeon/pigeon.dart';
 import 'package:test/test.dart';
-import 'package:pigeon/generator_tools.dart';
 
 void main() {
   test('gen one class', () {

--- a/packages/pigeon/test/kotlin_generator_test.dart
+++ b/packages/pigeon/test/kotlin_generator_test.dart
@@ -1019,6 +1019,9 @@ void main() {
     ];
     int count = 0;
 
+    final List<String> unspacedComments = <String>['////////'];
+    int unspacedCount = 0;
+
     final Root root = Root(
       apis: <Api>[
         Api(
@@ -1065,7 +1068,10 @@ void main() {
       enums: <Enum>[
         Enum(
           name: 'enum',
-          documentationComments: <String>[comments[count++]],
+          documentationComments: <String>[
+            comments[count++],
+            unspacedComments[unspacedCount++]
+          ],
           members: <String>[
             'one',
             'two',
@@ -1084,6 +1090,7 @@ void main() {
               .hasMatch(code),
           true);
     }
+    expect(code, isNot(contains('*//')));
   });
 
   test('doesnt create codecs if no custom datatypes', () {

--- a/packages/pigeon/test/objc_generator_test.dart
+++ b/packages/pigeon/test/objc_generator_test.dart
@@ -1751,6 +1751,9 @@ void main() {
     ];
     int count = 0;
 
+    final List<String> unspacedComments = <String>['////////'];
+    int unspacedCount = 0;
+
     final Root root = Root(
       apis: <Api>[
         Api(
@@ -1797,7 +1800,10 @@ void main() {
       enums: <Enum>[
         Enum(
           name: 'enum',
-          documentationComments: <String>[comments[count++]],
+          documentationComments: <String>[
+            comments[count++],
+            unspacedComments[unspacedCount++]
+          ],
           members: <String>[
             'one',
             'two',
@@ -1811,6 +1817,7 @@ void main() {
     for (final String comment in comments) {
       expect(code, contains('///$comment'));
     }
+    expect(code, contains('/// ///'));
   });
 
   test('doesnt create codecs if no custom datatypes', () {

--- a/packages/pigeon/test/swift_generator_test.dart
+++ b/packages/pigeon/test/swift_generator_test.dart
@@ -958,6 +958,9 @@ void main() {
     ];
     int count = 0;
 
+    final List<String> unspacedComments = <String>['////////'];
+    int unspacedCount = 0;
+
     final Root root = Root(
       apis: <Api>[
         Api(
@@ -1004,7 +1007,10 @@ void main() {
       enums: <Enum>[
         Enum(
           name: 'enum',
-          documentationComments: <String>[comments[count++]],
+          documentationComments: <String>[
+            comments[count++],
+            unspacedComments[unspacedCount++]
+          ],
           members: <String>[
             'one',
             'two',
@@ -1019,6 +1025,7 @@ void main() {
     for (final String comment in comments) {
       expect(code, contains('///$comment'));
     }
+    expect(code, contains('/// ///'));
   });
 
   test('doesnt create codecs if no custom datatypes', () {


### PR DESCRIPTION
adds a space to all documentation comments that do not start with a space to avoid issues with languages that use */ to close block comments.

List which issues are fixed by this PR. You must list at least one issue.
fixes https://github.com/flutter/flutter/issues/115657

If you had to change anything in the [flutter/tests](https://github.com/flutter/tests) repo, include a link to the migration guide as per the [breaking change policy](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes).

Pre-launch Checklist
 I read the [Contributor Guide](https://github.com/flutter/packages/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
 I read the [Tree Hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene) wiki page, which explains my responsibilities.
 I read and followed the [relevant style guides](https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style) and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use dart format.)
 I signed the [CLA](https://cla.developers.google.com/).
 The title of the PR starts with the name of the package surrounded by square brackets, e.g. [shared_preferences]
 I listed at least one issue that this PR fixes in the description above.
 I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning), or this PR is [exempt from version changes](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates).
 I updated CHANGELOG.md to add a description of the change, [following repository CHANGELOG style](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style).
 I updated/added relevant documentation (doc comments with ///).
 I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/wiki/Tree-hygiene#tests).
 All existing and new tests are passing.