### PR TITLE
[google_maps_flutter_android] Fix for testToggleInfoWindow persistently flaky 

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -938,7 +938,7 @@ void googleMapsTests() {
 
     await tester.pumpAndSettle();
 
-    // TODO (mossmana): Adding this delay addresses 
+    // TODO(mossmana): Adding this delay addresses 
     // https://github.com/flutter/flutter/issues/131783. It may be related
     // to https://github.com/flutter/flutter/issues/54758 and should be
     // re-evaluated when that issue is fixed.

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -938,7 +938,7 @@ void googleMapsTests() {
 
     await tester.pumpAndSettle();
 
-    // TODO(mossmana): Adding this delay addresses 
+    // TODO(mossmana): Adding this delay addresses
     // https://github.com/flutter/flutter/issues/131783. It may be related
     // to https://github.com/flutter/flutter/issues/54758 and should be
     // re-evaluated when that issue is fixed.

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -936,26 +936,26 @@ void googleMapsTests() {
     final ExampleGoogleMapController controller =
         await controllerCompleter.future;
 
+    await tester.pumpAndSettle();
+
+    // TODO (mossmana): Adding this delay addresses 
+    // https://github.com/flutter/flutter/issues/131783. It may be related
+    // to https://github.com/flutter/flutter/issues/54758 and should be
+    // re-evaluated when that issue is fixed.
+    await Future<void>.delayed(const Duration(seconds: 1));
+
     bool iwVisibleStatus =
         await controller.isMarkerInfoWindowShown(marker.markerId);
     expect(iwVisibleStatus, false);
 
     await controller.showMarkerInfoWindow(marker.markerId);
-    // The Maps SDK doesn't always return true for whether it is shown
-    // immediately after showing it, so wait for it to report as shown.
-    iwVisibleStatus = await waitForValueMatchingPredicate<bool>(
-            tester,
-            () => controller.isMarkerInfoWindowShown(marker.markerId),
-            (bool visible) => visible) ??
-        false;
+    iwVisibleStatus = await controller.isMarkerInfoWindowShown(marker.markerId);
     expect(iwVisibleStatus, true);
 
     await controller.hideMarkerInfoWindow(marker.markerId);
     iwVisibleStatus = await controller.isMarkerInfoWindowShown(marker.markerId);
     expect(iwVisibleStatus, false);
-  },
-      // TODO(camsim99): Fix https://github.com/flutter/flutter/issues/131783.
-      skip: true);
+  });
 
   testWidgets('fromAssetImage', (WidgetTester tester) async {
     const double pixelRatio = 2;

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -949,7 +949,13 @@ void googleMapsTests() {
     expect(iwVisibleStatus, false);
 
     await controller.showMarkerInfoWindow(marker.markerId);
-    iwVisibleStatus = await controller.isMarkerInfoWindowShown(marker.markerId);
+    // The Maps SDK doesn't always return true for whether it is shown
+    // immediately after showing it, so wait for it to report as shown.
+    iwVisibleStatus = await waitForValueMatchingPredicate<bool>(
+            tester,
+            () => controller.isMarkerInfoWindowShown(marker.markerId),
+            (bool visible) => visible) ??
+        false;
     expect(iwVisibleStatus, true);
 
     await controller.hideMarkerInfoWindow(marker.markerId);


### PR DESCRIPTION
Fixes issue: https://github.com/flutter/flutter/issues/131783

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.