### PR TITLE
Export super types in route_data.dart library

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.0
+
+- Export supertypes in route_data.dart library
+
 ## 6.1.0
 
 - Adds `GoRouter.maybeOf` to get the closest `GoRouter` from the context, if there is any.

--- a/packages/go_router/lib/go_router.dart
+++ b/packages/go_router/lib/go_router.dart
@@ -12,7 +12,13 @@ export 'src/misc/extensions.dart';
 export 'src/misc/inherited_router.dart';
 export 'src/pages/custom_transition_page.dart';
 export 'src/route_data.dart'
-    show GoRouteData, TypedGoRoute, TypedShellRoute, ShellRouteData;
+    show
+        RouteData,
+        GoRouteData,
+        ShellRouteData,
+        TypedRoute,
+        TypedGoRoute,
+        TypedShellRoute;
 export 'src/router.dart';
 export 'src/typedefs.dart'
     show GoRouterPageBuilder, GoRouterRedirect, GoRouterWidgetBuilder;

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.1.0
+version: 6.2.0
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 


### PR DESCRIPTION
This makes it easier to annotate routes for https://github.com/flutter/packages/pull/3269

```dart
@TypedShellRoute<MyShellRouteData>(
  routes: <TypedRoute<RouteData>>[
    TypedGoRoute<FooRouteData>(path: '/foo'),
    TypedGoRoute<BarRouteData>(path: '/bar'),
  ],
)
class MyShellRouteData extends ShellRouteData {
  const MyShellRouteData();

  @override
  Widget builder(
    BuildContext context,
    GoRouterState state,
    Widget navigator,
  ) {
    return MyShellRouteScreen(child: navigator);
  }
}
```