### PR TITLE
[tools] Check version ranges when pathifying deps

### DIFF
--- a/script/tool/test/make_deps_path_based_command_test.dart
+++ b/script/tool/test/make_deps_path_based_command_test.dart
@@ -48,13 +48,14 @@ void main() {
 
   /// Adds dummy 'dependencies:' entries for each package in [dependencies]
   /// to [package].
-  void addDependencies(
-      RepositoryPackage package, Iterable<String> dependencies) {
+  void addDependencies(RepositoryPackage package, Iterable<String> dependencies,
+      {String constraint = '<2.0.0'}) {
     final List<String> lines = package.pubspecFile.readAsLinesSync();
     final int dependenciesStartIndex = lines.indexOf('dependencies:');
     assert(dependenciesStartIndex != -1);
     lines.insertAll(dependenciesStartIndex + 1, <String>[
-      for (final String dependency in dependencies) '  $dependency: ^1.0.0',
+      for (final String dependency in dependencies)
+        '  $dependency: $constraint',
     ]);
     package.pubspecFile.writeAsStringSync(lines.join('\n'));
   }
@@ -62,13 +63,14 @@ void main() {
   /// Adds a 'dev_dependencies:' section with entries for each package in
   /// [dependencies] to [package].
   void addDevDependenciesSection(
-      RepositoryPackage package, Iterable<String> devDependencies) {
+      RepositoryPackage package, Iterable<String> devDependencies,
+      {String constraint = '<2.0.0'}) {
     final String originalContent = package.pubspecFile.readAsStringSync();
     package.pubspecFile.writeAsStringSync('''
 $originalContent
 
 dev_dependencies:
-${devDependencies.map((String dep) => '  $dep: ^1.0.0').join('\n')}
+${devDependencies.map((String dep) => '  $dep: $constraint').join('\n')}
 ''');
   }
 
@@ -521,6 +523,87 @@ ${devDependencies.map((String dep) => '  $dep: ^1.0.0').join('\n')}
           contains('No target dependencies'),
         ]),
       );
+    });
+
+    test('does not update references with an older major version', () async {
+      const String newVersion = '2.0.1';
+      final RepositoryPackage targetPackage =
+          createFakePackage('foo', packagesDir, version: newVersion);
+      final RepositoryPackage referencingPackage =
+          createFakePackage('bar', packagesDir);
+
+      // For a dependency on ^1.0.0, the 2.0.0->2.0.1 update should not apply.
+      addDependencies(referencingPackage, <String>['foo'],
+          constraint: '^1.0.0');
+
+      final File pubspecFile = targetPackage.pubspecFile;
+      final String changedFileOutput = <File>[
+        pubspecFile,
+      ].map((File file) => file.path).join('\n');
+      processRunner.mockProcessesForExecutable['git-diff'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(stdout: changedFileOutput)),
+      ];
+      final String gitPubspecContents =
+          pubspecFile.readAsStringSync().replaceAll(newVersion, '2.0.0');
+      processRunner.mockProcessesForExecutable['git-show'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(stdout: gitPubspecContents)),
+      ];
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'make-deps-path-based',
+        '--target-dependencies-with-non-breaking-updates'
+      ]);
+
+      final Pubspec referencingPubspec = referencingPackage.parsePubspec();
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Rewriting references to: foo'),
+        ]),
+      );
+      expect(referencingPubspec.dependencyOverrides.isEmpty, true);
+    });
+
+    test('does update references with a matching version range', () async {
+      const String newVersion = '2.0.1';
+      final RepositoryPackage targetPackage =
+          createFakePackage('foo', packagesDir, version: newVersion);
+      final RepositoryPackage referencingPackage =
+          createFakePackage('bar', packagesDir);
+
+      // For a dependency on ^1.0.0, the 2.0.0->2.0.1 update should not apply.
+      addDependencies(referencingPackage, <String>['foo'],
+          constraint: '^2.0.0');
+
+      final File pubspecFile = targetPackage.pubspecFile;
+      final String changedFileOutput = <File>[
+        pubspecFile,
+      ].map((File file) => file.path).join('\n');
+      processRunner.mockProcessesForExecutable['git-diff'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(stdout: changedFileOutput)),
+      ];
+      final String gitPubspecContents =
+          pubspecFile.readAsStringSync().replaceAll(newVersion, '2.0.0');
+      processRunner.mockProcessesForExecutable['git-show'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(stdout: gitPubspecContents)),
+      ];
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'make-deps-path-based',
+        '--target-dependencies-with-non-breaking-updates'
+      ]);
+
+      final Pubspec referencingPubspec = referencingPackage.parsePubspec();
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Rewriting references to: foo'),
+        ]),
+      );
+      expect(referencingPubspec.dependencyOverrides['foo'] is PathDependency,
+          true);
     });
 
     test('skips anything outside of the packages directory', () async {


### PR DESCRIPTION
When making dependencies path-based using
`--target-dependencies-with-non-breaking-updates`, there was an edge case where a non-breaking change would cause breaking updates in packages that weren't on the latest version of the target. E.g., this happened when updating Pigeon from 9.0.0 to 9.0.1 and there were still packages using Pigeon 4.x-8.x.

Since the purpose of that flag is to find cases (particularly where we use it in CI) where publishing package B would break package A, we don't want to apply it in cases where the new version of B wouldn't be picked up by A anyway.

This adds filtering on a per-package level when in this mode, which validates that the on-disk package version is within the referencing package's constraint range before adding an override.

Fixes https://github.com/flutter/flutter/issues/121246

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
