### PR TITLE
[pigeon] Enable iOS Swift integration tests

### DIFF
--- a/packages/pigeon/platform_tests/test_plugin/ios/Classes/TestPlugin.swift
+++ b/packages/pigeon/platform_tests/test_plugin/ios/Classes/TestPlugin.swift
@@ -6,14 +6,30 @@ import Flutter
 import UIKit
 
 /**
- * This plugin is currently a no-op since only unit tests have been set up.
- * In the future, this will register Pigeon APIs used in integration tests.
+ * This plugin handles the native side of the integration tests in
+ * example/integration_test/.
  */
-public class TestPlugin: NSObject, FlutterPlugin {
+public class TestPlugin: NSObject, FlutterPlugin, AllVoidHostApi, HostEverything {
   public static func register(with registrar: FlutterPluginRegistrar) {
+    let plugin = TestPlugin()
+    AllVoidHostApiSetup.setUp(binaryMessenger: registrar.messenger(), api: plugin)
+    HostEverythingSetup.setUp(binaryMessenger: registrar.messenger(), api: plugin)
   }
 
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    result(FlutterMethodNotImplemented)
+  // MARK: AllVoidHostApi implementation
+
+  func doit() {
+    // No-op
+  }
+
+  // MARK: HostEverything implementation
+
+  func giveMeEverything() -> Everything {
+    // Currently unused in integration tests, so just return an empty object.
+    return Everything()
+  }
+
+  func echo(everything: Everything) -> Everything {
+    return everything
   }
 }

--- a/packages/pigeon/run_tests.sh
+++ b/packages/pigeon/run_tests.sh
@@ -165,6 +165,10 @@ run_ios_swift_unittests() {
   dart run tool/run_tests.dart -t ios_swift_unittests --skip-generation
 }
 
+run_ios_swift_e2e_tests() {
+  dart run tool/run_tests.dart -t ios_swift_integration_tests --skip-generation
+}
+
 run_macos_swift_unittests() {
   dart run tool/run_tests.dart -t macos_swift_unittests --skip-generation
 }
@@ -214,7 +218,7 @@ run_ios_unittests() {
   popd
 }
 
-run_ios_e2e_tests() {
+run_ios_e2e_legacy_tests() {
   DARTLE_H="e2e_tests/test_objc/ios/Runner/dartle.h"
   DARTLE_M="e2e_tests/test_objc/ios/Runner/dartle.m"
   DARTLE_DART="e2e_tests/test_objc/lib/dartle.dart"
@@ -262,9 +266,13 @@ should_run_android_unittests=true
 should_run_dart_compilation_tests=true
 should_run_dart_unittests=true
 should_run_flutter_unittests=true
-should_run_ios_e2e_tests=true
+should_run_ios_e2e_legacy_tests=true
 should_run_ios_unittests=true
 should_run_ios_swift_unittests=true
+# Currently these are testing exactly the same thing as macos_swift_e2e_tests,
+# so we don't need to run both by default. This should become `true` if any
+# iOS-only tests are added (e.g., for a feature not supported by macOS).
+should_run_ios_swift_e2e_tests=false
 should_run_mock_handler_tests=true
 should_run_macos_swift_unittests=true
 should_run_macos_swift_e2e_tests=true
@@ -280,9 +288,10 @@ while getopts "t:l?h" opt; do
     should_run_dart_compilation_tests=false
     should_run_dart_unittests=false
     should_run_flutter_unittests=false
-    should_run_ios_e2e_tests=false
+    should_run_ios_e2e_legacy_tests=false
     should_run_ios_unittests=false
     should_run_ios_swift_unittests=false
+    should_run_ios_swift_e2e_tests=false
     should_run_mock_handler_tests=false
     should_run_macos_swift_unittests=false
     should_run_macos_swift_e2e_tests=false
@@ -296,10 +305,11 @@ while getopts "t:l?h" opt; do
     dart_compilation_tests) should_run_dart_compilation_tests=true ;;
     dart_unittests) should_run_dart_unittests=true ;;
     flutter_unittests) should_run_flutter_unittests=true ;;
-    ios_e2e_tests) should_run_ios_e2e_tests=true ;;
+    ios_e2e_legacy_tests) should_run_ios_e2e_legacy_tests=true ;;
     # TODO(stuartmorgan): Rename to include "objc".
     ios_unittests) should_run_ios_unittests=true ;;
     ios_swift_unittests) should_run_ios_swift_unittests=true ;;
+    ios_swift_e2e_tests) should_run_ios_swift_e2e_tests=true ;;
     mock_handler_tests) should_run_mock_handler_tests=true ;;
     macos_swift_unittests) should_run_macos_swift_unittests=true ;;
     macos_swift_e2e_tests) should_run_macos_swift_e2e_tests=true ;;
@@ -320,9 +330,10 @@ while getopts "t:l?h" opt; do
   dart_compilation_tests   - Compilation tests on generated Dart code.
   dart_unittests           - Unit tests on and analysis on Pigeon's implementation.
   flutter_unittests        - Unit tests on generated Dart code.
-  ios_e2e_tests            - End-to-end objc tests run on iOS Simulator
+  ios_e2e_legacy_tests     - Legacy end-to-end Obj-C tests; build-only.
   ios_unittests            - Unit tests on generated Objc code.
   ios_swift_unittests      - Unit tests on generated Swift code.
