### PR TITLE
[file_selector] Avoids using path_provider in web example app.

### DIFF
--- a/packages/file_selector/file_selector/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/save_text_page.dart
@@ -5,7 +5,7 @@
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:path_provider/path_provider.dart' as path_provider;
 
 /// Page for showing an example of saving with file_selector
 class SaveTextPage extends StatelessWidget {
@@ -22,8 +22,9 @@ class SaveTextPage extends StatelessWidget {
     // This demonstrates using an initial directory for the prompt, which should
     // only be done in cases where the application can likely predict where the
     // file will be saved. In most cases, this parameter should not be provided.
-    final String initialDirectory =
-        (await getApplicationDocumentsDirectory()).path;
+    final String? initialDirectory = !kIsWeb
+        ? (await path_provider.getApplicationDocumentsDirectory()).path
+        : null;
     final FileSaveLocation? result = await getSaveLocation(
       initialDirectory: initialDirectory,
       suggestedName: fileName,

--- a/packages/file_selector/file_selector/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/save_text_page.dart
@@ -21,10 +21,11 @@ class SaveTextPage extends StatelessWidget {
     final String fileName = _nameController.text;
     // This demonstrates using an initial directory for the prompt, which should
     // only be done in cases where the application can likely predict where the
-    // file will be saved. In most cases, this parameter should not be provided.
-    final String? initialDirectory = !kIsWeb
-        ? (await path_provider.getApplicationDocumentsDirectory()).path
-        : null;
+    // file will be saved. In most cases, this parameter should not be provided,
+    // and in the web, path_provider shouldn't even be called.
+    final String? initialDirectory = kIsWeb
+        ? null
+        : (await path_provider.getApplicationDocumentsDirectory()).path;
     final FileSaveLocation? result = await getSaveLocation(
       initialDirectory: initialDirectory,
       suggestedName: fileName,


### PR DESCRIPTION
This is a minor change to the `file_selector` example app to prevent it from using `path_provider` when running on the web (because `path_provider` isn't available on the web).

Fixes https://github.com/flutter/flutter/issues/130368

(PS: This should be exempt from publishing requirements, because the modified file is not shown in pub.dev, or anywhere else AFAIK.)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
