### PR TITLE
[ci] Fix the new LUCI iOS build-all tasks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -45,7 +45,7 @@ platform_properties:
 
 targets:
   ### iOS tasks ###
-  - name: Mac_arm64 ios_build_all_plugins master
+  - name: Mac_arm64 ios_build_all_packages master
     bringup: true
     recipe: packages/packages
     timeout: 30
@@ -55,7 +55,7 @@ targets:
       target_file: ios_build_all_packages.yaml
       channel: master
 
-  - name: Mac_arm64 ios_build_all_plugins stable
+  - name: Mac_arm64 ios_build_all_packages stable
     bringup: true
     recipe: packages/packages
     timeout: 30

--- a/.ci/targets/ios_build_all_packages.yaml
+++ b/.ci/targets/ios_build_all_packages.yaml
@@ -4,8 +4,8 @@ tasks:
   - name: create all_packages app
     script: .ci/scripts/create_all_packages_app.sh
   - name: build all_packages for iOS debug
-    script: .ci/scripts/build_all_packages.sh
+    script: .ci/scripts/build_all_packages_app.sh
     args: ["ios", "debug", "--no-codesign"]
   - name: build all_packages for iOS release
-    script: .ci/scripts/build_all_packages.sh
+    script: .ci/scripts/build_all_packages_app.sh
     args: ["ios", "release", "--no-codesign"]


### PR DESCRIPTION
Corrects the name of the tasks; they accidentally used the old "plugins" name rather than the new generic "packages" name that we're moving to for anything that is not actually plugin-specific.

Also fixes the script referenced in the build step.