### PR TITLE
[video_player] fix: add missing isPlaybackLikelyToKeepUp check.

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
 
+## 2.4.7
+
+* Fixes missing `isPlaybackLikelyToKeepUp` check for iOS video player `bufferingEnd` event and `bufferingStart` event.
+
 ## 2.4.6
 
 * Fixes hang when seeking to end of video.

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -338,14 +338,17 @@ NS_INLINE UIViewController *rootViewController(void) {
     }
   } else if (context == playbackBufferEmptyContext) {
     if (_eventSink != nil) {
-      _eventSink(@{@"event" : @"bufferingStart"});
       if ([[_player currentItem] isPlaybackLikelyToKeepUp]) {
         _eventSink(@{@"event" : @"bufferingEnd"});
+      } else {
+        _eventSink(@{@"event" : @"bufferingStart"});
       }
     }
   } else if (context == playbackBufferFullContext) {
     if (_eventSink != nil) {
-      _eventSink(@{@"event" : @"bufferingEnd"});
+      if ([[_player currentItem] isPlaybackLikelyToKeepUp]) {
+        _eventSink(@{@"event" : @"bufferingEnd"});
+      }
     }
   } else if (context == rateContext) {
     // Important: Make sure to cast the object to AVPlayer when observing the rate property,

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -339,6 +339,9 @@ NS_INLINE UIViewController *rootViewController(void) {
   } else if (context == playbackBufferEmptyContext) {
     if (_eventSink != nil) {
       _eventSink(@{@"event" : @"bufferingStart"});
+      if ([[_player currentItem] isPlaybackLikelyToKeepUp]) {
+        _eventSink(@{@"event" : @"bufferingEnd"});
+      }
     }
   } else if (context == playbackBufferFullContext) {
     if (_eventSink != nil) {

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -348,6 +348,8 @@ NS_INLINE UIViewController *rootViewController(void) {
     if (_eventSink != nil) {
       if ([[_player currentItem] isPlaybackLikelyToKeepUp]) {
         _eventSink(@{@"event" : @"bufferingEnd"});
+      } else {
+        _eventSink(@{@"event" : @"bufferingStart"});
       }
     }
   } else if (context == rateContext) {

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.6
+version: 2.4.7
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
 When watching a live stream, if the playback buffers but the AVPlayerItem is likely to keep up, it is necessary to recheck AVPlayerItem.isPlaybackLikelyToKeepUp. If isPlaybackLikelyToKeepUp, a bufferingEnd event should be immediately triggered. I am encountering an issue with my product where, when watching a live stream, if I seek to the latest time, it continuously `bufferingStart` and does not come to an `bufferingEnd`. Old ticket https://github.com/flutter/packages/pull/3826

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
