### PR TITLE
[url_launcher] Set broadcast reciever visability as required by target api 34

### DIFF
--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.0.33
 
-* Explicitly set if reciever for close should be exported.
+* Explicitly sets if reciever for close should be exported.
 
 ## 6.0.32
 

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.33
+
+* Explicitly set if reciever for close should be exported.
+
 ## 6.0.32
 
 * Updates gradle, AGP and fixes some lint errors.

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     compileOnly 'androidx.annotation:annotation:1.2.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.1.1'
-    testImplementation "androidx.test:core:$core_version"
+    testImplementation 'androidx.test:core:1.0.0'
     testImplementation 'org.robolectric:robolectric:4.4.1'
 
     // org.jetbrains.kotlin:kotlin-bom artifact purpose is to align kotlin stdlib and related code versions.

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -59,9 +59,18 @@ android {
 }
 
 dependencies {
+    def core_version = "1.10.1"
+
+    // Java language implementation
+    implementation "androidx.core:core:$core_version"
+
     compileOnly 'androidx.annotation:annotation:1.2.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.1.1'
-    testImplementation 'androidx.test:core:1.0.0'
+    testImplementation "androidx.test:core:$core_version"
     testImplementation 'org.robolectric:robolectric:4.4.1'
+
+    // org.jetbrains.kotlin:kotlin-bom artifact purpose is to align kotlin stdlib and related code versions.
+    // See: https://youtrack.jetbrains.com/issue/KT-55297/kotlin-stdlib-should-declare-constraints-on-kotlin-stdlib-jdk8-and-kotlin-stdlib-jdk7
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.10"))
 }

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -26,6 +26,7 @@ import androidx.annotation.VisibleForTesting;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import androidx.core.content.ContextCompat;
 
 /*  Launches WebView activity */
 public class WebViewActivity extends Activity {
@@ -144,6 +145,11 @@ public class WebViewActivity extends Activity {
 
     // Register receiver that may finish this Activity.
     registerReceiver(broadcastReceiver, closeIntentFilter);
+    ContextCompat.registerReceiver(
+        this.getApplication(),
+        broadcastReceiver,
+        closeIntentFilter,
+        ContextCompat.RECEIVER_EXPORTED);
   }
 
   @VisibleForTesting

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -23,10 +23,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.content.ContextCompat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import androidx.core.content.ContextCompat;
 
 /*  Launches WebView activity */
 public class WebViewActivity extends Activity {

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -144,7 +144,6 @@ public class WebViewActivity extends Activity {
     webview.setWebChromeClient(new FlutterWebChromeClient());
 
     // Register receiver that may finish this Activity.
-    registerReceiver(broadcastReceiver, closeIntentFilter);
     ContextCompat.registerReceiver(
         this.getApplication(),
         broadcastReceiver,

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.32
+version: 6.0.33
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
- Update the version of androidx used.
- Explicitly set Exported on previously exported broadcast reciever
[126460](https://github.com/flutter/flutter/issues/126460)

This change is a no-op in behavior. I am open to the argument that instead we make this configurable. 

https://developer.android.com/guide/components/broadcasts#context-registered-receivers

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
