### PR TITLE
[ci] Enable ios_platform_images tests

### DIFF
--- a/script/configs/exclude_integration_ios.yaml
+++ b/script/configs/exclude_integration_ios.yaml
@@ -1,5 +1,3 @@
-# Currently missing: https://github.com/flutter/flutter/issues/82208
-- ios_platform_images
 # Can't use Flutter integration tests due to native modal UI.
 - file_selector_ios
 - file_selector


### PR DESCRIPTION
https://github.com/flutter/packages/pull/4899 added integration tests, but I forgot that they were being excluded in CI. This enables them.

Fixes https://github.com/flutter/flutter/issues/82208
