### PR TITLE
[go_router]Show ShellRoute's routes in debug log

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.5.6
 
-- Fixed an issue where ShellRoute routes were not logged when debugLogDiagnostic was enabled.
+- Fixes an issue where ShellRoute routes were not logged when debugLogDiagnostic was enabled.
 
 ## 6.5.5
 

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.6
+
+- Fixed an issue where ShellRoute routes were not logged when debugLogDiagnostic was enabled.
+
 ## 6.5.5
 
 - Fixes an issue when popping pageless route would accidentally complete imperative page.

--- a/packages/go_router/example/lib/shell_route.dart
+++ b/packages/go_router/example/lib/shell_route.dart
@@ -31,6 +31,7 @@ class ShellRouteExampleApp extends StatelessWidget {
   final GoRouter _router = GoRouter(
     navigatorKey: _rootNavigatorKey,
     initialLocation: '/a',
+    debugLogDiagnostics: true,
     routes: <RouteBase>[
       /// Application shell
       ShellRoute(

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -172,7 +172,9 @@ class RouteConfiguration {
     return 'RouterConfiguration: $routes';
   }
 
-  /// Returns full paths of all routes and known full paths of route names.
+  /// Returns the full path of [routes].
+  /// A path is prefixed with spaces, depending on the depth of the hierarchy.
+  /// If there are any named routes, they are also appended.
   @visibleForTesting
   String debugKnownRoutes() {
     final StringBuffer sb = StringBuffer();

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -26,7 +26,7 @@ class RouteConfiguration {
         assert(_debugCheckParentNavigatorKeys(
             routes, <GlobalKey<NavigatorState>>[navigatorKey])) {
     _cacheNameToPath('', routes);
-    log.info(_debugKnownRoutes());
+    log.info(debugKnownRoutes());
   }
 
   static bool _debugCheckPath(List<RouteBase> routes, bool isTopLevel) {
@@ -172,7 +172,9 @@ class RouteConfiguration {
     return 'RouterConfiguration: $routes';
   }
 
-  String _debugKnownRoutes() {
+  /// Returns full paths of all routes and known full paths of route names.
+  @visibleForTesting
+  String debugKnownRoutes() {
     final StringBuffer sb = StringBuffer();
     sb.writeln('Full paths for routes:');
     _debugFullPathsFor(routes, '', 0, sb);

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -173,6 +173,7 @@ class RouteConfiguration {
   }
 
   /// Returns the full path of [routes].
+  ///
   /// Each path is indented based depth of the hierarchy, and its `name`
   /// is also appended if not null
   @visibleForTesting

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -194,6 +194,8 @@ class RouteConfiguration {
         final String fullpath = concatenatePaths(parentFullpath, route.path);
         sb.writeln('  => ${''.padLeft(depth * 2)}$fullpath');
         _debugFullPathsFor(route.routes, fullpath, depth + 1, sb);
+      } else if (route is ShellRoute) {
+        _debugFullPathsFor(route.routes, parentFullpath, depth, sb);
       }
     }
   }

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -173,8 +173,8 @@ class RouteConfiguration {
   }
 
   /// Returns the full path of [routes].
-  /// A path is prefixed with spaces, depending on the depth of the hierarchy.
-  /// If there are any named routes, they are also appended.
+  /// Each path is indented based depth of the hierarchy, and its `name`
+  /// is also appended if not null
   @visibleForTesting
   String debugKnownRoutes() {
     final StringBuffer sb = StringBuffer();

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 6.5.5
+version: 6.5.6
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/configuration_test.dart
+++ b/packages/go_router/test/configuration_test.dart
@@ -502,6 +502,77 @@ void main() {
         throwsAssertionError,
       );
     });
+
+    test(
+      'All known route strings returned by debugKnownRoutes are correct',
+      () {
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
+
+        expect(
+          RouteConfiguration(
+            navigatorKey: root,
+            routes: <RouteBase>[
+              GoRoute(
+                path: '/a',
+                parentNavigatorKey: root,
+                builder: _mockScreenBuilder,
+                routes: <RouteBase>[
+                  ShellRoute(
+                    navigatorKey: shell,
+                    builder: _mockShellBuilder,
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: 'b',
+                        parentNavigatorKey: shell,
+                        builder: _mockScreenBuilder,
+                      ),
+                      GoRoute(
+                        path: 'c',
+                        parentNavigatorKey: shell,
+                        builder: _mockScreenBuilder,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              GoRoute(
+                path: '/d',
+                parentNavigatorKey: root,
+                builder: _mockScreenBuilder,
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: 'e',
+                    parentNavigatorKey: root,
+                    builder: _mockScreenBuilder,
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: 'f',
+                        parentNavigatorKey: root,
+                        builder: _mockScreenBuilder,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+            redirectLimit: 10,
+            topRedirect: (BuildContext context, GoRouterState state) {
+              return null;
+            },
+          ).debugKnownRoutes(),
+          'Full paths for routes:\n'
+          '  => /a\n'
+          '  =>   /a/b\n'
+          '  =>   /a/c\n'
+          '  => /d\n'
+          '  =>   /d/e\n'
+          '  =>     /d/e/f\n',
+        );
+      },
+    );
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/113819

Fix ShellRoute's sub routes to log output when `debugLogDiagnostics` is `true`.
In `example/lib/shell_route.dart`, the following log is output.

```
[GoRouter] Full paths for routes:
             => /a
             =>   /a/details
             => /b
             =>   /b/details
             => /c
             =>   /c/details
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
