### PR TITLE
[various] Remove enableR8

### DIFF
--- a/packages/camera/camera/example/android/gradle.properties
+++ b/packages/camera/camera/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=false
-android.enableR8=true

--- a/packages/camera/camera_android/example/android/gradle.properties
+++ b/packages/camera/camera_android/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=false
-android.enableR8=true

--- a/packages/espresso/example/android/gradle.properties
+++ b/packages/espresso/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/flutter_plugin_android_lifecycle/example/android/gradle.properties
+++ b/packages/flutter_plugin_android_lifecycle/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/gradle.properties
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true
 

--- a/packages/google_sign_in/google_sign_in/example/android/gradle.properties
+++ b/packages/google_sign_in/google_sign_in/example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true

--- a/packages/google_sign_in/google_sign_in_android/example/android/gradle.properties
+++ b/packages/google_sign_in/google_sign_in_android/example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true

--- a/packages/image_picker/image_picker/example/android/gradle.properties
+++ b/packages/image_picker/image_picker/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/in_app_purchase/in_app_purchase/example/android/gradle.properties
+++ b/packages/in_app_purchase/in_app_purchase/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/in_app_purchase/in_app_purchase_android/example/android/gradle.properties
+++ b/packages/in_app_purchase/in_app_purchase_android/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/local_auth/local_auth/example/android/gradle.properties
+++ b/packages/local_auth/local_auth/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/packages/local_auth/local_auth_android/example/android/gradle.properties
+++ b/packages/local_auth/local_auth_android/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/packages/path_provider/path_provider/example/android/gradle.properties
+++ b/packages/path_provider/path_provider/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/path_provider/path_provider_android/example/android/gradle.properties
+++ b/packages/path_provider/path_provider_android/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/quick_actions/quick_actions/example/android/gradle.properties
+++ b/packages/quick_actions/quick_actions/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/quick_actions/quick_actions_android/example/android/gradle.properties
+++ b/packages/quick_actions/quick_actions_android/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/url_launcher/url_launcher/example/android/gradle.properties
+++ b/packages/url_launcher/url_launcher/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/packages/url_launcher/url_launcher_android/example/android/gradle.properties
+++ b/packages/url_launcher/url_launcher_android/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/packages/video_player/video_player/example/android/gradle.properties
+++ b/packages/video_player/video_player/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/packages/video_player/video_player_android/example/android/gradle.properties
+++ b/packages/video_player/video_player_android/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/packages/webview_flutter/webview_flutter/example/android/gradle.properties
+++ b/packages/webview_flutter/webview_flutter/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true


### PR DESCRIPTION
Removes `enableR8` from all Android examples that use a recent AGP version, to fix a log message about it being deprecated.