### PR TITLE
[two_dimensional_scrollables] Fix repaint boundary override in builder delegate

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Fixes override of default TwoDimensionalChildBuilderDelegate.addRepaintBoundaries.
+
 ## 0.0.1+1
 
 * Adds pub topics to package metadata.

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table_delegate.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table_delegate.dart
@@ -124,7 +124,7 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
     required int rowCount,
     int pinnedColumnCount = 0,
     int pinnedRowCount = 0,
-    super.addRepaintBoundaries = false,
+    super.addRepaintBoundaries,
     required TableViewCellBuilder cellBuilder,
     required TableSpanBuilder columnBuilder,
     required TableSpanBuilder rowBuilder,

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.0.1+1
+version: 0.0.2
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/table_view/table_delegate_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_delegate_test.dart
@@ -146,6 +146,17 @@ void main() {
       expect(delegate.maxXIndex, 4); // columns
     });
 
+    test('Respects super class default for addRepaintBoundaries', () {
+      final TableCellBuilderDelegate delegate = TableCellBuilderDelegate(
+        cellBuilder: (_, __) => cell,
+        columnBuilder: (_) => span,
+        rowBuilder: (_) => span,
+        columnCount: 5,
+        rowCount: 6,
+      );
+      expect(delegate.addRepaintBoundaries, isTrue);
+    });
+
     test('Notifies listeners & rebuilds', () {
       int notified = 0;
       TableCellBuilderDelegate oldDelegate;

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -287,24 +287,17 @@ void main() {
       expect(viewport.mainAxis, Axis.vertical);
       // first child
       TableVicinity vicinity = const TableVicinity(column: 0, row: 0);
-      expect(
-        parentDataOf(viewport.firstChild!).vicinity,
-        vicinity,
-      );
       TableViewParentData parentData = parentDataOf(
-        tester.renderObject<RenderBox>(find.byKey(childKeys[vicinity]!)),
+        viewport.firstChild!,
       );
       expect(parentData.vicinity, vicinity);
       expect(parentData.layoutOffset, Offset.zero);
       expect(parentData.isVisible, isTrue);
       // after first child
       vicinity = const TableVicinity(column: 1, row: 0);
-      expect(
-        parentDataOf(viewport.childAfter(viewport.firstChild!)!).vicinity,
-        vicinity,
-      );
+
       parentData = parentDataOf(
-        tester.renderObject<RenderBox>(find.byKey(childKeys[vicinity]!)),
+        viewport.childAfter(viewport.firstChild!)!,
       );
       expect(parentData.vicinity, vicinity);
       expect(parentData.layoutOffset, const Offset(200, 0.0));
@@ -317,13 +310,7 @@ void main() {
 
       // last child
       vicinity = const TableVicinity(column: 4, row: 4);
-      expect(
-        parentDataOf(viewport.lastChild!).vicinity,
-        vicinity,
-      );
-      parentData = parentDataOf(
-        tester.renderObject<RenderBox>(find.byKey(childKeys[vicinity]!)),
-      );
+      parentData = parentDataOf(viewport.lastChild!);
       expect(parentData.vicinity, vicinity);
       expect(parentData.layoutOffset, const Offset(800.0, 800.0));
       expect(parentData.isVisible, isFalse);
@@ -334,12 +321,8 @@ void main() {
       );
       // before last child
       vicinity = const TableVicinity(column: 3, row: 4);
-      expect(
-        parentDataOf(viewport.childBefore(viewport.lastChild!)!).vicinity,
-        vicinity,
-      );
       parentData = parentDataOf(
-        tester.renderObject<RenderBox>(find.byKey(childKeys[vicinity]!)),
+        viewport.childBefore(viewport.lastChild!)!,
       );
       expect(parentData.vicinity, vicinity);
       expect(parentData.layoutOffset, const Offset(600.0, 800.0));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/133582

This fixes a small bug where we accidentally overwrote the default of addRepaintBoundaries

Because of this, I had to refactor a test here that used keys to identify children, but now that an additional render object widget is inserted through the RepaintBoundary, the look-ups broke.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
