### PR TITLE
bump mockito to version 5.4.1

### DIFF
--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -35,6 +35,6 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   plugin_platform_interface: ^2.0.0
   video_player: ^2.0.0

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -32,5 +32,5 @@ dev_dependencies:
   build_runner: ^2.2.0
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.1.0

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -25,5 +25,5 @@ dev_dependencies:
   build_runner: ^2.3.0
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.2.4

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -26,5 +26,5 @@ dev_dependencies:
   build_runner: ^2.3.2
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.2.4

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -26,5 +26,5 @@ dev_dependencies:
   build_runner: ^2.3.0
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.1.0

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -20,5 +20,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   standard_message_codec: ^0.0.1+3

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   async: ^2.5.0
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
   http: ^0.13.0
   integration_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -36,7 +36,7 @@ dev_dependencies:
   http: ^0.13.0
   integration_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
 
 # The example deliberately includes limited-use secrets.
 false_secrets:

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -19,4 +19,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   js: ^0.6.3
-  mockito: 5.4.0
+  mockito: 5.4.1
 
 flutter:
   uses-material-design: true

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -32,5 +32,5 @@ dev_dependencies:
   cross_file: ^0.3.1+1 # Mockito generates a direct include.
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   plugin_platform_interface: ^2.0.0

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -27,5 +27,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.2.5

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -24,5 +24,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.2.4

--- a/packages/image_picker/image_picker_windows/pubspec.yaml
+++ b/packages/image_picker/image_picker_windows/pubspec.yaml
@@ -26,4 +26,4 @@ dev_dependencies:
   build_runner: ^2.1.5
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -28,5 +28,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   json_serializable: ^6.3.1
-  mockito: 5.4.0
+  mockito: 5.4.1
   test: ^1.16.0

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -34,5 +34,5 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   plugin_platform_interface: ^2.1.2

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -28,5 +28,5 @@ dev_dependencies:
   build_runner: ^2.3.3
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.2.4

--- a/packages/local_auth/local_auth_ios/pubspec.yaml
+++ b/packages/local_auth/local_auth_ios/pubspec.yaml
@@ -26,5 +26,5 @@ dev_dependencies:
   build_runner: ^2.3.3
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.2.4

--- a/packages/local_auth/local_auth_platform_interface/pubspec.yaml
+++ b/packages/local_auth/local_auth_platform_interface/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -19,5 +19,5 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.1
   fake_async: ^1.2.0
-  mockito: 5.4.0
+  mockito: 5.4.1
   test: ^1.17.11

--- a/packages/path_provider/path_provider_foundation/pubspec.yaml
+++ b/packages/path_provider/path_provider_foundation/pubspec.yaml
@@ -30,6 +30,6 @@ dev_dependencies:
   build_runner: ^2.3.2
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   path: ^1.8.0
   pigeon: ^9.2.4

--- a/packages/pigeon/platform_tests/flutter_null_safe_unit_tests/pubspec.yaml
+++ b/packages/pigeon/platform_tests/flutter_null_safe_unit_tests/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   build_runner: ^2.1.10
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
 
 flutter:
   uses-material-design: true

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -24,5 +24,5 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
-  mockito: 5.4.0
+  mockito: 5.4.1
   test: ^1.16.0

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -29,5 +29,5 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   plugin_platform_interface: ^2.0.0

--- a/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   plugin_platform_interface: ^2.0.0
 
 flutter:

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -41,6 +41,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   plugin_platform_interface: ^2.0.0
   test: ^1.16.3

--- a/packages/url_launcher/url_launcher_android/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/example/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   plugin_platform_interface: ^2.0.0
 
 flutter:

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^10.0.0
   plugin_platform_interface: ^2.0.0
   test: ^1.16.3

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/url_launcher/url_launcher_web/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/example/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   url_launcher_platform_interface: ^2.0.3
   url_launcher_web:
     path: ../

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -29,5 +29,5 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   plugin_platform_interface: ^2.1.3

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -28,5 +28,5 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.2.4

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -20,4 +20,4 @@ dev_dependencies:
   build_runner: ^2.1.8
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/webview_flutter/webview_flutter_web/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_web/pubspec.yaml
@@ -29,4 +29,4 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -28,5 +28,5 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  mockito: 5.4.0
+  mockito: 5.4.1
   pigeon: ^9.2.4


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/127226

Follow up to https://github.com/flutter/packages/pull/3544. Version 5.4.0 from that PR is not new enough, see

```
Because mockito >=5.4.0 <5.4.1 depends on test_api >=0.2.1 <0.6.0 and every version of flutter_test from sdk depends on test_api 0.6.0, mockito >=5.4.0 <5.4.1 is incompatible with flutter_test from sdk.
So, because quick_actions_platform_interface depends on both flutter_test from sdk and mockito 5.4.0, version solving failed.
```

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8780090492483790881/+/u/run_test.dart_for_flutter_plugins_shard_and_subshard_analyze/test_stdout