### PR TITLE
[espresso] Enable warnings as errors

### DIFF
--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.2.1+1
+## 0.3.0
 
 * Aligns Dart and Flutter SDK constraints.
 * Changes the severity of `javac` warnings so that they are treated as errors and fixes the violations.
+* Migrates uses of the deprecated `@Beta` annotation to the new `@ExperimentalApi` annotation.
 
 ## 0.2.1
 

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## 0.3.0
 
+**BREAKING CHANGES**:
+  * Changes the severity of `javac` warnings so that they are treated as errors and fixes the violations.
+  * Migrates uses of the deprecated `@Beta` annotation to the new `@ExperimentalApi` annotation.
+
 * Aligns Dart and Flutter SDK constraints.
-* Changes the severity of `javac` warnings so that they are treated as errors and fixes the violations.
-* Migrates uses of the deprecated `@Beta` annotation to the new `@ExperimentalApi` annotation.
 
 ## 0.2.1
 

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.2.1+1
 
 * Aligns Dart and Flutter SDK constraints.
+* Changes the severity of `javac` warnings so that they are treated as errors and fixes the violations.
 
 ## 0.2.1
 

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## 0.3.0
 
-**BREAKING CHANGES**:
-  * Changes the severity of `javac` warnings so that they are treated as errors and fixes the violations.
-  * Migrates uses of the deprecated `@Beta` annotation to the new `@ExperimentalApi` annotation.
-
+* **BREAKING CHANGE**: Migrates uses of the deprecated `@Beta` annotation to the new `@ExperimentalApi` annotation.
+* Changes the severity of `javac` warnings so that they are treated as errors and fixes the violations.
 * Aligns Dart and Flutter SDK constraints.
 
 ## 0.2.1

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/EspressoFlutter.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/EspressoFlutter.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.any;
 
 import android.util.Log;
 import android.view.View;
-
 import androidx.test.annotation.ExperimentalTestApi;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/EspressoFlutter.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/EspressoFlutter.java
@@ -12,6 +12,8 @@ import static org.hamcrest.Matchers.any;
 
 import android.util.Log;
 import android.view.View;
