### PR TITLE
[go_router] Fix redirect being called with empty location for unknown routes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,3 +71,4 @@ TheOneWithTheBraid <the-one@with-the-braid.cf>
 Rulong Chen（陈汝龙） <rulong.crl@alibaba-inc.com>
 Hwanseok Kang <tttkhs96@gmail.com>
 Twin Sun, LLC <google-contrib@twinsunsolutions.com>
+Amir Panahandeh <amirpanahandeh@gmail.com>

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.1
+
+* Fix redirect being called with empty location for unknown routes.
+
 ## 6.5.0
 
 - Supports returning values on pop.

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -11,7 +11,9 @@ import 'configuration.dart';
 import 'delegate.dart';
 import 'information_provider.dart';
 import 'logging.dart';
+import 'match.dart';
 import 'matching.dart';
+import 'path_utils.dart';
 import 'redirection.dart';
 
 /// Converts between incoming URLs and a [RouteMatchList] using [RouteMatcher].
@@ -63,7 +65,11 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
 
       // If there is a matching error for the initial location, we should
       // still try to process the top-level redirects.
-      initialMatches = RouteMatchList.empty;
+      initialMatches = RouteMatchList(
+        <RouteMatch>[],
+        Uri.parse(canonicalUri(routeInformation.location!)),
+        const <String, String>{},
+      );
     }
     Future<RouteMatchList> processRedirectorResult(RouteMatchList matches) {
       if (matches.isEmpty) {

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.5.0
+version: 6.5.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/parser_test.dart
+++ b/packages/go_router/test/parser_test.dart
@@ -196,6 +196,38 @@ void main() {
         'Exception: no routes for location: /def');
   });
 
+  testWidgets(
+      'GoRouteInformationParser calls redirector with correct uri when unknown route',
+      (WidgetTester tester) async {
+    String? lastRedirectLocation;
+    final List<GoRoute> routes = <GoRoute>[
+      GoRoute(
+        path: '/',
+        builder: (_, __) => const Placeholder(),
+        routes: <GoRoute>[
+          GoRoute(
+            path: 'abc',
+            builder: (_, __) => const Placeholder(),
+          ),
+        ],
+      ),
+    ];
+    final GoRouteInformationParser parser = await createParser(
+      tester,
+      routes: routes,
+      redirectLimit: 100,
+      redirect: (_, GoRouterState state) {
+        lastRedirectLocation = state.location;
+        return null;
+      },
+    );
+
+    final BuildContext context = tester.element(find.byType(Router<Object>));
+    await parser.parseRouteInformationWithDependencies(
+        const RouteInformation(location: '/def'), context);
+    expect(lastRedirectLocation, '/def');
+  });
+
   testWidgets('GoRouteInformationParser can work with route parameters',
       (WidgetTester tester) async {
     final List<GoRoute> routes = <GoRoute>[


### PR DESCRIPTION
This is an attempt to fix the issue of redirect being called with empty location when trying to navigate to an unknown route.

- Fixes https://github.com/flutter/flutter/issues/115355

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
