### PR TITLE
[auick_action_ios] Retries multiple times to not fail ci when there is a flake

### DIFF
--- a/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
+++ b/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
@@ -4,10 +4,20 @@
 
 import XCTest
 
-private let elementWaitingTime: TimeInterval = 5
+private let elementWaitingTime: TimeInterval = 30
+// The duration in when pressing the app icon to open the
+// quick action menu. This duration is undocumented by Apple.
+// The duration will be adjusted with `pressDurationRetryAdjustment` if
+// this duration does not result in the quick action menu opened.
 private let quickActionPressDuration: TimeInterval = 1.5
+// If the previous try to open quick action menu did not work,
+// a new try with adjust the press time by this value.
+// The adjusment could be + or - depends on the result of the previous try.
 private let pressDurationRetryAdjustment: TimeInterval = 0.2
 // Max number of tries to open the quick action menu if failed.
+// This is to deflake a situation where the quick action menu is not present after
+// the long press.
+// See: https://github.com/flutter/flutter/issues/125509
 private let quickActionMaxRetries: Int = 4;
 
 class RunnerUITests: XCTestCase {

--- a/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
+++ b/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
@@ -34,16 +34,23 @@ class RunnerUITests: XCTestCase {
       )
     }
 
-    quickActionsAppIcon.press(forDuration: quickActionPressDuration)
-
-    let actionTwo = springboard.buttons["Action two"]
-    if !actionTwo.waitForExistence(timeout: elementWaitingTime) {
+    var actionTwo: XCUIElement?
+    for _ in 1...quickActionMaxRetries {
+      quickActionsAppIcon.press(forDuration: quickActionPressDuration)
+      actionTwo = springboard.buttons["Action two"]
+      if actionTwo!.waitForExistence(timeout: elementWaitingTime) {
+        break
+      }
+      // Reset to previous state.
+      XCUIDevice.shared.press(XCUIDevice.Button.home)
+    }
+    if (!actionTwo!.exists) {
       XCTFail(
         "Failed due to not able to find the actionTwo button from springboard with \(elementWaitingTime) seconds. Springboard debug description: \(springboard.debugDescription)"
       )
     }
 
-    actionTwo.tap()
+    actionTwo!.tap()
 
     let actionTwoConfirmation = exampleApp.otherElements["action_two"]
     if !actionTwoConfirmation.waitForExistence(timeout: elementWaitingTime) {
@@ -76,16 +83,23 @@ class RunnerUITests: XCTestCase {
       )
     }
 
-    quickActionsAppIcon.press(forDuration: quickActionPressDuration)
-
-    let actionOne = springboard.buttons["Action one"]
-    if !actionOne.waitForExistence(timeout: elementWaitingTime) {
+    var actionOne: XCUIElement?
+    for _ in 1...quickActionMaxRetries {
+      quickActionsAppIcon.press(forDuration: quickActionPressDuration)
+      actionOne = springboard.buttons["Action one"]
+      if actionOne!.waitForExistence(timeout: elementWaitingTime) {
+        break
+      }
+      // Reset to previous state.
+      XCUIDevice.shared.press(XCUIDevice.Button.home)
+    }
+    if (!actionOne!.exists) {
       XCTFail(
         "Failed due to not able to find the actionOne button from springboard with \(elementWaitingTime) seconds. Springboard debug description: \(springboard.debugDescription)"
       )
     }
 
-    actionOne.tap()
+    actionOne!.tap()
 
     let actionOneConfirmation = exampleApp.otherElements["action_one"]
     if !actionOneConfirmation.waitForExistence(timeout: elementWaitingTime) {

--- a/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
+++ b/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
@@ -5,6 +5,9 @@
 import XCTest
 
 private let elementWaitingTime: TimeInterval = 30
+private let quickActionPressDuration: TimeInterval = 1.5
+// Max number of tries to open the quick action menu if failed.
+private let quickActionMaxRetries: Int = 3;
 
 class RunnerUITests: XCTestCase {
 
@@ -31,7 +34,7 @@ class RunnerUITests: XCTestCase {
       )
     }
 
-    quickActionsAppIcon.press(forDuration: 2)
+    quickActionsAppIcon.press(forDuration: quickActionPressDuration)
 
     let actionTwo = springboard.buttons["Action two"]
     if !actionTwo.waitForExistence(timeout: elementWaitingTime) {
@@ -73,7 +76,7 @@ class RunnerUITests: XCTestCase {
       )
     }
 
-    quickActionsAppIcon.press(forDuration: 2)
+    quickActionsAppIcon.press(forDuration: quickActionPressDuration)
 
     let actionOne = springboard.buttons["Action one"]
     if !actionOne.waitForExistence(timeout: elementWaitingTime) {


### PR DESCRIPTION
The only way that we found to test quick action menu is to long press for a x second. Previously, we pressed it for 2 seconds but it is sometimes too long and the quick action menu is disappeared.

In this PR, we:
1. Reduce the press time to 1.5 seconds.
2. Retry 3 times.

fixes https://github.com/flutter/flutter/issues/125509

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
