### PR TITLE
[camera] MediaSettings are introduced to manage fps and bitrates of recorded video

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.6.0
+
+* [camera] MediaSettings are introduced to manage fps and bitrate of recorded video.
+* Aligns Dart and Flutter SDK constraints.
+
 ## 2.5.0
 
 * Adds NV21 as an image stream format (suitable for Android).

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 2.6.0
+## 2.5.1
 
-* [camera] MediaSettings are introduced to manage fps and bitrate of recorded video.
-* Aligns Dart and Flutter SDK constraints.
+* CameraPlatform.createCameraWithSettings method for tune fps and bitrate of recorded video.
 
 ## 2.5.0
 

--- a/packages/camera/camera_platform_interface/lib/camera_platform_interface.dart
+++ b/packages/camera/camera_platform_interface/lib/camera_platform_interface.dart
@@ -8,4 +8,5 @@ export 'package:cross_file/cross_file.dart';
 export 'src/events/camera_event.dart';
 export 'src/events/device_event.dart';
 export 'src/platform_interface/camera_platform.dart';
+export 'src/types/media_settings.dart';
 export 'src/types/types.dart';

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -85,17 +85,20 @@ class MethodChannelCamera extends CameraPlatform {
 
   @override
   Future<int> createCamera(
-    CameraDescription cameraDescription,
-    ResolutionPreset? resolutionPreset, {
+    CameraDescription cameraDescription, {
+    MediaSettings? mediaSettings,
     bool enableAudio = false,
   }) async {
     try {
       final Map<String, dynamic>? reply = await _channel
           .invokeMapMethod<String, dynamic>('create', <String, dynamic>{
         'cameraName': cameraDescription.name,
-        'resolutionPreset': resolutionPreset != null
-            ? _serializeResolutionPreset(resolutionPreset)
+        'resolutionPreset': null != mediaSettings?.resolutionPreset
+            ? _serializeResolutionPreset(mediaSettings!.resolutionPreset!)
             : null,
+        'fps': mediaSettings?.fps,
+        'videoBitrate': mediaSettings?.videoBitrate,
+        'audioBitrate': mediaSettings?.audioBitrate,
         'enableAudio': enableAudio,
       });
 

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -84,11 +84,10 @@ class MethodChannelCamera extends CameraPlatform {
   }
 
   @override
-  Future<int> createCamera(
-    CameraDescription cameraDescription, {
+  Future<int> createCameraWithSettings(
+    CameraDescription cameraDescription,
     MediaSettings? mediaSettings,
-    bool enableAudio = false,
-  }) async {
+  ) async {
     try {
       final Map<String, dynamic>? reply = await _channel
           .invokeMapMethod<String, dynamic>('create', <String, dynamic>{
@@ -99,7 +98,7 @@ class MethodChannelCamera extends CameraPlatform {
         'fps': mediaSettings?.fps,
         'videoBitrate': mediaSettings?.videoBitrate,
         'audioBitrate': mediaSettings?.audioBitrate,
-        'enableAudio': enableAudio,
+        'enableAudio': mediaSettings?.enableAudio ?? false,
       });
 
       return reply!['cameraId']! as int;

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -47,12 +47,26 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Creates an uninitialized camera instance and returns the cameraId.
+  /// Method will be deprecated. Use [createCameraWithSettings].
   Future<int> createCamera(
-    CameraDescription cameraDescription, {
-    MediaSettings? mediaSettings,
+    CameraDescription cameraDescription,
+    ResolutionPreset? resolutionPreset, {
     bool enableAudio = false,
-  }) {
-    throw UnimplementedError('createCamera() is not implemented.');
+  }) =>
+      createCameraWithSettings(
+        cameraDescription,
+        MediaSettings(
+          resolutionPreset: resolutionPreset,
+          enableAudio: enableAudio,
+        ),
+      );
+
+  /// Creates an uninitialized camera instance and returns the cameraId.
+  Future<int> createCameraWithSettings(
+    CameraDescription cameraDescription,
+    MediaSettings? mediaSettings,
+  ) {
+    throw UnimplementedError('createCameraWithSettings() is not implemented.');
   }
 
   /// Initializes the camera on the device.

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -48,8 +48,8 @@ abstract class CameraPlatform extends PlatformInterface {
 
   /// Creates an uninitialized camera instance and returns the cameraId.
   Future<int> createCamera(
-    CameraDescription cameraDescription,
-    ResolutionPreset? resolutionPreset, {
+    CameraDescription cameraDescription, {
+    MediaSettings? mediaSettings,
     bool enableAudio = false,
   }) {
     throw UnimplementedError('createCamera() is not implemented.');

--- a/packages/camera/camera_platform_interface/lib/src/types/media_settings.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/media_settings.dart
@@ -14,6 +14,7 @@ class MediaSettings {
     this.fps,
     this.videoBitrate,
     this.audioBitrate,
+    this.enableAudio = false,
   });
 
   /// Default low quality factory
@@ -36,6 +37,9 @@ class MediaSettings {
   /// recording audio bitrate
   final int? audioBitrate;
 
+  /// enable audio
+  final bool enableAudio;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -44,16 +48,18 @@ class MediaSettings {
           resolutionPreset == other.resolutionPreset &&
           fps == other.fps &&
           videoBitrate == other.videoBitrate &&
-          audioBitrate == other.audioBitrate;
+          audioBitrate == other.audioBitrate &&
+          enableAudio == other.enableAudio;
 
   @override
   int get hashCode =>
       resolutionPreset.hashCode ^
       fps.hashCode ^
       videoBitrate.hashCode ^
-      audioBitrate.hashCode;
+      audioBitrate.hashCode ^
+      enableAudio.hashCode;
 
   @override
   String toString() =>
-      'MediaSettings{resolutionPreset: $resolutionPreset, fps: $fps, videoBitrate: $videoBitrate, audioBitrate: $audioBitrate}';
+      'MediaSettings{resolutionPreset: $resolutionPreset, fps: $fps, videoBitrate: $videoBitrate, audioBitrate: $audioBitrate, enableAudio: $enableAudio}';
 }

--- a/packages/camera/camera_platform_interface/lib/src/types/media_settings.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/media_settings.dart
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
+
+import 'resolution_preset.dart';
+
+/// recording media settings.
+class MediaSettings {
+  /// constructor
+  const MediaSettings({
+    this.resolutionPreset,
+    this.fps,
+    this.videoBitrate,
+    this.audioBitrate,
+  });
+
+  /// Default low quality factory
+  static MediaSettings low() => const MediaSettings(
+        resolutionPreset: ResolutionPreset.low,
+        fps: 15,
+        videoBitrate: 200000,
+        audioBitrate: 32000,
+      );
+
+  /// resolution preset
+  final ResolutionPreset? resolutionPreset;
+
+  /// camera fps
+  final int? fps;
+
+  /// recording video bitrate
+  final int? videoBitrate;
+
+  /// recording audio bitrate
+  final int? audioBitrate;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MediaSettings &&
+          runtimeType == other.runtimeType &&
+          resolutionPreset == other.resolutionPreset &&
+          fps == other.fps &&
+          videoBitrate == other.videoBitrate &&
+          audioBitrate == other.audioBitrate;
+
+  @override
+  int get hashCode =>
+      resolutionPreset.hashCode ^
+      fps.hashCode ^
+      videoBitrate.hashCode ^
+      audioBitrate.hashCode;
+
+  @override
+  String toString() =>
+      'MediaSettings{resolutionPreset: $resolutionPreset, fps: $fps, videoBitrate: $videoBitrate, audioBitrate: $audioBitrate}';
+}

--- a/packages/camera/camera_platform_interface/lib/src/types/types.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/types.dart
@@ -9,5 +9,6 @@ export 'exposure_mode.dart';
 export 'flash_mode.dart';
 export 'focus_mode.dart';
 export 'image_format_group.dart';
+export 'media_settings.dart';
 export 'resolution_preset.dart';
 export 'video_capture_options.dart';

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.5.0
+version: 2.6.0
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.6.0
+version: 2.5.1
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
+++ b/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
@@ -157,13 +157,13 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.createCamera(
+        () => cameraPlatform.createCameraWithSettings(
           const CameraDescription(
             name: 'back',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          mediaSettings: MediaSettings.low(),
+          MediaSettings.low(),
         ),
         throwsUnimplementedError,
       );

--- a/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
+++ b/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
@@ -163,7 +163,7 @@ void main() {
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          ResolutionPreset.high,
+          mediaSettings: MediaSettings.low(),
         ),
         throwsUnimplementedError,
       );

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -33,12 +33,12 @@ void main() {
         final MethodChannelCamera camera = MethodChannelCamera();
 
         // Act
-        final int cameraId = await camera.createCamera(
+        final int cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
               name: 'Test',
               lensDirection: CameraLensDirection.back,
               sensorOrientation: 0),
-          mediaSettings: MediaSettings.low(),
+          MediaSettings.low(),
         );
 
         // Assert
@@ -74,13 +74,13 @@ void main() {
 
         // Act
         expect(
-          () => camera.createCamera(
+          () => camera.createCameraWithSettings(
             const CameraDescription(
               name: 'Test',
               lensDirection: CameraLensDirection.back,
               sensorOrientation: 0,
             ),
-            mediaSettings: MediaSettings.low(),
+            MediaSettings.low(),
           ),
           throwsA(
             isA<CameraException>()
@@ -108,13 +108,13 @@ void main() {
 
         // Act
         expect(
-          () => camera.createCamera(
+          () => camera.createCameraWithSettings(
             const CameraDescription(
               name: 'Test',
               lensDirection: CameraLensDirection.back,
               sensorOrientation: 0,
             ),
-            mediaSettings: MediaSettings.low(),
+            MediaSettings.low(),
           ),
           throwsA(
             isA<CameraException>()
@@ -170,13 +170,13 @@ void main() {
               'initialize': null
             });
         final MethodChannelCamera camera = MethodChannelCamera();
-        final int cameraId = await camera.createCamera(
+        final int cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          mediaSettings: MediaSettings.low(),
+          MediaSettings.low(),
         );
 
         // Act
@@ -217,13 +217,13 @@ void main() {
             });
 
         final MethodChannelCamera camera = MethodChannelCamera();
-        final int cameraId = await camera.createCamera(
+        final int cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          mediaSettings: MediaSettings.low(),
+          MediaSettings.low(),
         );
         final Future<void> initializeFuture = camera.initializeCamera(cameraId);
         camera.cameraEventStreamController.add(CameraInitializedEvent(
@@ -265,13 +265,13 @@ void main() {
           },
         );
         camera = MethodChannelCamera();
-        cameraId = await camera.createCamera(
+        cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          mediaSettings: MediaSettings.low(),
+          MediaSettings.low(),
         );
         final Future<void> initializeFuture = camera.initializeCamera(cameraId);
         camera.cameraEventStreamController.add(CameraInitializedEvent(
@@ -435,13 +435,13 @@ void main() {
           },
         );
         camera = MethodChannelCamera();
-        cameraId = await camera.createCamera(
+        cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          mediaSettings: MediaSettings.low(),
+          MediaSettings.low(),
         );
         final Future<void> initializeFuture = camera.initializeCamera(cameraId);
         camera.cameraEventStreamController.add(

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -38,7 +38,7 @@ void main() {
               name: 'Test',
               lensDirection: CameraLensDirection.back,
               sensorOrientation: 0),
-          ResolutionPreset.high,
+          mediaSettings: MediaSettings.low(),
         );
 
         // Assert
@@ -47,7 +47,10 @@ void main() {
             'create',
             arguments: <String, Object?>{
               'cameraName': 'Test',
-              'resolutionPreset': 'high',
+              'resolutionPreset': 'low',
+              'fps': 15,
+              'videoBitrate': 200000,
+              'audioBitrate': 32000,
               'enableAudio': false
             },
           ),
@@ -77,7 +80,7 @@ void main() {
               lensDirection: CameraLensDirection.back,
               sensorOrientation: 0,
             ),
-            ResolutionPreset.high,
+            mediaSettings: MediaSettings.low(),
           ),
           throwsA(
             isA<CameraException>()
@@ -111,7 +114,7 @@ void main() {
               lensDirection: CameraLensDirection.back,
               sensorOrientation: 0,
             ),
-            ResolutionPreset.high,
+            mediaSettings: MediaSettings.low(),
           ),
           throwsA(
             isA<CameraException>()
@@ -173,7 +176,7 @@ void main() {
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          ResolutionPreset.high,
+          mediaSettings: MediaSettings.low(),
         );
 
         // Act
@@ -220,7 +223,7 @@ void main() {
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          ResolutionPreset.high,
+          mediaSettings: MediaSettings.low(),
         );
         final Future<void> initializeFuture = camera.initializeCamera(cameraId);
         camera.cameraEventStreamController.add(CameraInitializedEvent(
@@ -268,7 +271,7 @@ void main() {
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          ResolutionPreset.high,
+          mediaSettings: MediaSettings.low(),
         );
         final Future<void> initializeFuture = camera.initializeCamera(cameraId);
         camera.cameraEventStreamController.add(CameraInitializedEvent(
@@ -438,7 +441,7 @@ void main() {
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          ResolutionPreset.high,
+          mediaSettings: MediaSettings.low(),
         );
         final Future<void> initializeFuture = camera.initializeCamera(cameraId);
         camera.cameraEventStreamController.add(


### PR DESCRIPTION
`{MediaSettings? mediaSettings}` are introduced  to manage fps and bitrate of recorded video. Previously used `ResolutionPreset?` is encapsulated into `MediaSettings`.

This is not breaking changing PR adds new method to `CameraPlatform`:
```dart
createCameraWithSettings(
    CameraDescription cameraDescription,
    MediaSettings? mediaSettings,
  )
```

This is first of splitted PRs.