### PR TITLE
[flutter_markdown] prepare for renderViewElement deprecation

### DIFF
--- a/packages/flutter_markdown/test/utils.dart
+++ b/packages/flutter_markdown/test/utils.dart
@@ -164,6 +164,8 @@ void expectLinkTap(MarkdownLink? actual, MarkdownLink expected) {
 }
 
 String dumpRenderView() {
+  // TODO(goderbauer): Migrate to rootElement once v3.9.0 is the oldest supported Flutter version.
+  // ignore: deprecated_member_use
   return WidgetsBinding.instance.renderViewElement!.toStringDeep().replaceAll(
         RegExp(r'SliverChildListDelegate#\d+', multiLine: true),
         'SliverChildListDelegate',


### PR DESCRIPTION
Preparation for https://github.com/flutter/flutter/pull/123352.