### PR TITLE
Update release action Flutter version to 3.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       # the change if it doesn't.
       run: |
         cd $HOME
-        git clone https://github.com/flutter/flutter.git --depth 1 -b 3.10.0 _flutter
+        git clone https://github.com/flutter/flutter.git --depth 1 -b 3.13.0 _flutter
         echo "$HOME/_flutter/bin" >> $GITHUB_PATH
         cd $GITHUB_WORKSPACE
     # Checks out a copy of the repo.


### PR DESCRIPTION
The new package `two_dimensional_scrollables` requires a minimum Flutter version of `3.13.0`, so this bumps the Flutter version of the release action to  `3.13.0`.
