### PR TITLE
Update tests to ignore `deprecated_member_use` where `TestWindow` API is used

### DIFF
--- a/packages/dynamic_layouts/example/test/staggered_example_test.dart
+++ b/packages/dynamic_layouts/example/test/staggered_example_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+// ignore_for_file: deprecated_member_use
+
 import 'package:example/staggered_layout_example.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/dynamic_layouts/example/test/staggered_example_test.dart
+++ b/packages/dynamic_layouts/example/test/staggered_example_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
-// ignore_for_file: deprecated_member_use
-
 import 'package:example/staggered_layout_example.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -12,7 +9,12 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('StaggeredExample lays out children correctly',
       (WidgetTester tester) async {
+    // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+    // ignore: deprecated_member_use
     tester.binding.window.physicalSizeTestValue = const Size(400, 200);
+
+    // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+    // ignore: deprecated_member_use
     tester.binding.window.devicePixelRatioTestValue = 1.0;
 
     await tester.pumpWidget(

--- a/packages/dynamic_layouts/test/staggered_layout_test.dart
+++ b/packages/dynamic_layouts/test/staggered_layout_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+// ignore_for_file: deprecated_member_use
+
 import 'package:dynamic_layouts/dynamic_layouts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/dynamic_layouts/test/staggered_layout_test.dart
+++ b/packages/dynamic_layouts/test/staggered_layout_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
-// ignore_for_file: deprecated_member_use
-
 import 'package:dynamic_layouts/dynamic_layouts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,7 +11,12 @@ void main() {
     testWidgets(
         'DynamicGridView works when using DynamicSliverGridDelegateWithFixedCrossAxisCount',
         (WidgetTester tester) async {
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.physicalSizeTestValue = const Size(400, 100);
+
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.devicePixelRatioTestValue = 1.0;
 
       await tester.pumpWidget(
@@ -57,7 +59,12 @@ void main() {
     testWidgets(
         'DynamicGridView works when using DynamicSliverGridDelegateWithMaxCrossAxisExtent',
         (WidgetTester tester) async {
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.physicalSizeTestValue = const Size(440, 100);
+
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.devicePixelRatioTestValue = 1.0;
 
       await tester.pumpWidget(
@@ -99,7 +106,12 @@ void main() {
   group('DynamicGridView.staggered', () {
     testWidgets('DynamicGridView.staggered works with simple layout',
         (WidgetTester tester) async {
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.physicalSizeTestValue = const Size(400, 100);
+
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.devicePixelRatioTestValue = 1.0;
 
       await tester.pumpWidget(
@@ -146,7 +158,12 @@ void main() {
     });
     testWidgets('DynamicGridView.staggered works with a horizontal grid',
         (WidgetTester tester) async {
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.physicalSizeTestValue = const Size(100, 500);
+
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.devicePixelRatioTestValue = 1.0;
 
       await tester.pumpWidget(
@@ -199,7 +216,12 @@ void main() {
     });
     testWidgets('DynamicGridView.staggered works with a reversed grid',
         (WidgetTester tester) async {
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.physicalSizeTestValue = const Size(600, 200);
+
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.devicePixelRatioTestValue = 1.0;
 
       await tester.pumpWidget(
@@ -268,7 +290,12 @@ void main() {
 
     testWidgets('DynamicGridView.staggered deletes children appropriately',
         (WidgetTester tester) async {
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.physicalSizeTestValue = const Size(600, 1000);
+
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.devicePixelRatioTestValue = 1.0;
       final List<Widget> children = List<Widget>.generate(
         50,
@@ -348,7 +375,12 @@ void main() {
   group('DynamicGridView.builder', () {
     testWidgets('DynamicGridView.builder works with a staggered layout',
         (WidgetTester tester) async {
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.physicalSizeTestValue = const Size(400, 100);
+
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.devicePixelRatioTestValue = 1.0;
 
       await tester.pumpWidget(
@@ -398,7 +430,12 @@ void main() {
     testWidgets(
         'DynamicGridView.builder works with an infinite grid using a staggered layout',
         (WidgetTester tester) async {
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.physicalSizeTestValue = const Size(400, 100);
+
+      // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+      // ignore: deprecated_member_use
       tester.binding.window.devicePixelRatioTestValue = 1.0;
 
       await tester.pumpWidget(

--- a/packages/dynamic_layouts/test/wrap_layout_test.dart
+++ b/packages/dynamic_layouts/test/wrap_layout_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
-// ignore_for_file: deprecated_member_use
-
 import 'package:dynamic_layouts/dynamic_layouts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -511,6 +508,8 @@ void main() {
     expect(find.text('Item 4'), findsNothing);
     await tester.binding.setSurfaceSize(const Size(280, 100));
     // resets the screen to its original size after the test end
+    // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+    // ignore: deprecated_member_use
     addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
     await tester.pumpAndSettle();
     expect(find.text('Item 0'), findsOneWidget);
@@ -573,6 +572,8 @@ void main() {
 
     await tester.binding.setSurfaceSize(const Size(560, 100));
     // resets the screen to its original size after the test end
+    // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+    // ignore: deprecated_member_use
     addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
     await tester.pumpAndSettle();
 

--- a/packages/dynamic_layouts/test/wrap_layout_test.dart
+++ b/packages/dynamic_layouts/test/wrap_layout_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+// ignore_for_file: deprecated_member_use
+
 import 'package:dynamic_layouts/dynamic_layouts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
-// ignore_for_file: deprecated_member_use
-
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
@@ -472,11 +469,15 @@ void main() {
       expect(
           coordinate.x,
           ((rect.center.dx - rect.topLeft.dx) *
+                  // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+                  // ignore: deprecated_member_use
                   tester.binding.window.devicePixelRatio)
               .round());
       expect(
           coordinate.y,
           ((rect.center.dy - rect.topLeft.dy) *
+                  // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+                  // ignore: deprecated_member_use
                   tester.binding.window.devicePixelRatio)
               .round());
     }

--- a/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
-// ignore_for_file: deprecated_member_use
-
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
@@ -474,11 +471,15 @@ void googleMapsTests() {
     expect(
         coordinate.x,
         ((rect.center.dx - rect.topLeft.dx) *
+                // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+                // ignore: deprecated_member_use
                 tester.binding.window.devicePixelRatio)
             .round());
     expect(
         coordinate.y,
         ((rect.center.dy - rect.topLeft.dy) *
+                // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+                // ignore: deprecated_member_use
                 tester.binding.window.devicePixelRatio)
             .round());
     await tester.binding.setSurfaceSize(null);

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';

--- a/packages/google_sign_in/google_sign_in/test/widgets_test.dart
+++ b/packages/google_sign_in/google_sign_in/test/widgets_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';

--- a/packages/google_sign_in/google_sign_in/test/widgets_test.dart
+++ b/packages/google_sign_in/google_sign_in/test/widgets_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
-// ignore_for_file: deprecated_member_use
-
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
@@ -103,6 +100,9 @@ void main() {
       id: 'userId',
       photoUrl: 'photoUrl',
     );
+
+    // TODO(pdblasi-google): Update `window` usages to new API after 3.9.0 is in stable. https://github.com/flutter/flutter/issues/122912
+    // ignore: deprecated_member_use
     tester.binding.window.physicalSizeTestValue = const Size(100, 100);
 
     await HttpOverrides.runZoned(


### PR DESCRIPTION
Update tests to ignore `deprecated_member_use` where `TestWindow` API is used.

With [#122824](https://github.com/flutter/flutter/pull/122824), the `TestWindow` API is deprecated. We need to ignore analysis errors from using deprecated members for CI to work, but don't want to update the API until 3.9.0 is in stable.

[#122912](https://github.com/flutter/flutter/pull/122912) tracks the eventual migration to the new `TestFlutterView` API.

Progress towards #121915.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.