### PR TITLE
[camera_platform_interface][camera_avfoundation]  Get all available camera on ios and add camera type for ios camera_description,then you can  easily choose dual camera or triple camera or other.

### DIFF
--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -19,6 +19,13 @@ dependencies:
   path_provider: ^2.0.0
   video_player: ^2.1.4
 
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  camera_avfoundation:
+    path: ../../camera_avfoundation
+  camera_platform_interface:
+    path: ../../camera_platform_interface
+
 dev_dependencies:
   build_runner: ^2.1.10
   flutter_driver:

--- a/packages/camera/camera/test/camera_value_test.dart
+++ b/packages/camera/camera/test/camera_value_test.dart
@@ -154,7 +154,7 @@ void main() {
       );
 
       expect(cameraValue.toString(),
-          'CameraValue(isRecordingVideo: false, isInitialized: false, errorDescription: null, previewSize: Size(10.0, 10.0), isStreamingImages: false, flashMode: FlashMode.auto, exposureMode: ExposureMode.auto, focusMode: FocusMode.auto, exposurePointSupported: true, focusPointSupported: true, deviceOrientation: DeviceOrientation.portraitUp, lockedCaptureOrientation: DeviceOrientation.portraitUp, recordingOrientation: DeviceOrientation.portraitUp, isPreviewPaused: true, previewPausedOrientation: DeviceOrientation.portraitUp, description: CameraDescription(, CameraLensDirection.back, 0))');
+          'CameraValue(isRecordingVideo: false, isInitialized: false, errorDescription: null, previewSize: Size(10.0, 10.0), isStreamingImages: false, flashMode: FlashMode.auto, exposureMode: ExposureMode.auto, focusMode: FocusMode.auto, exposurePointSupported: true, focusPointSupported: true, deviceOrientation: DeviceOrientation.portraitUp, lockedCaptureOrientation: DeviceOrientation.portraitUp, recordingOrientation: DeviceOrientation.portraitUp, isPreviewPaused: true, previewPausedOrientation: DeviceOrientation.portraitUp, description: CameraDescription(, CameraLensDirection.back, 0, AVCaptureDeviceType.unknown))');
     });
   });
 }

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.14
+
+* Allows get all available cameras.
+* Add cameraType to CameraDescription, such as dual camera, triple camera.
+
 ## 0.9.13+1
 
 * Clarifies explanation of endorsement in README.

--- a/packages/camera/camera_avfoundation/example/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/example/pubspec.yaml
@@ -14,12 +14,17 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  camera_platform_interface: ^2.4.0
+  camera_platform_interface: ^2.5.1
   flutter:
     sdk: flutter
   path_provider: ^2.0.0
   quiver: ^3.0.0
   video_player: ^2.1.4
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  camera_platform_interface:
+    path: ../../camera_platform_interface
 
 dev_dependencies:
   build_runner: ^2.1.10

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -104,14 +104,14 @@
 - (void)handleMethodCallAsync:(FlutterMethodCall *)call
                        result:(FLTThreadSafeFlutterResult *)result {
   if ([@"availableCameras" isEqualToString:call.method]) {
-    NSMutableArray *discoveryDevices =
-        [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
-            AVCaptureDeviceTypeBuiltInDualCamera,
-            AVCaptureDeviceTypeBuiltInTelephotoCamera ]
-            mutableCopy];
+    NSMutableArray *discoveryDevices = [@[
+      AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInDualCamera,
+      AVCaptureDeviceTypeBuiltInTelephotoCamera
+    ] mutableCopy];
     if (@available(iOS 13.0, *)) {
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInTrueDepthCamera];
-      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInTripleCamera];      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInDualWideCamera];
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInTripleCamera];
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInDualWideCamera];
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
     }
     if (@available(iOS 15.4, *)) {

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -105,10 +105,17 @@
                        result:(FLTThreadSafeFlutterResult *)result {
   if ([@"availableCameras" isEqualToString:call.method]) {
     NSMutableArray *discoveryDevices =
-        [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
+        [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+            AVCaptureDeviceTypeBuiltInDualCamera,
+            AVCaptureDeviceTypeBuiltInTelephotoCamera ]
             mutableCopy];
     if (@available(iOS 13.0, *)) {
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInTrueDepthCamera];
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInTripleCamera];      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInDualWideCamera];
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+    }
+    if (@available(iOS 15.4, *)) {
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
     }
     AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
         discoverySessionWithDeviceTypes:discoveryDevices
