### PR TITLE
[tool] Provide a --base-branch flag

### DIFF
--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -117,6 +117,7 @@ code changes across many packages:
 cd <repository root>
 dart run script/tool/bin/flutter_plugin_tools.dart update-release-info \
   --version=minimal \
+  --base-branch=upstream/main \
   --changelog="Fixes violations of new analysis option some_new_option."
 ```
 
@@ -124,9 +125,15 @@ The `minimal` option for `--version` will skip unchanged packages, and treat
 each changed package as either `bugfix` or `next` depending on the files that
 have changed in that package, so it is often the best choice for a bulk change.
 
-For cases where you know the change time, `minor` or `bugfix` will make the
+For cases where you know the change type, `minor` or `bugfix` will make the
 corresponding version bump, or `next` will update only `CHANGELOG.md` without
 changing the version.
+
+If you have a standard repository setup, `--base-branch=upstream/main` will
+usually give the behavior you want, finding all packages changed relative to
+the branch point from `upstream/main`. For more complex use cases where you want
+a different diff point, you can pass a different `--base-branch`, or use
+`--base-sha` to pick the exact diff point.
 
 ### Publish a Release
 


### PR DESCRIPTION
For CI, the default behavior of finding a base SHA for diffs using `FETCH_HEAD` works well because we can control `FETCH_HEAD` in the CI scripts. Now that we have a common use case (`update-release-info`) for running on changed packages locally instead of picking specific packges this has been problematic, because people get an
essentially-random-from-their-perspective diff base, or they have to provide an exact `--base-sha` which can be tricky as well.

This adds a new `--base-branch` which can be passed instead of `--base-sha` to give a simple way to get better behavior locally, and documents it for `update-release-info`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
