### PR TITLE
[dynamic_layouts] Refactor flaky test

### DIFF
--- a/packages/dynamic_layouts/example/lib/wrap_layout_example.dart
+++ b/packages/dynamic_layouts/example/lib/wrap_layout_example.dart
@@ -18,6 +18,7 @@ class WrapExample extends StatelessWidget {
       ),
       body: DynamicGridView.builder(
         gridDelegate: const SliverGridDelegateWithWrapping(),
+        itemCount: 20,
         itemBuilder: (BuildContext context, int index) {
           return Container(
             height: index.isEven ? index % 7 * 50 + 150 : index % 4 * 50 + 100,

--- a/packages/dynamic_layouts/example/test/wrap_example_test.dart
+++ b/packages/dynamic_layouts/example/test/wrap_example_test.dart
@@ -7,59 +7,81 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  void withinTolerance(Offset actual, Offset expected, double tolerance) {
-    expect(
-      actual.dx,
-      (double actual) => actual <= expected.dx + tolerance,
-      reason: '${actual.dx} <= ${expected.dx + tolerance}',
-    );
-    expect(
-      actual.dx,
-      (double actual) => actual >= expected.dx - tolerance,
-      reason: '${actual.dx} >= ${expected.dx - tolerance}',
-    );
-    expect(
-      actual.dy,
-      (double actual) => actual <= expected.dy + tolerance,
-      reason: '${actual.dy} <= ${expected.dy + tolerance}',
-    );
-    expect(
-      actual.dy,
-      (double actual) => actual >= expected.dy - tolerance,
-      reason: '${actual.dy} >= ${expected.dy - tolerance}',
-    );
-  }
-
-  testWidgets('Check that the children are layed out.',
-      (WidgetTester tester) async {
+  testWidgets('Check wrap layout', (WidgetTester tester) async {
     const MaterialApp app = MaterialApp(
       home: WrapExample(),
     );
     await tester.pumpWidget(app);
     await tester.pumpAndSettle();
 
-    // See if there are children layed out.
-    expect(find.text('Index 0'), findsOneWidget);
-    expect(find.text('Index 1'), findsOneWidget);
-    expect(find.text('Index 2'), findsOneWidget);
-    expect(find.text('Index 3'), findsOneWidget);
-    expect(find.text('Index 4'), findsOneWidget);
+    // Validate which children are laid out.
+    for (int i = 0; i <= 12; i++) {
+      expect(find.text('Index $i'), findsOneWidget);
+    }
+    for (int i = 13; i < 19; i++) {
+      expect(find.text('Index $i'), findsNothing);
+    }
 
-    // Material 3 changes the expected layout positioning.
-    final bool usesMaterial3 = (app.theme ?? ThemeData.light()).useMaterial3;
-    final Offset offset0 =
-        usesMaterial3 ? const Offset(0.0, 91.0) : const Offset(0.0, 103.0);
-    final Offset offset1 =
-        usesMaterial3 ? const Offset(65.0, 121.0) : const Offset(66.0, 124.0);
-    final Offset offset3 =
-        usesMaterial3 ? const Offset(270.0, 171.0) : const Offset(271.0, 174.0);
-    final Offset offset4 =
-        usesMaterial3 ? const Offset(380.0, 221.0) : const Offset(381.0, 224.0);
+    // Validate with the position of the box, not the text.
+    Finder getContainer(String text) {
+      return find.ancestor(
+        of: find.text(text),
+        matching: find.byType(Container),
+      );
+    }
 
-    // See if they are in expected position.
-    withinTolerance(tester.getTopLeft(find.text('Index 0')), offset0, 0.2);
-    withinTolerance(tester.getTopLeft(find.text('Index 1')), offset1, 0.2);
-    withinTolerance(tester.getTopLeft(find.text('Index 3')), offset3, 0.2);
-    withinTolerance(tester.getTopLeft(find.text('Index 4')), offset4, 0.2);
+    // Validate layout position.
+    expect(
+      tester.getTopLeft(getContainer('Index 0')),
+      const Offset(0.0, 56.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 1')),
+      const Offset(40.0, 56.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 2')),
+      const Offset(190.0, 56.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 3')),
+      const Offset(270.0, 56.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 4')),
+      const Offset(370.0, 56.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 5')),
+      const Offset(490.0, 56.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 6')),
+      const Offset(690.0, 56.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 7')),
+      const Offset(0.0, 506.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 8')),
+      const Offset(150.0, 506.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 9')),
+      const Offset(250.0, 506.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 10')),
+      const Offset(350.0, 506.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 11')),
+      const Offset(390.0, 506.0),
+    );
+    expect(
+      tester.getTopLeft(getContainer('Index 12')),
+      const Offset(590.0, 506.0),
+    );
   });
 }


### PR DESCRIPTION
This refactors a test for the example of a wrapped layout in dynamic_tests. This test had become brittle to small text changes because it would check the precise layout offset of the text.

It was patched in these cases in #4513 and #4677 to address tiny text variations across platforms and material 2/3 defaults. This refactor changes the test to check the layout offset of the parent Container of the text, which should not have these subtle variations.

Fixes https://github.com/flutter/flutter/issues/132321

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
