### PR TITLE
Add dashboard link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Flutter Packages
 
-[![Build Status](https://api.cirrus-ci.com/github/flutter/packages.svg)](https://cirrus-ci.com/github/flutter/packages/main)
 [![Release Status](https://github.com/flutter/packages/actions/workflows/release.yml/badge.svg)](https://github.com/flutter/packages/actions/workflows/release.yml)
+[![Build Dashboard](https://img.shields.io/badge/Build_Dashboard-60C9F8)](https://flutter-dashboard.appspot.com/#/build?repo=packages)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/flutter/packages/badge)](https://deps.dev/project/github/flutter%2Fpackages)
 
 This repo is a companion repo to the main [flutter repo](


### PR DESCRIPTION
Currently we have a badge for the build status in the repo README, but not a link to the Flutter dashboard for it which is now the primary source of truth. This adds a link to the official dashboard next to the build status.

(Ideally we'd do a dynamic badge based on the actual build status, but I don't know if we have an endpoint we can use to easily get that information, and the `release` badge we already have serves that purspose anyway, so this is fine for now.)