### PR TITLE
[url_lancher] Don't use `canLaunchUrl` in Link

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 6.1.12
 
+* Removes the use of `canLaunchUrl` in `Link`, to avoid issues on platforms where `canLaunchUrl` is unreliable or requires permissions.
 * Updates minimum supported macOS version to 10.14.
 * Fixes stale ignore: prefer_const_constructors.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.

--- a/packages/url_launcher/url_launcher/README.md
+++ b/packages/url_launcher/url_launcher/README.md
@@ -17,7 +17,7 @@ To use this plugin, add `url_launcher` as a [dependency in your pubspec.yaml fil
 ### Example
 
 <?code-excerpt "basic.dart (basic-example)"?>
-``` dart
+```dart
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -72,7 +72,7 @@ element must be added to your manifest as a child of the root element.
 Example:
 
 <?code-excerpt "../../android/app/src/main/AndroidManifest.xml (android-queries)" plaster="none"?>
-``` xml
+```xml
 <!-- Provide required visibility configuration for API level 30 and above -->
 <queries>
   <!-- If your app checks for SMS support -->

--- a/packages/url_launcher/url_launcher/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher/lib/src/link.dart
@@ -121,14 +121,18 @@ class DefaultLinkDelegate extends StatelessWidget {
 
     // At this point, we know that the link is external. So we use the
     // `launchUrl` API to open the link.
-    if (await canLaunchUrl(url)) {
-      await launchUrl(
+    bool success;
+    try {
+      success = await launchUrl(
         url,
         mode: _useWebView
             ? LaunchMode.inAppWebView
             : LaunchMode.externalApplication,
       );
-    } else {
+    } on PlatformException {
+      success = false;
+    }
+    if (!success) {
       FlutterError.reportError(FlutterErrorDetails(
         exception: 'Could not launch link $url',
         stack: StackTrace.current,

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.1.11
+version: 6.1.12
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/url_launcher/url_launcher/test/link_test.dart
+++ b/packages/url_launcher/url_launcher/test/link_test.dart
@@ -64,7 +64,9 @@ void main() {
         )
         ..setResponse(true);
       await followLink!();
-      expect(mock.canLaunchCalled, isTrue);
+      // Calling canLaunch just to pre-check launch is an anti-pattern, since
+      // canLaunch doesn't always work, so ensure that it's not called.
+      expect(mock.canLaunchCalled, isFalse);
       expect(mock.launchCalled, isTrue);
     });
 
@@ -93,7 +95,9 @@ void main() {
         )
         ..setResponse(true);
       await followLink!();
-      expect(mock.canLaunchCalled, isTrue);
+      // Calling canLaunch just to pre-check launch is an anti-pattern, since
+      // canLaunch doesn't always work, so ensure that it's not called.
+      expect(mock.canLaunchCalled, isFalse);
       expect(mock.launchCalled, isTrue);
     });
 


### PR DESCRIPTION
The pattern of calling `canLaunchUrl` when there's no fallback is an anti-pattern, and the README explicitly recommends against it; on some platforms, `canLaunchUrl` is unreliable in some cases, and/or requires extra permissions that `launchUrl` does not.

This reworks the launch call to just try, and handle failure, instead of trying to pre-check.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
