### PR TITLE
[url_launcher] Remove deprecated onPlatformMessage calls

### DIFF
--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 2.1.3
 
 * Updates minimum Flutter version to 3.3.
 * Aligns Dart and Flutter SDK constraints.
+* Removes deprecated API calls.
 
 ## 2.1.2
 

--- a/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
@@ -74,8 +74,6 @@ abstract class LinkInfo {
   bool get isDisabled;
 }
 
-typedef _SendMessage = Function(String, ByteData?, void Function(ByteData?));
-
 /// Pushes the [routeName] into Flutter's navigation system via a platform
 /// message.
 ///
@@ -91,11 +89,7 @@ Future<ByteData> pushRouteNameToFramework(Object? _, String routeName) {
   // https://github.com/flutter/flutter/issues/124045.
   // ignore: deprecated_member_use
   SystemNavigator.routeInformationUpdated(location: routeName);
-  final _SendMessage sendMessage = _ambiguate(WidgetsBinding.instance)
-          ?.platformDispatcher
-          .onPlatformMessage ??
-      ui.channelBuffers.push;
-  sendMessage(
+  ui.channelBuffers.push(
     'flutter/navigation',
     _codec.encodeMethodCall(
       MethodCall('pushRouteInformation', <dynamic, dynamic>{
@@ -107,9 +101,3 @@ Future<ByteData> pushRouteNameToFramework(Object? _, String routeName) {
   );
   return completer.future;
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
The framework has been fully migrated to ChannelBuffers about 2 years ago, meaning all Flutter versions supported by this package (>=3.3.0) only use ChannelBuffers and not the old `onPlatformMessage` call. Therefore, the old calls can now just be removed.

(This surfaced because we only remembered just now to deprecate the old long unused API.)