### PR TITLE
[video_player] duration updates event

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
+* Adds listener to `VideoEventType.durationUpdated`.
 
 ## 2.6.1
 

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -37,3 +37,8 @@ flutter:
     - assets/bumble_bee_captions.srt
     - assets/bumble_bee_captions.vtt
     - assets/Audio.mp3
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {video_player_platform_interface: {path: ../../../video_player/video_player_platform_interface}}

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -444,6 +444,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.isPlayingStateUpdate:
           value = value.copyWith(isPlaying: event.isPlaying);
           break;
+        case VideoEventType.durationUpdated:
+          value = value.copyWith(duration: event.duration);
+          break;
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -31,3 +31,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {video_player_platform_interface: {path: ../../video_player/video_player_platform_interface}}

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -803,6 +803,22 @@ void main() {
         expect(controller.value.isPlaying, isFalse);
         expect(controller.value.position, nonzeroDuration);
       });
+      testWidgets('duration updated', (WidgetTester tester) async {
+        final VideoPlayerController controller = VideoPlayerController.network(
+          'https://127.0.0.1',
+        );
+        await controller.initialize();
+        const Duration nonzeroDuration = Duration(milliseconds: 100);
+        controller.value = controller.value.copyWith(duration: nonzeroDuration);
+        final StreamController<VideoEvent> fakeVideoEventStream =
+            fakeVideoPlayerPlatform.streams[controller.textureId]!;
+        const Duration newDuration = Duration(seconds: 2);
+        fakeVideoEventStream.add(VideoEvent(
+            eventType: VideoEventType.durationUpdated, duration: newDuration));
+        await tester.pumpAndSettle();
+
+        expect(controller.value.duration, newDuration);
+      });
 
       testWidgets('playback status', (WidgetTester tester) async {
         final VideoPlayerController controller = VideoPlayerController.network(

--- a/packages/video_player/video_player_android/example/pubspec.yaml
+++ b/packages/video_player/video_player_android/example/pubspec.yaml
@@ -33,3 +33,8 @@ flutter:
   assets:
     - assets/flutter-mark-square-64.png
     - assets/Butterfly-209.mp4
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {video_player_platform_interface: {path: ../../../video_player/video_player_platform_interface}}

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -26,3 +26,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pigeon: ^9.2.5
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {video_player_platform_interface: {path: ../../video_player/video_player_platform_interface}}

--- a/packages/video_player/video_player_avfoundation/example/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/example/pubspec.yaml
@@ -33,3 +33,8 @@ flutter:
   assets:
     - assets/flutter-mark-square-64.png
     - assets/Butterfly-209.mp4
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {video_player_platform_interface: {path: ../../../video_player/video_player_platform_interface}}

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -25,3 +25,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pigeon: ^9.2.4
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {video_player_platform_interface: {path: ../../video_player/video_player_platform_interface}}

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
+* Adds the `VideoEventType.durationUpdated` event to track changes in video durations example(live stream).
 
 ## 6.1.0
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -293,12 +293,10 @@ enum VideoEventType {
   /// phone calls, or other app media such as music players.
   isPlayingStateUpdate,
 
-
   /// the video duration changed due to playing a live stream.
-  /// 
+  ///
   /// This event is fired when the video duration changes due to playing a live stream.
   durationUpdated,
-
 
   /// An unknown event has been received.
   unknown,

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -293,6 +293,13 @@ enum VideoEventType {
   /// phone calls, or other app media such as music players.
   isPlayingStateUpdate,
 
+
+  /// the video duration changed due to playing a live stream.
+  /// 
+  /// This event is fired when the video duration changes due to playing a live stream.
+  durationUpdated,
+
+
   /// An unknown event has been received.
   unknown,
 }

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -293,9 +293,7 @@ enum VideoEventType {
   /// phone calls, or other app media such as music players.
   isPlayingStateUpdate,
 
-  /// the video duration changed due to playing a live stream.
-  ///
-  /// This event is fired when the video duration changes due to playing a live stream.
+  /// The video duration changed due to playing a live stream.
   durationUpdated,
 
   /// An unknown event has been received.

--- a/packages/video_player/video_player_web/example/pubspec.yaml
+++ b/packages/video_player/video_player_web/example/pubspec.yaml
@@ -20,3 +20,8 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {video_player_platform_interface: {path: ../../../video_player/video_player_platform_interface}}

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -26,3 +26,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {video_player_platform_interface: {path: ../../video_player/video_player_platform_interface}}


### PR DESCRIPTION
I am the maintainer of the package [video_player_media_kit](https://pub.dev/packages/video_player_media_kit). While working with live streams, I encountered an issue where I needed to update the duration dynamically. However, I realized that there was no existing mechanism to update the duration.

This pull request aims to address this problem by introducing a new event called durationUpdate. This event allows the duration to be updated independently, providing greater flexibility when working with live streams. With this addition, developers will have the ability to send duration updates as needed.




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
