### PR TITLE
[image_picker] Fix crash due to `SecurityException`

### DIFF
--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.6+16
+
+* Fixes crashes caused by `SecurityException` when calling `getPathFromUri()`.
+
 ## 0.8.6+15
 
 * Bumps androidx.activity:activity from 1.6.1 to 1.7.0.

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -84,7 +84,7 @@ class FileUtils {
       // `SecurityException` on some devices in certain circumstances. Instead of crashing, we
       // return `null`.
       //
-      // See [this issue](https://github.com/flutter/flutter/issues/100025) for more details.
+      // See https://github.com/flutter/flutter/issues/100025 for more details.
       return null;
     }
   }

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -79,6 +79,13 @@ class FileUtils {
       // target file was written in full. Flushing the stream merely moves
       // the bytes into the OS, not necessarily to the file.
       return null;
+    } catch (SecurityException e) {
+      // Calling `ContentResolver#openInputStream()` has been reported to throw a
+      // `SecurityException` on some devices in certain circumstances. Instead of crashing, we
+      // return `null`.
+      //
+      // See [this issue](https://github.com/flutter/flutter/issues/100025) for more details.
+      return null;
     }
   }
 

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
@@ -5,10 +5,16 @@
 package io.flutter.plugins.imagepicker;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.content.ContentProvider;
+import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -66,7 +72,22 @@ public class FileUtilTest {
 
     assertTrue(bytes.length > 0);
     String imageStream = new String(bytes, UTF_8);
-    assertTrue(imageStream.equals("imageStream"));
+    assertEquals("imageStream", imageStream);
+  }
+
+  @Test
+  public void FileUtil_GetPathFromUri_securityException() throws IOException {
+    Uri uri = Uri.parse("content://dummy/dummy.png");
+
+    ContentResolver mockContentResolver = mock(ContentResolver.class);
+    when(mockContentResolver.openInputStream(any(Uri.class))).thenThrow(SecurityException.class);
+
+    Context mockContext = mock(Context.class);
+    when(mockContext.getContentResolver()).thenReturn(mockContentResolver);
+
+    String path = fileUtils.getPathFromUri(mockContext, uri);
+
+    assertNull(path);
   }
 
   @Test

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 
-version: 0.8.6+15
+version: 0.8.6+16
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Issue flutter/flutter#100025 mentions crashing of the image picker plugin due to a `SecurityException`. As research into the issue did not yield reproduction steps, we decided to surround the breaking method call with a `try/catch` block for now (see discussion in the issue). This PR implements just that. Instead of crashing on a `SecurityException`, the plugin will now return an image path of `null`.

This PR fixes flutter/flutter#100025.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.