### PR TITLE
[pigeon] Ignore deprecated `name`

### DIFF
--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -1004,6 +1004,9 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
     final dart_ast.NamedType? namedType =
         getFirstChildOfType<dart_ast.NamedType>(parameter);
     if (namedType != null) {
+      // TODO(stuartmorgan): Replace `name` when adopting the next version of
+      // analyzer.
+      // ignore: deprecated_member_use
       final String argTypeBaseName = namedType.name.name;
       final bool isNullable = namedType.question != null;
       final List<TypeDeclaration> argTypeArguments =
@@ -1086,6 +1089,9 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
         Method(
           name: node.name.lexeme,
           returnType: TypeDeclaration(
+              // TODO(stuartmorgan): Replace `name` when adopting the next
+              // version of analyzer.
+              // ignore: deprecated_member_use
               baseName: returnType.name.name,
               typeArguments:
                   typeAnnotationsToTypeArguments(returnType.typeArguments),
@@ -1135,6 +1141,9 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
       for (final Object x in typeArguments.childEntities) {
         if (x is dart_ast.NamedType) {
           result.add(TypeDeclaration(
+              // TODO(stuartmorgan): Replace `name` when adopting the next
+              // version of analyzer.
+              // ignore: deprecated_member_use
               baseName: x.name.name,
               isNullable: x.question != null,
               typeArguments: typeAnnotationsToTypeArguments(x.typeArguments)));
@@ -1165,6 +1174,9 @@ class _RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
           final dart_ast.TypeArgumentList? typeArguments = type.typeArguments;
           _currentClass!.fields.add(NamedType(
             type: TypeDeclaration(
+              // TODO(stuartmorgan): Replace `name` when adopting the next
+              // version of analyzer.
+              // ignore: deprecated_member_use
               baseName: type.name.name,
               isNullable: type.question != null,
               typeArguments: typeAnnotationsToTypeArguments(typeArguments),


### PR DESCRIPTION
Ignores a field deprecated in the latest `analyzer` update, causing out-of-band analyzer failures.

This is ignored for now rather than replaced to avoid dropping currently-supported Flutter versions in Pigeon right now.

Fixes https://github.com/flutter/flutter/issues/126393

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
