### PR TITLE
Revert "[video_player] Passing http headers to file constructor "

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,5 @@
-## 2.6.0
+## NEXT
 
-* Adds option to configure HTTP headers via `VideoPlayerController` to fix access to M3U8 files on Android.
 * Aligns Dart and Flutter SDK constraints.
 
 ## 2.5.3

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -230,7 +230,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// null.
   /// **Android only**: The [formatHint] option allows the caller to override
   /// the video format detection code.
-  /// [httpHeaders] option allows to specify HTTP headers.
+  /// [httpHeaders] option allows to specify HTTP headers
   /// for the request to the [dataSource].
   VideoPlayerController.network(
     this.dataSource, {
@@ -246,16 +246,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// Constructs a [VideoPlayerController] playing a video from a file.
   ///
   /// This will load the file from a file:// URI constructed from [file]'s path.
-  /// [httpHeaders] option allows to specify HTTP headers, mainly used for hls files like (m3u8).
   VideoPlayerController.file(File file,
-      {Future<ClosedCaptionFile>? closedCaptionFile,
-      this.videoPlayerOptions,
-      this.httpHeaders = const <String, String>{}})
+      {Future<ClosedCaptionFile>? closedCaptionFile, this.videoPlayerOptions})
       : _closedCaptionFileFuture = closedCaptionFile,
         dataSource = Uri.file(file.absolute.path).toString(),
         dataSourceType = DataSourceType.file,
         package = null,
         formatHint = null,
+        httpHeaders = const <String, String>{},
         super(VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [VideoPlayerController] playing a video from a contentUri.
@@ -346,7 +344,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.file,
           uri: dataSource,
-          httpHeaders: httpHeaders,
         );
         break;
       case DataSourceType.contentUri:

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.6.0
+version: 2.5.3
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -358,22 +358,6 @@ void main() {
             reason: 'Actual string: $uri');
       }, skip: kIsWeb /* Web does not support file assets. */);
 
