### PR TITLE
[ci] Add LUCI web platform tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -286,7 +286,6 @@ targets:
     recipe: packages/packages
     timeout: 60
     properties:
-      add_recipes_cq: "true"
       target_file: web_platform_tests.yaml
       cores: "32"
       version_file: flutter_master.version
@@ -298,7 +297,6 @@ targets:
     recipe: packages/packages
     timeout: 60
     properties:
-      add_recipes_cq: "true"
       target_file: web_platform_tests.yaml
       cores: "32"
       version_file: flutter_master.version
@@ -310,7 +308,6 @@ targets:
     recipe: packages/packages
     timeout: 60
     properties:
-      add_recipes_cq: "true"
       target_file: web_platform_tests.yaml
       cores: "32"
       version_file: flutter_stable.version
@@ -322,7 +319,6 @@ targets:
     recipe: packages/packages
     timeout: 60
     properties:
-      add_recipes_cq: "true"
       target_file: web_platform_tests.yaml
       cores: "32"
       version_file: flutter_stable.version

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -281,6 +281,54 @@ targets:
       target_file: web_build_all_packages.yaml
       channel: stable
 
+  - name: Linux_web web_platform_tests_shard_1 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      target_file: web_platform_tests.yaml
+      cores: "32"
+      version_file: flutter_master.version
+      channel: master
+      package_sharding: "--shardIndex 0 --shardCount 2"
+
+  - name: Linux_web web_platform_tests_shard_2 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      target_file: web_platform_tests.yaml
+      cores: "32"
+      version_file: flutter_master.version
+      channel: master
+      package_sharding: "--shardIndex 1 --shardCount 2"
+
+  - name: Linux_web web_platform_tests_shard_1 stable
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      target_file: web_platform_tests.yaml
+      cores: "32"
+      version_file: flutter_stable.version
+      channel: stable
+      package_sharding: "--shardIndex 0 --shardCount 2"
+
+  - name: Linux_web web_platform_tests_shard_2 stable
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      target_file: web_platform_tests.yaml
+      cores: "32"
+      version_file: flutter_stable.version
+      channel: stable
+      package_sharding: "--shardIndex 1 --shardCount 2"
+
   ### Linux desktop tasks
   - name: Linux_desktop build_all_packages master
     recipe: packages/packages

--- a/.ci/targets/web_platform_tests.yaml
+++ b/.ci/targets/web_platform_tests.yaml
@@ -1,0 +1,9 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  - name: build examples
+    script: script/tool_runner.sh
+    args: ["build-examples", "--web"]
+  - name: drive examples
+    script: script/tool_runner.sh
+    args: ["drive-examples", "--web", "--run-chromedriver", "--exclude=script/configs/exclude_integration_web.yaml"]

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -520,6 +520,54 @@ void main() {
           ]));
     });
 
+    test('runs chromedriver when requested', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/integration_test/plugin_test.dart',
+          'example/test_driver/integration_test.dart',
+          'example/web/index.html',
+        ],
+        platformSupport: <String, PlatformDetails>{
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
+        },
+      );
+
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['drive-examples', '--web', '--run-chromedriver']);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
+          contains('No issues found!'),
+        ]),
+      );
+
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            const ProcessCall('chromedriver', <String>['--port=4444'], null),
+            ProcessCall(
+                getFlutterCommand(mockPlatform),
+                const <String>[
+                  'drive',
+                  '-d',
+                  'web-server',
+                  '--web-port=7357',
+                  '--browser-name=chrome',
+                  '--driver',
+                  'test_driver/integration_test.dart',
+                  '--target',
+                  'integration_test/plugin_test.dart',
+                ],
+                pluginExampleDirectory.path),
+          ]));
+    });
+
     test('drives a web plugin with CHROME_EXECUTABLE', () async {
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',

--- a/script/tool/test/mocks.dart
+++ b/script/tool/test/mocks.dart
@@ -79,6 +79,9 @@ class MockProcess extends Mock implements io.Process {
 
   @override
   IOSink get stdin => stdinMock;
+
+  @override
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) => true;
 }
 
 class MockIOSink extends Mock implements IOSink {


### PR DESCRIPTION
Adds web platform tests for LUCI in bringup mode.

The Cirrus version of the test starts `chromedriver` at the beginning and just leaves it running, which is fine since it's a fresh docker image each run. For LUCI we don't want that behavior though, so instead this adds tooling support for running chromedriver as part of running the integration tests, controllable with a flag. This will also be useful for running locally.

Part of https://github.com/flutter/flutter/issues/114373