### PR TITLE
[ci] Add LUCI versions of remaining macOS host tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -65,6 +65,98 @@ targets:
       target_file: ios_build_all_packages.yaml
       channel: stable
 
+  # TODO(stuartmorgan): Remove "- packages" from all task names once
+  # flutter/plugins is merged into this repo and turned down; it's here only
+  # because names must be unique across all flutter repositories.
+  - name: Mac_arm64 ios_platform_tests_1_of_4 master - packages
+    bringup: true # New task
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 0 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_2_of_4 master - packages
+    bringup: true # New task
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 1 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_3_of_4 master - packages
+    bringup: true # New task
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 2 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_4_of_4 master - packages
+    bringup: true # New task
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 3 --shardCount 4"
+
+  # Don't run full platform tests on both channels in pre-submit.
+  - name: Mac_arm64 ios_platform_tests_1_of_4 stable - packages
+    bringup: true # New task
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 0 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_2_of_4 stable - packages
+    bringup: true # New task
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 1 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_3_of_4 stable - packages
+    bringup: true # New task
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 2 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_4_of_4 stable - packages
+    bringup: true # New task
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 3 --shardCount 4"
+
   ### macOS desktop tasks ###
   # macos-platform_tests builds all the packages on ARM, so this build is run
   # on Intel to give us build coverage of both host types.
@@ -85,6 +177,27 @@ targets:
       version_file: flutter_stable.version
       target_file: mac_build_all_packages.yaml
       channel: stable
+
+  - name: Mac_arm64 macos_platform_tests master - packages
+    bringup: true # New task
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      channel: master
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: macos_platform_tests.yaml
+
+  - name: Mac_arm64 macos_platform_tests stable - packages
+    bringup: true # New task
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: macos_platform_tests.yaml
 
   - name: Mac_arm64 custom_package_tests master
     bringup: true # New configuration

--- a/.ci/scripts/create_simulator.sh
+++ b/.ci/scripts/create_simulator.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+device=com.apple.CoreSimulator.SimDeviceType.iPhone-13
+os=com.apple.CoreSimulator.SimRuntime.iOS-16-0
+
+xcrun simctl list
+xcrun simctl create Flutter-iPhone "$device" "$os" | xargs xcrun simctl boot

--- a/.ci/targets/ios_platform_tests.yaml
+++ b/.ci/targets/ios_platform_tests.yaml
@@ -1,0 +1,24 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  - name: create simulator
+    script: .ci/scripts/create_simulator.sh
+  - name: build examples
+    script: script/tool_runner.sh
+    args: ["build-examples", "--ios"]
+  - name: xcode analyze
+    script: script/tool_runner.sh
+    args: ["xcode-analyze", "--ios"]
+  - name: xcode analyze deprecation
+    # Ensure we don't accidentally introduce deprecated code.
+    script: script/tool_runner.sh
+    args: ["xcode-analyze", "--ios", "--ios-min-version=13.0"]
+  - name: native test
+    script: script/tool_runner.sh
+    args: ["native-test", "--ios", "--ios-destination", "platform=iOS Simulator,name=iPhone 13,OS=latest"]
+  - name: drive examples
+    # `drive-examples` contains integration tests, which changes the UI of the application.
+    # This UI change sometimes affects `xctest`.
+    # So we run `drive-examples` after `native-test`; changing the order will result ci failure.
+    script: script/tool_runner.sh
+    args: ["drive-examples", "--ios", "--exclude=script/configs/exclude_integration_ios.yaml"]

--- a/.ci/targets/mac_platform_tests.yaml
+++ b/.ci/targets/mac_platform_tests.yaml
@@ -1,0 +1,19 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  - name: build examples
+    script: script/tool_runner.sh
+    args: ["build-examples", "--macos"]
+  - name: xcode analyze
+    script: script/tool_runner.sh
+    args: ["xcode-analyze", "--macos"]
+  - name: xcode analyze deprecation
+    # Ensure we don't accidentally introduce deprecated code.
+    script: script/tool_runner.sh
+    args: ["xcode-analyze", "--macos", "--macos-min-version=12.3"]
+  - name: native test
+    script: script/tool_runner.sh
+    args: ["native-test", "--macos"]
+  - name: drive examples
+    script: script/tool_runner.sh
+    args: ["drive-examples", "--macos"]


### PR DESCRIPTION
This continues the LUCI migration of macOS host tests, now that ARM configurations should be working in LUCI, adding both iOS and macOS platform tests. In order to reduce later work aligning with flutter/plugins, this adds the same iOS sharding that is currently used in flutter/plugins, even though it's overkill for flutter/packages at the moment.