### PR TITLE
[ci] Switch some tests to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -338,7 +338,7 @@ targets:
       channel: master
       version_file: flutter_master.version
       cores: "32"
-      package_sharding: "--shardIndex 6 --shardCount 6"
+      package_sharding: "--shardIndex 5 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_1 stable
     recipe: packages/packages
@@ -404,7 +404,7 @@ targets:
       channel: stable
       version_file: flutter_stable.version
       cores: "32"
-      package_sharding: "--shardIndex 6 --shardCount 6"
+      package_sharding: "--shardIndex 5 --shardCount 6"
 
   ### Web tasks ###
   - name: Linux_web web_build_all_packages master

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -97,7 +97,6 @@ targets:
       version_file: flutter_master.version
 
   - name: Linux repo_checks
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
@@ -282,7 +281,6 @@ targets:
       channel: stable
 
   - name: Linux_android android_platform_tests_shard_1 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -293,7 +291,6 @@ targets:
       package_sharding: "--shardIndex 0 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_2 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -304,7 +301,6 @@ targets:
       package_sharding: "--shardIndex 1 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_3 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -315,7 +311,6 @@ targets:
       package_sharding: "--shardIndex 2 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_4 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -326,7 +321,6 @@ targets:
       package_sharding: "--shardIndex 3 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_5 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -337,7 +331,6 @@ targets:
       package_sharding: "--shardIndex 4 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_6 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -348,7 +341,6 @@ targets:
       package_sharding: "--shardIndex 6 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_1 stable
-    bringup: true # New target
     recipe: packages/packages
     presubmit: false
     timeout: 60
@@ -360,7 +352,6 @@ targets:
       package_sharding: "--shardIndex 0 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_2 stable
-    bringup: true # New target
     recipe: packages/packages
     presubmit: false
     timeout: 60
@@ -372,7 +363,6 @@ targets:
       package_sharding: "--shardIndex 1 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_3 stable
-    bringup: true # New target
     recipe: packages/packages
     presubmit: false
     timeout: 60
@@ -384,7 +374,6 @@ targets:
       package_sharding: "--shardIndex 2 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_4 stable
-    bringup: true # New target
     recipe: packages/packages
     presubmit: false
     timeout: 60
@@ -396,7 +385,6 @@ targets:
       package_sharding: "--shardIndex 3 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_5 stable
-    bringup: true # New target
     recipe: packages/packages
     presubmit: false
     timeout: 60
@@ -408,7 +396,6 @@ targets:
       package_sharding: "--shardIndex 4 --shardCount 6"
 
   - name: Linux_android android_platform_tests_shard_6 stable
-    bringup: true # New target
     recipe: packages/packages
     presubmit: false
     timeout: 60
@@ -438,7 +425,6 @@ targets:
       channel: stable
 
   - name: Linux_web web_platform_tests_shard_1 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -449,7 +435,6 @@ targets:
       package_sharding: "--shardIndex 0 --shardCount 2"
 
   - name: Linux_web web_platform_tests_shard_2 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -460,7 +445,6 @@ targets:
       package_sharding: "--shardIndex 1 --shardCount 2"
 
   - name: Linux_web web_platform_tests_shard_1 stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -471,7 +455,6 @@ targets:
       package_sharding: "--shardIndex 0 --shardCount 2"
 
   - name: Linux_web web_platform_tests_shard_2 stable
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:

--- a/.ci/targets/android_platform_tests.yaml
+++ b/.ci/targets/android_platform_tests.yaml
@@ -11,9 +11,11 @@ tasks:
   # different exclusions.
   # TODO(stuartmorgan): Eliminate the native unit test exclusion, and combine
   # these steps.
-  - name: native unit tests
-    script: script/tool_runner.sh
-    args: ["native-test", "--android", "--no-integration", "--exclude=script/configs/exclude_native_unit_android.yaml"]
+  # TODO(stuartmorgan): Enable this once https://github.com/flutter/flutter/issues/130148
+  # is resolved.
+  #- name: native unit tests
+  #  script: script/tool_runner.sh
+  #  args: ["native-test", "--android", "--no-integration", "--exclude=script/configs/exclude_native_unit_android.yaml"]
   # TODO(stuartmorgan): Enable these once
   # https://github.com/flutter/flutter/issues/120736 is implemented.
   # See also https://github.com/flutter/flutter/issues/114373

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -169,6 +169,10 @@ task:
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[d6583b08f79f91ea4844c77460f04539965e46ad2fd97fb7c062b4dfe88016228b86ebe8c220ab4187e0c4bd773dc1e7]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[1a2eebf9367197bbe812d9a0ea83a53a05aeba4bb5e4964fe6a69727883cd87e51238d39237b1f80b0894c48419ac268]
+      native_unit_test_script:
+        # Native integration tests are handled by Firebase Test Lab below, so
+        # only run unit tests.
+        - ./script/tool_runner.sh native-test --android --no-integration --exclude script/configs/exclude_native_unit_android.yaml
       firebase_test_lab_script:
         - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
         -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,20 +65,6 @@ task:
     # (on Flutter master).
     - name: repo_checks
       always:
