### PR TITLE
[video_player] Ensures autoplay is false on the web.

### DIFF
--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+* Ensures that the `autoplay` attribute of the underlying video element is set
+  to **false**.
+
 ## 2.1.0
 
 * Adds web options to customize the control list and context menu display.

--- a/packages/video_player/video_player_web/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player_web/example/integration_test/video_player_test.dart
@@ -31,8 +31,11 @@ void main() {
 
       expect(video.controls, isFalse,
           reason: 'Video is controlled through code');
-      expect(video.getAttribute('autoplay'), 'false',
-          reason: 'Cannot autoplay on the web');
+      expect(video.autoplay, isFalse,
+          reason: 'autoplay attribute on HTMLVideoElement MUST be false');
+      // see: https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML
+      expect(video.getAttribute('autoplay'), isNull,
+          reason: 'autoplay attribute on video tag must NOT be set');
       expect(video.getAttribute('playsinline'), 'true',
           reason: 'Needed by safari iOS');
     });

--- a/packages/video_player/video_player_web/lib/src/video_player.dart
+++ b/packages/video_player/video_player_web/lib/src/video_player.dart
@@ -63,11 +63,12 @@ class VideoPlayer {
       ..autoplay = false
       ..controls = false;
 
-    // Allows Safari iOS to play the video inline
+    // Allows Safari iOS to play the video inline.
+    //
+    // This property is not exposed through dart:html so we use the
+    // HTML Boolean attribute form (when present with any value => true)
+    // See: https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML
     _videoElement.setAttribute('playsinline', 'true');
-
-    // Ensure autoplay is not set through the DOM!
-    _videoElement.removeAttribute('autoplay');
 
     _videoElement.onCanPlay.listen((dynamic _) {
       if (!_isInitialized) {

--- a/packages/video_player/video_player_web/lib/src/video_player.dart
+++ b/packages/video_player/video_player_web/lib/src/video_player.dart
@@ -66,8 +66,8 @@ class VideoPlayer {
     // Allows Safari iOS to play the video inline
     _videoElement.setAttribute('playsinline', 'true');
 
-    // Set autoplay to false since most browsers won't autoplay a video unless it is muted
-    _videoElement.setAttribute('autoplay', 'false');
+    // Ensure autoplay is not set through the DOM!
+    _videoElement.removeAttribute('autoplay');
 
     _videoElement.onCanPlay.listen((dynamic _) {
       if (!_isInitialized) {

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.1.0
+version: 2.1.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
### Description

This PR changes the initialization of the `video` element used by the web implementation of the video_player plugin to **ensure the `autoplay` attribute is set to _**false**_**, as expected by the code.

### Issues

* Fixes flutter/flutter#135194
* ~~May be the root cause of flutter/flutter#130147~~ (it isn't, I've seen the integration test failing again)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
