### PR TITLE
[pigeon] Enable Android integration tests in CI

### DIFF
--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -113,11 +113,8 @@ Future<void> main(List<String> args) async {
     androidJavaUnitTests,
     androidJavaLint,
     androidKotlinUnitTests,
-    // TODO(stuartmorgan): Include these once CI supports running simulator
-    // tests. Currently these tests aren't run in CI.
-    // See https://github.com/flutter/flutter/issues/111505.
-    // androidJavaIntegrationTests,
-    // androidKotlinIntegrationTests,
+    androidJavaIntegrationTests,
+    androidKotlinIntegrationTests,
   ];
   const List<String> macOSHostTests = <String>[
     iOSObjCUnitTests,


### PR DESCRIPTION
(WIP, creating as a test case for CI changes to add emulator support.)

Fixes https://github.com/flutter/flutter/issues/111505