### PR TITLE
[tool] Add command aliases

### DIFF
--- a/.ci/scripts/dart_unit_tests_win32.sh
+++ b/.ci/scripts/dart_unit_tests_win32.sh
@@ -4,6 +4,6 @@
 # found in the LICENSE file.
 set -e
 
-dart ./script/tool/bin/flutter_plugin_tools.dart test \
+dart ./script/tool/bin/flutter_plugin_tools.dart dart-test \
   --exclude=script/configs/windows_unit_tests_exceptions.yaml \
   --packages-for-branch --log-timing

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -231,13 +231,13 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       unit_test_script:
-        - ./script/tool_runner.sh test --exclude=script/configs/dart_unit_tests_exceptions.yaml
+        - ./script/tool_runner.sh dart-test --exclude=script/configs/dart_unit_tests_exceptions.yaml
       pathified_unit_test_script:
         # Run tests with path-based dependencies to ensure that publishing
         # the changes won't break tests of other packages in the repository
         # that depend on it.
         - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
-        - $PLUGIN_TOOL_COMMAND test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
+        - $PLUGIN_TOOL_COMMAND dart-test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
     - name: linux-custom_package_tests
       env:
         PATH: $PATH:/usr/local/bin

--- a/script/tool/lib/src/custom_test_command.dart
+++ b/script/tool/lib/src/custom_test_command.dart
@@ -29,6 +29,9 @@ class CustomTestCommand extends PackageLoopingCommand {
   final String name = 'custom-test';
 
   @override
+  List<String> get aliases => <String>['test-custom'];
+
+  @override
   final String description = 'Runs package-specific custom tests defined in '
       "a package's tool/$_scriptName file.\n\n"
       'This command requires "dart" to be in your path.';

--- a/script/tool/lib/src/dart_test_command.dart
+++ b/script/tool/lib/src/dart_test_command.dart
@@ -12,9 +12,9 @@ import 'common/process_runner.dart';
 import 'common/repository_package.dart';
 
 /// A command to run Dart unit tests for packages.
-class TestCommand extends PackageLoopingCommand {
+class DartTestCommand extends PackageLoopingCommand {
   /// Creates an instance of the test command.
-  TestCommand(
+  DartTestCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     Platform platform = const LocalPlatform(),
@@ -30,7 +30,13 @@ class TestCommand extends PackageLoopingCommand {
   }
 
   @override
-  final String name = 'test';
+  final String name = 'dart-test';
+
+  // TODO(stuartmorgan): Eventually remove 'test', which is a legacy name from
+  // before there were other test commands that made it ambiguous. For now it's
+  // an alias to avoid breaking people's workflows.
+  @override
+  List<String> get aliases => <String>['test', 'test-dart'];
 
   @override
   final String description = 'Runs the Dart tests for all packages.\n\n'

--- a/script/tool/lib/src/dependabot_check_command.dart
+++ b/script/tool/lib/src/dependabot_check_command.dart
@@ -33,6 +33,9 @@ class DependabotCheckCommand extends PackageLoopingCommand {
   final String name = 'dependabot-check';
 
   @override
+  List<String> get aliases => <String>['check-dependabot'];
+
+  @override
   final String description =
       'Checks that all packages have Dependabot coverage.';
 

--- a/script/tool/lib/src/federation_safety_check_command.dart
+++ b/script/tool/lib/src/federation_safety_check_command.dart
@@ -53,6 +53,9 @@ class FederationSafetyCheckCommand extends PackageLoopingCommand {
   final String name = 'federation-safety-check';
 
   @override
+  List<String> get aliases => <String>['check-federation-safety'];
+
+  @override
   final String description =
       'Checks that the change does not violate repository rules around changes '
       'to federated plugin packages.';

--- a/script/tool/lib/src/gradle_check_command.dart
+++ b/script/tool/lib/src/gradle_check_command.dart
@@ -24,6 +24,9 @@ class GradleCheckCommand extends PackageLoopingCommand {
   final String name = 'gradle-check';
 
   @override
+  List<String> get aliases => <String>['check-gradle'];
+
+  @override
   final String description =
       'Checks that gradle files follow repository conventions.';
 

--- a/script/tool/lib/src/license_check_command.dart
+++ b/script/tool/lib/src/license_check_command.dart
@@ -115,6 +115,9 @@ class LicenseCheckCommand extends PackageCommand {
   final String name = 'license-check';
 
   @override
+  List<String> get aliases => <String>['check-license'];
+
+  @override
   final String description =
       'Ensures that all code files have copyright/license blocks.';
 

--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -13,6 +13,7 @@ import 'build_examples_command.dart';
 import 'common/core.dart';
 import 'create_all_packages_app_command.dart';
 import 'custom_test_command.dart';
+import 'dart_test_command.dart';
 import 'dependabot_check_command.dart';
 import 'drive_examples_command.dart';
 import 'federation_safety_check_command.dart';
@@ -31,7 +32,6 @@ import 'publish_command.dart';
 import 'pubspec_check_command.dart';
 import 'readme_check_command.dart';
 import 'remove_dev_dependencies_command.dart';
-import 'test_command.dart';
 import 'update_dependency_command.dart';
 import 'update_excerpts_command.dart';
 import 'update_min_sdk_command.dart';
@@ -76,7 +76,7 @@ void main(List<String> args) {
     ..addCommand(PubspecCheckCommand(packagesDir))
     ..addCommand(ReadmeCheckCommand(packagesDir))
     ..addCommand(RemoveDevDependenciesCommand(packagesDir))
-    ..addCommand(TestCommand(packagesDir))
+    ..addCommand(DartTestCommand(packagesDir))
     ..addCommand(UpdateDependencyCommand(packagesDir))
     ..addCommand(UpdateExcerptsCommand(packagesDir))
     ..addCommand(UpdateMinSdkCommand(packagesDir))

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -74,6 +74,9 @@ class NativeTestCommand extends PackageLoopingCommand {
   final String name = 'native-test';
 
   @override
+  List<String> get aliases => <String>['test-native'];
+
+  @override
   final String description = '''
 Runs native unit tests and native integration tests.
 

--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -31,7 +31,7 @@ class PodspecCheckCommand extends PackageLoopingCommand {
   final String name = 'podspec-check';
 
   @override
-  List<String> get aliases => <String>['podspec', 'podspecs'];
+  List<String> get aliases => <String>['podspec', 'podspecs', 'check-podspec'];
 
   @override
   final String description =

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -54,6 +54,9 @@ class PublishCheckCommand extends PackageLoopingCommand {
   final String name = 'publish-check';
 
   @override
+  List<String> get aliases => <String>['check-publish'];
+
+  @override
   final String description =
       'Checks to make sure that a package *could* be published.';
 

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -90,6 +90,9 @@ class PubspecCheckCommand extends PackageLoopingCommand {
   final String name = 'pubspec-check';
 
   @override
+  List<String> get aliases => <String>['check-pubspec'];
+
+  @override
   final String description =
       'Checks that pubspecs follow repository conventions.';
 
@@ -104,8 +107,8 @@ class PubspecCheckCommand extends PackageLoopingCommand {
   Future<void> initializeRun() async {
     // Find all local, published packages.
     for (final File pubspecFile in (await packagesDir.parent
-        .list(recursive: true, followLinks: false)
-        .toList())
+            .list(recursive: true, followLinks: false)
+            .toList())
         .whereType<File>()
         .where((File entity) => p.basename(entity.path) == 'pubspec.yaml')) {
       final Pubspec? pubspec = _tryParsePubspec(pubspecFile.readAsStringSync());

--- a/script/tool/lib/src/readme_check_command.dart
+++ b/script/tool/lib/src/readme_check_command.dart
@@ -49,6 +49,9 @@ class ReadmeCheckCommand extends PackageLoopingCommand {
   final String name = 'readme-check';
 
   @override
+  List<String> get aliases => <String>['check-readme'];
+
+  @override
   final String description =
       'Checks that READMEs follow repository conventions.';
 

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -172,6 +172,9 @@ class VersionCheckCommand extends PackageLoopingCommand {
   final String name = 'version-check';
 
   @override
+  List<String> get aliases => <String>['check-version'];
+
+  @override
   final String description =
       'Checks if the versions of packages have been incremented per pub specification.\n'
       'Also checks if the latest version in CHANGELOG matches the version in pubspec.\n\n'

--- a/script/tool/lib/src/xcode_analyze_command.dart
+++ b/script/tool/lib/src/xcode_analyze_command.dart
@@ -43,6 +43,9 @@ class XcodeAnalyzeCommand extends PackageLoopingCommand {
   final String name = 'xcode-analyze';
 
   @override
+  List<String> get aliases => <String>['analyze-xcode'];
+
+  @override
   final String description =
       'Runs Xcode analysis on the iOS and/or macOS example apps.';
 

--- a/script/tool/test/dart_test_command_test.dart
+++ b/script/tool/test/dart_test_command_test.dart
@@ -7,7 +7,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
-import 'package:flutter_plugin_tools/src/test_command.dart';
+import 'package:flutter_plugin_tools/src/dart_test_command.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
@@ -27,14 +27,29 @@ void main() {
       mockPlatform = MockPlatform();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
-      final TestCommand command = TestCommand(
+      final DartTestCommand command = DartTestCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
       );
 
-      runner = CommandRunner<void>('test_test', 'Test for $TestCommand');
+      runner = CommandRunner<void>('test_test', 'Test for $DartTestCommand');
       runner.addCommand(command);
+    });
+
+    test('legacy name still works', () async {
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir,
+          extraFiles: <String>['test/a_test.dart']);
+
+      await runCapturingPrint(runner, <String>['test']);
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall(getFlutterCommand(mockPlatform),
+              const <String>['test', '--color'], plugin.path),
+        ]),
+      );
     });
 
     test('runs flutter test on each plugin', () async {
@@ -43,7 +58,7 @@ void main() {
       final RepositoryPackage plugin2 = createFakePlugin('plugin2', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
 
-      await runCapturingPrint(runner, <String>['test']);
+      await runCapturingPrint(runner, <String>['dart-test']);
 
       expect(
         processRunner.recordedCalls,
@@ -63,7 +78,7 @@ void main() {
             'example/test/an_example_test.dart'
           ]);
 
-      await runCapturingPrint(runner, <String>['test']);
+      await runCapturingPrint(runner, <String>['dart-test']);
 
       expect(
         processRunner.recordedCalls,
@@ -86,13 +101,13 @@ void main() {
               .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
           <FakeProcessInfo>[
         FakeProcessInfo(
-            MockProcess(exitCode: 1), <String>['test']), // plugin 1 test
-        FakeProcessInfo(MockProcess(), <String>['test']), // plugin 2 test
+            MockProcess(exitCode: 1), <String>['dart-test']), // plugin 1 test
+        FakeProcessInfo(MockProcess(), <String>['dart-test']), // plugin 2 test
       ];
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
-          runner, <String>['test'], errorHandler: (Error e) {
+          runner, <String>['dart-test'], errorHandler: (Error e) {
         commandError = e;
       });
 
@@ -110,7 +125,7 @@ void main() {
       final RepositoryPackage plugin2 = createFakePlugin('plugin2', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
 
-      await runCapturingPrint(runner, <String>['test']);
+      await runCapturingPrint(runner, <String>['dart-test']);
 
       expect(
         processRunner.recordedCalls,
@@ -128,7 +143,7 @@ void main() {
           extraFiles: <String>['test/empty_test.dart']);
 
       await runCapturingPrint(
-          runner, <String>['test', '--enable-experiment=exp1']);
+          runner, <String>['dart-test', '--enable-experiment=exp1']);
 
       expect(
         processRunner.recordedCalls,
@@ -153,7 +168,7 @@ void main() {
         'example/test/an_example_test.dart'
       ]);
 
-      await runCapturingPrint(runner, <String>['test']);
+      await runCapturingPrint(runner, <String>['dart-test']);
 
       expect(
         processRunner.recordedCalls,
@@ -178,7 +193,7 @@ void main() {
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
-          runner, <String>['test'], errorHandler: (Error e) {
+          runner, <String>['dart-test'], errorHandler: (Error e) {
         commandError = e;
       });
 
@@ -203,7 +218,7 @@ void main() {
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
-          runner, <String>['test'], errorHandler: (Error e) {
+          runner, <String>['dart-test'], errorHandler: (Error e) {
         commandError = e;
       });
 
@@ -226,7 +241,7 @@ void main() {
         },
       );
 
-      await runCapturingPrint(runner, <String>['test']);
+      await runCapturingPrint(runner, <String>['dart-test']);
 
       expect(
         processRunner.recordedCalls,
@@ -249,7 +264,7 @@ void main() {
         },
       );
 
-      await runCapturingPrint(runner, <String>['test']);
+      await runCapturingPrint(runner, <String>['dart-test']);
 
       expect(
         processRunner.recordedCalls,
@@ -267,7 +282,7 @@ void main() {
           extraFiles: <String>['test/empty_test.dart']);
 
       await runCapturingPrint(
-          runner, <String>['test', '--enable-experiment=exp1']);
+          runner, <String>['dart-test', '--enable-experiment=exp1']);
 
       expect(
         processRunner.recordedCalls,

--- a/script/tool/test/dart_test_command_test.dart
+++ b/script/tool/test/dart_test_command_test.dart
@@ -37,7 +37,7 @@ void main() {
       runner.addCommand(command);
     });
 
-    test('legacy name still works', () async {
+    test('legacy "test" name still works', () async {
       final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir,
           extraFiles: <String>['test/a_test.dart']);
 


### PR DESCRIPTION
Adds aliases for all commands that put the verb first, since currently they are inconsistent which can make it hard to remember (in particular, I often write `check-foo` instead of `foo-check` when running locally, and it fails).

Also does the long-overdue renaming of `test` to `dart-test`, since we now have `native-test`, `custom-test`, etc. `test` continues to work as an alias for individual muscle memory.
