### PR TITLE
[pigeon] Allow specifying multiple tests

### DIFF
--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -337,7 +337,7 @@ Future<int> _runWindowsIntegrationTests() async {
 
 Future<void> main(List<String> args) async {
   final ArgParser parser = ArgParser()
-    ..addOption(_testFlag, abbr: 't', help: 'Only run specified test.')
+    ..addMultiOption(_testFlag, abbr: 't', help: 'Only run specified tests.')
     ..addFlag(_listFlag,
         negatable: false, abbr: 'l', help: 'List available tests.')
     // Temporarily provide a way for run_test.sh to bypass generation, since
@@ -368,7 +368,7 @@ usage: dart run tool/run_tests.dart [-l | -t <test name>]
 ${parser.usage}''');
     exit(0);
   } else if (argResults.wasParsed(_testFlag)) {
-    testsToRun = <String>[argResults[_testFlag]];
+    testsToRun = argResults[_testFlag];
   }
 
   if (!argResults.wasParsed(_skipGenerationFlag)) {

--- a/packages/pigeon/tool/shared/process_utils.dart
+++ b/packages/pigeon/tool/shared/process_utils.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-
 import 'dart:io' show Process, stderr, stdout;
 
 Future<Process> _streamOutput(Future<Process> processFuture) async {

--- a/packages/pigeon/tool/shared/process_utils.dart
+++ b/packages/pigeon/tool/shared/process_utils.dart
@@ -2,12 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'dart:io' show Process, stderr, stdout;
 
 Future<Process> _streamOutput(Future<Process> processFuture) async {
   final Process process = await processFuture;
-  stdout.addStream(process.stdout);
-  stderr.addStream(process.stderr);
+  await Future.wait(<Future<Object?>>[
+    stdout.addStream(process.stdout),
+    stderr.addStream(process.stderr),
+  ]);
   return process;
 }
 


### PR DESCRIPTION
Make the `-t` flag to `run_tests.dart` a multi-flag, so that it's
possible to run multiple tests (other than all default tests) in a single
invocation.

Fixes a bug exposed by this, where we were not waiting for streams to finish before trying to add new streams, which is fatal.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
