### PR TITLE
Remove legacy xcode properties and dependencies

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -24,13 +24,11 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14e222b"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       os: Mac-12
       device_type: none
       cpu: arm64
-      xcode: 14e222b
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e222b"
@@ -39,13 +37,11 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14e222b"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       os: Mac-12
       device_type: none
       cpu: x86
-      xcode: 14e222b
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e222b"


### PR DESCRIPTION
Now only `$flutter/osx_sdk` property is being used, and it's safe to remove deprecated entries from ci.yaml.

Part of https://github.com/flutter/flutter/issues/127534