### PR TITLE
[ci] Ensure scripts fail if a command fails

### DIFF
--- a/.ci/scripts/build_all_packages_app.sh
+++ b/.ci/scripts/build_all_packages_app.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 platform="$1"
 build_mode="$2"

--- a/.ci/scripts/build_examples_win32.sh
+++ b/.ci/scripts/build_examples_win32.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 dart ./script/tool/bin/flutter_plugin_tools.dart build-examples --windows \
    --packages-for-branch --log-timing

--- a/.ci/scripts/create_all_packages_app.sh
+++ b/.ci/scripts/create_all_packages_app.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 dart ./script/tool/bin/flutter_plugin_tools.dart create-all-packages-app \
     --output-dir=. --exclude script/configs/exclude_all_packages_app.yaml

--- a/.ci/scripts/create_simulator.sh
+++ b/.ci/scripts/create_simulator.sh
@@ -2,6 +2,9 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
+# Ensure that the create/boot pipeline fails if `create` fails
+set -o pipefail
 
 # The name here must match remove_simulator.sh
 readonly DEVICE_NAME=Flutter-iPhone

--- a/.ci/scripts/custom_package_tests.sh
+++ b/.ci/scripts/custom_package_tests.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 # Exclusions
 #

--- a/.ci/scripts/dart_unit_tests_win32.sh
+++ b/.ci/scripts/dart_unit_tests_win32.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 dart ./script/tool/bin/flutter_plugin_tools.dart test \
   --exclude=script/configs/windows_unit_tests_exceptions.yaml \

--- a/.ci/scripts/drive_examples_win32.sh
+++ b/.ci/scripts/drive_examples_win32.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 dart ./script/tool/bin/flutter_plugin_tools.dart drive-examples --windows \
    --exclude=script/configs/exclude_integration_win32.yaml --packages-for-branch --log-timing

--- a/.ci/scripts/native_test_win32.sh
+++ b/.ci/scripts/native_test_win32.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 dart ./script/tool/bin/flutter_plugin_tools.dart native-test --windows \
    --no-integration --packages-for-branch --log-timing

--- a/.ci/scripts/plugin_tools_tests.sh
+++ b/.ci/scripts/plugin_tools_tests.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 cd script/tool
 dart pub run test

--- a/.ci/scripts/prepare_tool.sh
+++ b/.ci/scripts/prepare_tool.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 # To set FETCH_HEAD for "git merge-base" to work
 git fetch origin main

--- a/.ci/scripts/remove_simulator.sh
+++ b/.ci/scripts/remove_simulator.sh
@@ -2,6 +2,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+set -e
 
 # The name here must match create_simulator.sh
 readonly DEVICE_NAME=Flutter-iPhone


### PR DESCRIPTION
Cirrus automatically fails as soon as a command fails, but when converting Cirrus steps to LUCI bash scripts we forgot to add `set -e`.

Also adds `pipefail` to the simulator creation script so that part of the pipeline failing will fail the command.

Fixes https://github.com/flutter/flutter/issues/125243