### PR TITLE
Bump Dart SDK upper bound to 4.0.0

### DIFF
--- a/third_party/packages/cupertino_icons/pubspec.yaml
+++ b/third_party/packages/cupertino_icons/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 1.0.5
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 flutter:
   fonts:


### PR DESCRIPTION
This SDK constraint is causing pub version solving issues. Example: https://github.com/flutter/devtools/actions/runs/3688647196/jobs/6243745534