### PR TITLE
[ci] Enable min SDK version checks

### DIFF
--- a/.ci/scripts/prepare_tool.sh
+++ b/.ci/scripts/prepare_tool.sh
@@ -8,4 +8,4 @@ git fetch origin main
 
 # Pinned version of the plugin tools, to avoid breakage in this repository
 # when pushing updates from flutter/plugins.
-dart pub global activate flutter_plugin_tools 0.13.2
+dart pub global activate flutter_plugin_tools 0.13.4

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -99,7 +99,9 @@ task:
       always:
         format_script: ./script/tool_runner.sh format --fail-on-change
         license_script: $PLUGIN_TOOL_COMMAND license-check
-        pubspec_script: ./script/tool_runner.sh pubspec-check
+        # The major and minor versions here should match the lowest version
+        # analyzed in legacy_version_analyze.
+        pubspec_script: ./script/tool_runner.sh pubspec-check --min-min-flutter-version=3.0.0 --min-min-dart-version=2.17.0
         readme_script:
           - ./script/tool_runner.sh readme-check
           # Re-run with --require-excerpts, skipping packages that still need
@@ -157,6 +159,7 @@ task:
     - name: legacy_version_analyze
       depends_on: analyze
       matrix:
+        # Change the arguments to pubspec-check when changing these values.
         env:
           CHANNEL: "3.0.5"
           DART_VERSION: "2.17.6"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: dart pub global activate flutter_plugin_tools 0.13.2
+      run: dart pub global activate flutter_plugin_tools 0.13.4
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests

--- a/packages/animations/example/pubspec.yaml
+++ b/packages/animations/example/pubspec.yaml
@@ -7,6 +7,7 @@ version: 0.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   animations:

--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum SDK version to Flutter 3.0.
+
 ## 0.3.3+2
 
 * Fixes lint warnings in tests.

