### PR TITLE
[ci] Switch FTL to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -470,7 +470,6 @@ targets:
   # https://github.com/flutter/flutter/issues/131429.
 
   - name: Linux_android android_device_tests_shard_1 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -480,7 +479,6 @@ targets:
       package_sharding: "--shardIndex 0 --shardCount 6"
 
   - name: Linux_android android_device_tests_shard_2 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -490,7 +488,6 @@ targets:
       package_sharding: "--shardIndex 1 --shardCount 6"
 
   - name: Linux_android android_device_tests_shard_3 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -500,7 +497,6 @@ targets:
       package_sharding: "--shardIndex 2 --shardCount 6"
 
   - name: Linux_android android_device_tests_shard_4 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -510,7 +506,6 @@ targets:
       package_sharding: "--shardIndex 3 --shardCount 6"
 
   - name: Linux_android android_device_tests_shard_5 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:
@@ -520,7 +515,6 @@ targets:
       package_sharding: "--shardIndex 4 --shardCount 6"
 
   - name: Linux_android android_device_tests_shard_6 master
-    bringup: true # New target
     recipe: packages/packages
     timeout: 60
     properties:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,12 +5,12 @@ only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'main')
 
 setup_template: &SETUP_TEMPLATE
   upgrade_flutter_script:
+    - PINNED_VERSION=$(< .ci/flutter_master.version)
     # Ensure that the repository has everything.
     - cd $FLUTTER_HOME
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch origin
     # Switch to the pinned master version.
-    - PINNED_VERSION=$(< .ci/flutter_master.version)
     - git checkout $TARGET_TREEISH
     # Run doctor to allow auditing of what version of Flutter the run is using.
     - flutter doctor -v

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,5 @@
+gcp_credentials: ENCRYPTED[!9c8e92e8da192ce2a51b7d4ed9948c4250d0bae3660193d9b901196c9692abbebe784d4a32e9f38b328571d65f6e7aed!]
+
 # Run on PRs and main branch post submit only. Don't run tests when tagging.
 only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'main')
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,37 +1,20 @@
 # Run on PRs and main branch post submit only. Don't run tests when tagging.
 only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'main')
-env:
-  CHANNEL: "master" # Default to master when not explicitly set by a task.
 
 setup_template: &SETUP_TEMPLATE
   upgrade_flutter_script:
-    # Channels that are part of our normal test matrix use a pinned,
-    # auto-rolled version to prevent out-of-band CI failures due to changes in
-    # Flutter.
-    - TARGET_TREEISH=$CHANNEL
-    - if [[ "$CHANNEL" == "master" || "$CHANNEL" == "stable" ]]; then
-    -   TARGET_TREEISH=$(< .ci/flutter_$CHANNEL.version)
-    - fi
-    # Ensure that the repository has all the branches.
+    # Ensure that the repository has everything.
     - cd $FLUTTER_HOME
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch origin
-    # Switch to the requested channel.
+    # Switch to the pinned master version.
+    - PINNED_VERSION=$(< .ci/flutter_master.version)
     - git checkout $TARGET_TREEISH
-    # When using a branch rather than a hash or version tag, reset to the
-    # upstream branch rather than using pull, since the base image can sometimes
-    # be in a state where it has diverged from upstream (!).
-    - if [[ "$TARGET_TREEISH" == "$CHANNEL" ]] && [[ "$CHANNEL" != *"."* ]]; then
-    -   git reset --hard @{u}
-    - fi
     # Run doctor to allow auditing of what version of Flutter the run is using.
     - flutter doctor -v
   tool_setup_script:
     - .ci/scripts/prepare_tool.sh
 
-# Light-workload Linux tasks.
-# These use default machines, with fewer CPUs, to reduce pressure on the
-# concurrency limits.
 task:
   << : *SETUP_TEMPLATE
   gke_container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,7 @@
-gcp_credentials: ENCRYPTED[!9c8e92e8da192ce2a51b7d4ed9948c4250d0bae3660193d9b901196c9692abbebe784d4a32e9f38b328571d65f6e7aed!]
-
 # Run on PRs and main branch post submit only. Don't run tests when tagging.
 only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'main')
 env:
   CHANNEL: "master" # Default to master when not explicitly set by a task.
-  PLUGIN_TOOL_COMMAND: "dart ./script/tool/bin/flutter_plugin_tools.dart"
 
 setup_template: &SETUP_TEMPLATE
   upgrade_flutter_script:
@@ -50,44 +47,3 @@ task:
       only_if: $CIRRUS_PR != ''
       version_script:
         - ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$CIRRUS_PR_LABELS"
-
-# Heavy-workload Linux tasks.
-# These use machines with more CPUs and memory, so will reduce parallelization
-# for non-credit runs.
-task:
-  << : *SETUP_TEMPLATE
-  gke_container:
-    dockerfile: .ci/Dockerfile
-    builder_image_name: docker-builder-linux # gce vm image
-    builder_image_project: flutter-cirrus
-    cluster_name: test-cluster
-    zone: us-central1-a
-    namespace: default
-    cpu: 4
-    memory: 16G
-  matrix:
-    ### Android tasks ###
-    - name: android-platform_tests
-      # Don't run full platform tests on both channels in pre-submit.
-      skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
-      env:
-        matrix:
-          PACKAGE_SHARDING: "--shardIndex 0 --shardCount 6"
-          PACKAGE_SHARDING: "--shardIndex 1 --shardCount 6"
-          PACKAGE_SHARDING: "--shardIndex 2 --shardCount 6"
-          PACKAGE_SHARDING: "--shardIndex 3 --shardCount 6"
-          PACKAGE_SHARDING: "--shardIndex 4 --shardCount 6"
-          PACKAGE_SHARDING: "--shardIndex 5 --shardCount 6"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-        GCLOUD_KEY_PATH: $HOME/gcloud-service-key.json
-        MAPS_API_KEY: ENCRYPTED[d6583b08f79f91ea4844c77460f04539965e46ad2fd97fb7c062b4dfe88016228b86ebe8c220ab4187e0c4bd773dc1e7]
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[1a2eebf9367197bbe812d9a0ea83a53a05aeba4bb5e4964fe6a69727883cd87e51238d39237b1f80b0894c48419ac268]
-      firebase_test_lab_script:
-        - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
-        -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > "${GCLOUD_KEY_PATH}"
-        -   ./script/tool_runner.sh firebase-test-lab --device model=redfin,version=30 --exclude=script/configs/exclude_integration_android.yaml --project=flutter-cirrus --results-bucket=flutter_cirrus_testlab --service-key="${GCLOUD_KEY_PATH}"
-        - else
-        -   echo "This user does not have permission to run Firebase Test Lab tests."
-        - fi


### PR DESCRIPTION
Enables the new LUCI targets, and removes the Cirrus version.

Now that Cirrus is only used for a single task that only ever runs against Flutter `master`, also simplifies the remaining Cirrus setup logic to only handle `master`.