### PR TITLE
[flutter_markdown] Require pkg:markdown v7.0.0

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.14
+
+* Require `markdown: ^7.0.0`
+
 ## 0.6.13+1
 
 * Adjusts code to account for nullability change in Flutter SDK.

--- a/packages/flutter_markdown/example/pubspec.yaml
+++ b/packages/flutter_markdown/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   flutter_markdown:
     path: ../
-  markdown: ^6.0.0
+  markdown: ^7.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -470,31 +470,12 @@ class MarkdownBuilder implements md.NodeVisitor {
         current.children.add(_buildRichText(const TextSpan(text: '\n')));
       } else if (tag == 'th' || tag == 'td') {
         TextAlign? align;
-        // `style` was using in pkg:markdown <= 6.0.1
-        // Can be removed when min pkg:markedwn > 6.0.1
-        final String? style = element.attributes['style'];
-        if (style == null) {
-          // `align` is using in pkg:markdown > 6.0.1
-          final String? alignAttribute = element.attributes['align'];
-          if (alignAttribute == null) {
-            align = tag == 'th' ? styleSheet.tableHeadAlign : TextAlign.left;
-          } else {
-            switch (alignAttribute) {
-              case 'left':
-                align = TextAlign.left;
-                break;
-              case 'center':
-                align = TextAlign.center;
-                break;
-              case 'right':
-                align = TextAlign.right;
-                break;
-            }
-          }
+        // `align` is using in pkg:markdown > 6.0.1
+        final String? alignAttribute = element.attributes['align'];
+        if (alignAttribute == null) {
+          align = tag == 'th' ? styleSheet.tableHeadAlign : TextAlign.left;
         } else {
-          final RegExp regExp = RegExp(r'text-align: (left|center|right)');
-          final Match match = regExp.matchAsPrefix(style)!;
-          switch (match[1]) {
+          switch (alignAttribute) {
             case 'left':
               align = TextAlign.left;
               break;
@@ -506,6 +487,7 @@ class MarkdownBuilder implements md.NodeVisitor {
               break;
           }
         }
+
         final Widget child = _buildTableCell(
           _mergeInlineChildren(current.children, align),
           textAlign: align,

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -470,7 +470,6 @@ class MarkdownBuilder implements md.NodeVisitor {
         current.children.add(_buildRichText(const TextSpan(text: '\n')));
       } else if (tag == 'th' || tag == 'td') {
         TextAlign? align;
-        // `align` is using in pkg:markdown > 6.0.1
         final String? alignAttribute = element.attributes['align'];
         if (alignAttribute == null) {
           align = tag == 'th' ? styleSheet.tableHeadAlign : TextAlign.left;

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -486,7 +486,6 @@ class MarkdownBuilder implements md.NodeVisitor {
               break;
           }
         }
-
         final Widget child = _buildTableCell(
           _mergeInlineChildren(current.children, align),
           textAlign: align,

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.6.13+1
+version: 0.6.14
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  markdown: ^6.0.0
+  markdown: ^7.0.0
   meta: ^1.3.0
   path: ^1.8.0
 

--- a/packages/flutter_markdown/test/link_test.dart
+++ b/packages/flutter_markdown/test/link_test.dart
@@ -629,13 +629,7 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!newMarkdown) {
-          // For pkg:markdown <= v6.0.1
-          expectLinkTap(linkTapResults, const MarkdownLink('link', 'foo\bar'));
-        } else {
-          // For pkg:markdown > v6.0.1
-          expectLinkTap(linkTapResults, const MarkdownLink('link', 'foo%08ar'));
-        }
+        expectLinkTap(linkTapResults, const MarkdownLink('link', 'foo%08ar'));
       },
     );
 
@@ -656,15 +650,8 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!newMarkdown) {
-          // For pkg:markdown <= v6.0.1
-          expectLinkTap(
-              linkTapResults, const MarkdownLink('link', 'foo%20b&auml;'));
-        } else {
-          // For pkg:markdown > v6.0.1
-          expectLinkTap(
-              linkTapResults, const MarkdownLink('link', 'foo%20b%C3%A4'));
-        }
+        expectLinkTap(
+            linkTapResults, const MarkdownLink('link', 'foo%20b%C3%A4'));
       },
     );
 
@@ -773,15 +760,8 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!newMarkdown) {
-          // For pkg:markdown <= v6.0.1
-          expectLinkTap(linkTapResults,
-              const MarkdownLink('link', '/url', 'title %22&quot;'));
-        } else {
-          // For pkg:markdown > v6.0.1
-          expectLinkTap(linkTapResults,
-              const MarkdownLink('link', '/url', 'title &quot;&quot;'));
-        }
+        expectLinkTap(linkTapResults,
+            const MarkdownLink('link', '/url', 'title &quot;&quot;'));
       },
     );
 
