### PR TITLE
[image_picker] Roll dependancies to avoid error

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Rolls platform implementations to avoid `UnimplementedError`.
+
 ## 1.0.0
 
 * **BREAKING CHANGE**: Removes the deprecated `get*` methods. Clients who have

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.1
 
-* Rolls platform implementations to avoid `UnimplementedError`.
+* Rolls platform implementations to ensure that `pickMedia` and
+  `pickMultipleMedia` have platform implementations.
 
 ## 1.0.0
 

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=2.18.0 <4.0.0"
@@ -28,13 +28,13 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  image_picker_android: ^0.8.4+11
-  image_picker_for_web: ^2.1.0
-  image_picker_ios: ^0.8.6+1
-  image_picker_linux: ^0.2.0
-  image_picker_macos: ^0.2.0
+  image_picker_android: ^0.8.7
+  image_picker_for_web: ^2.2.0
+  image_picker_ios: ^0.8.8
+  image_picker_linux: ^0.2.1
+  image_picker_macos: ^0.2.1
   image_picker_platform_interface: ^2.8.0
-  image_picker_windows: ^0.2.0
+  image_picker_windows: ^0.2.1
 
 dev_dependencies:
   build_runner: ^2.1.10


### PR DESCRIPTION
Rolling platform implementations that should have been done with `getMedia` changes.

fixes https://github.com/flutter/flutter/issues/130250

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests


