### PR TITLE
[various] Update links to the old linter site to point to dart.dev

### DIFF
--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.2
 
+* Update links to the old linter site in the README and example to point to dart.dev.
 * Updates minimum supported SDK version to Flutter 3.3/Dart 2.18.
 
 ## 2.0.1

--- a/packages/flutter_lints/README.md
+++ b/packages/flutter_lints/README.md
@@ -42,8 +42,7 @@ linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`
   # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
+  # and their documentation is published at https://dart.dev/lints.
   #
   # Instead of disabling a lint rule for the entire project in the
   # section below, it can also be suppressed for a single line of code

--- a/packages/flutter_lints/example/analysis_options.yaml
+++ b/packages/flutter_lints/example/analysis_options.yaml
@@ -13,8 +13,7 @@ linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`
   # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
+  # and their documentation is published at https://dart.dev/lints.
   #
   # Instead of disabling a lint rule for the entire project in the
   # section below, it can also be suppressed for a single line of code

--- a/packages/flutter_lints/pubspec.yaml
+++ b/packages/flutter_lints/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_lints
 description: Recommended lints for Flutter apps, packages, and plugins to encourage good coding practices.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_lints
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_lints%22
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -166,7 +166,7 @@
 
 ## 6.0.5
 
-- Fixes [unnecessary_null_comparison](https://dart-lang.github.io/linter/lints/unnecessary_null_checks.html) lint warnings.
+- Fixes [unnecessary_null_comparison](https://dart.dev/lints/unnecessary_null_checks) lint warnings.
 
 ## 6.0.4
 
@@ -664,7 +664,7 @@
 - enable case-insensitive path matching while still preserving path and query
   parameter cases
 - change a lifetime of habit to sort constructors first as per
-  [sort_constructors_first](https://dart-lang.github.io/linter/lints/sort_constructors_first.html).
+  [sort_constructors_first](https://dart.dev/lints/sort_constructors_first).
   Thanks for the PR, [Abhishek01039](https://github.com/Abhishek01039)!
 - set the initial transition example route to `/none` to make pushing the 'fade
   transition' button on the first run through more fun


### PR DESCRIPTION
Contributes to https://github.com/dart-lang/linter/issues/4460 and https://github.com/dart-lang/site-www/issues/4499