### PR TITLE
[ci] Switch Linux platform tests to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -509,7 +509,6 @@ targets:
       channel: stable
 
   - name: Linux_desktop platform_tests master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 30
     properties:
@@ -523,7 +522,6 @@ targets:
         ]
 
   - name: Linux_desktop platform_tests stable
-    bringup: true # New target
     recipe: packages/packages
     presubmit: false
     timeout: 30

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,20 +69,6 @@ task:
           - else
           -   ./script/tool_runner.sh federation-safety-check
           - fi
-    ### Linux desktop tasks ###
-    - name: linux-platform_tests
-      # Don't run full platform tests on both channels in pre-submit.
-      skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
-      env:
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      build_script:
-        - ./script/tool_runner.sh build-examples --linux
-      native_test_script:
-        - xvfb-run ./script/tool_runner.sh native-test --linux --no-integration
-      drive_script:
-        - xvfb-run ./script/tool_runner.sh drive-examples --linux --exclude=script/configs/exclude_integration_linux.yaml
 
 # Heavy-workload Linux tasks.
 # These use machines with more CPUs and memory, so will reduce parallelization


### PR DESCRIPTION
Enables the new LUCI targets, and removes the Cirrus version.

Part of https://github.com/flutter/flutter/issues/114373