### PR TITLE
[webview_flutter_platform_interface] Adds platform interface for onHttpError callback

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Updates minimum Flutter version to 3.3.
 * Fixes common typos in tests and documentation.
-* Adds platform interface for onHttpError callback
+* Adds support for listening to HTTP errors. See
+  `PlatformNavigationDelegate.setOnHttpError`.
 
 ## 2.1.0
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Updates minimum Flutter version to 3.3.
 * Fixes common typos in tests and documentation.
+* Adds platform interface for onHttpError callback
 
 ## 2.1.0
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.2.0
 
 * Updates minimum Flutter version to 3.3.
 * Fixes common typos in tests and documentation.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
@@ -19,6 +19,9 @@ typedef PageEventCallback = void Function(String url);
 /// Signature for callbacks that report loading progress of a page.
 typedef ProgressCallback = void Function(int progress);
 
+/// Signature for callbacks that report http errors during loading a page.
+typedef HttpResponseErrorCallback = void Function(HttpResponseError error);
+
 /// Signature for callbacks that report a resource loading error.
 typedef WebResourceErrorCallback = void Function(WebResourceError error);
 
@@ -88,6 +91,16 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
   ) {
     throw UnimplementedError(
         'setOnPageFinished is not implemented on the current platform.');
+  }
+
+  /// Invoked when an error has occurred during loading.
+  ///
+  /// See [PlatformWebViewController.setPlatformNavigationDelegate].
+  Future<void> setOnHttpError(
+    HttpResponseErrorCallback onHttpError,
+  ) {
+    throw UnimplementedError(
+        'setOnHttpError is not implemented on the current platform.');
   }
 
   /// Invoked when a page is loading to report the progress.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
@@ -93,7 +93,7 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
         'setOnPageFinished is not implemented on the current platform.');
   }
 
-  /// Invoked when an error has occurred during loading.
+  /// Invoked when an HTTP error has occurred during loading.
   ///
   /// See [PlatformWebViewController.setPlatformNavigationDelegate].
   Future<void> setOnHttpError(

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/http_response_error.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/http_response_error.dart
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+/// Error returned in `PlatformNavigationDelegate.setOnHttpError` when an HTTP
+/// response error has been received.
+/// 
+/// Platform specific implementations can add additional fields by extending
+/// this class.
+///
+/// This example demonstrates how to extend the [HttpResponseError] to
+/// provide additional platform specific parameters.
+///
+/// When extending [HttpResponseError] additional parameters should always
+/// accept `null` or have a default value to prevent breaking changes.
+///
+/// ```dart
+/// class IOSHttpResponseError extends HttpResponseError {
+///   IOSHttpResponseError._(HttpResponseError error, {required this.domain})
+///       : super(
+///           statusCode: error.statusCode,
+///         );
+///
+///   factory IOSHttpResponseError.fromHttpResponseError(
+///     HttpResponseError error, {
+///     required String? domain,
+///   }) {
+///     return IOSHttpResponseError._(error, domain: domain);
+///   }
+///
+///   final String? domain;
+/// }
+/// ```
+@immutable
+class HttpResponseError {
+  /// Used by the platform implementation to create a new [HttpResponseError].
+  const HttpResponseError({
+    required this.statusCode,
+  });
+
+  /// The HTTP status code.
+  final int statusCode;
+}

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/http_response_error.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/http_response_error.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 
 /// Error returned in `PlatformNavigationDelegate.setOnHttpError` when an HTTP
 /// response error has been received.
-/// 
+///
 /// Platform specific implementations can add additional fields by extending
 /// this class.
 ///

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/types.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/types.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'http_response_error.dart';
 export 'javascript_message.dart';
 export 'javascript_mode.dart';
 export 'load_request_params.dart';

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/webview_flutt
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.0
+version: 2.2.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_navigation_delegate_test.dart
@@ -91,6 +91,20 @@ void main() {
   });
 
   test(
+      'Default implementation of setOnHttpError should throw unimplemented error',
+      () {
+    final PlatformNavigationDelegate callbackDelegate =
+        ExtendsPlatformNavigationDelegate(
+            const PlatformNavigationDelegateCreationParams());
+
+    expect(
+      () => callbackDelegate.setOnHttpError((HttpResponseError error) {}),
+      throwsUnimplementedError,
+    );
+  });
+
+  test(
+      // ignore: lines_longer_than_80_chars
       'Default implementation of setOnProgress should throw unimplemented error',
       () {
     final PlatformNavigationDelegate callbackDelegate =

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_webview_controller_test.mocks.dart
@@ -83,6 +83,16 @@ class MockPlatformNavigationDelegate extends _i1.Mock
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
+  _i4.Future<void> setOnHttpError(_i3.HttpResponseErrorCallback? onHttpError) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setOnHttpError,
+          [onHttpError],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
   _i4.Future<void> setOnProgress(_i3.ProgressCallback? onProgress) =>
       (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
Reference https://github.com/flutter/packages/pull/3278.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
