### PR TITLE
[ci] Switch Dart unit tests to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -93,10 +93,10 @@ targets:
       version_file: flutter_master.version
 
   - name: Linux dart_unit_test_shard_1 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       target_file: dart_unit_tests.yaml
       channel: master
       version_file: flutter_master.version
@@ -104,10 +104,10 @@ targets:
       package_sharding: "--shardIndex 0 --shardCount 2"
 
   - name: Linux dart_unit_test_shard_2 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       target_file: dart_unit_tests.yaml
       channel: master
       version_file: flutter_master.version
@@ -115,7 +115,6 @@ targets:
       package_sharding: "--shardIndex 1 --shardCount 2"
 
   - name: Linux dart_unit_test_shard_1 stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -126,7 +125,6 @@ targets:
       package_sharding: "--shardIndex 0 --shardCount 2"
 
   - name: Linux dart_unit_test_shard_2 stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -158,22 +158,6 @@ task:
     memory: 16G
   matrix:
     ### Platform-agnostic tasks ###
-    - name: dart_unit_tests
-      env:
-        matrix:
-          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 2"
-          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 2"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      unit_test_script:
-        - ./script/tool_runner.sh dart-test --exclude=script/configs/dart_unit_tests_exceptions.yaml
-      pathified_unit_test_script:
-        # Run tests with path-based dependencies to ensure that publishing
-        # the changes won't break tests of other packages in the repository
-        # that depend on it.
-        - ./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
-        - $PLUGIN_TOOL_COMMAND dart-test --run-on-dirty-packages --exclude=script/configs/dart_unit_tests_exceptions.yaml
     - name: linux-custom_package_tests
       env:
         PATH: $PATH:/usr/local/bin


### PR DESCRIPTION
Enables the new LUCI Dart unit tests, and removes the Cirrus version.

Part of https://github.com/flutter/flutter/issues/114373