### PR TITLE
[ci] Simplify Dockerfile

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,7 +1,6 @@
 # The Flutter version is not important here, since the CI scripts update Flutter
 # before running. What matters is that the base image is pinned to minimize
 # unintended changes when modifying this file.
-# This is the hash for the 3.0.0 image.
 FROM cirrusci/flutter@sha256:d99b1ba2602240a74722970b5c0cd704bbe60a7eba7557157c784f2f693c393f
 
 RUN apt-get update -y
@@ -15,29 +14,3 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
 RUN apt-get update && apt-get install -y google-cloud-sdk && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true
-
-# Install formatter for C-based languages.
-RUN apt-get install -y clang-format
-
-# Install Linux desktop requirements:
-# - build tools.
-RUN apt-get install -y clang cmake ninja-build file pkg-config
-# - libraries.
-RUN apt-get install -y libgtk-3-dev
-# - xvfb to allow running headless.
-RUN apt-get install -y xvfb libegl1-mesa
-
-# Install Chrome and make it the default browser, for Linux url_launcher tests.
-# IMPORTANT: Web tests should use a pinned version of Chromium, not this, since
-# this isn't pinned, so any time the docker image is re-created the version of
-# Chrome may change.
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
-RUN apt-get update && apt-get install -y --no-install-recommends google-chrome-stable
-# Make Chrome the default for http:, https: and file:.
-RUN apt-get install -y xdg-utils
-RUN xdg-settings set default-web-browser google-chrome.desktop
-RUN xdg-mime default google-chrome.desktop inode/directory
-
-# Needed for web_benchmarks.
-RUN sudo apt-get install -y libgbm-dev


### PR DESCRIPTION
Most of the things installed by the Dockerfile are for tests that have moved to LUCI, so are no longer used. This simlifies down to just the FTL requirements while we work on that final conversion.