### PR TITLE
[ci] Roll Docker base image to 3.7.0

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,8 +1,8 @@
 # The Flutter version is not important here, since the CI scripts update Flutter
 # before running. What matters is that the base image is pinned to minimize
 # unintended changes when modifying this file.
-# This is the hash for the 3.0.0 image.
-FROM cirrusci/flutter@sha256:794fbbce5422e79aae1dbf6e6cbfcf5fe89aff50350d7c018853b3cfdf35821a
+# This is the hash for the 3.7.0 image.
+FROM cirrusci/flutter@sha256:5f3e4afb7487351e6dca2659e021c12ee7f74014b87616d982f912322b164c08
 
 RUN apt-get update -y
 

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,8 +1,8 @@
 # The Flutter version is not important here, since the CI scripts update Flutter
 # before running. What matters is that the base image is pinned to minimize
 # unintended changes when modifying this file.
-# This is the hash for the 3.7.0 image.
-FROM cirrusci/flutter@sha256:5f3e4afb7487351e6dca2659e021c12ee7f74014b87616d982f912322b164c08
+# This is the hash for the 3.3.10 image.
+FROM cirrusci/flutter@sha256:6252a6c1f7f24a5d74114630190dceaf419c476d9ca177c4d91ef916628d9e7f
 
 RUN apt-get update -y
 


### PR DESCRIPTION
Rolls the Dockerfile's base image forward, so that we're on a newer system image.