### PR TITLE
[ci] Enable Windows Dart unit test sharding

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -743,7 +743,6 @@ targets:
         ]
 
   - name: Windows dart_unit_tests_shard_1 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -753,7 +752,6 @@ targets:
       package_sharding: "--shardIndex 0 --shardCount 2"
 
   - name: Windows dart_unit_tests_shard_2 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -761,21 +759,6 @@ targets:
       channel: master
       version_file: flutter_master.version
       package_sharding: "--shardIndex 1 --shardCount 2"
-
-  # TODO(stuartmorgan): Remove this when enabling the sharded versions.
-  - name: Windows dart_unit_tests master - packages
-    recipe: packages/packages
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_dart_unit_tests.yaml
-      channel: master
-      version_file: flutter_master.version
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"},
-          {"dependency": "open_jdk", "version": "version:11"}
-        ]
 
   - name: Windows win32-platform_tests_shard_1 master
     recipe: packages/packages


### PR DESCRIPTION
Enables the newly-added sharded tasks, and removes the unsharded version.