### PR TITLE
[ci] Move Linux repo tool tests to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -46,7 +46,6 @@ platform_properties:
 targets:
   ### Linux tasks ###
   - name: Linux repo_tools_tests
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,11 +83,6 @@ task:
     zone: us-central1-a
     namespace: default
   matrix:
-    ### Platform-agnostic tasks ###
-    - name: Linux plugin_tools_tests
-      script:
-        - cd script/tool
-        - dart pub run test
     # Repository rules and best-practice enforcement.
     # Only channel-agnostic tests should go here since it is only run once
     # (on Flutter master).


### PR DESCRIPTION
Enables the new LUCI repo tools test, and removes the Cirrus version.

Part of https://github.com/flutter/flutter/issues/114373