### PR TITLE
[shared_preferences] Adds allowList to setPrefix method.

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+* Adds `allowList` option to setPrefix.
+
 ## 2.1.2
 
 * Fixes singleton initialization race condition introduced during NNBD

--- a/packages/shared_preferences/shared_preferences/README.md
+++ b/packages/shared_preferences/shared_preferences/README.md
@@ -100,6 +100,7 @@ by any non-flutter versions of the app (for migrating from a native app to flutt
 If the prefix is set to a value such as `''` that causes it to read values that were 
 not originally stored by the `SharedPreferences`, initializing `SharedPreferences` 
 may fail if any of the values are of types that are not supported by `SharedPreferences`.
+In this case, you can set an `allowList` that contains only preferences of supported types.
 
 If you decide to remove the prefix entirely, you can still access previously created
 preferences by manually adding the previous prefix `flutter.` to the beginning of 

--- a/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -96,8 +96,8 @@ void main() {
       preferences = await SharedPreferences.getInstance();
     });
 
-    tearDown(() {
-      preferences.clear();
+    tearDown(() async {
+      await preferences.clear();
       SharedPreferences.resetStatic();
     });
 
@@ -111,8 +111,8 @@ void main() {
       preferences = await SharedPreferences.getInstance();
     });
 
-    tearDown(() {
-      preferences.clear();
+    tearDown(() async {
+      await preferences.clear();
       SharedPreferences.resetStatic();
     });
 
@@ -126,11 +126,40 @@ void main() {
       preferences = await SharedPreferences.getInstance();
     });
 
-    tearDown(() {
-      preferences.clear();
+    tearDown(() async {
+      await preferences.clear();
       SharedPreferences.resetStatic();
     });
 
     runAllTests();
+  });
+
+  testWidgets('allowList only gets allowed items', (WidgetTester _) async {
+    const String allowedString = 'stringKey';
+    const String allowedBool = 'boolKey';
+    const String notAllowedDouble = 'doubleKey';
+    const String resultString = 'resultString';
+
+    const Set<String> allowList = <String>{allowedString, allowedBool};
+
+    SharedPreferences.resetStatic();
+    SharedPreferences.setPrefix('', allowList: allowList);
+
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    await prefs.setString(allowedString, resultString);
+    await prefs.setBool(allowedBool, true);
+    await prefs.setDouble(notAllowedDouble, 3.14);
+
+    await prefs.reload();
+
+    final String? testString = prefs.getString(allowedString);
+    expect(testString, resultString);
+
+    final bool? testBool = prefs.getBool(allowedBool);
+    expect(testBool, true);
+
+    final double? testDouble = prefs.getDouble(notAllowedDouble);
+    expect(testDouble, null);
   });
 }

--- a/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/types.dart';
 
 /// Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android), providing
 /// a persistent store for simple data.
@@ -17,6 +18,8 @@ class SharedPreferences {
   static String _prefix = 'flutter.';
 
   static bool _prefixHasBeenChanged = false;
+
+  static Set<String>? _allowList;
 
   static Completer<SharedPreferences>? _completer;
 
@@ -33,17 +36,23 @@ class SharedPreferences {
   /// previous behavior of this plugin. To use preferences with no prefix,
   /// set [prefix] to ''.
   ///
+  /// If [prefix] is set to '', you may encounter preferences that are
+  /// incompatible with shared_preferences. The optional parameter
+  /// [allowList] will cause the plugin to only return preferences that
+  /// are both contained in the list AND match the provided prefix.
+  ///
   /// No migration of existing preferences is performed by this method.
   /// If you set a different prefix, and have previously stored preferences,
   /// you will need to handle any migration yourself.
   ///
   /// This cannot be called after `getInstance`.
-  static void setPrefix(String prefix) {
+  static void setPrefix(String prefix, {Set<String>? allowList}) {
     if (_completer != null) {
       throw StateError('setPrefix cannot be called after getInstance');
     }
     _prefix = prefix;
     _prefixHasBeenChanged = true;
+    _allowList = allowList;
   }
 
   /// Resets class's static values to allow for testing of setPrefix flow.
@@ -52,6 +61,7 @@ class SharedPreferences {
     _completer = null;
     _prefix = 'flutter.';
     _prefixHasBeenChanged = false;
+    _allowList = null;
   }
 
   /// Loads and parses the [SharedPreferences] for this app from disk.
@@ -182,8 +192,14 @@ class SharedPreferences {
     _preferenceCache.clear();
     if (_prefixHasBeenChanged) {
       try {
-        // ignore: deprecated_member_use
-        return _store.clearWithPrefix(_prefix);
+        return _store.clearWithParameters(
+          ClearParameters(
+            filter: PreferencesFilter(
+              prefix: _prefix,
+              allowList: _allowList,
+            ),
+          ),
+        );
       } catch (e) {
         // Catching and clarifying UnimplementedError to provide a more robust message.
         if (e is UnimplementedError) {
@@ -214,8 +230,16 @@ Either update the implementation to support setPrefix, or do not call setPrefix.
     final Map<String, Object> fromSystem = <String, Object>{};
     if (_prefixHasBeenChanged) {
       try {
-        // ignore: deprecated_member_use
-        fromSystem.addAll(await _store.getAllWithPrefix(_prefix));
+        fromSystem.addAll(
+          await _store.getAllWithParameters(
+            GetAllParameters(
+              filter: PreferencesFilter(
+                prefix: _prefix,
+                allowList: _allowList,
+              ),
+            ),
+          ),
+        );
       } catch (e) {
         // Catching and clarifying UnimplementedError to provide a more robust message.
         if (e is UnimplementedError) {

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.1.2
+version: 2.2.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"
@@ -31,7 +31,7 @@ dependencies:
   shared_preferences_android: ^2.1.0
   shared_preferences_foundation: ^2.2.0
   shared_preferences_linux: ^2.2.0
-  shared_preferences_platform_interface: ^2.2.0
+  shared_preferences_platform_interface: ^2.3.0
   shared_preferences_web: ^2.1.0
   shared_preferences_windows: ^2.2.0
 

--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
@@ -299,7 +299,7 @@ void main() {
     expect(testStrings, 'test');
   });
 
-  test('unimplemented errors in withOptions methods are updated', () async {
+  test('unimplemented errors in withParameters methods are updated', () async {
     final UnimplementedSharedPreferencesStore localStore =
         UnimplementedSharedPreferencesStore();
     SharedPreferencesStorePlatform.instance = localStore;
@@ -319,7 +319,7 @@ void main() {
             "Shared Preferences doesn't yet support the setPrefix method"));
   });
 
-  test('non-Unimplemented errors pass through withOptions methods correctly',
+  test('non-Unimplemented errors pass through withParameters methods correctly',
       () async {
     final ThrowingSharedPreferencesStore localStore =
         ThrowingSharedPreferencesStore();

--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/types.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -256,6 +257,30 @@ void main() {
     expect(testDouble, 3.14);
   });
 
+  test('allowList only gets allowed items', () async {
+    const Set<String> allowList = <String>{'stringKey', 'boolKey'};
+
+    SharedPreferences.resetStatic();
+    SharedPreferences.setPrefix('', allowList: allowList);
+
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    await prefs.setString('stringKey', 'test');
+    await prefs.setBool('boolKey', true);
+    await prefs.setDouble('doubleKey', 3.14);
+
+    await prefs.reload();
+
+    final String? testString = prefs.getString('stringKey');
+    expect(testString, 'test');
+
+    final bool? testBool = prefs.getBool('boolKey');
+    expect(testBool, true);
+
+    final double? testDouble = prefs.getDouble('doubleKey');
+    expect(testDouble, null);
+  });
+
   test('using reload after setPrefix properly reloads the cache', () async {
     const String newPrefix = 'newPrefix';
 
@@ -274,7 +299,7 @@ void main() {
     expect(testStrings, 'test');
   });
 
-  test('unimplemented errors in withPrefix methods are updated', () async {
+  test('unimplemented errors in withOptions methods are updated', () async {
     final UnimplementedSharedPreferencesStore localStore =
         UnimplementedSharedPreferencesStore();
     SharedPreferencesStorePlatform.instance = localStore;
@@ -294,7 +319,7 @@ void main() {
             "Shared Preferences doesn't yet support the setPrefix method"));
   });
 
-  test('non-Unimplemented errors pass through withPrefix methods correctly',
+  test('non-Unimplemented errors pass through withOptions methods correctly',
       () async {
     final ThrowingSharedPreferencesStore localStore =
         ThrowingSharedPreferencesStore();
@@ -327,16 +352,22 @@ class FakeSharedPreferencesStore extends SharedPreferencesStorePlatform {
   }
 
   @override
+  Future<bool> clearWithParameters(ClearParameters parameters) {
+    log.add(const MethodCall('clearWithParameters'));
+    return backend.clearWithParameters(parameters);
+  }
+
+  @override
   Future<Map<String, Object>> getAll() {
     log.add(const MethodCall('getAll'));
     return backend.getAll();
   }
 
   @override
-  Future<Map<String, Object>> getAllWithPrefix(String prefix) {
-    log.add(const MethodCall('getAllWithPrefix'));
-    // ignore: deprecated_member_use
-    return backend.getAllWithPrefix(prefix);
+  Future<Map<String, Object>> getAllWithParameters(
+      GetAllParameters parameters) {
+    log.add(const MethodCall('getAllWithParameters'));
+    return backend.getAllWithParameters(parameters);
   }
 
   @override
@@ -406,7 +437,8 @@ class ThrowingSharedPreferencesStore extends SharedPreferencesStorePlatform {
   }
 
   @override
-  Future<Map<String, Object>> getAllWithPrefix(String prefix) {
+  Future<Map<String, Object>> getAllWithParameters(
+      GetAllParameters parameters) {
     throw StateError('State Error');
   }
 }


### PR DESCRIPTION
Creates optional allow list for preference keys when setting custom prefix.

Also makes integration tests more homogenous across platforms. 

Fixes https://github.com/flutter/flutter/issues/128948

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests


