### PR TITLE
[video_player] added iOS exception on incorrect asset path

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.4.7
 
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
+* Added iOS exception on incorrect asset path
 
 ## 2.4.6
 

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.4.7
 
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
-* Added iOS exception on incorrect asset path
+* Adds iOS exception on incorrect asset path
 
 ## 2.4.6
 

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -621,14 +621,13 @@ NS_INLINE UIViewController *rootViewController(void) {
       assetPath = [_registrar lookupKeyForAsset:input.asset];
     }
     @try {
-        player = [[FLTVideoPlayer alloc] initWithAsset:assetPath
-                                          frameUpdater:frameUpdater
-                                         playerFactory:_playerFactory];
-        return [self onPlayerSetup:player frameUpdater:frameUpdater];
-    }
-    @catch (NSException *exception) {
-        *error = [FlutterError errorWithCode:@"video_player" message:exception.reason details:nil];
-        return nil;
+      player = [[FLTVideoPlayer alloc] initWithAsset:assetPath
+                                        frameUpdater:frameUpdater
+                                       playerFactory:_playerFactory];
+      return [self onPlayerSetup:player frameUpdater:frameUpdater];
+    } @catch (NSException *exception) {
+      *error = [FlutterError errorWithCode:@"video_player" message:exception.reason details:nil];
+      return nil;
     }
   } else if (input.uri) {
     player = [[FLTVideoPlayer alloc] initWithURL:[NSURL URLWithString:input.uri]

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -620,10 +620,16 @@ NS_INLINE UIViewController *rootViewController(void) {
     } else {
       assetPath = [_registrar lookupKeyForAsset:input.asset];
     }
-    player = [[FLTVideoPlayer alloc] initWithAsset:assetPath
-                                      frameUpdater:frameUpdater
-                                     playerFactory:_playerFactory];
-    return [self onPlayerSetup:player frameUpdater:frameUpdater];
+    @try {
+        player = [[FLTVideoPlayer alloc] initWithAsset:assetPath
+                                          frameUpdater:frameUpdater
+                                         playerFactory:_playerFactory];
+        return [self onPlayerSetup:player frameUpdater:frameUpdater];
+    }
+    @catch (NSException *exception) {
+        *error = [FlutterError errorWithCode:@"video_player" message:exception.reason details:nil];
+        return nil;
+    }
   } else if (input.uri) {
     player = [[FLTVideoPlayer alloc] initWithURL:[NSURL URLWithString:input.uri]
                                     frameUpdater:frameUpdater

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.6
+version: 2.4.7
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -135,6 +135,15 @@ void main() {
       expect(textureId, 3);
     });
 
+    test('create with incorrect asset', () async {
+      try {
+        await player.create(DataSource(sourceType: DataSourceType.asset));
+        fail('should throw PlatformException');
+      } catch (e) {
+        expect(e, isException);
+      }
+    });
+
     test('create with network', () async {
       final int? textureId = await player.create(DataSource(
         sourceType: DataSourceType.network,

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -137,7 +137,10 @@ void main() {
 
     test('create with incorrect asset', () async {
       try {
-        await player.create(DataSource(sourceType: DataSourceType.asset));
+        await player.create(DataSource(
+          sourceType: DataSourceType.asset,
+          asset: 'incorrectAsset',
+        ));
         fail('should throw PlatformException');
       } catch (e) {
         expect(e, isException);

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -135,7 +135,7 @@ void main() {
       expect(textureId, 3);
     });
 
-    test('create with incorrect asset', () async {
+    test('create with incorrect asset throws exception', () async {
       try {
         await player.create(DataSource(
           sourceType: DataSourceType.asset,

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -139,7 +139,7 @@ void main() {
       try {
         await player.create(DataSource(
           sourceType: DataSourceType.asset,
-          asset: 'incorrectAsset',
+          asset: '/path/to/incorrect_asset',
         ));
         fail('should throw PlatformException');
       } catch (e) {


### PR DESCRIPTION
surfaced the incorrect asset path error to dart using try catch.

Fixes [#118660](https://github.com/flutter/flutter/issues/118660)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
