### PR TITLE
[pigeon] Only check generated files on master

### DIFF
--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -167,7 +167,7 @@ Future<void> main(List<String> args) async {
     // Only run on master, since Dart format can change between versions.
     // TODO(stuartmorgan): Make a more generic way to run this check only on
     // master; this currently won't work for anything but Cirrus.
-    if (Platform.environment['CHANNEL'] != 'stable') {
+    if (Platform.environment['CHANNEL'] == 'stable') {
       print('Skipping generated file validation on stable.');
     } else {
       await _validateGeneratedTestFiles();

--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -164,7 +164,14 @@ Future<void> main(List<String> args) async {
   // configurations have different setups (e.g., different clang-format versions
   // or no clang-format at all).
   if (Platform.isLinux) {
-    await _validateGeneratedTestFiles();
+    // Only run on master, since Dart format can change between versions.
+    // TODO(stuartmorgan): Make a more generic way to run this check only on
+    // master; this currently won't work for anything but Cirrus.
+    if (Platform.environment['CHANNEL'] != 'stable') {
+      print('Skipping generated file validation on stable.');
+    } else {
+      await _validateGeneratedTestFiles();
+    }
   }
 
   final List<String> testsToRun;


### PR DESCRIPTION
Skip output file checks on stable, since `dart format` can change between channels.

This helps unblock the roll.
