### PR TITLE
[ci] Exclude maps unit tests on Windows

### DIFF
--- a/packages/local_auth/local_auth/example/android/app/build.gradle
+++ b/packages/local_auth/local_auth/example/android/app/build.gradle
@@ -36,6 +36,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     buildTypes {

--- a/script/configs/windows_unit_tests_exceptions.yaml
+++ b/script/configs/windows_unit_tests_exceptions.yaml
@@ -15,6 +15,7 @@
 - camera_web
 - file_selector
 - file_selector_web
+- google_maps_flutter
 - google_maps_flutter_web
 - google_sign_in
 - google_sign_in_web


### PR DESCRIPTION
Now that `google_maps_flutter` supports web, add it to the list of tests that don't currently run correctly on a Windows CI host.

Also enables multidex in `local_auth` to fix an OOB failure from the recent publishing of local_auth_android.