### PR TITLE
[go_router] Provide return values for replace methods

### DIFF
--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -173,10 +173,10 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
   /// * [replace] which replaces the top-most page of the page stack but treats
   ///   it as the same page. The page key will be reused. This will preserve the
   ///   state and not run any page animation.
-  void pushReplacement(RouteMatchList matches) {
+  Future<T?> pushReplacement<T extends Object?>(RouteMatchList matches) {
     assert(matches.last.route is! ShellRoute);
     _matchList.remove(_matchList.last);
-    push(matches); // [push] will notify the listeners.
+    return push(matches); // [push] will notify the listeners.
   }
 
   /// Replaces the top-most page of the page stack with the given one but treats
@@ -189,13 +189,13 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
   /// * [push] which pushes the given location onto the page stack.
   /// * [pushReplacement] which replaces the top-most page of the page stack but
   ///   always uses a new page key.
-  void replace(RouteMatchList matches) {
+  Future<T?> replace<T extends Object?>(RouteMatchList matches) {
     assert(matches.last.route is! ShellRoute);
     final RouteMatch routeMatch = _matchList.last;
     final ValueKey<String> pageKey = routeMatch.pageKey;
     _matchList.remove(routeMatch);
-    _push(matches, pageKey);
     notifyListeners();
+    return _push(matches, pageKey);
   }
 
   /// For internal use; visible for testing only.

--- a/packages/go_router/lib/src/misc/extensions.dart
+++ b/packages/go_router/lib/src/misc/extensions.dart
@@ -77,7 +77,10 @@ extension GoRouterHelper on BuildContext {
   /// * [replace] which replaces the top-most page of the page stack but treats
   ///   it as the same page. The page key will be reused. This will preserve the
   ///   state and not run any page animation.
-  void pushReplacement(String location, {Object? extra}) =>
+  Future<T?> pushReplacement<T extends Object?>(
+    String location, {
+    Object? extra,
+  }) =>
       GoRouter.of(this).pushReplacement(location, extra: extra);
 
   /// Replaces the top-most page of the page stack with the named route w/
@@ -87,7 +90,7 @@ extension GoRouterHelper on BuildContext {
   /// See also:
   /// * [goNamed] which navigates a named route.
   /// * [pushNamed] which pushes a named route onto the page stack.
-  void pushReplacementNamed(
+  Future<T?> pushReplacementNamed<T extends Object?>(
     String name, {
     Map<String, String> params = const <String, String>{},
     Map<String, dynamic> queryParams = const <String, dynamic>{},
@@ -110,7 +113,7 @@ extension GoRouterHelper on BuildContext {
   /// * [push] which pushes the given location onto the page stack.
   /// * [pushReplacement] which replaces the top-most page of the page stack but
   ///   always uses a new page key.
-  void replace(String location, {Object? extra}) =>
+  Future<T?> replace<T extends Object?>(String location, {Object? extra}) =>
       GoRouter.of(this).replace(location, extra: extra);
 
   /// Replaces the top-most page with the named route and optional parameters,
@@ -124,7 +127,7 @@ extension GoRouterHelper on BuildContext {
   /// * [pushNamed] which pushes the given location onto the page stack.
   /// * [pushReplacementNamed] which replaces the top-most page of the page
   ///   stack but always uses a new page key.
-  void replaceNamed(
+  Future<T?> replaceNamed<T extends Object?>(
     String name, {
     Map<String, String> params = const <String, String>{},
     Map<String, dynamic> queryParams = const <String, dynamic>{},

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -266,9 +266,12 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
   /// * [replace] which replaces the top-most page of the page stack but treats
   ///   it as the same page. The page key will be reused. This will preserve the
   ///   state and not run any page animation.
-  void pushReplacement(String location, {Object? extra}) {
-    routeInformationParser
-        .parseRouteInformationWithDependencies(
+  Future<T?> pushReplacement<T extends Object?>(
+    String location, {
+    Object? extra,
+  }) async {
+    final RouteMatchList matchList =
+        await routeInformationParser.parseRouteInformationWithDependencies(
       // TODO(chunhtai): remove this ignore and migrate the code
       // https://github.com/flutter/flutter/issues/124045.
       // ignore: deprecated_member_use
@@ -276,10 +279,9 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
       // TODO(chunhtai): avoid accessing the context directly through global key.
       // https://github.com/flutter/flutter/issues/99112
       _routerDelegate.navigatorKey.currentContext!,
-    )
-        .then<void>((RouteMatchList matchList) {
-      routerDelegate.pushReplacement(matchList);
-    });
+    );
+
+    return routerDelegate.pushReplacement(matchList);
   }
 
   /// Replaces the top-most page of the page stack with the named route w/
@@ -289,13 +291,13 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
   /// See also:
   /// * [goNamed] which navigates a named route.
   /// * [pushNamed] which pushes a named route onto the page stack.
-  void pushReplacementNamed(
+  Future<T?> pushReplacementNamed<T extends Object?>(
     String name, {
     Map<String, String> params = const <String, String>{},
     Map<String, dynamic> queryParams = const <String, dynamic>{},
     Object? extra,
   }) {
-    pushReplacement(
+    return pushReplacement(
       namedLocation(name, params: params, queryParams: queryParams),
       extra: extra,
     );
@@ -311,9 +313,12 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
   /// * [push] which pushes the given location onto the page stack.
   /// * [pushReplacement] which replaces the top-most page of the page stack but
   ///   always uses a new page key.
-  void replace(String location, {Object? extra}) {
-    routeInformationParser
-        .parseRouteInformationWithDependencies(
+  Future<T?> replace<T extends Object?>(
+    String location, {
+    Object? extra,
+  }) async {
+    final RouteMatchList matchList =
+        await routeInformationParser.parseRouteInformationWithDependencies(
       // TODO(chunhtai): remove this ignore and migrate the code
       // https://github.com/flutter/flutter/issues/124045.
       // ignore: deprecated_member_use
@@ -321,10 +326,8 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
       // TODO(chunhtai): avoid accessing the context directly through global key.
       // https://github.com/flutter/flutter/issues/99112
       _routerDelegate.navigatorKey.currentContext!,
-    )
-        .then<void>((RouteMatchList matchList) {
-      routerDelegate.replace(matchList);
-    });
+    );
+    return routerDelegate.replace(matchList);
   }
 
   /// Replaces the top-most page with the named route and optional parameters,
@@ -338,13 +341,13 @@ class GoRouter extends ChangeNotifier implements RouterConfig<RouteMatchList> {
   /// * [pushNamed] which pushes the given location onto the page stack.
   /// * [pushReplacementNamed] which replaces the top-most page of the page
   ///   stack but always uses a new page key.
-  void replaceNamed(
+  Future<T?> replaceNamed<T extends Object?>(
     String name, {
     Map<String, String> params = const <String, String>{},
     Map<String, dynamic> queryParams = const <String, dynamic>{},
     Object? extra,
   }) {
-    replace(
+    return replace(
       namedLocation(name, params: params, queryParams: queryParams),
       extra: extra,
     );


### PR DESCRIPTION
This PR is aimed to add the `Future<T?>` results for the following methods:
* `pushReplacement`
* `pushReplacementNamed`
* `replace`
* `replaceNamed`

This PR addresses the following issue: https://github.com/flutter/flutter/issues/124686

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests

PS I'm not sure either the patch or minor version should be changed. Ready to update the PR in case I made something incorrect