### PR TITLE
[pigeon] Add local-only Kotlin integration tests

### DIFF
--- a/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/TestPlugin.kt
+++ b/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/TestPlugin.kt
@@ -13,13 +13,32 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
 /**
- * This plugin is currently a no-op since only unit tests have been set up.
- * In the future, this will register Pigeon APIs used in integration tests.
+ * This plugin handles the native side of the integration tests in
+ * example/integration_test/.
  */
-class TestPlugin: FlutterPlugin {
-  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+class TestPlugin: FlutterPlugin, AllVoidHostApi, HostEverything {
+  override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    AllVoidHostApi.setUp(binding.getBinaryMessenger(), this)
+    HostEverything.setUp(binding.getBinaryMessenger(), this)
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+  }
+
+  // AllVoidHostApi
+
+  override fun doit() {
+    // No-op.
+  }
+
+  // HostEverything
+
+  override fun giveMeEverything(): Everything {
+    // Currently unused in integration tests, so just return an empty object.
+    return Everything()
+  }
+
+  override fun echo(everything: Everything): Everything {
+    return everything
   }
 }

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -177,6 +177,10 @@ run_android_kotlin_unittests() {
   dart run tool/run_tests.dart -t android_kotlin_unittests --skip-generation
 }
 
+run_android_kotlin_e2e_tests() {
+  dart run tool/run_tests.dart -t android_kotlin_integration_tests --skip-generation
+}
+
 run_dart_compilation_tests() {
   local temp_dir=$(mktmpdir)
   local flutter_project_dir=$temp_dir/project
@@ -261,6 +265,9 @@ should_run_mock_handler_tests=true
 should_run_macos_swift_unittests=true
 should_run_macos_swift_e2e_tests=true
 should_run_android_kotlin_unittests=true
+# Default to false until there is CI support. See
+# https://github.com/flutter/flutter/issues/111505
+should_run_android_kotlin_e2e_tests=false
 while getopts "t:l?h" opt; do
   case $opt in
   t)
@@ -275,6 +282,7 @@ while getopts "t:l?h" opt; do
     should_run_macos_swift_unittests=false
     should_run_macos_swift_e2e_tests=false
     should_run_android_kotlin_unittests=false
+    should_run_android_kotlin_e2e_tests=false
     case $OPTARG in
     # TODO(stuartmorgan): Rename to include "java".
     android_unittests) should_run_android_unittests=true ;;
@@ -289,6 +297,7 @@ while getopts "t:l?h" opt; do
     macos_swift_unittests) should_run_macos_swift_unittests=true ;;
     macos_swift_e2e_tests) should_run_macos_swift_e2e_tests=true ;;
     android_kotlin_unittests) should_run_android_kotlin_unittests=true ;;
+    android_kotlin_e2e_tests) should_run_android_kotlin_e2e_tests=true ;;
     *)
       echo "unrecognized test: $OPTARG"
       exit 1
@@ -299,6 +308,7 @@ while getopts "t:l?h" opt; do
     echo "available tests for -t:
   android_unittests        - Unit tests on generated Java code.
   android_kotlin_unittests - Unit tests on generated Kotlin code on Android.
+  android_kotlin_e2e_tests - Integration tests on generated Kotlin code on Android.
   dart_compilation_tests   - Compilation tests on generated Dart code.
   dart_unittests           - Unit tests on and analysis on Pigeon's implementation.
   flutter_unittests        - Unit tests on generated Dart code.
@@ -369,4 +379,7 @@ if [ "$should_run_macos_swift_e2e_tests" = true ]; then
 fi
 if [ "$should_run_android_kotlin_unittests" = true ]; then
   run_android_kotlin_unittests
+fi
+if [ "$should_run_android_kotlin_e2e_tests" = true ]; then
+  run_android_kotlin_e2e_tests
 fi

--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -16,6 +16,7 @@ import 'package:args/args.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
+import 'shared/flutter_utils.dart';
 import 'shared/generation.dart';
 import 'shared/native_project_runners.dart';
 import 'shared/process_utils.dart';
@@ -23,6 +24,8 @@ import 'shared/process_utils.dart';
 const String _testFlag = 'test';
 const String _listFlag = 'list';
 const String _skipGenerationFlag = 'skip-generation';
