### PR TITLE
[ci] Shard Windows Dart unit tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -748,6 +748,27 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
 
+  - name: Windows dart_unit_tests_shard_1 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: windows_dart_unit_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      package_sharding: "--shardIndex 0 --shardCount 2"
+
+  - name: Windows dart_unit_tests_shard_2 master
+    bringup: true # New target
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: windows_dart_unit_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      package_sharding: "--shardIndex 1 --shardCount 2"
+
+  # TODO(stuartmorgan): Remove this when enabling the sharded versions.
   - name: Windows dart_unit_tests master - packages
     recipe: packages/packages
     timeout: 60

--- a/.ci/scripts/dart_unit_tests_win32.sh
+++ b/.ci/scripts/dart_unit_tests_win32.sh
@@ -6,4 +6,4 @@ set -e
 
 dart ./script/tool/bin/flutter_plugin_tools.dart dart-test \
   --exclude=script/configs/windows_unit_tests_exceptions.yaml \
-  --packages-for-branch --log-timing
+  --packages-for-branch --log-timing $PACKAGE_SHARDING


### PR DESCRIPTION
The test currently takes about 45 minutes; this starts the process of spliting it into two shards, as on Linux, to bring it more in line with the other repo test durations.