### PR TITLE
[ci] Switch analyze tests to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -80,16 +80,15 @@ targets:
       version_file: flutter_master.version
 
   - name: Linux analyze master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
+      add_recipes_cq: "true"
       target_file: analyze.yaml
       channel: master
       version_file: flutter_master.version
 
   - name: Linux analyze stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
@@ -98,16 +97,15 @@ targets:
       version_file: flutter_stable.version
 
   - name: Linux analyze_downgraded master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
+      add_recipes_cq: "true"
       target_file: analyze_downgraded.yaml
       channel: master
       version_file: flutter_master.version
 
   - name: Linux analyze_downgraded stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,30 +115,6 @@ task:
           - else
           -   ./script/tool_runner.sh federation-safety-check
           - fi
-    - name: analyze
-      env:
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      analyze_tool_script:
-        - cd script/tool
-        - dart analyze --fatal-infos
-      analyze_script:
-        # DO NOT change the custom-analysis argument here without changing the Dart repo.
-        # See the comment in script/configs/custom_analysis.yaml for details.
-        - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
-      pathified_analyze_script:
-        # Re-run analysis with path-based dependencies to ensure that publishing
-        # the changes won't break analysis of other packages in the respository
-        # that depend on it.
-        - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
-        # This uses --run-on-dirty-packages rather than --packages-for-branch
-        # since only the packages changed by 'make-deps-path-based' need to be
-        # checked.
-        - $PLUGIN_TOOL_COMMAND analyze --run-on-dirty-packages --log-timing --custom-analysis=script/configs/custom_analysis.yaml
-        # Restore the tree to a clean state, to avoid accidental issues if
-        # other script steps are added to this task.
-        - git checkout .
     # Does a sanity check that packages at least pass analysis on the N-1 and N-2
     # versions of Flutter stable if the package claims to support that version.
     # This is to minimize accidentally making changes that break old versions
@@ -147,7 +123,6 @@ task:
     # Note: The versions below should be manually updated after a new stable
     # version comes out.
     - name: legacy_version_analyze
-      depends_on: analyze
       matrix:
         # Change the arguments to pubspec-check when changing these values.
         env:
@@ -164,14 +139,6 @@ task:
         # Only analyze lib/; non-client code doesn't need to work on
         # all supported legacy version.
         - ./script/tool_runner.sh analyze --lib-only --skip-if-not-supporting-flutter-version="$CHANNEL" --skip-if-not-supporting-dart-version="$DART_VERSION" --custom-analysis=script/configs/custom_analysis.yaml
-    # Does a sanity check that packages pass analysis with the lowest possible
-    # versions of all dependencies. This is to catch cases where we add use of
-    # new APIs but forget to update minimum versions of dependencies to where
-    # those APIs are introduced.
-    - name: downgraded_analyze
-      depends_on: analyze
-      analyze_script:
-        - ./script/tool_runner.sh analyze --downgrade --custom-analysis=script/configs/custom_analysis.yaml
     - name: readme_excerpts
       env:
         CIRRUS_CLONE_SUBMODULES: true


### PR DESCRIPTION
Fully enables the new analyze and downgraded-analyze tests in LUCI, and removes the Cirrus versions.

Part of https://github.com/flutter/flutter/issues/114373