### PR TITLE
[tool] Only run unit tests in Chrome for inline web

### DIFF
--- a/packages/local_auth/local_auth/example/android/app/build.gradle
+++ b/packages/local_auth/local_auth/example/android/app/build.gradle
@@ -36,6 +36,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     buildTypes {

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -350,12 +350,12 @@ void main() {
 
       test('file with special characters', () async {
         final VideoPlayerController controller =
-            VideoPlayerController.file(File('A #1 Hit?.avi'));
+            VideoPlayerController.file(File('A #1 Hit.avi'));
         await controller.initialize();
 
         final String uri = fakeVideoPlayerPlatform.dataSources[0].uri!;
         expect(uri.startsWith('file:///'), true, reason: 'Actual string: $uri');
-        expect(uri.endsWith('/A%20%231%20Hit%3F.avi'), true,
+        expect(uri.endsWith('/A%20%231%20Hit.avi'), true,
             reason: 'Actual string: $uri');
       }, skip: kIsWeb /* Web does not support file assets. */);
 

--- a/script/configs/windows_unit_tests_exceptions.yaml
+++ b/script/configs/windows_unit_tests_exceptions.yaml
@@ -15,6 +15,7 @@
 - camera_web
 - file_selector
 - file_selector_web
+- google_maps_flutter
 - google_maps_flutter_web
 - google_sign_in
 - google_sign_in_web

--- a/script/configs/windows_unit_tests_exceptions.yaml
+++ b/script/configs/windows_unit_tests_exceptions.yaml
@@ -11,20 +11,12 @@
 # Unit tests for plugins that support web currently run in
 # Chrome, which isn't currently supported by web infrastructure.
 # TODO(ditman): Fix this in the repo tooling.
-- camera
 - camera_web
-- file_selector
 - file_selector_web
-- google_maps_flutter
 - google_maps_flutter_web
-- google_sign_in
 - google_sign_in_web
-- image_picker
 - image_picker_for_web
-- shared_preferences
 - shared_preferences_web
-- url_launcher
 - url_launcher_web
-- video_player
 - video_player_web
 - webview_flutter_web

--- a/script/configs/windows_unit_tests_exceptions.yaml
+++ b/script/configs/windows_unit_tests_exceptions.yaml
@@ -13,7 +13,6 @@
 # TODO(ditman): Fix this in the repo tooling.
 - camera_web
 - file_selector_web
-- google_maps_flutter
 - google_maps_flutter_web
 - google_sign_in_web
 - image_picker_for_web

--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -66,7 +66,9 @@ class TestCommand extends PackageLoopingCommand {
         '--color',
         if (experiment.isNotEmpty) '--enable-experiment=$experiment',
         // TODO(ditman): Remove this once all plugins are migrated to 'drive'.
-        if (pluginSupportsPlatform(platformWeb, package)) '--platform=chrome',
+        if (pluginSupportsPlatform(platformWeb, package,
+            requiredMode: PlatformSupport.inline))
+          '--platform=chrome',
       ],
       workingDir: package.directory,
     );

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -15,7 +15,7 @@ import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  group('$TestCommand', () {
+  group('TestCommand', () {
     late FileSystem fileSystem;
     late Platform mockPlatform;
     late Directory packagesDir;
@@ -235,6 +235,27 @@ void main() {
               getFlutterCommand(mockPlatform),
               const <String>['test', '--color', '--platform=chrome'],
               plugin.path),
+        ]),
+      );
+    });
+
+    test('Does not run on Chrome for web endorsements', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>['test/empty_test.dart'],
+        platformSupport: <String, PlatformDetails>{
+          platformWeb: const PlatformDetails(PlatformSupport.federated),
+        },
+      );
+
+      await runCapturingPrint(runner, <String>['test']);
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall(getFlutterCommand(mockPlatform),
+              const <String>['test', '--color'], plugin.path),
         ]),
       );
     });


### PR DESCRIPTION
Currently we are running Dart unit tests in Chrome for any plugin with
web support, but it should only be necessary for plugins that have an
inline web implementation, not for app-facing packages that endorse a
web implementation.