### PR TITLE
[file_selector] Remove uses of `macUTIs`

### DIFF
--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.9.2+5
 
+* Updates references to the deprecated `macUTIs`.
 * Aligns Dart and Flutter SDK constraints.
 
 ## 0.9.2+4

--- a/packages/file_selector/file_selector/README.md
+++ b/packages/file_selector/file_selector/README.md
@@ -99,12 +99,12 @@ Different platforms support different type group filter options. To avoid
 filters that cover all platforms you are targeting, or that you conditionally
 pass different `XTypeGroup`s based on `Platform`.
 
-|                | Linux | macOS  | Web | Windows     |
-|----------------|-------|--------|-----|-------------|
-| `extensions`   | ✔️     | ✔️      | ✔️   | ✔️           |
-| `mimeTypes`    | ✔️     | ✔️†     | ✔️   |             |
-| `macUTIs`      |       | ✔️      |     |             |
-| `webWildCards` |       |        | ✔️   |             |
+|                          | iOS | Linux | macOS  | Web | Windows     |
+|--------------------------|-----|-------|--------|-----|-------------|
+| `extensions`             |     | ✔️     | ✔️      | ✔️   | ✔️           |
+| `mimeTypes`              |     | ✔️     | ✔️†     | ✔️   |             |
+| `uniformTypeIdentifiers` | ✔️   |       | ✔️      |     |             |
+| `webWildCards`           |     |       |        | ✔️   |             |
 
 † `mimeTypes` are not supported on version of macOS earlier than 11 (Big Sur).
 

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for opening and saving files, or selecting
   directories, using native file selection UI.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.2+4
+version: 0.9.2+5
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -27,7 +27,7 @@ dependencies:
   file_selector_ios: ^0.5.0
   file_selector_linux: ^0.9.0
   file_selector_macos: ^0.9.0
-  file_selector_platform_interface: ^2.2.0
+  file_selector_platform_interface: ^2.3.0
   file_selector_web: ^0.9.0
   file_selector_windows: ^0.9.0
   flutter:

--- a/packages/file_selector/file_selector_ios/CHANGELOG.md
+++ b/packages/file_selector/file_selector_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1+4
+
+* Updates references to the deprecated `macUTIs`.
+
 ## 0.5.1+3
 
 * Updates pigeon to fix warnings with clang 15.

--- a/packages/file_selector/file_selector_ios/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_image_page.dart
@@ -18,7 +18,7 @@ class OpenImagePage extends StatelessWidget {
     const XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
       extensions: <String>['jpg', 'png'],
-      macUTIs: <String>['public.image'],
+      uniformTypeIdentifiers: <String>['public.image'],
     );
     final XFile? file = await FileSelectorPlatform.instance
         .openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);

--- a/packages/file_selector/file_selector_ios/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_multiple_images_page.dart
@@ -18,12 +18,12 @@ class OpenMultipleImagesPage extends StatelessWidget {
     const XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
       extensions: <String>['jpg', 'jpeg'],
-      macUTIs: <String>['public.jpeg'],
+      uniformTypeIdentifiers: <String>['public.jpeg'],
     );
     const XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
       extensions: <String>['png'],
-      macUTIs: <String>['public.png'],
+      uniformTypeIdentifiers: <String>['public.png'],
     );
     final List<XFile> files = await FileSelectorPlatform.instance
         .openFiles(acceptedTypeGroups: <XTypeGroup>[

--- a/packages/file_selector/file_selector_ios/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_text_page.dart
@@ -15,7 +15,7 @@ class OpenTextPage extends StatelessWidget {
     const XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
       extensions: <String>['txt', 'json'],
-      macUTIs: <String>['public.text'],
+      uniformTypeIdentifiers: <String>['public.text'],
     );
     final XFile? file = await FileSelectorPlatform.instance
         .openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);

--- a/packages/file_selector/file_selector_ios/lib/file_selector_ios.dart
+++ b/packages/file_selector/file_selector_ios/lib/file_selector_ios.dart
@@ -53,11 +53,11 @@ class FileSelectorIOS extends FileSelectorPlatform {
       if (typeGroup.allowsAny) {
         return <String>[];
       }
-      if (typeGroup.macUTIs?.isEmpty ?? true) {
+      if (typeGroup.uniformTypeIdentifiers?.isEmpty ?? true) {
         throw ArgumentError('The provided type group $typeGroup should either '
-            'allow all files, or have a non-empty "macUTIs"');
+            'allow all files, or have a non-empty "uniformTypeIdentifiers"');
       }
-      allowedUTIs.addAll(typeGroup.macUTIs!);
+      allowedUTIs.addAll(typeGroup.uniformTypeIdentifiers!);
     }
     return allowedUTIs;
   }

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_ios
 description: iOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.5.1+3
