### PR TITLE
[go_router_builder] ignore pubspec.yaml in ensure build test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -137,7 +137,7 @@ task:
         - ./script/tool_runner.sh test --exclude=script/configs/dart_unit_tests_exceptions.yaml
       pathified_unit_test_script:
         # Run tests with path-based dependencies to ensure that publishing
-        # the changes won't break tests of other packages in the respository
+        # the changes won't break tests of other packages in the repository
         # that depend on it.
         - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
         - $PLUGIN_TOOL_COMMAND test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml

--- a/packages/go_router_builder/example/pubspec.yaml
+++ b/packages/go_router_builder/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  build_verify: ^3.0.0
+  build_verify: ^3.1.0
   flutter_test:
     sdk: flutter
   go_router_builder:

--- a/packages/go_router_builder/example/test/ensure_build_test.dart
+++ b/packages/go_router_builder/example/test/ensure_build_test.dart
@@ -10,6 +10,7 @@ void main() {
     'ensure_build',
     () => expectBuildClean(
       packageRelativeDirectory: 'packages/go_router_builder/example',
+      gitDiffPathArguments: <String>[':!pubspec.yaml'],
     ),
     timeout: const Timeout.factor(3),
   );


### PR DESCRIPTION
The dart_unit_test will insert dep override in pubpsec.yaml during the test, this cause false positive in the ensure build test. This pr ignores the file in the test

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
