### PR TITLE
[path_provider] Adopt readme excerpts

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.14
 
+* Updates README to use code excerpts.
 * Aligns Dart and Flutter SDK constraints.
 
 ## 2.0.13

--- a/packages/path_provider/path_provider/README.md
+++ b/packages/path_provider/path_provider/README.md
@@ -1,4 +1,5 @@
 # path_provider
+<?code-excerpt path-base="excerpts/packages/path_provider_example"?>
 
 [![pub package](https://img.shields.io/pub/v/path_provider.svg)](https://pub.dev/packages/path_provider)
 
@@ -15,12 +16,13 @@ Not all methods are supported on all platforms.
 To use this plugin, add `path_provider` as a [dependency in your pubspec.yaml file](https://flutter.dev/docs/development/platform-integration/platform-channels).
 
 ## Example
+<?code-excerpt "readme_excerpts.dart (Example)"?>
 ```dart
-Directory tempDir = await getTemporaryDirectory();
-String tempPath = tempDir.path;
+final Directory tempDir = await getTemporaryDirectory();
 
-Directory appDocDir = await getApplicationDocumentsDirectory();
-String appDocPath = appDocDir.path;
+final Directory appDocumentsDir = await getApplicationDocumentsDirectory();
+
+final Directory? downloadsDir = await getDownloadsDirectory();
 ```
 
 ## Supported platforms and paths

--- a/packages/path_provider/path_provider/example/build.excerpt.yaml
+++ b/packages/path_provider/path_provider/example/build.excerpt.yaml
@@ -1,0 +1,15 @@
+targets:
+  $default:
+    sources:
+      include:
+        - lib/**
+        # Some default includes that aren't really used here but will prevent
+        # false-negative warnings:
+        - $package$
+        - lib/$lib$
+      exclude:
+        - '**/.*/**'
+        - '**/build/**'
+    builders:
+      code_excerpter|code_excerpter:
+        enabled: true

--- a/packages/path_provider/path_provider/example/lib/readme_excerpts.dart
+++ b/packages/path_provider/path_provider/example/lib/readme_excerpts.dart
@@ -1,0 +1,20 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+/// Runs example code for README.md.
+Future<List<Directory?>> readmeSnippets() async {
+  // #docregion Example
+  final Directory tempDir = await getTemporaryDirectory();
+
+  final Directory appDocumentsDir = await getApplicationDocumentsDirectory();
+
+  final Directory? downloadsDir = await getDownloadsDirectory();
+  // #enddocregion Example
+
+  return <Directory?>[tempDir, appDocumentsDir, downloadsDir];
+}

--- a/packages/path_provider/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/path_provider/example/pubspec.yaml
@@ -16,8 +16,10 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
+  path_provider_platform_interface: ^2.0.0
 
 dev_dependencies:
+  build_runner: ^2.1.10
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/path_provider/path_provider/example/test/readme_excerpts_test.dart
+++ b/packages/path_provider/path_provider/example/test/readme_excerpts_test.dart
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_example/readme_excerpts.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PathProviderPlatform.instance = FakePathProvider();
+  });
+
+  test('sanity check readmeSnippets', () async {
+    // Ensure that the snippet code runs successfully.
+    final List<Directory?> results = await readmeSnippets();
+    // It should demonstrate a couple of calls.
+    expect(results.length, greaterThan(2));
+    // And the calls should all be different.
+    expect(results.toSet().length, results.length);
+  });
+}
+
+class FakePathProvider extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async {
+    return 'docs';
+  }
+
+  @override
+  Future<String?> getDownloadsPath() async {
+    return 'downloads';
+  }
+
+  @override
+  Future<String?> getTemporaryPath() async {
+    return 'temp';
+  }
+}

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.13
+version: 2.0.14
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/script/configs/temp_exclude_excerpt.yaml
+++ b/script/configs/temp_exclude_excerpt.yaml
@@ -23,7 +23,6 @@
 - ios_platform_images
 - multicast_dns
 - palette_generator
-- path_provider/path_provider
 - pigeon
 - plugin_platform_interface
 - pointer_interceptor


### PR DESCRIPTION
Converts the README from manually-maintained code snippets to using excerpts from a code file.

Also updates the snippet slightly:
- Adds an example of a nullable method, to show that not all are non-nullable.
- Removes the demonstrating of getting the string from the Directory, since that's not related to this package.

Includes sanity check tests of the snippet code to make sure it runs successfully.

Part of https://github.com/flutter/flutter/issues/102679

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
