### PR TITLE
[ci] Update legacy Flutter version tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -161,8 +161,8 @@ task:
           CHANNEL: "3.0.5"
           DART_VERSION: "2.17.6"
         env:
-          CHANNEL: "2.10.5"
-          DART_VERSION: "2.16.2"
+          CHANNEL: "3.3.10"
+          DART_VERSION: "2.18.6"
       package_prep_script:
         # Allow analyzing packages that use a dev dependency with a higher
         # minimum Flutter/Dart version than the package itself.

--- a/packages/css_colors/CHANGELOG.md
+++ b/packages/css_colors/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-- Updates minimum Flutter version to 2.10.
+- Updates minimum Flutter version to 3.0.
 - Updates package description.
 
 ## 1.1.1

--- a/packages/css_colors/pubspec.yaml
+++ b/packages/css_colors/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.1.1
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/dynamic_layouts/CHANGELOG.md
+++ b/packages/dynamic_layouts/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum Flutter version to 2.10.
+* Updates minimum Flutter version to 3.0.
 
 ## 0.0.1
 

--- a/packages/dynamic_layouts/pubspec.yaml
+++ b/packages/dynamic_layouts/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: none
 
 environment:
   sdk: '>=2.17.6 <3.0.0'
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
+++ b/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum Flutter version to 2.10.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.0.7
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   extension_google_sign_in_as_googleapis_auth:

--- a/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
@@ -12,7 +12,7 @@ version: 2.0.7
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_markdown/example/pubspec.yaml
+++ b/packages/flutter_markdown/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/pubspec.yaml
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: '>=2.18.0 <3.0.0'
-  flutter: ">=2.5.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/pigeon/platform_tests/test_plugin/pubspec.yaml
+++ b/packages/pigeon/platform_tests/test_plugin/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: '>=2.18.0 <3.0.0'
-  flutter: ">=2.5.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/pointer_interceptor/CHANGELOG.md
+++ b/packages/pointer_interceptor/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.9.3+3
 
 * Fixes lint warnings.

--- a/packages/pointer_interceptor/example/pubspec.yaml
+++ b/packages/pointer_interceptor/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/pointer_interceptor/pubspec.yaml
+++ b/packages/pointer_interceptor/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.9.3+3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Updates the N-1 and N-2 version tests to 3.0 and 3.3 now that 3.7 is on stable.

Updates all packages to require at least Flutter 3.0 since we won't be testing earlier versions at all.