### PR TITLE
[go_router] Migrate tests away from old handlePlatformMessage

### DIFF
--- a/packages/go_router/example/test/path_and_query_params_test.dart
+++ b/packages/go_router/example/test/path_and_query_params_test.dart
@@ -18,7 +18,7 @@ void main() {
     ByteData message = const JSONMethodCodec().encodeMethodCall(
       MethodCall('pushRouteInformation', testRouteInformation),
     );
-    await ServicesBinding.instance.defaultBinaryMessenger
+    await tester.binding.defaultBinaryMessenger
         .handlePlatformMessage('flutter/navigation', message, (_) {});
 
     await tester.pumpAndSettle();
@@ -34,7 +34,7 @@ void main() {
     message = const JSONMethodCodec().encodeMethodCall(
       MethodCall('pushRouteInformation', testRouteInformation),
     );
-    await ServicesBinding.instance.defaultBinaryMessenger
+    await tester.binding.defaultBinaryMessenger
         .handlePlatformMessage('flutter/navigation', message, (_) {});
 
     await tester.pumpAndSettle();

--- a/packages/go_router/example/test/redirection_test.dart
+++ b/packages/go_router/example/test/redirection_test.dart
@@ -19,7 +19,7 @@ void main() {
     ByteData message = const JSONMethodCodec().encodeMethodCall(
       MethodCall('pushRouteInformation', testRouteInformation),
     );
-    await ServicesBinding.instance.defaultBinaryMessenger
+    await tester.binding.defaultBinaryMessenger
         .handlePlatformMessage('flutter/navigation', message, (_) {});
 
     await tester.pumpAndSettle();
@@ -36,7 +36,7 @@ void main() {
     message = const JSONMethodCodec().encodeMethodCall(
       MethodCall('pushRouteInformation', testRouteInformation),
     );
-    await ServicesBinding.instance.defaultBinaryMessenger
+    await tester.binding.defaultBinaryMessenger
         .handlePlatformMessage('flutter/navigation', message, (_) {});
 
     await tester.pumpAndSettle();

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -28,7 +28,7 @@ Future<void> sendPlatformUrl(String url) async {
   final ByteData message = const JSONMethodCodec().encodeMethodCall(
     MethodCall('pushRouteInformation', testRouteInformation),
   );
-  await ServicesBinding.instance.defaultBinaryMessenger
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .handlePlatformMessage('flutter/navigation', message, (_) {});
 }
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -21,14 +21,14 @@ import 'test_helpers.dart';
 const bool enableLogs = false;
 final Logger log = Logger('GoRouter tests');
 
-Future<void> sendPlatformUrl(String url) async {
+Future<void> sendPlatformUrl(String url, WidgetTester tester) async {
   final Map<String, dynamic> testRouteInformation = <String, dynamic>{
     'location': url,
   };
   final ByteData message = const JSONMethodCodec().encodeMethodCall(
     MethodCall('pushRouteInformation', testRouteInformation),
   );
-  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+  await tester.binding.defaultBinaryMessenger
       .handlePlatformMessage('flutter/navigation', message, (_) {});
 }
 
@@ -1495,7 +1495,7 @@ void main() {
 
       redirected = false;
       // Directly set the url through platform message.
-      await sendPlatformUrl('/dummy');
+      await sendPlatformUrl('/dummy', tester);
 
       await tester.pumpAndSettle();
       expect(router.location, '/login');
@@ -1528,7 +1528,7 @@ void main() {
 
       expect(router.location, '/');
       // Directly set the url through platform message.
-      await sendPlatformUrl('/dummy');
+      await sendPlatformUrl('/dummy', tester);
       await tester.pumpAndSettle();
       expect(router.location, '/dummy');
     });
@@ -1631,7 +1631,7 @@ void main() {
       });
       redirected = false;
       // Directly set the url through platform message.
-      await sendPlatformUrl('/dummy');
+      await sendPlatformUrl('/dummy', tester);
 
       await tester.pumpAndSettle();
       expect(router.location, '/login');
@@ -2024,7 +2024,7 @@ void main() {
       final GoRouter router = await createRouter(routes, tester);
 
       // Directly set the url through platform message.
-      await sendPlatformUrl('/dummy/dummy2');
+      await sendPlatformUrl('/dummy/dummy2', tester);
 
       await tester.pumpAndSettle();
       expect(router.location, '/other');


### PR DESCRIPTION
New API has been around for 2-ish years, was introduced in https://github.com/flutter/flutter/commit/5e0cc4cba416866225821c0eaba581ac7c0a712c. Old API is to be deprecated in https://github.com/flutter/flutter/pull/123812.