### PR TITLE
[ci] Remove jcenter from legacy project

### DIFF
--- a/.ci/legacy_project/README.md
+++ b/.ci/legacy_project/README.md
@@ -35,3 +35,5 @@ flutter create -a java all_packages
 and then deleting everything but `android/` from it:
 
 - Added license boilerplate.
+- Replaced `jcenter` in build.gradle with `mavenCentral`, due to the
+  jcenter.bintray.com shutdown.

--- a/.ci/legacy_project/all_packages/android/build.gradle
+++ b/.ci/legacy_project/all_packages/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -12,7 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
The checked in legacy Android project used for compat testing accidentally re-introduced a `jcenter` depedency into the repo. Since that has server implications, we shouldn't be using it; this updates the legacy package to replace `jcenter` with `mavenCentral`, as we did a while ago in all of our packages and templates.

Fixes(?) https://github.com/flutter/flutter/issues/129467