### PR TITLE
[tool] Move Android lint checks

### DIFF
--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
@@ -57,7 +57,3 @@ android {
         testImplementation "org.mockito:mockito-core:5.1.1"
     }
 }
-
-project.getTasks().withType(JavaCompile){
-    options.compilerArgs.addAll(["-Xlint:all", "-Werror"])
-}

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/build.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/build.gradle
@@ -29,3 +29,11 @@ subprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+gradle.projectsEvaluated {
+    project(":alternate_language_test_plugin") {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:all" << "-Werror"
+        }
+    }
+}

--- a/packages/pigeon/platform_tests/test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/android/build.gradle
@@ -58,6 +58,12 @@ android {
         }
     }
 
+    lintOptions {
+        checkAllWarnings true
+        warningsAsErrors true
+        disable 'AndroidGradlePluginVersion', 'InvalidPackage', 'GradleDependency'
+    }
+
     dependencies {
         testImplementation 'junit:junit:4.+'
         testImplementation "io.mockk:mockk:1.13.5"

--- a/packages/pigeon/platform_tests/test_plugin/example/android/build.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/example/android/build.gradle
@@ -29,3 +29,11 @@ subprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+gradle.projectsEvaluated {
+    project(":test_plugin") {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:all" << "-Werror"
+        }
+    }
+}

--- a/script/tool/lib/src/common/repository_package.dart
+++ b/script/tool/lib/src/common/repository_package.dart
@@ -151,4 +151,19 @@ class RepositoryPackage {
         .map((FileSystemEntity entity) =>
             RepositoryPackage(entity as Directory));
   }
+
+  /// Returns the package that this package is a part of, if any.
+  ///
+  /// Currently this is limited to checking up two directories, since that
+  /// covers all the example structures currently used.
+  RepositoryPackage? getEnclosingPackage() {
+    final Directory parent = directory.parent;
+    if (isPackage(parent)) {
+      return RepositoryPackage(parent);
+    }
+    if (isPackage(parent.parent)) {
+      return RepositoryPackage(parent.parent);
+    }
+    return null;
+  }
 }

--- a/script/tool/lib/src/gradle_check_command.dart
+++ b/script/tool/lib/src/gradle_check_command.dart
@@ -84,6 +84,8 @@ class GradleCheckCommand extends PackageLoopingCommand {
         .childFile('AndroidManifest.xml');
   }
 
