### PR TITLE
[pigeon] feat: add support for generating public encoder and decoder

### DIFF
--- a/packages/pigeon/lib/java_generator.dart
+++ b/packages/pigeon/lib/java_generator.dart
@@ -36,6 +36,7 @@ class JavaOptions {
     this.package,
     this.copyrightHeader,
     this.useGeneratedAnnotation,
+    this.areEncoderDecoderPublic,
   });
 
   /// The name of the class that will house all the generated classes.
@@ -46,6 +47,9 @@ class JavaOptions {
 
   /// A copyright header that will get prepended to generated code.
   final Iterable<String>? copyrightHeader;
+
+  /// If true, generated encoders and decoders will be public.
+  final bool? areEncoderDecoderPublic;
 
   /// Determines if the `javax.annotation.Generated` is used in the output. This
   /// is false by default since that dependency isn't available in plugins by
@@ -61,6 +65,7 @@ class JavaOptions {
       className: map['className'] as String?,
       package: map['package'] as String?,
       copyrightHeader: copyrightHeader?.cast<String>(),
+      areEncoderDecoderPublic: map['areEncoderDecoderPublic'] as bool?,
       useGeneratedAnnotation: map['useGeneratedAnnotation'] as bool?,
     );
   }
@@ -72,6 +77,8 @@ class JavaOptions {
       if (className != null) 'className': className!,
       if (package != null) 'package': package!,
       if (copyrightHeader != null) 'copyrightHeader': copyrightHeader!,
+      if (areEncoderDecoderPublic != null)
+        'areEncoderDecoderPublic': areEncoderDecoderPublic!,
       if (useGeneratedAnnotation != null)
         'useGeneratedAnnotation': useGeneratedAnnotation!,
     };
@@ -332,7 +339,8 @@ class JavaGenerator extends StructuredGenerator<JavaOptions> {
   }) {
     indent.newln();
     indent.writeln('@NonNull');
-    indent.write('ArrayList<Object> toList() ');
+    indent.write(
+        '${generatorOptions.areEncoderDecoderPublic ?? false ? 'public ' : ''}ArrayList<Object> toList() ');
     indent.addScoped('{', '}', () {
       indent.writeln(
           'ArrayList<Object> toListResult = new ArrayList<Object>(${klass.fields.length});');
@@ -371,7 +379,7 @@ class JavaGenerator extends StructuredGenerator<JavaOptions> {
   }) {
     indent.newln();
     indent.write(
-        'static @NonNull ${klass.name} fromList(@NonNull ArrayList<Object> list) ');
+        'static ${generatorOptions.areEncoderDecoderPublic ?? false ? 'public ' : ''} @NonNull ${klass.name} fromList(@NonNull ArrayList<Object> list) ');
     indent.addScoped('{', '}', () {
       const String result = 'pigeonResult';
       indent.writeln('${klass.name} $result = new ${klass.name}();');

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -190,6 +190,7 @@ class PigeonOptions {
     this.astOut,
     this.debugGenerators,
     this.basePath,
+    this.areEncoderDecoderPublic,
     String? dartPackageName,
   }) : _dartPackageName = dartPackageName;
 
@@ -259,6 +260,9 @@ class PigeonOptions {
   /// The name of the package the pigeon files will be used in.
   final String? _dartPackageName;
 
+  /// If true, generated encoders and decoders will be public.
+  final bool? areEncoderDecoderPublic;
+
   /// Creates a [PigeonOptions] from a Map representation where:
   /// `x = PigeonOptions.fromMap(x.toMap())`.
   static PigeonOptions fromMap(Map<String, Object> map) {
@@ -296,6 +300,7 @@ class PigeonOptions {
       astOut: map['astOut'] as String?,
       debugGenerators: map['debugGenerators'] as bool?,
       basePath: map['basePath'] as String?,
+      areEncoderDecoderPublic: map['areEncoderDecoderPublic'] as bool?,
       dartPackageName: map['dartPackageName'] as String?,
     );
   }
@@ -325,6 +330,8 @@ class PigeonOptions {
       if (oneLanguage != null) 'oneLanguage': oneLanguage!,
       if (debugGenerators != null) 'debugGenerators': debugGenerators!,
       if (basePath != null) 'basePath': basePath!,
+      if (areEncoderDecoderPublic != null)
+        'areEncoderDecoderPublic': areEncoderDecoderPublic!,
       if (_dartPackageName != null) 'dartPackageName': _dartPackageName!,
     };
     return result;


### PR DESCRIPTION
When using pigeon in a project with EventChannel, I end up needing to keep an untyped EventChannel. If the Encoder and Decoder methods were public I could use them to type my EventChannels manually by calling `toList` in Native and `decode` in Dart.

https://github.com/flutter/flutter/issues/66711

This PR adds an option to `PigeonOptions` to allow the user to configure the encoder and decoders to be public.

This PR is not yet complete as I would like to get feedback on it. Is it something that could be accepted by the Flutter Team?

It would particularly help with the FlutterFire repository as we are adding Windows support.


I'm not sure what would be the proper way of testing this new feature. Could you provide guidance around this?

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
