### PR TITLE
[go_router] Fixed so that it works even if Scaffold.showBottomSheet is closed.

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Fixed so that it works even if Scaffold.showBottomSheet is closed.
+
 ## 10.1.2
 
 * Adds pub topics to package metadata.

--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -594,7 +594,14 @@ class _PagePopContext {
     final Page<Object?> page = route.settings as Page<Object?>;
 
     final RouteMatch match = _routeMatchesLookUp[page]!.last;
-    _routeMatchesLookUp[page]!.removeLast();
+
+    // If a popup is opened using something like Scaffold.showBottomSheet,
+    // it will be registered in LocalHistoryRoute._localHistory,
+    // so it should be deleted from _routeMatchesLookUp only if
+    // LocalHistoryRoute.willHandlePopInternally is false.
+    if (route is LocalHistoryRoute && route.willHandlePopInternally == false) {
+      _routeMatchesLookUp[page]!.removeLast();
+    }
 
     return onPopPageWithRouteMatch(route, result, match);
   }

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 10.1.2
+version: 10.1.3
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/builder_test.dart
+++ b/packages/go_router/test/builder_test.dart
@@ -356,7 +356,6 @@ void main() {
           'scope1');
     });
 
-
     group('LocalHistoryRoute', () {
       testWidgets('showBottomSheet', (WidgetTester tester) async {
         final List<GoRoute> routes = <GoRoute>[
@@ -380,19 +379,16 @@ void main() {
         final GoRouter router = await createRouter(routes, tester);
         router.go('/');
         await tester.pumpAndSettle();
-        expect(
-          router.routerDelegate.currentConfiguration.matches.last.matchedLocation,
-          '/',
-        );
+        List<RouteMatch> matches =
+            router.routerDelegate.currentConfiguration.matches;
+        expect(matches.last.matchedLocation, '/');
         expect(find.byType(HomeScreen), findsOneWidget);
 
         // "/" -> "/detail"
         router.go('/detail');
         await tester.pumpAndSettle();
-        expect(
-          router.routerDelegate.currentConfiguration.matches.last.matchedLocation,
-          '/detail',
-        );
+        matches = router.routerDelegate.currentConfiguration.matches;
+        expect(matches.last.matchedLocation, '/detail');
         expect(find.byType(_BottomSheetScreen), findsOneWidget);
 
         // "/" -> "/detail" -> showBottomSheet
@@ -446,7 +442,6 @@ class _DetailsScreen extends StatelessWidget {
 }
 
 class _BottomSheetScreen extends StatelessWidget {
-
   const _BottomSheetScreen();
 
   @override


### PR DESCRIPTION
Fixed an issue where using Scaffold.showBottomSheet would prevent screen transitions using the AppBar's back button.

*List which issues are fixed by this PR. You must list at least one issue.*
- [flutter/issue#134370](/flutter/flutter/issues/134370)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
