### PR TITLE
[various] Set cmake_policy versions

### DIFF
--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.2.1+6
 
+* Sets a cmake_policy compatibility version to fix build warnings.
 * Aligns Dart and Flutter SDK constraints.
 
 ## 0.2.1+5

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_windows
 description: A Flutter plugin for getting information about and controlling the camera on Windows.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.2.1+5
+version: 0.2.1+6
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/camera/camera_windows/windows/CMakeLists.txt
+++ b/packages/camera/camera_windows/windows/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME "camera_windows")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+cmake_policy(VERSION 3.14...3.24)
+
 # This value is used when generating builds using this plugin, so it must
 # not be changed
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")

--- a/packages/file_selector/file_selector_linux/CHANGELOG.md
+++ b/packages/file_selector/file_selector_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1+3
+
+* Sets a cmake_policy compatibility version to fix build warnings.
+
 ## 0.9.1+2
 
 * Clarifies explanation of endorsement in README.

--- a/packages/file_selector/file_selector_linux/linux/CMakeLists.txt
+++ b/packages/file_selector/file_selector_linux/linux/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 set(PROJECT_NAME "file_selector_linux")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+cmake_policy(VERSION 3.10...3.24)
+
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
 
 list(APPEND PLUGIN_SOURCES

--- a/packages/file_selector/file_selector_linux/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_linux
 description: Liunx implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.1+2
+version: 0.9.1+3
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/file_selector/file_selector_windows/CHANGELOG.md
+++ b/packages/file_selector/file_selector_windows/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.9.1+8
 
+* Sets a cmake_policy compatibility version to fix build warnings.
 * Updates minimum Flutter version to 3.3.
 
 ## 0.9.1+7

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_windows
 description: Windows implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.1+7
+version: 0.9.1+8
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/file_selector/file_selector_windows/windows/CMakeLists.txt
+++ b/packages/file_selector/file_selector_windows/windows/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME "file_selector_windows")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+cmake_policy(VERSION 3.14...3.24)
+
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
 
 list(APPEND PLUGIN_SOURCES

--- a/packages/local_auth/local_auth_windows/CHANGELOG.md
+++ b/packages/local_auth/local_auth_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+* Sets a cmake_policy compatibility version to fix build warnings.
+
 ## 1.0.7
 
 * Clarifies explanation of endorsement in README.

--- a/packages/local_auth/local_auth_windows/pubspec.yaml
+++ b/packages/local_auth/local_auth_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_windows
 description: Windows implementation of the local_auth plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/local_auth/local_auth_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.7
+version: 1.0.8
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/local_auth/local_auth_windows/windows/CMakeLists.txt
+++ b/packages/local_auth/local_auth_windows/windows/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 set(PROJECT_NAME "local_auth_windows")
+cmake_policy(VERSION 3.15...3.24)
 set(WIL_VERSION "1.0.220201.1")
 set(CPPWINRT_VERSION "2.0.220418.1")
 project(${PROJECT_NAME} LANGUAGES CXX)

--- a/packages/pigeon/platform_tests/test_plugin/windows/CMakeLists.txt
+++ b/packages/pigeon/platform_tests/test_plugin/windows/CMakeLists.txt
@@ -8,6 +8,8 @@ cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME "test_plugin")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+cmake_policy(VERSION 3.14...3.24)
+
 # This value is used when generating builds using this plugin, so it must
 # not be changed
 set(PLUGIN_NAME "test_plugin_plugin")

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.5
+
+* Sets a cmake_policy compatibility version to fix build warnings.
+
 ## 3.0.4
 
 * Clarifies explanation of endorsement in README.

--- a/packages/url_launcher/url_launcher_linux/linux/CMakeLists.txt
+++ b/packages/url_launcher/url_launcher_linux/linux/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 set(PROJECT_NAME "url_launcher_linux")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+cmake_policy(VERSION 3.10...3.24)
+
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
 
 list(APPEND PLUGIN_SOURCES

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 3.0.4
+version: 3.0.5
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.6
+
+* Sets a cmake_policy compatibility version to fix build warnings.
+
 ## 3.0.5
 
 * Clarifies explanation of endorsement in README.

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_windows
 description: Windows implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 3.0.5
+version: 3.0.6
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/url_launcher/url_launcher_windows/windows/CMakeLists.txt
+++ b/packages/url_launcher/url_launcher_windows/windows/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 set(PROJECT_NAME "url_launcher_windows")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+cmake_policy(VERSION 3.10...3.24)
+
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
 
 list(APPEND PLUGIN_SOURCES


### PR DESCRIPTION
Use of `FetchContent` with default policy settings has a warning starting with CMake 3.24. This opts those plugins into new behaviors for everything up through 3.24 to avoid those warnings.

The `VERSION` is used rather than an explicity policy setting since this is the approach recommended by CMake docs. For any policies that we aren't currently hitting, we would want new behavior by default in the future so that we don't accidentally depend on deprecated behavior.

See https://github.com/flutter/flutter/issues/116866

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
