### PR TITLE
[ci] Switch iOS build-all to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -45,8 +45,10 @@ platform_properties:
 
 targets:
   ### iOS tasks ###
+  # TODO(stuartmorgan): Switch ios_build_all_packages to Intel once the
+  # iOS platform tests are brough up on ARM, to give build coverage on
+  # both host architectures.
   - name: Mac_arm64 ios_build_all_packages master
-    bringup: true
     recipe: packages/packages
     timeout: 30
     properties:
@@ -56,7 +58,6 @@ targets:
       channel: master
 
   - name: Mac_arm64 ios_build_all_packages stable
-    bringup: true
     recipe: packages/packages
     timeout: 30
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -358,14 +358,6 @@ task:
       xcode_analyze_deprecation_script:
         # Ensure we don't accidentally introduce deprecated code.
         - ./script/tool_runner.sh xcode-analyze --ios --ios-min-version=13.0
-    ### iOS tasks ###
-    - name: ios-build_all_packages
-      env:
-        BUILD_ALL_ARGS: "ios --no-codesign"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      << : *BUILD_ALL_PACKAGES_APP_TEMPLATE
     ### macOS desktop tasks ###
     - name: macos-platform_tests
       # Don't run full platform tests on both channels in pre-submit.


### PR DESCRIPTION
Takes the LUCI version out of bringup mode, and removes the Cirrus version.

Part of the overall migration of macOS host tasks to LUCI.