### PR TITLE
[ci] Enable Android maps tests for emulators

### DIFF
--- a/script/configs/exclude_integration_android_emulator.yaml
+++ b/script/configs/exclude_integration_android_emulator.yaml
@@ -3,6 +3,3 @@
 - camera/camera
 - camera_android
 - camera_android_camerax
-# Frequent flaky failures, see https://github.com/flutter/flutter/issues/130986
-# TODO(stuartmorgan): Remove once the flake is fixed.
-- google_maps_flutter_android


### PR DESCRIPTION
With the recent flaky test disabling, this enables the maps tests in emulators.

Fixes https://github.com/flutter/flutter/issues/130986