### PR TITLE
[pigeon] Enable Android emulator tests in CI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -247,16 +247,19 @@ targets:
   - name: Linux_android custom_package_tests master
     recipe: packages/packages
     timeout: 30
+    dimensions:
+      kvm: "1"
     properties:
       add_recipes_cq: "true"
       version_file: flutter_master.version
       target_file: linux_custom_package_tests.yaml
-      cores: "32"
-      # Pigeon tests need Andoid deps (thus the Linux_android base) and
-      # clang-format.
+      # Pigeon tests need Andoid deps (thus the Linux_android base), emulator,
+      # and clang-format.
       # web_benchmarks needs Chrome.
+    properties:
       dependencies: >-
         [
+          {"dependency": "android_virtual_device", "version": "33"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "chrome_and_driver", "version": "version:114.0"}
         ]
@@ -265,13 +268,15 @@ targets:
   - name: Linux_android custom_package_tests stable
     recipe: packages/packages
     timeout: 30
+    dimensions:
+      kvm: "1"
     properties:
       version_file: flutter_stable.version
       target_file: linux_custom_package_tests.yaml
-      cores: "32"
       # See comments on 'master' version above.
       dependencies: >-
         [
+          {"dependency": "android_virtual_device", "version": "33"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "chrome_and_driver", "version": "version:114.0"}
         ]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -256,7 +256,6 @@ targets:
       # Pigeon tests need Andoid deps (thus the Linux_android base), emulator,
       # and clang-format.
       # web_benchmarks needs Chrome.
-    properties:
       dependencies: >-
         [
           {"dependency": "android_virtual_device", "version": "33"},

--- a/packages/pigeon/tool/run_tests.dart
+++ b/packages/pigeon/tool/run_tests.dart
@@ -167,11 +167,8 @@ Future<void> main(List<String> args) async {
     androidJavaUnitTests,
     androidJavaLint,
     androidKotlinUnitTests,
-    // TODO(stuartmorgan): Include these once CI supports running simulator
-    // tests. Currently these tests aren't run in CI.
-    // See https://github.com/flutter/flutter/issues/111505.
-    // androidJavaIntegrationTests,
-    // androidKotlinIntegrationTests,
+    androidJavaIntegrationTests,
+    androidKotlinIntegrationTests,
   ];
   const List<String> macOSHostTests = <String>[
     iOSObjCUnitTests,
@@ -198,9 +195,6 @@ Future<void> main(List<String> args) async {
     windowsHostTests,
     // Tests that are deliberately not included in CI:
     <String>[
-      // See comment in linuxHostTests:
-      androidJavaIntegrationTests,
-      androidKotlinIntegrationTests,
       // See comments in macOSHostTests:
       iOSObjCIntegrationTests,
       iOSSwiftIntegrationTests,


### PR DESCRIPTION
Enables the new emulator support for the Linux custom package test targets, and enables the emulator-based Android integration tests for Pigeon.

Drops the cores from the high-core config (32) to the default (8) since the emulator requires KVM, and there are currently no 32-core KVM machines in the pool. In practice, it appears that this doesn't have much affect on the runtime.

Fixes https://github.com/flutter/flutter/issues/111505