### PR TITLE
[tool] Pins package:logging dependency.

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.4+5
+
+* Pins `package:logging` dependency until `package:build_runner` catches up. [Issue](https://github.com/dart-lang/logging/issues/143).
+
 ## 0.13.4+4
 
 * Allows code excerpts in `example/README.md`.

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.3
+  logging: '>=1.1.0 <1.2.0' # dart-lang/logging#143
   matcher: ^0.12.10
   mockito: '>=5.3.2 <=5.4.0'
 

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity and CI utils for flutter/packages
 repository: https://github.com/flutter/packages/tree/main/script/tool
-version: 0.13.4+4
+version: 0.13.4+5
 
 dependencies:
   args: ^2.1.0
@@ -26,7 +26,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.3
-  logging: '>=1.1.0 <1.2.0' # dart-lang/logging#143
+  # Pin logging to <1.2.0 until dart-lang/logging#143
+  logging: '>=1.1.0 <1.2.0'
   matcher: ^0.12.10
   mockito: '>=5.3.2 <=5.4.0'
 


### PR DESCRIPTION
Pins package:logging dependency to v 1.1.1 until package:build_runner_core catches up with the API changes (see `class BuildForInputLogger implements Logger`)

This should fix re-enable the `readme_excerpts` verification task in the repo.

## Fixes

Things like this: https://cirrus-ci.com/task/6678013467688960?logs=main#L93

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
