### PR TITLE
[ci] Add LUCI repo tool tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -44,7 +44,18 @@ platform_properties:
       xcode: 14e222b
 
 targets:
-  ### iOS+macOS tasks ***
+  ### Linux tasks ###
+  - name: Linux repo_tools_tests
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      add_recipes_cq: "true"
+      target_file: repo_tools_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+
+  ### iOS+macOS tasks ###
   # TODO(stuartmorgan): Move this to ARM once google_maps_flutter has ARM
   # support. `pod lint` makes a synthetic target that doesn't respect the
   # pod's arch exclusions, so fails to build.

--- a/.ci/targets/plugin_tools_tests.yaml
+++ b/.ci/targets/plugin_tools_tests.yaml
@@ -1,5 +1,0 @@
-tasks:
-  - name: prepare tool
-    script: .ci/scripts/prepare_tool.sh
-  - name: tool unit tests
-    script: .ci/scripts/plugin_tools_tests.sh

--- a/.ci/targets/repo_tools_tests.yaml
+++ b/.ci/targets/repo_tools_tests.yaml
@@ -1,4 +1,5 @@
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
-  # TODO(stuartmorgan): Add actual tests here when moving the repo tooling.
+  - name: tool unit tests
+    script: .ci/scripts/plugin_tools_tests.sh

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -283,7 +283,9 @@ void main() {
         'Test for publish-check command.',
       );
       runner.addCommand(PublishCheckCommand(packagesDir,
-          processRunner: processRunner, httpClient: mockClient));
+          platform: mockPlatform,
+          processRunner: processRunner,
+          httpClient: mockClient));
 
       processRunner.mockProcessesForExecutable['flutter'] = <FakeProcessInfo>[
         FakeProcessInfo(MockProcess(exitCode: 1, stdout: 'Some error from pub'),
@@ -339,7 +341,9 @@ void main() {
         'Test for publish-check command.',
       );
       runner.addCommand(PublishCheckCommand(packagesDir,
-          processRunner: processRunner, httpClient: mockClient));
+          platform: mockPlatform,
+          processRunner: processRunner,
+          httpClient: mockClient));
 
       final List<String> output =
           await runCapturingPrint(runner, <String>['publish-check']);


### PR DESCRIPTION
- Adds a LUCI version of the Linux repo tools test, as a first test of a Linux repository test being migrated to LUCI.
- Fixes the Windows repo tools test to actually run a test, which it wasn't due to a mistaken duplicate yaml file, only one of which was correct (the one that wasn't being used).