### PR TITLE
[webview_flutter] Explicitly disable ATS in example apps

### DIFF
--- a/packages/webview_flutter/webview_flutter/example/ios/Runner/Info.plist
+++ b/packages/webview_flutter/webview_flutter/example/ios/Runner/Info.plist
@@ -45,5 +45,10 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+	    <key>NSAllowsArbitraryLoadsInWebContent</key>
+	    <true/>
+	</dict>
 </dict>
 </plist>

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/Runner/Info.plist
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/Runner/Info.plist
@@ -47,5 +47,10 @@
 	<true/>
     <key>NSCameraUsageDescription</key>
     <string>If you want to use the camera, you have to give permission.</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+	    <key>NSAllowsArbitraryLoadsInWebContent</key>
+	    <true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Our integration tests connect to a local server via HTTP; currently we are relying on ATS default behavior of allowing that for local network requests, but we should instead explicitly allow the example apps to load HTTP URLs in the webview via `NSAppTransportSecurity`.

This allows integration tests to run on iOS 17, which appears to have tightened the ATS defaults.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
