### PR TITLE
[webview_flutter_platform_interface] Signatures for handling basic authentication requests

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+* Adds support for handling basic authentication. See `PlatformNavigationDelegate.setOnReceiveHttpAuthRequest` and `PlatformWebViewController.setHttpAuthCredentials`.
+
 ## 2.3.1
 
 * Removes obsolete null checks on non-nullable values.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
@@ -30,6 +30,9 @@ typedef WebResourceErrorCallback = void Function(WebResourceError error);
 /// url of the web view.
 typedef UrlChangeCallback = void Function(UrlChange change);
 
+/// Signature for callbacks that report basic auth events by the native web view
+typedef HttpAuthRequestCallback = void Function(String host, String realm);
+
 /// An interface defining navigation events that occur on the native platform.
 ///
 /// The [PlatformWebViewController] is notifying this delegate on events that
@@ -131,5 +134,14 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
     throw UnimplementedError(
       'setOnUrlChange is not implemented on the current platform.',
     );
+  }
+
+  /// Invoked when a page requests basic authorization.
+  ///
+  /// See [PlatformWebViewController.setPlatformNavigationDelegate].
+  Future<void> setOnReceiveHttpAuthRequest(
+      HttpAuthRequestCallback onHttpAuthRequest) {
+    throw UnimplementedError(
+        'setOnReceiveHttpAuthRequest is not implemented on the current platform.');
   }
 }

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
@@ -261,6 +261,13 @@ abstract class PlatformWebViewController extends PlatformInterface {
         'setUserAgent is not implemented on the current platform');
   }
 
+  /// Sets the auth credentials for basic authentication and can be used on onReceiveHttpAuthRequest with NavigationDelegate.
+  Future<void> setHttpAuthCredentials(
+      String host, String realm, String username, String password) {
+    throw UnimplementedError(
+        'setHttpAuthCredentials is not implemented on the current platform');
+  }
+
   /// Sets a callback that notifies the host application that web content is
   /// requesting permission to access the specified resources.
   Future<void> setOnPlatformPermissionRequest(

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/webview_flutt
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.1
+version: 2.4.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_navigation_delegate_test.dart
@@ -142,6 +142,20 @@ void main() {
       throwsUnimplementedError,
     );
   });
+
+  test(
+  'Default implementation of setOnReceiveHttpAuthRequest should throw unimplemented error',
+  () {
+    final PlatformNavigationDelegate callbackDelegate =
+        ExtendsPlatformNavigationDelegate(
+            const PlatformNavigationDelegateCreationParams());
+
+    expect(
+      () => callbackDelegate.setOnReceiveHttpAuthRequest((String host, String realm) {}),
+      throwsUnimplementedError,
+    );
+  });
+
 }
 
 class MockWebViewPlatformWithMixin extends MockWebViewPlatform

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_navigation_delegate_test.dart
@@ -144,18 +144,18 @@ void main() {
   });
 
   test(
-  'Default implementation of setOnReceiveHttpAuthRequest should throw unimplemented error',
-  () {
+      'Default implementation of setOnReceiveHttpAuthRequest should throw unimplemented error',
+      () {
     final PlatformNavigationDelegate callbackDelegate =
         ExtendsPlatformNavigationDelegate(
             const PlatformNavigationDelegateCreationParams());
 
     expect(
-      () => callbackDelegate.setOnReceiveHttpAuthRequest((String host, String realm) {}),
+      () => callbackDelegate
+          .setOnReceiveHttpAuthRequest((String host, String realm) {}),
       throwsUnimplementedError,
     );
   });
-
 }
 
 class MockWebViewPlatformWithMixin extends MockWebViewPlatform

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_webview_controller_test.dart
@@ -387,6 +387,20 @@ void main() {
       throwsUnimplementedError,
     );
   });
+
+  test(
+    'Default implementation of setHttpAuthCredentials should throw unimplemented error',
+    () {
+  final PlatformWebViewController controller =
+      ExtendsPlatformWebViewController(
+          const PlatformWebViewControllerCreationParams());
+
+  expect(
+    () => controller.setHttpAuthCredentials('host', 'realm', 'username', 'password'),
+    throwsUnimplementedError,
+  );
+});
+
 }
 
 class MockWebViewPlatformWithMixin extends MockWebViewPlatform

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_webview_controller_test.dart
@@ -389,18 +389,18 @@ void main() {
   });
 
   test(
-    'Default implementation of setHttpAuthCredentials should throw unimplemented error',
-    () {
-  final PlatformWebViewController controller =
-      ExtendsPlatformWebViewController(
-          const PlatformWebViewControllerCreationParams());
+      'Default implementation of setHttpAuthCredentials should throw unimplemented error',
+      () {
+    final PlatformWebViewController controller =
+        ExtendsPlatformWebViewController(
+            const PlatformWebViewControllerCreationParams());
 
-  expect(
-    () => controller.setHttpAuthCredentials('host', 'realm', 'username', 'password'),
-    throwsUnimplementedError,
-  );
-});
-
+    expect(
+      () => controller.setHttpAuthCredentials(
+          'host', 'realm', 'username', 'password'),
+      throwsUnimplementedError,
+    );
+  });
 }
 
 class MockWebViewPlatformWithMixin extends MockWebViewPlatform


### PR DESCRIPTION
## Description
This PR introduces signatures for a method and a callback for handling basic authentication.
See `PlatformNavigationDelegate.setOnReceiveHttpAuthRequest` and `PlatformWebViewController.setHttpAuthCredentials`.

## Issues fixed by this PR:
Closes flutter/flutter#83556

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


