### PR TITLE
[go_router_builder] fixed typo in README

### DIFF
--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -341,7 +341,7 @@ class FancyRoute extends GoRouteData {
 
 ## TypedShellRoute and navigator keys
 
-There may be situations were a child route of a shell needs to be displayed on a
+There may be situations where a child route of a shell needs to be displayed on a
 different navigator. This kind of scenarios can be achieved by declaring a
 **static** navigator key named:
 


### PR DESCRIPTION
Replaced "were" in line 344 of the README with "where".