### PR TITLE
[go_router] Refactors GoRouter.pop to handle pageless route

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.1
+
+- Refactors `GoRouter.pop` to be able to pop individual pageless route with result.
+
 ## 5.2.0
 
 - Fixes `GoRouterState.location` and `GoRouterState.param` to return correct value.

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -128,13 +128,16 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
     );
   }
 
-  /// Pops the top page off the GoRouter's page stack.
-  void _onPopPage() {
+  bool _onPopPage(Route<Object?> route, Object? result) {
+    if (!route.didPop(result)) {
+      return false;
+    }
     _matchList.pop();
     assert(() {
       _debugAssertMatchListNotEmpty();
       return true;
     }());
+    return true;
   }
 
   /// Replaces the top-most page of the page stack with the given one.
@@ -181,6 +184,12 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
   }
 }
 
+/// An iterator that iterates through navigators that [GoRouterDelegate]
+/// created from the inner to outer.
+///
+/// The iterator starts with the navigator that hosts the top-most route. This
+/// navigator may not be the inner-most navigator if the top-most route is a
+/// pageless route, such as a dialog or bottom sheet.
 class _NavigatorStateIterator extends Iterator<NavigatorState> {
   _NavigatorStateIterator(this.matchList, this.root)
       : index = matchList.matches.length;

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -11,6 +11,7 @@ import 'builder.dart';
 import 'configuration.dart';
 import 'match.dart';
 import 'matching.dart';
+import 'misc/errors.dart';
 import 'typedefs.dart';
 
 /// GoRouter implementation of [RouterDelegate].
@@ -59,38 +60,19 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
   final Map<String, int> _pushCounts = <String, int>{};
   final RouteConfiguration _configuration;
 
+  _NavigatorStateIterator _createNavigatorStateIterator() =>
+      _NavigatorStateIterator(_matchList, navigatorKey.currentState!);
+
   @override
   Future<bool> popRoute() async {
-    // Iterate backwards through the RouteMatchList until seeing a GoRoute with
-    // a non-null parentNavigatorKey or a ShellRoute with a non-null
-    // parentNavigatorKey and pop from that Navigator instead of the root.
-    final int matchCount = _matchList.matches.length;
-    for (int i = matchCount - 1; i >= 0; i -= 1) {
-      final RouteMatch match = _matchList.matches[i];
-      final RouteBase route = match.route;
-
-      if (route is GoRoute && route.parentNavigatorKey != null) {
-        final bool didPop =
-            await route.parentNavigatorKey!.currentState!.maybePop();
-
-        // Continue if didPop was false.
-        if (didPop) {
-          return didPop;
-        }
-      } else if (route is ShellRoute) {
-        final bool didPop = await route.navigatorKey.currentState!.maybePop();
-
-        // Continue if didPop was false.
-        if (didPop) {
-          return didPop;
-        }
+    final _NavigatorStateIterator iterator = _createNavigatorStateIterator();
+    while (iterator.moveNext()) {
+      final bool didPop = await iterator.current.maybePop();
+      if (didPop) {
+        return true;
       }
     }
-
-    // Use the root navigator if no ShellRoute Navigators were found and didn't
-    // pop
-    final NavigatorState navigator = navigatorKey.currentState!;
-    return navigator.maybePop();
+    return false;
   }
 
   /// Pushes the given location onto the page stack
@@ -117,29 +99,25 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
 
   /// Returns `true` if the active Navigator can pop.
   bool canPop() {
-    // Loop through navigators in reverse and call canPop()
-    final int matchCount = _matchList.matches.length;
-    for (int i = matchCount - 1; i >= 0; i -= 1) {
-      final RouteMatch match = _matchList.matches[i];
-      final RouteBase route = match.route;
-      if (route is GoRoute && route.parentNavigatorKey != null) {
-        final bool canPop =
-            route.parentNavigatorKey!.currentState?.canPop() ?? false;
-
-        // Continue if canPop is false.
-        if (canPop) {
-          return canPop;
-        }
-      } else if (route is ShellRoute) {
-        final bool canPop = route.navigatorKey.currentState?.canPop() ?? false;
-
-        // Continue if canPop is false.
-        if (canPop) {
-          return canPop;
-        }
+    final _NavigatorStateIterator iterator = _createNavigatorStateIterator();
+    while (iterator.moveNext()) {
+      if (iterator.current.canPop()) {
+        return true;
       }
     }
-    return navigatorKey.currentState?.canPop() ?? false;
+    return false;
+  }
+
+  /// Pops the top-most route.
+  void pop<T extends Object?>([T? result]) {
+    final _NavigatorStateIterator iterator = _createNavigatorStateIterator();
+    while (iterator.moveNext()) {
+      if (iterator.current.canPop()) {
+        iterator.current.pop<T>(result);
+        return;
+      }
+    }
+    throw GoError('There is nothing to pop');
   }
 
   void _debugAssertMatchListNotEmpty() {
@@ -150,14 +128,13 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
     );
   }
 
-  /// Pop the top page off the GoRouter's page stack.
-  void pop() {
+  /// Pops the top page off the GoRouter's page stack.
+  void _onPopPage() {
     _matchList.pop();
     assert(() {
       _debugAssertMatchListNotEmpty();
       return true;
     }());
-    notifyListeners();
   }
 
   /// Replaces the top-most page of the page stack with the given one.
@@ -187,7 +164,7 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
     return builder.build(
       context,
       _matchList,
-      pop,
+      _onPopPage,
       routerNeglect,
     );
   }
@@ -201,6 +178,78 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
     // Use [SynchronousFuture] so that the initial url is processed
     // synchronously and remove unwanted initial animations on deep-linking
     return SynchronousFuture<void>(null);
+  }
+}
+
+class _NavigatorStateIterator extends Iterator<NavigatorState> {
+  _NavigatorStateIterator(this.matchList, this.root)
+      : index = matchList.matches.length;
+
+  final RouteMatchList matchList;
+  int index = 0;
+  final NavigatorState root;
+  @override
+  late NavigatorState current;
+
+  @override
+  bool moveNext() {
+    if (index < 0) {
+      return false;
+    }
+    for (index -= 1; index >= 0; index -= 1) {
+      final RouteMatch match = matchList.matches[index];
+      final RouteBase route = match.route;
+      if (route is GoRoute && route.parentNavigatorKey != null) {
+        final GlobalKey<NavigatorState> parentNavigatorKey =
+            route.parentNavigatorKey!;
+        final ModalRoute<Object?>? parentModalRoute =
+            ModalRoute.of(parentNavigatorKey.currentContext!);
+        // The ModalRoute can be null if the parentNavigatorKey references the
+        // root navigator.
+        if (parentModalRoute == null) {
+          index = -1;
+          assert(root == parentNavigatorKey.currentState);
+          current = root;
+          return true;
+        }
+        // It must be a ShellRoute that holds this parentNavigatorKey;
+        // otherwise, parentModalRoute would have been null. Updates the index
+        // to the ShellRoute
+        for (index -= 1; index >= 0; index -= 1) {
+          final RouteBase route = matchList.matches[index].route;
+          if (route is ShellRoute) {
+            if (route.navigatorKey == parentNavigatorKey) {
+              break;
+            }
+          }
+        }
+        // There may be a pageless route on top of ModalRoute that the
+        // NavigatorState of parentNavigatorKey is in. For example, an open
+        // dialog. In that case we want to find the navigator that host the
+        // pageless route.
+        if (parentModalRoute.isCurrent == false) {
+          continue;
+        }
+
+        current = parentNavigatorKey.currentState!;
+        return true;
+      } else if (route is ShellRoute) {
+        // Must have a ModalRoute parent because the navigator ShellRoute
+        // created must not be the root navigator.
+        final ModalRoute<Object?> parentModalRoute =
+            ModalRoute.of(route.navigatorKey.currentContext!)!;
+        // There may be pageless route on top of ModalRoute that the
+        // parentNavigatorKey is in. For example an open dialog.
+        if (parentModalRoute.isCurrent == false) {
+          continue;
+        }
+        current = route.navigatorKey.currentState!;
+        return true;
+      }
+    }
+    assert(index == -1);
+    current = root;
+    return true;
   }
 }
 

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -273,6 +273,9 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
   }
 
   /// Pop the top-most route off the current screen.
+  ///
+  /// If the top-most route is a pop up or dialog, this method pops it instead
+  /// of any GoRoute under it.
   void pop<T extends Object?>([T? result]) {
     assert(() {
       log.info('popping $location');

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -142,7 +142,7 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
   String get location => _location;
   String _location = '/';
 
-  /// Returns `true` if there is more than 1 page on the stack.
+  /// Returns `true` if there is at least two or more route can be pop.
   bool canPop() => _routerDelegate.canPop();
 
   void _handleStateMayChange() {
@@ -272,13 +272,13 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
     );
   }
 
-  /// Pop the top page off the GoRouter's page stack.
-  void pop() {
+  /// Pop the top-most route off the current screen.
+  void pop<T extends Object?>([T? result]) {
     assert(() {
       log.info('popping $location');
       return true;
     }());
-    _routerDelegate.pop();
+    _routerDelegate.pop<T>(result);
   }
 
   /// Refresh the route.

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 5.2.0
+version: 5.2.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/builder_test.dart
+++ b/packages/go_router/test/builder_test.dart
@@ -346,7 +346,7 @@ class _BuilderTestWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: builder.tryBuild(context, matches, () {}, false,
+      home: builder.tryBuild(context, matches, (_, __) => false, false,
           routeConfiguration.navigatorKey, <Page<Object?>, GoRouterState>{}),
       // builder: (context, child) => ,
     );

--- a/packages/go_router/test/delegate_test.dart
+++ b/packages/go_router/test/delegate_test.dart
@@ -36,24 +36,21 @@ void main() {
     testWidgets('removes the last element', (WidgetTester tester) async {
       final GoRouter goRouter = await createGoRouter(tester)
         ..push('/error');
+      await tester.pumpAndSettle();
 
-      goRouter.routerDelegate.addListener(expectAsync0(() {}));
       final RouteMatch last = goRouter.routerDelegate.matches.matches.last;
-      goRouter.routerDelegate.pop();
+      await goRouter.routerDelegate.popRoute();
       expect(goRouter.routerDelegate.matches.matches.length, 1);
       expect(goRouter.routerDelegate.matches.matches.contains(last), false);
     });
 
-    testWidgets('throws when it pops more than matches count',
+    testWidgets('pops more than matches count should return false',
         (WidgetTester tester) async {
       final GoRouter goRouter = await createGoRouter(tester)
         ..push('/error');
-      expect(
-        () => goRouter.routerDelegate
-          ..pop()
-          ..pop(),
-        throwsA(isAssertionError),
-      );
+      await tester.pumpAndSettle();
+      await goRouter.routerDelegate.popRoute();
+      expect(await goRouter.routerDelegate.popRoute(), isFalse);
     });
   });
 

--- a/packages/go_router/test/test_helpers.dart
+++ b/packages/go_router/test/test_helpers.dart
@@ -130,7 +130,7 @@ class GoRouterPopSpy extends GoRouter {
   bool popped = false;
 
   @override
-  void pop() {
+  void pop<T extends Object?>([T? result]) {
     popped = true;
   }
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/100933

also make canPop and popRoute(android back button) to be able to pop dialog pushed to any navigator 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
