### PR TITLE
[extension_gsi] Update extension to support gsi 5 and 6.

### DIFF
--- a/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
+++ b/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.9
+
+* Makes the extension compatible with `google_sign_in` version `^5.0.0` and `^6.0.0`.
+* Fixes a small typo in the code (`oath` -> `oauth`).
+* Updates example app to use `google_sign_in: ^6.0.0`.
+
 ## 2.0.8
 
 * Updates links for the merge of flutter/plugins into flutter/packages.

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/.gitignore
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/.gitignore
@@ -32,7 +32,6 @@
 /build/
 
 # Web related
-lib/generated_plugin_registrant.dart
 
 # Symbolication related
 app.*.symbols

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/lib/main.dart
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/lib/main.dart
@@ -19,7 +19,7 @@ final GoogleSignIn _googleSignIn = GoogleSignIn(
 void main() {
   runApp(
     const MaterialApp(
-      title: 'Google Sign In',
+      title: 'Google Sign In + googleapis',
       home: SignInDemo(),
     ),
   );
@@ -149,7 +149,7 @@ class SignInDemoState extends State<SignInDemo> {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          title: const Text('Google Sign In'),
+          title: const Text('Google Sign In + googleapis'),
         ),
         body: ConstrainedBox(
           constraints: const BoxConstraints.expand(),

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/pubspec.yaml
@@ -16,12 +16,11 @@ dependencies:
     path: ../
   flutter:
     sdk: flutter
-  google_sign_in: ^5.1.0
-  googleapis: ^5.0.1
+  google_sign_in: ^6.0.0
+  googleapis: ^10.1.0
   googleapis_auth: ^1.1.0
 
 dev_dependencies:
-  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/web/index.html
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/web/index.html
@@ -22,12 +22,12 @@ found in the LICENSE file. -->
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="The Google Sign In example app, using the googleapis package.">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="example">
+  <meta name="apple-mobile-web-app-title" content="Google Sign In + googleapis">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
@@ -37,75 +37,30 @@ found in the LICENSE file. -->
 
   <!-- Google Sign In configuration -->
   <meta name="google-signin-client_id" content="[YOUR_OAUTH_2_CLIENT_ID_FOR_WEB]" />
-  <title>Google Sign-in Example</title>
+  <title>Google Sign In + googleapis</title>
+
+  <script>
+    // The value below is injected by flutter build, do not touch.
+    var serviceWorkerVersion = null;
+  </script>
+  <!-- This script adds the flutter initialization JS code -->
+  <script src="flutter.js" defer></script>
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
-    var scriptLoaded = false;
-    function loadMainDartJs() {
-      if (scriptLoaded) {
-        return;
-      }
-      scriptLoaded = true;
-      var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
-      scriptTag.type = 'application/javascript';
-      document.body.append(scriptTag);
-    }
-
-    if ('serviceWorker' in navigator) {
-      // Service workers are supported. Use them.
-      window.addEventListener('load', function () {
-        // Wait for registration to finish before dropping the <script> tag.
-        // Otherwise, the browser will load the script multiple times,
-        // potentially different versions.
-        var serviceWorkerUrl = 'flutter_service_worker.js?v=' + serviceWorkerVersion;
-        navigator.serviceWorker.register(serviceWorkerUrl)
-          .then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener('statechange', () => {
-                if (serviceWorker.state == 'activated') {
-                  console.log('Installed new service worker.');
-                  loadMainDartJs();
-                }
-              });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing || reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
-              // When the app updates the serviceWorkerVersion changes, so we
-              // need to ask the service worker to update.
-              console.log('New service worker available.');
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              // Existing service worker is still good.
-              console.log('Loading app from service worker.');
-              loadMainDartJs();
-            }
+    window.addEventListener('load', function(ev) {
+      // Download main.dart.js
+      _flutter.loader.loadEntrypoint({
+        serviceWorker: {
+          serviceWorkerVersion: serviceWorkerVersion,
+        },
+        onEntrypointLoaded: function(engineInitializer) {
+          engineInitializer.initializeEngine().then(function(appRunner) {
+            appRunner.runApp();
           });
-
-        // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plaint <script> tag.
-        setTimeout(() => {
-          if (!scriptLoaded) {
-            console.warn(
-              'Failed to load app from service worker. Falling back to plain <script> tag.',
-            );
-            loadMainDartJs();
-          }
-        }, 4000);
+        }
       });
-    } else {
-      // Service workers not supported. Just drop the <script> tag.
-      loadMainDartJs();
-    }
+    });
   </script>
 </body>
 </html>

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/web/manifest.json
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "example",
-    "short_name": "example",
+    "name": "Google Sign In + googleapis",
+    "short_name": "gsi+googleapis",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",
     "theme_color": "#0175C2",
-    "description": "A new Flutter project.",
+    "description": "The Google Sign In example app, using the googleapis package.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [

--- a/packages/extension_google_sign_in_as_googleapis_auth/lib/extension_google_sign_in_as_googleapis_auth.dart
+++ b/packages/extension_google_sign_in_as_googleapis_auth/lib/extension_google_sign_in_as_googleapis_auth.dart
@@ -19,14 +19,14 @@ extension GoogleApisGoogleSignInAuth on GoogleSignIn {
   }) async {
     final GoogleSignInAuthentication? auth =
         debugAuthentication ?? await currentUser?.authentication;
-    final String? oathTokenString = auth?.accessToken;
-    if (oathTokenString == null) {
+    final String? oauthTokenString = auth?.accessToken;
+    if (oauthTokenString == null) {
       return null;
     }
     final gapis.AccessCredentials credentials = gapis.AccessCredentials(
       gapis.AccessToken(
         'Bearer',
-        oathTokenString,
+        oauthTokenString,
         // TODO(kevmoo): Use the correct value once it's available from authentication
         // See https://github.com/flutter/flutter/issues/80905
         DateTime.now().toUtc().add(const Duration(days: 365)),

--- a/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
@@ -8,7 +8,7 @@ name: extension_google_sign_in_as_googleapis_auth
 description: A bridge package between google_sign_in and googleapis_auth, to create Authenticated Clients from google_sign_in user credentials.
 repository: https://github.com/flutter/packages/tree/main/packages/extension_google_sign_in_as_googleapis_auth
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+extension_google_sign_in_as_googleapis_auth%22
-version: 2.0.8
+version: 2.0.9
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_sign_in: ^5.0.0
+  google_sign_in: ">=5.0.0 <7.0.0"
   googleapis_auth: ^1.1.0
   http: ^0.13.0
   meta: ^1.3.0


### PR DESCRIPTION
This PR updates the `extension_gsi_as_googleapis_auth` package so it supports both `google_sign_in: ^5.0.0` and `google_sign_in: ^6.0.0`.

In addition to the above, the example app is updated to use `google_sign_in: ^6.0.0`, and some of its code updated to the latest Flutter web standards.

### Tests

A built version of the app is deployed here, for manual testing:

* https://dit-gis-test.web.app

### Issues

* Fixes https://github.com/flutter/flutter/issues/121165
* Closes https://github.com/flutter/packages/pull/3228

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
