### PR TITLE
[in_app_purchase] Enable -Werror for Android

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
+++ b/packages/in_app_purchase/in_app_purchase_android/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
@@ -24,16 +24,12 @@ import com.android.billingclient.api.BillingFlowParams.ProrationMode;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeParams;
 import com.android.billingclient.api.ConsumeResponseListener;
-import com.android.billingclient.api.PriceChangeFlowParams;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchaseHistoryRecord;
 import com.android.billingclient.api.PurchaseHistoryResponseListener;
 import com.android.billingclient.api.PurchasesResponseListener;
 import com.android.billingclient.api.QueryPurchaseHistoryParams;
 import com.android.billingclient.api.QueryPurchasesParams;
-import com.android.billingclient.api.SkuDetails;
-import com.android.billingclient.api.SkuDetailsParams;
-import com.android.billingclient.api.SkuDetailsResponseListener;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import java.util.HashMap;
@@ -55,7 +51,9 @@ class MethodCallHandlerImpl
   private final Context applicationContext;
   private final MethodChannel methodChannel;
 
-  private HashMap<String, SkuDetails> cachedSkus = new HashMap<>();
+  // TODO(stuartmorgan): Migrate this code. See TODO on querySkuDetailsAsync.
+  @SuppressWarnings("deprecation")
+  private HashMap<String, com.android.billingclient.api.SkuDetails> cachedSkus = new HashMap<>();
 
   /** Constructs the MethodCallHandlerImpl */
   MethodCallHandlerImpl(
@@ -185,21 +183,29 @@ class MethodCallHandlerImpl
     result.success(billingClient.isReady());
   }
 
