### PR TITLE
[go_router] Fixes an issue where the params are removed after popping

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.1
+
+- Fixes an issue where the params are removed after popping.
+
 ## 6.5.0
 
 - Supports returning values on pop.
@@ -20,7 +24,7 @@
 
 ## 6.2.0
 
-- Export supertypes in route_data.dart library
+- Exports supertypes in route_data.dart library
 
 ## 6.1.0
 

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 6.2.0
 
-- Exports supertypes in route_data.dart library
+- Exports supertypes in route_data.dart library.
 
 ## 6.1.0
 

--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -274,7 +274,7 @@ class RouteBuilder {
       name: name,
       path: path,
       fullpath: effectiveMatchList.fullpath,
-      params: effectiveMatchList.pathParameters,
+      params: Map<String, String>.from(effectiveMatchList.pathParameters),
       error: match.error,
       queryParams: effectiveMatchList.uri.queryParameters,
       queryParametersAll: effectiveMatchList.uri.queryParametersAll,

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.5.0
+version: 6.5.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_router_state_test.dart
+++ b/packages/go_router/test/go_router_state_test.dart
@@ -95,9 +95,10 @@ void main() {
       router.go('/123');
       await tester.pumpAndSettle();
       expect(find.text('2 123'), findsOneWidget);
-      // The query parameter is removed, so is the location in first page.
       router.pop();
       await tester.pump();
+      // Page 2 is in popping animation but should still be on screen with the
+      // correct path parameter.
       expect(find.text('2 123'), findsOneWidget);
     });
 

--- a/packages/go_router/test/go_router_state_test.dart
+++ b/packages/go_router/test/go_router_state_test.dart
@@ -67,6 +67,40 @@ void main() {
       expect(find.text('1 /a', skipOffstage: false), findsOneWidget);
     });
 
+    testWidgets('path parameter persists after page is popped',
+        (WidgetTester tester) async {
+      final List<GoRoute> routes = <GoRoute>[
+        GoRoute(
+            path: '/',
+            builder: (_, __) {
+              return Builder(builder: (BuildContext context) {
+                return Text('1 ${GoRouterState.of(context).location}');
+              });
+            },
+            routes: <GoRoute>[
+              GoRoute(
+                  path: ':id',
+                  builder: (_, __) {
+                    return Builder(builder: (BuildContext context) {
+                      return Text(
+                          '2 ${GoRouterState.of(context).params['id']}');
+                    });
+                  }),
+            ]),
+      ];
+      final GoRouter router = await createRouter(routes, tester);
+      await tester.pumpAndSettle();
+      expect(find.text('1 /'), findsOneWidget);
+
+      router.go('/123');
+      await tester.pumpAndSettle();
+      expect(find.text('2 123'), findsOneWidget);
+      // The query parameter is removed, so is the location in first page.
+      router.pop();
+      await tester.pump();
+      expect(find.text('2 123'), findsOneWidget);
+    });
+
     testWidgets('registry retains GoRouterState for exiting route',
         (WidgetTester tester) async {
       final UniqueKey key = UniqueKey();


### PR DESCRIPTION
pop will remove pathparameter from routeMatchList, and the goRouterState also use the same reference to the pathparameter in the routeMatchList, thus parameters got removed as well

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
