### PR TITLE
[ci] Add partial LUCI Android platform tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -233,6 +233,144 @@ targets:
       target_file: android_build_all_packages.yaml
       channel: stable
 
+  - name: Linux_android android_platform_tests_shard_1 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      cores: "32"
+      package_sharding: "--shardIndex 0 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_2 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      cores: "32"
+      package_sharding: "--shardIndex 1 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_3 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      cores: "32"
+      package_sharding: "--shardIndex 2 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_4 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      cores: "32"
+      package_sharding: "--shardIndex 3 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_5 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      cores: "32"
+      package_sharding: "--shardIndex 4 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_6 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      cores: "32"
+      package_sharding: "--shardIndex 6 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_1 stable
+    bringup: true # New target
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: stable
+      version_file: flutter_stable.version
+      cores: "32"
+      package_sharding: "--shardIndex 0 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_2 stable
+    bringup: true # New target
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: stable
+      version_file: flutter_stable.version
+      cores: "32"
+      package_sharding: "--shardIndex 1 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_3 stable
+    bringup: true # New target
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: stable
+      version_file: flutter_stable.version
+      cores: "32"
+      package_sharding: "--shardIndex 2 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_4 stable
+    bringup: true # New target
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: stable
+      version_file: flutter_stable.version
+      cores: "32"
+      package_sharding: "--shardIndex 3 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_5 stable
+    bringup: true # New target
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: stable
+      version_file: flutter_stable.version
+      cores: "32"
+      package_sharding: "--shardIndex 4 --shardCount 6"
+
+  - name: Linux_android android_platform_tests_shard_6 stable
+    bringup: true # New target
+    recipe: packages/packages
+    presubmit: false
+    timeout: 60
+    properties:
+      target_file: android_platform_tests.yaml
+      channel: stable
+      version_file: flutter_stable.version
+      cores: "32"
+      package_sharding: "--shardIndex 6 --shardCount 6"
+
   ### Web tasks ###
   - name: Linux_web web_build_all_packages master
     recipe: packages/packages

--- a/.ci/targets/android_platform_tests.yaml
+++ b/.ci/targets/android_platform_tests.yaml
@@ -1,0 +1,25 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  - name: build examples
+    script: script/tool_runner.sh
+    args: ["build-examples", "--apk"]
+  - name: lint
+    script: script/tool_runner.sh
+    args: ["lint-android"]
+  # Native unit and native integration are split into two steps to allow for
+  # different exclusions.
+  # TODO(stuartmorgan): Eliminate the native unit test exclusion, and combine
+  # these steps.
+  - name: native unit tests
+    script: script/tool_runner.sh
+    args: ["native-test", "--android", "--no-integration", "--exclude=script/configs/exclude_native_unit_android.yaml"]
+  # TODO(stuartmorgan): Enable these once
+  # https://github.com/flutter/flutter/issues/120736 is implemented.
+  # See also https://github.com/flutter/flutter/issues/114373
+  #- name: native integration tests
+  #  script: script/tool_runner.sh
+  #  args: ["native-test", "--android", "--no-unit"]
+  #- name: drive examples
+  #  script: script/tool_runner.sh
+  #  args: ["drive-examples", "--android", "--exclude=script/configs/exclude_integration_android.yaml"]

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -251,6 +251,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
           <String>[
             'build',
             'apk',
+            '--config-only',
             if (experiment.isNotEmpty) '--enable-experiment=$experiment',
           ],
           workingDir: project.androidDirectory);

--- a/script/tool/lib/src/lint_android_command.dart
+++ b/script/tool/lib/src/lint_android_command.dart
@@ -43,9 +43,15 @@ class LintAndroidCommand extends PackageLoopingCommand {
           processRunner: processRunner, platform: platform);
 
       if (!project.isConfigured()) {
-        // TODO(stuartmorgan): Replace this with a --config-only build once
-        // that's available on stable.
-        return PackageResult.fail(<String>['Build examples before linting']);
+        final int exitCode = await processRunner.runAndStream(
+          flutterCommand,
+          <String>['build', 'apk', '--config-only'],
+          workingDir: example.directory,
+        );
+        if (exitCode != 0) {
+          printError('Unable to configure Gradle project.');
+          return PackageResult.fail(<String>['Unable to configure Gradle.']);
+        }
       }
 
       final String packageName = package.directory.basename;

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -276,7 +276,6 @@ this command.
     bool ranUnitTests = false;
     bool ranAnyTests = false;
     bool failed = false;
-    bool hasMissingBuild = false;
     bool hasMisconfiguredIntegrationTest = false;
     // Iterate through all examples (in the rare case that there is more than
     // one example); running any tests found for each one. Requirements on what
@@ -311,12 +310,16 @@ this command.
         platform: platform,
       );
       if (!project.isConfigured()) {
-        printError('ERROR: Run "flutter build apk" on $exampleName, or run '
-            'this tool\'s "build-examples --apk" command, '
-            'before executing tests.');
-        failed = true;
-        hasMissingBuild = true;
-        continue;
+        final int exitCode = await processRunner.runAndStream(
+          flutterCommand,
+          <String>['build', 'apk', '--config-only'],
+          workingDir: example.directory,
+        );
+        if (exitCode != 0) {
+          printError('Unable to configure Gradle project.');
+          failed = true;
+          continue;
+        }
       }
 
       if (runUnitTests) {
@@ -379,10 +382,7 @@ this command.
     }
 
     if (failed) {
-      return _PlatformResult(RunState.failed,
-          error: hasMissingBuild
-              ? 'Examples must be built before testing.'
-              : null);
+      return _PlatformResult(RunState.failed);
     }
     if (hasMisconfiguredIntegrationTest) {
       return _PlatformResult(RunState.failed,

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -622,7 +622,7 @@ public class MainActivityTest {
         orderedEquals(<ProcessCall>[
           ProcessCall(
             'flutter',
-            'build apk'.split(' '),
+            'build apk --config-only'.split(' '),
             '/packages/plugin/example/android',
           ),
           ProcessCall(


### PR DESCRIPTION
Adds an initial Android platform tests LUCI script, and initial targets in bringup mode (using 6 shards instead of the 8 we have in Cirrus since the added shards were to try to address what in retrospect was likely a device availability issue, and since for now this will be running fewer tests; once everything is migrated we can evaluate whether we need more shards).

Rather than wait for emulator and/or FTL support in LUCI to do the migration of this target, this will partially migrate; the script currently does only the parts that don't require any kind of device. That will let us set up a baseline of LUCI Android platform tests bots to easily expand from as we figure out those pieces, and we can turn down these parts of the tests in Cirrus once these come out of bringup mode to minimize duplication.

To avoid having to run a full `flutter build` for both versions, this also updates the repo tooling to use the new `flutter build apk --config-only` option to create `gradlew` without doing a full build.

Part of https://github.com/flutter/flutter/issues/114373