### PR TITLE
[shared_preferences] Variable binding in a condition requires an initializer fix

### DIFF
--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences_android: ^2.1.0
-  shared_preferences_foundation: ^2.3.1
+  shared_preferences_foundation: ^2.2.0
   shared_preferences_linux: ^2.2.0
   shared_preferences_platform_interface: ^2.3.0
   shared_preferences_web: ^2.1.0

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences_android: ^2.1.0
-  shared_preferences_foundation: ^2.2.0
+  shared_preferences_foundation: ^2.3.1
   shared_preferences_linux: ^2.2.0
   shared_preferences_platform_interface: ^2.3.0
   shared_preferences_web: ^2.1.0

--- a/packages/shared_preferences/shared_preferences_foundation/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_foundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+* Fixes variable binding bug on older versions of Xcode.
+
 ## 2.3.0
 
 * Adds `clearWithParameters` and `getAllWithParameters` methods.

--- a/packages/shared_preferences/shared_preferences_foundation/darwin/Classes/SharedPreferencesPlugin.swift
+++ b/packages/shared_preferences/shared_preferences_foundation/darwin/Classes/SharedPreferencesPlugin.swift
@@ -55,7 +55,7 @@ public class SharedPreferencesPlugin: NSObject, FlutterPlugin, UserDefaultsApi {
   func getAllPrefs(prefix: String, allowList: [String]?) -> [String: Any] {
     var filteredPrefs: [String: Any] = [:]
     var allowSet: Set<String>?;
-    if let allowList {
+    if let allowList = allowList {
       allowSet = Set(allowList)
     }
     if let appDomain = Bundle.main.bundleIdentifier,

--- a/packages/shared_preferences/shared_preferences_foundation/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_foundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_foundation
 description: iOS and macOS implementation of the shared_preferences plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_foundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.3.0
+version: 2.3.1
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Not sure that testing for this makes sense, unless we want to add old xcode versions to our test suite.

Let me know if I'm thinking about this incorrectly though.

fixes https://github.com/flutter/flutter/issues/129983

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests


