### PR TITLE
[file_selector] Fix default accept types on iOS

### DIFF
--- a/packages/file_selector/file_selector_ios/CHANGELOG.md
+++ b/packages/file_selector/file_selector_ios/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.5.1+5
 
+* Fixes the behavior of no type groups to allow selecting any file.
 * Migrates `styleFrom` usage in examples off of deprecated `primary` and `onPrimary` parameters.
 
 ## 0.5.1+4

--- a/packages/file_selector/file_selector_ios/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/home_page.dart
@@ -37,6 +37,12 @@ class HomePage extends StatelessWidget {
             const SizedBox(height: 10),
             ElevatedButton(
               style: style,
+              child: const Text('Open any file'),
+              onPressed: () => Navigator.pushNamed(context, '/open/any'),
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              style: style,
               child: const Text('Open multiple images'),
               onPressed: () => Navigator.pushNamed(context, '/open/images'),
             ),

--- a/packages/file_selector/file_selector_ios/example/lib/main.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/main.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import 'home_page.dart';
+import 'open_any_page.dart';
 import 'open_image_page.dart';
 import 'open_multiple_images_page.dart';
 import 'open_text_page.dart';
@@ -32,6 +33,7 @@ class MyApp extends StatelessWidget {
         '/open/images': (BuildContext context) =>
             const OpenMultipleImagesPage(),
         '/open/text': (BuildContext context) => const OpenTextPage(),
+        '/open/any': (BuildContext context) => const OpenAnyPage(),
       },
     );
   }

--- a/packages/file_selector/file_selector_ios/example/lib/open_any_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_any_page.dart
@@ -1,0 +1,78 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/material.dart';
+
+/// Screen that allows the user to select any file file using `openFile`, then
+/// displays its path in a dialog.
+class OpenAnyPage extends StatelessWidget {
+  /// Default Constructor
+  const OpenAnyPage({super.key});
+
+  Future<void> _openTextFile(BuildContext context) async {
+    final XFile? file = await FileSelectorPlatform.instance.openFile();
+    if (file == null) {
+      // Operation was canceled by the user.
+      return;
+    }
+
+    if (context.mounted) {
+      await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) => PathDisplay(file.name, file.path),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Open a file'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blue,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('Press to open a file of any type'),
+              onPressed: () => _openTextFile(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Widget that displays a text file in a dialog.
+class PathDisplay extends StatelessWidget {
+  /// Default Constructor.
+  const PathDisplay(this.fileName, this.filePath, {super.key});
+
+  /// The name of the selected file.
+  final String fileName;
+
+  /// The contents of the text file.
+  final String filePath;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(fileName),
+      content: Text(filePath),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Close'),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/file_selector/file_selector_ios/lib/file_selector_ios.dart
+++ b/packages/file_selector/file_selector_ios/lib/file_selector_ios.dart
@@ -44,14 +44,18 @@ class FileSelectorIOS extends FileSelectorPlatform {
   // Converts the type group list into a list of all allowed UTIs, since
   // iOS doesn't support filter groups.
   List<String> _allowedUtiListFromTypeGroups(List<XTypeGroup>? typeGroups) {
+    // iOS requires a list of allowed types, so allowing all is expressed via
+    // a root type rather than an empty list.
+    const List<String> allowAny = <String>['public.data'];
+
     if (typeGroups == null || typeGroups.isEmpty) {
-      return <String>[];
+      return allowAny;
     }
     final List<String> allowedUTIs = <String>[];
     for (final XTypeGroup typeGroup in typeGroups) {
       // If any group allows everything, no filtering should be done.
       if (typeGroup.allowsAny) {
-        return <String>[];
+        return allowAny;
       }
       if (typeGroup.uniformTypeIdentifiers?.isEmpty ?? true) {
         throw ArgumentError('The provided type group $typeGroup should either '

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_ios
 description: iOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.5.1+4
+version: 0.5.1+5
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/file_selector/file_selector_ios/test/file_selector_ios_test.dart
+++ b/packages/file_selector/file_selector_ios/test/file_selector_ios_test.dart
@@ -72,13 +72,25 @@ void main() {
           throwsArgumentError);
     });
 
-    test('allows a wildcard group', () async {
+    test('correctly handles no type groups', () async {
+      await expectLater(plugin.openFile(), completes);
+      final VerificationResult result = verify(mockApi.openFile(captureAny));
+      final FileSelectorConfig config =
+          result.captured[0] as FileSelectorConfig;
+      expect(listEquals(config.utis, <String>['public.data']), isTrue);
+    });
+
+    test('correctly handles a wildcard group', () async {
       const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 
       await expectLater(
           plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group]), completes);
+      final VerificationResult result = verify(mockApi.openFile(captureAny));
+      final FileSelectorConfig config =
+          result.captured[0] as FileSelectorConfig;
+      expect(listEquals(config.utis, <String>['public.data']), isTrue);
     });
   });
 
@@ -113,6 +125,7 @@ void main() {
           isTrue);
       expect(config.allowMultiSelection, isTrue);
     });
+
     test('throws for a type group that does not support iOS', () async {
       const XTypeGroup group = XTypeGroup(
         label: 'images',
@@ -124,13 +137,25 @@ void main() {
           throwsArgumentError);
     });
 
-    test('allows a wildcard group', () async {
+    test('correctly handles no type groups', () async {
+      await expectLater(plugin.openFiles(), completes);
+      final VerificationResult result = verify(mockApi.openFile(captureAny));
+      final FileSelectorConfig config =
+          result.captured[0] as FileSelectorConfig;
+      expect(listEquals(config.utis, <String>['public.data']), isTrue);
+    });
+
+    test('correctly handles a wildcard group', () async {
       const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 
       await expectLater(
           plugin.openFiles(acceptedTypeGroups: <XTypeGroup>[group]), completes);
+      final VerificationResult result = verify(mockApi.openFile(captureAny));
+      final FileSelectorConfig config =
+          result.captured[0] as FileSelectorConfig;
+      expect(listEquals(config.utis, <String>['public.data']), isTrue);
     });
   });
 }


### PR DESCRIPTION
Uses `public.data` as the default accept type on iOS, instead of an empty list, since unlike on macOS an empty list of accept types doesn't mean to accept every type, so the default on iOS was not allowing any files.

Adds another page to the implementation package's example app to facilitate manual testing of this behavior for package developers.

Fixes https://github.com/flutter/flutter/issues/132211

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
