### PR TITLE
[path_provider] Allow win32 up to version 5.x

### DIFF
--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.1.7
 
+* Adds compatibility with `win32` 5.x.
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
 
 ## 2.1.6

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.6
+version: 2.1.7
 
 environment:
   sdk: ">=2.18.0 <4.0.0"
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   path: ^1.8.0
   path_provider_platform_interface: ^2.0.0
-  win32: ">=2.1.0 <5.0.0"
+  win32: ">=2.1.0 <6.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updating pubspec.yaml in path_provider package to support win32 v5.

Fixes [#127289](https://github.com/flutter/flutter/issues/127289)
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