+  ios_swift_e2e_tests      - Integration tests on generated Swift code on iOS.
   mock_handler_tests       - Unit tests on generated Dart mock handler code.
   macos_swift_unittests    - Unit tests on generated Swift code on macOS.
   macos_swift_e2e_tests    - Integration tests on generated Swift code on macOS.
@@ -373,8 +384,11 @@ fi
 if [ "$should_run_ios_swift_unittests" = true ]; then
   run_ios_swift_unittests
 fi
-if [ "$should_run_ios_e2e_tests" = true ]; then
-  run_ios_e2e_tests
+if [ "$should_run_ios_swift_e2e_tests" = true ]; then
+  run_ios_swift_e2e_tests
+fi
+if [ "$should_run_ios_e2e_legacy_tests" = true ]; then
+  run_ios_e2e_legacy_tests
 fi
 if [ "$should_run_android_unittests" = true ]; then
   run_android_unittests

--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -68,11 +68,14 @@ const Map<String, _TestInfo> _tests = <String, _TestInfo>{
       function: _runFlutterUnitTests,
       description: 'Unit tests on generated Dart code.'),
   'ios_unittests': _TestInfo(
-      function: _runIosUnitTests,
+      function: _runIOSUnitTests,
       description: 'Unit tests on generated Objective-C code.'),
   'ios_swift_unittests': _TestInfo(
-      function: _runIosSwiftUnitTests,
+      function: _runIOSSwiftUnitTests,
       description: 'Unit tests on generated Swift code.'),
+  'ios_swift_integration_tests': _TestInfo(
+      function: _runIOSSwiftIntegrationTests,
+      description: 'Integration tests on generated Swift code.'),
   'macos_swift_unittests': _TestInfo(
       function: _runMacOSSwiftUnitTests,
       description: 'Unit tests on generated Swift code on macOS.'),
@@ -89,7 +92,8 @@ Future<int> _runAndroidJavaUnitTests() async {
 }
 
 Future<int> _runAndroidJavaIntegrationTests() async {
-  return _runAndroidIntegrationTests(_alternateLanguageTestPluginRelativePath);
+  return _runMobileIntegrationTests(
+      'Android', _alternateLanguageTestPluginRelativePath);
 }
 
 Future<int> _runAndroidKotlinUnitTests() async {
@@ -107,14 +111,15 @@ Future<int> _runAndroidKotlinUnitTests() async {
 }
 
 Future<int> _runAndroidKotlinIntegrationTests() async {
-  return _runAndroidIntegrationTests(_testPluginRelativePath);
+  return _runMobileIntegrationTests('Android', _testPluginRelativePath);
 }
 
-Future<int> _runAndroidIntegrationTests(String testPluginPath) async {
-  final String? device = await getDeviceForPlatform('android');
+Future<int> _runMobileIntegrationTests(
+    String platform, String testPluginPath) async {
+  final String? device = await getDeviceForPlatform(platform.toLowerCase());
   if (device == null) {
-    print('No Android device available. Attach an Android device or start '
-        'an emulator to run integration tests');
+    print('No $platform device available. Attach an $platform device or start '
+        'an emulator/simulator to run integration tests');
     return _noDeviceAvailableExitCode;
   }
 
@@ -218,7 +223,7 @@ Future<int> _runFlutterUnitTests() async {
   return 0;
 }
 
-Future<int> _runIosUnitTests() async {
+Future<int> _runIOSUnitTests() async {
   throw UnimplementedError('See run_tests.sh.');
 }
 
@@ -244,7 +249,7 @@ Future<int> _runMacOSSwiftIntegrationTests() async {
   );
 }
 
-Future<int> _runIosSwiftUnitTests() async {
+Future<int> _runIOSSwiftUnitTests() async {
   const String examplePath = './$_testPluginRelativePath/example';
   final int compileCode = await runFlutterBuild(
     examplePath,
@@ -261,6 +266,10 @@ Future<int> _runIosSwiftUnitTests() async {
     destination: 'platform=iOS Simulator,name=iPhone 8',
     extraArguments: <String>['test'],
   );
+}
+
+Future<int> _runIOSSwiftIntegrationTests() async {
+  return _runMobileIntegrationTests('iOS', _testPluginRelativePath);
 }
 
 Future<int> _runMockHandlerTests() async {

--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -29,7 +29,7 @@ const int _noDeviceAvailableExitCode = 100;
 
 const String _testPluginRelativePath = 'platform_tests/test_plugin';
 const String _alternateLanguageTestPluginRelativePath =
-    'platform_tests/test_plugin';
+    'platform_tests/alternate_language_test_plugin';
 const String _integrationTestFileRelativePath = 'integration_test/test.dart';
 
 @immutable


### PR DESCRIPTION
Enables the new shared integration tests for the iOS Swift generator, adding the new corresponding test script target. It is currently not on by default (e.g., for CI) since currently the test set is exactly the same as the macOS Swift integration tests (which are easier and faster to run since they don't require a simulator).

Renames the non-running legacy iOS integration tests to reduce confusion until they are ported and removed.

Part of https://github.com/flutter/flutter/issues/111505

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
