### PR TITLE
[flutter_migrate] Skip slow tests

### DIFF
--- a/packages/flutter_migrate/test/compute_test.dart
+++ b/packages/flutter_migrate/test/compute_test.dart
@@ -251,7 +251,10 @@ void main() {
               .existsSync(),
           false);
     }, timeout: const Timeout(Duration(seconds: 500)));
-  });
+  },
+      // TODO(stuartmorgan): These should not be unit tests, see
+      // https://github.com/flutter/flutter/issues/121257.
+      skip: 'TODO: Speed up, or move to another type of test');
 
   group('MigrateRevisions', () {
     setUp(() async {
@@ -486,7 +489,10 @@ migration:
               .baseRevision,
           '36427af29421f406ac95ff55ea31d1dc49a45b5f');
     });
-  });
+  },
+      // TODO(stuartmorgan): These should not be unit tests, see
+      // https://github.com/flutter/flutter/issues/121257.
+      skip: 'TODO: Speed up, or move to another type of test');
 
   group('project operations', () {
     setUp(() async {
@@ -865,5 +871,8 @@ migration:
       expect(result.mergeResults[10].hasConflict, false);
       expect(result.mergeResults[11].hasConflict, false);
     }, timeout: const Timeout(Duration(seconds: 500)));
-  });
+  },
+      // TODO(stuartmorgan): These should not be unit tests, see
+      // https://github.com/flutter/flutter/issues/121257.
+      skip: 'TODO: Speed up, or move to another type of test');
 }

--- a/packages/flutter_migrate/test/migrate_test.dart
+++ b/packages/flutter_migrate/test/migrate_test.dart
@@ -106,7 +106,11 @@ Modified files:
             .existsSync(),
         true);
     expect(tempDir.childFile('analysis_options.yaml').existsSync(), true);
-  }, timeout: const Timeout(Duration(seconds: 500)), skip: isWindows);
+  },
+      timeout: const Timeout(Duration(seconds: 500)),
+      // TODO(stuartmorgan): These should not be unit tests, see
+      // https://github.com/flutter/flutter/issues/121257.
+      skip: true);
 
   // Migrates a clean untouched app generated with flutter create
   testUsingContext('vanilla migrate builds', () async {
@@ -167,7 +171,11 @@ class MyApp extends StatelessWidget {
     // Skipped due to being flaky, the build completes successfully, but sometimes
     // Gradle crashes due to resources on the bot. We should fine tune this to
     // make it stable.
-  }, timeout: const Timeout(Duration(seconds: 900)), skip: true);
+  },
+      timeout: const Timeout(Duration(seconds: 900)),
+      // TODO(stuartmorgan): These should not be unit tests, see
+      // https://github.com/flutter/flutter/issues/121257.
+      skip: true);
 
   testUsingContext('migrate abandon', () async {
     // Abandon in an empty dir fails.
@@ -209,7 +217,11 @@ class MyApp extends StatelessWidget {
     ], workingDirectory: tempDir.path);
     expect(result.exitCode, 0);
     expect(result.stdout.toString(), contains('Abandon complete'));
-  }, timeout: const Timeout(Duration(seconds: 300)));
+  },
+      timeout: const Timeout(Duration(seconds: 300)),
+      // TODO(stuartmorgan): These should not be unit tests, see
+      // https://github.com/flutter/flutter/issues/121257.
+      skip: true);
 
   // Migrates a user-modified app
   testUsingContext('modified migrate process succeeds', () async {
@@ -436,5 +448,9 @@ flutter:
             .existsSync(),
         true);
     expect(tempDir.childFile('analysis_options.yaml').existsSync(), true);
-  }, timeout: const Timeout(Duration(seconds: 500)), skip: isWindows);
+  },
+      timeout: const Timeout(Duration(seconds: 500)),
+      // TODO(stuartmorgan): These should not be unit tests, see
+      // https://github.com/flutter/flutter/issues/121257.
+      skip: true);
 }

--- a/packages/flutter_migrate/test/utils_test.dart
+++ b/packages/flutter_migrate/test/utils_test.dart
@@ -281,7 +281,11 @@ void main() {
 
       projectRoot.deleteSync(recursive: true);
     });
-  }, timeout: const Timeout(Duration(seconds: 500)));
+  },
+      timeout: const Timeout(Duration(seconds: 500)),
+      // TODO(stuartmorgan): These should not be unit tests, see
+      // https://github.com/flutter/flutter/issues/121257.
+      skip: 'TODO: Speed up, or move to another type of test');
 
   testWithoutContext('conflictsResolved', () async {
     expect(utils.conflictsResolved(''), true);


### PR DESCRIPTION
Currently `flutter_migrate` unit tests take 10 minutes to run, which is 1/6 of our total time allowance for a Cirrus test run, and 1-2 orders of magnitude slower than all of our other unit tests.

This skips the slow tests, with references to a tracking issue. At some point when there are more eng resources on `flutter_migrate` someone can revisit these tests to speed them up and/or make them another type of test (such as a custom `run_tests` test).

Part of https://github.com/flutter/flutter/issues/121257

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
