### PR TITLE
[ci] Enable no_runtimeType_toString

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -114,7 +114,7 @@ linter:
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
     - no_logic_in_create_state
-    # - no_runtimeType_toString # ok in tests; we enable this only in packages/
+    - no_runtimeType_toString # DIFFERENT FROM FLUTTER/FLUTTER
     - non_constant_identifier_names
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter

--- a/packages/flutter_image/CHANGELOG.md
+++ b/packages/flutter_image/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.5
+
+* Removes use of `runtimeType.toString()`.
+
 ## 4.1.4
 
 * Ignores lint warnings from new changes in Flutter master.

--- a/packages/flutter_image/lib/network.dart
+++ b/packages/flutter_image/lib/network.dart
@@ -214,8 +214,8 @@ class NetworkImageWithRetry extends ImageProvider<NetworkImageWithRetry> {
       FlutterError.onError!(FlutterErrorDetails(
         exception: lastFailure!,
         library: 'package:flutter_image',
-        context:
-            ErrorDescription('$runtimeType failed to load ${instructions.uri}'),
+        context: ErrorDescription(
+            '${objectRuntimeType(this, 'NetworkImageWithRetry')} failed to load ${instructions.uri}'),
       ));
     }
 
@@ -236,7 +236,8 @@ class NetworkImageWithRetry extends ImageProvider<NetworkImageWithRetry> {
   int get hashCode => Object.hash(url, scale);
 
   @override
-  String toString() => '$runtimeType("$url", scale: $scale)';
+  String toString() =>
+      '${objectRuntimeType(this, 'NetworkImageWithRetry')}("$url", scale: $scale)';
 }
 
 /// This function is called to get [FetchInstructions] to fetch an image.
@@ -295,7 +296,7 @@ class FetchInstructions {
 
   @override
   String toString() {
-    return '$runtimeType(\n'
+    return '${objectRuntimeType(this, 'FetchInstructions')}(\n'
         '  shouldGiveUp: $shouldGiveUp\n'
         '  timeout: $timeout\n'
         '  uri: $uri\n'
@@ -332,7 +333,7 @@ class FetchFailure implements Exception {
 
   @override
   String toString() {
-    return '$runtimeType(\n'
+    return '${objectRuntimeType(this, 'FetchFailure')}(\n'
         '  attemptCount: $attemptCount\n'
         '  httpStatusCode: $httpStatusCode\n'
         '  totalDuration: $totalDuration\n'

--- a/packages/flutter_image/pubspec.yaml
+++ b/packages/flutter_image/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Image utilities for Flutter: improved network providers, effects, etc.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_image
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_image%22
-version: 4.1.4
+version: 4.1.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/flutter_migrate/CHANGELOG.md
+++ b/packages/flutter_migrate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+2
+
+* Removes use of `runtimeType.toString()`.
+
 ## 0.0.1+1
 
 * Updates code to fix strict-cast violations.

--- a/packages/flutter_migrate/lib/src/base/terminal.dart
+++ b/packages/flutter_migrate/lib/src/base/terminal.dart
@@ -72,7 +72,7 @@ class OutputPreferences {
 
   @override
   String toString() {
-    return '$runtimeType[wrapText: $wrapText, wrapColumn: $wrapColumn, showColor: $showColor]';
+    return 'OutputPreferences[wrapText: $wrapText, wrapColumn: $wrapColumn, showColor: $showColor]';
   }
 }
 

--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_migrate
 description: A tool to migrate legacy flutter projects to modern versions.
-version: 0.0.1+1
+version: 0.0.1+2
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_migrate
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ap%3A%20flutter_migrate
 publish_to: none

--- a/packages/flutter_migrate/test/src/fakes.dart
+++ b/packages/flutter_migrate/test/src/fakes.dart
@@ -265,7 +265,7 @@ class FakeStopwatch implements Stopwatch {
   }
 
   @override
-  String toString() => '$runtimeType $elapsed $isRunning';
+  String toString() => 'FakeStopwatch $elapsed $isRunning';
 }
 
 class FakeStopwatchFactory implements StopwatchFactory {

--- a/packages/multicast_dns/CHANGELOG.md
+++ b/packages/multicast_dns/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.3.2+3
 
+* Removes use of `runtimeType.toString()`.
 * Updates minimum SDK version to Flutter 3.0.
 
 ## 0.3.2+2

--- a/packages/multicast_dns/lib/src/resource_record.dart
+++ b/packages/multicast_dns/lib/src/resource_record.dart
@@ -167,7 +167,7 @@ class ResourceRecordQuery {
 
   @override
   String toString() =>
-      '$runtimeType{$fullyQualifiedName, type: ${ResourceRecordType.toDebugString(resourceRecordType)}, isMulticast: $isMulticast}';
+      'ResourceRecordQuery{$fullyQualifiedName, type: ${ResourceRecordType.toDebugString(resourceRecordType)}, isMulticast: $isMulticast}';
 }
 
 /// Base implementation of DNS resource records (RRs).

--- a/packages/multicast_dns/pubspec.yaml
+++ b/packages/multicast_dns/pubspec.yaml
@@ -2,7 +2,7 @@ name: multicast_dns
 description: Dart package for performing mDNS queries (e.g. Bonjour, Avahi).
 repository: https://github.com/flutter/packages/tree/main/packages/multicast_dns
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+multicast_dns%22
-version: 0.3.2+2
+version: 0.3.2+3
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.0.8
 
+* Removes use of `runtimeType.toString()`.
 * Updates code to fix strict-cast violations.
 
 ## 1.0.7

--- a/packages/rfw/lib/src/flutter/content.dart
+++ b/packages/rfw/lib/src/flutter/content.dart
@@ -7,6 +7,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart' show objectRuntimeType;
+
 import '../dart/model.dart';
 
 /// Signature for the callback passed to [DynamicContent.subscribe].
@@ -188,7 +190,7 @@ class DynamicContent {
   }
 
   @override
-  String toString() => '$runtimeType($_root)';
+  String toString() => '${objectRuntimeType(this, 'DynamicContent')}($_root)';
 }
 
 // Node in the [DynamicContent] tree. This should contain no [BlobNode]s.

--- a/packages/rfw/pubspec.yaml
+++ b/packages/rfw/pubspec.yaml
@@ -2,7 +2,7 @@ name: rfw
 description: "Remote Flutter widgets: a library for rendering declarative widget description files at runtime."
 repository: https://github.com/flutter/packages/tree/main/packages/rfw
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+rfw%22
-version: 1.0.7
+version: 1.0.8
 
 environment:
   sdk: ">=2.13.0 <3.0.0"


### PR DESCRIPTION
Enables the `no_runtimeType_toString` analysis option. This isn't part of the base flutter/flutter analysis options, but is set in flutter/packages which this repo better corresponds to.

This is already enabled in flutter/plugins, and is being enabled here as part of aligning their options.

Part of https://github.com/flutter/flutter/issues/113764