### PR TITLE
[ci] Always clean up simulators

### DIFF
--- a/.ci/targets/ios_platform_tests.yaml
+++ b/.ci/targets/ios_platform_tests.yaml
@@ -24,3 +24,4 @@ tasks:
     args: ["drive-examples", "--ios", "--exclude=script/configs/exclude_integration_ios.yaml"]
   - name: remove simulator
     script: .ci/scripts/remove_simulator.sh
+    always: true

--- a/.ci/targets/macos_custom_package_tests.yaml
+++ b/.ci/targets/macos_custom_package_tests.yaml
@@ -7,3 +7,4 @@ tasks:
     script: .ci/scripts/custom_package_tests.sh
   - name: remove simulator
     script: .ci/scripts/remove_simulator.sh
+    always: true


### PR DESCRIPTION
Adds the new `always` flag to the simulator cleanup step to ensure that it runs even if the tests fail.

See https://github.com/flutter/flutter/issues/122629