### PR TITLE
[go-router] Add ability to pop with result using extension #116506

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.2
+
+- Fixes missing result on pop in go_router extension.
+
 ## 6.0.1
 
 - Fixes crashes when popping navigators manually.

--- a/packages/go_router/lib/src/misc/extensions.dart
+++ b/packages/go_router/lib/src/misc/extensions.dart
@@ -59,7 +59,7 @@ extension GoRouterHelper on BuildContext {
 
   /// Pop the top page off the Navigator's page stack by calling
   /// [Navigator.pop].
-  void pop() => GoRouter.of(this).pop();
+  void pop<T extends Object?>([T? result]) => GoRouter.of(this).pop(result);
 
   /// Replaces the top-most page of the page stack with the given URL location
   /// w/ optional query parameters, e.g. `/family/f2/person/p1?color=blue`.

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.0.1
+version: 6.0.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -2681,6 +2681,21 @@ void main() {
       );
       key.currentContext!.pop();
       expect(router.popped, true);
+      expect(router.poppedResult, null);
+    });
+
+    testWidgets('calls [pop] on closest GoRouter with result',
+        (WidgetTester tester) async {
+      final GoRouterPopSpy router = GoRouterPopSpy(routes: routes);
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          title: 'GoRouter Example',
+        ),
+      );
+      key.currentContext!.pop('result');
+      expect(router.popped, true);
+      expect(router.poppedResult, 'result');
     });
   });
 

--- a/packages/go_router/test/test_helpers.dart
+++ b/packages/go_router/test/test_helpers.dart
@@ -127,10 +127,12 @@ class GoRouterPopSpy extends GoRouter {
   GoRouterPopSpy({required super.routes});
 
   bool popped = false;
+  dynamic poppedResult;
 
   @override
   void pop<T extends Object?>([T? result]) {
     popped = true;
+    poppedResult = result;
   }
 }
 

--- a/packages/go_router/test/test_helpers.dart
+++ b/packages/go_router/test/test_helpers.dart
@@ -127,7 +127,7 @@ class GoRouterPopSpy extends GoRouter {
   GoRouterPopSpy({required super.routes});
 
   bool popped = false;
-  dynamic poppedResult;
+  Object? poppedResult;
 
   @override
   void pop<T extends Object?>([T? result]) {


### PR DESCRIPTION
Simple fix to add `result` to `pop()` method in the extension `GoRouterHelper`

Fixes [#116506](https://github.com/flutter/flutter/issues/116506)