### PR TITLE
[ci] Remove `starqlteue` from FTL tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -198,7 +198,7 @@ task:
       firebase_test_lab_script:
         - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
         -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
-        -   ./script/tool_runner.sh firebase-test-lab --device model=redfin,version=30 --device model=starqlteue,version=26 --exclude=script/configs/exclude_integration_android.yaml
+        -   ./script/tool_runner.sh firebase-test-lab --device model=redfin,version=30 --exclude=script/configs/exclude_integration_android.yaml
         - else
         -   echo "This user does not have permission to run Firebase Test Lab tests."
         - fi


### PR DESCRIPTION
This device seems to have undocumented availability issues that are causing very long wait times and thus frequent CI timeouts.

Hopefully fixes https://github.com/flutter/flutter/issues/129873

See also https://github.com/flutter/flutter/issues/130010
