### PR TITLE
Add advice on code review for this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,20 @@ Additional resources specific to the packages repository:
   [**PRs need tests**](https://github.com/flutter/flutter/wiki/Tree-hygiene#tests), so
   this is critical to read before submitting a plugin PR.
 
-## Notes
+### Code review processes and automation
+
+Each package has a code owner (specified in 
+[CODEOWNERS](https://github.com/flutter/packages/blob/main/CODEOWNERS));
+PRs will automatically be assigned to the appropriate code owners for review.
+Review is expected within a week or two (but preferred much quicker than that!).
+
+Code owners need to explicitly pick a
+[Flutter team member](https://github.com/flutter/flutter/wiki/Contributor-access)
+as their code reviewer for PRs that affect their package,
+usually someone who has contributed to the package before.
+
+For help, join the `#hackers-ecosystem` channel on our
+[Discord server](https://github.com/flutter/flutter/wiki/Chat).
 
 ### Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,18 +20,12 @@ Additional resources specific to the packages repository:
 
 ### Code review processes and automation
 
-Each package has a code owner (specified in 
-[CODEOWNERS](https://github.com/flutter/packages/blob/main/CODEOWNERS));
-PRs will automatically be assigned to the appropriate code owners for review.
-Review is expected within a week or two (but preferred much quicker than that!).
-
-Code owners need to explicitly pick a
+PRs will automatically be assigned to
+[code owners](https://github.com/flutter/packages/blob/main/CODEOWNERS)
+for review.
+If a code owner is creating a PR, they should explicitly pick another
 [Flutter team member](https://github.com/flutter/flutter/wiki/Contributor-access)
-as their code reviewer for PRs that affect their package,
-usually someone who has contributed to the package before.
-
-For help, join the `#hackers-ecosystem` channel on our
-[Discord server](https://github.com/flutter/flutter/wiki/Chat).
+as a code reviewer.
 
 ### Style
 


### PR DESCRIPTION

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
