### PR TITLE
Prepare for utf8.encode() to return more precise Uint8List type

### DIFF
--- a/packages/image_picker/image_picker_for_web/example/integration_test/image_picker_for_web_test.dart
+++ b/packages/image_picker/image_picker_for_web/example/integration_test/image_picker_for_web_test.dart
@@ -13,8 +13,8 @@ import 'package:integration_test/integration_test.dart';
 
 const String expectedStringContents = 'Hello, world!';
 const String otherStringContents = 'Hello again, world!';
-final Uint8List bytes = utf8.encode(expectedStringContents) as Uint8List;
-final Uint8List otherBytes = utf8.encode(otherStringContents) as Uint8List;
+final Uint8List bytes = const Utf8Encoder().convert(expectedStringContents);
+final Uint8List otherBytes = const Utf8Encoder().convert(otherStringContents);
 final Map<String, dynamic> options = <String, dynamic>{
   'type': 'text/plain',
   'lastModified': DateTime.utc(2017, 12, 13).millisecondsSinceEpoch,

--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixes stale ignore: prefer_const_constructors.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Changes package internals to avoid explicit `as Uint8List` downcast.
 
 ## 1.0.9
 

--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 1.0.10
 
 * Fixes stale ignore: prefer_const_constructors.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.

--- a/packages/rfw/lib/src/dart/binary.dart
+++ b/packages/rfw/lib/src/dart/binary.dart
@@ -521,7 +521,7 @@ class _BlobEncoder {
   }
 
   void _writeString(String value) {
-    final Uint8List buffer = utf8.encode(value) as Uint8List;
+    final Uint8List buffer = const Utf8Encoder().convert(value);
     _writeInt64(buffer.length);
     bytes.add(buffer);
   }

--- a/packages/rfw/pubspec.yaml
+++ b/packages/rfw/pubspec.yaml
@@ -2,7 +2,7 @@ name: rfw
 description: "Remote Flutter widgets: a library for rendering declarative widget description files at runtime."
 repository: https://github.com/flutter/packages/tree/main/packages/rfw
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+rfw%22
-version: 1.0.9
+version: 1.0.10
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
To avoid analyzer warnings when `utf8.encode()` will return the more precise `Uint8List` type, we use `const Utf8Encoder().convert()` which already returns `Uint8List`

See https://github.com/dart-lang/sdk/issues/52801