### PR TITLE
[various] Conditionalize the namespace in all Android plugins

### DIFF
--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.6+2
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 0.10.6+1
 
 * Adds a namespace for compatibility with AGP 8.0.

--- a/packages/camera/camera_android/android/build.gradle
+++ b/packages/camera/camera_android/android/build.gradle
@@ -27,7 +27,10 @@ project.getTasks().withType(JavaCompile){
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.camera'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.camera'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android
 description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.6+1
+version: 0.10.6+2
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/camera/camera_android_camerax/android/build.gradle
+++ b/packages/camera/camera_android_camerax/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.camerax'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.camerax'
+    }
     // CameraX dependencies require compilation against version 33 or later.
     compileSdkVersion 33
 

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+4
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 0.3.0+3
 
 * Adds `targetCompatibilty` matching `sourceCompatibility` for older toolchains.

--- a/packages/espresso/android/build.gradle
+++ b/packages/espresso/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'com.example.espresso'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.example.espresso'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -3,7 +3,7 @@ description: Java classes for testing Flutter apps using Espresso.
   Allows driving Flutter widgets from a native Espresso test.
 repository: https://github.com/flutter/packages/tree/main/packages/espresso
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+espresso%22
-version: 0.3.0+3
+version: 0.3.0+4
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.13
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 2.0.12
 
 * Adds `targetCompatibilty` matching `sourceCompatibility` for older toolchains.

--- a/packages/flutter_plugin_android_lifecycle/android/build.gradle
+++ b/packages/flutter_plugin_android_lifecycle/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.flutter_plugin_android_lifecycle'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.flutter_plugin_android_lifecycle'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_android_lifecycle
 description: Flutter plugin for accessing an Android Lifecycle within other plugins.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_plugin_android_lifecycle
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_plugin_android_lifecycle%22
-version: 2.0.12
+version: 2.0.13
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.13
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 2.4.12
 
 * Fixes Java warnings.

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.googlemaps'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.googlemaps'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_android
 description: Android implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.4.12
+version: 2.4.13
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.14
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 6.1.13
 
 * Adds `targetCompatibilty` matching `sourceCompatibility` for older toolchains.

--- a/packages/google_sign_in/google_sign_in_android/android/build.gradle
+++ b/packages/google_sign_in/google_sign_in_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.googlesignin'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.googlesignin'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_android
 description: Android implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 6.1.13
+version: 6.1.14
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.6+9
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 0.8.6+8
 
 * Adds a namespace for compatibility with AGP 8.0.

--- a/packages/image_picker/image_picker_android/android/build.gradle
+++ b/packages/image_picker/image_picker_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.imagepicker'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.imagepicker'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 
-version: 0.8.6+8
+version: 0.8.6+9
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5+3
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 0.2.5+2
 
 * Updates androidx.annotation:annotation from 1.5.0 to 1.6.0.

--- a/packages/in_app_purchase/in_app_purchase_android/android/build.gradle
+++ b/packages/in_app_purchase/in_app_purchase_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.inapppurchase'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.inapppurchase'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.5+3
+version: 0.2.5+4
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.5+2
+version: 0.2.5+3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.27
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 1.0.26
 
 * Adds `targetCompatibilty` matching `sourceCompatibility` for older toolchains.

--- a/packages/local_auth/local_auth_android/android/build.gradle
+++ b/packages/local_auth/local_auth_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.localauth'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.localauth'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.26
+version: 1.0.27
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.27
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 2.0.26
 
 * Adds a namespace for compatibility with AGP 8.0.

--- a/packages/path_provider/path_provider_android/android/build.gradle
+++ b/packages/path_provider/path_provider_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.pathprovider'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.pathprovider'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_android
 description: Android implementation of the path_provider plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.26
