### PR TITLE
[tool] Fix --current-package for app-facing packages

### DIFF
--- a/script/tool/lib/src/common/package_command.dart
+++ b/script/tool/lib/src/common/package_command.dart
@@ -595,7 +595,15 @@ abstract class PackageCommand extends Command<void> {
     // ... and then check whether it has an enclosing package.
     final RepositoryPackage package = RepositoryPackage(currentDir);
     final RepositoryPackage? enclosingPackage = package.getEnclosingPackage();
-    return (enclosingPackage ?? package).directory.basename;
+    final RepositoryPackage rootPackage = enclosingPackage ?? package;
+    final String name = rootPackage.directory.basename;
+    // For an app-facing package in a federated plugin, return the fully
+    // qualified name, since returning just the name will cause the entire
+    // group to run.
+    if (rootPackage.directory.parent.basename == name) {
+      return '$name/$name';
+    }
+    return name;
   }
 
   // Returns true if the current checkout is on an ancestor of [branch].

--- a/script/tool/test/common/package_command_test.dart
+++ b/script/tool/test/common/package_command_test.dart
@@ -433,6 +433,21 @@ packages/plugin1/plugin1/plugin1.dart
         expect(command.plugins, unorderedEquals(<String>[package.path]));
       });
 
+      test('runs only app-facing package of a federated plugin', () async {
+        const String pluginName = 'foo';
+        final Directory groupDir = packagesDir.childDirectory(pluginName);
+        final RepositoryPackage package =
+            createFakePlugin(pluginName, groupDir);
+        createFakePlugin('${pluginName}_someplatform', groupDir);
+        createFakePackage('${pluginName}_platform_interface', groupDir);
+        fileSystem.currentDirectory = package.directory;
+
+        await runCapturingPrint(
+            runner, <String>['sample', '--current-package']);
+
+        expect(command.plugins, unorderedEquals(<String>[package.path]));
+      });
+
       test('runs on a package when run from a package example directory',
           () async {
         final RepositoryPackage package = createFakePlugin(


### PR DESCRIPTION
The new `--current-package` flag was returning `foo` when run in the app-facing package of a federated plugin called `foo`, but `foo` as a package argument is treated as being the entire group, so it was running all for all of the packages in the plugin. This fixes it to return `foo/foo` in that case, which is how the tool targets app-facing packages specifically.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