+version: 0.5.1+4
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -17,7 +17,7 @@ flutter:
         pluginClass: FFSFileSelectorPlugin
 
 dependencies:
-  file_selector_platform_interface: ^2.2.0
+  file_selector_platform_interface: ^2.3.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_ios/test/file_selector_ios_test.dart
+++ b/packages/file_selector/file_selector_ios/test/file_selector_ios_test.dart
@@ -40,14 +40,14 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
+        uniformTypeIdentifiers: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image'],
+          uniformTypeIdentifiers: <String>['public.image'],
           webWildCards: <String>['image/*']);
 
       await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
@@ -56,7 +56,7 @@ void main() {
       final FileSelectorConfig config =
           result.captured[0] as FileSelectorConfig;
 
-      // iOS only accepts macUTIs.
+      // iOS only accepts uniformTypeIdentifiers.
       expect(listEquals(config.utis, <String>['public.text', 'public.image']),
           isTrue);
       expect(config.allowMultiSelection, isFalse);
@@ -92,14 +92,14 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
+        uniformTypeIdentifiers: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image'],
+          uniformTypeIdentifiers: <String>['public.image'],
           webWildCards: <String>['image/*']);
 
       await plugin.openFiles(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
@@ -108,7 +108,7 @@ void main() {
       final FileSelectorConfig config =
           result.captured[0] as FileSelectorConfig;
 
-      // iOS only accepts macUTIs.
+      // iOS only accepts uniformTypeIdentifiers.
       expect(listEquals(config.utis, <String>['public.text', 'public.image']),
           isTrue);
       expect(config.allowMultiSelection, isTrue);

--- a/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -38,15 +38,12 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
         label: 'image',
         extensions: <String>['jpg'],
         mimeTypes: <String>['image/jpg'],
-        macUTIs: <String>['public.image'],
-        webWildCards: <String>['image/*'],
       );
 
       await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
@@ -144,15 +141,12 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
         label: 'image',
         extensions: <String>['jpg'],
         mimeTypes: <String>['image/jpg'],
-        macUTIs: <String>['public.image'],
-        webWildCards: <String>['image/*'],
       );
 
       await plugin.openFiles(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
@@ -250,15 +244,12 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
         label: 'image',
         extensions: <String>['jpg'],
         mimeTypes: <String>['image/jpg'],
-        macUTIs: <String>['public.image'],
-        webWildCards: <String>['image/*'],
       );
 
       await plugin

--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+9
+
+* Updates references to the deprecated `macUTIs`.
+
 ## 0.9.0+8
 
 * Updates pigeon for null value handling fixes.

--- a/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
+++ b/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
@@ -104,17 +104,17 @@ class FileSelectorMacOS extends FileSelectorPlatform {
       // Reject a filter that isn't an allow-any, but doesn't set any
       // macOS-supported filter categories.
       if ((typeGroup.extensions?.isEmpty ?? true) &&
-          (typeGroup.macUTIs?.isEmpty ?? true) &&
+          (typeGroup.uniformTypeIdentifiers?.isEmpty ?? true) &&
           (typeGroup.mimeTypes?.isEmpty ?? true)) {
         throw ArgumentError('Provided type group $typeGroup does not allow '
             'all files, but does not set any of the macOS-supported filter '
-            'categories. At least one of "extensions", "macUTIs", or '
-            '"mimeTypes" must be non-empty for macOS if anything is '
-            'non-empty.');
+            'categories. At least one of "extensions", '
+            '"uniformTypeIdentifiers", or "mimeTypes" must be non-empty for '
+            'macOS if anything is non-empty.');
       }
       allowedTypes.extensions.addAll(typeGroup.extensions ?? <String>[]);
       allowedTypes.mimeTypes.addAll(typeGroup.mimeTypes ?? <String>[]);
