### PR TITLE
[video_player] Create new getter `VideoPlayerValue.aspectRatioOrNull`

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.7.0
+
+* Add new getter `aspectRatioOrNull` that returns `null` when video aspect ratio is not yet available
+
 ## 2.6.0
 
 * Adds option to configure HTTP headers via `VideoPlayerController` to fix access to M3U8 files on Android.

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -141,11 +141,11 @@ class VideoPlayerValue {
     if (!isInitialized || size.width == 0 || size.height == 0) {
       return null;
     }
-    final double localAspectRatio = size.width / size.height;
-    if (localAspectRatio <= 0) {
+    final double aspectRatio = size.width / size.height;
+    if (aspectRatio <= 0) {
       return null;
     }
-    return localAspectRatio;
+    return aspectRatio;
   }
 
   /// Returns a new instance that has the same values as this current instance,

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -141,11 +141,11 @@ class VideoPlayerValue {
     if (!isInitialized || size.width == 0 || size.height == 0) {
       return null;
     }
-    final double aspectRatio = size.width / size.height;
-    if (aspectRatio <= 0) {
+    final double localAspectRatio = size.width / size.height;
+    if (localAspectRatio <= 0) {
       return null;
     }
-    return aspectRatio;
+    return localAspectRatio;
   }
 
   /// Returns a new instance that has the same values as this current instance,

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -129,13 +129,21 @@ class VideoPlayerValue {
   /// * [isInitialized] is `false`
   /// * [size.width], or [size.height] is equal to `0.0`
   /// * aspect ratio would be less than or equal to `0.0`
-  double get aspectRatio {
+  double get aspectRatio => aspectRatioOrNull ?? 1.0;
+
+  /// Returns [size.width] / [size.height] if available.
+  ///
+  /// Will return null if:
+  /// * [isInitialized] is `false`
+  /// * [size.width], or [size.height] is equal to `0.0`
+  /// * aspect ratio would be less than or equal to `0.0`
+  double? get aspectRatioOrNull {
     if (!isInitialized || size.width == 0 || size.height == 0) {
-      return 1.0;
+      return null;
     }
     final double aspectRatio = size.width / size.height;
     if (aspectRatio <= 0) {
-      return 1.0;
+      return null;
     }
     return aspectRatio;
   }

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.6.0
+version: 2.7.0
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -882,6 +882,7 @@ void main() {
       expect(uninitialized.isInitialized, isFalse);
       expect(uninitialized.hasError, isFalse);
       expect(uninitialized.aspectRatio, 1.0);
+      expect(uninitialized.aspectRatioOrNull, null);
     });
 
     test('erroneous()', () {
@@ -903,6 +904,7 @@ void main() {
       expect(error.isInitialized, isFalse);
       expect(error.hasError, isTrue);
       expect(error.aspectRatio, 1.0);
+      expect(uninitialized.aspectRatioOrNull, null);
     });
 
     test('toString()', () {
@@ -1026,6 +1028,52 @@ void main() {
           duration: const Duration(seconds: 1),
         );
         expect(value.aspectRatio, 1.0);
+      });
+    });
+
+    group('aspectRatioOrNull', () {
+      test('640x480 -> 4:3', () {
+        final VideoPlayerValue value = VideoPlayerValue(
+          isInitialized: true,
+          size: const Size(640, 480),
+          duration: const Duration(seconds: 1),
+        );
+        expect(value.aspectRatio, 4 / 3);
+      });
+
+      test('no size -> null', () {
+        final VideoPlayerValue value = VideoPlayerValue(
+          isInitialized: true,
+          duration: const Duration(seconds: 1),
+        );
+        expect(value.aspectRatio, null);
+      });
+
+      test('height = 0 -> null', () {
+        final VideoPlayerValue value = VideoPlayerValue(
+          isInitialized: true,
+          size: const Size(640, 0),
+          duration: const Duration(seconds: 1),
+        );
+        expect(value.aspectRatio, null);
+      });
+
+      test('width = 0 -> null', () {
+        final VideoPlayerValue value = VideoPlayerValue(
+          isInitialized: true,
+          size: const Size(0, 480),
+          duration: const Duration(seconds: 1),
+        );
+        expect(value.aspectRatio, null);
+      });
+
+      test('negative aspect ratio -> null', () {
+        final VideoPlayerValue value = VideoPlayerValue(
+          isInitialized: true,
+          size: const Size(640, -480),
+          duration: const Duration(seconds: 1),
+        );
+        expect(value.aspectRatio, null);
       });
     });
   });

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -1038,7 +1038,7 @@ void main() {
           size: const Size(640, 480),
           duration: const Duration(seconds: 1),
         );
-        expect(value.aspectRatio, 4 / 3);
+        expect(value.aspectRatioOrNull, 4 / 3);
       });
 
       test('no size -> null', () {
@@ -1046,7 +1046,7 @@ void main() {
           isInitialized: true,
           duration: const Duration(seconds: 1),
         );
-        expect(value.aspectRatio, null);
+        expect(value.aspectRatioOrNull, null);
       });
 
       test('height = 0 -> null', () {
@@ -1055,7 +1055,7 @@ void main() {
           size: const Size(640, 0),
           duration: const Duration(seconds: 1),
         );
-        expect(value.aspectRatio, null);
+        expect(value.aspectRatioOrNull, null);
       });
 
       test('width = 0 -> null', () {
@@ -1064,7 +1064,7 @@ void main() {
           size: const Size(0, 480),
           duration: const Duration(seconds: 1),
         );
-        expect(value.aspectRatio, null);
+        expect(value.aspectRatioOrNull, null);
       });
 
       test('negative aspect ratio -> null', () {
@@ -1073,7 +1073,7 @@ void main() {
           size: const Size(640, -480),
           duration: const Duration(seconds: 1),
         );
-        expect(value.aspectRatio, null);
+        expect(value.aspectRatioOrNull, null);
       });
     });
   });

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -904,7 +904,7 @@ void main() {
       expect(error.isInitialized, isFalse);
       expect(error.hasError, isTrue);
       expect(error.aspectRatio, 1.0);
-      expect(uninitialized.aspectRatioOrNull, null);
+      expect(error.aspectRatioOrNull, null);
     });
 
     test('toString()', () {


### PR DESCRIPTION
Currently, to get the video aspect of ratio, we use `videoPlayerValue.aspectRatio`. However, after the video source is initialized, and before the actual aspect ratio is fetched, there's a brief moment when the aspect ratio is unavailable. `videoPlayerValue.aspectRatio` returns `1.0` in that case, which is not accurate, because that may not be the true aspect ratio of the video.

Using the current API of getting the aspect ratio, we have no way of telling whether the aspect ratio is unavailable, or the aspect ratio is actually `1.0`.

Ideally, I believe the value returned should be `null` if the aspect ratio is unavailable. To not break existing usage, in this PR I'm adding a new API named `aspectRatioOrNull` for this purpose.

*List which issues are fixed by this PR. You must list at least one issue.*
- API returns an inaccurate aspect ratio for a brief moment before the true aspect ratio is fetched, and developers have no way to tell.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
This is not a breaking change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
