### PR TITLE
[url_launcher] Adds lint ignores to the usage of RouteInformation.loc…

### DIFF
--- a/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
@@ -87,6 +87,9 @@ typedef _SendMessage = Function(String, ByteData?, void Function(ByteData?));
 // TODO(ianh): Remove the first argument.
 Future<ByteData> pushRouteNameToFramework(Object? _, String routeName) {
   final Completer<ByteData> completer = Completer<ByteData>();
+  // TODO(chunhtai): remove this ignore and migrate the code
+  // https://github.com/flutter/flutter/issues/124045.
+  // ignore: deprecated_member_use
   SystemNavigator.routeInformationUpdated(location: routeName);
   final _SendMessage sendMessage = _ambiguate(WidgetsBinding.instance)
           ?.platformDispatcher

--- a/packages/url_launcher/url_launcher_platform_interface/test/link_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/link_test.dart
@@ -83,6 +83,10 @@ class _RouteDelegate extends RouterDelegate<RouteInformation>
     if (_history.isEmpty) {
       return const Placeholder(key: Key('empty'));
     }
+    // TODO(chunhtai): remove the ignore once the following line can migrate to
+    // use RouteInformation.uri after the issue is resolved.
+    // https://github.com/flutter/flutter/issues/100624.
+    // ignore: unnecessary_string_interpolations, deprecated_member_use
     return Placeholder(key: Key('${_history.last.location}'));
   }
 }

--- a/packages/url_launcher/url_launcher_platform_interface/test/link_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/link_test.dart
@@ -83,9 +83,8 @@ class _RouteDelegate extends RouterDelegate<RouteInformation>
     if (_history.isEmpty) {
       return const Placeholder(key: Key('empty'));
     }
-    // TODO(chunhtai): remove the ignore once the following line can migrate to
-    // use RouteInformation.uri after the issue is resolved.
-    // https://github.com/flutter/flutter/issues/100624.
+    // TODO(chunhtai): remove this ignore and migrate the code
+    // https://github.com/flutter/flutter/issues/124045.
     // ignore: unnecessary_string_interpolations, deprecated_member_use
     return Placeholder(key: Key('${_history.last.location}'));
   }


### PR DESCRIPTION
…ation

unblocks https://github.com/flutter/flutter/pull/119968/files

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
