### PR TITLE
[google_maps] Relax the Android renderer request test

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/latest_renderer_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/latest_renderer_test.dart
@@ -22,7 +22,14 @@ void main() {
   });
 
   testWidgets('initialized with latest renderer', (WidgetTester _) async {
-    expect(initializedRenderer, AndroidMapRenderer.latest);
+    // There is no guarantee that the server will return the latest renderer
+    // even when requested, so there's no way to deterministically test that.
+    // Instead, just test that the request succeeded and returned a valid
+    // value.
+    expect(
+        initializedRenderer == AndroidMapRenderer.latest ||
+            initializedRenderer == AndroidMapRenderer.legacy,
+        true);
   });
 
   testWidgets('throws PlatformException on multiple renderer initializations',


### PR DESCRIPTION
Updates the "initialized with latest renderer" test to just test that the rest resulted in some valid response, since we can't actually control what the server returns; the request is non-binding, and there are cases where (e.g., depending on the device details) the legacy renderer will be returned regardless.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
