### PR TITLE
[go_router] Added `onPushRoute`; intercepts route pushes from the application host

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.4.2
+- Adds `onPushRoute` callback to **GoRouter** that can be used to intercept route pushes from the application host.
+
 ## 6.4.1
 - Adds `initialExtra` to **GoRouter** to pass extra data alongside `initialRoute`.
 

--- a/packages/go_router/lib/go_router.dart
+++ b/packages/go_router/lib/go_router.dart
@@ -8,6 +8,7 @@ library go_router;
 
 export 'src/configuration.dart'
     show GoRoute, GoRouterState, RouteBase, ShellRoute;
+export 'src/information_provider.dart' show PushRouteDecision;
 export 'src/misc/extensions.dart';
 export 'src/misc/inherited_router.dart';
 export 'src/pages/custom_transition_page.dart';

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 /// The decision on how to handle the route
 /// when host tells the application to push a new one.
 enum PushRouteDecision {
-  /// Delegate the route information to [WidgetsBindingObserver.didPushRoute]),
+  /// Delegate the route information to [WidgetsBindingObserver.didPushRoute],
   /// in registration order, until one returns true.
   delegate,
 

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -32,7 +32,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
   /// Creates a [GoRouteInformationProvider].
   GoRouteInformationProvider({
     required RouteInformation initialRouteInformation,
-    required PushRouteCallback onPushRoute,
+    PushRouteCallback? onPushRoute,
     Listenable? refreshListenable,
   })  : _refreshListenable = refreshListenable,
         _onPushRoute = onPushRoute,
@@ -41,7 +41,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
   }
 
   final Listenable? _refreshListenable;
-  final PushRouteCallback _onPushRoute;
+  final PushRouteCallback? _onPushRoute;
 
   // ignore: unnecessary_non_null_assertion
   static WidgetsBinding get _binding => WidgetsBinding.instance;
@@ -84,7 +84,11 @@ class GoRouteInformationProvider extends RouteInformationProvider
   Future<bool> _platformReportsNewRouteInformation(
     RouteInformation routeInformation,
   ) async {
-    switch (await _onPushRoute(routeInformation)) {
+    final PushRouteDecision decision =
+        await _onPushRoute?.call(routeInformation) ??
+            PushRouteDecision.navigate;
+
+    switch (decision) {
       case PushRouteDecision.delegate:
         return false;
       case PushRouteDecision.prevent:

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -90,6 +90,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
       case PushRouteDecision.prevent:
         return true;
       case PushRouteDecision.navigate:
+        assert(hasListeners);
         if (_value != routeInformation) {
           _value = routeInformation;
           _valueInEngine = routeInformation;
@@ -125,18 +126,13 @@ class GoRouteInformationProvider extends RouteInformationProvider
   }
 
   @override
-  Future<bool> didPushRouteInformation(
-    RouteInformation routeInformation,
-  ) async {
-    assert(hasListeners);
+  Future<bool> didPushRouteInformation(RouteInformation routeInformation) {
     return _platformReportsNewRouteInformation(routeInformation);
   }
 
   @override
   Future<bool> didPushRoute(String route) {
-    assert(hasListeners);
-    return _platformReportsNewRouteInformation(
-      RouteInformation(location: route),
-    );
+    final RouteInformation routeInformation = RouteInformation(location: route);
+    return _platformReportsNewRouteInformation(routeInformation);
   }
 }

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -64,6 +64,7 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
     bool debugLogDiagnostics = false,
     GlobalKey<NavigatorState>? navigatorKey,
     String? restorationScopeId,
+    PushRouteCallback onPushRoute = _defaultPushRouteHandler,
   })  : backButtonDispatcher = RootBackButtonDispatcher(),
         assert(
           initialExtra == null || initialLocation != null,
@@ -91,6 +92,7 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
         location: _effectiveInitialLocation(initialLocation),
         state: initialExtra,
       ),
+      onPushRoute: onPushRoute,
       refreshListenable: refreshListenable,
     );
 
