### PR TITLE
[flutter_migrate] Fix intl version to support localized apps

### DIFF
--- a/packages/flutter_migrate/CHANGELOG.md
+++ b/packages/flutter_migrate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+4
+
+* Use any version of intl package to avoid conflicts with localized apps.
+
 ## 0.0.1+3
 
 * Removes obsolete null checks on non-nullable values.

--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_migrate
 description: A tool to migrate legacy flutter projects to modern versions.
-version: 0.0.1+3
+version: 0.0.1+4
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_migrate
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ap%3A%20flutter_migrate
 publish_to: none
@@ -12,7 +12,7 @@ dependencies:
   args: ^2.3.1
   convert: 3.0.2
   file: 6.1.4
-  intl: 0.17.0
+  intl: any
   meta: 1.8.0
   path: ^1.8.0
   process: 4.2.4


### PR DESCRIPTION
Uses intl: any instead of hardcoded version to avoid conflicts with flutter_localizations from sdk.

for issue https://github.com/flutter/flutter/issues/130493
