### PR TITLE
[ci] Add partial LUCI version of repo_checks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -14,6 +14,10 @@ platform_properties:
       os: Ubuntu
       cores: "8"
       device_type: none
+      dependencies: >-
+        [
+          {"dependency": "curl", "version": "version:7.64.0"}
+        ]
   linux_android:
     properties:
       os: Ubuntu

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -88,7 +88,18 @@ targets:
     timeout: 30
     properties:
       add_recipes_cq: "true"
-      target_file: repo_tools_tests.yaml
+      # NOT FOR LANDING; presubmit testing only
+      target_file: repo_checks.yaml
+      channel: master
+      version_file: flutter_master.version
+
+  - name: Linux repo_checks
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      add_recipes_cq: "true"
+      target_file: repo_checks.yaml
       channel: master
       version_file: flutter_master.version
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -88,15 +88,9 @@ targets:
     timeout: 30
     properties:
       add_recipes_cq: "true"
-      # NOT FOR LANDING; presubmit testing only
-      target_file: repo_checks.yaml
+      target_file: repo_tools_tests.yaml
       channel: master
       version_file: flutter_master.version
-      # NOT FOR LANDING; presubmit testing only
-      dependencies: >-
-        [
-          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"}
-        ]
 
   - name: Linux repo_checks
     bringup: true # New target

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -92,6 +92,11 @@ targets:
       target_file: repo_checks.yaml
       channel: master
       version_file: flutter_master.version
+      # NOT FOR LANDING; presubmit testing only
+      dependencies: >-
+        [
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"}
+        ]
 
   - name: Linux repo_checks
     bringup: true # New target
@@ -102,6 +107,11 @@ targets:
       target_file: repo_checks.yaml
       channel: master
       version_file: flutter_master.version
+      # The format check requires clang-format.
+      dependencies: >-
+        [
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"}
+        ]
 
   - name: Linux dart_unit_test_shard_1 master
     recipe: packages/packages

--- a/.ci/targets/repo_checks.yaml
+++ b/.ci/targets/repo_checks.yaml
@@ -1,0 +1,47 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  - name: format
+    script: script/tool_runner.sh
+    args: ["format", "--fail-on-change"]
+    always: true
+  - name: license validation
+    script: script/tool_runner.sh
+    args: ["license-check"]
+    always: true
+    # The major and minor version here should match the lowest version analyzed
+    # in legacy version analysis (currently .cirrus.yaml legacy_version_analyze).
+  - name: pubspec validation
+    script: script/tool_runner.sh
+    args:
+      - "pubspec-check"
+      - "--min-min-flutter-version=3.3.0"
+      - "--allow-dependencies=script/configs/allowed_unpinned_deps.yaml"
+      - "--allow-pinned-dependencies=script/configs/allowed_pinned_deps.yaml"
+    always: true
+  - name: README validation
+    script: script/tool_runner.sh
+    args: ["readme-check"]
+    always: true
+    # Re-run with --require-excerpts, skipping packages that still need
+    # to be converted. Once https://github.com/flutter/flutter/issues/102679
+    # has been fixed, this can be removed --require-excerpts added to the
+    # run above.
+  - name: README snippet validation
+    script: script/tool_runner.sh
+    args: ["readme-check", "--require-excerpts", "--exclude=script/configs/temp_exclude_excerpt.yaml"]
+    always: true
+  - name: Gradle validation
+    script: script/tool_runner.sh
+    args: ["gradle-check"]
+    always: true
+  - name: Dependabot coverage validation
+    script: script/tool_runner.sh
+    args: ["dependabot-check"]
+    always: true
+  - name: publishability
+    script: script/tool_runner.sh
+    args: ["publish-check", "--allow-pre-release"]
+    always: true
+  # TODO(stuartmorgan): Convert remaining checks from Cirrus repo_checks. See
+  # https://github.com/flutter/flutter/issues/114373


### PR DESCRIPTION
Adds a bringup-mode version of the parts of `repo_checks` that can currently be run on LUCI.

When this is enabled in a follow-up I'll remove the relevant checks from the Cirrus version, leaving `repo_checks` split across the two systems for now, but without duplication. This has a slight overhead in terms of machine setup, but allow better isolating the parts of the CI that are still actually blocked from migration.

Part of https://github.com/flutter/flutter/issues/114373
