### PR TITLE
[xdg_directories] Return null from `getUserDirectory` instead of throwing exception

### DIFF
--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+3
+
+* Return null instead of throwing exception from xdg_directories/getUserDirectory when xdg-user-dir executable is missing.
+
 ## 0.2.0+2
 
 * Fixes unit tests on Windows.

--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.0+3
 
-* Return null instead of throwing exception from xdg_directories/getUserDirectory when xdg-user-dir executable is missing.
+* Returns null instead of throwing exception from getUserDirectory when xdg-user-dir executable is missing.
 
 ## 0.2.0+2
 

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -149,7 +149,12 @@ Directory? get runtimeDir => _directoryFromEnvironment('XDG_RUNTIME_DIR');
 /// Gets the xdg user directory named by `dirName`.
 ///
 /// Use [getUserDirectoryNames] to find out the list of available names.
+///
+/// If the `xdg-user-dir` executable is not present this returns null.
 Directory? getUserDirectory(String dirName) {
+  if (!_processManager.canRun('xdg-user-dir')) {
+    return null;
+  }
   final ProcessResult result = _processManager.runSync(
     <String>['xdg-user-dir', dirName],
     stdoutEncoding: utf8,

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -2,7 +2,7 @@ name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
 repository: https://github.com/flutter/packages/tree/main/packages/xdg_directories
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+xdg_directories%22
-version: 0.2.0+2
+version: 0.2.0+3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -113,6 +113,28 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     xdg.xdgProcessManager = const LocalProcessManager();
   });
 
+  test('Returns null when xdg-user-dir executable is not present', () {
+    xdg.xdgProcessManager = FakeProcessManager(
+      <String, String>{},
+      canRunExecutable: false,
+    );
+    final List<String> userDirVariables = <String>[
+      'DESKTOP',
+      'DOCUMENTS',
+      'DOWNLOAD',
+      'MUSIC',
+      'PICTURES',
+      'PUBLICSHARE',
+      'TEMPLATES',
+      'VIDEOS',
+    ];
+    for (final String key in userDirVariables) {
+      expect(xdg.getUserDirectory(key), isNull,
+          reason: 'Found xdg user directory without access to xdg-user-dir');
+    }
+    xdg.xdgProcessManager = const LocalProcessManager();
+  });
+
   test('Throws StateError when HOME not set', () {
     fakeEnv.clear();
     expect(() {
@@ -122,9 +144,10 @@ XDG_VIDEOS_DIR="$HOME/Videos"
 }
 
 class FakeProcessManager extends Fake implements ProcessManager {
-  FakeProcessManager(this.expected);
+  FakeProcessManager(this.expected, {this.canRunExecutable = true});
 
   Map<String, String> expected;
+  final bool canRunExecutable;
 
   @override
   ProcessResult runSync(
@@ -137,5 +160,10 @@ class FakeProcessManager extends Fake implements ProcessManager {
     Encoding stderrEncoding = systemEncoding,
   }) {
     return ProcessResult(0, 0, expected[command[1]], '');
+  }
+
+  @override
+  bool canRun(dynamic executable, {String? workingDirectory}) {
+    return canRunExecutable;
   }
 }

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -118,20 +118,8 @@ XDG_VIDEOS_DIR="$HOME/Videos"
       <String, String>{},
       canRunExecutable: false,
     );
-    final List<String> userDirVariables = <String>[
-      'DESKTOP',
-      'DOCUMENTS',
-      'DOWNLOAD',
-      'MUSIC',
-      'PICTURES',
-      'PUBLICSHARE',
-      'TEMPLATES',
-      'VIDEOS',
-    ];
-    for (final String key in userDirVariables) {
-      expect(xdg.getUserDirectory(key), isNull,
-          reason: 'Found xdg user directory without access to xdg-user-dir');
-    }
+    expect(xdg.getUserDirectory('DESKTOP'), isNull,
+        reason: 'Found xdg user directory without access to xdg-user-dir');
     xdg.xdgProcessManager = const LocalProcessManager();
   });
 


### PR DESCRIPTION
Returns null from `getUserDirectory` instead of throwing an exception when the `xdg-user-dir` executable is missing.

Partially fixes https://github.com/flutter/flutter/issues/74392

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
