### PR TITLE
[ci] Switch to LUCI for Android build-all

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -126,7 +126,6 @@ targets:
 
   ### Android tasks ###
   - name: Linux_android android_build_all_packages master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
@@ -136,7 +135,6 @@ targets:
       channel: master
 
   - name: Linux_android android_build_all_packages stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,22 +47,6 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
     - flutter doctor -v
   << : *TOOL_SETUP_TEMPLATE
 
-# Ensures that the latest versions of all of the 1P packages can be used
-# together. See script/configs/exclude_all_packages_app.yaml for exceptions.
-build_all_packages_app_template: &BUILD_ALL_PACKAGES_APP_TEMPLATE
-  create_all_packages_app_script:
-    - $PLUGIN_TOOL_COMMAND create-all-packages-app --output-dir=. --exclude script/configs/exclude_all_packages_app.yaml
-  build_all_packages_debug_script:
-    - cd all_packages
-    - if [[ "$BUILD_ALL_ARGS" == "web" ]]; then
-    -   echo "Skipping; web does not support debug builds"
-    - else
-    -   flutter build $BUILD_ALL_ARGS --debug
-    - fi
-  build_all_packages_release_script:
-    - cd all_packages
-    - flutter build $BUILD_ALL_ARGS --release
-
 # Light-workload Linux tasks.
 # These use default machines, with fewer CPUs, to reduce pressure on the
 # concurrency limits.
@@ -240,18 +224,6 @@ task:
           path: "**/reports/lint-results-debug.xml"
           type: text/xml
           format: android-lint
-    - name: android-build_all_packages
-      env:
-        BUILD_ALL_ARGS: "apk"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      << : *BUILD_ALL_PACKAGES_APP_TEMPLATE
-      create_all_packages_app_legacy_script:
-        - $PLUGIN_TOOL_COMMAND create-all-packages-app --legacy-source=.ci/legacy_project/all_packages --output-dir=legacy/ --exclude script/configs/exclude_all_packages_app.yaml
-      build_all_packages_legacy_script:
-        - cd legacy/all_packages
-        - flutter build $BUILD_ALL_ARGS --debug
     ### Web tasks ###
     - name: web-platform_tests
       env:


### PR DESCRIPTION
Enables the new LUCI version of the Android build-all-packages test, and removes the Cirrus version.

Part of https://github.com/flutter/flutter/issues/114373