-        format_script: ./script/tool_runner.sh format --fail-on-change
-        license_script: $PLUGIN_TOOL_COMMAND license-check
-        # The major and minor version here should match the lowest version
-        # analyzed in legacy_version_analyze.
-        pubspec_script: ./script/tool_runner.sh pubspec-check --min-min-flutter-version=3.3.0 --allow-dependencies=script/configs/allowed_unpinned_deps.yaml --allow-pinned-dependencies=script/configs/allowed_pinned_deps.yaml
-        readme_script:
-          - ./script/tool_runner.sh readme-check
-          # Re-run with --require-excerpts, skipping packages that still need
-          # to be converted. Once https://github.com/flutter/flutter/issues/102679
-          # has been fixed, this can be removed and there can just be a single
-          # run with --require-excerpts and no exclusions.
-          - ./script/tool_runner.sh readme-check --require-excerpts --exclude=script/configs/temp_exclude_excerpt.yaml
-        dependabot_script: $PLUGIN_TOOL_COMMAND dependabot-check
-        gradle_script: $PLUGIN_TOOL_COMMAND gradle-check
         version_script:
           # For pre-submit, pass the PR labels to the script to allow for
           # check overrides.
@@ -90,7 +76,6 @@ task:
           - else
           -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
           - fi
-        publishable_script: ./script/tool_runner.sh publish-check --allow-pre-release
         federated_safety_script:
           # This check is only meaningful for PRs, as it validates changes
           # rather than state.
@@ -173,28 +158,17 @@ task:
       skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
       env:
         matrix:
-          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 8"
-          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 8"
-          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 8"
-          PACKAGE_SHARDING: "--shardIndex 3 --shardCount 8"
-          PACKAGE_SHARDING: "--shardIndex 4 --shardCount 8"
-          PACKAGE_SHARDING: "--shardIndex 5 --shardCount 8"
-          PACKAGE_SHARDING: "--shardIndex 6 --shardCount 8"
-          PACKAGE_SHARDING: "--shardIndex 7 --shardCount 8"
+          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 6"
+          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 6"
+          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 6"
+          PACKAGE_SHARDING: "--shardIndex 3 --shardCount 6"
+          PACKAGE_SHARDING: "--shardIndex 4 --shardCount 6"
+          PACKAGE_SHARDING: "--shardIndex 5 --shardCount 6"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[d6583b08f79f91ea4844c77460f04539965e46ad2fd97fb7c062b4dfe88016228b86ebe8c220ab4187e0c4bd773dc1e7]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[1a2eebf9367197bbe812d9a0ea83a53a05aeba4bb5e4964fe6a69727883cd87e51238d39237b1f80b0894c48419ac268]
-      build_script:
-        - ./script/tool_runner.sh build-examples --apk
-      lint_script:
-        - ./script/tool_runner.sh lint-android # must come after build-examples
-      native_unit_test_script:
-        # Native integration tests are handled by Firebase Test Lab below, so
-        # only run unit tests.
-        # Must come after build-examples.
-        - ./script/tool_runner.sh native-test --android --no-integration --exclude script/configs/exclude_native_unit_android.yaml
       firebase_test_lab_script:
         - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
         -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
@@ -202,28 +176,7 @@ task:
         - else
         -   echo "This user does not have permission to run Firebase Test Lab tests."
         - fi
-      # Upload the full lint results to Cirrus to display in the results UI.
-      always:
-        android-lint_artifacts:
-          path: "**/reports/lint-results-debug.xml"
-          type: text/xml
-          format: android-lint
     ### Web tasks ###
-    - name: web-platform_tests
-      env:
-        matrix:
-          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 2"
-          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 2"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      << : *INSTALL_CHROME_LINUX
-      chromedriver_background_script:
-        - $CHROMEDRIVER_EXECUTABLE --port=4444
-      build_script:
-        - ./script/tool_runner.sh build-examples --web
-      drive_script:
-        - ./script/tool_runner.sh drive-examples --web --exclude=script/configs/exclude_integration_web.yaml
     - name: web_benchmarks_test
       env:
         matrix:

--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -142,6 +142,8 @@ void main() {
         expect(controller.value.isPlaying, false);
         expect(controller.value.position, tenMillisBeforeEnd);
       },
+      // Flaky on web: https://github.com/flutter/flutter/issues/130147
+      skip: kIsWeb,
     );
 
     testWidgets(


### PR DESCRIPTION
Enables various new LUCI targets and removes the corresponding Cirrus versions:
- The parts of `repo_checks` that have been migrated.
- Android platform tests other than FTL.
- Web platform tests.

Since the Cirrus Android platform tests are now doing less work, the number of shards has been reduced slightly.

Part of https://github.com/flutter/flutter/issues/114373