### PR TITLE
[Go_Router] 117514: Added hasRoute to GoRouter -  Checks if the given path matches a registered route

### DIFF
--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -164,6 +164,19 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
     }
   }
 
+  /// Checks if the given path matches a registered route.
+  bool hasRoute(String path) {
+    bool hasRoute = false;
+    try {
+      hasRoute = _routeInformationParser.matcher.findMatch(path).isNotEmpty;
+    } catch (e) {
+      log.warning('Failed to match route $path: $e');
+      hasRoute = false;
+    }
+
+    return hasRoute;
+  }
+
   /// Get a location from route name and parameters.
   /// This is useful for redirecting to a named location.
   String namedLocation(

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -165,16 +165,13 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
   }
 
   /// Checks if the given path matches a registered route.
-  bool hasRoute(String path) {
-    bool hasRoute = false;
+  /// Returns a [RouteMatchList] if the path matches, otherwise returns `null`.
+  RouteMatchList? tryParseRoute(String path) {
     try {
-      hasRoute = _routeInformationParser.matcher.findMatch(path).isNotEmpty;
-    } catch (e) {
-      log.warning('Failed to match route $path: $e');
-      hasRoute = false;
+      return _routeInformationParser.matcher.findMatch(path);
+    } catch (_) {
+      return null;
     }
-
-    return hasRoute;
   }
 
   /// Get a location from route name and parameters.

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -554,6 +554,22 @@ void main() {
     });
 
     testWidgets(
+        'hasRoute returns true if the route we pass in exists, false otherwise',
+        (WidgetTester tester) async {
+          final List<GoRoute> routes = <GoRoute>[
+            GoRoute(path: '/', builder: dummy),
+            GoRoute(path: '/page1', builder: dummy)
+          ];
+
+          final GoRouter router = await createRouter(routes, tester);
+          await tester.pumpAndSettle();
+
+          expect(router.hasRoute('/'), true);
+          expect(router.hasRoute('/page1'), true);
+          expect(router.hasRoute('/page2'), false);
+        });
+
+    testWidgets(
         'If there is more than one route to match, use the first match.',
         (WidgetTester tester) async {
       final List<GoRoute> routes = <GoRoute>[

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -554,7 +554,7 @@ void main() {
     });
 
     testWidgets(
-        'hasRoute returns true if the route we pass in exists, false otherwise',
+        'tryParseRoute returns a RouteMatchList if the route we pass exists, null otherwise',
         (WidgetTester tester) async {
           final List<GoRoute> routes = <GoRoute>[
             GoRoute(path: '/', builder: dummy),
@@ -564,9 +564,9 @@ void main() {
           final GoRouter router = await createRouter(routes, tester);
           await tester.pumpAndSettle();
 
-          expect(router.hasRoute('/'), true);
-          expect(router.hasRoute('/page1'), true);
-          expect(router.hasRoute('/page2'), false);
+          expect(router.tryParseRoute('/'), isA<RouteMatchList>());
+          expect(router.tryParseRoute('/page1'), isA<RouteMatchList>());
+          expect(router.tryParseRoute('/page2'), null);
         });
 
     testWidgets(


### PR DESCRIPTION
This is the implementation for a new feature suggested in [117514](https://github.com/flutter/flutter/issues/117514)

The issue does a great job explaining the use case.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
