### PR TITLE
[google_sign_in_web] Fixes force unwrap on values that can be null

### DIFF
--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0+3
+
+* Fixes null cast error on accounts without picture or name details.
+
 ## 0.12.0+2
 
 * Adds compatibility with `http` 1.0.

--- a/packages/google_sign_in/google_sign_in_web/example/integration_test/src/jwt_examples.dart
+++ b/packages/google_sign_in/google_sign_in_web/example/integration_test/src/jwt_examples.dart
@@ -18,6 +18,12 @@ final CredentialResponse goodCredential =
   'credential': goodJwtToken,
 });
 
+/// A CredentialResponse wrapping a known good JWT Token as its `credential`.
+final CredentialResponse minimalCredential =
+    jsifyAs<CredentialResponse>(<String, Object?>{
+  'credential': minimalJwtToken,
+});
+
 /// A JWT token with predefined values.
 ///
 /// 'email': 'adultman@example.com',
@@ -37,6 +43,22 @@ const String goodJwtToken =
 /// 'picture': 'https://thispersondoesnotexist.com/image?x=.jpg',
 const String goodPayload =
     'eyJlbWFpbCI6ImFkdWx0bWFuQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2IiwibmFtZSI6IlZpbmNlbnQgQWR1bHRtYW4iLCJwaWN0dXJlIjoiaHR0cHM6Ly90aGlzcGVyc29uZG9lc25vdGV4aXN0LmNvbS9pbWFnZT94PS5qcGcifQ';
+
+/// A JWT token with minimal set of predefined values.
+///
+/// 'email': 'adultman@example.com',
+/// 'sub': '123456'
+///
+/// Signed with HS256 and the private key: 'symmetric-encryption-is-weak'
+const String minimalJwtToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.$minimalPayload.UTAe7dpdtFIMwsOqkZkjyjqyHnho5xHCcQylUFmOutM';
+
+/// The payload of a JWT token that contains only non-nullable values.
+///
+/// "email": "adultman@example.com",
+/// "sub": "123456"
+const String minimalPayload =
+    'eyJlbWFpbCI6ImFkdWx0bWFuQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2In0';
 
 // More encrypted JWT Tokens may be created on https://jwt.io.
 //

--- a/packages/google_sign_in/google_sign_in_web/example/integration_test/utils_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/example/integration_test/utils_test.dart
@@ -57,6 +57,17 @@ void main() {
       expect(data.idToken, goodJwtToken);
     });
 
+    testWidgets('happy case (minimal)', (_) async {
+      final GoogleSignInUserData data =
+          gisResponsesToUserData(minimalCredential)!;
+
+      expect(data.displayName, isNull);
+      expect(data.id, '123456');
+      expect(data.email, 'adultman@example.com');
+      expect(data.photoUrl, isNull);
+      expect(data.idToken, minimalJwtToken);
+    });
+
     testWidgets('null response -> null', (_) async {
       expect(gisResponsesToUserData(null), isNull);
     });
@@ -88,6 +99,14 @@ void main() {
             'picture',
             'https://thispersondoesnotexist.com/image?x=.jpg',
           ));
+    });
+
+    testWidgets('happy case (minimal) -> data', (_) async {
+      final Map<String, Object?>? data = getJwtTokenPayload(minimalJwtToken);
+
+      expect(data, isNotNull);
+      expect(data, containsPair('email', 'adultman@example.com'));
+      expect(data, containsPair('sub', '123456'));
     });
 
     testWidgets('null Token -> null', (_) async {

--- a/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
@@ -72,8 +72,8 @@ GoogleSignInUserData? gisResponsesToUserData(
   return GoogleSignInUserData(
     email: payload['email']! as String,
     id: payload['sub']! as String,
-    displayName: payload['name']! as String,
-    photoUrl: payload['picture']! as String,
+    displayName: payload['name'] as String?,
+    photoUrl: payload['picture'] as String?,
     idToken: credentialResponse.credential,
   );
 }

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.12.0+2
+version: 0.12.0+3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
During Google Sign-in, the code uses two force unwraps on values (name and picture) that can be not present in the response. This cause an unhandled error that blocks sign-in.

Fixes https://github.com/flutter/flutter/issues/130002 reported by me. The bug report describes how to get that error together with a screenshot of a given line.

My PR fixes that and add additional test for the future.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
