### PR TITLE
[various] Update invalid NSURL tests

### DIFF
--- a/packages/url_launcher/url_launcher_ios/example/ios/RunnerTests/URLLauncherTests.swift
+++ b/packages/url_launcher/url_launcher_ios/example/ios/RunnerTests/URLLauncherTests.swift
@@ -39,11 +39,19 @@ final class URLLauncherTests: XCTestCase {
     var error: FlutterError?
     let result = createPlugin().canLaunchURL("urls can't have spaces", error: &error)
 
-    XCTAssertNil(result)
-    XCTAssertNotNil(error)
-    XCTAssertEqual(error?.code, "argument_error")
-    XCTAssertEqual(error?.message, "Unable to parse URL")
-    XCTAssertEqual(error?.details as? String, "Provided URL: urls can't have spaces")
+    if (error == nil) {
+      // When linking against the iOS 17 SDK or later, NSURL uses a lenient parser, and won't
+      // fail to parse URLs, so the test must allow for either outcome.
+      XCTAssertNotNil(result)
+      XCTAssertFalse(result?.boolValue ?? true)
+      XCTAssertNil(error)
+    } else {
+      XCTAssertNil(result)
+      XCTAssertNotNil(error)
+      XCTAssertEqual(error?.code, "argument_error")
+      XCTAssertEqual(error?.message, "Unable to parse URL")
+      XCTAssertEqual(error?.details as? String, "Provided URL: urls can't have spaces")
+    }
   }
 
   func testLaunchSuccess() {
@@ -75,11 +83,19 @@ final class URLLauncherTests: XCTestCase {
     let expectation = XCTestExpectation(description: "completion called")
 
     createPlugin().launchURL("urls can't have spaces", universalLinksOnly: false) { result, error in
-      XCTAssertNil(result)
-      XCTAssertNotNil(error)
-      XCTAssertEqual(error?.code, "argument_error")
-      XCTAssertEqual(error?.message, "Unable to parse URL")
-      XCTAssertEqual(error?.details as? String, "Provided URL: urls can't have spaces")
+      if (error == nil) {
+        // When linking against the iOS 17 SDK or later, NSURL uses a lenient parser, and won't
+        // fail to parse URLs, so the test must allow for either outcome.
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result?.boolValue ?? true)
+        XCTAssertNil(error)
+      } else {
+        XCTAssertNil(result)
+        XCTAssertNotNil(error)
+        XCTAssertEqual(error?.code, "argument_error")
+        XCTAssertEqual(error?.message, "Unable to parse URL")
+        XCTAssertEqual(error?.details as? String, "Provided URL: urls can't have spaces")
+      }
 
       expectation.fulfill()
     }

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
@@ -56,7 +56,6 @@ static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
 
 - (void)testLoadRequestWithInvalidUrl {
   FWFWebView *mockWebView = OCMClassMock([FWFWebView class]);
-  OCMReject([mockWebView loadRequest:OCMOCK_ANY]);
 
   FWFInstanceManager *instanceManager = [[FWFInstanceManager alloc] init];
   [instanceManager addDartCreatedInstance:mockWebView withIdentifier:0];
@@ -65,16 +64,24 @@ static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
       initWithBinaryMessenger:OCMProtocolMock(@protocol(FlutterBinaryMessenger))
               instanceManager:instanceManager];
 
+  NSString *badURLString = @"%invalidUrl%";
   FlutterError *error;
-  FWFNSUrlRequestData *requestData = [FWFNSUrlRequestData makeWithUrl:@"%invalidUrl%"
+  FWFNSUrlRequestData *requestData = [FWFNSUrlRequestData makeWithUrl:badURLString
                                                            httpMethod:nil
                                                              httpBody:nil
                                                   allHttpHeaderFields:@{}];
   [hostAPI loadRequestForWebViewWithIdentifier:@0 request:requestData error:&error];
-  XCTAssertNotNil(error);
-  XCTAssertEqualObjects(error.code, @"FWFURLRequestParsingError");
-  XCTAssertEqualObjects(error.message, @"Failed instantiating an NSURLRequest.");
-  XCTAssertEqualObjects(error.details, @"URL was: '%invalidUrl%'");
+  // When linking against the iOS 17 SDK or later, NSURL uses a lenient parser, and won't
+  // fail to parse URLs, so the test must allow for either outcome.
+  if (error) {
+    XCTAssertEqualObjects(error.code, @"FWFURLRequestParsingError");
+    XCTAssertEqualObjects(error.message, @"Failed instantiating an NSURLRequest.");
+    XCTAssertEqualObjects(error.details, @"URL was: '%invalidUrl%'");
+  } else {
+    NSMutableURLRequest *request =
+        [NSMutableURLRequest requestWithURL:[NSURL URLWithString:badURLString]];
+    OCMVerify([mockWebView loadRequest:request]);
+  }
 }
 
 - (void)testSetCustomUserAgent {


### PR DESCRIPTION
For applications linked against iOS 17 or later, NSURL no longer returns `nil` for invalid URLs, so tests that were specific to that behavior have to be adjusted to allow for another outcome.

Fixes https://github.com/flutter/flutter/issues/134972
Part of https://github.com/flutter/flutter/issues/134971

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