+version: 2.0.27
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'com.example.alternate_language_test_plugin'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.example.alternate_language_test_plugin'
+    }
     compileSdkVersion 33
 
     compileOptions {

--- a/packages/pigeon/platform_tests/test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/android/build.gradle
@@ -25,7 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'com.example.test_plugin'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.example.test_plugin'
+    }
     compileSdkVersion 33
 
     compileOptions {

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 1.0.3
 
 * Adds a namespace for compatibility with AGP 8.0.

--- a/packages/quick_actions/quick_actions_android/android/build.gradle
+++ b/packages/quick_actions/quick_actions_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.quickactions'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.quickactions'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_android
 description: An implementation for the Android platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/quick_actions/quick_actions_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 1.0.3
+version: 1.0.4
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.4
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 2.1.3
 
 * Adds a namespace for compatibility with AGP 8.0.

--- a/packages/shared_preferences/shared_preferences_android/android/build.gradle
+++ b/packages/shared_preferences/shared_preferences_android/android/build.gradle
@@ -30,7 +30,10 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.sharedpreferences'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.sharedpreferences'
+    }
     compileSdkVersion 33
 
     compileOptions {

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.1.3
+version: 2.1.4
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.31
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 6.0.30
 
 * Adds `targetCompatibilty` matching `sourceCompatibility` for older toolchains.

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.urllauncher'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.urllauncher'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.30
+version: 6.0.31
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.6
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 2.4.5
 
 * Adds a namespace for compatibility with AGP 8.0.

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -27,7 +27,10 @@ project.getTasks().withType(JavaCompile){
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.videoplayer'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.videoplayer'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.5
+version: 2.4.6
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.2
+
+* Fixes compatibility with AGP versions older than 4.2.
+
 ## 3.6.1
 
 * Adds a namespace for compatibility with AGP 8.0.

--- a/packages/webview_flutter/webview_flutter_android/android/build.gradle
+++ b/packages/webview_flutter/webview_flutter_android/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.webviewflutter'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.flutter.plugins.webviewflutter'
+    }
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.6.1
+version: 3.6.2
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/script/tool/lib/src/gradle_check_command.dart
+++ b/script/tool/lib/src/gradle_check_command.dart
@@ -153,13 +153,30 @@ class GradleCheckCommand extends PackageLoopingCommand {
         RegExp('^\\s*namespace\\s+[\'"](.*?)[\'"]', multiLine: true);
     final RegExpMatch? namespaceMatch =
         namespaceRegex.firstMatch(gradleContents);
+
+    // For plugins, make sure the namespace is conditionalized so that it
+    // doesn't break client apps using AGP 4.1 and earlier (which don't have
+    // a namespace property, and will fail to build if it's set).
+    const String namespaceConditional =
+        'if (project.android.hasProperty("namespace"))';
+    String exampleSetNamespace = "namespace 'dev.flutter.foo'";
+    if (!isExample) {
+      exampleSetNamespace = '''
+$namespaceConditional {
+    $exampleSetNamespace
+}''';
+    }
+    final String exampleAndroidNamespaceBlock = '''
+    android {
+        ${exampleSetNamespace.split('\n').join('\n        ')}
+    }
+''';
+
     if (namespaceMatch == null) {
-      const String errorMessage = '''
+      final String errorMessage = '''
 build.gradle must set a "namespace":
 
-    android {
-        namespace 'dev.flutter.foo'
-    }
+$exampleAndroidNamespaceBlock
 
 The value must match the "package" attribute in AndroidManifest.xml, if one is
 present. For more information, see:
@@ -170,6 +187,18 @@ https://developer.android.com/build/publish-library/prep-lib-release#choose-name
           '$indentation${errorMessage.split('\n').join('\n$indentation')}');
       return false;
     } else {
+      if (!isExample && !gradleContents.contains(namespaceConditional)) {
+        final String errorMessage = '''
+build.gradle for a plugin must conditionalize "namespace":
+
+$exampleAndroidNamespaceBlock
+''';
+
+        printError(
+            '$indentation${errorMessage.split('\n').join('\n$indentation')}');
+        return false;
+      }
+
       return _validateNamespaceMatchesManifest(package,
           isExample: isExample, namespace: namespaceMatch.group(1)!);
     }

--- a/script/tool/lib/src/gradle_check_command.dart
+++ b/script/tool/lib/src/gradle_check_command.dart
@@ -166,6 +166,8 @@ $namespaceConditional {
     $exampleSetNamespace
 }''';
     }
+    // Wrap the namespace command in an `android` block, adding the indentation
+    // to make it line up correctly.
     final String exampleAndroidNamespaceBlock = '''
     android {
         ${exampleSetNamespace.split('\n').join('\n        ')}


### PR DESCRIPTION
The recent change to add `namespace` to all plugins broke builds for apps using AGP 4.1 or earlier. This conditionalizes setting the namespace based on whether the property exists at all, making it compatible with both AGP 8.0 and AGP <4.2.

Updates tooling to enforce this for plugin (but not example app) build.gradle files.

Fixes https://github.com/flutter/flutter/issues/125621

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
