### PR TITLE
[ci] Enable LUCI stable custom Linux tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -246,11 +246,9 @@ targets:
       channel: master
 
   - name: Linux_android custom_package_tests stable
-    bringup: true # Blocked on https://github.com/flutter/flutter/issues/130071
     recipe: packages/packages
     timeout: 30
     properties:
-      add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: linux_custom_package_tests.yaml
       cores: "32"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,16 +157,6 @@ task:
     cpu: 4
     memory: 16G
   matrix:
-    ### Platform-agnostic tasks ###
-    - name: linux-custom_package_tests
-      env:
-        PATH: $PATH:/usr/local/bin
-        # Master has been migrated to LUCI, but stable is blocked on
-        # https://github.com/flutter/flutter/issues/130071
-        CHANNEL: "stable"
-      << : *INSTALL_CHROME_LINUX
-      local_tests_script:
-        - ./script/tool_runner.sh custom-test
     ### Android tasks ###
     - name: android-platform_tests
       # Don't run full platform tests on both channels in pre-submit.


### PR DESCRIPTION
Enables the stable variant of the Linux-host custom package tests, now that the channel is available in the environment, and removes the Cirrus version.

Part of https://github.com/flutter/flutter/issues/114373
