### PR TITLE
[ci] More cirrus.yml pre-alignment with flutter/plugins

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -296,12 +296,7 @@ task:
       build_script:
         - ./script/tool_runner.sh build-examples --web
       drive_script:
-        # google_identity_services_web tests need Dart >=2.17, which is not available in stable.
-        - if [[ "$CHANNEL" == "master" ]]; then
-        -   ./script/tool_runner.sh drive-examples --web
-        - else
-        -   ./script/tool_runner.sh drive-examples --web --exclude=google_identity_services_web
-        - fi
+        - ./script/tool_runner.sh drive-examples --web
     - name: web_benchmarks_test
       env:
         matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -224,6 +224,19 @@ task:
     memory: 16G
   matrix:
     ### Platform-agnostic tasks ###
+    - name: dart_unit_tests
+      env:
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
+      unit_test_script:
+        - ./script/tool_runner.sh test --exclude=script/configs/dart_unit_tests_exceptions.yaml
+      pathified_unit_test_script:
+        # Run tests with path-based dependencies to ensure that publishing
+        # the changes won't break tests of other packages in the repository
+        # that depend on it.
+        - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
+        - $PLUGIN_TOOL_COMMAND test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
     - name: linux-custom_package_tests
       env:
         PATH: $PATH:/usr/local/bin
@@ -295,19 +308,6 @@ task:
         - cd ../..
         - flutter packages get
         - dart testing/web_benchmarks_test.dart
-    - name: dart_unit_tests
-      env:
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      unit_test_script:
-        - ./script/tool_runner.sh test --exclude=script/configs/dart_unit_tests_exceptions.yaml
-      pathified_unit_test_script:
-        # Run tests with path-based dependencies to ensure that publishing
-        # the changes won't break tests of other packages in the repository
-        # that depend on it.
-        - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
-        - $PLUGIN_TOOL_COMMAND test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
 
 # macOS tasks.
 task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ install_chrome_linux_template: &INSTALL_CHROME_LINUX
   install_chromium_script:
     # Install a pinned version of Chromium and its corresponding ChromeDriver.
     # Setting CHROME_EXECUTABLE above causes this version to be used for tests.
-    - ./script/install_chromium.sh "$CHROME_DIR"
+    - ./script/install_chromium.sh
 
 tool_setup_template: &TOOL_SETUP_TEMPLATE
   tool_setup_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -266,8 +266,14 @@ task:
         - ./script/tool_runner.sh build-examples --apk --exclude=extension_google_sign_in_as_googleapis_auth
       lint_script:
         - ./script/tool_runner.sh lint-android # must come after build-examples
-      native_unit_test_scipt:
+      native_unit_test_script:
+        # Native integration tests are handled by Firebase Test Lab below, so
+        # only run unit tests.
+        # Must come after build-examples.
         - ./script/tool_runner.sh native-test --android --no-integration
+      # TODO(stuartmorgan): Copy firebase_test_lab_script from flutter/plugins
+      # once https://github.com/flutter/flutter/issues/119730 is resolved.
+      # firebase_test_lab_script:
       # Upload the full lint results to Cirrus to display in the results UI.
       always:
         android-lint_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -252,8 +252,11 @@ task:
       skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
       env:
         matrix:
-          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 2"
-          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 2"
+          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 5"
+          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 5"
+          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 5"
+          PACKAGE_SHARDING: "--shardIndex 3 --shardCount 5"
+          PACKAGE_SHARDING: "--shardIndex 4 --shardCount 5"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
@@ -281,6 +284,9 @@ task:
     ### Web tasks ###
     - name: web-platform_tests
       env:
+        matrix:
+          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 2"
+          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -261,9 +261,7 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       build_script:
-        # extension_google_sign_in_as_googleapis_auth is currently not building, see
-        # https://github.com/flutter/flutter/issues/89301
-        - ./script/tool_runner.sh build-examples --apk --exclude=extension_google_sign_in_as_googleapis_auth
+        - ./script/tool_runner.sh build-examples --apk
       lint_script:
         - ./script/tool_runner.sh lint-android # must come after build-examples
       native_unit_test_script:


### PR DESCRIPTION
Minor adjustments to Cirrus configuration as part of pre-alignment with flutter/plugins for the eventual repo merge:
- Move Dart unit tests up to the platform-agnostic section (it was accidentally put in the wrong place when it was moved out of light workload).
- Update sharding to match flutter/plugins; it's not currently necessary here, but this avoids having to make CI changes in the same PR where we do the actual move of the packages.
- Remove some exclusions that should no longer be needed.
- Add a placeholder where FTL still needs to be added.

Part of https://github.com/flutter/flutter/issues/113764