+
+import androidx.test.annotation.ExperimentalTestApi;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.flutter.action.FlutterViewAction;
@@ -99,6 +101,7 @@ public final class EspressoFlutter {
      * @param widgetActions one or more actions that shall be performed. Cannot be {@code null}.
      * @return this interaction for further perform/verification calls.
      */
+    @ExperimentalTestApi()
     public WidgetInteraction perform(@Nonnull final WidgetAction... widgetActions) {
       checkNotNull(widgetActions);
       for (WidgetAction widgetAction : widgetActions) {
@@ -115,6 +118,7 @@ public final class EspressoFlutter {
      * @param assertion a widget assertion that shall be made on the matched Flutter widget. Cannot
      *     be {@code null}.
      */
+    @ExperimentalTestApi()
     public WidgetInteraction check(@Nonnull WidgetAssertion assertion) {
       checkNotNull(
           assertion,
@@ -130,6 +134,7 @@ public final class EspressoFlutter {
       return this;
     }
 
+    @ExperimentalTestApi()
     @SuppressWarnings("unchecked")
     private <T> T performInternal(FlutterAction<T> flutterAction) {
       checkNotNull(

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/EspressoFlutter.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/EspressoFlutter.java
@@ -137,7 +137,7 @@ public final class EspressoFlutter {
           "The action cannot be null. You must specify an action to perform on the matched"
               + " Flutter widget.");
       FlutterViewAction<T> flutterViewAction =
-          new FlutterViewAction(
+          new FlutterViewAction<>(
               widgetMatcher, flutterAction, okHttpClient, idGenerator, taskExecutor);
       onView(flutterViewMatcher).perform(flutterViewAction);
       T result;

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/FlutterActions.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/FlutterActions.java
@@ -4,6 +4,7 @@
 
 package androidx.test.espresso.flutter.action;
 
+import androidx.test.annotation.ExperimentalTestApi;
 import androidx.test.espresso.flutter.api.WidgetAction;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,6 +44,7 @@ public final class FlutterActions {
    * by directly injecting key events to the Android system. Uses this {@link #syntheticClick()}
    * only when there are special cases that {@link #click()} cannot handle properly.
    */
+  @ExperimentalTestApi()
   public static WidgetAction syntheticClick() {
     return new SyntheticClickAction();
   }

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/FlutterViewAction.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/FlutterViewAction.java
@@ -47,7 +47,6 @@ import org.hamcrest.Matcher;
  * <p>This class acts as a bridge to perform {@code WidgetAction} on a Flutter widget on the given
  * {@code FlutterView}.
  */
-@ExperimentalTestApi
 public final class FlutterViewAction<T> implements ViewAction {
 
   private static final String FLUTTER_IDLE_TASK_NAME = "flutterIdlingResource";
@@ -96,6 +95,7 @@ public final class FlutterViewAction<T> implements ViewAction {
         "Perform a %s action on the Flutter widget matched %s.", widgetAction, widgetMatcher);
   }
 
+  @ExperimentalTestApi
   @Override
   public void perform(UiController uiController, View flutterView) {
     // There could be a gap between when the Flutter view is available in the view hierarchy and the
@@ -139,6 +139,7 @@ public final class FlutterViewAction<T> implements ViewAction {
     }
   }
 
+  @ExperimentalTestApi
   @VisibleForTesting
   void perform(
       View flutterView, FlutterTestingProtocol flutterTestingProtocol, UiController uiController) {

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/FlutterViewAction.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/FlutterViewAction.java
@@ -104,8 +104,11 @@ public final class FlutterViewAction<T> implements ViewAction {
     loopUntilFlutterViewRendered(flutterView, uiController);
     // The url {@code FlutterNativeView} returns is the http url that the Dart VM Observatory http
     // server serves at. Need to convert to the one that the WebSocket uses.
+
+    // TODO(stuartmorgan): migrate to getVMServiceUri() once that is available on stable.
+    @SuppressWarnings("deprecation")
     URI dartVmServiceProtocolUrl =
-        DartVmServiceUtil.getServiceProtocolUri(FlutterJNI.getVMServiceUri());
+        DartVmServiceUtil.getServiceProtocolUri(FlutterJNI.getObservatoryUri());
     String isolateId = DartVmServiceUtil.getDartIsolateId(flutterView);
     final FlutterTestingProtocol flutterTestingProtocol =
         new DartVmService(

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/FlutterViewAction.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/FlutterViewAction.java
@@ -13,7 +13,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 
 import android.os.Looper;
 import android.view.View;
-import androidx.test.annotation.Beta;
+import androidx.test.annotation.ExperimentalTestApi;
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.IdlingResource;
 import androidx.test.espresso.UiController;
@@ -47,7 +47,7 @@ import org.hamcrest.Matcher;
  * <p>This class acts as a bridge to perform {@code WidgetAction} on a Flutter widget on the given
  * {@code FlutterView}.
  */
-@Beta
+@ExperimentalTestApi
 public final class FlutterViewAction<T> implements ViewAction {
 
   private static final String FLUTTER_IDLE_TASK_NAME = "flutterIdlingResource";
@@ -105,7 +105,7 @@ public final class FlutterViewAction<T> implements ViewAction {
     // The url {@code FlutterNativeView} returns is the http url that the Dart VM Observatory http
     // server serves at. Need to convert to the one that the WebSocket uses.
     URI dartVmServiceProtocolUrl =
-        DartVmServiceUtil.getServiceProtocolUri(FlutterJNI.getObservatoryUri());
+        DartVmServiceUtil.getServiceProtocolUri(FlutterJNI.getVMServiceUri());
     String isolateId = DartVmServiceUtil.getDartIsolateId(flutterView);
     final FlutterTestingProtocol flutterTestingProtocol =
         new DartVmService(

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/SyntheticClickAction.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/SyntheticClickAction.java
@@ -5,7 +5,8 @@
 package androidx.test.espresso.flutter.action;
 
 import android.view.View;
-import androidx.test.annotation.Beta;
+
+import androidx.test.annotation.ExperimentalTestApi;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.flutter.api.FlutterTestingProtocol;
 import androidx.test.espresso.flutter.api.SyntheticAction;
@@ -21,7 +22,7 @@ import javax.annotation.Nullable;
  * <p>Note, this is not a real click gesture event issued from Android system. Espresso delegates to
  * Flutter engine to perform the {@link SyntheticClick} action.
  */
-@Beta
+@ExperimentalTestApi
 public final class SyntheticClickAction implements WidgetAction {
 
   @Override

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/SyntheticClickAction.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/SyntheticClickAction.java
@@ -5,7 +5,6 @@
 package androidx.test.espresso.flutter.action;
 
 import android.view.View;
-
 import androidx.test.annotation.ExperimentalTestApi;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.flutter.api.FlutterTestingProtocol;

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/SyntheticClickAction.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/action/SyntheticClickAction.java
@@ -21,9 +21,9 @@ import javax.annotation.Nullable;
  * <p>Note, this is not a real click gesture event issued from Android system. Espresso delegates to
  * Flutter engine to perform the {@link SyntheticClick} action.
  */
-@ExperimentalTestApi
 public final class SyntheticClickAction implements WidgetAction {
 
+  @ExperimentalTestApi
   @Override
   public Future<Void> perform(
       @Nullable WidgetMatcher targetWidget,

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/AmbiguousWidgetMatcherException.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/AmbiguousWidgetMatcherException.java
@@ -13,6 +13,8 @@ import androidx.test.espresso.EspressoException;
 public final class AmbiguousWidgetMatcherException extends RuntimeException
     implements EspressoException {
 
+  private static final long serialVersionUID = 9000L;
+
   public AmbiguousWidgetMatcherException(String message) {
     super(message);
   }

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/AmbiguousWidgetMatcherException.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/AmbiguousWidgetMatcherException.java
@@ -13,7 +13,7 @@ import androidx.test.espresso.EspressoException;
 public final class AmbiguousWidgetMatcherException extends RuntimeException
     implements EspressoException {
 
-  private static final long serialVersionUID = 9000L;
+  private static final long serialVersionUID = 0L;
 
   public AmbiguousWidgetMatcherException(String message) {
     super(message);

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/InvalidFlutterViewException.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/InvalidFlutterViewException.java
@@ -10,6 +10,8 @@ import androidx.test.espresso.EspressoException;
 public final class InvalidFlutterViewException extends RuntimeException
     implements EspressoException {
 
+  private static final long serialVersionUID = 9001L;
+
   /** Constructs with an error message. */
   public InvalidFlutterViewException(String message) {
     super(message);

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/InvalidFlutterViewException.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/InvalidFlutterViewException.java
@@ -10,7 +10,7 @@ import androidx.test.espresso.EspressoException;
 public final class InvalidFlutterViewException extends RuntimeException
     implements EspressoException {
 
-  private static final long serialVersionUID = 9001L;
+  private static final long serialVersionUID = 0L;
 
   /** Constructs with an error message. */
   public InvalidFlutterViewException(String message) {

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/NoMatchingWidgetException.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/NoMatchingWidgetException.java
@@ -11,7 +11,7 @@ import androidx.test.espresso.EspressoException;
  * hierarchy.
  */
 public final class NoMatchingWidgetException extends RuntimeException implements EspressoException {
-  private static final long serialVersionUID = 9002L;
+  private static final long serialVersionUID = 0L;
 
   public NoMatchingWidgetException(String message) {
     super(message);

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/NoMatchingWidgetException.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/exception/NoMatchingWidgetException.java
@@ -11,6 +11,7 @@ import androidx.test.espresso.EspressoException;
  * hierarchy.
  */
 public final class NoMatchingWidgetException extends RuntimeException implements EspressoException {
+  private static final long serialVersionUID = 9002L;
 
   public NoMatchingWidgetException(String message) {
     super(message);

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/internal/protocol/impl/FlutterProtocolException.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/internal/protocol/impl/FlutterProtocolException.java
@@ -6,7 +6,7 @@ package androidx.test.espresso.flutter.internal.protocol.impl;
 
 /** Represents an exception/error relevant to Dart VM service. */
 public final class FlutterProtocolException extends RuntimeException {
-  private static final long serialVersionUID = 8999L;
+  private static final long serialVersionUID = 0L;
 
   public FlutterProtocolException(String message) {
     super(message);

--- a/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/internal/protocol/impl/FlutterProtocolException.java
+++ b/packages/espresso/android/src/main/java/androidx/test/espresso/flutter/internal/protocol/impl/FlutterProtocolException.java
@@ -6,6 +6,7 @@ package androidx.test.espresso.flutter.internal.protocol.impl;
 
 /** Represents an exception/error relevant to Dart VM service. */
 public final class FlutterProtocolException extends RuntimeException {
+  private static final long serialVersionUID = 8999L;
 
   public FlutterProtocolException(String message) {
     super(message);

--- a/packages/espresso/example/android/build.gradle
+++ b/packages/espresso/example/android/build.gradle
@@ -35,7 +35,9 @@ task clean(type: Delete) {
 gradle.projectsEvaluated {
     project(":espresso") {
         tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:all" << "-Werror"
+            // Ignore classfile warnings due to https://bugs.openjdk.org/browse/JDK-8190452
+            // TODO(stuartmorgan): Remove that ignore once the build uses Java 11+.
+            options.compilerArgs << "-Xlint:all" << "-Werror" << "-Xlint:-classfile"
         }
     }
 }

--- a/packages/espresso/example/android/build.gradle
+++ b/packages/espresso/example/android/build.gradle
@@ -35,9 +35,7 @@ task clean(type: Delete) {
 gradle.projectsEvaluated {
     project(":espresso") {
         tasks.withType(JavaCompile) {
-            // TODO(stuartmorgan): Enable this. See
-            // https://github.com/flutter/flutter/issues/91868
-            //options.compilerArgs << "-Xlint:all" << "-Werror"
+            options.compilerArgs << "-Xlint:all" << "-Werror"
         }
     }
 }

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -3,7 +3,7 @@ description: Java classes for testing Flutter apps using Espresso.
   Allows driving Flutter widgets from a native Espresso test.
 repository: https://github.com/flutter/packages/tree/main/packages/espresso
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+espresso%22
-version: 0.2.1+1
+version: 0.3.0
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -3,7 +3,7 @@ description: Java classes for testing Flutter apps using Espresso.
   Allows driving Flutter widgets from a native Espresso test.
 repository: https://github.com/flutter/packages/tree/main/packages/espresso
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+espresso%22
-version: 0.2.1
+version: 0.2.1+1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
This PR enables `javac` lint options for `espresso` and fixes the violations.

*List which issues are fixed by this PR. You must list at least one issue.*
Part of https://github.com/flutter/flutter/issues/91868

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
N/A

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