+
+const int _noDeviceAvailableExitCode = 100;
 
 const String _testPluginRelativePath = 'platform_tests/test_plugin';
 const String _integrationTestFileRelativePath = 'integration_test/test.dart';
@@ -44,6 +47,9 @@ const Map<String, _TestInfo> _tests = <String, _TestInfo>{
   'android_kotlin_unittests': _TestInfo(
       function: _runAndroidKotlinUnitTests,
       description: 'Unit tests on generated Kotlin code.'),
+  'android_kotlin_integration_tests': _TestInfo(
+      function: _runAndroidKotlinIntegrationTests,
+      description: 'Integration tests on generated Kotlin code.'),
   'dart_compilation_tests': _TestInfo(
       function: _runDartCompilationTests,
       description: 'Compilation tests on generated Dart code.'),
@@ -86,6 +92,22 @@ Future<int> _runAndroidKotlinUnitTests() async {
   }
 
   return runGradleBuild(androidProjectPath, 'testDebugUnitTest');
+}
+
+Future<int> _runAndroidKotlinIntegrationTests() async {
+  final String? device = await getDeviceForPlatform('android');
+  if (device == null) {
+    print('No Android device available. Attach an Android device or start '
+        'an emulator to run integration tests');
+    return _noDeviceAvailableExitCode;
+  }
+
+  const String examplePath = './$_testPluginRelativePath/example';
+  return runFlutterCommand(
+    examplePath,
+    'test',
+    <String>[_integrationTestFileRelativePath, '-d', device],
+  );
 }
 
 Future<int> _runDartCompilationTests() async {

--- a/packages/pigeon/tool/shared/flutter_utils.dart
+++ b/packages/pigeon/tool/shared/flutter_utils.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:io';
+
+String getFlutterCommand() => Platform.isWindows ? 'flutter.bat' : 'flutter';
+
+/// Returns the first device listed by `flutter devices` that targets
+/// [platform], or null if there is no such device.
+Future<String?> getDeviceForPlatform(String platform) async {
+  final ProcessResult result = await Process.run(
+    getFlutterCommand(),
+    <String>['devices', '--machine'],
+    stdoutEncoding: utf8,
+  );
+  if (result.exitCode != 0) {
+    return null;
+  }
+
+  String output = result.stdout as String;
+  // --machine doesn't currently prevent the tool from printing banners;
+  // see https://github.com/flutter/flutter/issues/86055. This workaround
+  // can be removed once that is fixed.
+  output = output.substring(output.indexOf('['));
+
+  final List<Map<String, dynamic>> devices =
+      (jsonDecode(output) as List<dynamic>).cast<Map<String, dynamic>>();
+  for (final Map<String, dynamic> deviceInfo in devices) {
+    final String targetPlatform =
+        (deviceInfo['targetPlatform'] as String?) ?? '';
+    if (targetPlatform.startsWith(platform)) {
+      final String? deviceId = deviceInfo['id'] as String?;
+      if (deviceId != null) {
+        return deviceId;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/pigeon/tool/shared/flutter_utils.dart
+++ b/packages/pigeon/tool/shared/flutter_utils.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/packages/pigeon/tool/shared/native_project_runners.dart
+++ b/packages/pigeon/tool/shared/native_project_runners.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
+import 'flutter_utils.dart';
 import 'process_utils.dart';
 
 Future<int> runFlutterCommand(
@@ -11,9 +10,8 @@ Future<int> runFlutterCommand(
   String command, [
   List<String> commandArguments = const <String>[],
 ]) {
-  final String flutterCommand = Platform.isWindows ? 'flutter.bat' : 'flutter';
   return runProcess(
-    flutterCommand,
+    getFlutterCommand(),
     <String>[
       command,
       ...commandArguments,


### PR DESCRIPTION
Adds a new test target to run the new shared integration tests on Kotlin, and adds the necessary native-side plumbing.

This is not run by default because it requires a device or emulator to be present, and we don't have that set up for CI yet (and we don't yet have a different script entrypoint for manual vs CI tests).

Enabling this in CI is tracked in
https://github.com/flutter/flutter/issues/111505, but landing it now allows for better manual testing of generator changes during development.

Part of https://github.com/flutter/flutter/issues/111505

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
