### PR TITLE
[ci] Roll tooling to 0.13.4+2

### DIFF
--- a/.ci/scripts/prepare_tool.sh
+++ b/.ci/scripts/prepare_tool.sh
@@ -8,4 +8,4 @@ git fetch origin main
 
 # Pinned version of the plugin tools, to avoid breakage in this repository
 # when pushing updates from flutter/plugins.
-dart pub global activate flutter_plugin_tools 0.13.4
+dart pub global activate flutter_plugin_tools 0.13.4+2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0 # Fetch all history so the tool can get all the tags to determine version.
     - name: Set up tools
-      run: dart pub global activate flutter_plugin_tools 0.13.4
+      run: dart pub global activate flutter_plugin_tools 0.13.4+2
 
     # # This workflow should be the last to run. So wait for all the other tests to succeed.
     - name: Wait on all tests


### PR DESCRIPTION
Picks up the improved post-submit branch detection, so that postsubmit in LUCI will only run for changed packages as intended.