### PR TITLE
[flutter_migrate] Export as library

### DIFF
--- a/packages/flutter_migrate/lib/executable.dart
+++ b/packages/flutter_migrate/lib/executable.dart
@@ -35,13 +35,12 @@ Future<void> main(List<String> args) async {
       verbose: verbose,
       logger: baseDependencies.logger,
       fileSystem: baseDependencies.fileSystem,
-      processManager: baseDependencies.processManager,
     ),
     MigrateAbandonCommand(
-        logger: baseDependencies.logger,
-        fileSystem: baseDependencies.fileSystem,
-        terminal: baseDependencies.terminal,
-        processManager: baseDependencies.processManager),
+      logger: baseDependencies.logger,
+      fileSystem: baseDependencies.fileSystem,
+      terminal: baseDependencies.terminal,
+    ),
     MigrateApplyCommand(
         verbose: verbose,
         logger: baseDependencies.logger,

--- a/packages/flutter_migrate/lib/flutter_migrate.dart
+++ b/packages/flutter_migrate/lib/flutter_migrate.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// A library to render markdown formatted text.
 library flutter_migrate;
 
 export 'src/base_dependencies.dart';

--- a/packages/flutter_migrate/lib/flutter_migrate.dart
+++ b/packages/flutter_migrate/lib/flutter_migrate.dart
@@ -4,8 +4,8 @@
 
 library flutter_migrate;
 
-export 'src/base_dependencies.dart';
 export 'src/base/command.dart';
+export 'src/base_dependencies.dart';
 export 'src/commands/abandon.dart';
 export 'src/commands/apply.dart';
 export 'src/commands/start.dart';

--- a/packages/flutter_migrate/lib/flutter_migrate.dart
+++ b/packages/flutter_migrate/lib/flutter_migrate.dart
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// A library to render markdown formatted text.
+library flutter_migrate;
+
+export 'src/base_dependencies.dart';
+export 'src/base/command.dart';
+export 'src/commands/abandon.dart';
+export 'src/commands/apply.dart';
+export 'src/commands/start.dart';
+export 'src/commands/status.dart';

--- a/packages/flutter_migrate/lib/src/commands/abandon.dart
+++ b/packages/flutter_migrate/lib/src/commands/abandon.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:process/process.dart';
-
 import '../base/command.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
@@ -18,12 +16,10 @@ class MigrateAbandonCommand extends MigrateCommand {
     required this.logger,
     required this.fileSystem,
     required this.terminal,
-    required ProcessManager processManager,
     this.standalone = false,
   }) : migrateUtils = MigrateUtils(
           logger: logger,
           fileSystem: fileSystem,
-          processManager: processManager,
         ) {
     argParser.addOption(
       'staging-directory',

--- a/packages/flutter_migrate/lib/src/commands/apply.dart
+++ b/packages/flutter_migrate/lib/src/commands/apply.dart
@@ -31,7 +31,6 @@ class MigrateApplyCommand extends MigrateCommand {
         migrateUtils = MigrateUtils(
           logger: logger,
           fileSystem: fileSystem,
-          processManager: processManager,
         ) {
     argParser.addOption(
       'staging-directory',

--- a/packages/flutter_migrate/lib/src/commands/start.dart
+++ b/packages/flutter_migrate/lib/src/commands/start.dart
@@ -26,7 +26,6 @@ class MigrateStartCommand extends MigrateCommand {
         migrateUtils = MigrateUtils(
           logger: logger,
           fileSystem: fileSystem,
-          processManager: processManager,
         ) {
     argParser.addOption(
       'staging-directory',

--- a/packages/flutter_migrate/lib/src/commands/status.dart
+++ b/packages/flutter_migrate/lib/src/commands/status.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:process/process.dart';
-
 import '../base/command.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
@@ -19,13 +17,11 @@ class MigrateStatusCommand extends MigrateCommand {
     bool verbose = false,
     required this.logger,
     required this.fileSystem,
-    required ProcessManager processManager,
     this.standalone = false,
   })  : _verbose = verbose,
         migrateUtils = MigrateUtils(
           logger: logger,
           fileSystem: fileSystem,
-          processManager: processManager,
         ) {
     argParser.addOption(
       'staging-directory',
@@ -65,6 +61,7 @@ class MigrateStatusCommand extends MigrateCommand {
   final FileSystem fileSystem;
 
   final MigrateUtils migrateUtils;
+
 
   final bool standalone;
 

--- a/packages/flutter_migrate/lib/src/commands/status.dart
+++ b/packages/flutter_migrate/lib/src/commands/status.dart
@@ -62,7 +62,6 @@ class MigrateStatusCommand extends MigrateCommand {
 
   final MigrateUtils migrateUtils;
 
-
   final bool standalone;
 
   @override

--- a/packages/flutter_migrate/lib/src/utils.dart
+++ b/packages/flutter_migrate/lib/src/utils.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:process/process.dart';
-
 import 'base/common.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
@@ -21,18 +19,15 @@ class MigrateUtils {
   MigrateUtils({
     required Logger logger,
     required FileSystem fileSystem,
-    required ProcessManager processManager,
-  })  : _processManager = processManager,
-        _logger = logger,
+  })  : _logger = logger,
         _fileSystem = fileSystem;
 
   final Logger _logger;
   final FileSystem _fileSystem;
-  final ProcessManager _processManager;
 
   Future<ProcessResult> _runCommand(List<String> command,
       {String? workingDirectory, bool runInShell = false}) {
-    return _processManager.run(command,
+    return Process.run(command[0], command.sublist(1),
         workingDirectory: workingDirectory, runInShell: runInShell);
   }
 

--- a/packages/flutter_migrate/lib/src/utils.dart
+++ b/packages/flutter_migrate/lib/src/utils.dart
@@ -100,7 +100,7 @@ class MigrateUtils {
       return outputDirectory;
     }
 
-    final List<String> cmdArgs = <String>['$flutterBinPath/flutter', 'create'];
+    final List<String> cmdArgs = <String>['$flutterBinPath${_fileSystem.path.separator}flutter', 'create'];
     if (!legacyNameParameter) {
       cmdArgs.add('--project-name=$name');
     }

--- a/packages/flutter_migrate/lib/src/utils.dart
+++ b/packages/flutter_migrate/lib/src/utils.dart
@@ -100,7 +100,10 @@ class MigrateUtils {
       return outputDirectory;
     }
 
-    final List<String> cmdArgs = <String>['$flutterBinPath${_fileSystem.path.separator}flutter', 'create'];
+    final List<String> cmdArgs = <String>[
+      '$flutterBinPath${_fileSystem.path.separator}flutter${isWin ? '.bat' : ''}',
+      'create'
+    ];
     if (!legacyNameParameter) {
       cmdArgs.add('--project-name=$name');
     }

--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_migrate
 description: A tool to migrate legacy flutter projects to modern versions.
-version: 0.0.1
+version: 0.1.1
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_migrate
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ap%3A%20flutter_migrate
 publish_to: none
@@ -9,15 +9,15 @@ environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  args: ^2.3.1
-  file: 6.1.4
-  intl: 0.17.0
-  meta: 1.8.0
-  path: ^1.8.0
-  process: 4.2.4
-  yaml: 3.1.1
+  args: any
+  file: any
+  intl: any
+  meta: any
+  path: any
+  process: any
+  yaml: any
 
 dev_dependencies:
-  file_testing: ^3.0.0
-  test: ^1.16.0
-  test_api: ^0.4.13
+  file_testing: any
+  test: any
+  test_api: any

--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -10,19 +10,14 @@ environment:
 
 dependencies:
   args: ^2.3.1
-  convert: 3.0.2
   file: 6.1.4
   intl: 0.17.0
   meta: 1.8.0
   path: ^1.8.0
   process: 4.2.4
-  vm_service: 9.3.0
-  xml: ^6.1.0
   yaml: 3.1.1
 
 dev_dependencies:
-  collection: 1.16.0
   file_testing: ^3.0.0
-  lints: ^2.0.0
   test: ^1.16.0
   test_api: ^0.4.13

--- a/packages/flutter_migrate/test/abandon_test.dart
+++ b/packages/flutter_migrate/test/abandon_test.dart
@@ -39,7 +39,6 @@ void main() {
       logger: logger,
       fileSystem: fileSystem,
       terminal: terminal,
-      processManager: processManager,
     );
     final Directory stagingDir =
         appDir.childDirectory(kDefaultMigrateStagingDirectoryName);

--- a/packages/flutter_migrate/test/base/file_system_test.dart
+++ b/packages/flutter_migrate/test/base/file_system_test.dart
@@ -210,8 +210,7 @@ void main() {
       );
 
       try {
-        localFileSystem.systemTempDirectory;
-        fail('expected tool exit');
+        expect(localFileSystem.systemTempDirectory, true);
       } on ToolExit catch (e) {
         expect(
             e.message,

--- a/packages/flutter_migrate/test/compute_test.dart
+++ b/packages/flutter_migrate/test/compute_test.dart
@@ -14,7 +14,6 @@ import 'package:flutter_migrate/src/migrate_logger.dart';
 import 'package:flutter_migrate/src/result.dart';
 import 'package:flutter_migrate/src/utils.dart';
 import 'package:path/path.dart';
-import 'package:process/process.dart';
 
 import 'environment_test.dart';
 import 'src/common.dart';
@@ -32,7 +31,6 @@ void main() {
   late Directory newerTargetFlutterDirectory;
   late Directory currentDir;
   late FlutterToolsEnvironment environment;
-  late ProcessManager processManager;
   late FakeProcessManager envProcessManager;
   late String separator;
 
@@ -43,11 +41,9 @@ void main() {
     fileSystem = LocalFileSystem.test(signals: LocalSignals.instance);
     currentDir = createResolvedTempDirectorySync('current_app.');
     logger = BufferLogger.test();
-    processManager = const LocalProcessManager();
     utils = MigrateUtils(
       logger: logger,
       fileSystem: fileSystem,
-      processManager: processManager,
     );
     await MigrateProject.installProject('version:1.22.6_stable', currentDir);
     final FlutterProjectFactory flutterFactory = FlutterProjectFactory();
@@ -261,7 +257,6 @@ void main() {
       utils = MigrateUtils(
         logger: logger,
         fileSystem: fileSystem,
-        processManager: const LocalProcessManager(),
       );
       await MigrateProject.installProject('version:1.22.6_stable', currentDir);
       final FlutterProjectFactory flutterFactory = FlutterProjectFactory();

--- a/packages/flutter_migrate/test/src/common.dart
+++ b/packages/flutter_migrate/test/src/common.dart
@@ -94,9 +94,9 @@ String getMigrateMain() {
 
 Future<ProcessResult> runMigrateCommand(List<String> args,
     {String? workingDirectory}) {
-  final List<String> commandArgs = <String>['dart', 'run', getMigrateMain()];
+  final List<String> commandArgs = <String>['run', getMigrateMain()];
   commandArgs.addAll(args);
-  return processManager.run(commandArgs, workingDirectory: workingDirectory);
+  return Process.run('dart', commandArgs, workingDirectory: workingDirectory);
 }
 
 /// The tool overrides `test` to ensure that files created under the

--- a/packages/flutter_migrate/test/status_test.dart
+++ b/packages/flutter_migrate/test/status_test.dart
@@ -36,7 +36,6 @@ void main() {
       verbose: true,
       logger: logger,
       fileSystem: fileSystem,
-      processManager: processManager,
     );
     final Directory stagingDir =
         appDir.childDirectory(kDefaultMigrateStagingDirectoryName);

--- a/packages/flutter_migrate/test/update_locks_test.dart
+++ b/packages/flutter_migrate/test/update_locks_test.dart
@@ -33,7 +33,6 @@ void main() {
     utils = MigrateUtils(
       logger: logger,
       fileSystem: fileSystem,
-      processManager: const LocalProcessManager(),
     );
     final FlutterProjectFactory flutterFactory = FlutterProjectFactory();
     flutterProject = flutterFactory.fromDirectory(currentDir);

--- a/packages/flutter_migrate/test/utils_test.dart
+++ b/packages/flutter_migrate/test/utils_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_migrate/src/base/io.dart';
 import 'package:flutter_migrate/src/base/logger.dart';
 import 'package:flutter_migrate/src/base/signals.dart';
 import 'package:flutter_migrate/src/utils.dart';
-import 'package:process/process.dart';
 
 import 'src/common.dart';
 
@@ -18,16 +17,13 @@ void main() {
   late Directory projectRoot;
   late String projectRootPath;
   late MigrateUtils utils;
-  late ProcessManager processManager;
 
   setUpAll(() async {
     fileSystem = LocalFileSystem.test(signals: LocalSignals.instance);
     logger = BufferLogger.test();
-    processManager = const LocalProcessManager();
     utils = MigrateUtils(
       logger: logger,
       fileSystem: fileSystem,
-      processManager: processManager,
     );
   });
 


### PR DESCRIPTION
Export classes so that migrate can be used programmatically as a dart package. Also cleans up unused dependencies and removes version restrictions.