-      test('file with headers (m3u8)', () async {
-        final VideoPlayerController controller = VideoPlayerController.file(
-          File('a.avi'),
-          httpHeaders: <String, String>{'Authorization': 'Bearer token'},
-        );
-        await controller.initialize();
-
-        final String uri = fakeVideoPlayerPlatform.dataSources[0].uri!;
-        expect(uri.startsWith('file:///'), true, reason: 'Actual string: $uri');
-        expect(uri.endsWith('/a.avi'), true, reason: 'Actual string: $uri');
-
-        expect(
-          fakeVideoPlayerPlatform.dataSources[0].httpHeaders,
-          <String, String>{'Authorization': 'Bearer token'},
-        );
-      }, skip: kIsWeb /* Web does not support file assets. */);
       test('successful initialize on controller with error clears error',
           () async {
         final VideoPlayerController controller = VideoPlayerController.network(

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.4.0
-
-* Allows setting the ExoPlayer user agent by passing a User-Agent HTTP header.
-
 ## 2.3.12
 
 * Clarifies explanation of endorsement in README.

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -5,20 +5,15 @@
 package io.flutter.plugins.videoplayer;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.Format;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.view.TextureRegistry;
 import java.util.HashMap;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +29,6 @@ public class VideoPlayerTest {
   private TextureRegistry.SurfaceTextureEntry fakeSurfaceTextureEntry;
   private VideoPlayerOptions fakeVideoPlayerOptions;
   private QueuingEventSink fakeEventSink;
-  private DefaultHttpDataSource.Factory httpDataSourceFactorySpy;
 
   @Captor private ArgumentCaptor<HashMap<String, Object>> eventCaptor;
 
@@ -47,76 +41,6 @@ public class VideoPlayerTest {
     fakeSurfaceTextureEntry = mock(TextureRegistry.SurfaceTextureEntry.class);
     fakeVideoPlayerOptions = mock(VideoPlayerOptions.class);
     fakeEventSink = mock(QueuingEventSink.class);
-    httpDataSourceFactorySpy = spy(new DefaultHttpDataSource.Factory());
-  }
-
-  @Test
-  public void videoPlayer_buildsHttpDataSourceFactoryProperlyWhenHttpHeadersNull() {
-    VideoPlayer videoPlayer =
-        new VideoPlayer(
-            fakeExoPlayer,
-            fakeEventChannel,
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            fakeEventSink,
-            httpDataSourceFactorySpy);
-
-    videoPlayer.buildHttpDataSourceFactory(new HashMap<>());
-
-    verify(httpDataSourceFactorySpy).setUserAgent("ExoPlayer");
-    verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
-    verify(httpDataSourceFactorySpy, never()).setDefaultRequestProperties(any());
-  }
-
-  @Test
-  public void
-      videoPlayer_buildsHttpDataSourceFactoryProperlyWhenHttpHeadersNonNullAndUserAgentSpecified() {
-    VideoPlayer videoPlayer =
-        new VideoPlayer(
-            fakeExoPlayer,
-            fakeEventChannel,
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            fakeEventSink,
-            httpDataSourceFactorySpy);
-    Map<String, String> httpHeaders =
-        new HashMap<String, String>() {
-          {
-            put("header", "value");
-            put("User-Agent", "userAgent");
-          }
-        };
-
-    videoPlayer.buildHttpDataSourceFactory(httpHeaders);
-
-    verify(httpDataSourceFactorySpy).setUserAgent("userAgent");
-    verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
-    verify(httpDataSourceFactorySpy).setDefaultRequestProperties(httpHeaders);
-  }
-
-  @Test
-  public void
-      videoPlayer_buildsHttpDataSourceFactoryProperlyWhenHttpHeadersNonNullAndUserAgentNotSpecified() {
-    VideoPlayer videoPlayer =
-        new VideoPlayer(
-            fakeExoPlayer,
-            fakeEventChannel,
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            fakeEventSink,
-            httpDataSourceFactorySpy);
-    Map<String, String> httpHeaders =
-        new HashMap<String, String>() {
-          {
-            put("header", "value");
-          }
-        };
-
-    videoPlayer.buildHttpDataSourceFactory(httpHeaders);
-
-    verify(httpDataSourceFactorySpy).setUserAgent("ExoPlayer");
-    verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
-    verify(httpDataSourceFactorySpy).setDefaultRequestProperties(httpHeaders);
   }
 
   @Test
@@ -127,8 +51,7 @@ public class VideoPlayerTest {
             fakeEventChannel,
             fakeSurfaceTextureEntry,
             fakeVideoPlayerOptions,
-            fakeEventSink,
-            httpDataSourceFactorySpy);
+            fakeEventSink);
     Format testFormat =
         new Format.Builder().setWidth(100).setHeight(200).setRotationDegrees(90).build();
 
@@ -156,8 +79,7 @@ public class VideoPlayerTest {
             fakeEventChannel,
             fakeSurfaceTextureEntry,
             fakeVideoPlayerOptions,
-            fakeEventSink,
-            httpDataSourceFactorySpy);
+            fakeEventSink);
     Format testFormat =
         new Format.Builder().setWidth(100).setHeight(200).setRotationDegrees(270).build();
 
@@ -185,8 +107,7 @@ public class VideoPlayerTest {
             fakeEventChannel,
             fakeSurfaceTextureEntry,
             fakeVideoPlayerOptions,
-            fakeEventSink,
-            httpDataSourceFactorySpy);
+            fakeEventSink);
     Format testFormat =
         new Format.Builder().setWidth(100).setHeight(200).setRotationDegrees(0).build();
 
@@ -214,8 +135,7 @@ public class VideoPlayerTest {
             fakeEventChannel,
             fakeSurfaceTextureEntry,
             fakeVideoPlayerOptions,
-            fakeEventSink,
-            httpDataSourceFactorySpy);
+            fakeEventSink);
     Format testFormat =
         new Format.Builder().setWidth(100).setHeight(200).setRotationDegrees(180).build();
 

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -49,7 +49,6 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
         break;
       case DataSourceType.file:
         uri = dataSource.uri;
-        httpHeaders = dataSource.httpHeaders;
         break;
       case DataSourceType.contentUri:
         uri = dataSource.uri;

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.0
+version: 2.3.12
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -176,18 +176,6 @@ void main() {
       expect(textureId, 3);
     });
 
-    test('create with file (some headers)', () async {
-      final int? textureId = await player.create(DataSource(
-        sourceType: DataSourceType.file,
-        uri: 'someUri',
-        httpHeaders: <String, String>{'Authorization': 'Bearer token'},
-      ));
-      expect(log.log.last, 'create');
-      expect(log.createMessage?.uri, 'someUri');
-      expect(log.createMessage?.httpHeaders,
-          <String, String>{'Authorization': 'Bearer token'});
-      expect(textureId, 3);
-    });
     test('setLooping', () async {
       await player.setLooping(1, true);
       expect(log.log.last, 'setLooping');


### PR DESCRIPTION
Reverts flutter/packages#3266

Failed integration tests; it wasn't caught in presubmit since FTL only runs in presubmit for team member commits.