### PR TITLE
[flutter_adaptive_scaffold] Change `selectedIndex` on `standardNavigationRail` to allow null value.

### DIFF
--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.1.0
 
 * Change the `selectedIndex` parameter on `standardNavigationRail` to allow null values to indicate "no destination".
-* A null `selectIndex` applied to `standardBottomNavigationBar` will be set to -1.
+* An explicitly null `currentIndex` parameter passed to `standardBottomNavigationBar` will also default to 0, just like implicitly null missing parameters.
 
 
 ## 0.0.9

--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0
 
-* Change `selectedIndex` on `standardNavigationRail` to allow null value.
+* Change the `selectedIndex` parameter on `standardNavigationRail` to allow null values to indicate "no destination".
 * A null `selectIndex` applied to `standardBottomNavigationBar` will be set to -1.
 
 

--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0
 
-* Change `selectIndex` on `standardNavigatioRail` to allow null value.
+* Change `selectedIndex` on `standardNavigatioRail` to allow null value.
 
 
 ## 0.0.9

--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0
+
+* Change `selectIndex` on `standardNavigatioRail` to allow null value.
+
+
 ## 0.0.9
 
 * Fix passthrough of `leadingExtendedNavRail`, `leadingUnextendedNavRail` and `trailingNavRail`

--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.0
 
 * Change `selectedIndex` on `standardNavigationRail` to allow null value.
+* A null `selectIndex` applied to `standardBottomNavigationBar` will be set to -1.
 
 
 ## 0.0.9

--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0
 
-* Change `selectedIndex` on `standardNavigatioRail` to allow null value.
+* Change `selectedIndex` on `standardNavigationRail` to allow null value.
 
 
 ## 0.0.9

--- a/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
+++ b/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
@@ -313,7 +313,7 @@ class AdaptiveScaffold extends StatefulWidget {
     return Builder(
       builder: (_) {
         return BottomNavigationBar(
-          currentIndex: currentIndex!,
+          currentIndex: currentIndex ?? 0,
           iconSize: iconSize,
           items: destinations
               .map((NavigationDestination e) => _toBottomNavItem(e))

--- a/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
+++ b/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
@@ -110,7 +110,7 @@ class AdaptiveScaffold extends StatefulWidget {
   final List<NavigationDestination> destinations;
 
   /// The index to be used by the [NavigationRail].
-  final int selectedIndex;
+  final int? selectedIndex;
 
   /// Option to display a leading widget at the top of the navigation rail
   /// at the middle breakpoint.
@@ -305,14 +305,15 @@ class AdaptiveScaffold extends StatefulWidget {
   /// a list of [NavigationDestination]s.
   static Builder standardBottomNavigationBar({
     required List<NavigationDestination> destinations,
-    int currentIndex = 0,
+    int? currentIndex,
     double iconSize = 24,
     ValueChanged<int>? onDestinationSelected,
   }) {
+    currentIndex ??= 0;
     return Builder(
       builder: (_) {
         return BottomNavigationBar(
-          currentIndex: currentIndex,
+          currentIndex: currentIndex!,
           iconSize: iconSize,
           items: destinations
               .map((NavigationDestination e) => _toBottomNavItem(e))

--- a/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
+++ b/packages/flutter_adaptive_scaffold/lib/src/adaptive_scaffold.dart
@@ -251,7 +251,7 @@ class AdaptiveScaffold extends StatefulWidget {
   static Builder standardNavigationRail({
     required List<NavigationRailDestination> destinations,
     double width = 72,
-    int selectedIndex = 0,
+    int? selectedIndex,
     bool extended = false,
     Color backgroundColor = Colors.transparent,
     EdgeInsetsGeometry padding = const EdgeInsets.all(8.0),

--- a/packages/flutter_adaptive_scaffold/pubspec.yaml
+++ b/packages/flutter_adaptive_scaffold/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 0.0.9
+version: 0.1.0
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_adaptive_scaffold%22
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold
 

--- a/packages/flutter_adaptive_scaffold/test/adaptive_scaffold_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_scaffold_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_adaptive_scaffold/src/adaptive_scaffold.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import 'simulated_layout.dart';
 import 'test_breakpoints.dart';
 
@@ -219,6 +220,22 @@ void main() {
           expect(find.text('leading_unextended'), findsNothing);
           expect(find.text('trailing'), findsNothing);
         }
+      });
+    },
+  );
+
+  /// Verify that selectedIndex of [AdaptiveScaffold.standardNavigationRail]
+  /// and [AdaptiveScaffold] can be set to null
+  testWidgets(
+    'adaptive scaffold selectedIndex can be set to null',
+    (WidgetTester tester) async {
+      await Future.forEach(SimulatedLayout.values,
+          (SimulatedLayout region) async {
+        int? selectedIndex;
+        final MaterialApp app = region.app(initialIndex: selectedIndex);
+        await tester.binding.setSurfaceSize(region.size);
+        await tester.pumpWidget(app);
+        await tester.pumpAndSettle();
       });
     },
   );

--- a/packages/flutter_adaptive_scaffold/test/simulated_layout.dart
+++ b/packages/flutter_adaptive_scaffold/test/simulated_layout.dart
@@ -36,7 +36,7 @@ class TestScaffold extends StatefulWidget {
     this.isAnimated = true,
   });
 
-  final int initialIndex;
+  final int? initialIndex;
   final bool isAnimated;
 
   static const List<NavigationDestination> destinations =
@@ -63,7 +63,7 @@ class TestScaffold extends StatefulWidget {
 }
 
 class TestScaffoldState extends State<TestScaffold> {
-  late int index = widget.initialIndex;
+  late int? index = widget.initialIndex;
 
   @override
   Widget build(BuildContext context) {
@@ -110,7 +110,7 @@ enum SimulatedLayout {
   Size get size => Size(_width, _height);
 
   MaterialApp app({
-    int initialIndex = 0,
+    int? initialIndex,
     bool animations = true,
   }) {
     return MaterialApp(


### PR DESCRIPTION
Changed `selectedIndex` on `standardNavigationRail` to allow a null value to be set so that the NavRail can show nothing as being selected. The `selectedIndex` value is passed to `NavigationRail` which already permits null. 

Fixes: [#118888](https://github.com/flutter/flutter/issues/118888)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
