### PR TITLE
[local_auth] Fix cancel handling on Android

### DIFF
--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.0.29
 
+* Fixes a regression in 1.0.23 that caused canceled auths to return success.
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
 
 ## 1.0.28

--- a/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -155,7 +155,7 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
         if (activityPaused && isAuthSticky) {
           return;
         } else {
-          completionHandler.complete(Messages.AuthResult.SUCCESS);
+          completionHandler.complete(Messages.AuthResult.FAILURE);
         }
         break;
       default:

--- a/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/AuthenticationHelperTest.java
+++ b/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/AuthenticationHelperTest.java
@@ -1,0 +1,179 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.localauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.app.Application;
+import android.app.KeyguardManager;
+import android.app.NativeActivity;
+import android.content.Context;
+import androidx.biometric.BiometricManager;
+import androidx.biometric.BiometricPrompt;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.Lifecycle;
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugins.localauth.AuthenticationHelper.AuthCompletionHandler;
+import io.flutter.plugins.localauth.Messages.AuthClassification;
+import io.flutter.plugins.localauth.Messages.AuthClassificationWrapper;
+import io.flutter.plugins.localauth.Messages.AuthOptions;
+import io.flutter.plugins.localauth.Messages.AuthResult;
+import io.flutter.plugins.localauth.Messages.AuthResultWrapper;
+import io.flutter.plugins.localauth.Messages.AuthStrings;
+import io.flutter.plugins.localauth.Messages.Result;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+// TODO(stuartmorgan): Add injectable BiometricPrompt factory, and AlertDialog factor, and add
+// testing of the rest of the flows.
+
+@RunWith(RobolectricTestRunner.class)
+public class AuthenticationHelperTest {
+  static final AuthStrings dummyStrings =
+      new AuthStrings.Builder()
+          .setReason("a reason")
+          .setBiometricHint("a hint")
+          .setBiometricNotRecognized("biometric not recognized")
+          .setBiometricRequiredTitle("biometric required")
+          .setCancelButton("cancel")
+          .setDeviceCredentialsRequiredTitle("credentials required")
+          .setDeviceCredentialsSetupDescription("credentials setup description")
+          .setGoToSettingsButton("go")
+          .setGoToSettingsDescription("go to settings description")
+          .setSignInTitle("sign in")
+          .build();
+
+  static final AuthOptions defaultOptions =
+      new AuthOptions.Builder()
+          .setBiometricOnly(false)
+          .setSensitiveTransaction(false)
+          .setSticky(false)
+          .setUseErrorDialgs(false)
+          .build();
+
+  @Test
+  public void onAuthenticationError_withoutDialogs_returnsNotAvailableForNoCredential() {
+    final AuthCompletionHandler handler = mock(AuthCompletionHandler.class);
+    final AuthenticationHelper helper = new AuthenticationHelper(
+            null, buildMockActivityWithContext(mock(FragmentActivity.class)),
+            defaultOptions, dummyStrings, handler,true);
+
+    helper.onAuthenticationError(BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL, "");
+
+    verify(handler).complete(AuthResult.ERROR_NOT_AVAILABLE);
+  }
+
+  @Test
+  public void onAuthenticationError_withoutDialogs_returnsNotEnrolledForNoBiometrics() {
+    final AuthCompletionHandler handler = mock(AuthCompletionHandler.class);
+    final AuthenticationHelper helper = new AuthenticationHelper(
+            null, buildMockActivityWithContext(mock(FragmentActivity.class)),
+            defaultOptions, dummyStrings, handler,true);
+
+    helper.onAuthenticationError(BiometricPrompt.ERROR_NO_BIOMETRICS, "");
+
+    verify(handler).complete(AuthResult.ERROR_NOT_ENROLLED);
+  }
+
+  @Test
+  public void onAuthenticationError_returnsNotAvailableForHardwareUnavailable() {
+    final AuthCompletionHandler handler = mock(AuthCompletionHandler.class);
+    final AuthenticationHelper helper = new AuthenticationHelper(
+            null, buildMockActivityWithContext(mock(FragmentActivity.class)),
+            defaultOptions, dummyStrings, handler,true);
+
+    helper.onAuthenticationError(BiometricPrompt.ERROR_HW_UNAVAILABLE, "");
+
+    verify(handler).complete(AuthResult.ERROR_NOT_AVAILABLE);
+  }
+
+  @Test
+  public void onAuthenticationError_returnsNotAvailableForHardwareNotPresent() {
+    final AuthCompletionHandler handler = mock(AuthCompletionHandler.class);
+    final AuthenticationHelper helper = new AuthenticationHelper(
+            null, buildMockActivityWithContext(mock(FragmentActivity.class)),
+            defaultOptions, dummyStrings, handler,true);
+
+    helper.onAuthenticationError(BiometricPrompt.ERROR_HW_NOT_PRESENT, "");
+
+    verify(handler).complete(AuthResult.ERROR_NOT_AVAILABLE);
+  }
+
+  @Test
+  public void onAuthenticationError_returnsTemporaryLockoutForLockout() {
+    final AuthCompletionHandler handler = mock(AuthCompletionHandler.class);
+    final AuthenticationHelper helper = new AuthenticationHelper(
+            null, buildMockActivityWithContext(mock(FragmentActivity.class)),
+            defaultOptions, dummyStrings, handler,true);
+
+    helper.onAuthenticationError(BiometricPrompt.ERROR_LOCKOUT, "");
+
+    verify(handler).complete(AuthResult.ERROR_LOCKED_OUT_TEMPORARILY);
+  }
+
+  @Test
+  public void onAuthenticationError_returnsPermanentLockoutForLockoutPermanent() {
+    final AuthCompletionHandler handler = mock(AuthCompletionHandler.class);
+    final AuthenticationHelper helper = new AuthenticationHelper(
+            null, buildMockActivityWithContext(mock(FragmentActivity.class)),
+            defaultOptions, dummyStrings, handler,true);
+
+    helper.onAuthenticationError(BiometricPrompt.ERROR_LOCKOUT_PERMANENT, "");
+
+    verify(handler).complete(AuthResult.ERROR_LOCKED_OUT_PERMANENTLY);
+  }
+
+  @Test
+  public void onAuthenticationError_withoutSticky_returnsFailureForCanceled() {
+    final AuthCompletionHandler handler = mock(AuthCompletionHandler.class);
+    final AuthenticationHelper helper = new AuthenticationHelper(
+            null, buildMockActivityWithContext(mock(FragmentActivity.class)),
+            defaultOptions, dummyStrings, handler,true);
+
+    helper.onAuthenticationError(BiometricPrompt.ERROR_CANCELED, "");
+
+    verify(handler).complete(AuthResult.FAILURE);
+  }
+
+  @Test
+  public void onAuthenticationError_withoutSticky_returnsFailureForOtherCases() {
+    final AuthCompletionHandler handler = mock(AuthCompletionHandler.class);
+    final AuthenticationHelper helper = new AuthenticationHelper(
+            null, buildMockActivityWithContext(mock(FragmentActivity.class)),
+            defaultOptions, dummyStrings, handler,true);
+
+    helper.onAuthenticationError(BiometricPrompt.ERROR_VENDOR, "");
+
+    verify(handler).complete(AuthResult.FAILURE);
+  }
+
+  private FragmentActivity buildMockActivityWithContext(FragmentActivity mockActivity) {
+    final Application mockApplication = mock(Application.class);
+    final Context mockContext = mock(Context.class);
+    when(mockActivity.getBaseContext()).thenReturn(mockContext);
+    when(mockActivity.getApplicationContext()).thenReturn(mockContext);
+    when(mockActivity.getApplication()).thenReturn(mockApplication);
+    return mockActivity;
+  }
+}

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.28
+version: 1.0.29
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Fixes a regression introduced during the Pigeon conversion where a canceled auth returned success instead of failure.

Adds initial unit test coverage of `AuthenticationHelper`, which was previously untested, including coverage of the incorrect code path.

Fixes https://github.com/flutter/flutter/issues/127732

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
