### PR TITLE
Remove `equatable` and `xml` allowances

### DIFF
--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   path: ^1.8.0
   process: 4.2.4
   vm_service: 9.3.0
-  xml: ^6.1.0
   yaml: 3.1.1
 
 dev_dependencies:

--- a/script/configs/allowed_unpinned_deps.yaml
+++ b/script/configs/allowed_unpinned_deps.yaml
@@ -4,11 +4,6 @@
 # All entries here should have an explanation for why they are here, either
 # via being part of one of the default-allowed groups, or a specific reason.
 
-## Legacy allowances, for dependencies that predate the tooling.
-# TODO(stuartmorgan): Audit these. See
-# https://github.com/flutter/flutter/issues/122713
-- xml
-
 ## Explicit allowances
 
 # Owned by individual Flutter Team members.

--- a/script/configs/allowed_unpinned_deps.yaml
+++ b/script/configs/allowed_unpinned_deps.yaml
@@ -7,7 +7,6 @@
 ## Legacy allowances, for dependencies that predate the tooling.
 # TODO(stuartmorgan): Audit these. See
 # https://github.com/flutter/flutter/issues/122713
-- equatable
 - xml
 
 ## Explicit allowances


### PR DESCRIPTION
The only package that was using the `equatable` package removed it, so we no longer need this allowance.

The only package depending on `xml` was `flutter_migrate`, but it never actually used it, so that can be removed as well.

Part of https://github.com/flutter/flutter/issues/122713
