### PR TITLE
[in_app_purchase] Make the _FeatureCard constructor const in the Android example app

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
@@ -145,7 +145,7 @@ class _MyAppState extends State<_MyApp> {
             _buildConnectionCheckTile(),
             _buildProductList(),
             _buildConsumableBox(),
-            _FeatureCard(),
+            const _FeatureCard(),
           ],
         ),
       );
@@ -444,9 +444,9 @@ class _MyAppState extends State<_MyApp> {
 }
 
 class _FeatureCard extends StatelessWidget {
-  _FeatureCard();
+  const _FeatureCard();
 
-  final InAppPurchaseAndroidPlatformAddition addition =
+  InAppPurchaseAndroidPlatformAddition get addition =>
       InAppPurchasePlatformAddition.instance!
           as InAppPurchaseAndroidPlatformAddition;
 


### PR DESCRIPTION
This works around a Dart analyzer error that is blocking the engine->framework roll (see https://github.com/flutter/flutter/pull/128476)