### PR TITLE
[rfw] Run tests for package:rfw on stable as well.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,16 +78,8 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       script:
-        # Exclude:
-        # - flutter_image; its tests need a test server, so are run via
-        #   local_tests.sh.
-        # - rfw on stable; it includes golden tests whose results differ
-        #   between branch
-        - if [[ "$CHANNEL" == "master" ]]; then
-        -   ./script/tool_runner.sh test --exclude=flutter_image
-        - else
-        -   ./script/tool_runner.sh test --exclude=flutter_image,rfw
-        - fi
+        # We exclude flutter_image because its tests need a test server, so are run via local_tests.sh.
+        - ./script/tool_runner.sh test --exclude=flutter_image
       depends_on:
         - format+analyze
     - name: android-build+platform-tests
@@ -98,18 +90,8 @@ task:
       script:
         # extension_google_sign_in_as_googleapis_auth is currently not building, see
         # https://github.com/flutter/flutter/issues/89301
-        # rfw is excluded until the next Flutter stable release because it depends
-        # on features that have never shipped to stable. (The rfw package has
-        # never worked on stable so this is not going to break anyone.)
-        # When updating this, also look at the ios tests below.
-        # When updating this, also update the `rfw/run_tests.sh` file.
-        - if [[ "$CHANNEL" == "master" ]]; then
-        -   ./script/tool_runner.sh build-examples --apk --exclude=extension_google_sign_in_as_googleapis_auth
-        -   ./script/tool_runner.sh native-test --android --no-integration
-        - else
-        -   ./script/tool_runner.sh build-examples --apk --exclude=extension_google_sign_in_as_googleapis_auth,rfw
-        -   ./script/tool_runner.sh native-test --android --no-integration --exclude=rfw
-        - fi
+        - ./script/tool_runner.sh build-examples --apk --exclude=extension_google_sign_in_as_googleapis_auth
+        - ./script/tool_runner.sh native-test --android --no-integration
       depends_on:
         - format+analyze
     - name: web_benchmarks_test
@@ -140,16 +122,7 @@ task:
       CHANNEL: "stable"
   << : *FLUTTER_UPGRADE_TEMPLATE
   build_script:
-    # Exclude rfw until the next Flutter stable release because it depends
-    # on features that have never shipped to stable. (The rfw package has
-    # never worked on stable so this is not going to break anyone.)
-    # When updating this, also look at the android tests above.
-    # When updating this, also update the `rfw/run_tests.sh` file.
-    - if [[ "$CHANNEL" == "master" ]]; then
-    -   ./script/tool_runner.sh build-examples --ios
-    - else
-    -   ./script/tool_runner.sh build-examples --ios --exclude=rfw
-    - fi
+    - ./script/tool_runner.sh build-examples --ios
 
 task:
   name: local_tests

--- a/packages/rfw/README.md
+++ b/packages/rfw/README.md
@@ -266,3 +266,7 @@ When contributing code, ensure that `flutter test --coverage; lcov
 update `test_coverage/bin/test_coverage.dart` with the appropriate
 expectations to prevent future coverage regressions. (That program is
 run by `run_tests.sh`.)
+
+Golden tests are only run against the Flutter master channel and only
+run on Linux, since minor rendering differences are expected on
+different platforms and on different versions of Flutter.

--- a/packages/rfw/test/argument_decoders_test.dart
+++ b/packages/rfw/test/argument_decoders_test.dart
@@ -4,10 +4,17 @@
 
 // This file is hand-formatted.
 
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rfw/formats.dart' show parseLibraryFile;
 import 'package:rfw/rfw.dart';
+
+// See Contributing section of README.md file.
+final bool runGoldens = Platform.isLinux &&
+    (!Platform.environment.containsKey('CHANNEL') ||
+        Platform.environment['CHANNEL'] == 'master');
 
 void main() {
   testWidgets('String example', (WidgetTester tester) async {
@@ -494,5 +501,5 @@ void main() {
       find.byType(RemoteWidget),
       matchesGoldenFile('goldens/argument_decoders_test.gridview.custom.png'),
     );
-  });
+  }, skip: !runGoldens);
 }

--- a/packages/rfw/test/material_widgets_test.dart
+++ b/packages/rfw/test/material_widgets_test.dart
@@ -2,10 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rfw/formats.dart' show parseLibraryFile;
 import 'package:rfw/rfw.dart';
+
+// See Contributing section of README.md file.
+final bool runGoldens = Platform.isLinux &&
+    (!Platform.environment.containsKey('CHANNEL') ||
+        Platform.environment['CHANNEL'] == 'master');
 
 void main() {
   testWidgets('Material widgets', (WidgetTester tester) async {
@@ -140,5 +147,5 @@ void main() {
       find.byType(RemoteWidget),
       matchesGoldenFile('goldens/material_test.drawer.png'),
     );
-  });
+  }, skip: !runGoldens);
 }


### PR DESCRIPTION
For non-master-channel builds, the run_tests.sh script runs but doesn't bother checking the actual coverage, since I expect Dart's coverage logic to diverge in master and so we'd have to have per-channel covered line counts, and that way lies madness.

No version change: Only affects how tests are run, not a public-facing change.
No CHANGELOG change: Only affects how tests are run, not a public-facing change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
