### PR TITLE
[ci] Switch Linux and web build-all to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -81,16 +81,15 @@ targets:
 
   ### Web tasks ###
   - name: Linux_web web_build_all_packages master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
+      add_recipes_cq: "true"
       version_file: flutter_master.version
       target_file: web_build_all_packages.yaml
       channel: master
 
   - name: Linux_web web_build_all_packages stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
@@ -100,16 +99,15 @@ targets:
 
   ### Linux desktop tasks
   - name: Linux_desktop build_all_packages master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
+      add_recipes_cq: "true"
       version_file: flutter_master.version
       target_file: linux_build_all_packages.yaml
       channel: master
 
   - name: Linux_desktop build_all_packages stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
@@ -203,7 +201,6 @@ targets:
       target_file: ios_build_all_packages.yaml
 
   - name: Mac_x64 ios_build_all_packages stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -176,22 +176,7 @@ task:
       env:
         CIRRUS_CLONE_SUBMODULES: true
       script: ./script/tool_runner.sh update-excerpts --fail-on-change
-    ### Web tasks ###
-    - name: web-build_all_packages
-      env:
-        BUILD_ALL_ARGS: "web"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      << : *BUILD_ALL_PACKAGES_APP_TEMPLATE
     ### Linux desktop tasks ###
-    - name: linux-build_all_packages
-      env:
-        BUILD_ALL_ARGS: "linux"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      << : *BUILD_ALL_PACKAGES_APP_TEMPLATE
     - name: linux-platform_tests
       # Don't run full platform tests on both channels in pre-submit.
       skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'


### PR DESCRIPTION
Enables the recently added LUCI build-all for Linux and web, and removes the Cirrus version.

Also enables an iOS build-all that was never enabled.

Part of https://github.com/flutter/flutter/issues/114373