### PR TITLE
Revert "Bump ossf/scorecard-action from 2.0.6 to 2.1.1"

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@15c10fcf1cf912bd22260bfec67569a359ab87da # v2.0.3
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Reverts flutter/packages#2975

The update broke the tree.