### PR TITLE
[ci] Migrate remaing unblocked repo checks to LUCI

### DIFF
--- a/.ci/scripts/check_federated_safety.sh
+++ b/.ci/scripts/check_federated_safety.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+set -e
+
+if [[ $LUCI_PR == "" ]]; then
+  echo "This check is only run in presubmit"
+else
+  ./script/tool_runner.sh federation-safety-check
+fi

--- a/.ci/scripts/check_version.sh
+++ b/.ci/scripts/check_version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+set -e
+
+# For pre-submit, this is currently run in Cirrus; see TODO below.
+# For post-submit, ignore platform interface breaking version changes and
+# missing version/CHANGELOG detection since PR-level overrides aren't available
+# in post-submit.
+if [[ $LUCI_PR == "" ]]; then
+  ./script/tool_runner.sh version-check --ignore-platform-interface-breaks
+else
+  # TODO(stuartmorgan): Migrate this check from Cirrus. See
+  # https://github.com/flutter/flutter/issues/130076
+fi

--- a/.ci/scripts/check_version.sh
+++ b/.ci/scripts/check_version.sh
@@ -13,4 +13,5 @@ if [[ $LUCI_PR == "" ]]; then
 else
   # TODO(stuartmorgan): Migrate this check from Cirrus. See
   # https://github.com/flutter/flutter/issues/130076
+  :
 fi

--- a/.ci/targets/repo_checks.yaml
+++ b/.ci/targets/repo_checks.yaml
@@ -48,5 +48,9 @@ tasks:
     script: script/tool_runner.sh
     args: ["publish-check", "--allow-pre-release"]
     always: true
-  # TODO(stuartmorgan): Convert remaining checks from Cirrus repo_checks. See
-  # https://github.com/flutter/flutter/issues/114373
+  - name: CHANGELOG and version validation
+    script: .ci/scripts/check_version.sh
+    always: true
+  - name: federated safety check
+    script: .ci/scripts/check_federated_safety.sh
+    always: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,30 +45,11 @@ task:
     zone: us-central1-a
     namespace: default
   matrix:
-    # Repository rules and best-practice enforcement.
-    # Only channel-agnostic tests should go here since it is only run once
-    # (on Flutter master).
-    - name: repo_checks
-      always:
-        version_script:
-          # For pre-submit, pass the PR labels to the script to allow for
-          # check overrides.
-          # For post-submit, ignore platform version breaking version changes
-          # and missing version/CHANGELOG detection since the labels aren't
-          # available outside of the context of the PR.
-          - if [[ $CIRRUS_PR == "" ]]; then
-          -   ./script/tool_runner.sh version-check --ignore-platform-interface-breaks
-          - else
-          -   ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
-          - fi
-        federated_safety_script:
-          # This check is only meaningful for PRs, as it validates changes
-          # rather than state.
-          - if [[ $CIRRUS_PR == "" ]]; then
-          -   echo "Only run in presubmit"
-          - else
-          -   ./script/tool_runner.sh federation-safety-check
-          - fi
+    # TODO(stuartmorgan): Migrate this to LUCI; See check_version.sh.
+    - name: version_check
+      only_if: $CIRRUS_PR != ''
+      version_script:
+        - ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
 
 # Heavy-workload Linux tasks.
 # These use machines with more CPUs and memory, so will reduce parallelization


### PR DESCRIPTION
Migrates the federated safety check and the post-submit portion of the version check to LUCI, removing the Cirrus versions. Only the presubmit version check, with its specific TODO, is left in Cirrus since we don't yet have a solution for running it under LUCI.

Part of https://github.com/flutter/flutter/issues/114373