### PR TITLE
[pigeon]fix "as Any" workaround due to nested optional

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,5 +1,10 @@
-## NEXT
+## 10.0.0
 
+* [swift] Avoids using `Any` to represent `Optional` in Swift.
+* [swift] **Breaking Change** A raw `List` (without generic type argument) in Dart will be 
+  translated into `[Any?]` (rather than `[Any]`) in Swift.
+* [swift] **Breaking Change** A raw `Map` (without generic type argument) in Dart will be 
+  translated into `[AnyHashable:Any?]` (rather than `[AnyHashable:Any]`) in Swift. 
 * Adds an example application that uses Pigeon directly, rather than in a plugin.
 
 ## 9.2.5

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -11,7 +11,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '9.2.5';
+const String pigeonVersion = '10.0.0';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/swift_generator.dart
+++ b/packages/pigeon/lib/swift_generator.dart
@@ -169,7 +169,7 @@ import FlutterMacOS
     Set<String> customEnumNames,
   ) {
     final String className = klass.name;
-    indent.write('static func fromList(_ list: [Any]) -> $className? ');
+    indent.write('static func fromList(_ list: [Any?]) -> $className? ');
 
     indent.addScoped('{', '}', () {
       enumerate(getFieldsInSerializationOrder(klass),
@@ -524,7 +524,7 @@ import FlutterMacOS
               indent.writeln('case ${customClass.enumeration}:');
               indent.nest(1, () {
                 indent.writeln(
-                    'return ${customClass.name}.fromList(self.readValue() as! [Any])');
+                    'return ${customClass.name}.fromList(self.readValue() as! [Any?])');
               });
             }
             indent.writeln('default:');
@@ -628,7 +628,7 @@ import FlutterMacOS
       if (listEncodedClassNames != null &&
           listEncodedClassNames.contains(type.baseName)) {
         indent.writeln('var $variableName: $fieldType? = nil');
-        indent.write('if let ${variableName}List = $value as! [Any]? ');
+        indent.write('if let ${variableName}List = $value as! [Any?]? ');
         indent.addScoped('{', '}', () {
           indent.writeln(
               '$variableName = $fieldType.fromList(${variableName}List)');
@@ -652,7 +652,7 @@ import FlutterMacOS
       if (listEncodedClassNames != null &&
           listEncodedClassNames.contains(type.baseName)) {
         indent.writeln(
-            'let $variableName = $fieldType.fromList($value as! [Any])!');
+            'let $variableName = $fieldType.fromList($value as! [Any?])!');
       } else {
         indent.writeln(
             'let $variableName = ${castForceUnwrap(value, type, root)}');
@@ -695,7 +695,7 @@ import FlutterMacOS
 
 private func nilOrValue<T>(_ value: Any?) -> T? {
   if value is NSNull { return nil }
-  return (value as Any) as! T?
+  return value as! T?
 }''');
   }
 

--- a/packages/pigeon/lib/swift_generator.dart
+++ b/packages/pigeon/lib/swift_generator.dart
@@ -431,7 +431,7 @@ import FlutterMacOS
             indent.addScoped('{ $messageVarName, reply in', '}', () {
               final List<String> methodArgument = <String>[];
               if (components.arguments.isNotEmpty) {
-                indent.writeln('let args = message as! [Any]');
+                indent.writeln('let args = message as! [Any?]');
                 enumerate(components.arguments,
                     (int index, _SwiftFunctionArgument arg) {
                   final String argName =
@@ -605,8 +605,7 @@ import FlutterMacOS
             'nullable enums require special code that this helper does not supply');
         return '${_swiftTypeForDartType(type)}(rawValue: $value as! Int)!';
       } else if (type.baseName == 'Object') {
-        // Special-cased to avoid warnings about using 'as' with Any.
-        return value;
+        return value + (type.isNullable ? '' : '!');
       } else if (type.baseName == 'int') {
         if (type.isNullable) {
           // Nullable ints need to check for NSNull, and Int32 before casting can be done safely.
@@ -739,9 +738,9 @@ String _flattenTypeArguments(List<TypeDeclaration> args) {
 String _swiftTypeForBuiltinGenericDartType(TypeDeclaration type) {
   if (type.typeArguments.isEmpty) {
     if (type.baseName == 'List') {
-      return '[Any]';
+      return '[Any?]';
     } else if (type.baseName == 'Map') {
-      return '[AnyHashable: Any]';
+      return '[AnyHashable: Any?]';
     } else {
       return 'Any';
     }

--- a/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/EchoBinaryMessenger.swift
+++ b/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/EchoBinaryMessenger.swift
@@ -28,13 +28,14 @@ class EchoBinaryMessenger: NSObject, FlutterBinaryMessenger {
     
     guard
       let args = self.codec.decode(message) as? [Any?],
-      let firstArg: Any? = nilOrValue(args.first)
+      let firstArg = args.first,
+      let castedFirstArg: Any? = nilOrValue(firstArg)
     else {
       callback(self.defaultReturn.flatMap { self.codec.encode($0) })
       return
     }
     
-    callback(self.codec.encode(firstArg))
+    callback(self.codec.encode(castedFirstArg))
   }
   
   func setMessageHandlerOnChannel(

--- a/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/PrimitiveTests.swift
+++ b/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/PrimitiveTests.swift
@@ -11,8 +11,8 @@ class MockPrimitiveHostApi: PrimitiveHostApi {
   func aBool(value: Bool) -> Bool { value }
   func aString(value: String) -> String { value  }
   func aDouble(value: Double) -> Double { value }
-  func aMap(value: [AnyHashable: Any]) -> [AnyHashable: Any] { value }
-  func aList(value: [Any]) -> [Any] { value }
+  func aMap(value: [AnyHashable: Any?]) -> [AnyHashable: Any?] { value }
+  func aList(value: [Any?]) -> [Any?] { value }
   func anInt32List(value: FlutterStandardTypedData) -> FlutterStandardTypedData { value }
   func aBoolList(value: [Bool?]) -> [Bool?] { value }
   func aStringIntMap(value: [String?: Int64?]) -> [String?: Int64?] { value }

--- a/packages/pigeon/platform_tests/test_plugin/ios/Classes/CoreTests.gen.swift
+++ b/packages/pigeon/platform_tests/test_plugin/ios/Classes/CoreTests.gen.swift
@@ -54,8 +54,8 @@ struct AllTypes {
   var a4ByteArray: FlutterStandardTypedData
   var a8ByteArray: FlutterStandardTypedData
   var aFloatArray: FlutterStandardTypedData
-  var aList: [Any]
-  var aMap: [AnyHashable: Any]
+  var aList: [Any?]
+  var aMap: [AnyHashable: Any?]
   var anEnum: AnEnum
   var aString: String
 
@@ -68,8 +68,8 @@ struct AllTypes {
     let a4ByteArray = list[5] as! FlutterStandardTypedData
     let a8ByteArray = list[6] as! FlutterStandardTypedData
     let aFloatArray = list[7] as! FlutterStandardTypedData
-    let aList = list[8] as! [Any]
-    let aMap = list[9] as! [AnyHashable: Any]
+    let aList = list[8] as! [Any?]
+    let aMap = list[9] as! [AnyHashable: Any?]
     let anEnum = AnEnum(rawValue: list[10] as! Int)!
     let aString = list[11] as! String
 
@@ -116,8 +116,8 @@ struct AllNullableTypes {
   var aNullable4ByteArray: FlutterStandardTypedData? = nil
   var aNullable8ByteArray: FlutterStandardTypedData? = nil
   var aNullableFloatArray: FlutterStandardTypedData? = nil
-  var aNullableList: [Any]? = nil
-  var aNullableMap: [AnyHashable: Any]? = nil
+  var aNullableList: [Any?]? = nil
+  var aNullableMap: [AnyHashable: Any?]? = nil
   var nullableNestedList: [[Bool?]?]? = nil
   var nullableMapWithAnnotations: [String?: String?]? = nil
   var nullableMapWithObject: [String?: Any?]? = nil
@@ -133,8 +133,8 @@ struct AllNullableTypes {
     let aNullable4ByteArray: FlutterStandardTypedData? = nilOrValue(list[5])
     let aNullable8ByteArray: FlutterStandardTypedData? = nilOrValue(list[6])
     let aNullableFloatArray: FlutterStandardTypedData? = nilOrValue(list[7])
-    let aNullableList: [Any]? = nilOrValue(list[8])
-    let aNullableMap: [AnyHashable: Any]? = nilOrValue(list[9])
+    let aNullableList: [Any?]? = nilOrValue(list[8])
+    let aNullableMap: [AnyHashable: Any?]? = nilOrValue(list[9])
     let nullableNestedList: [[Bool?]?]? = nilOrValue(list[10])
     let nullableMapWithAnnotations: [String?: String?]? = nilOrValue(list[11])
     let nullableMapWithObject: [String?: Any?]? = nilOrValue(list[12])
@@ -206,10 +206,10 @@ struct AllNullableTypesWrapper {
 ///
 /// Generated class from Pigeon that represents data sent in messages.
 struct TestMessage {
-  var testList: [Any]? = nil
+  var testList: [Any?]? = nil
 
   static func fromList(_ list: [Any?]) -> TestMessage? {
-    let testList: [Any]? = nilOrValue(list[0])
+    let testList: [Any?]? = nilOrValue(list[0])
 
     return TestMessage(
       testList: testList
@@ -422,7 +422,7 @@ class HostIntegrationCoreApiSetup {
     let echoAllTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAllTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAllTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg = args[0] as! AllTypes
         do {
           let result = try api.echo(everythingArg)
@@ -480,7 +480,7 @@ class HostIntegrationCoreApiSetup {
     let echoIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
         do {
           let result = try api.echo(anIntArg)
@@ -496,7 +496,7 @@ class HostIntegrationCoreApiSetup {
     let echoDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg = args[0] as! Double
         do {
           let result = try api.echo(aDoubleArg)
@@ -512,7 +512,7 @@ class HostIntegrationCoreApiSetup {
     let echoBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg = args[0] as! Bool
         do {
           let result = try api.echo(aBoolArg)
@@ -528,7 +528,7 @@ class HostIntegrationCoreApiSetup {
     let echoStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg = args[0] as! String
         do {
           let result = try api.echo(aStringArg)
@@ -544,7 +544,7 @@ class HostIntegrationCoreApiSetup {
     let echoUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aUint8ListArg = args[0] as! FlutterStandardTypedData
         do {
           let result = try api.echo(aUint8ListArg)
@@ -560,8 +560,8 @@ class HostIntegrationCoreApiSetup {
     let echoObjectChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoObject", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoObjectChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
-        let anObjectArg = args[0]
+        let args = message as! [Any?]
+        let anObjectArg = args[0]!
         do {
           let result = try api.echo(anObjectArg)
           reply(wrapResult(result))
@@ -576,7 +576,7 @@ class HostIntegrationCoreApiSetup {
     let echoListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg = args[0] as! [Any?]
         do {
           let result = try api.echo(aListArg)
@@ -592,7 +592,7 @@ class HostIntegrationCoreApiSetup {
     let echoMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg = args[0] as! [String?: Any?]
         do {
           let result = try api.echo(aMapArg)
@@ -608,7 +608,7 @@ class HostIntegrationCoreApiSetup {
     let echoAllNullableTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAllNullableTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAllNullableTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg: AllNullableTypes? = nilOrValue(args[0])
         do {
           let result = try api.echo(everythingArg)
@@ -625,7 +625,7 @@ class HostIntegrationCoreApiSetup {
     let extractNestedNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.extractNestedNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       extractNestedNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let wrapperArg = args[0] as! AllNullableTypesWrapper
         do {
           let result = try api.extractNestedNullableString(from: wrapperArg)
@@ -642,7 +642,7 @@ class HostIntegrationCoreApiSetup {
     let createNestedNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.createNestedNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       createNestedNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let nullableStringArg: String? = nilOrValue(args[0])
         do {
           let result = try api.createNestedObject(with: nullableStringArg)
@@ -658,7 +658,7 @@ class HostIntegrationCoreApiSetup {
     let sendMultipleNullableTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.sendMultipleNullableTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       sendMultipleNullableTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableBoolArg: Bool? = nilOrValue(args[0])
         let aNullableIntArg: Int64? = args[1] is NSNull ? nil : (args[1] is Int64? ? args[1] as! Int64? : Int64(args[1] as! Int32))
         let aNullableStringArg: String? = nilOrValue(args[2])
@@ -676,7 +676,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableIntArg: Int64? = args[0] is NSNull ? nil : (args[0] is Int64? ? args[0] as! Int64? : Int64(args[0] as! Int32))
         do {
           let result = try api.echo(aNullableIntArg)
@@ -692,7 +692,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableDoubleArg: Double? = nilOrValue(args[0])
         do {
           let result = try api.echo(aNullableDoubleArg)
@@ -708,7 +708,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableBoolArg: Bool? = nilOrValue(args[0])
         do {
           let result = try api.echo(aNullableBoolArg)
@@ -724,7 +724,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableStringArg: String? = nilOrValue(args[0])
         do {
           let result = try api.echo(aNullableStringArg)
@@ -740,7 +740,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableUint8ListArg: FlutterStandardTypedData? = nilOrValue(args[0])
         do {
           let result = try api.echo(aNullableUint8ListArg)
@@ -756,7 +756,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableObjectChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableObject", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableObjectChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableObjectArg: Any? = args[0]
         do {
           let result = try api.echo(aNullableObjectArg)
@@ -772,7 +772,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableListArg: [Any?]? = nilOrValue(args[0])
         do {
           let result = try api.echoNullable(aNullableListArg)
@@ -788,7 +788,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableMapArg: [String?: Any?]? = nilOrValue(args[0])
         do {
           let result = try api.echoNullable(aNullableMapArg)
@@ -821,7 +821,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
         api.echoAsync(anIntArg) { result in
           switch result {
@@ -839,7 +839,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg = args[0] as! Double
         api.echoAsync(aDoubleArg) { result in
           switch result {
@@ -857,7 +857,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg = args[0] as! Bool
         api.echoAsync(aBoolArg) { result in
           switch result {
@@ -875,7 +875,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg = args[0] as! String
         api.echoAsync(aStringArg) { result in
           switch result {
@@ -893,7 +893,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aUint8ListArg = args[0] as! FlutterStandardTypedData
         api.echoAsync(aUint8ListArg) { result in
           switch result {
@@ -911,8 +911,8 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncObjectChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncObject", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncObjectChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
-        let anObjectArg = args[0]
+        let args = message as! [Any?]
+        let anObjectArg = args[0]!
         api.echoAsync(anObjectArg) { result in
           switch result {
             case .success(let res):
@@ -929,7 +929,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg = args[0] as! [Any?]
         api.echoAsync(aListArg) { result in
           switch result {
@@ -947,7 +947,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg = args[0] as! [String?: Any?]
         api.echoAsync(aMapArg) { result in
           switch result {
@@ -1013,7 +1013,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncAllTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncAllTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncAllTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg = args[0] as! AllTypes
         api.echoAsync(everythingArg) { result in
           switch result {
@@ -1031,7 +1031,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableAllNullableTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableAllNullableTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableAllNullableTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg: AllNullableTypes? = nilOrValue(args[0])
         api.echoAsync(everythingArg) { result in
           switch result {
@@ -1049,7 +1049,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg: Int64? = args[0] is NSNull ? nil : (args[0] is Int64? ? args[0] as! Int64? : Int64(args[0] as! Int32))
         api.echoAsyncNullable(anIntArg) { result in
           switch result {
@@ -1067,7 +1067,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg: Double? = nilOrValue(args[0])
         api.echoAsyncNullable(aDoubleArg) { result in
           switch result {
@@ -1085,7 +1085,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg: Bool? = nilOrValue(args[0])
         api.echoAsyncNullable(aBoolArg) { result in
           switch result {
@@ -1103,7 +1103,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg: String? = nilOrValue(args[0])
         api.echoAsyncNullable(aStringArg) { result in
           switch result {
@@ -1121,7 +1121,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aUint8ListArg: FlutterStandardTypedData? = nilOrValue(args[0])
         api.echoAsyncNullable(aUint8ListArg) { result in
           switch result {
@@ -1139,7 +1139,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableObjectChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableObject", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableObjectChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anObjectArg: Any? = args[0]
         api.echoAsyncNullable(anObjectArg) { result in
           switch result {
@@ -1157,7 +1157,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg: [Any?]? = nilOrValue(args[0])
         api.echoAsyncNullable(aListArg) { result in
           switch result {
@@ -1175,7 +1175,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg: [String?: Any?]? = nilOrValue(args[0])
         api.echAsyncoNullable(aMapArg) { result in
           switch result {
@@ -1237,7 +1237,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoAllTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoAllTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoAllTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg = args[0] as! AllTypes
         api.callFlutterEcho(everythingArg) { result in
           switch result {
@@ -1254,7 +1254,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterSendMultipleNullableTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterSendMultipleNullableTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterSendMultipleNullableTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableBoolArg: Bool? = nilOrValue(args[0])
         let aNullableIntArg: Int64? = args[1] is NSNull ? nil : (args[1] is Int64? ? args[1] as! Int64? : Int64(args[1] as! Int32))
         let aNullableStringArg: String? = nilOrValue(args[2])
@@ -1273,7 +1273,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg = args[0] as! Bool
         api.callFlutterEcho(aBoolArg) { result in
           switch result {
@@ -1290,7 +1290,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
         api.callFlutterEcho(anIntArg) { result in
           switch result {
@@ -1307,7 +1307,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg = args[0] as! Double
         api.callFlutterEcho(aDoubleArg) { result in
           switch result {
@@ -1324,7 +1324,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg = args[0] as! String
         api.callFlutterEcho(aStringArg) { result in
           switch result {
@@ -1341,7 +1341,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg = args[0] as! FlutterStandardTypedData
         api.callFlutterEcho(aListArg) { result in
           switch result {
@@ -1358,7 +1358,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg = args[0] as! [Any?]
         api.callFlutterEcho(aListArg) { result in
           switch result {
@@ -1375,7 +1375,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg = args[0] as! [String?: Any?]
         api.callFlutterEcho(aMapArg) { result in
           switch result {
@@ -1392,7 +1392,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg: Bool? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aBoolArg) { result in
           switch result {
@@ -1409,7 +1409,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg: Int64? = args[0] is NSNull ? nil : (args[0] is Int64? ? args[0] as! Int64? : Int64(args[0] as! Int32))
         api.callFlutterEchoNullable(anIntArg) { result in
           switch result {
@@ -1426,7 +1426,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg: Double? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aDoubleArg) { result in
           switch result {
@@ -1443,7 +1443,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg: String? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aStringArg) { result in
           switch result {
@@ -1460,7 +1460,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg: FlutterStandardTypedData? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aListArg) { result in
           switch result {
@@ -1477,7 +1477,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg: [Any?]? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aListArg) { result in
           switch result {
@@ -1494,7 +1494,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg: [String?: Any?]? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aMapArg) { result in
           switch result {
@@ -1794,7 +1794,7 @@ class HostSmallApiSetup {
     let echoChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostSmallApi.echo", binaryMessenger: binaryMessenger)
     if let api = api {
       echoChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg = args[0] as! String
         api.echo(aString: aStringArg) { result in
           switch result {

--- a/packages/pigeon/platform_tests/test_plugin/ios/Classes/CoreTests.gen.swift
+++ b/packages/pigeon/platform_tests/test_plugin/ios/Classes/CoreTests.gen.swift
@@ -35,7 +35,7 @@ private func wrapError(_ error: Any) -> [Any?] {
 
 private func nilOrValue<T>(_ value: Any?) -> T? {
   if value is NSNull { return nil }
-  return (value as Any) as! T?
+  return value as! T?
 }
 
 enum AnEnum: Int {
@@ -59,7 +59,7 @@ struct AllTypes {
   var anEnum: AnEnum
   var aString: String
 
-  static func fromList(_ list: [Any]) -> AllTypes? {
+  static func fromList(_ list: [Any?]) -> AllTypes? {
     let aBool = list[0] as! Bool
     let anInt = list[1] is Int64 ? list[1] as! Int64 : Int64(list[1] as! Int32)
     let anInt64 = list[2] is Int64 ? list[2] as! Int64 : Int64(list[2] as! Int32)
@@ -124,7 +124,7 @@ struct AllNullableTypes {
   var aNullableEnum: AnEnum? = nil
   var aNullableString: String? = nil
 
-  static func fromList(_ list: [Any]) -> AllNullableTypes? {
+  static func fromList(_ list: [Any?]) -> AllNullableTypes? {
     let aNullableBool: Bool? = nilOrValue(list[0])
     let aNullableInt: Int64? = list[1] is NSNull ? nil : (list[1] is Int64? ? list[1] as! Int64? : Int64(list[1] as! Int32))
     let aNullableInt64: Int64? = list[2] is NSNull ? nil : (list[2] is Int64? ? list[2] as! Int64? : Int64(list[2] as! Int32))
@@ -188,8 +188,8 @@ struct AllNullableTypes {
 struct AllNullableTypesWrapper {
   var values: AllNullableTypes
 
-  static func fromList(_ list: [Any]) -> AllNullableTypesWrapper? {
-    let values = AllNullableTypes.fromList(list[0] as! [Any])!
+  static func fromList(_ list: [Any?]) -> AllNullableTypesWrapper? {
+    let values = AllNullableTypes.fromList(list[0] as! [Any?])!
 
     return AllNullableTypesWrapper(
       values: values
@@ -208,7 +208,7 @@ struct AllNullableTypesWrapper {
 struct TestMessage {
   var testList: [Any]? = nil
 
-  static func fromList(_ list: [Any]) -> TestMessage? {
+  static func fromList(_ list: [Any?]) -> TestMessage? {
     let testList: [Any]? = nilOrValue(list[0])
 
     return TestMessage(
@@ -226,13 +226,13 @@ private class HostIntegrationCoreApiCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
       case 128:
-        return AllNullableTypes.fromList(self.readValue() as! [Any])
+        return AllNullableTypes.fromList(self.readValue() as! [Any?])
       case 129:
-        return AllNullableTypesWrapper.fromList(self.readValue() as! [Any])
+        return AllNullableTypesWrapper.fromList(self.readValue() as! [Any?])
       case 130:
-        return AllTypes.fromList(self.readValue() as! [Any])
+        return AllTypes.fromList(self.readValue() as! [Any?])
       case 131:
-        return TestMessage.fromList(self.readValue() as! [Any])
+        return TestMessage.fromList(self.readValue() as! [Any?])
       default:
         return super.readValue(ofType: type)
     }
@@ -1514,13 +1514,13 @@ private class FlutterIntegrationCoreApiCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
       case 128:
-        return AllNullableTypes.fromList(self.readValue() as! [Any])
+        return AllNullableTypes.fromList(self.readValue() as! [Any?])
       case 129:
-        return AllNullableTypesWrapper.fromList(self.readValue() as! [Any])
+        return AllNullableTypesWrapper.fromList(self.readValue() as! [Any?])
       case 130:
-        return AllTypes.fromList(self.readValue() as! [Any])
+        return AllTypes.fromList(self.readValue() as! [Any?])
       case 131:
-        return TestMessage.fromList(self.readValue() as! [Any])
+        return TestMessage.fromList(self.readValue() as! [Any?])
       default:
         return super.readValue(ofType: type)
     }
@@ -1829,7 +1829,7 @@ private class FlutterSmallApiCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
       case 128:
-        return TestMessage.fromList(self.readValue() as! [Any])
+        return TestMessage.fromList(self.readValue() as! [Any?])
       default:
         return super.readValue(ofType: type)
     }

--- a/packages/pigeon/platform_tests/test_plugin/macos/Classes/CoreTests.gen.swift
+++ b/packages/pigeon/platform_tests/test_plugin/macos/Classes/CoreTests.gen.swift
@@ -54,8 +54,8 @@ struct AllTypes {
   var a4ByteArray: FlutterStandardTypedData
   var a8ByteArray: FlutterStandardTypedData
   var aFloatArray: FlutterStandardTypedData
-  var aList: [Any]
-  var aMap: [AnyHashable: Any]
+  var aList: [Any?]
+  var aMap: [AnyHashable: Any?]
   var anEnum: AnEnum
   var aString: String
 
@@ -68,8 +68,8 @@ struct AllTypes {
     let a4ByteArray = list[5] as! FlutterStandardTypedData
     let a8ByteArray = list[6] as! FlutterStandardTypedData
     let aFloatArray = list[7] as! FlutterStandardTypedData
-    let aList = list[8] as! [Any]
-    let aMap = list[9] as! [AnyHashable: Any]
+    let aList = list[8] as! [Any?]
+    let aMap = list[9] as! [AnyHashable: Any?]
     let anEnum = AnEnum(rawValue: list[10] as! Int)!
     let aString = list[11] as! String
 
@@ -116,8 +116,8 @@ struct AllNullableTypes {
   var aNullable4ByteArray: FlutterStandardTypedData? = nil
   var aNullable8ByteArray: FlutterStandardTypedData? = nil
   var aNullableFloatArray: FlutterStandardTypedData? = nil
-  var aNullableList: [Any]? = nil
-  var aNullableMap: [AnyHashable: Any]? = nil
+  var aNullableList: [Any?]? = nil
+  var aNullableMap: [AnyHashable: Any?]? = nil
   var nullableNestedList: [[Bool?]?]? = nil
   var nullableMapWithAnnotations: [String?: String?]? = nil
   var nullableMapWithObject: [String?: Any?]? = nil
@@ -133,8 +133,8 @@ struct AllNullableTypes {
     let aNullable4ByteArray: FlutterStandardTypedData? = nilOrValue(list[5])
     let aNullable8ByteArray: FlutterStandardTypedData? = nilOrValue(list[6])
     let aNullableFloatArray: FlutterStandardTypedData? = nilOrValue(list[7])
-    let aNullableList: [Any]? = nilOrValue(list[8])
-    let aNullableMap: [AnyHashable: Any]? = nilOrValue(list[9])
+    let aNullableList: [Any?]? = nilOrValue(list[8])
+    let aNullableMap: [AnyHashable: Any?]? = nilOrValue(list[9])
     let nullableNestedList: [[Bool?]?]? = nilOrValue(list[10])
     let nullableMapWithAnnotations: [String?: String?]? = nilOrValue(list[11])
     let nullableMapWithObject: [String?: Any?]? = nilOrValue(list[12])
@@ -206,10 +206,10 @@ struct AllNullableTypesWrapper {
 ///
 /// Generated class from Pigeon that represents data sent in messages.
 struct TestMessage {
-  var testList: [Any]? = nil
+  var testList: [Any?]? = nil
 
   static func fromList(_ list: [Any?]) -> TestMessage? {
-    let testList: [Any]? = nilOrValue(list[0])
+    let testList: [Any?]? = nilOrValue(list[0])
 
     return TestMessage(
       testList: testList
@@ -422,7 +422,7 @@ class HostIntegrationCoreApiSetup {
     let echoAllTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAllTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAllTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg = args[0] as! AllTypes
         do {
           let result = try api.echo(everythingArg)
@@ -480,7 +480,7 @@ class HostIntegrationCoreApiSetup {
     let echoIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
         do {
           let result = try api.echo(anIntArg)
@@ -496,7 +496,7 @@ class HostIntegrationCoreApiSetup {
     let echoDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg = args[0] as! Double
         do {
           let result = try api.echo(aDoubleArg)
@@ -512,7 +512,7 @@ class HostIntegrationCoreApiSetup {
     let echoBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg = args[0] as! Bool
         do {
           let result = try api.echo(aBoolArg)
@@ -528,7 +528,7 @@ class HostIntegrationCoreApiSetup {
     let echoStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg = args[0] as! String
         do {
           let result = try api.echo(aStringArg)
@@ -544,7 +544,7 @@ class HostIntegrationCoreApiSetup {
     let echoUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aUint8ListArg = args[0] as! FlutterStandardTypedData
         do {
           let result = try api.echo(aUint8ListArg)
@@ -560,8 +560,8 @@ class HostIntegrationCoreApiSetup {
     let echoObjectChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoObject", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoObjectChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
-        let anObjectArg = args[0]
+        let args = message as! [Any?]
+        let anObjectArg = args[0]!
         do {
           let result = try api.echo(anObjectArg)
           reply(wrapResult(result))
@@ -576,7 +576,7 @@ class HostIntegrationCoreApiSetup {
     let echoListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg = args[0] as! [Any?]
         do {
           let result = try api.echo(aListArg)
@@ -592,7 +592,7 @@ class HostIntegrationCoreApiSetup {
     let echoMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg = args[0] as! [String?: Any?]
         do {
           let result = try api.echo(aMapArg)
@@ -608,7 +608,7 @@ class HostIntegrationCoreApiSetup {
     let echoAllNullableTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAllNullableTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAllNullableTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg: AllNullableTypes? = nilOrValue(args[0])
         do {
           let result = try api.echo(everythingArg)
@@ -625,7 +625,7 @@ class HostIntegrationCoreApiSetup {
     let extractNestedNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.extractNestedNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       extractNestedNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let wrapperArg = args[0] as! AllNullableTypesWrapper
         do {
           let result = try api.extractNestedNullableString(from: wrapperArg)
@@ -642,7 +642,7 @@ class HostIntegrationCoreApiSetup {
     let createNestedNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.createNestedNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       createNestedNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let nullableStringArg: String? = nilOrValue(args[0])
         do {
           let result = try api.createNestedObject(with: nullableStringArg)
@@ -658,7 +658,7 @@ class HostIntegrationCoreApiSetup {
     let sendMultipleNullableTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.sendMultipleNullableTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       sendMultipleNullableTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableBoolArg: Bool? = nilOrValue(args[0])
         let aNullableIntArg: Int64? = args[1] is NSNull ? nil : (args[1] is Int64? ? args[1] as! Int64? : Int64(args[1] as! Int32))
         let aNullableStringArg: String? = nilOrValue(args[2])
@@ -676,7 +676,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableIntArg: Int64? = args[0] is NSNull ? nil : (args[0] is Int64? ? args[0] as! Int64? : Int64(args[0] as! Int32))
         do {
           let result = try api.echo(aNullableIntArg)
@@ -692,7 +692,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableDoubleArg: Double? = nilOrValue(args[0])
         do {
           let result = try api.echo(aNullableDoubleArg)
@@ -708,7 +708,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableBoolArg: Bool? = nilOrValue(args[0])
         do {
           let result = try api.echo(aNullableBoolArg)
@@ -724,7 +724,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableStringArg: String? = nilOrValue(args[0])
         do {
           let result = try api.echo(aNullableStringArg)
@@ -740,7 +740,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableUint8ListArg: FlutterStandardTypedData? = nilOrValue(args[0])
         do {
           let result = try api.echo(aNullableUint8ListArg)
@@ -756,7 +756,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableObjectChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableObject", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableObjectChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableObjectArg: Any? = args[0]
         do {
           let result = try api.echo(aNullableObjectArg)
@@ -772,7 +772,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableListArg: [Any?]? = nilOrValue(args[0])
         do {
           let result = try api.echoNullable(aNullableListArg)
@@ -788,7 +788,7 @@ class HostIntegrationCoreApiSetup {
     let echoNullableMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoNullableMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoNullableMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableMapArg: [String?: Any?]? = nilOrValue(args[0])
         do {
           let result = try api.echoNullable(aNullableMapArg)
@@ -821,7 +821,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
         api.echoAsync(anIntArg) { result in
           switch result {
@@ -839,7 +839,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg = args[0] as! Double
         api.echoAsync(aDoubleArg) { result in
           switch result {
@@ -857,7 +857,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg = args[0] as! Bool
         api.echoAsync(aBoolArg) { result in
           switch result {
@@ -875,7 +875,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg = args[0] as! String
         api.echoAsync(aStringArg) { result in
           switch result {
@@ -893,7 +893,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aUint8ListArg = args[0] as! FlutterStandardTypedData
         api.echoAsync(aUint8ListArg) { result in
           switch result {
@@ -911,8 +911,8 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncObjectChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncObject", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncObjectChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
-        let anObjectArg = args[0]
+        let args = message as! [Any?]
+        let anObjectArg = args[0]!
         api.echoAsync(anObjectArg) { result in
           switch result {
             case .success(let res):
@@ -929,7 +929,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg = args[0] as! [Any?]
         api.echoAsync(aListArg) { result in
           switch result {
@@ -947,7 +947,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg = args[0] as! [String?: Any?]
         api.echoAsync(aMapArg) { result in
           switch result {
@@ -1013,7 +1013,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncAllTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncAllTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncAllTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg = args[0] as! AllTypes
         api.echoAsync(everythingArg) { result in
           switch result {
@@ -1031,7 +1031,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableAllNullableTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableAllNullableTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableAllNullableTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg: AllNullableTypes? = nilOrValue(args[0])
         api.echoAsync(everythingArg) { result in
           switch result {
@@ -1049,7 +1049,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg: Int64? = args[0] is NSNull ? nil : (args[0] is Int64? ? args[0] as! Int64? : Int64(args[0] as! Int32))
         api.echoAsyncNullable(anIntArg) { result in
           switch result {
@@ -1067,7 +1067,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg: Double? = nilOrValue(args[0])
         api.echoAsyncNullable(aDoubleArg) { result in
           switch result {
@@ -1085,7 +1085,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg: Bool? = nilOrValue(args[0])
         api.echoAsyncNullable(aBoolArg) { result in
           switch result {
@@ -1103,7 +1103,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg: String? = nilOrValue(args[0])
         api.echoAsyncNullable(aStringArg) { result in
           switch result {
@@ -1121,7 +1121,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aUint8ListArg: FlutterStandardTypedData? = nilOrValue(args[0])
         api.echoAsyncNullable(aUint8ListArg) { result in
           switch result {
@@ -1139,7 +1139,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableObjectChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableObject", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableObjectChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anObjectArg: Any? = args[0]
         api.echoAsyncNullable(anObjectArg) { result in
           switch result {
@@ -1157,7 +1157,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg: [Any?]? = nilOrValue(args[0])
         api.echoAsyncNullable(aListArg) { result in
           switch result {
@@ -1175,7 +1175,7 @@ class HostIntegrationCoreApiSetup {
     let echoAsyncNullableMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.echoAsyncNullableMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       echoAsyncNullableMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg: [String?: Any?]? = nilOrValue(args[0])
         api.echAsyncoNullable(aMapArg) { result in
           switch result {
@@ -1237,7 +1237,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoAllTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoAllTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoAllTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let everythingArg = args[0] as! AllTypes
         api.callFlutterEcho(everythingArg) { result in
           switch result {
@@ -1254,7 +1254,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterSendMultipleNullableTypesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterSendMultipleNullableTypes", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterSendMultipleNullableTypesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aNullableBoolArg: Bool? = nilOrValue(args[0])
         let aNullableIntArg: Int64? = args[1] is NSNull ? nil : (args[1] is Int64? ? args[1] as! Int64? : Int64(args[1] as! Int32))
         let aNullableStringArg: String? = nilOrValue(args[2])
@@ -1273,7 +1273,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg = args[0] as! Bool
         api.callFlutterEcho(aBoolArg) { result in
           switch result {
@@ -1290,7 +1290,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
         api.callFlutterEcho(anIntArg) { result in
           switch result {
@@ -1307,7 +1307,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg = args[0] as! Double
         api.callFlutterEcho(aDoubleArg) { result in
           switch result {
@@ -1324,7 +1324,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg = args[0] as! String
         api.callFlutterEcho(aStringArg) { result in
           switch result {
@@ -1341,7 +1341,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg = args[0] as! FlutterStandardTypedData
         api.callFlutterEcho(aListArg) { result in
           switch result {
@@ -1358,7 +1358,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg = args[0] as! [Any?]
         api.callFlutterEcho(aListArg) { result in
           switch result {
@@ -1375,7 +1375,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg = args[0] as! [String?: Any?]
         api.callFlutterEcho(aMapArg) { result in
           switch result {
@@ -1392,7 +1392,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableBoolChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableBool", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableBoolChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aBoolArg: Bool? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aBoolArg) { result in
           switch result {
@@ -1409,7 +1409,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableIntChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableInt", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableIntChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let anIntArg: Int64? = args[0] is NSNull ? nil : (args[0] is Int64? ? args[0] as! Int64? : Int64(args[0] as! Int32))
         api.callFlutterEchoNullable(anIntArg) { result in
           switch result {
@@ -1426,7 +1426,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableDoubleChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableDouble", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableDoubleChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aDoubleArg: Double? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aDoubleArg) { result in
           switch result {
@@ -1443,7 +1443,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableStringChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableString", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableStringChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg: String? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aStringArg) { result in
           switch result {
@@ -1460,7 +1460,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableUint8ListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableUint8List", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableUint8ListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg: FlutterStandardTypedData? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aListArg) { result in
           switch result {
@@ -1477,7 +1477,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableListChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableList", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableListChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aListArg: [Any?]? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aListArg) { result in
           switch result {
@@ -1494,7 +1494,7 @@ class HostIntegrationCoreApiSetup {
     let callFlutterEchoNullableMapChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostIntegrationCoreApi.callFlutterEchoNullableMap", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       callFlutterEchoNullableMapChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aMapArg: [String?: Any?]? = nilOrValue(args[0])
         api.callFlutterEchoNullable(aMapArg) { result in
           switch result {
@@ -1794,7 +1794,7 @@ class HostSmallApiSetup {
     let echoChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.HostSmallApi.echo", binaryMessenger: binaryMessenger)
     if let api = api {
       echoChannel.setMessageHandler { message, reply in
-        let args = message as! [Any]
+        let args = message as! [Any?]
         let aStringArg = args[0] as! String
         api.echo(aString: aStringArg) { result in
           switch result {

--- a/packages/pigeon/platform_tests/test_plugin/macos/Classes/CoreTests.gen.swift
+++ b/packages/pigeon/platform_tests/test_plugin/macos/Classes/CoreTests.gen.swift
@@ -35,7 +35,7 @@ private func wrapError(_ error: Any) -> [Any?] {
 
 private func nilOrValue<T>(_ value: Any?) -> T? {
   if value is NSNull { return nil }
-  return (value as Any) as! T?
+  return value as! T?
 }
 
 enum AnEnum: Int {
@@ -59,7 +59,7 @@ struct AllTypes {
   var anEnum: AnEnum
   var aString: String
 
-  static func fromList(_ list: [Any]) -> AllTypes? {
+  static func fromList(_ list: [Any?]) -> AllTypes? {
     let aBool = list[0] as! Bool
     let anInt = list[1] is Int64 ? list[1] as! Int64 : Int64(list[1] as! Int32)
     let anInt64 = list[2] is Int64 ? list[2] as! Int64 : Int64(list[2] as! Int32)
@@ -124,7 +124,7 @@ struct AllNullableTypes {
   var aNullableEnum: AnEnum? = nil
   var aNullableString: String? = nil
 
-  static func fromList(_ list: [Any]) -> AllNullableTypes? {
+  static func fromList(_ list: [Any?]) -> AllNullableTypes? {
     let aNullableBool: Bool? = nilOrValue(list[0])
     let aNullableInt: Int64? = list[1] is NSNull ? nil : (list[1] is Int64? ? list[1] as! Int64? : Int64(list[1] as! Int32))
     let aNullableInt64: Int64? = list[2] is NSNull ? nil : (list[2] is Int64? ? list[2] as! Int64? : Int64(list[2] as! Int32))
@@ -188,8 +188,8 @@ struct AllNullableTypes {
 struct AllNullableTypesWrapper {
   var values: AllNullableTypes
 
-  static func fromList(_ list: [Any]) -> AllNullableTypesWrapper? {
-    let values = AllNullableTypes.fromList(list[0] as! [Any])!
+  static func fromList(_ list: [Any?]) -> AllNullableTypesWrapper? {
+    let values = AllNullableTypes.fromList(list[0] as! [Any?])!
 
     return AllNullableTypesWrapper(
       values: values
@@ -208,7 +208,7 @@ struct AllNullableTypesWrapper {
 struct TestMessage {
   var testList: [Any]? = nil
 
-  static func fromList(_ list: [Any]) -> TestMessage? {
+  static func fromList(_ list: [Any?]) -> TestMessage? {
     let testList: [Any]? = nilOrValue(list[0])
 
     return TestMessage(
@@ -226,13 +226,13 @@ private class HostIntegrationCoreApiCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
       case 128:
-        return AllNullableTypes.fromList(self.readValue() as! [Any])
+        return AllNullableTypes.fromList(self.readValue() as! [Any?])
       case 129:
-        return AllNullableTypesWrapper.fromList(self.readValue() as! [Any])
+        return AllNullableTypesWrapper.fromList(self.readValue() as! [Any?])
       case 130:
-        return AllTypes.fromList(self.readValue() as! [Any])
+        return AllTypes.fromList(self.readValue() as! [Any?])
       case 131:
-        return TestMessage.fromList(self.readValue() as! [Any])
+        return TestMessage.fromList(self.readValue() as! [Any?])
       default:
         return super.readValue(ofType: type)
     }
@@ -1514,13 +1514,13 @@ private class FlutterIntegrationCoreApiCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
       case 128:
-        return AllNullableTypes.fromList(self.readValue() as! [Any])
+        return AllNullableTypes.fromList(self.readValue() as! [Any?])
       case 129:
-        return AllNullableTypesWrapper.fromList(self.readValue() as! [Any])
+        return AllNullableTypesWrapper.fromList(self.readValue() as! [Any?])
       case 130:
-        return AllTypes.fromList(self.readValue() as! [Any])
+        return AllTypes.fromList(self.readValue() as! [Any?])
       case 131:
-        return TestMessage.fromList(self.readValue() as! [Any])
+        return TestMessage.fromList(self.readValue() as! [Any?])
       default:
         return super.readValue(ofType: type)
     }
@@ -1829,7 +1829,7 @@ private class FlutterSmallApiCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
       case 128:
-        return TestMessage.fromList(self.readValue() as! [Any])
+        return TestMessage.fromList(self.readValue() as! [Any?])
       default:
         return super.readValue(ofType: type)
     }

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 9.2.5 # This must match the version in lib/generator_tools.dart
+version: 10.0.0 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/pigeon/test/swift_generator_test.dart
+++ b/packages/pigeon/test/swift_generator_test.dart
@@ -31,7 +31,7 @@ void main() {
     final String code = sink.toString();
     expect(code, contains('struct Foobar'));
     expect(code, contains('var field1: Int64? = nil'));
-    expect(code, contains('static func fromList(_ list: [Any]) -> Foobar?'));
+    expect(code, contains('static func fromList(_ list: [Any?]) -> Foobar?'));
     expect(code, contains('func toList() -> [Any?]'));
   });
 
@@ -392,7 +392,7 @@ void main() {
     generator.generate(swiftOptions, root, sink);
     final String code = sink.toString();
     expect(code, contains('struct Foobar'));
-    expect(code, contains('var field1: [Any]? = nil'));
+    expect(code, contains('var field1: [Any?]? = nil'));
   });
 
   test('gen map', () {
@@ -412,7 +412,7 @@ void main() {
     generator.generate(swiftOptions, root, sink);
     final String code = sink.toString();
     expect(code, contains('struct Foobar'));
-    expect(code, contains('var field1: [AnyHashable: Any]? = nil'));
+    expect(code, contains('var field1: [AnyHashable: Any?]? = nil'));
   });
 
   test('gen nested', () {
@@ -451,7 +451,7 @@ void main() {
     expect(code, contains('struct Outer'));
     expect(code, contains('struct Nested'));
     expect(code, contains('var nested: Nested? = nil'));
-    expect(code, contains('static func fromList(_ list: [Any]) -> Outer?'));
+    expect(code, contains('static func fromList(_ list: [Any?]) -> Outer?'));
     expect(code, contains('nested = Nested.fromList(nestedList)'));
     expect(code, contains('func toList() -> [Any?]'));
   });
@@ -796,7 +796,7 @@ void main() {
     generator.generate(swiftOptions, root, sink);
     final String code = sink.toString();
     expect(code, contains('func add(x: Int64, y: Int64) throws -> Int64'));
-    expect(code, contains('let args = message as! [Any]'));
+    expect(code, contains('let args = message as! [Any?]'));
     expect(
         code,
         contains(


### PR DESCRIPTION
## The problem

This PR fixes a weird casting behavior discussed [here](https://github.com/flutter/packages/pull/3545#discussion_r1155061282): 
```
private func nilOrValue<T>(_ value: Any?) -> T? {
  if value is NSNull { return nil }
  return (value as Any) as! T?  // <- HERE
}
```
Without this intermediate `as Any` cast, [these 3 tests](https://github.com/flutter/packages/blob/5662a7e5799c723f76e9589a75c9d9310e2ba8c1/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/RunnerTests.swift#L10-L29) would crash with `SIGABRT: Could not cast value of type 'Swift.Optional<Any>' (0x7ff865e84b38) to 'Swift.String' (0x7ff865e7de08).`

## Investigation

The crash happens because `value` here is actually of type `Any??` (nested optional!). When it crashes, the debugger simply shows `value` is `nil`. But if we print in `lldb`, the `value` here is actually an inner `Optional.none` case nested by an outer `Optional.some` case. 

### Why does `Any??` crash

Since outer case is `some`, it fails to force cast to `T?` (e.g. `String?`) due to type mismatch. 

### How did we end up with `Any??`

It's related to the signature of these 3 functions: 

- `func toList() -> [Any?]`
- `func fromList(args: [Any])`
- `func nilOrValue<T>(_ value: Any?) -> T?`

Firstly `toList` returns `nil` (of type `Any?`) as the first element of array. Then the type gets coerced as an `Any` type in `fromList`. Then because `nilOrValue` takes `Any?`, this `nil` value gets wrapped by an `Optional.some`. Hence the nested optional. 

## Workarounds

### Workaround 1: `as Any`

This is the current code [in this PR](https://github.com/flutter/packages/pull/3545/files#r1155061282). When casting `Optional.some(nil) as Any`, it erases the outer Optional, so no problem casting to `T?`. 
 
### Workaround 2: 

Handle with nested optional directly: 

```
private func nilOrValue<T>(_ value: Any?) -> T? {
  if value is NSNull { return nil }

  // `if let` deals with "outer some" case and then erase the outer Optional
  if let val = value { 
    // here returns "outer some + inner some" or "outer some + inner none"
    return val as! T?
  }
  // here returns "outer none"
  return nil 
}
```

A similar version of this was also [attempted in this PR](https://github.com/flutter/packages/pull/3545/files/241f0e31e32917f5501dab11f81ab0fbf064687f#diff-bfdb6a91beb03a906435e77e0168117f3f3977ee4d6f8bcaa1724156ae4dc27cR647-R650). It just that we did not know why that worked previously, and now we know! 

### Workaround 3

Casting value to nested optional (`T??`), then stripe the outer optional

```
private func nilOrValue<T>(_ value: Any?) -> T? {
  if value is NSNull { return nil }
  return (value as! T??) ?? nil
}
```

## Solutions

These above workarounds handle nested optionals. However, **a real solution should prevent nested optionals from happening in the first place**, since they are so tricky. 

### Solution 1 (This PR)

The nested optional happens when we do cast from `Any?` to `Any` and then wrapped into `Any?`. (Refer to "How did we end up with Any??" section). 

So the easiest way is just to use `func fromList(args: [Any?])` to match the types of `func toList` and `func nilOrValue`. 

### Solution 2

Solution 2 is the opposite - avoid using `Any?` as much as possible. 

Drawbacks compare to Solution 1: 
a. When inter-op with ObjC, `nullable id` is exported as `Any?`. So we can't 100% prevent `Any?` usage. Though this can be addressed by immediately cast it to `Any`. 
b. Losing of semantic meaning of `Any?` that it <s>can</s> must be optional. The hidden/implicit optional **is** the culprit here in the first place. 
c. While this solution fixes the nested optional issue, it does not address all issues related to implicit optional. For example: 

https://github.com/flutter/packages/blob/c53db71f496b436e48629a8f3e4152c48e63cd66/packages/pigeon/platform_tests/test_plugin/ios/Classes/CoreTests.gen.swift#L563-L564

This is supposed to crash if `args[0]` is `nil`. However, the crash is silenced because `as! [Any]` will make `args[0]` an implicit optional!

The correct codegen should instead be: 
```
let args = message as! [Any?]
let anObjectArg = args[0]!
```

### Solution 3

Just remove `as Any` and update the test. 

The nested optional won't happen in production code, because ObjC `NSArray` contains `NSNull` rather than `nil` when exporting to Swift. 

We can simply fix [the tests](https://github.com/flutter/packages/blob/5662a7e5799c723f76e9589a75c9d9310e2ba8c1/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/RunnerTests.swift#L10-L29) by replacing `nil`s with `NSNull`s. 

However, if we were to re-write engine's codec to Swift, it's actually better practice to use `nil` and not `NSNull` in the array. 

## Additional TODO

We would've caught this earlier if this were an error rather than warning in our unit test. 

![Screenshot 2023-04-06 at 4 15 07 PM](https://user-images.githubusercontent.com/41930132/230510477-1505f830-2fc5-4a4d-858f-e658729fa7bf.png)

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/packages/pull/3545#discussion_r1155061282

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
