### PR TITLE
[ci] Downgrade iOS simulator

### DIFF
--- a/.ci/scripts/create_simulator.sh
+++ b/.ci/scripts/create_simulator.sh
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-device=com.apple.CoreSimulator.SimDeviceType.iPhone-13
+device=com.apple.CoreSimulator.SimDeviceType.iPhone-11
 os=com.apple.CoreSimulator.SimRuntime.iOS-16-0
 
 xcrun simctl list

--- a/.ci/targets/ios_platform_tests.yaml
+++ b/.ci/targets/ios_platform_tests.yaml
@@ -15,7 +15,7 @@ tasks:
     args: ["xcode-analyze", "--ios", "--ios-min-version=13.0"]
   - name: native test
     script: script/tool_runner.sh
-    args: ["native-test", "--ios", "--ios-destination", "platform=iOS Simulator,name=iPhone 13,OS=latest"]
+    args: ["native-test", "--ios", "--ios-destination", "platform=iOS Simulator,name=iPhone 11,OS=latest"]
   - name: drive examples
     # `drive-examples` contains integration tests, which changes the UI of the application.
     # This UI change sometimes affects `xctest`.


### PR DESCRIPTION
Switches from iPhone 13 to iPhone 11. See discussion in https://github.com/flutter/plugins/pull/7131 for context.

Part of https://github.com/flutter/flutter/issues/113764