### PR TITLE
[google_maps_flutter_web] Allow marker position updates

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.4.0+8
 
 * Updates minimum Flutter version to 3.3.
+* Allows marker position updates. Issue [#83467](https://github.com/flutter/flutter/issues/83467).
 
 ## 0.4.0+7
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/marker_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/marker_test.dart
@@ -100,13 +100,16 @@ void main() {
     testWidgets('update', (WidgetTester tester) async {
       final MarkerController controller = MarkerController(marker: marker);
       final gmaps.MarkerOptions options = gmaps.MarkerOptions()
-        ..draggable = true;
+        ..draggable = true
+        ..position = gmaps.LatLng(42, 54);
 
       expect(marker.draggable, isNull);
 
       controller.update(options);
 
       expect(marker.draggable, isTrue);
+      expect(marker.position?.lat, equals(42));
+      expect(marker.position?.lng, equals(54));
     });
 
     testWidgets('infoWindow null, showInfoWindow.',

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
@@ -55,15 +55,21 @@ void main() {
       expect(
           controller.markers[const MarkerId('1')]?.marker?.draggable, isFalse);
 
-      // Update the marker with radius 10
+      // Update the marker with draggability and position
       final Set<Marker> updatedMarkers = <Marker>{
-        const Marker(markerId: MarkerId('1'), draggable: true),
+        const Marker(
+          markerId: MarkerId('1'),
+          draggable: true,
+          position: LatLng(42, 54),
+        ),
       };
       controller.changeMarkers(updatedMarkers);
 
       expect(controller.markers.length, 1);
-      expect(
-          controller.markers[const MarkerId('1')]?.marker?.draggable, isTrue);
+      final marker = controller.markers[const MarkerId('1')]?.marker;
+      expect(marker?.draggable, isTrue);
+      expect(marker?.position?.lat, equals(42));
+      expect(marker?.position?.lng, equals(54));
     });
 
     testWidgets('removeMarkers', (WidgetTester tester) async {

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
@@ -47,15 +47,19 @@ void main() {
     });
 
     testWidgets('changeMarkers', (WidgetTester tester) async {
+      gmaps.Marker? marker;
+
       final Set<Marker> markers = <Marker>{
         const Marker(markerId: MarkerId('1')),
       };
       controller.addMarkers(markers);
 
-      expect(
-          controller.markers[const MarkerId('1')]?.marker?.draggable, isFalse);
+      marker = controller.markers[const MarkerId('1')]?.marker;
+      expect(marker, isNotNull);
+      expect(marker!.draggable, isFalse);
+      expect(marker.position, isNull);
 
-      // Update the marker with draggability and position
+      // Update the marker with draggable and position
       final Set<Marker> updatedMarkers = <Marker>{
         const Marker(
           markerId: MarkerId('1'),
@@ -64,12 +68,100 @@ void main() {
         ),
       };
       controller.changeMarkers(updatedMarkers);
-
       expect(controller.markers.length, 1);
-      final marker = controller.markers[const MarkerId('1')]?.marker;
-      expect(marker?.draggable, isTrue);
-      expect(marker?.position?.lat, equals(42));
-      expect(marker?.position?.lng, equals(54));
+
+      marker = controller.markers[const MarkerId('1')]?.marker;
+      expect(marker, isNotNull);
+      expect(marker!.draggable, isTrue);
+
+      final gmaps.LatLng? position = marker.position;
+      expect(position, isNotNull);
+      expect(position!.lat, equals(42));
+      expect(position.lng, equals(54));
+    });
+
+    testWidgets(
+        'changeMarkers can update a marker without resetting its position',
+        (WidgetTester tester) async {
+      gmaps.Marker? marker;
+      gmaps.LatLng? position;
+
+      final Set<Marker> markers = <Marker>{
+        const Marker(
+          markerId: MarkerId('1'),
+          position: LatLng(42, 54),
+        ),
+      };
+      controller.addMarkers(markers);
+
+      marker = controller.markers[const MarkerId('1')]?.marker;
+      expect(marker, isNotNull);
+      expect(marker!.draggable, isFalse);
+
+      position = marker.position;
+      expect(position, isNotNull);
+      expect(position!.lat, equals(42));
+      expect(position.lng, equals(54));
+
+      // Update the marker without position
+      final Set<Marker> updatedMarkers = <Marker>{
+        const Marker(
+          markerId: MarkerId('1'),
+          draggable: true,
+        ),
+      };
+      controller.changeMarkers(updatedMarkers);
+      expect(controller.markers.length, 1);
+
+      marker = controller.markers[const MarkerId('1')]?.marker;
+      expect(marker, isNotNull);
+      expect(marker!.draggable, isTrue);
+
+      position = marker.position;
+      expect(position, isNotNull);
+      expect(position!.lat, equals(42));
+      expect(position.lng, equals(54));
+    });
+
+    testWidgets(
+        'changeMarkers can place a marker really close to Null Island',
+        (WidgetTester tester) async {
+      gmaps.Marker? marker;
+      gmaps.LatLng? position;
+
+      final Set<Marker> markers = <Marker>{
+        const Marker(
+          markerId: MarkerId('1'),
+          position: LatLng(42, 54),
+        ),
+      };
+      controller.addMarkers(markers);
+
+      marker = controller.markers[const MarkerId('1')]?.marker;
+      expect(marker, isNotNull);
+
+      position = marker!.position;
+      expect(position, isNotNull);
+      expect(position!.lat, equals(42));
+      expect(position.lng, equals(54));
+
+      // Update the marker without position
+      final Set<Marker> updatedMarkers = <Marker>{
+        const Marker(
+          markerId: MarkerId('1'),
+          position: LatLng(0, 1e-10),
+        ),
+      };
+      controller.changeMarkers(updatedMarkers);
+      expect(controller.markers.length, 1);
+
+      marker = controller.markers[const MarkerId('1')]?.marker;
+      expect(marker, isNotNull);
+
+      position = marker!.position;
+      expect(position, isNotNull);
+      expect(position!.lat, equals(0));
+      expect(position.lng, moreOrLessEquals(0));
     });
 
     testWidgets('removeMarkers', (WidgetTester tester) async {

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
@@ -123,8 +123,7 @@ void main() {
       expect(position.lng, equals(54));
     });
 
-    testWidgets(
-        'changeMarkers can place a marker really close to Null Island',
+    testWidgets('changeMarkers can place a marker really close to Null Island',
         (WidgetTester tester) async {
       gmaps.Marker? marker;
       gmaps.LatLng? position;

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
@@ -48,6 +48,7 @@ void main() {
 
     testWidgets('changeMarkers', (WidgetTester tester) async {
       gmaps.Marker? marker;
+      gmaps.LatLng? position;
 
       final Set<Marker> markers = <Marker>{
         const Marker(markerId: MarkerId('1')),
@@ -57,7 +58,12 @@ void main() {
       marker = controller.markers[const MarkerId('1')]?.marker;
       expect(marker, isNotNull);
       expect(marker!.draggable, isFalse);
-      expect(marker.position, isNull);
+
+      // By default, markers fall in LatLng(0, 0)
+      position = marker.position;
+      expect(position, isNotNull);
+      expect(position!.lat, equals(0));
+      expect(position.lng, equals(0));
 
       // Update the marker with draggable and position
       final Set<Marker> updatedMarkers = <Marker>{
@@ -74,14 +80,14 @@ void main() {
       expect(marker, isNotNull);
       expect(marker!.draggable, isTrue);
 
-      final gmaps.LatLng? position = marker.position;
+      position = marker.position;
       expect(position, isNotNull);
       expect(position!.lat, equals(42));
       expect(position.lng, equals(54));
     });
 
     testWidgets(
-        'changeMarkers can update a marker without resetting its position',
+        'changeMarkers resets marker position if not passed when updating!',
         (WidgetTester tester) async {
       gmaps.Marker? marker;
       gmaps.LatLng? position;
@@ -119,48 +125,8 @@ void main() {
 
       position = marker.position;
       expect(position, isNotNull);
-      expect(position!.lat, equals(42));
-      expect(position.lng, equals(54));
-    });
-
-    testWidgets('changeMarkers can place a marker really close to Null Island',
-        (WidgetTester tester) async {
-      gmaps.Marker? marker;
-      gmaps.LatLng? position;
-
-      final Set<Marker> markers = <Marker>{
-        const Marker(
-          markerId: MarkerId('1'),
-          position: LatLng(42, 54),
-        ),
-      };
-      controller.addMarkers(markers);
-
-      marker = controller.markers[const MarkerId('1')]?.marker;
-      expect(marker, isNotNull);
-
-      position = marker!.position;
-      expect(position, isNotNull);
-      expect(position!.lat, equals(42));
-      expect(position.lng, equals(54));
-
-      // Update the marker without position
-      final Set<Marker> updatedMarkers = <Marker>{
-        const Marker(
-          markerId: MarkerId('1'),
-          position: LatLng(0, 1e-10),
-        ),
-      };
-      controller.changeMarkers(updatedMarkers);
-      expect(controller.markers.length, 1);
-
-      marker = controller.markers[const MarkerId('1')]?.marker;
-      expect(marker, isNotNull);
-
-      position = marker!.position;
-      expect(position, isNotNull);
       expect(position!.lat, equals(0));
-      expect(position.lng, moreOrLessEquals(0));
+      expect(position.lng, equals(0));
     });
 
     testWidgets('removeMarkers', (WidgetTester tester) async {

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/regen_mocks.sh
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/regen_mocks.sh
@@ -7,4 +7,4 @@ flutter pub get
 
 echo "(Re)generating mocks."
 
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -290,17 +290,15 @@ gmaps.Icon? _gmIconFromBitmapDescriptor(BitmapDescriptor bitmapDescriptor) {
 
 // Computes the options for a new [gmaps.Marker] from an incoming set of options
 // [marker], and the existing marker registered with the map: [currentMarker].
-// Preserves the position from the [currentMarker], if set.
 gmaps.MarkerOptions _markerOptionsFromMarker(
   Marker marker,
   gmaps.Marker? currentMarker,
 ) {
   return gmaps.MarkerOptions()
-    ..position = currentMarker?.position ??
-        gmaps.LatLng(
-          marker.position.latitude,
-          marker.position.longitude,
-        )
+    ..position = gmaps.LatLng(
+      marker.position.latitude,
+      marker.position.longitude,
+    )
     ..title = sanitizeHtml(marker.infoWindow.title ?? '')
     ..zIndex = marker.zIndex
     ..visible = marker.visible

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -294,11 +294,22 @@ gmaps.MarkerOptions _markerOptionsFromMarker(
   Marker marker,
   gmaps.Marker? currentMarker,
 ) {
+  // The incoming Marker position always defaults to LatLng(0,0), so it's
+  // not possible to distinguish if users want to update the position of the
+  // marker or not.
+  // Since "Null Island" is an unlikely position for anything to happen, we
+  // assume that LatLng(0,0) means "do not change the current position", so
+  // Marker updates don't need to always specify a location.
+  // A workaround to position a Marker on "Null Island" is to pass an
+  // non-exactly-zero value (like Number.EPSILON) to either lat/lng of the
+  // update.
+  gmaps.LatLng? newPosition =
+      (marker.position.latitude != 0 || marker.position.longitude != 0)
+          ? gmaps.LatLng(marker.position.latitude, marker.position.longitude)
+          : currentMarker?.position;
+
   return gmaps.MarkerOptions()
-    ..position = gmaps.LatLng(
-      marker.position.latitude,
-      marker.position.longitude,
-    )
+    ..position = newPosition
     ..title = sanitizeHtml(marker.infoWindow.title ?? '')
     ..zIndex = marker.zIndex
     ..visible = marker.visible

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -303,7 +303,7 @@ gmaps.MarkerOptions _markerOptionsFromMarker(
   // A workaround to position a Marker on "Null Island" is to pass an
   // non-exactly-zero value (like Number.EPSILON) to either lat/lng of the
   // update.
-  gmaps.LatLng? newPosition =
+  final gmaps.LatLng? newPosition =
       (marker.position.latitude != 0 || marker.position.longitude != 0)
           ? gmaps.LatLng(marker.position.latitude, marker.position.longitude)
           : currentMarker?.position;

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -294,22 +294,11 @@ gmaps.MarkerOptions _markerOptionsFromMarker(
   Marker marker,
   gmaps.Marker? currentMarker,
 ) {
-  // The incoming Marker position always defaults to LatLng(0,0), so it's
-  // not possible to distinguish if users want to update the position of the
-  // marker or not.
-  // Since "Null Island" is an unlikely position for anything to happen, we
-  // assume that LatLng(0,0) means "do not change the current position", so
-  // Marker updates don't need to always specify a location.
-  // A workaround to position a Marker on "Null Island" is to pass an
-  // non-exactly-zero value (like Number.EPSILON) to either lat/lng of the
-  // update.
-  final gmaps.LatLng? newPosition =
-      (marker.position.latitude != 0 || marker.position.longitude != 0)
-          ? gmaps.LatLng(marker.position.latitude, marker.position.longitude)
-          : currentMarker?.position;
-
   return gmaps.MarkerOptions()
-    ..position = newPosition
+    ..position = gmaps.LatLng(
+      marker.position.latitude,
+      marker.position.longitude,
+    )
     ..title = sanitizeHtml(marker.infoWindow.title ?? '')
     ..zIndex = marker.zIndex
     ..visible = marker.visible

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.4.0+7
+version: 0.4.0+8
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Unconditionally convert the current marker position in `convert.dart:_markerOptionsFromMarker`, to allow for position updates.

Also adds position changes to `marker_test.dart/MarkerController/update` and `markers_test.dart/MarkersController/changeMarkers`. The `MarkersController` case is fixed by this patch.

### Issues

* Grafted from: https://github.com/flutter/plugins/pull/6753
* Fixes: https://github.com/flutter/flutter/issues/83467

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
