### PR TITLE
[ci] Disable Windows repo tool tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -335,6 +335,7 @@ targets:
         ]
 
   - name: Windows repo_tools_tests
+    bringup: true # https://github.com/flutter/flutter/issues/126750
     recipe: packages/packages
     timeout: 30
     properties:


### PR DESCRIPTION
They are failing in postsubmit, even though they passed presubmit. Disabling them to re-open the tree pending investigation.

https://github.com/flutter/flutter/issues/126750