-      allowedTypes.utis.addAll(typeGroup.macUTIs ?? <String>[]);
+      allowedTypes.utis.addAll(typeGroup.uniformTypeIdentifiers ?? <String>[]);
     }
 
     return allowedTypes;

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.0+8
+version: 0.9.0+9
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.2.0
+  file_selector_platform_interface: ^2.3.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
+++ b/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
@@ -69,14 +69,14 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
+        uniformTypeIdentifiers: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image'],
+          uniformTypeIdentifiers: <String>['public.image'],
           webWildCards: <String>['image/*']);
 
       await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
@@ -165,14 +165,14 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
+        uniformTypeIdentifiers: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image'],
+          uniformTypeIdentifiers: <String>['public.image'],
           webWildCards: <String>['image/*']);
 
       await plugin.openFiles(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
@@ -256,14 +256,14 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
+        uniformTypeIdentifiers: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image'],
+          uniformTypeIdentifiers: <String>['public.image'],
           webWildCards: <String>['image/*']);
 
       await plugin
@@ -372,13 +372,13 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
+        uniformTypeIdentifiers: <String>['public.text'],
       ),
       const XTypeGroup(
         label: 'image',
         extensions: <String>['jpg'],
         mimeTypes: <String>['image/jpg'],
-        macUTIs: <String>['public.image'],
+        uniformTypeIdentifiers: <String>['public.image'],
       ),
       const XTypeGroup(
         label: 'any',

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -17,7 +17,7 @@ flutter:
         fileName: file_selector_web.dart
 
 dependencies:
-  file_selector_platform_interface: ^2.2.0
+  file_selector_platform_interface: ^2.3.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/file_selector/file_selector_web/test/utils_test.dart
+++ b/packages/file_selector/file_selector_web/test/utils_test.dart
@@ -56,7 +56,8 @@ void main() {
 
       test('throws for a type group that does not support web', () {
         const List<XTypeGroup> acceptedTypes = <XTypeGroup>[
-          XTypeGroup(label: 'text', macUTIs: <String>['public.text']),
+          XTypeGroup(
+              label: 'text', uniformTypeIdentifiers: <String>['public.text']),
         ];
         expect(() => acceptedTypesToString(acceptedTypes), throwsArgumentError);
       });

--- a/packages/file_selector/file_selector_windows/test/file_selector_windows_test.dart
+++ b/packages/file_selector/file_selector_windows/test/file_selector_windows_test.dart
@@ -51,14 +51,13 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
-          label: 'image',
-          extensions: <String>['jpg'],
-          mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image']);
+        label: 'image',
+        extensions: <String>['jpg'],
+        mimeTypes: <String>['image/jpg'],
+      );
 
       await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
@@ -129,14 +128,13 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
-          label: 'image',
-          extensions: <String>['jpg'],
-          mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image']);
+        label: 'image',
+        extensions: <String>['jpg'],
+        mimeTypes: <String>['image/jpg'],
+      );
 
       await plugin.openFiles(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
@@ -235,14 +233,13 @@ void main() {
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
-        macUTIs: <String>['public.text'],
       );
 
       const XTypeGroup groupTwo = XTypeGroup(
-          label: 'image',
-          extensions: <String>['jpg'],
-          mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image']);
+        label: 'image',
+        extensions: <String>['jpg'],
+        mimeTypes: <String>['image/jpg'],
+      );
 
       await plugin
           .getSavePath(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);


### PR DESCRIPTION
A change to replace `macUTIs` with `uniformTypeIdentifiers` (with `macUTIs` staying as an alias for compatibility) landed a while ago in the platform interface, but the rest of the packages were never updated to use it. This removes uses from all other packages, in preparation for formally deprecating `macUTIs`.

Mostly completes https://github.com/flutter/flutter/issues/103743

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