@@ -134,6 +141,7 @@
         @"name" : [device uniqueID],
         @"lensFacing" : lensFacing,
         @"sensorOrientation" : @90,
+        @"cameraType" : [device deviceType],
       }];
     }
     [result sendSuccessWithData:reply];

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -84,6 +84,8 @@ class AVFoundationCamera extends CameraPlatform {
           lensDirection:
               parseCameraLensDirection(camera['lensFacing']! as String),
           sensorOrientation: camera['sensorOrientation']! as int,
+          cameraType: AVCaptureDeviceType.parseFromString(
+              camera['cameraType'] as String?),
         );
       }).toList();
     } on PlatformException catch (e) {

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.13+1
+version: 0.9.14
 
 environment:
   sdk: ">=2.18.0 <4.0.0"
@@ -17,10 +17,15 @@ flutter:
         dartPluginClass: AVFoundationCamera
 
 dependencies:
-  camera_platform_interface: ^2.4.0
+  camera_platform_interface: ^2.5.1
   flutter:
     sdk: flutter
   stream_transform: ^2.0.0
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  camera_platform_interface:
+    path: ../camera_platform_interface
 
 dev_dependencies:
   async: ^2.5.0

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -487,12 +487,14 @@ void main() {
         <String, dynamic>{
           'name': 'Test 1',
           'lensFacing': 'front',
-          'sensorOrientation': 1
+          'sensorOrientation': 1,
+          'cameraType': 'AVCaptureDeviceTypeBuiltInWideAngleCamera'
         },
         <String, dynamic>{
           'name': 'Test 2',
           'lensFacing': 'back',
-          'sensorOrientation': 2
+          'sensorOrientation': 2,
+          'cameraType': 'AVCaptureDeviceTypeBuiltInUltraWideCamera'
         }
       ];
       final MethodChannelMock channel = MethodChannelMock(
@@ -516,6 +518,7 @@ void main() {
           lensDirection:
               parseCameraLensDirection(typedData['lensFacing']! as String),
           sensorOrientation: typedData['sensorOrientation']! as int,
+          cameraType: AVCaptureDeviceType.parseFromString(typedData['cameraType'] as String?)
         );
         expect(cameras[i], cameraDescription);
       }

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -514,12 +514,12 @@ void main() {
         final Map<String, Object?> typedData =
             (returnData[i] as Map<dynamic, dynamic>).cast<String, Object?>();
         final CameraDescription cameraDescription = CameraDescription(
-          name: typedData['name']! as String,
-          lensDirection:
-              parseCameraLensDirection(typedData['lensFacing']! as String),
-          sensorOrientation: typedData['sensorOrientation']! as int,
-          cameraType: AVCaptureDeviceType.parseFromString(typedData['cameraType'] as String?)
-        );
+            name: typedData['name']! as String,
+            lensDirection:
+                parseCameraLensDirection(typedData['lensFacing']! as String),
+            sensorOrientation: typedData['sensorOrientation']! as int,
+            cameraType: AVCaptureDeviceType.parseFromString(
+                typedData['cameraType'] as String?));
         expect(cameras[i], cameraDescription);
       }
     });

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.1
+
+* Add cameraType to CameraDescription, such as dual camera, triple camera.
+
 ## 2.5.0
 
 * Adds NV21 as an image stream format (suitable for Android).

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
@@ -114,7 +114,7 @@ class CameraDescription {
           cameraType == other.cameraType;
 
   @override
-  int get hashCode => Object.hash(name, lensDirection);
+  int get hashCode => Object.hash(name, lensDirection, cameraType);
 
   @override
   String toString() {

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
@@ -16,6 +16,64 @@ enum CameraLensDirection {
   external,
 }
 
+/// The camera's device type in ios
+/// IOS only
+enum AVCaptureDeviceType {
+  /// A built-in wide angle camera device.
+  /// These devices are suitable for general purpose use.
+  wideAngleCamera(name: 'AVCaptureDeviceTypeBuiltInWideAngleCamera'),
+
+  /// A built-in camera device with a longer focal length than a wide angle camera.
+  telephotoCamera(name: 'AVCaptureDeviceTypeBuiltInTelephotoCamera'),
+
+  /// A built-in camera device with a shorter focal length than a wide angle camera.
+  ultraWideCamera(name: 'AVCaptureDeviceTypeBuiltInUltraWideCamera'),
+
+  /// A device that consists of two fixed focal length cameras,
+  /// one wide and one telephoto.
+  dualCamera(name: 'AVCaptureDeviceTypeBuiltInDualCamera'),
+
+  /// A device that consists of two fixed focal length cameras,
+  /// one ultra wide and one wide angle.
+  dualWideCamera(name: 'AVCaptureDeviceTypeBuiltInDualWideCamera'),
+
+  /// A device that consists of three fixed focal length cameras,
+  /// one ultra wide, one wide angle, and one telephoto.
+  tripleCamera(name: 'AVCaptureDeviceTypeBuiltInTripleCamera'),
+
+  /// A device that consists of two cameras, one YUV and one Infrared.
+  /// The infrared camera provides high quality depth information
+  /// that is synchronized and perspective corrected to frames produced by the YUV camera.
+  /// While the resolution of the depth data and YUV frames may differ,
+  /// their field of view and aspect ratio always match.
+  trueDepthCamera(name: 'AVCaptureDeviceTypeBuiltInTrueDepthCamera'),
+
+  /// A device that consists of two cameras, one YUV and one LiDAR.
+  /// The LiDAR camera provides high quality, high accuracy depth information by
+  /// measuring the round trip of an artificial light signal emitted by a laser.
+  /// The depth is synchronized and perspective corrected to frames produced by
+  /// the paired YUV camera. While the resolution of the depth data and YUV frames may differ,
+  /// their field of view and aspect ratio always match.
+  liDARDepthCamera(name: 'AVCaptureDeviceTypeBuiltInLiDARDepthCamera'),
+
+  /// An unknown device type.
+  unknown;
+
+  /// AVCaptureDeviceType
+  const AVCaptureDeviceType({this.name});
+
+  /// The device type string from IOS
+  final String? name;
+
+  /// Parse device type from string
+  static AVCaptureDeviceType parseFromString(String? deviceType) {
+    return AVCaptureDeviceType.values.singleWhere(
+      (AVCaptureDeviceType element) => element.name == deviceType,
+      orElse: () => AVCaptureDeviceType.unknown,
+    );
+  }
+}
+
 /// Properties of a camera device.
 @immutable
 class CameraDescription {
@@ -24,6 +82,7 @@ class CameraDescription {
     required this.name,
     required this.lensDirection,
     required this.sensorOrientation,
+    this.cameraType = AVCaptureDeviceType.unknown,
   });
 
   /// The name of the camera device.
@@ -41,13 +100,18 @@ class CameraDescription {
   /// is from top to bottom in the sensor's coordinate system.
   final int sensorOrientation;
 
+  /// Camera type,IOS only
+  /// TrueDepthCamera  DualCamera  TripleCamera  LiDARDepthCamera  DeskViewCamera DualWideCamera ExternalUnknown WideAngleCamera TelephotoCamera UltraWideCamera
+  final AVCaptureDeviceType cameraType;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is CameraDescription &&
           runtimeType == other.runtimeType &&
           name == other.name &&
-          lensDirection == other.lensDirection;
+          lensDirection == other.lensDirection &&
+          cameraType == other.cameraType;
 
   @override
   int get hashCode => Object.hash(name, lensDirection);
@@ -55,6 +119,6 @@ class CameraDescription {
   @override
   String toString() {
     return '${objectRuntimeType(this, 'CameraDescription')}('
-        '$name, $lensDirection, $sensorOrientation)';
+        '$name, $lensDirection, $sensorOrientation, $cameraType)';
   }
 }

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.5.0
+version: 2.5.1
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/camera/camera_platform_interface/test/types/camera_description_test.dart
+++ b/packages/camera/camera_platform_interface/test/types/camera_description_test.dart
@@ -24,17 +24,61 @@ void main() {
     });
   });
 
+  group('AVCaptureDeviceType tests', () {
+    test('AVCaptureDeviceType should contain 8 options', () {
+      const List<AVCaptureDeviceType> values = AVCaptureDeviceType.values;
+
+      expect(values.length, 9);
+    });
+
+    test('CameraLensDirection enum should have items in correct index', () {
+      const List<AVCaptureDeviceType> values = AVCaptureDeviceType.values;
+
+      expect(values[0], AVCaptureDeviceType.wideAngleCamera);
+      expect(values[1], AVCaptureDeviceType.telephotoCamera);
+      expect(values[2], AVCaptureDeviceType.ultraWideCamera);
+      expect(values[3], AVCaptureDeviceType.dualCamera);
+      expect(values[4], AVCaptureDeviceType.dualWideCamera);
+      expect(values[5], AVCaptureDeviceType.tripleCamera);
+      expect(values[6], AVCaptureDeviceType.trueDepthCamera);
+      expect(values[7], AVCaptureDeviceType.liDARDepthCamera);
+      expect(values[8], AVCaptureDeviceType.unknown);
+    });
+
+    test('CameraLensDirection enum should have items with correct name', () {
+      expect(AVCaptureDeviceType.wideAngleCamera.name,
+          'AVCaptureDeviceTypeBuiltInWideAngleCamera');
+      expect(AVCaptureDeviceType.telephotoCamera.name,
+          'AVCaptureDeviceTypeBuiltInTelephotoCamera');
+      expect(AVCaptureDeviceType.ultraWideCamera.name,
+          'AVCaptureDeviceTypeBuiltInUltraWideCamera');
+      expect(AVCaptureDeviceType.dualCamera.name,
+          'AVCaptureDeviceTypeBuiltInDualCamera');
+      expect(AVCaptureDeviceType.dualWideCamera.name,
+          'AVCaptureDeviceTypeBuiltInDualWideCamera');
+      expect(AVCaptureDeviceType.tripleCamera.name,
+          'AVCaptureDeviceTypeBuiltInTripleCamera');
+      expect(AVCaptureDeviceType.trueDepthCamera.name,
+          'AVCaptureDeviceTypeBuiltInTrueDepthCamera');
+      expect(AVCaptureDeviceType.liDARDepthCamera.name,
+          'AVCaptureDeviceTypeBuiltInLiDARDepthCamera');
+      expect(AVCaptureDeviceType.unknown.name, null);
+    });
+  });
+
   group('CameraDescription tests', () {
     test('Constructor should initialize all properties', () {
       const CameraDescription description = CameraDescription(
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        cameraType: AVCaptureDeviceType.dualCamera,
       );
 
       expect(description.name, 'Test');
       expect(description.lensDirection, CameraLensDirection.front);
       expect(description.sensorOrientation, 90);
+      expect(description.cameraType, AVCaptureDeviceType.dualCamera);
     });
 
     test('equals should return true if objects are the same', () {
@@ -42,11 +86,13 @@ void main() {
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        cameraType: AVCaptureDeviceType.dualCamera,
       );
       const CameraDescription secondDescription = CameraDescription(
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        cameraType: AVCaptureDeviceType.dualCamera,
       );
 
       expect(firstDescription == secondDescription, true);
@@ -97,6 +143,22 @@ void main() {
       expect(firstDescription == secondDescription, true);
     });
 
+    test('equals should return false if camera type is different', () {
+      const CameraDescription firstDescription = CameraDescription(
+        name: 'Test',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 90,
+        cameraType: AVCaptureDeviceType.dualCamera,
+      );
+      const CameraDescription secondDescription = CameraDescription(
+        name: 'Test',
+        lensDirection: CameraLensDirection.back,
+        sensorOrientation: 90,
+      );
+
+      expect(firstDescription == secondDescription, false);
+    });
+
     test('hashCode should match hashCode of all equality-tested properties',
         () {
       const CameraDescription description = CameraDescription(
@@ -104,8 +166,11 @@ void main() {
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 0,
       );
-      final int expectedHashCode =
-          Object.hash(description.name, description.lensDirection);
+      final int expectedHashCode = Object.hash(
+        description.name,
+        description.lensDirection,
+        description.cameraType,
+      );
 
       expect(description.hashCode, expectedHashCode);
     });


### PR DESCRIPTION
Get all available camera on ios, add dual camera, triple camera, true depth camera and lidarDepth camera for discovery. Add camera type for ios camera_description, so you can better choose which kind camera you want on ios

issue like [#104439](https://github.com/flutter/flutter/issues/104439),  fixed by [#80865](https://github.com/flutter/flutter/issues/80865).
but on my iphone 13, ios 16.3.1 , it still can't get all cameras, so i do this pull request. 

- [x] I read the [Contributor Guide](https://github.com/flutter/packages/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x]  I read the [Tree Hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene) wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides](https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style) and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use dart format.)
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x]  The title of the PR starts with the name of the package surrounded by square brackets, e.g. [shared_preferences]
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning), or this PR is [exempt from version changes](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates).
- [x] I updated CHANGELOG.md to add a description of the change, [following repository CHANGELOG style](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style).
- [x]  I updated/added relevant documentation (doc comments with ///).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/wiki/Tree-hygiene#tests).
- [x] All existing and new tests are passing.