### PR TITLE
[webview_flutter_wkwebview] NSError.toString

### DIFF
--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.3
+
+* Introduces `NSError.toString` for better diagnostics.
+
 ## 3.6.2 
 
 * Fixes unawaited_futures violations.

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/foundation/foundation.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/foundation/foundation.dart
@@ -215,7 +215,7 @@ class NSError {
 
   /// The error code.
   ///
-  /// Note that errors are domain-specific.
+  /// Error codes are [domain]-specific.
   final int code;
 
   /// A string containing the error domain.
@@ -223,6 +223,14 @@ class NSError {
 
   /// A string containing the localized description of the error.
   final String localizedDescription;
+
+  @override
+  String toString() {
+    if (localizedDescription.isEmpty) {
+      return 'Error $domain:$code';
+    }
+    return '$localizedDescription ($domain:$code)';
+  }
 }
 
 /// A representation of an HTTP cookie.

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.6.2
+version: 3.6.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/src/foundation/foundation_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/src/foundation/foundation_test.dart
@@ -246,4 +246,39 @@ void main() {
       });
     });
   });
+
+  test('NSError', () {
+    expect(
+      const NSError(
+        code: 0,
+        domain: 'domain',
+        localizedDescription: 'desc',
+      ).toString(),
+      'desc (domain:0)',
+    );
+    expect(
+      const NSError(
+        code: 0,
+        domain: 'domain',
+        localizedDescription: '',
+      ).toString(),
+      'Error domain:0',
+    );
+    expect(
+      const NSError(
+        code: 255,
+        domain: 'bar',
+        localizedDescription: 'baz',
+      ).toString(),
+      'baz (bar:255)',
+    );
+    expect(
+      const NSError(
+        code: 255,
+        domain: 'bar',
+        localizedDescription: '',
+      ).toString(),
+      'Error bar:255',
+    );
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/128596

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
