### PR TITLE
[cross_file] Fix accidental constructor change

### DIFF
--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,5 +1,10 @@
+## 0.3.3+4
+
+* Reverts an accidental change in a constructor argument's nullability.
+
 ## 0.3.3+3
 
+* **RETRACTED**
 * Updates code to fix strict-cast violations.
 * Updates minimum SDK version to Flutter 3.0.
 

--- a/packages/cross_file/lib/src/types/interface.dart
+++ b/packages/cross_file/lib/src/types/interface.dart
@@ -21,17 +21,15 @@ class XFile extends XFileBase {
   /// `name` may be passed from the outside, for those cases where the effective
   /// `path` of the file doesn't match what the user sees when selecting it
   /// (like in web)
-  // This is a false positive; super.path is a String?, not a String.
-  // ignore: use_super_parameters
   XFile(
-    String path, {
+    String super.path, {
     String? mimeType,
     String? name,
     int? length,
     Uint8List? bytes,
     DateTime? lastModified,
     @visibleForTesting CrossFileTestOverrides? overrides,
-  }) : super(path) {
+  }) {
     throw UnimplementedError(
         'CrossFile is not available in your current platform.');
   }

--- a/packages/cross_file/lib/src/types/interface.dart
+++ b/packages/cross_file/lib/src/types/interface.dart
@@ -21,15 +21,17 @@ class XFile extends XFileBase {
   /// `name` may be passed from the outside, for those cases where the effective
   /// `path` of the file doesn't match what the user sees when selecting it
   /// (like in web)
+  // This is a false positive; super.path is a String?, not a String.
+  // ignore: use_super_parameters
   XFile(
-    super.path, {
+    String path, {
     String? mimeType,
     String? name,
     int? length,
     Uint8List? bytes,
     DateTime? lastModified,
     @visibleForTesting CrossFileTestOverrides? overrides,
-  }) {
+  }) : super(path) {
     throw UnimplementedError(
         'CrossFile is not available in your current platform.');
   }

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -2,7 +2,7 @@ name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 repository: https://github.com/flutter/packages/tree/main/packages/cross_file
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+cross_file%22
-version: 0.3.3+3
+version: 0.3.3+4
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/cross_file/test/x_file_io_test.dart
+++ b/packages/cross_file/test/x_file_io_test.dart
@@ -70,6 +70,10 @@ void main() {
 
       await tempDir.delete(recursive: true);
     });
+
+    test('nullability is correct', () async {
+      expect(_ensureNonnullPathArgument('a/path'), isNotNull);
+    });
   });
 
   group('Create with data', () {
@@ -105,6 +109,13 @@ void main() {
       await tempDir.delete(recursive: true);
     });
   });
+}
+
+// This is to create an analysis error if the version of XFile in
+// interface.dart, which should never actually be used but is what the analyzer
+// runs against, has the nullability of `path` changed.
+XFile _ensureNonnullPathArgument(String? path) {
+  return XFile(path!);
 }
 
 /// An XFile subclass that tracks reads, for testing purposes.


### PR DESCRIPTION
In https://github.com/flutter/packages/pull/3095 I accidentally changed a constructor argument's nullability because I wasn't familiar with the correct variation of super parameters, and addressed a lint warning incorrectly. That version has been retracted; this restores the original behavior.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
