### PR TITLE
Alternative Stateful ShellRoute proof of concept

### DIFF
--- a/packages/go_router/example/lib/shell_route.dart
+++ b/packages/go_router/example/lib/shell_route.dart
@@ -35,6 +35,7 @@ class ShellRouteExampleApp extends StatelessWidget {
       /// Application shell
       ShellRoute(
         navigatorKey: _shellNavigatorKey,
+        perserveState: true,
         builder: (BuildContext context, GoRouterState state, Widget child) {
           return ScaffoldWithNavBar(child: child);
         },
@@ -261,7 +262,7 @@ class ScreenC extends StatelessWidget {
 }
 
 /// The details screen for either the A, B or C screen.
-class DetailsScreen extends StatelessWidget {
+class DetailsScreen extends StatefulWidget {
   /// Constructs a [DetailsScreen].
   const DetailsScreen({
     required this.label,
@@ -272,15 +273,35 @@ class DetailsScreen extends StatelessWidget {
   final String label;
 
   @override
+  State<DetailsScreen> createState() => _DetailsScreenState();
+}
+
+class _DetailsScreenState extends State<DetailsScreen> {
+  int count = 0;
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Details Screen'),
       ),
+      floatingActionButton: FloatingActionButton(
+        child: const Icon(Icons.add),
+        onPressed: () => setState(() {
+          count++;
+        }),
+      ),
       body: Center(
-        child: Text(
-          'Details for $label',
-          style: Theme.of(context).textTheme.headlineMedium,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Details for ${widget.label}',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            Text(
+              'Clicked $count times',
+            ),
+          ],
         ),
       ),
     );

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -421,6 +421,7 @@ class ShellRoute extends RouteBase {
     this.builder,
     this.pageBuilder,
     this.observers,
+    this.perserveState = false,
     super.routes,
     GlobalKey<NavigatorState>? navigatorKey,
   })  : assert(routes.isNotEmpty),
@@ -433,6 +434,9 @@ class ShellRoute extends RouteBase {
       }
     }
   }
+
+  /// Perserves the state of subroutes
+  final bool perserveState;
 
   /// The widget builder for a shell route.
   ///


### PR DESCRIPTION
This is an incomplete proof of concept alternative to https://github.com/flutter/packages/pull/2650
which relies on manipulating the Navigator's `pages` property to keep old pages in the widget tree, therefore maintains their state

to opt-in this you need to set `ShellRoute.perserveState` to true

I have also updated the `shell_route` example to include this.

Pros:

1. This approach introduces nothing new, it only adds a single boolean field to opt-in
2. Instead of caching multiple Navigators, this caches the routes instead, means lower memory usage, and less prone to mistakes

Cons: 

1. Since this relies on manipulating a single navigator, users who get a reference to the NavigatorState via global key will see the cached pages, which might be an unexpected behavior
2. There is a current bug when working with the `AppBar` is that it will show back button when it isn't supposed to, since a navigator expects that it can pop whenever there are pages available, but the browser history navigation works.

feel free to close/ignore this PR if it isn't useful

