### PR TITLE
[ci] Increase Android sharding

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -265,13 +265,14 @@ task:
       skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
       env:
         matrix:
-          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 7"
-          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 7"
-          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 7"
-          PACKAGE_SHARDING: "--shardIndex 3 --shardCount 7"
-          PACKAGE_SHARDING: "--shardIndex 4 --shardCount 7"
-          PACKAGE_SHARDING: "--shardIndex 5 --shardCount 7"
-          PACKAGE_SHARDING: "--shardIndex 6 --shardCount 7"
+          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 8"
+          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 8"
+          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 8"
+          PACKAGE_SHARDING: "--shardIndex 3 --shardCount 8"
+          PACKAGE_SHARDING: "--shardIndex 4 --shardCount 8"
+          PACKAGE_SHARDING: "--shardIndex 5 --shardCount 8"
+          PACKAGE_SHARDING: "--shardIndex 6 --shardCount 8"
+          PACKAGE_SHARDING: "--shardIndex 7 --shardCount 8"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"


### PR DESCRIPTION
We're seeing more timeouts recently with Android platform tests. Longer term we can revisit this, especially once we have emulator tests where the timings may change significantly, but for now increase the shards by one.