--- a/packages/cross_file/lib/src/types/html.dart
+++ b/packages/cross_file/lib/src/types/html.dart
@@ -26,6 +26,7 @@ class XFile extends XFileBase {
   ///
   /// `name` needs to be passed from the outside, since it's only available
   /// while handling [html.File]s (when the ObjectUrl is created).
+  // ignore: use_super_parameters
   XFile(
     String path, {
     String? mimeType,

--- a/packages/cross_file/lib/src/types/interface.dart
+++ b/packages/cross_file/lib/src/types/interface.dart
@@ -22,14 +22,14 @@ class XFile extends XFileBase {
   /// `path` of the file doesn't match what the user sees when selecting it
   /// (like in web)
   XFile(
-    String path, {
+    super.path, {
     String? mimeType,
     String? name,
     int? length,
     Uint8List? bytes,
     DateTime? lastModified,
     @visibleForTesting CrossFileTestOverrides? overrides,
-  }) : super(path) {
+  }) {
     throw UnimplementedError(
         'CrossFile is not available in your current platform.');
   }

--- a/packages/cross_file/lib/src/types/io.dart
+++ b/packages/cross_file/lib/src/types/io.dart
@@ -17,6 +17,7 @@ class XFile extends XFileBase {
   /// [bytes] is ignored; the parameter exists only to match the web version of
   /// the constructor. To construct a dart:io XFile from bytes, use
   /// [XFile.fromData].
+  // ignore: use_super_parameters
   XFile(
     String path, {
     String? mimeType,

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.3.3+2
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   js: ^0.6.3

--- a/packages/cross_file/test/x_file_io_test.dart
+++ b/packages/cross_file/test/x_file_io_test.dart
@@ -109,7 +109,7 @@ void main() {
 
 /// An XFile subclass that tracks reads, for testing purposes.
 class TestXFile extends XFile {
-  TestXFile(String path) : super(path);
+  TestXFile(super.path);
 
   bool hasBeenRead = false;
 

--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Updates minimum SDK version to Flutter 3.0.
+
 ## 2.0.1
 
 * Updated readme to document suggestion process for new lints

--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,7 +1,3 @@
-## NEXT
-
-* Updates minimum SDK version to Flutter 3.0.
-
 ## 2.0.1
 
 * Updated readme to document suggestion process for new lints

--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.2
+## NEXT
 
 * Updates minimum SDK version to Flutter 3.0.
 

--- a/packages/flutter_lints/example/pubspec.yaml
+++ b/packages/flutter_lints/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: A project that showcases how to enable the recommended lints for Fl
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 # Add the latest version of `package:flutter_lints` as a dev_dependency. The
 # lint set provided by this package is activated in the `analysis_options.yaml`

--- a/packages/flutter_lints/pubspec.yaml
+++ b/packages/flutter_lints/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.0.1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   lints: ^2.0.0

--- a/packages/flutter_template_images/CHANGELOG.md
+++ b/packages/flutter_template_images/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum SDK version to Flutter 3.0.
+
 ## 4.2.0
 
 * Adds iOS template app icons, updated to square icons with no transparency.

--- a/packages/flutter_template_images/pubspec.yaml
+++ b/packages/flutter_template_images/pubspec.yaml
@@ -5,4 +5,4 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 4.2.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"

--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum SDK version to Flutter 3.0.
+
 ## 1.0.6
 
 - Fixes lint warnings.

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/metrics_cente
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+metrics_center%22
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   crypto: ^3.0.1

--- a/packages/multicast_dns/CHANGELOG.md
+++ b/packages/multicast_dns/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum SDK version to Flutter 3.0.
+
 ## 0.3.2+2
 
 * Fixes lints warnings.

--- a/packages/multicast_dns/pubspec.yaml
+++ b/packages/multicast_dns/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.3.2+2
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   meta: ^1.3.0

--- a/packages/palette_generator/example/pubspec.yaml
+++ b/packages/palette_generator/example/pubspec.yaml
@@ -5,6 +5,7 @@ version: 0.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/pigeon/mock_handler_tester/pubspec.yaml
+++ b/packages/pigeon/mock_handler_tester/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/packages/pigeon/platform_tests/flutter_null_safe_unit_tests/pubspec.yaml
+++ b/packages/pigeon/platform_tests/flutter_null_safe_unit_tests/pubspec.yaml
@@ -4,6 +4,7 @@ publish_to: none # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 environment:
   sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/pigeon/platform_tests/ios_unit_tests/pubspec.yaml
+++ b/packages/pigeon/platform_tests/ios_unit_tests/pubspec.yaml
@@ -16,6 +16,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.5

--- a/packages/rfw/example/hello/pubspec.yaml
+++ b/packages/rfw/example/hello/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=2.13.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/rfw/example/local/pubspec.yaml
+++ b/packages/rfw/example/local/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=2.13.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/rfw/example/remote/pubspec.yaml
+++ b/packages/rfw/example/remote/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=2.13.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/rfw/example/wasm/pubspec.yaml
+++ b/packages/rfw/example/wasm/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=2.13.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/rfw/test_coverage/pubspec.yaml
+++ b/packages/rfw/test_coverage/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   lcov_parser: 0.1.1

--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum SDK version to Flutter 3.0.
+
 ## 0.2.0+3
 
 * Returns null instead of throwing exception from getUserDirectory when xdg-user-dir executable is missing.

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.2.0+3
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 platforms:
   linux:

--- a/third_party/packages/cupertino_icons/CHANGELOG.md
+++ b/third_party/packages/cupertino_icons/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum SDK version to Flutter 3.0.
+
 ## 1.0.5
 
 * Updates README to reference correct URL.

--- a/third_party/packages/cupertino_icons/pubspec.yaml
+++ b/third_party/packages/cupertino_icons/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 1.0.5
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 flutter:
   fonts:


### PR DESCRIPTION
Rolls the repository tools forward to 0.13.4 and enables the new repo checks that no package claims to support an older version than the legacy analyzer tests are validating, since we have no idea if they actually work.

Updates packages as necessary to fix violations (those that didn't have a Flutter SDK constraint at all, since those were caught in the legacy test update).

This deliberately does not update any package versions, since we don't want to actively publish this change, only have it apply to future releases.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
