### PR TITLE
[video_player] Remove added listener before unmounting widget in example

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.2
+
+* Removes added listener before unmounting widget in example
+
 ## 2.6.1
 
 * Synchronizes `VideoPlayerValue.isPlaying` with underlying video player.

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -389,17 +389,20 @@ class _PlayerVideoAndPopPageState extends State<_PlayerVideoAndPopPage> {
   late VideoPlayerController _videoPlayerController;
   bool startedPlaying = false;
 
+  void listener() {
+    if (startedPlaying && !_videoPlayerController.value.isPlaying) {
+      _videoPlayerController.removeListener(listener);
+      Navigator.pop(context);
+    }
+  }
+
   @override
   void initState() {
     super.initState();
 
     _videoPlayerController =
         VideoPlayerController.asset('assets/Butterfly-209.mp4');
-    _videoPlayerController.addListener(() {
-      if (startedPlaying && !_videoPlayerController.value.isPlaying) {
-        Navigator.pop(context);
-      }
-    });
+    _videoPlayerController.addListener(listener);
   }
 
   @override

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -389,9 +389,9 @@ class _PlayerVideoAndPopPageState extends State<_PlayerVideoAndPopPage> {
   late VideoPlayerController _videoPlayerController;
   bool startedPlaying = false;
 
-  void listener() {
+  void _onVideoControllerValueUpdated() {
     if (startedPlaying && !_videoPlayerController.value.isPlaying) {
-      _videoPlayerController.removeListener(listener);
+      _videoPlayerController.removeListener(_onVideoControllerValueUpdated);
       Navigator.pop(context);
     }
   }
@@ -402,7 +402,7 @@ class _PlayerVideoAndPopPageState extends State<_PlayerVideoAndPopPage> {
 
     _videoPlayerController =
         VideoPlayerController.asset('assets/Butterfly-209.mp4');
-    _videoPlayerController.addListener(listener);
+    _videoPlayerController.addListener(_onVideoControllerValueUpdated);
   }
 
   @override

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.6.1
+version: 2.6.2
 
 environment:
   sdk: ">=2.17.0 <4.0.0"


### PR DESCRIPTION
Fixes [#122690](https://github.com/flutter/flutter/issues/122690) by removing added listener before unmounting the widget in the example code. I slightly changed the solution I proposed in the issue. I moved the code to remove the listener from `dispose` method to the listener itself because the first fix wasn't working in this example. The listener was being called one more time after calling `Navigator.pop(context)` but before the `videoPlayerController.removeListener(listener);` is called in dispose method.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
