### PR TITLE
[url_launcher] Add ignores for deprecated member to test

### DIFF
--- a/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
@@ -243,7 +243,8 @@ void main() {
               as TestWidgetsFlutterBinding;
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       // TODO(goderbauer): Migrate to binding.renderViews when that is available in the oldest supported stable.
-      final RenderView renderView = binding.renderView; // ignore: deprecated_member_use
+      final RenderView renderView =
+          binding.renderView; // ignore: deprecated_member_use
       renderView.automaticSystemUiAdjustment = true;
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);
@@ -274,7 +275,8 @@ void main() {
               as TestWidgetsFlutterBinding;
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       // TODO(goderbauer): Migrate to binding.renderViews when that is available in the oldest supported stable.
-      final RenderView renderView = binding.renderView; // ignore: deprecated_member_use
+      final RenderView renderView =
+          binding.renderView; // ignore: deprecated_member_use
       expect(renderView.automaticSystemUiAdjustment, true);
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);

--- a/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
@@ -7,6 +7,7 @@
 import 'dart:ui' show Brightness;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher/src/legacy_api.dart';
@@ -241,15 +242,17 @@ void main() {
           _anonymize(TestWidgetsFlutterBinding.ensureInitialized())!
               as TestWidgetsFlutterBinding;
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      binding.renderView.automaticSystemUiAdjustment = true;
+      // TODO(goderbauer): Migrate to binding.renderViews when that is available in the oldest supported stable.
+      final RenderView renderView = binding.renderView; // ignore: deprecated_member_use
+      renderView.automaticSystemUiAdjustment = true;
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);
 
       // Should take over control of the automaticSystemUiAdjustment while it's
       // pending, then restore it back to normal after the launch finishes.
-      expect(binding.renderView.automaticSystemUiAdjustment, isFalse);
+      expect(renderView.automaticSystemUiAdjustment, isFalse);
       await launchResult;
-      expect(binding.renderView.automaticSystemUiAdjustment, isTrue);
+      expect(renderView.automaticSystemUiAdjustment, isTrue);
     });
 
     test('sets automaticSystemUiAdjustment to not be null', () async {
@@ -270,15 +273,17 @@ void main() {
           _anonymize(TestWidgetsFlutterBinding.ensureInitialized())!
               as TestWidgetsFlutterBinding;
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      expect(binding.renderView.automaticSystemUiAdjustment, true);
+      // TODO(goderbauer): Migrate to binding.renderViews when that is available in the oldest supported stable.
+      final RenderView renderView = binding.renderView; // ignore: deprecated_member_use
+      expect(renderView.automaticSystemUiAdjustment, true);
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);
 
       // The automaticSystemUiAdjustment should be set before the launch
       // and equal to true after the launch result is complete.
-      expect(binding.renderView.automaticSystemUiAdjustment, true);
+      expect(renderView.automaticSystemUiAdjustment, true);
       await launchResult;
-      expect(binding.renderView.automaticSystemUiAdjustment, true);
+      expect(renderView.automaticSystemUiAdjustment, true);
     });
 
     test('open non-parseable url', () async {


### PR DESCRIPTION
We are going to deprecate `RendererBinding.renderView` for multi-view where the binding will manages multiple RenderViews. Change for that is staged in https://github.com/flutter/flutter/pull/125003.