### PR TITLE
[local_auth] Add localizedCancelTitle support for iOS

### DIFF
--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   flutter:
     sdk: flutter
   local_auth_android: ^1.0.0
-  local_auth_ios: ^1.0.0
+  local_auth_ios: ^1.0.1
   local_auth_platform_interface: ^1.0.1
   local_auth_windows: ^1.0.0
 

--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -24,7 +24,10 @@ dependencies:
     sdk: flutter
   local_auth_android: ^1.0.0
   local_auth_ios:
-    path: ../local_auth_ios
+    git:
+      url: https://github.com/0ttik/packages.git
+      ref: 0ttik-patch-1
+      path: packages/local_auth/local_auth_ios
   local_auth_platform_interface: ^1.0.1
   local_auth_windows: ^1.0.0
 

--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -23,7 +23,8 @@ dependencies:
   flutter:
     sdk: flutter
   local_auth_android: ^1.0.0
-  local_auth_ios: ^1.0.1
+  local_auth_ios:
+    path: ../local_auth_ios
   local_auth_platform_interface: ^1.0.1
   local_auth_windows: ^1.0.0
 

--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -23,11 +23,7 @@ dependencies:
   flutter:
     sdk: flutter
   local_auth_android: ^1.0.0
-  local_auth_ios:
-    git:
-      url: https://github.com/0ttik/packages.git
-      ref: 0ttik-patch-1
-      path: packages/local_auth/local_auth_ios
+  local_auth_ios: ^1.0.0
   local_auth_platform_interface: ^1.0.1
   local_auth_windows: ^1.0.0
 

--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixes stale ignore: prefer_const_constructors.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Adds support for localizedCancelTitle for iOS. 
 
 ## 1.1.3
 

--- a/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
@@ -85,6 +85,9 @@ typedef void (^FLAAuthCompletion)(FLAAuthResultDetails *_Nullable, FlutterError 
   NSError *authError = nil;
   self.lastCallState = nil;
   context.localizedFallbackTitle = strings.localizedFallbackTitle;
+  if (@available(iOS 10.0, *)) {
+    context.localizedCancelTitle = strings.localizedCancelTitle;
+  }
 
   LAPolicy policy = options.biometricOnly.boolValue
                         ? LAPolicyDeviceOwnerAuthenticationWithBiometrics

--- a/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
@@ -86,7 +86,7 @@ typedef void (^FLAAuthCompletion)(FLAAuthResultDetails *_Nullable, FlutterError 
   self.lastCallState = nil;
   context.localizedFallbackTitle = strings.localizedFallbackTitle;
   if (@available(iOS 10.0, *)) {
-    context.localizedCancelTitle = strings.localizedCancelTitle;
+    context.localizedCancelTitle = strings.cancelButton;
   }
 
   LAPolicy policy = options.biometricOnly.boolValue


### PR DESCRIPTION
Add localizedCancelTitle support for iOS.

Issue: https://github.com/flutter/flutter/issues/132033. 

I haven't found any tests regarding testing localisation of Apple system local auth dialogs (FaceID, Fingerprint). So I left it as is. 

Please, advise me if the change is ok and I will fill other information for the PR (pubspec.yaml, etc). Thank you!

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
