### PR TITLE
[flutter_markdown] Change the way tests get screen size

### DIFF
--- a/packages/flutter_markdown/test/list_test.dart
+++ b/packages/flutter_markdown/test/list_test.dart
@@ -202,7 +202,8 @@ void defineTests() {
           ),
         );
 
-        final double screenWidth = tester.allElements.first.size!.width;
+        final double screenWidth =
+            find.byType(Column).evaluate().first.size!.width;
         final double markdownBodyWidth =
             find.byType(MarkdownBody).evaluate().single.size!.width;
 
@@ -225,7 +226,8 @@ void defineTests() {
           ),
         );
 
-        final double screenWidth = tester.allElements.first.size!.width;
+        final double screenWidth =
+            find.byType(Column).evaluate().first.size!.width;
         final double markdownBodyWidth =
             find.byType(MarkdownBody).evaluate().single.size!.width;
 


### PR DESCRIPTION
As of https://github.com/flutter/flutter/pull/125003 the current method these tests use to get the screen width throws an exception, since it assumes that the first widget in the tree has certain properties. To make the test more robust, this get the width of the outmost Column, which is part of the test setup, rather than whatever the first widget is.

Unblocks the flutter->packgaes roller.
