### PR TITLE
[tool] Support running main.dart

### DIFF
--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -41,9 +41,13 @@ import 'xcode_analyze_command.dart';
 
 void main(List<String> args) {
   const FileSystem fileSystem = LocalFileSystem();
-  final Directory scriptBinDir =
+  final Directory scriptDir =
       fileSystem.file(io.Platform.script.toFilePath()).parent;
-  final Directory root = scriptBinDir.parent.parent.parent;
+  // Support running either via directly invoking main.dart, or the wrapper in
+  // bin/.
+  final Directory toolsDir =
+      scriptDir.basename == 'bin' ? scriptDir.parent : scriptDir.parent.parent;
+  final Directory root = toolsDir.parent.parent;
   final Directory packagesDir = root.childDirectory('packages');
 
   if (!packagesDir.existsSync()) {


### PR DESCRIPTION
The change to how the repository is located assumed the script was being run from bin/flutter_plugin_tools.dart, but it can also be run directly from lib/src/main.dart which was broken. This restores the ability to run it either way.

Fixes the tree breakage in `release`.