### PR TITLE
[ci] Add LUCI version of the analyze tasks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -97,6 +97,24 @@ targets:
       channel: stable
       version_file: flutter_stable.version
 
+  - name: Linux analyze_downgraded master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      target_file: analyze_downgraded.yaml
+      channel: master
+      version_file: flutter_master.version
+
+  - name: Linux analyze_downgraded stable
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      target_file: analyze_downgraded.yaml
+      channel: stable
+      version_file: flutter_stable.version
+
   ### Web tasks ###
   - name: Linux_web web_build_all_packages master
     bringup: true # New target

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -79,6 +79,24 @@ targets:
       channel: master
       version_file: flutter_master.version
 
+  - name: Linux analyze master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      target_file: analyze.yaml
+      channel: master
+      version_file: flutter_master.version
+
+  - name: Linux analyze stable
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      target_file: analyze.yaml
+      channel: stable
+      version_file: flutter_stable.version
+
   ### Web tasks ###
   - name: Linux_web web_build_all_packages master
     bringup: true # New target

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -69,7 +69,7 @@ platform_properties:
         }
 
 targets:
-  ### Linux-host tasks ###
+  ### Linux-host general tasks ###
   - name: Linux repo_tools_tests
     recipe: packages/packages
     timeout: 30

--- a/.ci/scripts/analyze_repo_tools.sh
+++ b/.ci/scripts/analyze_repo_tools.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+set -e
+
+cd script/tool
+dart analyze --fatal-infos

--- a/.ci/scripts/pathified_analyze.sh
+++ b/.ci/scripts/pathified_analyze.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+set -e
+
+# Pathify the dependencies on changed packages (excluding major version
+# changes, which won't affect clients).
+./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
+# This uses --run-on-dirty-packages rather than --packages-for-branch
+# since only the packages changed by 'make-deps-path-based' need to be
+# re-checked.
+dart ./script/tool/bin/flutter_plugin_tools.dart analyze --run-on-dirty-packages \
+    --log-timing --custom-analysis=script/configs/custom_analysis.yaml
+# Restore the tree to a clean state, to avoid accidental issues if
+# other script steps are added to the enclosing task.
+git checkout .

--- a/.ci/targets/analyze.yaml
+++ b/.ci/targets/analyze.yaml
@@ -1,0 +1,15 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  - name: analyze repo tools
+    script: .ci/scripts/analyze_repo_tools.sh
+  - name: analyze
+    script: script/tool_runner.sh
+    # DO NOT change the custom-analysis argument here without changing the Dart repo.
+    # See the comment in script/configs/custom_analysis.yaml for details.
+    args: ["analyze", "--custom-analysis=script/configs/custom_analysis.yaml"]
+    # Re-run analysis with path-based dependencies to ensure that publishing
+    # the changes won't break analysis of other packages in the respository
+    # that depend on it.
+  - name: analyze - pathified
+    script: .ci/scripts/pathified_analyze.sh

--- a/.ci/targets/analyze_downgraded.yaml
+++ b/.ci/targets/analyze_downgraded.yaml
@@ -1,0 +1,10 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  # Does a sanity check that packages pass analysis with the lowest possible
+  # versions of all dependencies. This is to catch cases where we add use of
+  # new APIs but forget to update minimum versions of dependencies to where
+  # those APIs are introduced.
+  - name: analyze - downgraded
+    script: script/tool_runner.sh
+    args: ["analyze", "--downgrade", "--custom-analysis=script/configs/custom_analysis.yaml"]

--- a/.ci/targets/repo_tools_tests.yaml
+++ b/.ci/targets/repo_tools_tests.yaml
@@ -3,7 +3,7 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
 # Not for landing: pre-testing adding analyze.
   - name: analyze repo tools
-    script: script/analyze_repo_tools.sh
+    script: .ci/script/analyze_repo_tools.sh
   - name: analyze
     script: script/tool_runner.sh
     # DO NOT change the custom-analysis argument here without changing the Dart repo.
@@ -13,6 +13,6 @@ tasks:
     # the changes won't break analysis of other packages in the respository
     # that depend on it.
   - name: analyze - pathified
