### PR TITLE
[ci] Clean up iOS simulators

### DIFF
--- a/.ci/scripts/create_simulator.sh
+++ b/.ci/scripts/create_simulator.sh
@@ -3,8 +3,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-device=com.apple.CoreSimulator.SimDeviceType.iPhone-13
-os=com.apple.CoreSimulator.SimRuntime.iOS-16-0
+# The name here must match remove_simulator.sh
+readonly DEVICE_NAME=Flutter-iPhone
+readonly DEVICE=com.apple.CoreSimulator.SimDeviceType.iPhone-13
+readonly OS=com.apple.CoreSimulator.SimRuntime.iOS-16-0
 
 xcrun simctl list
-xcrun simctl create Flutter-iPhone "$device" "$os" | xargs xcrun simctl boot
+xcrun simctl create "$DEVICE_NAME" "$DEVICE" "$OS" | xargs xcrun simctl boot

--- a/.ci/scripts/remove_simulator.sh
+++ b/.ci/scripts/remove_simulator.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# The name here must match create_simulator.sh
+readonly DEVICE_NAME=Flutter-iPhone
+
+xcrun simctl shutdown "$DEVICE_NAME"
+xcrun simctl delete "$DEVICE_NAME"
+xcrun simctl list

--- a/.ci/targets/ios_platform_tests.yaml
+++ b/.ci/targets/ios_platform_tests.yaml
@@ -22,3 +22,5 @@ tasks:
     # So we run `drive-examples` after `native-test`; changing the order will result ci failure.
     script: script/tool_runner.sh
     args: ["drive-examples", "--ios", "--exclude=script/configs/exclude_integration_ios.yaml"]
+  - name: remove simulator
+    script: .ci/scripts/remove_simulator.sh

--- a/.ci/targets/macos_custom_package_tests.yaml
+++ b/.ci/targets/macos_custom_package_tests.yaml
@@ -5,3 +5,5 @@ tasks:
     script: .ci/scripts/create_simulator.sh
   - name: custom package tests
     script: .ci/scripts/custom_package_tests.sh
+  - name: remove simulator
+    script: .ci/scripts/remove_simulator.sh


### PR DESCRIPTION
Balances the simulator creation step with a removal step, since LUCI bots aren't automatically restored to a clean slate after every run.

Fixes https://github.com/flutter/flutter/issues/122416