### PR TITLE
[camerax] Add a dependency on kotlin-bom to align versions of kotlin-stdlib

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.5.0+2
 
-* Add a dependency on kotlin-bom to align versions kotlin transitive dependencies.
-* Remove note in `README.md` regarding duplicate Kotlin classes issue.
+* Adds a dependency on kotlin-bom to align versions of Kotlin transitive dependencies.
+* Removes note in `README.md` regarding duplicate Kotlin classes issue.
 
 ## 0.5.0+1
 

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+2
+
+* Add a dependency on kotlin-bom to align versions kotlin transitive dependencies.
+
 ## 0.5.0+1
 
 * Update `README.md` to include known duplicate Kotlin classes issue.

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.0+2
 
 * Add a dependency on kotlin-bom to align versions kotlin transitive dependencies.
+* Remove note in `README.md` regarding duplicate Kotlin classes issue.
 
 ## 0.5.0+1
 

--- a/packages/camera/camera_android_camerax/README.md
+++ b/packages/camera/camera_android_camerax/README.md
@@ -49,15 +49,6 @@ Any specified `ResolutionPreset` wll go unused in favor of CameraX defaults and
 
 `setZoomLevel` is unimplemented.
 
-## Known Issues
-
-### Receiving `Duplicate class kotlin.*` error
-
-If you receive a `Duplicate class kotlin.*` error when using this plugin
-implementation, you may need to update your app's Kotlin version. You can do
-this by finding your app's `android/build.gradle` file and updating the
-`org.jetbrains.kotlin:kotlin-stdlib-jdk7` dependency to at least version 1.18.10.
-
 ## Contributing
 
 For more information on contributing to this plugin, see [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/packages/camera/camera_android_camerax/android/build.gradle
+++ b/packages/camera/camera_android_camerax/android/build.gradle
@@ -72,4 +72,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:5.0.0'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.8'
+
+    // org.jetbrains.kotlin:kotlin-bom artifact purpose is to align kotlin stdlib and related code versions.
+    // See: https://youtrack.jetbrains.com/issue/KT-55297/kotlin-stdlib-should-declare-constraints-on-kotlin-stdlib-jdk8-and-kotlin-stdlib-jdk7
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.10"))
 }

--- a/packages/camera/camera_android_camerax/example/android/build.gradle
+++ b/packages/camera/camera_android_camerax/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the camera plugin using the CameraX libra
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 
-version: 0.5.0+1
+version: 0.5.0+2
 
 environment:
   sdk: ">=2.19.0 <4.0.0"


### PR DESCRIPTION
A fresh sample app that adds a dependency on the camerax implementation of the camera plugin will fail to build with an error about duplicate classes*. This PR adds a dependency on kotlin-bom to align versions of kotlin transitive dependencies that are used.

The idea for the fix comes [from here](https://youtrack.jetbrains.com/issue/KT-55297/kotlin-stdlib-should-declare-constraints-on-kotlin-stdlib-jdk8-and-kotlin-stdlib-jdk7), which has some more discussion about the problem (but in a different context, unrelated to flutter).

\* The error looks like this:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugDuplicateClasses'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   > Duplicate class kotlin.collections.jdk8.CollectionsJDK8Kt found in modules jetified-kotlin-stdlib-1.8.10 (org.jetbrains.kotlin:kotlin-stdlib:1.8.10) and jetified-kotlin-stdlib-jdk8-1.5.30 (org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.30)
     Duplicate class kotlin.internal.jdk7.JDK7PlatformImplementations found in modules jetified-kotlin-stdlib-1.8.10 (org.jetbrains.kotlin:kotlin-stdlib:1.8.10) and jetified-kotlin-stdlib-jdk7-1.7.10 (org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10)
...
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
