### PR TITLE
[flutter_adaptive_scaffold] Fix leading Navigation Rail Widgets

### DIFF
--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.9
+
+* Fix passthrough of `leadingExtendedNavRail`, `leadingUnextendedNavRail` and `trailingNavRail`
+
 ## 0.0.8
 
 Make fuchsia a mobile platform.

--- a/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
+++ b/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
@@ -480,6 +480,8 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
             ? Drawer(
                 child: NavigationRail(
                   extended: true,
+                  leading: widget.leadingExtendedNavRail,
+                  trailing: widget.trailingNavRail,
                   selectedIndex: widget.selectedIndex,
                   destinations: widget.destinations
                       .map((_) => AdaptiveScaffold.toRailDestination(_))
@@ -498,6 +500,8 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                 key: const Key('primaryNavigation'),
                 builder: (_) => AdaptiveScaffold.standardNavigationRail(
                   width: widget.navigationRailWidth,
+                  leading: widget.leadingUnextendedNavRail,
+                  trailing: widget.trailingNavRail,
                   selectedIndex: widget.selectedIndex,
                   destinations: widget.destinations
                       .map((_) => AdaptiveScaffold.toRailDestination(_))
@@ -510,6 +514,8 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                 builder: (_) => AdaptiveScaffold.standardNavigationRail(
                   width: widget.extendedNavigationRailWidth,
                   extended: true,
+                  leading: widget.leadingExtendedNavRail,
+                  trailing: widget.trailingNavRail,
                   selectedIndex: widget.selectedIndex,
                   destinations: widget.destinations
                       .map((_) => AdaptiveScaffold.toRailDestination(_))

--- a/packages/flutter_adaptive_scaffold/pubspec.yaml
+++ b/packages/flutter_adaptive_scaffold/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 0.0.8
+version: 0.0.9
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_adaptive_scaffold%22
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold
 

--- a/packages/flutter_adaptive_scaffold/test/adaptive_scaffold_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_scaffold_test.dart
@@ -193,6 +193,35 @@ void main() {
       expect(find.byType(PreferredSizeWidgetImpl), findsOneWidget);
     },
   );
+
+  // Verify that the leading navigation rail widget is displayed
+  // based on the screen size
+  testWidgets(
+    'adaptive scaffold displays leading widget in navigation rail',
+    (WidgetTester tester) async {
+      await Future.forEach(SimulatedLayout.values,
+          (SimulatedLayout region) async {
+        final MaterialApp app = region.app();
+        await tester.binding.setSurfaceSize(region.size);
+        await tester.pumpWidget(app);
+        await tester.pumpAndSettle();
+
+        if (region.size == SimulatedLayout.large.size) {
+          expect(find.text('leading_extended'), findsOneWidget);
+          expect(find.text('leading_unextended'), findsNothing);
+          expect(find.text('trailing'), findsOneWidget);
+        } else if (region.size == SimulatedLayout.medium.size) {
+          expect(find.text('leading_extended'), findsNothing);
+          expect(find.text('leading_unextended'), findsOneWidget);
+          expect(find.text('trailing'), findsOneWidget);
+        } else if (region.size == SimulatedLayout.small.size) {
+          expect(find.text('leading_extended'), findsNothing);
+          expect(find.text('leading_unextended'), findsNothing);
+          expect(find.text('trailing'), findsNothing);
+        }
+      });
+    },
+  );
 }
 
 /// An empty widget that implements [PreferredSizeWidget] to ensure that

--- a/packages/flutter_adaptive_scaffold/test/simulated_layout.dart
+++ b/packages/flutter_adaptive_scaffold/test/simulated_layout.dart
@@ -86,6 +86,9 @@ class TestScaffoldState extends State<TestScaffold> {
       smallSecondaryBody: (_) => Container(color: Colors.red),
       secondaryBody: (_) => Container(color: Colors.green),
       largeSecondaryBody: (_) => Container(color: Colors.blue),
+      leadingExtendedNavRail: const Text('leading_extended'),
+      leadingUnextendedNavRail: const Text('leading_unextended'),
+      trailingNavRail: const Text('trailing'),
     );
   }
 }


### PR DESCRIPTION
The leading Navigation Rail widgets were not being passed through to the Navigation Rail. This PR passes through the leading widget and adds a test to verify that the leading widget is displayed correctly based on the screen size.

Fixes https://github.com/flutter/flutter/issues/114684

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
