### PR TITLE
[shared_preferences] Fixed shared preferences crash for Date type objects on iOS.

### DIFF
--- a/packages/go_router/example/pubspec.yaml
+++ b/packages/go_router/example/pubspec.yaml
@@ -27,3 +27,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {shared_preferences: {path: ../../shared_preferences/shared_preferences}}

--- a/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
@@ -30,3 +30,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {shared_preferences: {path: ../../../shared_preferences/shared_preferences}}

--- a/packages/in_app_purchase/in_app_purchase_android/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/example/pubspec.yaml
@@ -29,3 +29,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {shared_preferences: {path: ../../../shared_preferences/shared_preferences}}

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/pubspec.yaml
@@ -29,3 +29,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {shared_preferences: {path: ../../../shared_preferences/shared_preferences}}

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+* Added handling of Date type objects on iOS in UserDefaults.
+
 ## 2.1.2
 
 * Fixes singleton initialization race condition introduced during NNBD

--- a/packages/shared_preferences/shared_preferences/README.md
+++ b/packages/shared_preferences/shared_preferences/README.md
@@ -101,6 +101,8 @@ If the prefix is set to a value such as `''` that causes it to read values that 
 not originally stored by the `SharedPreferences`, initializing `SharedPreferences` 
 may fail if any of the values are of types that are not supported by `SharedPreferences`.
 
+On iOS/macOS if UserDefaults include Date type objects, they are converted into timestamps.
+
 If you decide to remove the prefix entirely, you can still access previously created
 preferences by manually adding the previous prefix `flutter.` to the beginning of 
 the preference key.

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -28,3 +28,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {shared_preferences: {path: ../../../shared_preferences/shared_preferences}, shared_preferences_foundation: {path: ../../../shared_preferences/shared_preferences_foundation}}

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -42,3 +42,8 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {shared_preferences_foundation: {path: ../../shared_preferences/shared_preferences_foundation}}

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/shared_preferences/shared_preferences_foundation/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_foundation/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Updates minimum supported macOS version to 10.14.
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
 
+## 2.2.3
+
+* Added handling of Date type objects on iOS in UserDefaults.
+
 ## 2.2.2
 
 * Updates minimum iOS version to 11.

--- a/packages/shared_preferences/shared_preferences_foundation/darwin/Classes/SharedPreferencesPlugin.swift
+++ b/packages/shared_preferences/shared_preferences_foundation/darwin/Classes/SharedPreferencesPlugin.swift
@@ -5,24 +5,24 @@
 import Foundation
 
 #if os(iOS)
-import Flutter
+  import Flutter
 #elseif os(macOS)
-import FlutterMacOS
+  import FlutterMacOS
 #endif
 
 public class SharedPreferencesPlugin: NSObject, FlutterPlugin, UserDefaultsApi {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let instance = SharedPreferencesPlugin()
     // Workaround for https://github.com/flutter/flutter/issues/118103.
-#if os(iOS)
-    let messenger = registrar.messenger()
-#else
-    let messenger = registrar.messenger
-#endif
+    #if os(iOS)
+      let messenger = registrar.messenger()
+    #else
+      let messenger = registrar.messenger
+    #endif
     UserDefaultsApiSetup.setUp(binaryMessenger: messenger, api: instance)
   }
 
-  func getAllWithPrefix(prefix: String) -> [String? : Any?] {
+  func getAllWithPrefix(prefix: String) -> [String?: Any?] {
     let prefs = getAllPrefs(prefix: prefix)
     return convertDates(prefs)
   }
@@ -66,23 +66,21 @@ public class SharedPreferencesPlugin: NSObject, FlutterPlugin, UserDefaultsApi {
   /// Recursively convert all Date type objects into timestamp.
   private func convertDates<T>(_ value: T) -> T {
     var result: Any
-    if (value is Date) {
+    if value is Date {
       result = Int((value as! Date).timeIntervalSince1970)
-    } else if(value is Dictionary<String, Any>) {
-      var dict: Dictionary<String, Any> = [:]
-      for (k, v) in value as! Dictionary<String, Any> {
+    } else if value is [String: Any] {
+      var dict: [String: Any] = [:]
+      for (k, v) in value as! [String: Any] {
         dict[k] = convertDates(v) as Any
       }
       result = dict
-    }
-    else if(value is Array<Any>) {
-      var list: Array<Any> = []
-      for v in value as! Array<Any> {
+    } else if value is [Any] {
+      var list: [Any] = []
+      for v in value as! [Any] {
         list.append(convertDates(v))
       }
       result = list
-    }
-    else {
+    } else {
       result = value
     }
     return result as! T

--- a/packages/shared_preferences/shared_preferences_foundation/darwin/Classes/SharedPreferencesPlugin.swift
+++ b/packages/shared_preferences/shared_preferences_foundation/darwin/Classes/SharedPreferencesPlugin.swift
@@ -23,7 +23,8 @@ public class SharedPreferencesPlugin: NSObject, FlutterPlugin, UserDefaultsApi {
   }
 
   func getAllWithPrefix(prefix: String) -> [String? : Any?] {
-    return getAllPrefs(prefix: prefix)
+    let prefs = getAllPrefs(prefix: prefix)
+    return convertDates(prefs)
   }
 
   func setBool(key: String, value: Bool) {
@@ -60,5 +61,30 @@ public class SharedPreferencesPlugin: NSObject, FlutterPlugin, UserDefaultsApi {
       }
     }
     return filteredPrefs
+  }
+
+  /// Recursively convert all Date type objects into timestamp.
+  private func convertDates<T>(_ value: T) -> T {
+    var result: Any
+    if (value is Date) {
+      result = Int((value as! Date).timeIntervalSince1970)
+    } else if(value is Dictionary<String, Any>) {
+      var dict: Dictionary<String, Any> = [:]
+      for (k, v) in value as! Dictionary<String, Any> {
+        dict[k] = convertDates(v) as Any
+      }
+      result = dict
+    }
+    else if(value is Array<Any>) {
+      var list: Array<Any> = []
+      for v in value as! Array<Any> {
+        list.append(convertDates(v))
+      }
+      result = list
+    }
+    else {
+      result = value
+    }
+    return result as! T
   }
 }

--- a/packages/shared_preferences/shared_preferences_foundation/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_foundation/example/pubspec.yaml
@@ -28,3 +28,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {shared_preferences_foundation: {path: ../../../shared_preferences/shared_preferences_foundation}}

--- a/packages/shared_preferences/shared_preferences_foundation/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_foundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_foundation
 description: iOS and macOS implementation of the shared_preferences plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_foundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.2.2
+version: 2.2.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
*iOS handle Date type in user preferences, but shared_preferences package not. If UserDefaults include Date type object, application will crash during reading preferences.
To resolve the problem Date type is covert into timestamp, and app not crash.*

*List which issues are fixed by this PR. You must list at least one issue. https://github.com/flutter/flutter/issues/128948*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