-  // TODO(garyq): Migrate to new subscriptions API: https://developer.android.com/google/play/billing/migrate-gpblv5
+  // TODO(stuartmorgan): Migrate to new subscriptions API. See:
+  // - https://developer.android.com/google/play/billing/migrate-gpblv5
+  // - https://github.com/flutter/flutter/issues/114265
+  // - https://github.com/flutter/flutter/issues/107370
+  @SuppressWarnings("deprecation")
   private void querySkuDetailsAsync(
       final String skuType, final List<String> skusList, final MethodChannel.Result result) {
     if (billingClientError(result)) {
       return;
     }
 
-    SkuDetailsParams params =
-        SkuDetailsParams.newBuilder().setType(skuType).setSkusList(skusList).build();
+    com.android.billingclient.api.SkuDetailsParams params =
+        com.android.billingclient.api.SkuDetailsParams.newBuilder()
+            .setType(skuType)
+            .setSkusList(skusList)
+            .build();
     billingClient.querySkuDetailsAsync(
         params,
-        new SkuDetailsResponseListener() {
+        new com.android.billingclient.api.SkuDetailsResponseListener() {
           @Override
           public void onSkuDetailsResponse(
-              BillingResult billingResult, List<SkuDetails> skuDetailsList) {
+              BillingResult billingResult,
+              List<com.android.billingclient.api.SkuDetails> skuDetailsList) {
             updateCachedSkus(skuDetailsList);
             final Map<String, Object> skuDetailsResponse = new HashMap<>();
             skuDetailsResponse.put("billingResult", Translator.fromBillingResult(billingResult));
@@ -220,7 +226,9 @@ class MethodCallHandlerImpl
     if (billingClientError(result)) {
       return;
     }
-    SkuDetails skuDetails = cachedSkus.get(sku);
+    // TODO(stuartmorgan): Migrate this code. See TODO on querySkuDetailsAsync.
+    @SuppressWarnings("deprecation")
+    com.android.billingclient.api.SkuDetails skuDetails = cachedSkus.get(sku);
     if (skuDetails == null) {
       result.error(
           "NOT_FOUND",
@@ -258,6 +266,8 @@ class MethodCallHandlerImpl
       return;
     }
 
+    // TODO(stuartmorgan): Migrate this code. See TODO on querySkuDetailsAsync.
+    @SuppressWarnings("deprecation")
     BillingFlowParams.Builder paramsBuilder =
         BillingFlowParams.newBuilder().setSkuDetails(skuDetails);
     if (accountId != null && !accountId.isEmpty()) {
@@ -401,16 +411,21 @@ class MethodCallHandlerImpl
         });
   }
 
-  private void updateCachedSkus(@Nullable List<SkuDetails> skuDetailsList) {
+  // TODO(stuartmorgan): Migrate this code. See TODO on querySkuDetailsAsync.
+  @SuppressWarnings("deprecation")
+  private void updateCachedSkus(
+      @Nullable List<com.android.billingclient.api.SkuDetails> skuDetailsList) {
     if (skuDetailsList == null) {
       return;
     }
 
-    for (SkuDetails skuDetails : skuDetailsList) {
+    for (com.android.billingclient.api.SkuDetails skuDetails : skuDetailsList) {
       cachedSkus.put(skuDetails.getSku(), skuDetails);
     }
   }
 
+  // TODO(stuartmorgan): Migrate this code. See TODO on querySkuDetailsAsync.
+  @SuppressWarnings("deprecation")
   private void launchPriceChangeConfirmationFlow(String sku, MethodChannel.Result result) {
     if (activity == null) {
       result.error(
@@ -428,7 +443,7 @@ class MethodCallHandlerImpl
     // is handled by the `billingClientError()` call.
     assert billingClient != null;
 
-    SkuDetails skuDetails = cachedSkus.get(sku);
+    com.android.billingclient.api.SkuDetails skuDetails = cachedSkus.get(sku);
     if (skuDetails == null) {
       result.error(
           "NOT_FOUND",
@@ -439,8 +454,10 @@ class MethodCallHandlerImpl
       return;
     }
 
-    PriceChangeFlowParams params =
-        new PriceChangeFlowParams.Builder().setSkuDetails(skuDetails).build();
+    com.android.billingclient.api.PriceChangeFlowParams params =
+        new com.android.billingclient.api.PriceChangeFlowParams.Builder()
+            .setSkuDetails(skuDetails)
+            .build();
     billingClient.launchPriceChangeConfirmationFlow(
         activity,
         params,

--- a/packages/in_app_purchase/in_app_purchase_android/android/src/main/java/io/flutter/plugins/inapppurchase/Translator.java
+++ b/packages/in_app_purchase/in_app_purchase_android/android/src/main/java/io/flutter/plugins/inapppurchase/Translator.java
@@ -9,7 +9,6 @@ import com.android.billingclient.api.AccountIdentifiers;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchaseHistoryRecord;
-import com.android.billingclient.api.SkuDetails;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Currency;
@@ -19,7 +18,9 @@ import java.util.Locale;
 
 /** Handles serialization of {@link com.android.billingclient.api.BillingClient} related objects. */
 /*package*/ class Translator {
-  static HashMap<String, Object> fromSkuDetail(SkuDetails detail) {
+  // TODO(stuartmorgan): Migrate this code. See TODO on MethodCallHandlerImpl.querySkuDetailsAsync.
+  @SuppressWarnings("deprecation")
+  static HashMap<String, Object> fromSkuDetail(com.android.billingclient.api.SkuDetails detail) {
     HashMap<String, Object> info = new HashMap<>();
     info.put("title", detail.getTitle());
     info.put("description", detail.getDescription());
@@ -40,14 +41,16 @@ import java.util.Locale;
     return info;
   }
 
+  // TODO(stuartmorgan): Migrate this code. See TODO on MethodCallHandlerImpl.querySkuDetailsAsync.
+  @SuppressWarnings("deprecation")
   static List<HashMap<String, Object>> fromSkuDetailsList(
-      @Nullable List<SkuDetails> skuDetailsList) {
+      @Nullable List<com.android.billingclient.api.SkuDetails> skuDetailsList) {
     if (skuDetailsList == null) {
       return Collections.emptyList();
     }
 
     ArrayList<HashMap<String, Object>> output = new ArrayList<>();
-    for (SkuDetails detail : skuDetailsList) {
+    for (com.android.billingclient.api.SkuDetails detail : skuDetailsList) {
       output.add(fromSkuDetail(detail));
     }
     return output;
@@ -55,6 +58,8 @@ import java.util.Locale;
 
   static HashMap<String, Object> fromPurchase(Purchase purchase) {
     HashMap<String, Object> info = new HashMap<>();
+    // TODO(stuartmorgan): Migrate this code. See TODO on MethodCallHandlerImpl.querySkuDetailsAsync.
+    @SuppressWarnings("deprecation")
     List<String> skus = purchase.getSkus();
     info.put("orderId", purchase.getOrderId());
     info.put("packageName", purchase.getPackageName());
@@ -79,6 +84,8 @@ import java.util.Locale;
   static HashMap<String, Object> fromPurchaseHistoryRecord(
       PurchaseHistoryRecord purchaseHistoryRecord) {
     HashMap<String, Object> info = new HashMap<>();
+    // TODO(stuartmorgan): Migrate this code. See TODO on MethodCallHandlerImpl.querySkuDetailsAsync.
+    @SuppressWarnings("deprecation")
     List<String> skus = purchaseHistoryRecord.getSkus();
     info.put("purchaseTime", purchaseHistoryRecord.getPurchaseTime());
     info.put("purchaseToken", purchaseHistoryRecord.getPurchaseToken());

--- a/packages/in_app_purchase/in_app_purchase_android/android/src/test/java/io/flutter/plugins/inapppurchase/InAppPurchasePluginTest.java
+++ b/packages/in_app_purchase/in_app_purchase_android/android/src/test/java/io/flutter/plugins/inapppurchase/InAppPurchasePluginTest.java
@@ -15,6 +15,7 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -25,18 +26,23 @@ public class InAppPurchasePluginTest {
 
   static final String PROXY_PACKAGE_KEY = "PROXY_PACKAGE";
 
+  @SuppressWarnings("deprecation")
+  @Mock
+  PluginRegistry.Registrar mockRegistrar; // For v1 embedding
+
   @Mock Activity activity;
   @Mock Context context;
-  @Mock PluginRegistry.Registrar mockRegistrar; // For v1 embedding
   @Mock BinaryMessenger mockMessenger;
   @Mock Application mockApplication;
   @Mock Intent mockIntent;
   @Mock ActivityPluginBinding activityPluginBinding;
   @Mock FlutterPlugin.FlutterPluginBinding flutterPluginBinding;
 
+  AutoCloseable mockCloseable;
+
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mockCloseable = MockitoAnnotations.openMocks(this);
     when(mockRegistrar.activity()).thenReturn(activity);
     when(mockRegistrar.messenger()).thenReturn(mockMessenger);
     when(mockRegistrar.context()).thenReturn(context);
@@ -44,6 +50,11 @@ public class InAppPurchasePluginTest {
     when(activityPluginBinding.getActivity()).thenReturn(activity);
     when(flutterPluginBinding.getBinaryMessenger()).thenReturn(mockMessenger);
     when(flutterPluginBinding.getApplicationContext()).thenReturn(context);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mockCloseable.close();
   }
 
   @Test

--- a/packages/in_app_purchase/in_app_purchase_android/android/src/test/java/io/flutter/plugins/inapppurchase/TranslatorTest.java
+++ b/packages/in_app_purchase/in_app_purchase_android/android/src/test/java/io/flutter/plugins/inapppurchase/TranslatorTest.java
@@ -16,7 +16,6 @@ import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchaseHistoryRecord;
-import com.android.billingclient.api.SkuDetails;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,6 +26,10 @@ import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 
+// TODO(stuartmorgan): Migrate this code. See TODO on MethodCallHandlerImpl.querySkuDetailsAsync.
+// This is supressed at the class level since until the code is migrated, the tests will be
+// full of deprecation warnings.
+@SuppressWarnings("deprecation")
 public class TranslatorTest {
   private static final String SKU_DETAIL_EXAMPLE_JSON =
       "{\"productId\":\"example\",\"type\":\"inapp\",\"price\":\"$0.99\",\"price_amount_micros\":990000,\"price_currency_code\":\"USD\",\"title\":\"Example title\",\"description\":\"Example description.\",\"original_price\":\"$0.99\",\"original_price_micros\":990000}";
@@ -41,7 +44,8 @@ public class TranslatorTest {
 
   @Test
   public void fromSkuDetail() throws JSONException {
-    final SkuDetails expected = new SkuDetails(SKU_DETAIL_EXAMPLE_JSON);
+    final com.android.billingclient.api.SkuDetails expected =
+        new com.android.billingclient.api.SkuDetails(SKU_DETAIL_EXAMPLE_JSON);
 
     Map<String, Object> serialized = Translator.fromSkuDetail(expected);
 
@@ -52,9 +56,10 @@ public class TranslatorTest {
   public void fromSkuDetailsList() throws JSONException {
     final String SKU_DETAIL_EXAMPLE_2_JSON =
         "{\"productId\":\"example2\",\"type\":\"inapp\",\"price\":\"$0.99\",\"price_amount_micros\":990000,\"price_currency_code\":\"USD\",\"title\":\"Example title\",\"description\":\"Example description.\",\"original_price\":\"$0.99\",\"original_price_micros\":990000}";
-    final List<SkuDetails> expected =
+    final List<com.android.billingclient.api.SkuDetails> expected =
         Arrays.asList(
-            new SkuDetails(SKU_DETAIL_EXAMPLE_JSON), new SkuDetails(SKU_DETAIL_EXAMPLE_2_JSON));
+            new com.android.billingclient.api.SkuDetails(SKU_DETAIL_EXAMPLE_JSON),
+            new com.android.billingclient.api.SkuDetails(SKU_DETAIL_EXAMPLE_2_JSON));
 
     final List<HashMap<String, Object>> serialized = Translator.fromSkuDetailsList(expected);
 
@@ -169,7 +174,8 @@ public class TranslatorTest {
     }
   }
 
-  private void assertSerialized(SkuDetails expected, Map<String, Object> serialized) {
+  private void assertSerialized(
+      com.android.billingclient.api.SkuDetails expected, Map<String, Object> serialized) {
     assertEquals(expected.getDescription(), serialized.get("description"));
     assertEquals(expected.getFreeTrialPeriod(), serialized.get("freeTrialPeriod"));
     assertEquals(expected.getIntroductoryPrice(), serialized.get("introductoryPrice"));

--- a/packages/in_app_purchase/in_app_purchase_android/example/android/build.gradle
+++ b/packages/in_app_purchase/in_app_purchase_android/example/android/build.gradle
@@ -35,9 +35,7 @@ task clean(type: Delete) {
 gradle.projectsEvaluated {
     project(":in_app_purchase_android") {
         tasks.withType(JavaCompile) {
-            // TODO(stuartmorgan): Enable this. See
-            // https://github.com/flutter/flutter/issues/91868
-            //options.compilerArgs << "-Xlint:all" << "-Werror"
+            options.compilerArgs << "-Xlint:all" << "-Werror"
         }
     }
 }


### PR DESCRIPTION
Enables the `-Werror` flag on the Java compilation step, fixing and suppressing the existing issues.

Unlike most other packages where we've enabled this, this consists almost entirely of sweeping suppressions (specifically, `deprecation`), since the package was updated to the v5 billing library but still uses many APIs from v4 that are deprecated in v5. While this is more suppression than we would normally want to do, it still sets us up to catch other kinds of warnings going forward. It may also help when the full migration to v5 API is done, since just removing the deprecation suppressions will make it easy to find all of the code than needs to be updated. Given that, I believe this is still a net improvement over having `-Werror` off.

Part of https://github.com/flutter/flutter/issues/91868

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
