### PR TITLE
[ci] Switch `master` Linux custom package tests to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -215,7 +215,6 @@ targets:
       version_file: flutter_stable.version
 
   - name: Linux_android custom_package_tests master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
@@ -232,7 +231,6 @@ targets:
       channel: master
 
   - name: Linux_android custom_package_tests stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -231,6 +231,7 @@ targets:
       channel: master
 
   - name: Linux_android custom_package_tests stable
+    bringup: true # Blocked on https://github.com/flutter/flutter/issues/130071
     recipe: packages/packages
     timeout: 30
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,6 +157,16 @@ task:
     cpu: 4
     memory: 16G
   matrix:
+    ### Platform-agnostic tasks ###
+    - name: linux-custom_package_tests
+      env:
+        PATH: $PATH:/usr/local/bin
+        # Master has been migrated to LUCI, but stable is blocked on
+        # https://github.com/flutter/flutter/issues/130071
+        CHANNEL: "stable"
+      << : *INSTALL_CHROME_LINUX
+      local_tests_script:
+        - ./script/tool_runner.sh custom-test
     ### Android tasks ###
     - name: android-platform_tests
       # Don't run full platform tests on both channels in pre-submit.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,16 +157,6 @@ task:
     cpu: 4
     memory: 16G
   matrix:
-    ### Platform-agnostic tasks ###
-    - name: linux-custom_package_tests
-      env:
-        PATH: $PATH:/usr/local/bin
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      << : *INSTALL_CHROME_LINUX
-      local_tests_script:
-        - ./script/tool_runner.sh custom-test
     ### Android tasks ###
     - name: android-platform_tests
       # Don't run full platform tests on both channels in pre-submit.


### PR DESCRIPTION
Enables the new LUCI target for `master`, and removes the Cirrus version.

I only pre-tested `master`, and it turns out that `stable` is blocked by https://github.com/flutter/flutter/issues/130071.

Part of https://github.com/flutter/flutter/issues/114373