### PR TITLE
[url_launcher_android] Enable Android WebView to open PDFs and non-HTTP URLs (`mailto:`, `tel:`, `sms:`, etc.)

### DIFF
--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.37
+
+* Enables in-app Android WebView to open non-https urls, e.g. `mailto:`, `sms:`
+* Enables in-app Android WebView to open `.pdf` documents
+
 ## 6.0.36
 
 * Bumps androidx.annotation:annotation from 1.2.0 to 1.6.0.

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/FlutterWebViewClient.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/FlutterWebViewClient.java
@@ -6,7 +6,7 @@ import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
 public class FlutterWebViewClient extends WebViewClient {
@@ -48,7 +48,8 @@ public class FlutterWebViewClient extends WebViewClient {
     }
     return false;
   }
-  public static boolean resourceShouldOpenDocument(WebView view, String url) {
+
+  public static boolean resourceShouldOpenDocument(@NonNull WebView view, @NonNull String url) {
     // Check if URL is PDF
     if (url.endsWith(".pdf")) {
       Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -59,7 +60,7 @@ public class FlutterWebViewClient extends WebViewClient {
     return false;
   }
 
-  public static boolean urlShouldRunActivity(WebView view, String url) {
+  public static boolean urlShouldRunActivity(@NonNull WebView view, @NonNull String url) {
     // Check if URL is not an HTTP(S) request
     // Handles mailto:, sms:, etc.
     if (!url.startsWith("http://") && !url.startsWith("https://")) {

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/FlutterWebViewClient.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/FlutterWebViewClient.java
@@ -1,0 +1,74 @@
+package io.flutter.plugins.urllauncher;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import androidx.annotation.RequiresApi;
+
+public class FlutterWebViewClient extends WebViewClient {
+  @Override
+  public void onLoadResource(WebView view, String url) {
+    if (!resourceShouldOpenDocument(view, url)) {
+      super.onLoadResource(view, url);
+    }
+  }
+
+  /*
+   * This method is deprecated in API 24. Still overridden to support
+   * earlier Android versions.
+   */
+  @SuppressWarnings("deprecation")
+  @Override
+  public boolean shouldOverrideUrlLoading(WebView view, String url) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+      if (urlShouldRunActivity(view, url)) {
+        return true;
+      } else {
+        view.loadUrl(url);
+      }
+      return false;
+    }
+    return super.shouldOverrideUrlLoading(view, url);
+  }
+
+  @RequiresApi(Build.VERSION_CODES.N)
+  @Override
+  public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      String url = request.getUrl().toString();
+      if (urlShouldRunActivity(view, url)) {
+        return true;
+      } else {
+        view.loadUrl(url);
+      }
+    }
+    return false;
+  }
+  public static boolean resourceShouldOpenDocument(WebView view, String url) {
+    // Check if URL is PDF
+    if (url.endsWith(".pdf")) {
+      Intent intent = new Intent(Intent.ACTION_VIEW);
+      intent.setDataAndType(Uri.parse(url), "application/pdf");
+      view.getContext().startActivity(intent);
+      return true;
+    }
+    return false;
+  }
+
+  public static boolean urlShouldRunActivity(WebView view, String url) {
+    // Check if URL is not an HTTP(S) request
+    // Handles mailto:, sms:, etc.
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+      view.getContext().startActivity(intent);
+      return true;
+    }
+
+    // Otherwise, let WebView load URL
+    return false;
+  }
+}

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -110,7 +110,8 @@ public class WebViewActivity extends Activity {
     // Open new urls inside the webview itself.
     webview.setWebViewClient(new FlutterWebViewClient());
 
-    // Multi windows is set with FlutterWebChromeClient by default to handle internal bug: b/159892679.
+    // Multi windows is set with FlutterWebChromeClient by default to handle internal bug:
+    // b/159892679.
     webview.getSettings().setSupportMultipleWindows(true);
     webview.setWebChromeClient(new FlutterWebChromeClient());
 
@@ -146,14 +147,11 @@ public class WebViewActivity extends Activity {
     return super.onKeyDown(keyCode, event);
   }
 
-  @VisibleForTesting
-  static final String URL_EXTRA = "url";
+  @VisibleForTesting static final String URL_EXTRA = "url";
 
-  @VisibleForTesting
-  static final String ENABLE_JS_EXTRA = "enableJavaScript";
+  @VisibleForTesting static final String ENABLE_JS_EXTRA = "enableJavaScript";
 
-  @VisibleForTesting
-  static final String ENABLE_DOM_EXTRA = "enableDomStorage";
+  @VisibleForTesting static final String ENABLE_DOM_EXTRA = "enableDomStorage";
 
   /* Hides the constants used to forward data to the Activity instance. */
   public static @NonNull Intent createIntent(

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -52,6 +52,12 @@ public class WebViewActivity extends Activity {
 
   private final WebViewClient webViewClient =
       new WebViewClient() {
+        @Override
+        public void onLoadResource(WebView view, String url) {
+          if (!resourceShouldOpenDocument(view, url)) {
+            super.onLoadResource(view, url);
+          }
+        }
 
         /*
          * This method is deprecated in API 24. Still overridden to support
@@ -61,7 +67,9 @@ public class WebViewActivity extends Activity {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
           if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            if (!checkUrlForActivity(view, url)) {
+            if (urlShouldRunActivity(view, url)) {
+              return true;
+            } else {
               view.loadUrl(url);
             }
             return false;
@@ -74,14 +82,16 @@ public class WebViewActivity extends Activity {
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             String url = request.getUrl().toString();
-            if (!checkUrlForActivity(view, url)) {
+            if (urlShouldRunActivity(view, url)) {
+              return true;
+            } else {
               view.loadUrl(url);
             }
           }
           return false;
         }
 
-        private boolean checkUrlForActivity(WebView view, String url) {
+        private boolean resourceShouldOpenDocument(WebView view, String url) {
           // Check if URL is PDF
           if (url.endsWith(".pdf")) {
             Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -89,7 +99,10 @@ public class WebViewActivity extends Activity {
             view.getContext().startActivity(intent);
             return true;
           }
+          return false;
+        }
 
+        private boolean urlShouldRunActivity(WebView view, String url) {
           // Check if URL is not an HTTP(S) request
           // Handles mailto:, sms:, etc.
           if (!url.startsWith("http://") && !url.startsWith("https://")) {

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -10,7 +10,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
@@ -20,12 +19,9 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,72 +43,6 @@ public class WebViewActivity extends Activity {
           if (ACTION_CLOSE.equals(action)) {
             finish();
           }
-        }
-      };
-
-  private final WebViewClient webViewClient =
-      new WebViewClient() {
-        @Override
-        public void onLoadResource(WebView view, String url) {
-          if (!resourceShouldOpenDocument(view, url)) {
-            super.onLoadResource(view, url);
-          }
-        }
-
-        /*
-         * This method is deprecated in API 24. Still overridden to support
-         * earlier Android versions.
-         */
-        @SuppressWarnings("deprecation")
-        @Override
-        public boolean shouldOverrideUrlLoading(WebView view, String url) {
-          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            if (urlShouldRunActivity(view, url)) {
-              return true;
-            } else {
-              view.loadUrl(url);
-            }
-            return false;
-          }
-          return super.shouldOverrideUrlLoading(view, url);
-        }
-
-        @RequiresApi(Build.VERSION_CODES.N)
-        @Override
-        public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            String url = request.getUrl().toString();
-            if (urlShouldRunActivity(view, url)) {
-              return true;
-            } else {
-              view.loadUrl(url);
-            }
-          }
-          return false;
-        }
-
-        private boolean resourceShouldOpenDocument(WebView view, String url) {
-          // Check if URL is PDF
-          if (url.endsWith(".pdf")) {
-            Intent intent = new Intent(Intent.ACTION_VIEW);
-            intent.setDataAndType(Uri.parse(url), "application/pdf");
-            view.getContext().startActivity(intent);
-            return true;
-          }
-          return false;
-        }
-
-        private boolean urlShouldRunActivity(WebView view, String url) {
-          // Check if URL is not an HTTP(S) request
-          // Handles mailto:, sms:, etc.
-          if (!url.startsWith("http://") && !url.startsWith("https://")) {
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-            view.getContext().startActivity(intent);
-            return true;
-          }
-
-          // Otherwise, let WebView load URL
-          return false;
         }
       };
 
@@ -178,7 +108,7 @@ public class WebViewActivity extends Activity {
     webview.getSettings().setDomStorageEnabled(enableDomStorage);
 
     // Open new urls inside the webview itself.
-    webview.setWebViewClient(webViewClient);
+    webview.setWebViewClient(new FlutterWebViewClient());
 
     // Multi windows is set with FlutterWebChromeClient by default to handle internal bug: b/159892679.
     webview.getSettings().setSupportMultipleWindows(true);

--- a/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 import android.content.Context;
 import android.content.Intent;
 import android.webkit.WebView;

--- a/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import android.content.Context;
 import android.content.Intent;
-import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import java.util.Collections;
 import org.junit.Before;
@@ -26,13 +25,11 @@ public class WebViewActivityTest {
 
   private WebView webView;
   private Context context;
-  private WebResourceRequest webResourceRequest;
 
   @Before
   public void setUp() {
     webView = Mockito.mock(WebView.class);
     context = Mockito.mock(Context.class);
-    webResourceRequest = Mockito.mock(WebResourceRequest.class);
     Mockito.when(webView.getContext()).thenReturn(context);
     Mockito.when(webView.getWebViewClient()).thenReturn(new FlutterWebViewClient());
   }
@@ -84,7 +81,8 @@ public class WebViewActivityTest {
 
   @Test
   public void marketLink_startsActivity() {
-    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "market://details?id=com.example.test");
+    boolean result =
+        FlutterWebViewClient.urlShouldRunActivity(webView, "market://details?id=com.example.test");
 
     verify(context, times(1)).startActivity(any(Intent.class));
     assertTrue(result);
@@ -92,7 +90,9 @@ public class WebViewActivityTest {
 
   @Test
   public void contentLink_startsActivity() {
-    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "content://media/external/images/media/");
+    boolean result =
+        FlutterWebViewClient.urlShouldRunActivity(
+            webView, "content://media/external/images/media/");
 
     verify(context, times(1)).startActivity(any(Intent.class));
     assertTrue(result);
@@ -100,7 +100,8 @@ public class WebViewActivityTest {
 
   @Test
   public void fileLink_startsActivity() {
-    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "file:///sdcard/download/example.jpg");
+    boolean result =
+        FlutterWebViewClient.urlShouldRunActivity(webView, "file:///sdcard/download/example.jpg");
 
     verify(context, times(1)).startActivity(any(Intent.class));
     assertTrue(result);

--- a/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -5,13 +5,122 @@
 package io.flutter.plugins.urllauncher;
 
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import android.content.Context;
+import android.content.Intent;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
 import java.util.Collections;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
 
+@RunWith(JUnit4.class)
 public class WebViewActivityTest {
+
+  private WebView webView;
+  private Context context;
+  private WebResourceRequest webResourceRequest;
+
+  @Before
+  public void setUp() {
+    webView = Mockito.mock(WebView.class);
+    context = Mockito.mock(Context.class);
+    webResourceRequest = Mockito.mock(WebResourceRequest.class);
+    Mockito.when(webView.getContext()).thenReturn(context);
+    Mockito.when(webView.getWebViewClient()).thenReturn(new FlutterWebViewClient());
+  }
+
   @Test
   public void extractHeaders_returnsEmptyMapWhenHeadersBundleNull() {
     assertEquals(WebViewActivity.extractHeaders(null), Collections.emptyMap());
+  }
+
+  @Test
+  public void httpRequest_doesNotStartActivity() {
+    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "http://www.flutter.dev/");
+
+    verify(context, times(0)).startActivity(any(Intent.class));
+    assertFalse(result);
+  }
+
+  @Test
+  public void httpsRequest_doesNotStartActivity() {
+    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "https://www.flutter.dev/");
+
+    verify(context, times(0)).startActivity(any(Intent.class));
+    assertFalse(result);
+  }
+
+  @Test
+  public void smsLink_startsActivity() {
+    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "sms:1234567890");
+
+    verify(context, times(1)).startActivity(any(Intent.class));
+    assertTrue(result);
+  }
+
+  @Test
+  public void telLink_startsActivity() {
+    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "tel:1234567890");
+
+    verify(context, times(1)).startActivity(any(Intent.class));
+    assertTrue(result);
+  }
+
+  @Test
+  public void geoLink_startsActivity() {
+    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "geo:34.090335,-84.255769");
+
+    verify(context, times(1)).startActivity(any(Intent.class));
+    assertTrue(result);
+  }
+
+  @Test
+  public void marketLink_startsActivity() {
+    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "market://details?id=com.example.test");
+
+    verify(context, times(1)).startActivity(any(Intent.class));
+    assertTrue(result);
+  }
+
+  @Test
+  public void contentLink_startsActivity() {
+    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "content://media/external/images/media/");
+
+    verify(context, times(1)).startActivity(any(Intent.class));
+    assertTrue(result);
+  }
+
+  @Test
+  public void fileLink_startsActivity() {
+    boolean result = FlutterWebViewClient.urlShouldRunActivity(webView, "file:///sdcard/download/example.jpg");
+
+    verify(context, times(1)).startActivity(any(Intent.class));
+    assertTrue(result);
+  }
+
+  @Test
+  public void onLoadResource_allowsWebPageLoad() {
+    String url = "https://www.flutter.dev/";
+    webView.getWebViewClient().onLoadResource(webView, url);
+
+    verify(context, times(0)).startActivity(any(Intent.class));
+    assertFalse(FlutterWebViewClient.resourceShouldOpenDocument(webView, url));
+  }
+
+  @Test
+  public void onLoadResource_loadsPdf() {
+    String url = "https://www.flutter.dev/test.pdf";
+    webView.getWebViewClient().onLoadResource(webView, url);
+
+    verify(context, times(1)).startActivity(any(Intent.class));
+    assertTrue(FlutterWebViewClient.resourceShouldOpenDocument(webView, url));
   }
 }

