### PR TITLE
[image_picker] Move HashSet construction within if-statement

### DIFF
--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.6+2
+
+* Fixes null pointer exception in `saveResult`.
+
 ## 0.8.6+1
 
 * Refactors code in preparation for adopting Pigeon.

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
@@ -98,8 +98,7 @@ class ImagePickerCache {
 
     SharedPreferences.Editor editor = prefs.edit();
     if (path != null) {
-      Set<String> imageSet = new HashSet<>();
-      imageSet.addAll(path);
+      Set<String> imageSet = new HashSet<>(path);
       editor.putStringSet(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY, imageSet);
     }
     if (errorCode != null) {

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
@@ -96,10 +96,10 @@ class ImagePickerCache {
   void saveResult(
       @Nullable ArrayList<String> path, @Nullable String errorCode, @Nullable String errorMessage) {
 
-    Set<String> imageSet = new HashSet<>();
-    imageSet.addAll(path);
     SharedPreferences.Editor editor = prefs.edit();
     if (path != null) {
+      Set<String> imageSet = new HashSet<>();
+      imageSet.addAll(path);
       editor.putStringSet(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY, imageSet);
     }
     if (errorCode != null) {

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerCacheTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerCacheTest.java
@@ -121,6 +121,7 @@ public class ImagePickerCacheTest {
   public void imageCache_shouldNotThrowIfPathIsNullInSaveResult() {
     final ImagePickerCache cache = new ImagePickerCache(mockActivity);
     cache.saveResult(null, "errorCode", "errorMessage");
-      assertTrue("No exception thrown when ImagePickerCache.saveResult() was passed a null path", true);
+    assertTrue(
+        "No exception thrown when ImagePickerCache.saveResult() was passed a null path", true);
   }
 }

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerCacheTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerCacheTest.java
@@ -7,6 +7,7 @@ package io.flutter.plugins.imagepicker;
 import static io.flutter.plugins.imagepicker.ImagePickerCache.SHARED_PREFERENCES_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -114,5 +115,12 @@ public class ImagePickerCacheTest {
     int defaultImageQuality =
         (int) resultMapWithDefaultQuality.get(ImagePickerCache.MAP_KEY_IMAGE_QUALITY);
     assertThat(defaultImageQuality, equalTo(100));
+  }
+
+  @Test
+  public void imageCache_shouldNotThrowIfPathIsNullInSaveResult() {
+    final ImagePickerCache cache = new ImagePickerCache(mockActivity);
+    cache.saveResult(null, "errorCode", "errorMessage");
+      assertTrue("No exception thrown when ImagePickerCache.saveResult() was passed a null path", true);
   }
 }

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 
-version: 0.8.6+1
+version: 0.8.6+2
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
Fixes the NPE mentioned in [#108334](https://github.com/flutter/flutter/issues/108334) by moving the creation of the `HashSet` within the if-statement in `saveResult` in `ImagePickerCache.java`.

Previously, the `HashSet` would be created and filled using `HashSet.addAll`, even though this is only necessary when `path != null`. As `addAll` throws when its argument is null, this had the potential to throw a NPE.

With this PR, the `HashSet` will only be created and filled when `path` is non-null. This saves resources when `path` is non-null and prevents the NPE from occurring.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
