### PR TITLE
[go_router] Sets correct reverseTransitionDuration on NoTransitionPage (#123368)

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.2
+
+- NoTransitionPage now has an instant reverse transition
+
 ## 6.5.1
 
 - Fixes an issue where the params are removed after popping.

--- a/packages/go_router/lib/src/pages/custom_transition_page.dart
+++ b/packages/go_router/lib/src/pages/custom_transition_page.dart
@@ -175,7 +175,8 @@ class NoTransitionPage<T> extends CustomTransitionPage<T> {
     super.key,
   }) : super(
           transitionsBuilder: _transitionsBuilder,
-          transitionDuration: const Duration(microseconds: 1),
+          transitionDuration: Duration.zero,
+          reverseTransitionDuration: Duration.zero,
         );
 
   static Widget _transitionsBuilder(

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.5.1
+version: 6.5.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/custom_transition_page_test.dart
+++ b/packages/go_router/test/custom_transition_page_test.dart
@@ -61,28 +61,59 @@ void main() {
 
     final Finder homeScreenFinder = find.byType(HomeScreen);
 
+    expect(homeScreenFinder, findsNothing);
+
     showHomeValueNotifier.value = true;
+
     await tester.pump();
-    final Offset homeScreenPositionInTheMiddleOfAddition =
-        tester.getTopLeft(homeScreenFinder);
+
+    expect(homeScreenFinder, findsOneWidget);
+
     await tester.pumpAndSettle();
-    final Offset homeScreenPositionAfterAddition =
-        tester.getTopLeft(homeScreenFinder);
 
     showHomeValueNotifier.value = false;
-    await tester.pump();
-    final Offset homeScreenPositionInTheMiddleOfRemoval =
-        tester.getTopLeft(homeScreenFinder);
-    await tester.pumpAndSettle();
 
-    expect(
-      homeScreenPositionInTheMiddleOfAddition,
-      homeScreenPositionAfterAddition,
+    await tester.pump();
+
+    expect(homeScreenFinder, findsNothing);
+
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('NoTransitionPage does not apply any reverse transition',
+      (WidgetTester tester) async {
+    final ValueNotifier<bool> showHomeValueNotifier = ValueNotifier<bool>(true);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder<bool>(
+          valueListenable: showHomeValueNotifier,
+          builder: (_, bool showHome, __) {
+            return Navigator(
+              pages: <Page<void>>[
+                const NoTransitionPage<void>(
+                  child: LoginScreen(),
+                ),
+                if (showHome)
+                  const NoTransitionPage<void>(
+                    child: HomeScreen(),
+                  ),
+              ],
+              onPopPage: (Route<dynamic> route, dynamic result) {
+                return route.didPop(result);
+              },
+            );
+          },
+        ),
+      ),
     );
-    expect(
-      homeScreenPositionAfterAddition,
-      homeScreenPositionInTheMiddleOfRemoval,
-    );
+
+    final Finder homeScreenFinder = find.byType(HomeScreen);
+
+    showHomeValueNotifier.value = false;
+
+    await tester.pump();
+
+    expect(homeScreenFinder, findsNothing);
   });
 
   testWidgets('Dismiss a screen by tapping a modal barrier',


### PR DESCRIPTION
Sets the reverseTransitionDuration of NoTransitionPage to 1 microsecond to match the transition duration (and to ensure there is an instant reverse transition).

fixes https://github.com/flutter/flutter/issues/123368

*List which issues are fixed by this PR. You must list at least one issue.*

* https://github.com/flutter/flutter/issues/123368

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
