### PR TITLE
:bug: Fix typo in flutter provider import

### DIFF
--- a/packages/go_router/example/pubspec.yaml
+++ b/packages/go_router/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   go_router:
     path: ..
   logging: ^1.0.0
-  provider: 6.0.5
+  provider: ^6.0.5
   shared_preferences: ^2.0.11
   url_launcher: ^6.0.7
 


### PR DESCRIPTION
Adding the ^ symbol which was missing in provider import : provider: 6.0.5
