### PR TITLE
[ci] Add FTL to Cirrus, and do more minor alignment with flutter/plugins

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,6 +128,8 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       analyze_script:
+        # DO NOT change the custom-analysis argument here without changing the Dart repo.
+        # See the comment in script/configs/custom_analysis.yaml for details.
         - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
       pathified_analyze_script:
         # Re-run analysis with path-based dependencies to ensure that publishing
@@ -206,7 +208,7 @@ task:
       native_test_script:
         - xvfb-run ./script/tool_runner.sh native-test --linux --no-integration
       drive_script:
-        - xvfb-run ./script/tool_runner.sh drive-examples --linux
+        - xvfb-run ./script/tool_runner.sh drive-examples --linux --exclude=script/configs/exclude_integration_linux.yaml
 
 # Heavy-workload Linux tasks.
 # These use machines with more CPUs and memory, so will reduce parallelization
@@ -270,7 +272,7 @@ task:
         # Native integration tests are handled by Firebase Test Lab below, so
         # only run unit tests.
         # Must come after build-examples.
-        - ./script/tool_runner.sh native-test --android --no-integration
+        - ./script/tool_runner.sh native-test --android --no-integration --exclude script/configs/exclude_native_unit_android.yaml
       firebase_test_lab_script:
         - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
         -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
@@ -306,7 +308,7 @@ task:
       build_script:
         - ./script/tool_runner.sh build-examples --web
       drive_script:
-        - ./script/tool_runner.sh drive-examples --web
+        - ./script/tool_runner.sh drive-examples --web --exclude=script/configs/exclude_integration_web.yaml
     - name: web_benchmarks_test
       env:
         matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -262,8 +262,8 @@ task:
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
-        MAPS_API_KEY=ENCRYPTED[d6583b08f79f91ea4844c77460f04539965e46ad2fd97fb7c062b4dfe88016228b86ebe8c220ab4187e0c4bd773dc1e7]
-        GCLOUD_FIREBASE_TESTLAB_KEY=ENCRYPTED[62dec6b6b5e7f32dd915552cc33202a350796824de621870bbc54c9ae28a10751e6bd8112f9e21f7f77e65fde1d588cf]
+        MAPS_API_KEY: ENCRYPTED[d6583b08f79f91ea4844c77460f04539965e46ad2fd97fb7c062b4dfe88016228b86ebe8c220ab4187e0c4bd773dc1e7]
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[62dec6b6b5e7f32dd915552cc33202a350796824de621870bbc54c9ae28a10751e6bd8112f9e21f7f77e65fde1d588cf]
       build_script:
         - ./script/tool_runner.sh build-examples --apk
       lint_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -260,6 +260,8 @@ task:
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
+        MAPS_API_KEY=ENCRYPTED[d6583b08f79f91ea4844c77460f04539965e46ad2fd97fb7c062b4dfe88016228b86ebe8c220ab4187e0c4bd773dc1e7]
+        GCLOUD_FIREBASE_TESTLAB_KEY=ENCRYPTED[62dec6b6b5e7f32dd915552cc33202a350796824de621870bbc54c9ae28a10751e6bd8112f9e21f7f77e65fde1d588cf]
       build_script:
         - ./script/tool_runner.sh build-examples --apk
       lint_script:
@@ -269,9 +271,13 @@ task:
         # only run unit tests.
         # Must come after build-examples.
         - ./script/tool_runner.sh native-test --android --no-integration
-      # TODO(stuartmorgan): Copy firebase_test_lab_script from flutter/plugins
-      # once https://github.com/flutter/flutter/issues/119730 is resolved.
-      # firebase_test_lab_script:
+      firebase_test_lab_script:
+        - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
+        -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
+        -   ./script/tool_runner.sh firebase-test-lab --device model=redfin,version=30 --device model=starqlteue,version=26 --exclude=script/configs/exclude_integration_android.yaml
+        - else
+        -   echo "This user does not have permission to run Firebase Test Lab tests."
+        - fi
       # Upload the full lint results to Cirrus to display in the results UI.
       always:
         android-lint_artifacts:

--- a/script/configs/exclude_integration_android.yaml
+++ b/script/configs/exclude_integration_android.yaml
@@ -1,1 +1,11 @@
-[]
+# Manually exclude all non-plugin packages until
+# https://github.com/flutter/flutter/issues/120450
+# is fixed.
+- animations
+- dynamic_layouts
+- extension_google_sign_in_as_googleapis_auth
+- flutter_adaptive_scaffold
+- flutter_markdown
+- go_router
+- palette_generator
+- rfw


### PR DESCRIPTION
Adds the FTL tests that are currently part of flutter/plugins to this repository, including the flutter/packages versions of the necessary key (plus the key that will be needed when the maps plugin moves).

Also does some more minor alignment, mostly adding exclusion file references that are not yet needed here, but have placeholder files here now that can be referenced to minimize diffs during the merge (as was done for LUCI recently).

This makes flutter/packages's Cirrus config a superset of the flutter/plugins version, with the exception of the task that are for the repo tooling, which will be added as part of moving the repo tooling, before moving all of the packages.

Part of https://github.com/flutter/flutter/issues/113764
Fixes https://github.com/flutter/flutter/issues/119730