### PR TITLE
[tools] Fix format instructions

### DIFF
--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -104,9 +104,9 @@ class FormatCommand extends PackageCommand {
     print('These files are not formatted correctly (see diff below):');
     LineSplitter.split(stdout).map((String line) => '  $line').forEach(print);
 
-    print('\nTo fix run "dart pub global activate flutter_plugin_tools && '
-        'dart pub global run flutter_plugin_tools format" or copy-paste '
-        'this command into your terminal:');
+    print('\nTo fix run the repository tooling `format` command: '
+        'https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code\n'
+        'or copy-paste this command into your terminal:');
 
     final io.ProcessResult diff = await processRunner.run(
       'git',

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -512,6 +512,9 @@ void main() {
         containsAllInOrder(<Matcher>[
           contains('These files are not formatted correctly'),
           contains(changedFilePath),
+          // Ensure the error message links to instructions.
+          contains(
+              'https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code'),
           contains('patch -p1 <<DONE'),
         ]));
   });


### PR DESCRIPTION
The instructions for `format` failures still referred to using `activate`, which is no longer how tools are invoked. Replace the specific instructions with a link to the relevant README section to make them evergreen.