### PR TITLE
[go_router] #127016 preserved route name case when caching `_nameToPath`

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.0.2
+
+- Preserves route name case when caching `_nameToPath` by not using `toLowerCase()`.<br>
+this is useful to make route names case sensitive
+
 ## 8.0.1
 
 - Fixes a link for an example in `path` documentation.

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -221,7 +221,7 @@ class RouteConfiguration {
           '${queryParameters.isEmpty ? '' : ', queryParameters: $queryParameters'}');
       return true;
     }());
-    final String keyName = name.toLowerCase();
+    final String keyName = name;
     assert(_nameToPath.containsKey(keyName), 'unknown route name: $name');
     final String path = _nameToPath[keyName]!;
     assert(() {
@@ -564,7 +564,7 @@ class RouteConfiguration {
         final String fullPath = concatenatePaths(parentFullPath, route.path);
 
         if (route.name != null) {
-          final String name = route.name!.toLowerCase();
+          final String name = route.name!;
           assert(
               !_nameToPath.containsKey(name),
               'duplication fullpaths for name '

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 8.0.1
+version: 8.0.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 


### PR DESCRIPTION
preserved route name case when caching `_nameToPath` by not using `toLowerCase()`

Related issue:
[#127016](https://github.com/flutter/flutter/issues/127016)