### PR TITLE
[shared_preferences] Adopt readme excerpts

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.19
 
+* Updates README to use code excerpts.
 * Aligns Dart and Flutter SDK constraints.
 
 ## 2.0.18

--- a/packages/shared_preferences/shared_preferences/README.md
+++ b/packages/shared_preferences/shared_preferences/README.md
@@ -1,4 +1,5 @@
 # Shared preferences plugin
+<?code-excerpt path-base="excerpts/packages/shared_preferences_example"?>
 
 [![pub package](https://img.shields.io/pub/v/shared_preferences.svg)](https://pub.dev/packages/shared_preferences)
 
@@ -21,9 +22,10 @@ To use this plugin, add `shared_preferences` as a [dependency in your pubspec.ya
 Here are small examples that show you how to use the API.
 
 #### Write data
+<?code-excerpt "readme_excerpts.dart (Write)"?>
 ```dart
 // Obtain shared preferences.
-final prefs = await SharedPreferences.getInstance();
+final SharedPreferences prefs = await SharedPreferences.getInstance();
 
 // Save an integer value to 'counter' key.
 await prefs.setInt('counter', 10);
@@ -38,6 +40,7 @@ await prefs.setStringList('items', <String>['Earth', 'Moon', 'Sun']);
 ```
 
 #### Read data
+<?code-excerpt "readme_excerpts.dart (Read)"?>
 ```dart
 // Try reading data from the 'counter' key. If it doesn't exist, returns null.
 final int? counter = prefs.getInt('counter');
@@ -52,17 +55,21 @@ final List<String>? items = prefs.getStringList('items');
 ```
 
 #### Remove an entry
+<?code-excerpt "readme_excerpts.dart (Clear)"?>
 ```dart
 // Remove data for the 'counter' key.
-final success = await prefs.remove('counter');
+await prefs.remove('counter');
 ```
 
 ### Testing
 
-You can populate `SharedPreferences` with initial values in your tests by running this code:
+In tests, you can replace the standard `SharedPreferences` implementation with
+a mock implementation with initial values. This implementation is in-memory
+only, and will not persist values to the usual preference store.
 
+<?code-excerpt "readme_excerpts.dart (Tests)"?>
 ```dart
-Map<String, Object> values = <String, Object>{'counter': 1};
+final Map<String, Object> values = <String, Object>{'counter': 1};
 SharedPreferences.setMockInitialValues(values);
 ```
 

--- a/packages/shared_preferences/shared_preferences/example/build.excerpt.yaml
+++ b/packages/shared_preferences/shared_preferences/example/build.excerpt.yaml
@@ -1,0 +1,15 @@
+targets:
+  $default:
+    sources:
+      include:
+        - lib/**
+        # Some default includes that aren't really used here but will prevent
+        # false-negative warnings:
+        - $package$
+        - lib/$lib$
+      exclude:
+        - '**/.*/**'
+        - '**/build/**'
+    builders:
+      code_excerpter|code_excerpter:
+        enabled: true

--- a/packages/shared_preferences/shared_preferences/example/lib/readme_excerpts.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/readme_excerpts.dart
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs, unused_local_variable, invalid_use_of_visible_for_testing_member
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> readmeSnippets() async {
+  // #docregion Write
+  // Obtain shared preferences.
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  // Save an integer value to 'counter' key.
+  await prefs.setInt('counter', 10);
+  // Save an boolean value to 'repeat' key.
+  await prefs.setBool('repeat', true);
+  // Save an double value to 'decimal' key.
+  await prefs.setDouble('decimal', 1.5);
+  // Save an String value to 'action' key.
+  await prefs.setString('action', 'Start');
+  // Save an list of strings to 'items' key.
+  await prefs.setStringList('items', <String>['Earth', 'Moon', 'Sun']);
+  // #enddocregion Write
+
+  // #docregion Read
+  // Try reading data from the 'counter' key. If it doesn't exist, returns null.
+  final int? counter = prefs.getInt('counter');
+  // Try reading data from the 'repeat' key. If it doesn't exist, returns null.
+  final bool? repeat = prefs.getBool('repeat');
+  // Try reading data from the 'decimal' key. If it doesn't exist, returns null.
+  final double? decimal = prefs.getDouble('decimal');
+  // Try reading data from the 'action' key. If it doesn't exist, returns null.
+  final String? action = prefs.getString('action');
+  // Try reading data from the 'items' key. If it doesn't exist, returns null.
+  final List<String>? items = prefs.getStringList('items');
+  // #enddocregion Read
+
+  // #docregion Clear
+  // Remove data for the 'counter' key.
+  await prefs.remove('counter');
+  // #enddocregion Clear
+}
+
+// Uses test-only code. invalid_use_of_visible_for_testing_member is suppressed
+// for the whole file since otherwise there's no way to avoid it showing up in
+// the excerpt, and that is definitely not something people should be copying
+// from examples.
+Future<void> readmeTestSnippets() async {
+  // #docregion Tests
+  final Map<String, Object> values = <String, Object>{'counter': 1};
+  SharedPreferences.setMockInitialValues(values);
+  // #enddocregion Tests
+}

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
     path: ../
 
 dev_dependencies:
+  build_runner: ^2.1.10
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/shared_preferences/shared_preferences/example/test/readme_excerpts_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/test/readme_excerpts_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_example/readme_excerpts.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('sanity check readmeSnippets', () async {
+    // This key is set and cleared in the snippets.
+    const String clearedKey = 'counter';
+
+    // Set a mock store so that there's a platform implementation.
+    SharedPreferences.setMockInitialValues(<String, Object>{clearedKey: 2});
+
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    // Ensure that the snippet code runs successfully.
+    await readmeSnippets();
+    // Spot-check some functionality to ensure that it's showing working calls.
+    // It should also set some preferences.
+    expect(prefs.getBool('repeat'), isNotNull);
+    expect(prefs.getDouble('decimal'), isNotNull);
+    // It should clear this preference.
+    expect(prefs.getInt(clearedKey), isNull);
+  });
+
+  test('readmeTestSnippets', () async {
+    await readmeTestSnippets();
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    // The snippet sets a single initial pref.
+    expect(prefs.getKeys().length, 1);
+  });
+}

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.18
+version: 2.0.19
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/script/configs/temp_exclude_excerpt.yaml
+++ b/script/configs/temp_exclude_excerpt.yaml
@@ -29,6 +29,5 @@
 - pointer_interceptor
 - quick_actions/quick_actions
 - rfw
-- shared_preferences/shared_preferences
 - webview_flutter_android
 - webview_flutter_web


### PR DESCRIPTION
Converts the README from manually-maintained code snippets to using excerpts from a code file.

Includes sanity check tests of the snippet code to make sure it runs successfully.

Part of https://github.com/flutter/flutter/issues/102679

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
