### PR TITLE
[gsi_interface] Introduces canAccessScopes and userDataEvents.

### DIFF
--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.4.0
 
+* Introduces: `canAccessScopes` method and `userDataEvents` stream.
 * Updates minimum Flutter version to 3.3.
 * Aligns Dart and Flutter SDK constraints.
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.4.0
 
 * Introduces: `canAccessScopes` method and `userDataEvents` stream.
+  * These enable separation of Authentication and Authorization, and asynchronous
+    sign-in operations where needed (on the web, for example!)
 * Updates minimum Flutter version to 3.3.
 * Aligns Dart and Flutter SDK constraints.
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
@@ -139,4 +139,22 @@ abstract class GoogleSignInPlatform extends PlatformInterface {
   Future<bool> requestScopes(List<String> scopes) async {
     throw UnimplementedError('requestScopes() has not been implmented.');
   }
+
+  /// Determines if the current user can access all [scopes].
+  ///
+  /// Optionally, an [accessToken] can be passed for applications where a
+  /// long-lived token may be cached (like the web).
+  Future<bool> canAccessScopes(
+    List<String> scopes, {
+    String? accessToken,
+  }) async {
+    return isSignedIn();
+  }
+
+  /// Returns a stream of [GoogleSignInUserData] authentication events.
+  ///
+  /// These will normally come from asynchronous flows, like the Google Sign-In
+  /// Button Widget from the Web implementation, and will be funneled directly
+  /// to the `onCurrentUserChanged` Stream of the plugin.
+  Stream<GoogleSignInUserData?>? get userDataEvents => null;
 }

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
@@ -137,7 +137,7 @@ abstract class GoogleSignInPlatform extends PlatformInterface {
   /// Scopes should come from the full  list
   /// [here](https://developers.google.com/identity/protocols/googlescopes).
   Future<bool> requestScopes(List<String> scopes) async {
-    throw UnimplementedError('requestScopes() has not been implmented.');
+    throw UnimplementedError('requestScopes() has not been implemented.');
   }
 
   /// Determines if the current user can access all [scopes].
@@ -148,7 +148,7 @@ abstract class GoogleSignInPlatform extends PlatformInterface {
     List<String> scopes, {
     String? accessToken,
   }) async {
-    throw UnimplementedError('canAccessScopes() has not been implmented.');
+    throw UnimplementedError('canAccessScopes() has not been implemented.');
   }
 
   /// Returns a stream of [GoogleSignInUserData] authentication events.

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
@@ -148,7 +148,7 @@ abstract class GoogleSignInPlatform extends PlatformInterface {
     List<String> scopes, {
     String? accessToken,
   }) async {
-    return isSignedIn();
+    throw UnimplementedError('canAccessScopes() has not been implmented.');
   }
 
   /// Returns a stream of [GoogleSignInUserData] authentication events.

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_sign_i
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.2
+version: 2.4.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_sign_i
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.1
+version: 2.3.2
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/google_sign_in/google_sign_in_platform_interface/test/method_channel_google_sign_in_test.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/test/method_channel_google_sign_in_test.dart
@@ -141,19 +141,11 @@ void main() {
       expect(log, tests.values);
     });
 
-    test('canAccessScopes is the same as isSignedIn', () async {
-      await googleSignIn.canAccessScopes(<String>['someScope']);
-      expect(log, <Matcher>[
-        isMethodCall('isSignedIn', arguments: null),
-      ]);
-    });
-
-    test('canAccessScopes can accept an optional accessToken', () async {
-      await googleSignIn
-          .canAccessScopes(<String>['someScope'], accessToken: 'token');
-      expect(log, <Matcher>[
-        isMethodCall('isSignedIn', arguments: null),
-      ]);
+    test('canAccessScopes is unimplemented', () async {
+      expect(() async {
+        await googleSignIn
+            .canAccessScopes(<String>['someScope'], accessToken: 'token');
+      }, throwsUnimplementedError);
     });
 
     test('userDataEvents returns null', () async {

--- a/packages/google_sign_in/google_sign_in_platform_interface/test/method_channel_google_sign_in_test.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/test/method_channel_google_sign_in_test.dart
@@ -141,6 +141,25 @@ void main() {
       expect(log, tests.values);
     });
 
+    test('canAccessScopes is the same as isSignedIn', () async {
+      await googleSignIn.canAccessScopes(<String>['someScope']);
+      expect(log, <Matcher>[
+        isMethodCall('isSignedIn', arguments: null),
+      ]);
+    });
+
+    test('canAccessScopes can accept an optional accessToken', () async {
+      await googleSignIn
+          .canAccessScopes(<String>['someScope'], accessToken: 'token');
+      expect(log, <Matcher>[
+        isMethodCall('isSignedIn', arguments: null),
+      ]);
+    });
+
+    test('userDataEvents returns null', () async {
+      expect(googleSignIn.userDataEvents, isNull);
+    });
+
     test('initWithParams passes through arguments to the channel', () async {
       await googleSignIn.initWithParams(const SignInInitParameters(
           hostedDomain: 'example.com',


### PR DESCRIPTION
Introduces: `canAccessScopes` method and `userDataEvents` stream to the platform_interface of the google_sign_in plugin.

Default implementations:

* canAccessScopes => throw not implemented.
* userDataEvents => null (currently user data events cannot be introduced asynchronously from the native side)

The changes above enable the separation of Authentication and Authorization, and asynchronous sign-in operations as needed (the web needs this now).

## Issues

* Starts landing: https://github.com/flutter/packages/pull/3461
* Enables fixing: https://github.com/flutter/flutter/issues/121781
  * Enables fixing: https://github.com/flutter/flutter/issues/121275

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
