### PR TITLE
[tools] Fix OOB test error

### DIFF
--- a/script/tool/test/update_min_sdk_command_test.dart
+++ b/script/tool/test/update_min_sdk_command_test.dart
@@ -28,14 +28,14 @@ void main() {
   });
 
   test('fails if --flutter-min is missing', () async {
-    Exception? commandError;
+    Error? commandError;
     await runCapturingPrint(runner, <String>[
       'update-min-sdk',
-    ], exceptionHandler: (Exception e) {
+    ], errorHandler: (Error e) {
       commandError = e;
     });
 
-    expect(commandError, isA<UsageException>());
+    expect(commandError, isA<ArgumentError>());
   });
 
   test('updates Dart when only Dart is present', () async {

--- a/script/tool/test/update_release_info_command_test.dart
+++ b/script/tool/test/update_release_info_command_test.dart
@@ -50,15 +50,15 @@ void main() {
 
   group('flags', () {
     test('fails if --changelog is missing', () async {
-      Exception? commandError;
+      Error? commandError;
       await runCapturingPrint(runner, <String>[
         'update-release-info',
         '--version=next',
-      ], exceptionHandler: (Exception e) {
+      ], errorHandler: (Error e) {
         commandError = e;
       });
 
-      expect(commandError, isA<UsageException>());
+      expect(commandError, isA<ArgumentError>());
     });
 
     test('fails if --changelog is blank', () async {

--- a/script/tool/test/update_release_info_command_test.dart
+++ b/script/tool/test/update_release_info_command_test.dart
@@ -76,14 +76,14 @@ void main() {
     });
 
     test('fails if --version is missing', () async {
-      Exception? commandError;
+      Error? commandError;
       await runCapturingPrint(
-          runner, <String>['update-release-info', '--changelog', ''],
-          exceptionHandler: (Exception e) {
+          runner, <String>['update-release-info', '--changelog', 'A change.'],
+          errorHandler: (Error e) {
         commandError = e;
       });
 
-      expect(commandError, isA<UsageException>());
+      expect(commandError, isA<ArgumentError>());
     });
 
     test('fails if --version is an unknown value', () async {
@@ -92,7 +92,7 @@ void main() {
         'update-release-info',
         '--version=foo',
         '--changelog',
-        '',
+        'A change.',
       ], exceptionHandler: (Exception e) {
         commandError = e;
       });


### PR DESCRIPTION
An update to `args` changed the failure mode for a missing flag; this updates the tests accordingly to fix the tree.