@@ -802,15 +782,8 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!newMarkdown) {
-          // For pkg:markdown <= v6.0.1
-          expectLinkTap(linkTapResults,
-              const MarkdownLink('link', '/url\u{C2A0}%22title%22'));
-        } else {
-          // For pkg:markdown > v6.0.1
-          expectLinkTap(linkTapResults,
-              const MarkdownLink('link', '/url%EC%8A%A0%22title%22'));
-        }
+        expectLinkTap(linkTapResults,
+            const MarkdownLink('link', '/url%EC%8A%A0%22title%22'));
       },
     );
 
@@ -853,17 +826,10 @@ void defineTests() {
         );
 
         expectValidLink('link');
-        if (!newMarkdown) {
-          // For pkg:markdown <= v6.0.1
-          expectLinkTap(linkTapResults,
-              const MarkdownLink('link', '/url', 'title %22and%22 title'));
-        } else {
-          // For pkg:markdown > v6.0.1
-          expectLinkTap(
-            linkTapResults,
-            const MarkdownLink('link', '/url', 'title &quot;and&quot; title'),
-          );
-        }
+        expectLinkTap(
+          linkTapResults,
+          const MarkdownLink('link', '/url', 'title &quot;and&quot; title'),
+        );
       },
     );
 

--- a/packages/flutter_markdown/test/list_test.dart
+++ b/packages/flutter_markdown/test/list_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import 'utils.dart';
 
 void main() => defineTests();
@@ -86,35 +87,18 @@ void defineTests() {
         );
 
         final Iterable<Widget> widgets = tester.allWidgets;
-        if (!newMarkdown) {
-          // For pkg:markdown <= v6.0.1
-          expectTextStrings(widgets, <String>[
-            '1.',
-            'Item 1',
-            '2.',
-            'Item 2',
-            '3.',
-            'Item 3',
-            '10.',
-            'Item 10',
-            '11.',
-            'Item 11'
-          ]);
-        } else {
-          // For pkg:markdown > v6.0.1
-          expectTextStrings(widgets, <String>[
-            '1.',
-            'Item 1',
-            '2.',
-            'Item 2',
-            '3.',
-            'Item 3',
-            '4.',
-            'Item 10',
-            '5.',
-            'Item 11'
-          ]);
-        }
+        expectTextStrings(widgets, <String>[
+          '1.',
+          'Item 1',
+          '2.',
+          'Item 2',
+          '3.',
+          'Item 3',
+          '4.',
+          'Item 10',
+          '5.',
+          'Item 11'
+        ]);
       },
     );
 

