### PR TITLE
[ci] Pin the Flutter version for `release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,18 @@ jobs:
       # Github Actions don't support templates so it is hard to share this snippet with another action
       # If we eventually need to use this in more workflow, we could create a shell script that contains this
       # snippet.
+      #
+      # This uses a pinned version of Flutter rather than `stable` so that it is
+      # not subject to out-of-band failures when new releases happen. It does
+      # not use the auto-rolled pin because there's no way for the autoroller
+      # to test the actual release flow, so changes would still show up in
+      # post-submit. A manually-rolled pin means that any changes here must be
+      # made deliberately, so that the person updating it knows to watch the
+      # next actual auto-release to ensure that it works, and knows to revert
+      # the change if it doesn't.
       run: |
         cd $HOME
-        git clone https://github.com/flutter/flutter.git --depth 1 -b stable _flutter
+        git clone https://github.com/flutter/flutter.git --depth 1 -b 3.10.0 _flutter
         echo "$HOME/_flutter/bin" >> $GITHUB_PATH
         cd $GITHUB_WORKSPACE
     # Checks out a copy of the repo.


### PR DESCRIPTION
Pins to a specific version of Flutter, rather than using a branch, to avoid issue like https://github.com/flutter/packages/pull/3962 being surprise out-of-band failures.

This does not change current behavior, as `stable` currently points to the same commit as `3.10.0`.