### PR TITLE
[ci] Allow simctl shutdown to fail

### DIFF
--- a/.ci/scripts/remove_simulator.sh
+++ b/.ci/scripts/remove_simulator.sh
@@ -7,6 +7,7 @@ set -e
 # The name here must match create_simulator.sh
 readonly DEVICE_NAME=Flutter-iPhone
 
-xcrun simctl shutdown "$DEVICE_NAME"
+# Allow shutdown to fail; cases like "already shut down" exit with failure.
+xcrun simctl shutdown "$DEVICE_NAME" || :
 xcrun simctl delete "$DEVICE_NAME"
 xcrun simctl list


### PR DESCRIPTION
Since adding `set -e`, this script sometimes fails with:

```
An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=405):
Unable to shutdown device in current state: Shutdown
```

Allow shutdown to fail; if something is really wrong that prevents cleanup, deleting the device should still fail, so this should be harmless.