### PR TITLE
[tool] Ensure that publish credential path is available

### DIFF
--- a/script/tool/lib/src/publish_command.dart
+++ b/script/tool/lib/src/publish_command.dart
@@ -415,6 +415,7 @@ If running this command on CI, you can set the pub credential content in the $_p
 ''');
       throw ToolExit(1);
     }
+    credentialFile.createSync(recursive: true);
     credentialFile.openSync(mode: FileMode.writeOnlyAppend)
       ..writeStringSync(credential)
       ..closeSync();

--- a/script/tool/test/publish_command_test.dart
+++ b/script/tool/test/publish_command_test.dart
@@ -263,6 +263,25 @@ void main() {
           ]));
     });
 
+    test('creates credential file from envirnoment variable if necessary',
+        () async {
+      createFakePlugin('foo', packagesDir, examples: <String>[]);
+      const String credentials = 'some credential';
+      platform.environment['PUB_CREDENTIALS'] = credentials;
+
+      await runCapturingPrint(commandRunner, <String>[
+        'publish',
+        '--packages=foo',
+        '--skip-confirmation',
+        '--pub-publish-flags',
+        '--server=bar'
+      ]);
+
+      final File credentialFile = fileSystem.file(command.credentialsPath);
+      expect(credentialFile.existsSync(), true);
+      expect(credentialFile.readAsStringSync(), credentials);
+    });
+
     test('throws if pub publish fails', () async {
       createFakePlugin('foo', packagesDir, examples: <String>[]);
 


### PR DESCRIPTION
When writing pub credentials, ensure that the target paths exists before trying to write the file. In the past this would have worked because the credentials were in the pub cache, and the pub cache would exist by the time the repo tooling code was running. The new location, however, is a configuration directory that is unlikely to exist before anything involving `pub` credentials has run.

Should fix the latest `release` failure:
https://github.com/flutter/packages/actions/runs/4949005383/jobs/8854219784

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
