### PR TITLE
[file_selector] Fix unknown extensions on macOS

### DIFF
--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3+3
+
+* Fixes handling of unknown file extensions on macOS 11+.
+
 ## 0.9.3+2
 
 * Adds pub topics to package metadata.

--- a/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -67,7 +67,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
     if let panel = panelController.openPanel {
       XCTAssertTrue(panel.canChooseFiles)
@@ -104,7 +104,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
     if let panel = panelController.openPanel {
       XCTAssertEqual(panel.directoryURL?.path, "/some/dir")
@@ -140,7 +140,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
   }
 
@@ -173,7 +173,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
     if let panel = panelController.openPanel {
       if #available(macOS 11.0, *) {
@@ -184,6 +184,51 @@ class exampleTests: XCTestCase {
       } else {
         // MIME type is not supported for the legacy codepath, but the rest should be set.
         XCTAssertEqual(panel.allowedFileTypes, ["txt", "json", "public.text", "public.image"])
+      }
+    }
+  }
+
+  func testFilterUnknownFileExtension() throws {
+    let panelController = TestPanelController()
+    let plugin = FileSelectorPlugin(
+      viewProvider: TestViewProvider(),
+      panelController: panelController)
+
+    let unknownExtension = "somenewextension"
+    let returnPath = "/foo/bar"
+    panelController.openURLs = [URL(fileURLWithPath: returnPath)]
+
+    let called = XCTestExpectation()
+    let options = OpenPanelOptions(
+      allowsMultipleSelection: true,
+      canChooseDirectories: false,
+      canChooseFiles: true,
+      baseOptions: SavePanelOptions(
+        allowedFileTypes: AllowedTypes(
+          extensions: [unknownExtension],
+          mimeTypes: [],
+          utis: [])))
+    plugin.displayOpenPanel(options: options) { result in
+      switch result {
+      case .success(let paths):
+        XCTAssertEqual(paths[0], returnPath)
+      case .failure(let error):
+        XCTFail("\(error)")
+      }
+      called.fulfill()
+    }
+
+    wait(for: [called])
+    XCTAssertNotNil(panelController.openPanel)
+    if let panel = panelController.openPanel {
+      if #available(macOS 11.0, *) {
+        XCTAssertEqual(panel.allowedContentTypes.count, 1)
+        XCTAssertEqual(panel.allowedContentTypes[0].preferredFilenameExtension, unknownExtension)
+        // If this isn't true, the dynamic type created for the extension won't work as a file
+        // extension filter.
+        XCTAssertTrue(panel.allowedContentTypes[0].conforms(to: UTType.data))
+      } else {
+        XCTAssertEqual(panel.allowedFileTypes, [unknownExtension])
       }
     }
   }
@@ -218,7 +263,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
     if let panel = panelController.openPanel {
       // On the legacy path, the allowedFileTypes should be set directly.
@@ -257,7 +302,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
   }
 
@@ -282,7 +327,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.savePanel)
   }
 
@@ -309,7 +354,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.savePanel)
     if let panel = panelController.savePanel {
       XCTAssertEqual(panel.directoryURL?.path, "/some/dir")
@@ -335,7 +380,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.savePanel)
   }
 
@@ -364,7 +409,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
     if let panel = panelController.openPanel {
       XCTAssertTrue(panel.canChooseDirectories)
@@ -398,7 +443,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
   }
 
@@ -408,7 +453,7 @@ class exampleTests: XCTestCase {
       viewProvider: TestViewProvider(),
       panelController: panelController)
 
-    let returnPaths = ["/foo/bar", "/foo/test"];
+    let returnPaths = ["/foo/bar", "/foo/test"]
     panelController.openURLs = returnPaths.map({ path in URL(fileURLWithPath: path) })
 
     let called = XCTestExpectation()
@@ -427,7 +472,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
     if let panel = panelController.openPanel {
       XCTAssertTrue(panel.canChooseDirectories)
@@ -459,7 +504,7 @@ class exampleTests: XCTestCase {
       called.fulfill()
     }
 
-    wait(for: [called], timeout: 0.5)
+    wait(for: [called])
     XCTAssertNotNil(panelController.openPanel)
   }
 }

--- a/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
@@ -105,12 +105,12 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin, FileSelectorApi {
         // that via the types; see messages.dart and https://github.com/flutter/flutter/issues/97848
         allowedTypes.append(contentsOf: acceptedTypes.utis.compactMap({ UTType($0!) }))
         allowedTypes.append(
-          contentsOf: acceptedTypes.extensions.flatMap({
-            UTType.types(tag: $0!, tagClass: UTTagClass.filenameExtension, conformingTo: nil)
+          contentsOf: acceptedTypes.extensions.compactMap({
+            UTType.init(filenameExtension: $0!)
           }))
         allowedTypes.append(
-          contentsOf: acceptedTypes.mimeTypes.flatMap({
-            UTType.types(tag: $0!, tagClass: UTTagClass.mimeType, conformingTo: nil)
+          contentsOf: acceptedTypes.mimeTypes.compactMap({
+            UTType.init(mimeType: $0!)
           }))
         if !allowedTypes.isEmpty {
           panel.allowedContentTypes = allowedTypes

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.3+2
+version: 0.9.3+3
 
 environment:
   sdk: ">=2.19.0 <4.0.0"


### PR DESCRIPTION
Fixes a bug in the type lookup that would cause the dynamic `UTType` created for unknown extensions to not work as a save/open panel filter.

As incidental cleanup, removes test timeouts that shouldn't exist per Flutter policy.

Fixes https://github.com/flutter/flutter/issues/134963

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
