### PR TITLE
[ios_platform_images] Add integration tests

### DIFF
--- a/packages/ios_platform_images/example/integration_test/ios_platform_images_test.dart
+++ b/packages/ios_platform_images/example/integration_test/ios_platform_images_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:ios_platform_images/ios_platform_images.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('resolves URL', (WidgetTester _) async {
+    final String? path = await IosPlatformImages.resolveURL('textfile');
+    expect(Uri.parse(path!).scheme, 'file');
+    expect(path.contains('Runner.app'), isTrue);
+  });
+
+  testWidgets('loads image', (WidgetTester _) async {
+    final Completer<bool> successCompleter = Completer<bool>();
+    final ImageProvider<Object> provider = IosPlatformImages.load('flutter');
+    final ImageStream imageStream = provider.resolve(ImageConfiguration.empty);
+    imageStream.addListener(
+        ImageStreamListener((ImageInfo image, bool synchronousCall) {
+      successCompleter.complete(true);
+    }, onError: (Object e, StackTrace? _) {
+      successCompleter.complete(false);
+    }));
+
+    final bool succeeded = await successCompleter.future;
+    expect(succeeded, true);
+  });
+}

--- a/packages/ios_platform_images/example/pubspec.yaml
+++ b/packages/ios_platform_images/example/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Currently there are no end-to-end tests for this package that would fail if the communication with the native implementation didn't work, or if the native implementation were broken. This is especially problematic since we want to convert this plugin to both Swift and Pigeon, each of which has the potential to break things that would currently not be caught.

This adds basic integration tests of both methods to ensure that the simple case of a successful call works as expected.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