--- a/packages/url_launcher/url_launcher_android/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_android/example/lib/main.dart
@@ -41,6 +41,8 @@ class _MyHomePageState extends State<MyHomePage> {
   bool _hasCallSupport = false;
   Future<void>? _launched;
   String _phone = '';
+  final TextEditingController _urlTextController =
+      TextEditingController(text: 'https://www.cylog.org/headers/');
 
   @override
   void initState() {
@@ -51,6 +53,12 @@ class _MyHomePageState extends State<MyHomePage> {
         _hasCallSupport = result;
       });
     });
+  }
+
+  @override
+  void dispose() {
+    _urlTextController.dispose();
+    super.dispose();
   }
 
   Future<void> _launchInBrowser(String url) async {
@@ -141,7 +149,6 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     // onPressed calls using this URL are not gated on a 'canLaunch' check
     // because the assumption is that every device can launch a web URL.
-    const String toLaunch = 'https://www.cylog.org/headers/';
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
@@ -168,39 +175,47 @@ class _MyHomePageState extends State<MyHomePage> {
                     ? const Text('Make phone call')
                     : const Text('Calling not supported'),
               ),
-              const Padding(
-                padding: EdgeInsets.all(16.0),
-                child: Text(toLaunch),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: TextField(
+                  controller: _urlTextController,
+                  decoration: const InputDecoration(
+                    labelText: 'URL to Launch',
+                    hintText: 'Input the URL to launch',
+                  ),
+                ),
               ),
               ElevatedButton(
                 onPressed: () => setState(() {
-                  _launched = _launchInBrowser(toLaunch);
+                  _launched = _launchInBrowser(_urlTextController.text);
                 }),
                 child: const Text('Launch in browser'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               ElevatedButton(
                 onPressed: () => setState(() {
-                  _launched = _launchInWebView(toLaunch);
+                  _launched = _launchInWebView(_urlTextController.text);
                 }),
                 child: const Text('Launch in app'),
               ),
               ElevatedButton(
                 onPressed: () => setState(() {
-                  _launched = _launchInWebViewWithJavaScript(toLaunch);
+                  _launched =
+                      _launchInWebViewWithJavaScript(_urlTextController.text);
                 }),
                 child: const Text('Launch in app (JavaScript ON)'),
               ),
               ElevatedButton(
                 onPressed: () => setState(() {
-                  _launched = _launchInWebViewWithDomStorage(toLaunch);
+                  _launched =
+                      _launchInWebViewWithDomStorage(_urlTextController.text);
                 }),
                 child: const Text('Launch in app (DOM storage ON)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               ElevatedButton(
                 onPressed: () => setState(() {
-                  _launched = _launchInWebView(toLaunch);
+                  _launched = _launchInWebView(_urlTextController.text);
                   Timer(const Duration(seconds: 5), () {
                     launcher.closeWebView();
                   });

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.36
+version: 6.0.37
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
This PR adds the ability of the launched WebView in Android to follow and open non-HTTP links by starting new Intents, such as opening a PDF viewer or your preferred email application.

Issues fixed: 
[#106331](https://github.com/flutter/flutter/issues/106331) - this fix was inspired by the attempted fix [here](https://github.com/flutter/plugins/pull/6006), but I had to extend the `WebViewClient` to make it testable
[#27309](https://github.com/flutter/flutter/issues/27309) - opening PDFs wasn't causing a crash for me, but was not opening PDFs on any Android device

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
