### PR TITLE
[tools] adds 'android' alias for build-example script

### DIFF
--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -39,6 +39,8 @@ const String _flutterBuildTypeMacOS = 'macos';
 const String _flutterBuildTypeWeb = 'web';
 const String _flutterBuildTypeWindows = 'windows';
 
+const String _flutterBuildTypeAndroidAlias = 'android';
+
 /// A command to build the example applications for packages.
 class BuildExamplesCommand extends PackageLoopingCommand {
   /// Creates an instance of the build command.
@@ -52,7 +54,8 @@ class BuildExamplesCommand extends PackageLoopingCommand {
     argParser.addFlag(platformWeb);
     argParser.addFlag(platformWindows);
     argParser.addFlag(platformIOS);
-    argParser.addFlag(_platformFlagApk);
+    argParser.addFlag(_platformFlagApk,
+        aliases: const <String>[_flutterBuildTypeAndroidAlias]);
     argParser.addOption(
       kEnableExperiment,
       defaultsTo: '',

--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -13,6 +13,9 @@ typedef Print = void Function(Object? object);
 /// Key for APK (Android) platform.
 const String platformAndroid = 'android';
 
+/// Alias for APK (Android) platform.
+const String platformAndroidAlias = 'apk';
+
 /// Key for IPA (iOS) platform.
 const String platformIOS = 'ios';
 

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -26,7 +26,8 @@ class DriveExamplesCommand extends PackageLoopingCommand {
     Platform platform = const LocalPlatform(),
   }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addFlag(platformAndroid,
-        help: 'Runs the Android implementation of the examples');
+        help: 'Runs the Android implementation of the examples',
+        aliases: const <String>[platformAndroidAlias]);
     argParser.addFlag(platformIOS,
         help: 'Runs the iOS implementation of the examples');
     argParser.addFlag(platformLinux,

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -408,6 +408,34 @@ void main() {
           ]));
     });
 
+    test('building for Android with alias', () async {
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
+          platformSupport: <String, PlatformDetails>{
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
+          });
+
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'build-examples',
+        '--android',
+      ]);
+
+      expect(
+        output,
+        containsAllInOrder(<String>[
+          '\nBUILDING plugin/example for Android (apk)',
+        ]),
+      );
+
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(getFlutterCommand(mockPlatform),
+                const <String>['build', 'apk'], pluginExampleDirectory.path),
+          ]));
+    });
+
     test('enable-experiment flag for Android', () async {
       final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -805,6 +805,56 @@ void main() {
           ]));
     });
 
+    test('driving on an Android plugin with alias', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test_driver/plugin.dart',
+          'example/android/android.java',
+        ],
+        platformSupport: <String, PlatformDetails>{
+          platformAndroid: const PlatformDetails(PlatformSupport.inline),
+        },
+      );
+
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
+
+      setMockFlutterDevicesOutput();
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--apk',
+      ]);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
+          contains('No issues found!'),
+        ]),
+      );
+
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(getFlutterCommand(mockPlatform),
+                const <String>['devices', '--machine'], null),
+            ProcessCall(
+                getFlutterCommand(mockPlatform),
+                const <String>[
+                  'drive',
+                  '-d',
+                  _fakeAndroidDevice,
+                  '--driver',
+                  'test_driver/plugin_test.dart',
+                  '--target',
+                  'test_driver/plugin.dart'
+                ],
+                pluginExampleDirectory.path),
+          ]));
+    });
+
     test('driving when plugin does not support Android is no-op', () async {
       createFakePlugin(
         'plugin',


### PR DESCRIPTION
I keep adding the wrong argument for build-example when running tests, so I thought I'd add it as an alias. I'm sure other people run into this as well, since the argument naming is inconsistent from one command to another as well as between platforms.
