### PR TITLE
[image_picker_web] Listens to file input cancel event.

### DIFF
--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 2.3.0
+## 3.0.0
 
+* **BREAKING CHANGE:** Removes all code and tests mentioning `PickedFile`.
 * Listens to `cancel` event on file selection. When the selection is canceled:
   * `Future<XFile?>` methods return `null`
   * `Future<List<XFile>>` methods return an empty list.
-* Removes all code and tests mentioning `PickedFile`.
-* Updates README to mention `XFile`.
 
 ## 2.2.0
 

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.3.0
+
+* Listens to `cancel` event on file selection. When the selection is canceled:
+  * `Future<XFile?>` methods return `null`
+  * `Future<List<XFile>>` methods return an empty list.
+* Removes all code and tests mentioning `PickedFile`.
+* Updates README to mention `XFile`.
+
 ## 2.2.0
 
 * Adds `getMedia` method.

--- a/packages/image_picker/image_picker_for_web/README.md
+++ b/packages/image_picker/image_picker_for_web/README.md
@@ -70,7 +70,7 @@ should add it to your `pubspec.yaml` as usual.
 You should be able to use `package:image_picker` _almost_ as normal.
 
 Once the user has picked a file, the returned `XFile` instance will contain a
-`network`-accessible Blob URL (pointing to a location within the browser).
+`network`-accessible `Blob` URL (pointing to a location within the browser).
 
 The instance will also let you retrieve the bytes of the selected file across all platforms.
 

--- a/packages/image_picker/image_picker_for_web/README.md
+++ b/packages/image_picker/image_picker_for_web/README.md
@@ -4,23 +4,9 @@ A web implementation of [`image_picker`][1].
 
 ## Limitations on the web platform
 
-Since Web Browsers don't offer direct access to their users' file system,
-this plugin provides a `PickedFile` abstraction to make access uniform
-across platforms.
+This plugin uses `XFile` objects to abstract files picked/created by the user.
 
