### PR TITLE
[tool] Skip non-plugin packages in FTL command

### DIFF
--- a/script/configs/exclude_integration_android.yaml
+++ b/script/configs/exclude_integration_android.yaml
@@ -1,11 +1,1 @@
-# Manually exclude all non-plugin packages until
-# https://github.com/flutter/flutter/issues/120450
-# is fixed.
-- animations
-- dynamic_layouts
-- extension_google_sign_in_as_googleapis_auth
-- flutter_adaptive_scaffold
-- flutter_markdown
-- go_router
-- palette_generator
-- rfw
+[]

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -12,6 +12,7 @@ import 'package:uuid/uuid.dart';
 import 'common/core.dart';
 import 'common/gradle.dart';
 import 'common/package_looping_command.dart';
+import 'common/plugin_utils.dart';
 import 'common/process_runner.dart';
 import 'common/repository_package.dart';
 
@@ -158,8 +159,13 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
         .childDirectory('androidTest');
     if (!uiTestDirectory.existsSync()) {
       printError('No androidTest directory found.');
-      return PackageResult.fail(
-          <String>['No tests ran (use --exclude if this is intentional).']);
+      if (isFlutterPlugin(package)) {
+        return PackageResult.fail(
+            <String>['No tests ran (use --exclude if this is intentional).']);
+      } else {
+        return PackageResult.skip(
+            '${example.displayName} has no native Android tests.');
+      }
     }
 
     // Ensure that the Dart integration tests will be run, not just native UI

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -420,7 +420,7 @@ public class MainActivityTest {
       );
     });
 
-    test('fails for packages with no androidTest directory', () async {
+    test('fails for plugins with no androidTest directory', () async {
       createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
         'example/android/gradlew',
@@ -448,6 +448,30 @@ public class MainActivityTest {
           contains('The following packages had errors:'),
           contains('plugin:\n'
               '    No tests ran (use --exclude if this is intentional).'),
+        ]),
+      );
+    });
+
+    test('skips for non-plugin packages with no androidTest directory',
+        () async {
+      createFakePackage('a_package', packagesDir, extraFiles: <String>[
+        'example/integration_test/foo_test.dart',
+        'example/android/gradlew',
+      ]);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'firebase-test-lab',
+        '--device',
+        'model=redfin,version=30',
+      ]);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Running for a_package'),
+          contains('No androidTest directory found.'),
+          contains('No examples support Android.'),
+          contains('Skipped 1 package'),
         ]),
       );
     });


### PR DESCRIPTION
The `firebase-test-lab` expectations were written for flutter/plugins, where everything was supposed to have an integration test. This makes non-plugin packages skip, not fail, if they don't have native Android integration tests.

Fixes https://github.com/flutter/flutter/issues/120450

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
