### PR TITLE
[ci] Increase Android platform test sharding

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -264,11 +264,13 @@ task:
       skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
       env:
         matrix:
-          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 5"
-          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 5"
-          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 5"
-          PACKAGE_SHARDING: "--shardIndex 3 --shardCount 5"
-          PACKAGE_SHARDING: "--shardIndex 4 --shardCount 5"
+          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 7"
+          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 7"
+          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 7"
+          PACKAGE_SHARDING: "--shardIndex 3 --shardCount 7"
+          PACKAGE_SHARDING: "--shardIndex 4 --shardCount 7"
+          PACKAGE_SHARDING: "--shardIndex 5 --shardCount 7"
+          PACKAGE_SHARDING: "--shardIndex 6 --shardCount 7"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"


### PR DESCRIPTION
We were using five shards in flutter/plugins, but with the added time of building all of the other packages for Android that's not enough; shards are taking 35-45 minutes. This increases to 7 shards to make cycle times more reasonable.