-The web version of the plugin puts network-accessible URIs as the `path`
-in the returned `PickedFile`.
-
-### URL.createObjectURL()
-
-The `PickedFile` object in web is backed by [`URL.createObjectUrl` Web API](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL),
-which is reasonably well supported across all browsers:
-
-![Data on support for the bloburls feature across the major browsers from caniuse.com](https://caniuse.bitsofco.de/image/bloburls.png)
-
-However, the returned `path` attribute of the `PickedFile` points to a `network` resource, and not a
-local path in your users' drive. See **Use the plugin** below for some examples on how to use this
-return value in a cross-platform way.
+Read more about `XFile` on the web in [`package:cross_file`'s README](https://pub.dev/packages/cross_file)
 
 ### input file "accept"
 
@@ -41,6 +27,12 @@ In order to "take a photo", some mobile browsers offer a [`capture` attribute](h
 
 Each browser may implement `capture` any way they please, so it may (or may not) make a
 difference in your users' experience.
+
+### input file "cancel"
+
+The [`cancel` event](https://caniuse.com/mdn-api_htmlinputelement_cancel_event)
+used by the plugin to detect when users close the file selector without picking
+a file is relatively new, and will only work in recent browsers.
 
 ### pickImage()
 The arguments `maxWidth`, `maxHeight` and `imageQuality` are not supported for gif images.
@@ -65,8 +57,8 @@ should add it to your `pubspec.yaml` as usual.
 
 You should be able to use `package:image_picker` _almost_ as normal.
 
-Once the user has picked a file, the returned `PickedFile` instance will contain a
-`network`-accessible URL (pointing to a location within the browser).
+Once the user has picked a file, the returned `XFile` instance will contain a
+`network`-accessible Blob URL (pointing to a location within the browser).
 
 The instance will also let you retrieve the bytes of the selected file across all platforms.
 

--- a/packages/image_picker/image_picker_for_web/README.md
+++ b/packages/image_picker/image_picker_for_web/README.md
@@ -4,9 +4,12 @@ A web implementation of [`image_picker`][1].
 
 ## Limitations on the web platform
 
+### `XFile`
+
 This plugin uses `XFile` objects to abstract files picked/created by the user.
 
-Read more about `XFile` on the web in [`package:cross_file`'s README](https://pub.dev/packages/cross_file)
+Read more about `XFile` on the web in
+[`package:cross_file`'s README](https://pub.dev/packages/cross_file).
 
 ### input file "accept"
 
@@ -34,11 +37,19 @@ The [`cancel` event](https://caniuse.com/mdn-api_htmlinputelement_cancel_event)
 used by the plugin to detect when users close the file selector without picking
 a file is relatively new, and will only work in recent browsers.
 
-### pickImage()
-The arguments `maxWidth`, `maxHeight` and `imageQuality` are not supported for gif images.
-The argument `imageQuality` only works for jpeg and webp images.
+### `getImage()` parameters and `MediaOptions`
 
-### pickVideo()
+The `getImage`, `getMultiImage` and `getMedia` methods receive either a
+`MediaOptions` object with `maxWidth`, `maxHeight` and `imageQuality` options,
+or separately as individual parameters.
+
+On the web:
+
+* `maxWidth`, `maxHeight` and `imageQuality` are not supported for `gif` images.
+* `imageQuality` only affects `jpg` and `webp` images.
+
+### `getVideo()`
+
 The argument `maxDuration` is not supported on the web.
 
 ## Usage

--- a/packages/image_picker/image_picker_for_web/README.md
+++ b/packages/image_picker/image_picker_for_web/README.md
@@ -37,11 +37,12 @@ The [`cancel` event](https://caniuse.com/mdn-api_htmlinputelement_cancel_event)
 used by the plugin to detect when users close the file selector without picking
 a file is relatively new, and will only work in recent browsers.
 
-### `getImage()` parameters and `MediaOptions`
+### `ImagePickerOptions` support
 
-The `getImage`, `getMultiImage` and `getMedia` methods receive either a
-`MediaOptions` object with `maxWidth`, `maxHeight` and `imageQuality` options,
-or separately as individual parameters.
+The `ImagePickerOptions` configuration object allows passing resize (`maxWidth`,
+`maxHeight`) and quality (`imageQuality`) parameters to some methods of this
+plugin, which in other platforms control how selected images are resized or
+re-encoded.
 
 On the web:
 

--- a/packages/image_picker/image_picker_for_web/example/integration_test/image_picker_for_web_test.dart
+++ b/packages/image_picker/image_picker_for_web/example/integration_test/image_picker_for_web_test.dart
@@ -33,7 +33,9 @@ void main() {
     plugin = ImagePickerPlugin();
   });
 
-  testWidgets('Can select a file', (WidgetTester tester) async {
+  testWidgets('getImageFromSource can select a file', (
+    WidgetTester _,
+  ) async {
     final html.FileUploadInputElement mockInput = html.FileUploadInputElement();
 
     final ImagePickerPluginTestOverrides overrides =
@@ -44,7 +46,9 @@ void main() {
     final ImagePickerPlugin plugin = ImagePickerPlugin(overrides: overrides);
 
     // Init the pick file dialog...
-    final Future<XFile?> image = plugin.getImage(source: ImageSource.camera);
+    final Future<XFile?> image = plugin.getImageFromSource(
+      source: ImageSource.camera,
+    );
 
     // Mock the browser behavior of selecting a file...
     mockInput.dispatchEvent(html.Event('change'));
@@ -66,8 +70,9 @@ void main() {
         ));
   });
 
-  testWidgets('getMultiImage can select multiple files',
-      (WidgetTester tester) async {
+  testWidgets('getMultiImageWithOptions can select multiple files', (
+    WidgetTester _,
+  ) async {
     final html.FileUploadInputElement mockInput = html.FileUploadInputElement();
 
     final ImagePickerPluginTestOverrides overrides =
@@ -79,7 +84,7 @@ void main() {
     final ImagePickerPlugin plugin = ImagePickerPlugin(overrides: overrides);
 
     // Init the pick file dialog...
-    final Future<List<XFile>> files = plugin.getMultiImage();
+    final Future<List<XFile>> files = plugin.getMultiImageWithOptions();
 
     // Mock the browser behavior of selecting a file...
     mockInput.dispatchEvent(html.Event('change'));
@@ -97,8 +102,7 @@ void main() {
     expect(secondFile.length(), completion(secondTextFile.size));
   });
 
-  testWidgets('getMedia can select multiple files',
-      (WidgetTester tester) async {
+  testWidgets('getMedia can select multiple files', (WidgetTester _) async {
     final html.FileUploadInputElement mockInput = html.FileUploadInputElement();
 
     final ImagePickerPluginTestOverrides overrides =
@@ -165,16 +169,18 @@ void main() {
       expect(await files, isEmpty);
     });
 
-    testWidgets('getMultiImage - returns empty list', (WidgetTester _) async {
-      final Future<List<XFile>?> files = plugin.getMultiImage();
+    testWidgets('getMultiImageWithOptions - returns empty list', (
+      WidgetTester _,
+    ) async {
+      final Future<List<XFile>?> files = plugin.getMultiImageWithOptions();
       mockCancel();
 
       expect(files, completes);
       expect(await files, isEmpty);
     });
 
-    testWidgets('getImage - returns null', (WidgetTester _) async {
-      final Future<XFile?> file = plugin.getImage(
+    testWidgets('getImageFromSource - returns null', (WidgetTester _) async {
+      final Future<XFile?> file = plugin.getImageFromSource(
         source: ImageSource.gallery,
       );
       mockCancel();
@@ -248,6 +254,104 @@ void main() {
       expect(input.attributes, containsPair('accept', 'any'));
       expect(input.attributes, containsPair('capture', 'something'));
       expect(input.attributes, contains('multiple'));
+    });
+  });
+
+  group('Deprecated methods', () {
+    late html.FileUploadInputElement mockInput;
+    late ImagePickerPluginTestOverrides overrides;
+    late ImagePickerPlugin plugin;
+
+    setUp(() {
+      mockInput = html.FileUploadInputElement();
+      overrides = ImagePickerPluginTestOverrides()
+        ..createInputElement = ((_, __) => mockInput)
+        ..getMultipleFilesFromInput = ((_) => <html.File>[textFile]);
+      plugin = ImagePickerPlugin(overrides: overrides);
+    });
+
+    void mockCancel() {
+      mockInput.dispatchEvent(html.Event('cancel'));
+    }
+
+    void mockChange() {
+      mockInput.dispatchEvent(html.Event('change'));
+    }
+
+    group('getImage', () {
+      testWidgets('can select a file', (WidgetTester _) async {
+        // ignore: deprecated_member_use
+        final Future<XFile?> image = plugin.getImage(
+          source: ImageSource.camera,
+        );
+
+        // Mock the browser behavior when selecting a file...
+        mockChange();
+
+        // Now the file should be available
+        expect(image, completes);
+
+        // And readable
+        final XFile? file = await image;
+        expect(file, isNotNull);
+        expect(file!.readAsBytes(), completion(isNotEmpty));
+        expect(file.name, textFile.name);
+        expect(file.length(), completion(textFile.size));
+        expect(file.mimeType, textFile.type);
+        expect(
+            file.lastModified(),
+            completion(
+              DateTime.fromMillisecondsSinceEpoch(textFile.lastModified!),
+            ));
+      });
+
+      testWidgets('returns null when canceled', (WidgetTester _) async {
+        // ignore: deprecated_member_use
+        final Future<XFile?> file = plugin.getImage(
+          source: ImageSource.gallery,
+        );
+        mockCancel();
+
+        expect(file, completes);
+        expect(await file, isNull);
+      });
+    });
+
+    group('getMultiImage', () {
+      testWidgets('can select multiple files', (WidgetTester _) async {
+        // Override the returned files...
+        overrides.getMultipleFilesFromInput =
+            (_) => <html.File>[textFile, secondTextFile];
+
+        // ignore: deprecated_member_use
+        final Future<List<XFile>> files = plugin.getMultiImage();
+
+        // Mock the browser behavior of selecting a file...
+        mockChange();
+
+        // Now the file should be available
+        expect(files, completes);
+
+        // And readable
+        expect((await files).first.readAsBytes(), completion(isNotEmpty));
+
+        // Peek into the second file...
+        final XFile secondFile = (await files).elementAt(1);
+        expect(secondFile.readAsBytes(), completion(isNotEmpty));
+        expect(secondFile.name, secondTextFile.name);
+        expect(secondFile.length(), completion(secondTextFile.size));
+      });
+
+      testWidgets('returns an empty list when canceled', (
+        WidgetTester _,
+      ) async {
+        // ignore: deprecated_member_use
+        final Future<List<XFile>?> files = plugin.getMultiImage();
+        mockCancel();
+
+        expect(files, completes);
+        expect(await files, isEmpty);
+      });
     });
   });
 }

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_for_web
 description: Web platform implementation of image_picker
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_for_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 2.2.0
+version: 2.3.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  image_picker_platform_interface: ^2.8.0
+  image_picker_platform_interface: ^2.9.0
   mime: ^1.0.4
 
 dev_dependencies:

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_for_web
 description: Web platform implementation of image_picker
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_for_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 2.3.0
+version: 3.0.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
## Changes

This PR listens to the `cancel` event from the `input type=file` used by the web implementation of the image_picker plugin, so apps don't end up endlessly awaiting for a file that will never come **in modern browsers** (Chrome 113, Safari 16.4, or newer). _Same API as https://github.com/flutter/packages/pull/3683._

Additionally, this PR:

* Removes all code and tests mentioning `PickedFile`. (Deprecated years ago, and unused since https://github.com/flutter/packages/pull/4285) **(Breaking change)**
* Updates README to mention `XFile` which is the current return type of the package.
* Updates the dependency on `image_picker_platform_interface` to `^2.9.0`.
  * Implements all non-deprecated methods from the interface, and makes deprecated methods use the fresh ones.
  * Updates tests.

### Issues

* Fixes https://github.com/flutter/flutter/issues/92176

### Testing

* Added integration testing coverage for the 'cancel' event.
* Tested manually in Chrome with the example app running on web.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
