### PR TITLE
[go_router] Fix for NavigatorObserver in ShellRoute.

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.1
+
+- Fixes for `NavigatorObserver` in `ShellRoute`.
+- Adds an `observers` parameter to `ShellRoute` to receive notifications for routes only inside `ShellRoute`.
+
 ## 6.0.0
 
 - **BREAKING CHANGE**

--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -189,7 +189,14 @@ class RouteBuilder {
 
       // Build the Navigator
       final Widget child = _buildNavigator(
-          onPopPage, keyToPages[shellNavigatorKey]!, shellNavigatorKey);
+        onPopPage,
+        keyToPages[shellNavigatorKey]!,
+        shellNavigatorKey,
+        observers: [
+          ...observers.map((o) => _ProxyNavigatorObserver(o)),
+          ...route.observers,
+        ],
+      );
 
       // Build the Page for this route
       final Page<Object?> page =
@@ -480,4 +487,59 @@ class _RouteBuilderException implements Exception {
   String toString() {
     return '$message ${exception ?? ""}';
   }
+}
+
+/// An navigator observer that is a proxy for the parent navigator observer.
+class _ProxyNavigatorObserver extends NavigatorObserver {
+  /// The navigator observer whose methods this navigator observer will call.
+  final NavigatorObserver parent;
+
+  _ProxyNavigatorObserver(this.parent);
+
+  /// The navigator that the observer is observing, if any.
+  NavigatorState? get navigator => _navigator;
+  NavigatorState? _navigator;
+
+  /// The [Navigator] pushed `route`.
+  ///
+  /// The route immediately below that one, and thus the previously active
+  /// route, is `previousRoute`.
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      parent.didPush(route, previousRoute);
+
+  /// The [Navigator] popped `route`.
+  ///
+  /// The route immediately below that one, and thus the newly active
+  /// route, is `previousRoute`.
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      parent.didPop(route, previousRoute);
+
+  /// The [Navigator] removed `route`.
+  ///
+  /// If only one route is being removed, then the route immediately below
+  /// that one, if any, is `previousRoute`.
+  ///
+  /// If multiple routes are being removed, then the route below the
+  /// bottommost route being removed, if any, is `previousRoute`, and this
+  /// method will be called once for each removed route, from the topmost route
+  /// to the bottommost route.
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      parent.didRemove(route, previousRoute);
+
+  /// The [Navigator] replaced `oldRoute` with `newRoute`.
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) =>
+      parent.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+
+  /// The [Navigator]'s routes are being moved by a user gesture.
+  ///
+  /// For example, this is called when an iOS back gesture starts, and is used
+  /// to disabled hero animations during such interactions.
+  void didStartUserGesture(
+          Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      parent.didStartUserGesture(route, previousRoute);
+
+  /// User gesture is no longer controlling the [Navigator].
+  ///
+  /// Paired with an earlier call to [didStartUserGesture].
+  void didStopUserGesture() => parent.didStopUserGesture();
 }

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -422,6 +422,7 @@ class ShellRoute extends RouteBase {
     this.pageBuilder,
     super.routes,
     GlobalKey<NavigatorState>? navigatorKey,
+    this.observers = const <NavigatorObserver>[],
   })  : assert(routes.isNotEmpty),
         navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>(),
         super._() {
@@ -432,6 +433,10 @@ class ShellRoute extends RouteBase {
       }
     }
   }
+
+  /// NavigatorObserver is used to receive notifications when navigating between
+  /// this shell's routes.
+  final List<NavigatorObserver> observers;
 
   /// The widget builder for a shell route.
   ///

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.0.0
+version: 6.0.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 


### PR DESCRIPTION
Currently, when using a `NavigatorObserver`, it does not receive all notifications for routes inside `ShellRoute` (in particular, `didPop` is not called). This PR adds notification proxying for routes inside `ShellRoute` to upstream observers in `GoRouter`.

Also added `observers` parameter to `ShellRoute` to receive notifications for routes only inside `ShellRoute`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- If you need help, consider asking for advice on the #hackers-new channel on [Discord]. -->

<!-- Links
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
-->