-    script: script/pathified_analyze.sh
+    script: .ci/script/pathified_analyze.sh
 #  - name: tool unit tests
 #    script: .ci/scripts/plugin_tools_tests.sh

--- a/.ci/targets/repo_tools_tests.yaml
+++ b/.ci/targets/repo_tools_tests.yaml
@@ -1,18 +1,10 @@
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
-# Not for landing: pre-testing adding analyze.
-  - name: analyze repo tools
-    script: .ci/scripts/analyze_repo_tools.sh
-  - name: analyze
+# Not for landing: pre-testing adding analyze scripts.
+# WIP test for downgraded_analyze
+  - name: analyze - downgraded
     script: script/tool_runner.sh
-    # DO NOT change the custom-analysis argument here without changing the Dart repo.
-    # See the comment in script/configs/custom_analysis.yaml for details.
-    args: ["analyze", "--custom-analysis=script/configs/custom_analysis.yaml"]
-    # Re-run analysis with path-based dependencies to ensure that publishing
-    # the changes won't break analysis of other packages in the respository
-    # that depend on it.
-  - name: analyze - pathified
-    script: .ci/scripts/pathified_analyze.sh
+    args: ["analyze", "--downgrade", "--custom-analysis=script/configs/custom_analysis.yaml"]
 #  - name: tool unit tests
 #    script: .ci/scripts/plugin_tools_tests.sh

--- a/.ci/targets/repo_tools_tests.yaml
+++ b/.ci/targets/repo_tools_tests.yaml
@@ -1,10 +1,5 @@
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
-# Not for landing: pre-testing adding analyze scripts.
-# WIP test for downgraded_analyze
-  - name: analyze - downgraded
-    script: script/tool_runner.sh
-    args: ["analyze", "--downgrade", "--custom-analysis=script/configs/custom_analysis.yaml"]
-#  - name: tool unit tests
-#    script: .ci/scripts/plugin_tools_tests.sh
+  - name: tool unit tests
+    script: .ci/scripts/plugin_tools_tests.sh

--- a/.ci/targets/repo_tools_tests.yaml
+++ b/.ci/targets/repo_tools_tests.yaml
@@ -1,5 +1,18 @@
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
-  - name: tool unit tests
-    script: .ci/scripts/plugin_tools_tests.sh
+# Not for landing: pre-testing adding analyze.
+  - name: analyze repo tools
+    script: script/analyze_repo_tools.sh
+  - name: analyze
+    script: script/tool_runner.sh
+    # DO NOT change the custom-analysis argument here without changing the Dart repo.
+    # See the comment in script/configs/custom_analysis.yaml for details.
+    args: ["analyze", "--custom-analysis=script/configs/custom_analysis.yaml"]
+    # Re-run analysis with path-based dependencies to ensure that publishing
+    # the changes won't break analysis of other packages in the respository
+    # that depend on it.
+  - name: analyze - pathified
+    script: script/pathified_analyze.sh
+#  - name: tool unit tests
+#    script: .ci/scripts/plugin_tools_tests.sh

--- a/.ci/targets/repo_tools_tests.yaml
+++ b/.ci/targets/repo_tools_tests.yaml
@@ -3,7 +3,7 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
 # Not for landing: pre-testing adding analyze.
   - name: analyze repo tools
-    script: .ci/script/analyze_repo_tools.sh
+    script: .ci/scripts/analyze_repo_tools.sh
   - name: analyze
     script: script/tool_runner.sh
     # DO NOT change the custom-analysis argument here without changing the Dart repo.
@@ -13,6 +13,6 @@ tasks:
     # the changes won't break analysis of other packages in the respository
     # that depend on it.
   - name: analyze - pathified
-    script: .ci/script/pathified_analyze.sh
+    script: .ci/scripts/pathified_analyze.sh
 #  - name: tool unit tests
 #    script: .ci/scripts/plugin_tools_tests.sh


### PR DESCRIPTION
Add LUCI versions of the analyze, pathified analyze, and downgraded analayze tasks. Does not include legacy analyze (N-1 and N-2 stable Flutter versions) since there are open questions about how to structure those in LUCI.

Part of https://github.com/flutter/flutter/issues/114373