+  bool _isCommented(String line) => line.trim().startsWith('//');
+
   /// Validates the build.gradle file for a plugin
   /// (some_plugin/android/build.gradle).
   bool _validatePluginBuildGradle(RepositoryPackage package, File gradleFile) {
@@ -101,6 +103,9 @@ class GradleCheckCommand extends PackageLoopingCommand {
     if (!_validateSourceCompatibilityVersion(lines)) {
       succeeded = false;
     }
+    if (!_validateGradleDrivenLintConfig(package, lines)) {
+      succeeded = false;
+    }
     return succeeded;
   }
 
@@ -110,9 +115,16 @@ class GradleCheckCommand extends PackageLoopingCommand {
       RepositoryPackage package, File gradleFile) {
     print('${indentation}Validating '
         '${getRelativePosixPath(gradleFile, from: package.directory)}.');
-    // TODO(stuartmorgan): Move the -Xlint validation from lint_android_command
-    // to here.
-    return true;
+    final String contents = gradleFile.readAsStringSync();
+    final List<String> lines = contents.split('\n');
+
+    // This is tracked as a variable rather than a sequence of &&s so that all
+    // failures are reported at once, not just the first one.
+    bool succeeded = true;
+    if (!_validateJavacLintConfig(package, lines)) {
+      succeeded = false;
+    }
+    return succeeded;
   }
 
   /// Validates the app-level build.gradle for an example app (e.g.,
@@ -193,11 +205,9 @@ build.gradle "namespace" must match the "package" attribute in AndroidManifest.x
   /// lead to compile errors that show up for clients, but not in CI).
   bool _validateSourceCompatibilityVersion(List<String> gradleLines) {
     if (!gradleLines.any((String line) =>
-            line.contains('languageVersion') &&
-            !line.trim().startsWith('//')) &&
+            line.contains('languageVersion') && !_isCommented(line)) &&
         !gradleLines.any((String line) =>
-            line.contains('sourceCompatibility') &&
-            !line.trim().startsWith('//'))) {
+            line.contains('sourceCompatibility') && !_isCommented(line))) {
       const String errorMessage = '''
 build.gradle must set an explicit Java compatibility version.
 
@@ -221,6 +231,69 @@ for more details.''';
 
       printError(
           '$indentation${errorMessage.split('\n').join('\n$indentation')}');
+      return false;
+    }
+    return true;
+  }
+
+  /// Returns whether the given gradle content is configured to enable all
+  /// Gradle-driven lints (those checked by ./gradlew lint) and treat them as
+  /// errors.
+  bool _validateGradleDrivenLintConfig(
+      RepositoryPackage package, List<String> gradleLines) {
+    final List<String> gradleBuildContents = package
+        .platformDirectory(FlutterPlatform.android)
+        .childFile('build.gradle')
+        .readAsLinesSync();
+    if (!gradleBuildContents.any((String line) =>
+            line.contains('checkAllWarnings true') && !_isCommented(line)) ||
+        !gradleBuildContents.any((String line) =>
+            line.contains('warningsAsErrors true') && !_isCommented(line))) {
+      printError('${indentation}This package is not configured to enable all '
+          'Gradle-driven lint warnings and treat them as errors. '
+          'Please add the following to the lintOptions section of '
+          'android/build.gradle:');
+      print('''
+        checkAllWarnings true
+        warningsAsErrors true
+''');
+      return false;
+    }
+    return true;
+  }
+
+  /// Validates whether the given example app's gradle content is configured to
+  /// build its plugin target with javac lints enabled and treated as errors.
+  ///
+  /// This can only be called on example packages. (Plugin packages should not
+  /// be configured this way, since it would affect clients.)
+  bool _validateJavacLintConfig(
+      RepositoryPackage example, List<String> gradleLines) {
+    final RepositoryPackage enclosingPackage = example.getEnclosingPackage()!;
+    final String enclosingPackageName = enclosingPackage.directory.basename;
+
+    // The check here is intentionally somewhat loose, to allow for the
+    // possibility of variations (e.g., not using Xlint:all in some cases, or
+    // passing other arguments).
+    if (!(gradleLines.any((String line) =>
+            line.contains('project(":$enclosingPackageName")')) &&
+        gradleLines.any((String line) =>
+            line.contains('options.compilerArgs') &&
+            line.contains('-Xlint') &&
+            line.contains('-Werror')))) {
+      printError('The example '
+          '"${getRelativePosixPath(example.directory, from: enclosingPackage.directory)}" '
+          'is not configured to treat javac lints and warnings as errors. '
+          'Please add the following to its build.gradle:');
+      print('''
+gradle.projectsEvaluated {
+    project(":$enclosingPackageName") {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:all" << "-Werror"
+        }
+    }
+}
+''');
       return false;
     }
     return true;

--- a/script/tool/lib/src/gradle_check_command.dart
+++ b/script/tool/lib/src/gradle_check_command.dart
@@ -6,6 +6,7 @@ import 'package:file/file.dart';
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
+import 'common/plugin_utils.dart';
 import 'common/repository_package.dart';
 
 /// A command to enforce gradle file conventions and best practices.
@@ -262,14 +263,22 @@ for more details.''';
     return true;
   }
 
-  /// Validates whether the given example app's gradle content is configured to
-  /// build its plugin target with javac lints enabled and treated as errors.
+  /// Validates whether the given [example]'s gradle content is configured to
+  /// build its plugin target with javac lints enabled and treated as errors,
+  /// if the enclosing package is a plugin.
   ///
   /// This can only be called on example packages. (Plugin packages should not
   /// be configured this way, since it would affect clients.)
+  ///
+  /// If [example]'s enclosing package is not a plugin package, this just
+  /// returns true.
   bool _validateJavacLintConfig(
       RepositoryPackage example, List<String> gradleLines) {
     final RepositoryPackage enclosingPackage = example.getEnclosingPackage()!;
+    if (!pluginSupportsPlatform(platformAndroid, enclosingPackage,
+        requiredMode: PlatformSupport.inline)) {
+      return true;
+    }
     final String enclosingPackageName = enclosingPackage.directory.basename;
 
     // The check here is intentionally somewhat loose, to allow for the

--- a/script/tool/lib/src/lint_android_command.dart
+++ b/script/tool/lib/src/lint_android_command.dart
@@ -38,22 +38,6 @@ class LintAndroidCommand extends PackageLoopingCommand {
           'Plugin does not have an Android implementation.');
     }
 
-    bool failed = false;
-
-    // Ensure that the plugin has a strict Gradle-driven lint configuration, so
-    // that this test actually catches most issues.
-    if (!_mainGradleHasLintConfig(package)) {
-      failed = true;
-      printError('This plugin is not configured to enable all Gradle-driven '
-          'lint warnings and treat them as errors. '
-          'Please add the following to the lintOptions section of '
-          'android/build.gradle:');
-      print('''
-        checkAllWarnings true
-        warningsAsErrors true
-''');
-    }
-
     for (final RepositoryPackage example in package.getExamples()) {
       final GradleProject project = GradleProject(example,
           processRunner: processRunner, platform: platform);
@@ -75,62 +59,10 @@ class LintAndroidCommand extends PackageLoopingCommand {
       // inline, and the rest have to be checked via the CI-uploaded artifact.
       final int exitCode = await project.runCommand('$packageName:lintDebug');
       if (exitCode != 0) {
-        failed = true;
-      }
-
-      // In addition to running the Gradle-driven lint step, also ensure that
-      // the example project is configured to build with javac lints enabled and
-      // treated as errors.
-      if (!_exampleGradleHasJavacLintConfig(example, packageName)) {
-        failed = true;
-        printError('The example '
-            '"${getRelativePosixPath(example.directory, from: package.directory)}" '
-            'is not configured to treat javac lints and warnings as errors. '
-            'Please add the following to its build.gradle:');
-        print('''
-gradle.projectsEvaluated {
-    project(":${package.directory.basename}") {
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:all" << "-Werror"
-        }
-    }
-}
-''');
+        return PackageResult.fail();
       }
     }
 
-    return failed ? PackageResult.fail() : PackageResult.success();
-  }
-
-  /// Returns whether the plugin project is configured to enable all Gradle
-  /// lints and treat them as errors.
-  bool _mainGradleHasLintConfig(RepositoryPackage package) {
-    final List<String> gradleBuildContents = package
-        .platformDirectory(FlutterPlatform.android)
-        .childFile('build.gradle')
-        .readAsLinesSync();
-    return gradleBuildContents
-            .any((String line) => line.contains('checkAllWarnings true')) &&
-        gradleBuildContents
-            .any((String line) => line.contains('warningsAsErrors true'));
-  }
-
-  /// Returns whether the example project is configured to build with javac
-  /// lints enabled and treated as errors.
-  bool _exampleGradleHasJavacLintConfig(
-      RepositoryPackage example, String pluginPackageName) {
-    final List<String> gradleBuildContents = example
-        .platformDirectory(FlutterPlatform.android)
-        .childFile('build.gradle')
-        .readAsLinesSync();
-    // The check here is intentionally somewhat loose, to allow for the
-    // possibility of variations (e.g., not using Xlint:all in some cases, or
-    // passing other arguments).
-    return gradleBuildContents.any(
-            (String line) => line.contains('project(":$pluginPackageName")')) &&
-        gradleBuildContents.any((String line) =>
-            line.contains('options.compilerArgs') &&
-            line.contains('-Xlint') &&
-            line.contains('-Werror'));
+    return PackageResult.success();
   }
 }

--- a/script/tool/test/lint_android_command_test.dart
+++ b/script/tool/test/lint_android_command_test.dart
@@ -37,79 +37,6 @@ void main() {
       runner.addCommand(command);
     });
 
-    void writeFakePluginBuildGradle(RepositoryPackage plugin,
-        {bool warningsConfigured = true}) {
-      const String warningConfig = '''
-    lintOptions {
-        checkAllWarnings true
-        warningsAsErrors true
-        disable 'AndroidGradlePluginVersion', 'InvalidPackage', 'GradleDependency'
-        baseline file("lint-baseline.xml")
-    }
-''';
-      final File gradleFile = plugin
-          .platformDirectory(FlutterPlatform.android)
-          .childFile('build.gradle');
-      gradleFile.createSync(recursive: true);
-      gradleFile.writeAsStringSync('''
-android {
-    compileSdkVersion 33
-
-    defaultConfig {
-        minSdkVersion 16
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-${warningsConfigured ? warningConfig : ''}
-    testOptions {
-        unitTests.returnDefaultValues = true
-        unitTests.all {
-            testLogging {
-               events "passed", "skipped", "failed", "standardOut", "standardError"
-               outputs.upToDateWhen {false}
-               showStandardStreams = true
-            }
-        }
-    }
-}
-
-''');
-    }
-
-    void writeFakeExampleBuildGradle(
-        RepositoryPackage example, String pluginName,
-        {bool warningsConfigured = true}) {
-      final String warningConfig = '''
-gradle.projectsEvaluated {
-    project(":$pluginName") {
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:all" << "-Werror"
-        }
-    }
-}
-''';
-      example
-          .platformDirectory(FlutterPlatform.android)
-          .childFile('build.gradle')
-          .writeAsStringSync('''
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
-    }
-}
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-${warningsConfigured ? warningConfig : ''}
-''');
-    }
-
     test('runs gradle lint', () async {
       final RepositoryPackage plugin =
           createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
@@ -117,8 +44,6 @@ ${warningsConfigured ? warningConfig : ''}
       ], platformSupport: <String, PlatformDetails>{
         platformAndroid: const PlatformDetails(PlatformSupport.inline)
       });
-      writeFakePluginBuildGradle(plugin);
-      writeFakeExampleBuildGradle(plugin.getExamples().first, 'plugin1');
 
       final Directory androidDir =
           plugin.getExamples().first.platformDirectory(FlutterPlatform.android);
@@ -156,10 +81,6 @@ ${warningsConfigured ? warningConfig : ''}
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.inline)
           });
-      writeFakePluginBuildGradle(plugin);
-      for (final RepositoryPackage example in plugin.getExamples()) {
-        writeFakeExampleBuildGradle(example, 'plugin1');
-      }
 
       final Iterable<Directory> exampleAndroidDirs = plugin.getExamples().map(
           (RepositoryPackage example) =>
@@ -193,7 +114,6 @@ ${warningsConfigured ? warningConfig : ''}
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.inline)
           });
-      writeFakePluginBuildGradle(plugin);
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -218,8 +138,6 @@ ${warningsConfigured ? warningConfig : ''}
       ], platformSupport: <String, PlatformDetails>{
         platformAndroid: const PlatformDetails(PlatformSupport.inline)
       });
-      writeFakePluginBuildGradle(plugin);
-      writeFakeExampleBuildGradle(plugin.getExamples().first, 'plugin1');
 
       final String gradlewPath = plugin
           .getExamples()
@@ -242,63 +160,6 @@ ${warningsConfigured ? warningConfig : ''}
           output,
           containsAllInOrder(
             <Matcher>[
-              contains('The following packages had errors:'),
-            ],
-          ));
-    });
-
-    test('fails if gradle-driven lint-warnings-as-errors is missing', () async {
-      final RepositoryPackage plugin =
-          createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
-        'example/android/gradlew',
-      ], platformSupport: <String, PlatformDetails>{
-        platformAndroid: const PlatformDetails(PlatformSupport.inline)
-      });
-      writeFakePluginBuildGradle(plugin, warningsConfigured: false);
-      writeFakeExampleBuildGradle(plugin.getExamples().first, 'plugin1');
-
-      Error? commandError;
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['lint-android'], errorHandler: (Error e) {
-        commandError = e;
-      });
-
-      expect(commandError, isA<ToolExit>());
-      expect(
-          output,
-          containsAllInOrder(
-            <Matcher>[
-              contains('This plugin is not configured to enable all '
-                  'Gradle-driven lint warnings and treat them as errors.'),
-              contains('The following packages had errors:'),
-            ],
-          ));
-    });
-
-    test('fails if javac lint-warnings-as-errors is missing', () async {
-      final RepositoryPackage plugin =
-          createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
-        'example/android/gradlew',
-      ], platformSupport: <String, PlatformDetails>{
-        platformAndroid: const PlatformDetails(PlatformSupport.inline)
-      });
-      writeFakePluginBuildGradle(plugin);
-      writeFakeExampleBuildGradle(plugin.getExamples().first, 'plugin1',
-          warningsConfigured: false);
-
-      Error? commandError;
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['lint-android'], errorHandler: (Error e) {
-        commandError = e;
-      });
-
-      expect(commandError, isA<ToolExit>());
-      expect(
-          output,
-          containsAllInOrder(
-            <Matcher>[
-              contains('The example "example" is not configured to treat javac '
-                  'lints and warnings as errors.'),
               contains('The following packages had errors:'),
             ],
           ));

--- a/script/tool/test/lint_android_command_test.dart
+++ b/script/tool/test/lint_android_command_test.dart
@@ -110,7 +110,7 @@ void main() {
     });
 
     test('fails if gradlew is missing', () async {
-      final RepositoryPackage plugin = createFakePlugin('plugin1', packagesDir,
+      createFakePlugin('plugin1', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.inline)
           });


### PR DESCRIPTION
Moves the checks for Android warning configuration from `lint-android`, where it made sense to put them at the time, to the new `check-gradle`, which is a newer command specifically for validating that our Gradle files are following best practices.

Makes minor changes to the Pigeon platform test projects to make them conform to the checks, since they are now included in the run. The changes shouldn't actually change the behavior of the Pigeon tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
