### PR TITLE
[go_router] Remove unused dependency

### DIFF
--- a/packages/go_router/example/pubspec.yaml
+++ b/packages/go_router/example/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  adaptive_dialog: 1.8.2
   adaptive_navigation: ^0.0.4
   collection: ^1.15.0
   cupertino_icons: ^1.0.2

--- a/script/configs/allowed_pinned_deps.yaml
+++ b/script/configs/allowed_pinned_deps.yaml
@@ -4,14 +4,16 @@
 # All entries here should have an explanation for why they are here.
 
 # TODO(stuartmorgan): Eliminate this in favor of standardizing on
-# mockito.
+# mockito. See https://github.com/flutter/flutter/issues/130757
 - mocktail
 
-# Legacy allowances, for dependencies that predate the tooling.
-# TODO(stuartmorgan): Audit these. See
-# https://github.com/flutter/flutter/issues/122713
+# Test-only dependency, so does not impact package clients, and
+# has limited impact so could be easily removed if there are
+# ever maintenance issues in the future.
 - lcov_parser
-- adaptive_dialog
+
+# This should be removed; see
+# https://github.com/flutter/flutter/issues/130897
 - provider
 
 ## Allowed by default


### PR DESCRIPTION
Removes `adaptive_dialog` from the example pubspec, as it is not used, and removes the repository allowance for it.

Also updates the comments for the remaining pinned dependency exceptions to reflect the results of the audit.

Part of https://github.com/flutter/flutter/issues/130897

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
