### PR TITLE
[various] Prep for more const widgets

### DIFF
--- a/packages/flutter_adaptive_scaffold/README.md
+++ b/packages/flutter_adaptive_scaffold/README.md
@@ -140,6 +140,7 @@ displayed and the entrance animation and exit animation.
             inAnimation: AdaptiveScaffold.leftOutIn,
             builder: (_) => AdaptiveScaffold.standardNavigationRail(
               extended: true,
+              // ···
               leading: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: const <Widget>[

--- a/packages/flutter_adaptive_scaffold/example/lib/adaptive_layout_demo.dart
+++ b/packages/flutter_adaptive_scaffold/example/lib/adaptive_layout_demo.dart
@@ -45,6 +45,8 @@ class MyHomePage extends StatelessWidget {
       children: <Widget>[
         const Divider(color: Colors.black),
         const SizedBox(height: 10),
+        // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+        // ignore: prefer_const_constructors
         Row(
           children: const <Widget>[
             SizedBox(
@@ -150,6 +152,8 @@ class MyHomePage extends StatelessWidget {
             inAnimation: AdaptiveScaffold.leftOutIn,
             builder: (_) => AdaptiveScaffold.standardNavigationRail(
               extended: true,
+              // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+              // ignore: prefer_const_constructors
               leading: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: const <Widget>[

--- a/packages/flutter_adaptive_scaffold/example/lib/adaptive_layout_demo.dart
+++ b/packages/flutter_adaptive_scaffold/example/lib/adaptive_layout_demo.dart
@@ -152,8 +152,10 @@ class MyHomePage extends StatelessWidget {
             inAnimation: AdaptiveScaffold.leftOutIn,
             builder: (_) => AdaptiveScaffold.standardNavigationRail(
               extended: true,
+              // #enddocregion Example
               // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
               // ignore: prefer_const_constructors
+              // #docregion Example
               leading: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: const <Widget>[

--- a/packages/flutter_adaptive_scaffold/example/lib/main.dart
+++ b/packages/flutter_adaptive_scaffold/example/lib/main.dart
@@ -409,6 +409,8 @@ class _LargeComposeIcon extends StatelessWidget {
       child: Column(children: <Widget>[
         Container(
           padding: const EdgeInsets.fromLTRB(6, 0, 0, 0),
+          // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+          // ignore: prefer_const_constructors
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: const <Widget>[
@@ -439,8 +441,12 @@ class _LargeComposeIcon extends StatelessWidget {
           ),
           width: 200,
           height: 50,
+          // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+          // ignore: prefer_const_constructors
           child: Padding(
             padding: const EdgeInsets.fromLTRB(16.0, 0, 0, 0),
+            // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+            // ignore: prefer_const_constructors
             child: Row(
               children: const <Widget>[
                 Icon(Icons.edit_outlined),

--- a/packages/flutter_markdown/test/list_test.dart
+++ b/packages/flutter_markdown/test/list_test.dart
@@ -210,6 +210,8 @@ void defineTests() {
 
         await tester.pumpWidget(
           boilerplate(
+            // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+            // ignore: prefer_const_constructors
             Column(
               children: const <Widget>[
                 MarkdownBody(fitContent: false, data: data),
@@ -233,6 +235,8 @@ void defineTests() {
 
         await tester.pumpWidget(
           boilerplate(
+            // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+            // ignore: prefer_const_constructors
             Column(
               children: const <Widget>[
                 MarkdownBody(data: data),

--- a/packages/flutter_markdown/test/markdown_body_shrink_wrap_test.dart
+++ b/packages/flutter_markdown/test/markdown_body_shrink_wrap_test.dart
@@ -15,17 +15,21 @@ void defineTests() {
       'Given a MarkdownBody with shrinkWrap=true '
       'Then it wraps its content',
       (WidgetTester tester) async {
-        await tester.pumpWidget(boilerplate(Stack(
-          children: const <Widget>[
-            Text('shrinkWrap=true'),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: MarkdownBody(
-                data: 'This is a [link](https://flutter.dev/)',
+        await tester.pumpWidget(boilerplate(
+          // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+          // ignore: prefer_const_constructors
+          Stack(
+            children: const <Widget>[
+              Text('shrinkWrap=true'),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: MarkdownBody(
+                  data: 'This is a [link](https://flutter.dev/)',
+                ),
               ),
-            ),
-          ],
-        )));
+            ],
+          ),
+        ));
 
         final Rect stackRect = tester.getRect(find.byType(Stack));
         final Rect textRect = tester.getRect(find.byType(Text));
@@ -43,18 +47,22 @@ void defineTests() {
       'Given a MarkdownBody with shrinkWrap=false '
       'Then it expands to the maximum allowed height',
       (WidgetTester tester) async {
-        await tester.pumpWidget(boilerplate(Stack(
-          children: const <Widget>[
-            Text('shrinkWrap=false test'),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: MarkdownBody(
-                data: 'This is a [link](https://flutter.dev/)',
-                shrinkWrap: false,
+        await tester.pumpWidget(boilerplate(
+          // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+          // ignore: prefer_const_constructors
+          Stack(
+            children: const <Widget>[
+              Text('shrinkWrap=false test'),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: MarkdownBody(
+                  data: 'This is a [link](https://flutter.dev/)',
+                  shrinkWrap: false,
+                ),
               ),
-            ),
-          ],
-        )));
+            ],
+          ),
+        ));
 
         final Rect stackRect = tester.getRect(find.byType(Stack));
         final Rect textRect = tester.getRect(find.byType(Text));

--- a/packages/rfw/example/remote/lib/main.dart
+++ b/packages/rfw/example/remote/lib/main.dart
@@ -87,10 +87,18 @@ class _ExampleState extends State<Example> {
         },
       );
     } else {
+      // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+      // ignore: prefer_const_constructors
       result = Material(
+        // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+        // ignore: prefer_const_constructors
         child: SafeArea(
+          // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+          // ignore: prefer_const_constructors
           child: Padding(
             padding: const EdgeInsets.all(20.0),
+            // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+            // ignore: prefer_const_constructors
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: const <Widget>[


### PR DESCRIPTION
Similar to https://github.com/flutter/plugins/pull/7074.

https://github.com/flutter/flutter/pull/119673 will make a few more widgets const. This prepares the plugins repo for that change.

I chose to ignore the resulting lint for now to ensure that the plugins continue to work on older versions of Flutter. Once the change referenced above is part of the oldest Flutter version supported by the plugins, we can resolve the TODO, remove the ignore, and make the widgets in question const.