### PR TITLE
[file_selector] Add MIME type support on macOS

### DIFF
--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+9
+
+* Adds support for MIME types on macOS 11+.
+
 ## 0.9.0+8
 
 * Updates pigeon for null value handling fixes.

--- a/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Cocoa
 import FlutterMacOS
-import Foundation
+import UniformTypeIdentifiers
 
 /// Protocol for showing panels, allowing for depenedency injection in tests.
 protocol PanelController {
@@ -47,6 +48,8 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin, FileSelectorApi {
   private let openMethod = "openFile"
   private let openDirectoryMethod = "getDirectoryPath"
   private let saveMethod = "getSavePath"
+
+  var forceLegacyTypes = false
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let instance = FileSelectorPlugin(
@@ -96,16 +99,31 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin, FileSelectorApi {
     }
 
     if let acceptedTypes = options.allowedFileTypes {
-      var allowedTypes: [String] = []
-      // The array values are non-null by convention even though Pigeon can't currently express
-      // that via the types; see messages.dart.
-      allowedTypes.append(contentsOf: acceptedTypes.extensions.map({ $0! }))
-      allowedTypes.append(contentsOf: acceptedTypes.utis.map({ $0! }))
-      // TODO: Add support for mimeTypes in macOS 11+. See
-      // https://github.com/flutter/flutter/issues/117843
-
-      if !allowedTypes.isEmpty {
-        panel.allowedFileTypes = allowedTypes
+      if #available(macOS 11, *), !forceLegacyTypes {
+        var allowedTypes: [UTType] = []
+        // The array values are non-null by convention even though Pigeon can't currently express
+        // that via the types; see messages.dart.
+        allowedTypes.append(contentsOf: acceptedTypes.utis.compactMap({ UTType($0!) }))
+        allowedTypes.append(
+          contentsOf: acceptedTypes.extensions.flatMap({
+            UTType.types(tag: $0!, tagClass: UTTagClass.filenameExtension, conformingTo: nil)
+          }))
+        allowedTypes.append(
+          contentsOf: acceptedTypes.mimeTypes.flatMap({
+            UTType.types(tag: $0!, tagClass: UTTagClass.mimeType, conformingTo: nil)
+          }))
+        if !allowedTypes.isEmpty {
+          panel.allowedContentTypes = allowedTypes
+        }
+      } else {
+        var allowedTypes: [String] = []
+        // The array values are non-null by convention even though Pigeon can't currently express
+        // that via the types; see messages.dart.
+        allowedTypes.append(contentsOf: acceptedTypes.extensions.map({ $0! }))
+        allowedTypes.append(contentsOf: acceptedTypes.utis.map({ $0! }))
+        if !allowedTypes.isEmpty {
+          panel.allowedFileTypes = allowedTypes
+        }
       }
     }
   }

--- a/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
@@ -102,7 +102,7 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin, FileSelectorApi {
       if #available(macOS 11, *), !forceLegacyTypes {
         var allowedTypes: [UTType] = []
         // The array values are non-null by convention even though Pigeon can't currently express
-        // that via the types; see messages.dart.
+        // that via the types; see messages.dart and https://github.com/flutter/flutter/issues/97848
         allowedTypes.append(contentsOf: acceptedTypes.utis.compactMap({ UTType($0!) }))
         allowedTypes.append(
           contentsOf: acceptedTypes.extensions.flatMap({
@@ -118,7 +118,7 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin, FileSelectorApi {
       } else {
         var allowedTypes: [String] = []
         // The array values are non-null by convention even though Pigeon can't currently express
-        // that via the types; see messages.dart.
+        // that via the types; see messages.dart and https://github.com/flutter/flutter/issues/97848
         allowedTypes.append(contentsOf: acceptedTypes.extensions.map({ $0! }))
         allowedTypes.append(contentsOf: acceptedTypes.utis.map({ $0! }))
         if !allowedTypes.isEmpty {

--- a/packages/file_selector/file_selector_macos/macos/Classes/messages.g.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/messages.g.swift
@@ -5,12 +5,13 @@
 // See also: https://pub.dev/packages/pigeon
 
 import Foundation
+
 #if os(iOS)
-import Flutter
+  import Flutter
 #elseif os(macOS)
-import FlutterMacOS
+  import FlutterMacOS
 #else
-#error("Unsupported platform.")
+  #error("Unsupported platform.")
 #endif
 
 private func wrapResult(_ result: Any?) -> [Any?] {
@@ -22,13 +23,13 @@ private func wrapError(_ error: Any) -> [Any?] {
     return [
       flutterError.code,
       flutterError.message,
-      flutterError.details
+      flutterError.details,
     ]
   }
   return [
     "\(error)",
     "\(type(of: error))",
-    "Stacktrace: \(Thread.callStackSymbols)"
+    "Stacktrace: \(Thread.callStackSymbols)",
   ]
 }
 
@@ -140,14 +141,14 @@ struct OpenPanelOptions {
 private class FileSelectorApiCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
-      case 128:
-        return AllowedTypes.fromList(self.readValue() as! [Any])
-      case 129:
-        return OpenPanelOptions.fromList(self.readValue() as! [Any])
-      case 130:
-        return SavePanelOptions.fromList(self.readValue() as! [Any])
-      default:
-        return super.readValue(ofType: type)
+    case 128:
+      return AllowedTypes.fromList(self.readValue() as! [Any])
+    case 129:
+      return OpenPanelOptions.fromList(self.readValue() as! [Any])
+    case 130:
+      return SavePanelOptions.fromList(self.readValue() as! [Any])
+    default:
+      return super.readValue(ofType: type)
     }
   }
 }
@@ -189,11 +190,13 @@ protocol FileSelectorApi {
   /// selected paths.
   ///
   /// An empty list corresponds to a cancelled selection.
-  func displayOpenPanel(options: OpenPanelOptions, completion: @escaping (Result<[String?], Error>) -> Void)
+  func displayOpenPanel(
+    options: OpenPanelOptions, completion: @escaping (Result<[String?], Error>) -> Void)
   /// Shows a save panel with the given [options], returning the selected path.
   ///
   /// A null return corresponds to a cancelled save.
-  func displaySavePanel(options: SavePanelOptions, completion: @escaping (Result<String?, Error>) -> Void)
+  func displaySavePanel(
+    options: SavePanelOptions, completion: @escaping (Result<String?, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -206,17 +209,19 @@ class FileSelectorApiSetup {
     /// selected paths.
     ///
     /// An empty list corresponds to a cancelled selection.
-    let displayOpenPanelChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.FileSelectorApi.displayOpenPanel", binaryMessenger: binaryMessenger, codec: codec)
+    let displayOpenPanelChannel = FlutterBasicMessageChannel(
+      name: "dev.flutter.pigeon.FileSelectorApi.displayOpenPanel", binaryMessenger: binaryMessenger,
+      codec: codec)
     if let api = api {
       displayOpenPanelChannel.setMessageHandler { message, reply in
         let args = message as! [Any]
         let optionsArg = args[0] as! OpenPanelOptions
         api.displayOpenPanel(options: optionsArg) { result in
           switch result {
-            case .success(let res):
-              reply(wrapResult(res))
-            case .failure(let error):
-              reply(wrapError(error))
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
           }
         }
       }
@@ -226,17 +231,19 @@ class FileSelectorApiSetup {
     /// Shows a save panel with the given [options], returning the selected path.
     ///
     /// A null return corresponds to a cancelled save.
-    let displaySavePanelChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.FileSelectorApi.displaySavePanel", binaryMessenger: binaryMessenger, codec: codec)
+    let displaySavePanelChannel = FlutterBasicMessageChannel(
+      name: "dev.flutter.pigeon.FileSelectorApi.displaySavePanel", binaryMessenger: binaryMessenger,
+      codec: codec)
     if let api = api {
       displaySavePanelChannel.setMessageHandler { message, reply in
         let args = message as! [Any]
         let optionsArg = args[0] as! SavePanelOptions
         api.displaySavePanel(options: optionsArg) { result in
           switch result {
-            case .success(let res):
-              reply(wrapResult(res))
-            case .failure(let error):
-              reply(wrapError(error))
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
           }
         }
       }

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.0+8
+version: 0.9.0+9
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Adds a macOS 11+ codepath that uses `UTType`s, allowing for supporting MIME type (and moving off of the deprecated `allowedFileTypes`).

Fixes https://github.com/flutter/flutter/issues/117843

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
