### PR TITLE
 getting 403 disallowed user agent

### DIFF
--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.39
+
+* The fix addresses a "403 disallow_useragent" error during Google OAuth user authorization
+
 ## 6.0.38
 
 * Updates android implementation to support api 34 broadcast receiver requirements.

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -143,6 +143,8 @@ public class WebViewActivity extends Activity {
     webview.getSettings().setSupportMultipleWindows(true);
     webview.setWebChromeClient(new FlutterWebChromeClient());
 
+    webview.getSettings().setUserAgentString(System.getProperty("http.agent"));
+
     // Register receiver that may finish this Activity.
     ContextCompat.registerReceiver(
         this, broadcastReceiver, closeIntentFilter, ContextCompat.RECEIVER_EXPORTED);

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.38
+version: 6.0.39
 environment:
   sdk: ">=2.18.0 <4.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
Hello!

I would like to present to you a fix that I have made to the `url_launcher_android` package, addressing an issue related to user authorization through Google OAuth.

Problem Description:
When attempting to authorize users via Google OAuth, a `403 disallow_useragent` error was occurring. After investigating the issue, I discovered that the problem was due to the absence of a User-Agent string being set for the `WebViewActivity`. In my fix, I added the following code to the `onCreate` method of the `WebViewActivity` class:

```java
webview.getSettings().setUserAgentString(System.getProperty("http.agent"));
```