@@ -391,4 +393,8 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
       return platformDefault;
     }
   }
+}
+
+PushRouteDecision _defaultPushRouteHandler(RouteInformation routeInformation) {
+  return PushRouteDecision.navigate;
 }

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -64,7 +64,7 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
     bool debugLogDiagnostics = false,
     GlobalKey<NavigatorState>? navigatorKey,
     String? restorationScopeId,
-    PushRouteCallback onPushRoute = _defaultPushRouteHandler,
+    PushRouteCallback? onPushRoute,
   })  : backButtonDispatcher = RootBackButtonDispatcher(),
         assert(
           initialExtra == null || initialLocation != null,
@@ -393,8 +393,4 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
       return platformDefault;
     }
   }
-}
-
-PushRouteDecision _defaultPushRouteHandler(RouteInformation routeInformation) {
-  return PushRouteDecision.navigate;
 }

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.4.1
+version: 6.4.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/information_provider_test.dart
+++ b/packages/go_router/test/information_provider_test.dart
@@ -17,8 +17,7 @@ void main() {
   group('GoRouteInformationProvider', () {
     testWidgets('notifies its listeners when set by the app',
         (WidgetTester tester) async {
-      late final GoRouteInformationProvider provider =
-          GoRouteInformationProvider(
+      final GoRouteInformationProvider provider = GoRouteInformationProvider(
         initialRouteInformation: initialRoute,
         onPushRoute: _defaultPushRouteHandler,
       );
@@ -28,13 +27,42 @@ void main() {
 
     testWidgets('notifies its listeners when set by the platform',
         (WidgetTester tester) async {
-      late final GoRouteInformationProvider provider =
-          GoRouteInformationProvider(
+      final GoRouteInformationProvider provider = GoRouteInformationProvider(
         initialRouteInformation: initialRoute,
         onPushRoute: _defaultPushRouteHandler,
       );
       provider.addListener(expectAsync0(() {}));
       provider.didPushRouteInformation(newRoute);
+    });
+
+    group('[push route decision]', () {
+      test('didPushRoute is false for "delegate"', () async {
+        final GoRouteInformationProvider provider = GoRouteInformationProvider(
+          initialRouteInformation: initialRoute,
+          onPushRoute: (_) => PushRouteDecision.delegate,
+        );
+        expect(await provider.didPushRoute('/new'), isFalse);
+        expect(await provider.didPushRouteInformation(newRoute), isFalse);
+      });
+
+      test('didPushRoute is true for "prevent"', () async {
+        final GoRouteInformationProvider provider = GoRouteInformationProvider(
+          initialRouteInformation: initialRoute,
+          onPushRoute: (_) => PushRouteDecision.prevent,
+        );
+        expect(await provider.didPushRoute('/new'), isTrue);
+        expect(await provider.didPushRouteInformation(newRoute), isTrue);
+      });
+
+      test('didPushRoute is true for "navigate"', () async {
+        final GoRouteInformationProvider provider = GoRouteInformationProvider(
+          initialRouteInformation: initialRoute,
+          onPushRoute: (_) => PushRouteDecision.navigate,
+        );
+        provider.addListener(expectAsync0(() {}));
+        expect(await provider.didPushRoute('/new'), isTrue);
+        expect(await provider.didPushRouteInformation(newRoute), isTrue);
+      });
     });
   });
 }

--- a/packages/go_router/test/information_provider_test.dart
+++ b/packages/go_router/test/information_provider_test.dart
@@ -9,17 +9,12 @@ import 'package:go_router/src/information_provider.dart';
 const RouteInformation initialRoute = RouteInformation(location: '/');
 const RouteInformation newRoute = RouteInformation(location: '/new');
 
-PushRouteDecision _defaultPushRouteHandler(RouteInformation routeInformation) {
-  return PushRouteDecision.navigate;
-}
-
 void main() {
   group('GoRouteInformationProvider', () {
     testWidgets('notifies its listeners when set by the app',
         (WidgetTester tester) async {
       final GoRouteInformationProvider provider = GoRouteInformationProvider(
         initialRouteInformation: initialRoute,
-        onPushRoute: _defaultPushRouteHandler,
       );
       provider.addListener(expectAsync0(() {}));
       provider.value = newRoute;
@@ -29,7 +24,6 @@ void main() {
         (WidgetTester tester) async {
       final GoRouteInformationProvider provider = GoRouteInformationProvider(
         initialRouteInformation: initialRoute,
-        onPushRoute: _defaultPushRouteHandler,
       );
       provider.addListener(expectAsync0(() {}));
       provider.didPushRouteInformation(newRoute);

--- a/packages/go_router/test/information_provider_test.dart
+++ b/packages/go_router/test/information_provider_test.dart
@@ -9,12 +9,19 @@ import 'package:go_router/src/information_provider.dart';
 const RouteInformation initialRoute = RouteInformation(location: '/');
 const RouteInformation newRoute = RouteInformation(location: '/new');
 
+PushRouteDecision _defaultPushRouteHandler(RouteInformation routeInformation) {
+  return PushRouteDecision.navigate;
+}
+
 void main() {
   group('GoRouteInformationProvider', () {
     testWidgets('notifies its listeners when set by the app',
         (WidgetTester tester) async {
       late final GoRouteInformationProvider provider =
-          GoRouteInformationProvider(initialRouteInformation: initialRoute);
+          GoRouteInformationProvider(
+        initialRouteInformation: initialRoute,
+        onPushRoute: _defaultPushRouteHandler,
+      );
       provider.addListener(expectAsync0(() {}));
       provider.value = newRoute;
     });
@@ -22,7 +29,10 @@ void main() {
     testWidgets('notifies its listeners when set by the platform',
         (WidgetTester tester) async {
       late final GoRouteInformationProvider provider =
-          GoRouteInformationProvider(initialRouteInformation: initialRoute);
+          GoRouteInformationProvider(
+        initialRouteInformation: initialRoute,
+        onPushRoute: _defaultPushRouteHandler,
+      );
       provider.addListener(expectAsync0(() {}));
       provider.didPushRouteInformation(newRoute);
     });

--- a/packages/go_router/test/test_helpers.dart
+++ b/packages/go_router/test/test_helpers.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:go_router/src/information_provider.dart';
 
 Future<GoRouter> createGoRouter(WidgetTester tester) async {
   final GoRouter goRouter = GoRouter(
@@ -145,6 +146,7 @@ Future<GoRouter> createRouter(
   int redirectLimit = 5,
   GlobalKey<NavigatorState>? navigatorKey,
   GoRouterWidgetBuilder? errorBuilder,
+  PushRouteCallback? onPushRoute,
 }) async {
   final GoRouter goRouter = GoRouter(
     routes: routes,
@@ -156,6 +158,7 @@ Future<GoRouter> createRouter(
         (BuildContext context, GoRouterState state) =>
             TestErrorScreen(state.error!),
     navigatorKey: navigatorKey,
+    onPushRoute: onPushRoute,
   );
   await tester.pumpWidget(
     MaterialApp.router(


### PR DESCRIPTION
Adds `onPushRoute` to the **GoRouter**.

```dart
GoRouter(
  ...
  onPushRoute: (RouteInformation routeInformation) {
    final location = routeInformation.location;

    if(location == '/prevent') return PushRouteDecision.prevent; // intercepts the route completely
    if(location == '/delegate') return PushRouteDecision.delegate; // delegates the route to other binding observers to handle
    return PushRouteDecision.navigate; // default; the router handles the route
  }
)
```

Fixes https://github.com/flutter/flutter/issues/103659
Fixes https://github.com/flutter/flutter/issues/121870

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
