### PR TITLE
[flutter_migrate] Add BUILD.gn and clean up unused dependencies

### DIFF
--- a/packages/flutter_migrate/.gitignore
+++ b/packages/flutter_migrate/.gitignore
@@ -32,5 +32,8 @@
 # Web related
 lib/generated_plugin_registrant.dart
 
+# Exceptions to above rules.	# Compiled kernel snapshots
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
 # Compiled kernel snapshots
 *.dill

--- a/packages/flutter_migrate/.gitignore
+++ b/packages/flutter_migrate/.gitignore
@@ -32,5 +32,5 @@
 # Web related
 lib/generated_plugin_registrant.dart
 
-# Exceptions to above rules.
-!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+# Compiled kernel snapshots
+*.dill

--- a/packages/flutter_migrate/.gitignore
+++ b/packages/flutter_migrate/.gitignore
@@ -32,7 +32,7 @@
 # Web related
 lib/generated_plugin_registrant.dart
 
-# Exceptions to above rules.	# Compiled kernel snapshots
+# Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 
 # Compiled kernel snapshots

--- a/packages/flutter_migrate/BUILD.gn
+++ b/packages/flutter_migrate/BUILD.gn
@@ -2,10 +2,18 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//flutter/testing/dart/compile_test.gni")
+import("//flutter/build/dart/rules.gni")
 
-compile_flutter_dart_test("compile_flutter_migrate") {
-  dart_file = "bin/flutter_migrate.dart"
-  dart_kernel = "$root_gen_dir/flutter_migrate.dill"
-  packages = ".dart_tool/package_config.json"
+application_snapshot("flutter_migrate") {
+  main_dart = "bin/flutter_migrate.dart"
+  package_config = ".dart_tool/package_config.json"
+  snapshot_kind = "kernel"
+  output = "$root_gen_dir/flutter_migrate.dill"
+
+  training_args = [ "--help" ]
+
+  inputs = [
+    "bin/flutter_migrate.dart",
+    ".dart_tool/package_config.json",
+  ]
 }

--- a/packages/flutter_migrate/BUILD.gn
+++ b/packages/flutter_migrate/BUILD.gn
@@ -1,0 +1,11 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/testing/dart/compile_test.gni")
+
+compile_flutter_dart_test("compile_flutter_migrate") {
+  dart_file = "bin/flutter_migrate.dart"
+  dart_kernel = "$root_gen_dir/flutter_migrate.dill"
+  packages = ".dart_tool/package_config.json"
+}

--- a/packages/flutter_migrate/BUILD.gn
+++ b/packages/flutter_migrate/BUILD.gn
@@ -2,6 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+# This build file is used by the flutter engine build system
+# to generate artifacts which are uploaded and then consumed
+# by the flutter tool.
+
 import("//flutter/build/dart/rules.gni")
 
 application_snapshot("flutter_migrate") {

--- a/packages/flutter_migrate/BUILD.gn
+++ b/packages/flutter_migrate/BUILD.gn
@@ -5,15 +5,10 @@
 import("//flutter/build/dart/rules.gni")
 
 application_snapshot("flutter_migrate") {
-  main_dart = "bin/flutter_migrate.dart"
+  main_dart = "lib/executable.dart"
   package_config = ".dart_tool/package_config.json"
   snapshot_kind = "kernel"
   output = "$root_gen_dir/flutter_migrate.dill"
 
-  training_args = [ "--help" ]
-
-  inputs = [
-    "bin/flutter_migrate.dart",
-    ".dart_tool/package_config.json",
-  ]
+  training_args = []
 }

--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -10,19 +10,12 @@ environment:
 
 dependencies:
   args: ^2.3.1
-  convert: 3.0.2
-  file: 6.1.4
   intl: 0.17.0
-  meta: 1.8.0
-  path: ^1.8.0
   process: 4.2.4
-  vm_service: 9.3.0
-  xml: ^6.1.0
   yaml: 3.1.1
 
 dev_dependencies:
-  collection: 1.16.0
   file_testing: ^3.0.0
-  lints: ^2.0.0
   test: ^1.16.0
   test_api: ^0.4.13
+

--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -10,7 +10,10 @@ environment:
 
 dependencies:
   args: ^2.3.1
+  file: 6.1.4
   intl: 0.17.0
+  meta: 1.8.0
+  path: ^1.8.0
   process: 4.2.4
   yaml: 3.1.1
 
@@ -18,4 +21,3 @@ dev_dependencies:
   file_testing: ^3.0.0
   test: ^1.16.0
   test_api: ^0.4.13
-


### PR DESCRIPTION
Adds a BUILD.gn to enable engine build system to add this as a target