--- a/packages/flutter_markdown/test/table_test.dart
+++ b/packages/flutter_markdown/test/table_test.dart
@@ -391,43 +391,18 @@ void defineTests() {
 
           expectTableSize(3, 2);
 
-          if (!newMarkdown) {
-            // For pkg:markdown <= v6.0.1
-            expect(find.byType(RichText), findsNWidgets(6));
-            final List<String?> text = find
-                .byType(RichText)
-                .evaluate()
-                .map((Element e) => e.widget)
-                .cast<RichText>()
-                .map((RichText richText) => richText.text)
-                .cast<TextSpan>()
-                .map((TextSpan e) => e.text)
-                .toList();
-            expect(text[0], 'abc');
-            expect(text[1], 'def');
-            expect(text[2], 'bar');
-            expect(text[3], 'baz');
-            expect(text[4], 'bar');
-            expect(table.defaultColumnWidth, columnWidth);
-
-            // Paragraph text
-            expect(text[5], 'bar');
-          } else {
-            // For pkg:markdown > v6.0.1
-            expect(find.byType(RichText), findsNWidgets(7));
-            final List<String?> text = find
-                .byType(RichText)
-                .evaluate()
-                .map((Element e) => e.widget)
-                .cast<RichText>()
-                .map((RichText richText) => richText.text)
-                .cast<TextSpan>()
-                .map((TextSpan e) => e.text)
-                .toList();
-            expect(
-                text, <String>['abc', 'def', 'bar', 'baz', 'bar', '', 'bar']);
-            expect(table.defaultColumnWidth, columnWidth);
-          }
+          expect(find.byType(RichText), findsNWidgets(7));
+          final List<String?> text = find
+              .byType(RichText)
+              .evaluate()
+              .map((Element e) => e.widget)
+              .cast<RichText>()
+              .map((RichText richText) => richText.text)
+              .cast<TextSpan>()
+              .map((TextSpan e) => e.text)
+              .toList();
+          expect(text, <String>['abc', 'def', 'bar', 'baz', 'bar', '', 'bar']);
+          expect(table.defaultColumnWidth, columnWidth);
         },
       );
 
@@ -460,7 +435,6 @@ void defineTests() {
               .toList();
           expect(text[0], '| abc | def | | --- | | bar |');
         },
-        skip: !newMarkdown,
       );
 
       testWidgets(
@@ -485,39 +459,18 @@ void defineTests() {
 
           expectTableSize(3, 2);
 
-          if (!newMarkdown) {
-            // For pkg:markdown <= v6.0.1
-            expect(find.byType(RichText), findsNWidgets(5));
-            final List<String?> cellText = find
-                .byType(RichText)
-                .evaluate()
-                .map((Element e) => e.widget)
-                .cast<RichText>()
-                .map((RichText richText) => richText.text)
-                .cast<TextSpan>()
-                .map((TextSpan e) => e.text)
-                .toList();
-            expect(cellText[0], 'abc');
-            expect(cellText[1], 'def');
-            expect(cellText[2], 'bar');
-            expect(cellText[3], 'bar');
-            expect(cellText[4], 'baz');
-            expect(table.defaultColumnWidth, columnWidth);
-          } else {
-            // For pkg:markdown > v6.0.1
-            expect(find.byType(RichText), findsNWidgets(6));
-            final List<String?> cellText = find
-                .byType(RichText)
-                .evaluate()
-                .map((Element e) => e.widget)
-                .cast<RichText>()
-                .map((RichText richText) => richText.text)
-                .cast<TextSpan>()
-                .map((TextSpan e) => e.text)
-                .toList();
-            expect(cellText, <String>['abc', 'def', 'bar', '', 'bar', 'baz']);
-            expect(table.defaultColumnWidth, columnWidth);
-          }
+          expect(find.byType(RichText), findsNWidgets(6));
+          final List<String?> cellText = find
+              .byType(RichText)
+              .evaluate()
+              .map((Element e) => e.widget)
+              .cast<RichText>()
+              .map((RichText richText) => richText.text)
+              .cast<TextSpan>()
+              .map((TextSpan e) => e.text)
+              .toList();
+          expect(cellText, <String>['abc', 'def', 'bar', '', 'bar', 'baz']);
+          expect(table.defaultColumnWidth, columnWidth);
         },
       );
 

--- a/packages/flutter_markdown/test/utils.dart
+++ b/packages/flutter_markdown/test/utils.dart
@@ -9,10 +9,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:markdown/markdown.dart' as md show version;
-
-// TODO(Zhiguang): delete this once the min version of pkg:markdown is updated
-final bool newMarkdown = md.version.compareTo('6.0.1') > 0;
 
 final TextTheme textTheme = Typography.material2018()
     .black


### PR DESCRIPTION
Remove code that supports markdown ^6.0.0

Closes https://github.com/flutter/flutter/issues/120486
