### PR TITLE
[google-maps][web] Add support for gaps, dashes and dots (PatternItems)

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+9
+
+* Allows for PatternItems to be used with Flutter Web. Issue [#73779](https://github.com/flutter/flutter/issues/73779).
+
 ## 0.4.0+8
 
 * Updates minimum Flutter version to 3.3.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/shapes_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/shapes_test.dart
@@ -367,5 +367,86 @@ void main() {
       expect(line.get('strokeColor'), '#fabada');
       expect(line.get('strokeOpacity'), closeTo(0.5, _acceptableDelta));
     });
+
+    testWidgets('Makes polyline invisible when PatternItems are specified',
+        (WidgetTester tester) async {
+      final Set<Polyline> lines = <Polyline>{
+        Polyline(
+          polylineId: const PolylineId('1'),
+          color: const Color(0x7FFABADA),
+          patterns: <PatternItem>[PatternItem.dash(10)],
+        ),
+      };
+
+      controller.addPolylines(lines);
+
+      final gmaps.Polyline line = controller.lines.values.first.line!;
+
+      expect(line.get('strokeOpacity'), closeTo(0.0, _acceptableDelta));
+    });
+
+    testWidgets(
+        'Creates vector based symbols for lines when PatternItems are specified',
+        (WidgetTester tester) async {
+      final Set<Polyline> lines = <Polyline>{
+        Polyline(
+          polylineId: const PolylineId('1'),
+          color: const Color(0x7FFABADA),
+          patterns: <PatternItem>[PatternItem.dash(10)],
+        ),
+      };
+
+      controller.addPolylines(lines);
+
+      final gmaps.Polyline line = controller.lines.values.first.line!;
+
+      expect(line.get('icons'), isNot(null));
+
+      final gmaps.IconSequence iconSequence =
+          (line.get('icons')! as List<gmaps.IconSequence>).first;
+
+      expect(iconSequence.icon?.strokeColor, '#fabada');
+      expect(iconSequence.icon?.strokeOpacity, closeTo(0.5, _acceptableDelta));
+      expect(iconSequence.offset, '0');
+      expect(iconSequence.repeat, '20px');
+    });
+
+    testWidgets(
+        'Creates a repeat at the correct value for lines when PatternItem Gap is specified',
+        (WidgetTester tester) async {
+      final Set<Polyline> lines = <Polyline>{
+        Polyline(
+          polylineId: const PolylineId('1'),
+          patterns: <PatternItem>[PatternItem.dash(10), PatternItem.gap(40)],
+        ),
+      };
+
+      controller.addPolylines(lines);
+
+      final gmaps.Polyline line = controller.lines.values.first.line!;
+
+      final gmaps.IconSequence iconSequence =
+          (line.get('icons')! as List<gmaps.IconSequence>).first;
+      expect(iconSequence.repeat, '40px');
+    });
+
+    testWidgets(
+        'Creates a dot pattern  for lines when PatternItem Dot is specified',
+        (WidgetTester tester) async {
+      final Set<Polyline> lines = <Polyline>{
+        const Polyline(
+          polylineId: PolylineId('1'),
+          patterns: <PatternItem>[PatternItem.dot],
+        ),
+      };
+
+      controller.addPolylines(lines);
+
+      final gmaps.Polyline line = controller.lines.values.first.line!;
+
+      final gmaps.IconSequence iconSequence =
+          (line.get('icons')! as List<gmaps.IconSequence>).first;
+      expect(iconSequence.icon?.path, gmaps.SymbolPath.CIRCLE);
+    });
   });
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/google_maps_flutter_web.dart
@@ -12,7 +12,6 @@ import 'dart:js_util';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:google_maps/google_maps.dart' as gmaps;
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.4.0+8
+version: 0.4.0+9
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Adds support for dashed lines, gaps and dots to Google Maps Web.

This is probably not perfect but would probably cover most use cases, to be able to add coloured lines and dots to a map. I've tried to disturb as little code as possible (this is my first ever contribution).

## Behaviour

- If no PatternItems are set then the existing behaviour of using solid Polylines
- If PatternItems are set then:
   - Try to parse them and make sensible decisions about spacing (e.g. setting a gap PatternItem will be used for spacing).
   - Default to dashes if parsing fails or values aren't right with a 20px gap
   - Only dot OR dash is used. If both are specified dot is used. Unsure if this is desired and an exception/assert would be better, it did not seem like it would be useful.
   - Pulls in the colours set for the Polyline
   - Hides the line (per example in the SDK guide)

https://github.com/flutter/flutter/issues/73779

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
