### PR TITLE
[tool] Include examples when pathifying deps

### DIFF
--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -50,8 +50,12 @@ class MakeDepsPathBasedCommand extends PackageCommand {
       'target-dependencies-with-non-breaking-updates';
 
   // The comment to add to temporary dependency overrides.
+  //
+  // Includes a reference to the docs so that reviewers who aren't familiar with
+  // the federated plugin change process don't think it's a mistake.
   static const String _dependencyOverrideWarningComment =
-      '# FOR TESTING ONLY. DO NOT MERGE.';
+      '# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.\n'
+      '# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins';
 
   @override
   final String name = 'make-deps-path-based';

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -205,6 +205,7 @@ class MakeDepsPathBasedCommand extends PackageCommand {
     String newContent = editablePubspec.toString();
     if (!newContent.contains(_dependencyOverrideWarningComment)) {
       newContent = newContent.replaceFirst('$dependencyOverridesKey:', '''
+
 $_dependencyOverrideWarningComment
 $dependencyOverridesKey:
 ''');

--- a/script/tool/test/make_deps_path_based_command_test.dart
+++ b/script/tool/test/make_deps_path_based_command_test.dart
@@ -105,14 +105,13 @@ ${devDependencies.map((String dep) => '  $dep: ^1.0.0').join('\n')}
   test('includes explanatory comment', () async {
     final RepositoryPackage packageA =
         createFakePackage('package_a', packagesDir, isFlutter: true);
-    final RepositoryPackage packageB =
-        createFakePackage('package_b', packagesDir, isFlutter: true);
+    createFakePackage('package_b', packagesDir, isFlutter: true);
 
     addDependencies(packageA, <String>[
       'package_b',
     ]);
 
-    final List<String> output = await runCapturingPrint(runner,
+    await runCapturingPrint(runner,
         <String>['make-deps-path-based', '--target-dependencies=package_b']);
 
     expect(

--- a/script/tool/test/make_deps_path_based_command_test.dart
+++ b/script/tool/test/make_deps_path_based_command_test.dart
@@ -310,6 +310,12 @@ ${devDependencies.map((String dep) => '  $dep: ^1.0.0').join('\n')}
       'make-deps-path-based',
       '--target-dependencies=bar,bar_platform_interface'
     ]);
+    final String simplePackageUpdatedContent =
+        simplePackage.pubspecFile.readAsStringSync();
+    final String appFacingPackageUpdatedContent =
+        pluginAppFacing.pubspecFile.readAsStringSync();
+    final String implementationPackageUpdatedContent =
+        pluginImplementation.pubspecFile.readAsStringSync();
     final List<String> output = await runCapturingPrint(runner, <String>[
       'make-deps-path-based',
       '--target-dependencies=bar,bar_platform_interface'
@@ -319,10 +325,16 @@ ${devDependencies.map((String dep) => '  $dep: ^1.0.0').join('\n')}
         output,
         containsAll(<String>[
           'Rewriting references to: bar, bar_platform_interface...',
-          '  Skipped packages/bar/bar/pubspec.yaml - Already rewritten',
-          '  Skipped packages/bar/bar_android/pubspec.yaml - Already rewritten',
-          '  Skipped packages/foo/pubspec.yaml - Already rewritten',
+          '  Modified packages/bar/bar/pubspec.yaml',
+          '  Modified packages/bar/bar_android/pubspec.yaml',
+          '  Modified packages/foo/pubspec.yaml',
         ]));
+    expect(simplePackageUpdatedContent,
+        simplePackage.pubspecFile.readAsStringSync());
+    expect(appFacingPackageUpdatedContent,
+        pluginAppFacing.pubspecFile.readAsStringSync());
+    expect(implementationPackageUpdatedContent,
+        pluginImplementation.pubspecFile.readAsStringSync());
   });
 
   group('target-dependencies-with-non-breaking-updates', () {


### PR DESCRIPTION
Improves the `make-deps-path-based` command:
- When adding an override to a package, also adds it to that package's examples. This is needed for integration tests of app-facing packages of federated plugins when adding features to implementation packages, for instance.
- Switches from string-based rewrites to `yaml_edit` to make it more robust (necessary to do the above without major restructuring)
- Improves the auto-added comment since reviewers new to the repository are often confused by the overrides the first time they encounter them and think their inclusion in the PR is a mistake.

Fixes https://github.com/flutter/flutter/issues/111091

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
