### PR TITLE
[image_picker] Move disk accesses to background thread

### DIFF
--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.6+17
+
+* Moves disk accesses to background thread.
+
 ## 0.8.6+16
 
 * Fixes crashes caused by `SecurityException` when calling `getPathFromUri()`.

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
@@ -7,6 +7,7 @@ package io.flutter.plugins.imagepicker;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import java.util.ArrayList;
@@ -51,10 +52,10 @@ class ImagePickerCache {
   @VisibleForTesting
   static final String SHARED_PREFERENCES_NAME = "flutter_image_picker_shared_preference";
 
-  private final SharedPreferences prefs;
+  private final @NonNull Context context;
 
-  ImagePickerCache(Context context) {
-    prefs = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+  ImagePickerCache(final @NonNull Context context) {
+    this.context = context;
   }
 
   void saveType(CacheType type) {
@@ -69,10 +70,14 @@ class ImagePickerCache {
   }
 
   private void setType(String type) {
+    final SharedPreferences prefs =
+        context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     prefs.edit().putString(SHARED_PREFERENCE_TYPE_KEY, type).apply();
   }
 
   void saveDimensionWithOutputOptions(Messages.ImageSelectionOptions options) {
+    final SharedPreferences prefs =
+        context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = prefs.edit();
     if (options.getMaxWidth() != null) {
       editor.putLong(
@@ -87,16 +92,21 @@ class ImagePickerCache {
   }
 
   void savePendingCameraMediaUriPath(Uri uri) {
+    final SharedPreferences prefs =
+        context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     prefs.edit().putString(SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY, uri.getPath()).apply();
   }
 
   String retrievePendingCameraMediaUriPath() {
-
+    final SharedPreferences prefs =
+        context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     return prefs.getString(SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY, "");
   }
 
   void saveResult(
       @Nullable ArrayList<String> path, @Nullable String errorCode, @Nullable String errorMessage) {
+    final SharedPreferences prefs =
+        context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
 
     SharedPreferences.Editor editor = prefs.edit();
     if (path != null) {
@@ -113,12 +123,17 @@ class ImagePickerCache {
   }
 
   void clear() {
+    final SharedPreferences prefs =
+        context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     prefs.edit().clear().apply();
   }
 
   Map<String, Object> getCacheMap() {
     Map<String, Object> resultMap = new HashMap<>();
     boolean hasData = false;
+
+    final SharedPreferences prefs =
+        context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
 
     if (prefs.contains(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY)) {
       final Set<String> imagePathList =

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -139,7 +139,9 @@ public class ImagePickerDelegate
   private final Object pendingCallStateLock = new Object();
 
   public ImagePickerDelegate(
-      final @NonNull Activity activity, final @NonNull ImageResizer imageResizer, final @NonNull ImagePickerCache cache) {
+      final @NonNull Activity activity,
+      final @NonNull ImageResizer imageResizer,
+      final @NonNull ImagePickerCache cache) {
     this(
         activity,
         imageResizer,

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -108,7 +108,6 @@ public class ImagePickerDelegate
   @VisibleForTesting final String fileProviderName;
 
   private final @NonNull Activity activity;
-  @VisibleForTesting final @NonNull File externalFilesDirectory;
   private final @NonNull ImageResizer imageResizer;
   private final @NonNull ImagePickerCache cache;
   private final PermissionManager permissionManager;
@@ -140,13 +139,9 @@ public class ImagePickerDelegate
   private final Object pendingCallStateLock = new Object();
 
   public ImagePickerDelegate(
-      final @NonNull Activity activity,
-      final @NonNull File externalFilesDirectory,
-      final @NonNull ImageResizer imageResizer,
-      final @NonNull ImagePickerCache cache) {
+      final @NonNull Activity activity, final @NonNull ImageResizer imageResizer, final @NonNull ImagePickerCache cache) {
     this(
         activity,
-        externalFilesDirectory,
         imageResizer,
         null,
         null,
@@ -195,7 +190,6 @@ public class ImagePickerDelegate
   @VisibleForTesting
   ImagePickerDelegate(
       final @NonNull Activity activity,
-      final @NonNull File externalFilesDirectory,
       final @NonNull ImageResizer imageResizer,
       final @Nullable ImageSelectionOptions pendingImageOptions,
       final @Nullable VideoSelectionOptions pendingVideoOptions,
@@ -206,7 +200,6 @@ public class ImagePickerDelegate
       final FileUtils fileUtils,
       final ExecutorService executor) {
     this.activity = activity;
-    this.externalFilesDirectory = externalFilesDirectory;
     this.imageResizer = imageResizer;
     this.fileProviderName = activity.getPackageName() + ".flutter.image_provider";
     if (result != null) {
@@ -493,6 +486,7 @@ public class ImagePickerDelegate
   private File createTemporaryWritableFile(String suffix) {
     String filename = UUID.randomUUID().toString();
     File image;
+    File externalFilesDirectory = activity.getCacheDir();
 
     try {
       externalFilesDirectory.mkdirs();

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -23,7 +23,6 @@ import io.flutter.plugins.imagepicker.Messages.FlutterError;
 import io.flutter.plugins.imagepicker.Messages.ImagePickerApi;
 import io.flutter.plugins.imagepicker.Messages.Result;
 import io.flutter.plugins.imagepicker.Messages.SourceSpecification;
-import java.io.File;
 import java.util.List;
 
 @SuppressWarnings("deprecation")
@@ -266,10 +265,9 @@ public class ImagePickerPlugin implements FlutterPlugin, ActivityAware, ImagePic
   final ImagePickerDelegate constructDelegate(final Activity setupActivity) {
     final ImagePickerCache cache = new ImagePickerCache(setupActivity);
 
-    final File externalFilesDirectory = setupActivity.getCacheDir();
     final ExifDataCopier exifDataCopier = new ExifDataCopier();
-    final ImageResizer imageResizer = new ImageResizer(externalFilesDirectory, exifDataCopier);
-    return new ImagePickerDelegate(setupActivity, externalFilesDirectory, imageResizer, cache);
+    final ImageResizer imageResizer = new ImageResizer(setupActivity, exifDataCopier);
+    return new ImagePickerDelegate(setupActivity, imageResizer, cache);
   }
 
   private @Nullable ImagePickerDelegate getImagePickerDelegate() {

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -4,6 +4,7 @@
 
 package io.flutter.plugins.imagepicker;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Log;
@@ -16,11 +17,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 class ImageResizer {
-  private final File externalFilesDirectory;
+  private final Context context;
   private final ExifDataCopier exifDataCopier;
 
-  ImageResizer(File externalFilesDirectory, ExifDataCopier exifDataCopier) {
-    this.externalFilesDirectory = externalFilesDirectory;
+  ImageResizer(final @NonNull Context context, final @NonNull ExifDataCopier exifDataCopier) {
+    this.context = context;
     this.exifDataCopier = exifDataCopier;
   }
 
@@ -193,7 +194,9 @@ class ImageResizer {
         saveAsPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG,
         imageQuality,
         outputStream);
-    File imageFile = createFile(externalFilesDirectory, name);
+
+    File cacheDirectory = context.getCacheDir();
+    File imageFile = createFile(cacheDirectory, name);
     FileOutputStream fileOutput = createOutputStream(imageFile);
     fileOutput.write(outputStream.toByteArray());
     fileOutput.close();

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/Messages.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/Messages.java
@@ -593,9 +593,13 @@ public class Messages {
     /** Sets up an instance of `ImagePickerApi` to handle messages through the `binaryMessenger`. */
     static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable ImagePickerApi api) {
       {
+        BinaryMessenger.TaskQueue taskQueue = binaryMessenger.makeBackgroundTaskQueue();
         BasicMessageChannel<Object> channel =
             new BasicMessageChannel<>(
-                binaryMessenger, "dev.flutter.pigeon.ImagePickerApi.pickImages", getCodec());
+                binaryMessenger,
+                "dev.flutter.pigeon.ImagePickerApi.pickImages",
+                getCodec(),
+                taskQueue);
         if (api != null) {
           channel.setMessageHandler(
               (message, reply) -> {
@@ -626,9 +630,13 @@ public class Messages {
         }
       }
       {
+        BinaryMessenger.TaskQueue taskQueue = binaryMessenger.makeBackgroundTaskQueue();
         BasicMessageChannel<Object> channel =
             new BasicMessageChannel<>(
-                binaryMessenger, "dev.flutter.pigeon.ImagePickerApi.pickVideos", getCodec());
+                binaryMessenger,
+                "dev.flutter.pigeon.ImagePickerApi.pickVideos",
+                getCodec(),
+                taskQueue);
         if (api != null) {
           channel.setMessageHandler(
               (message, reply) -> {
@@ -659,11 +667,13 @@ public class Messages {
         }
       }
       {
+        BinaryMessenger.TaskQueue taskQueue = binaryMessenger.makeBackgroundTaskQueue();
         BasicMessageChannel<Object> channel =
             new BasicMessageChannel<>(
                 binaryMessenger,
                 "dev.flutter.pigeon.ImagePickerApi.retrieveLostResults",
-                getCodec());
+                getCodec(),
+                taskQueue);
         if (api != null) {
           channel.setMessageHandler(
               (message, reply) -> {

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
@@ -4,8 +4,6 @@
 
 package io.flutter.plugins.imagepicker;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -14,7 +12,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -30,7 +27,6 @@ import io.flutter.plugins.imagepicker.Messages.FlutterError;
 import io.flutter.plugins.imagepicker.Messages.ImageSelectionOptions;
 import io.flutter.plugins.imagepicker.Messages.SourceSpecification;
 import io.flutter.plugins.imagepicker.Messages.VideoSelectionOptions;
-import java.io.File;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -200,20 +196,6 @@ public class ImagePickerPluginTest {
     new ImagePickerPlugin(mockImagePickerDelegate, mockActivity);
     assertTrue(
         "No exception thrown when ImagePickerPlugin() ran with context instanceof Activity", true);
-  }
-
-  @Test
-  public void constructDelegate_shouldUseInternalCacheDirectory() {
-    File mockDirectory = new File("/mockpath");
-    when(mockActivity.getCacheDir()).thenReturn(mockDirectory);
-
-    ImagePickerDelegate delegate = plugin.constructDelegate(mockActivity);
-
-    verify(mockActivity, times(1)).getCacheDir();
-    assertThat(
-        "Delegate uses cache directory for storing camera captures",
-        delegate.externalFilesDirectory,
-        equalTo(mockDirectory));
   }
 
   @Test

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImageResizerTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImageResizerTest.java
@@ -10,9 +10,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImageResizerTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImageResizerTest.java
@@ -12,7 +12,10 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import java.io.File;
@@ -33,8 +36,8 @@ import org.robolectric.RobolectricTestRunner;
 // But we can still test whether the original or scaled file is created.
 @RunWith(RobolectricTestRunner.class)
 public class ImageResizerTest {
-
   ImageResizer resizer;
+  Context mockContext;
   File imageFile;
   File svgImageFile;
   File externalDirectory;
@@ -51,7 +54,9 @@ public class ImageResizerTest {
     TemporaryFolder temporaryFolder = new TemporaryFolder();
     temporaryFolder.create();
     externalDirectory = temporaryFolder.newFolder("image_picker_testing_path");
-    resizer = new ImageResizer(externalDirectory, new ExifDataCopier());
+    mockContext = mock(Context.class);
+    when(mockContext.getCacheDir()).thenReturn(externalDirectory);
+    resizer = new ImageResizer(mockContext, new ExifDataCopier());
   }
 
   @After
@@ -81,14 +86,6 @@ public class ImageResizerTest {
   public void onResizeImageIfNeeded_whenHeightIsNotNull_shouldResize_returnResizedFile() {
     String outputFile = resizer.resizeImageIfNeeded(imageFile.getPath(), null, 50.0, 100);
     assertThat(outputFile, equalTo(externalDirectory.getPath() + "/scaled_pngImage.png"));
-  }
-
-  @Test
-  public void onResizeImageIfNeeded_whenParentDirectoryDoesNotExists_shouldNotCrash() {
-    File nonExistentDirectory = new File(externalDirectory, "/nonExistent");
-    ImageResizer invalidResizer = new ImageResizer(nonExistentDirectory, new ExifDataCopier());
-    String outputFile = invalidResizer.resizeImageIfNeeded(imageFile.getPath(), null, 50.0, 100);
-    assertThat(outputFile, equalTo(nonExistentDirectory.getPath() + "/scaled_pngImage.png"));
   }
 
   @Test

--- a/packages/image_picker/image_picker_android/pigeons/messages.dart
+++ b/packages/image_picker/image_picker_android/pigeons/messages.dart
@@ -87,6 +87,7 @@ abstract class ImagePickerApi {
   ///
   /// Elements must not be null, by convention. See
   /// https://github.com/flutter/flutter/issues/97848
+  @TaskQueue(type: TaskQueueType.serialBackgroundThread)
   @async
   List<String?> pickImages(SourceSpecification source,
       ImageSelectionOptions options, bool allowMultiple, bool usePhotoPicker);
@@ -95,10 +96,12 @@ abstract class ImagePickerApi {
   ///
   /// Elements must not be null, by convention. See
   /// https://github.com/flutter/flutter/issues/97848
+  @TaskQueue(type: TaskQueueType.serialBackgroundThread)
   @async
   List<String?> pickVideos(SourceSpecification source,
       VideoSelectionOptions options, bool allowMultiple, bool usePhotoPicker);
 
   /// Returns results from a previous app session, if any.
+  @TaskQueue(type: TaskQueueType.serialBackgroundThread)
   CacheRetrievalResult? retrieveLostResults();
 }

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 
-version: 0.8.6+16
+version: 0.8.6+17
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
The plugin accesses the disk on the UI thread at several occasions as reported by https://github.com/flutter/flutter/issues/91393. These instances can easily be found by running the plugin with [StrictMode](https://developer.android.com/reference/android/os/StrictMode) enabled. The occasions that are highlighted are when determining the application's cache directory and when fetching `SharedPreferences`.

By running method channel invocations on a background channel using Pidgeon's `@TaskQueue()` annotation and deferring said IO operations to the moment where they are actually needed, this PR makes sure the plugin no longer accesses the disk from the UI thread.

This PR is a follow-up to #3506
- Fixes https://github.com/flutter/flutter/issues/91393.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
