### PR TITLE
[ci] Add .g.dart to analysis ignore list

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,7 @@ analyzer:
     unnecessary_null_comparison: ignore
   exclude: # DIFFERENT FROM FLUTTER/FLUTTER
     # Ignore generated files
+    - '**/*.g.dart'
     - '**/*.mocks.dart' # Mockito @GenerateMocks
 
 linter:


### PR DESCRIPTION
In preparation for merging repos, this adds the `.g.dart` suffix we use for Pigeon-generated files in plugins to the analysis ignore list. This eliminates the last remaining difference between the two repos' analysis options.

Part of https://github.com/flutter/flutter/issues/113764