### PR TITLE
[image_picker_android] Modify FileUtils.getBaseName to return the whole filename when it contains no period

### DIFF
--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.8
+
+* Fixes a crash case when picking an image with a display name that does not contain a period.
+
 ## 0.8.7
 
 * Adds `getMedia` method.

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -137,7 +137,11 @@ class FileUtils {
   }
 
   private static String getBaseName(String fileName) {
+    int lastDotIndex = fileName.lastIndexOf('.');
+    if (lastDotIndex < 0) {
+      return fileName;
+    }
     // Basename is everything before the last '.'.
-    return fileName.substring(0, fileName.lastIndexOf('.'));
+    return fileName.substring(0, lastDotIndex);
   }
 }

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
@@ -114,7 +114,7 @@ public class FileUtilTest {
     Uri uri = MockContentProvider.NO_EXTENSION_URI;
     Robolectric.buildContentProvider(MockContentProvider.class).create("dummy");
     shadowContentResolver.registerInputStream(
-            uri, new ByteArrayInputStream("imageStream".getBytes(UTF_8)));
+        uri, new ByteArrayInputStream("imageStream".getBytes(UTF_8)));
     String path = fileUtils.getPathFromUri(context, uri);
     assertTrue(path.endsWith("abc.png"));
   }

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
@@ -110,6 +110,16 @@ public class FileUtilTest {
   }
 
   @Test
+  public void FileUtil_getPathFromUri_noExtensionInBaseName() throws IOException {
+    Uri uri = MockContentProvider.NO_EXTENSION_URI;
+    Robolectric.buildContentProvider(MockContentProvider.class).create("dummy");
+    shadowContentResolver.registerInputStream(
+            uri, new ByteArrayInputStream("imageStream".getBytes(UTF_8)));
+    String path = fileUtils.getPathFromUri(context, uri);
+    assertTrue(path.endsWith("abc.png"));
+  }
+
+  @Test
   public void FileUtil_getImageName_mismatchedType() throws IOException {
     Uri uri = MockContentProvider.WEBP_URI;
     Robolectric.buildContentProvider(MockContentProvider.class).create("dummy");
@@ -133,6 +143,7 @@ public class FileUtilTest {
     public static final Uri PNG_URI = Uri.parse("content://dummy/a.b.png");
     public static final Uri WEBP_URI = Uri.parse("content://dummy/c.d.png");
     public static final Uri UNKNOWN_URI = Uri.parse("content://dummy/e.f.g");
+    public static final Uri NO_EXTENSION_URI = Uri.parse("content://dummy/abc");
 
     @Override
     public boolean onCreate() {
@@ -157,6 +168,7 @@ public class FileUtilTest {
     public String getType(@NonNull Uri uri) {
       if (uri.equals(PNG_URI)) return "image/png";
       if (uri.equals(WEBP_URI)) return "image/webp";
+      if (uri.equals(NO_EXTENSION_URI)) return "image/png";
       return null;
     }
 

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 
-version: 0.8.7
+version: 0.8.8
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/124821

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
