### PR TITLE
[webview_flutter] Made the NavigationDegate cloneable

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 4.2.3
 
 * Updates minimum supported SDK version to Flutter 3.7/Dart 2.19.
+* Exposed the `onUrlChange` on the `NavigationDelegate` so it can be cloned.
 
 ## 4.2.2
 

--- a/packages/webview_flutter/webview_flutter/lib/src/navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/navigation_delegate.dart
@@ -118,7 +118,7 @@ class NavigationDelegate {
     this.onPageFinished,
     this.onProgress,
     this.onWebResourceError,
-    void Function(UrlChange change)? onUrlChange,
+    this.onUrlChange,
   }) {
     if (onNavigationRequest != null) {
       platform.setOnNavigationRequest(onNavigationRequest!);
@@ -136,7 +136,7 @@ class NavigationDelegate {
       platform.setOnWebResourceError(onWebResourceError!);
     }
     if (onUrlChange != null) {
-      platform.setOnUrlChange(onUrlChange);
+      platform.setOnUrlChange(onUrlChange!);
     }
   }
 
@@ -166,4 +166,7 @@ class NavigationDelegate {
 
   /// Invoked when a resource loading error occurred.
   final WebResourceErrorCallback? onWebResourceError;
+
+  /// Invoked when the underlying web view changes to a new url.
+  final Function(UrlChange change)? onUrlChange;
 }

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.2.2
+version: 4.2.3
 
 environment:
   sdk: ">=2.19.0 <4.0.0"

--- a/packages/webview_flutter/webview_flutter/test/navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/navigation_delegate_test.dart
@@ -14,6 +14,29 @@ import 'navigation_delegate_test.mocks.dart';
 @GenerateMocks(<Type>[WebViewPlatform, PlatformNavigationDelegate])
 void main() {
   group('NavigationDelegate', () {
+    test('clone', () async {
+      WebViewPlatform.instance = TestWebViewPlatform();
+
+      final NavigationDelegate delegate = NavigationDelegate();
+
+      final NavigationDelegate clone = NavigationDelegate(
+        onNavigationRequest: delegate.onNavigationRequest,
+        onPageStarted: delegate.onPageStarted,
+        onPageFinished: delegate.onPageFinished,
+        onProgress: delegate.onProgress,
+        onWebResourceError: delegate.onWebResourceError,
+        onUrlChange: delegate.onUrlChange,
+      );
+
+      // Assert that the callbacks of the clone are the same as those of the original delegate
+      expect(clone.onNavigationRequest, equals(delegate.onNavigationRequest));
+      expect(clone.onPageStarted, equals(delegate.onPageStarted));
+      expect(clone.onPageFinished, equals(delegate.onPageFinished));
+      expect(clone.onProgress, equals(delegate.onProgress));
+      expect(clone.onWebResourceError, equals(delegate.onWebResourceError));
+      expect(clone.onUrlChange, equals(delegate.onUrlChange));
+    });
+
     test('onNavigationRequest', () async {
       WebViewPlatform.instance = TestWebViewPlatform();
 


### PR DESCRIPTION
I've exposed the `onUrlChange` on the `NavigationDelegate` of the Flutter web view. I've done this so that I can create a custom controller that extends `WebViewController` and override the `setNavigationDelegate` like seen below.
```dart
  @override
  Future<void> setNavigationDelegate(
    NavigationDelegate delegate,
  ) {
    final onPageFinished = delegate.onPageFinished;
    final result = NavigationDelegate(
      onNavigationRequest: delegate.onNavigationRequest,
      onPageStarted: delegate.onPageStarted,
      onPageFinished: (url) {
        onPageFinished?.call(url);
        runJavaScript(
          'window.addEventListener("message", (event) => BeansApp.postMessage(event.data), false);',
        );
      },
      onWebResourceError: delegate.onWebResourceError,
      onProgress: delegate.onProgress,
      onUrlChange: delegate.onUrlChange,
    );
    super.setNavigationDelegate(result);
  }
```

*List which issues are fixed by this PR. You must list at least one issue.*

1. https://github.com/flutter/flutter/issues/132798

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
