### PR TITLE
[pigeon] Enable Obj-C integration tests in CI

### DIFF
--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -121,9 +121,7 @@ Future<void> main(List<String> args) async {
   ];
   const List<String> macOSHostTests = <String>[
     iOSObjCUnitTests,
-    // TODO(stuartmorgan): Enable by default once CI issues are solved; see
-    // https://github.com/flutter/packages/pull/2816.
-    //iOSObjCIntegrationTests,
+    iOSObjCIntegrationTests,
     // Currently these are testing exactly the same thing as
     // macOSSwiftIntegrationTests, so we don't need to run both by default. This
     // should be enabled if any iOS-only tests are added (e.g., for a feature


### PR DESCRIPTION
Enables the Obj-C integration tests now that CI has been updated.
