### PR TITLE
[ci] Enable LUCI legacy analysis

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -231,7 +231,6 @@ targets:
   # Analyze with the previous stable (N-1) and the stable before that (N-2). The
   # versions in `channel` should be updated after a new major stable release.
   - name: Linux analyze_legacy N-1
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
@@ -239,7 +238,6 @@ targets:
       channel: "3.7.12"
 
   - name: Linux analyze_legacy N-2
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,28 +84,6 @@ task:
           - else
           -   ./script/tool_runner.sh federation-safety-check
           - fi
-    # Does a sanity check that packages at least pass analysis on the N-1 and N-2
-    # versions of Flutter stable if the package claims to support that version.
-    # This is to minimize accidentally making changes that break old versions
-    # (which we don't commit to supporting, but don't want to actively break)
-    # without updating the constraints.
-    # Note: The versions below should be manually updated after a new stable
-    # version comes out.
-    - name: legacy_version_analyze
-      matrix:
-        # Change the arguments to pubspec-check when changing these values.
-        env:
-          CHANNEL: "3.7.12"
-        env:
-          CHANNEL: "3.3.10"
-      package_prep_script:
-        # Allow analyzing packages that use a dev dependency with a higher
-        # minimum Flutter/Dart version than the package itself.
-        - ./script/tool_runner.sh remove-dev-dependencies
-      analyze_script:
-        # Only analyze lib/; non-client code doesn't need to work on
-        # all supported legacy version.
-        - ./script/tool_runner.sh analyze --lib-only --skip-if-not-supporting-flutter-version="$CHANNEL" --custom-analysis=script/configs/custom_analysis.yaml
     - name: readme_excerpts
       env:
         CIRRUS_CLONE_SUBMODULES: true


### PR DESCRIPTION
Enables the new analyze_legacy targets in LUCI, and removes the Cirrus version.

Part of https://github.com/flutter/flutter/issues/114373