### PR TITLE
[image_picker_ios] In unit test write and read kCGImagePropertyExifUserComment property

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+* Updates metadata unit test to work on iOS 16.2.
+
 ## 0.8.7+3
 
 * Updates pigeon to fix warnings with clang 15.

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PhotoAssetUtilTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PhotoAssetUtilTests.m
@@ -76,7 +76,7 @@
   NSDictionary *dummyInfo = @{
     UIImagePickerControllerMediaMetadata : @{
       (__bridge NSString *)kCGImagePropertyExifDictionary :
-          @{(__bridge NSString *)kCGImagePropertyExifMakerNote : @"aNote"}
+          @{(__bridge NSString *)kCGImagePropertyExifUserComment : @"aNote"}
     }
   };
   UIImage *imageJPG = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
@@ -86,7 +86,7 @@
   NSData *data = [NSData dataWithContentsOfFile:savedPathJPG];
   NSDictionary *meta = [FLTImagePickerMetaDataUtil getMetaDataFromImageData:data];
   XCTAssertEqualObjects(meta[(__bridge NSString *)kCGImagePropertyExifDictionary]
-                            [(__bridge NSString *)kCGImagePropertyExifMakerNote],
+                            [(__bridge NSString *)kCGImagePropertyExifUserComment],
                         @"aNote");
 }
 


### PR DESCRIPTION
`testSaveImageWithPickerInfo_ShouldSaveWithTheCorrectExtentionAndMetaData` passed on iOS 16 but not iOS 16.2.  For some reason the latter doesn't want maintain `kCGImagePropertyExifMakerNote`.  Swap to `kCGImagePropertyExifUserComment` which does work on both versions, and tests the same thing: metadata can be written and read.

Fixes https://github.com/flutter/flutter/issues/125257

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
