### PR TITLE
[go_router] Fix redirection log

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.4
+
+- Fixes redirection info log.
+
 ## 6.0.3
 
 - Makes `CustomTransitionPage.barrierDismissible` work

--- a/packages/go_router/lib/src/matching.dart
+++ b/packages/go_router/lib/src/matching.dart
@@ -134,6 +134,11 @@ class RouteMatchList {
 
   /// Returns the error that this match intends to display.
   Exception? get error => matches.first.error;
+
+  @override
+  String toString() {
+    return fullpath;
+  }
 }
 
 /// An error that occurred during matching.

--- a/packages/go_router/lib/src/matching.dart
+++ b/packages/go_router/lib/src/matching.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'configuration.dart';
@@ -137,7 +138,7 @@ class RouteMatchList {
 
   @override
   String toString() {
-    return fullpath;
+    return '${objectRuntimeType(this, 'RouteMatchList')}($fullpath)';
   }
 }
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.0.3
+version: 6.0.4
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/matching_test.dart
+++ b/packages/go_router/test/matching_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/src/configuration.dart';
+import 'package:go_router/src/matching.dart';
+import 'package:go_router/src/router.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  testWidgets('RouteMatchList toString prints the fullPath', (WidgetTester tester) async {
+    final List<GoRoute> routes = <GoRoute>[
+      GoRoute(
+          path: '/page-0',
+          builder: (BuildContext context, GoRouterState state) => const Placeholder()),
+    ];
+
+    final GoRouter router = await createRouter(routes, tester);
+    router.go('/page-0');
+    await tester.pumpAndSettle();
+
+    final RouteMatchList matches = router.routerDelegate.matches;
+    expect(matches.toString(), contains('/page-0'));
+  });
+}

--- a/packages/go_router/test/matching_test.dart
+++ b/packages/go_router/test/matching_test.dart
@@ -11,11 +11,13 @@ import 'package:go_router/src/router.dart';
 import 'test_helpers.dart';
 
 void main() {
-  testWidgets('RouteMatchList toString prints the fullPath', (WidgetTester tester) async {
+  testWidgets('RouteMatchList toString prints the fullPath',
+      (WidgetTester tester) async {
     final List<GoRoute> routes = <GoRoute>[
       GoRoute(
           path: '/page-0',
-          builder: (BuildContext context, GoRouterState state) => const Placeholder()),
+          builder: (BuildContext context, GoRouterState state) =>
+              const Placeholder()),
     ];
 
     final GoRouter router = await createRouter(routes, tester);


### PR DESCRIPTION
Add custom `toString` to `RouteMatchList` so that `log.info('redirecting to $newMatch')` prints something more useful than `redirecting to Instance of 'RouteMatchList'`

Fixes https://github.com/flutter/flutter/issues/110930
Fixes https://github.com/flutter/flutter/issues/118196

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
