### PR TITLE
[go_router] Fixes the Android back button ignores top level route's o…

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.1
+
+- Fixes the Android back button ignores top level route's onExit.
+
 ## 11.0.0
 
 - Fixes the GoRouter.goBranch so that it doesn't reset extra to null if extra is not serializable.

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -62,6 +62,12 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
         return true;
       }
     }
+    // This should be the only place where the last GoRoute exit the screen.
+    final GoRoute lastRoute =
+        currentConfiguration.matches.last.route as GoRoute;
+    if (lastRoute.onExit != null && navigatorKey.currentContext != null) {
+      return !(await lastRoute.onExit!(navigatorKey.currentContext!));
+    }
     return false;
   }
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 11.0.0
+version: 11.0.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/on_exit_test.dart
+++ b/packages/go_router/test/on_exit_test.dart
@@ -166,4 +166,81 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byKey(home), findsOneWidget);
   });
+
+  testWidgets('android back button respects the last route.',
+      (WidgetTester tester) async {
+    bool allow = false;
+    final UniqueKey home = UniqueKey();
+    final List<GoRoute> routes = <GoRoute>[
+      GoRoute(
+        path: '/',
+        builder: (BuildContext context, GoRouterState state) =>
+            DummyScreen(key: home),
+        onExit: (BuildContext context) {
+          return allow;
+        },
+      ),
+    ];
+
+    final GoRouter router = await createRouter(routes, tester);
+    expect(find.byKey(home), findsOneWidget);
+
+    // Not allow system pop.
+    expect(await router.routerDelegate.popRoute(), true);
+
+    allow = true;
+    expect(await router.routerDelegate.popRoute(), false);
+  });
+
+  testWidgets('android back button respects the last route. async',
+      (WidgetTester tester) async {
+    bool allow = false;
+    final UniqueKey home = UniqueKey();
+    final List<GoRoute> routes = <GoRoute>[
+      GoRoute(
+        path: '/',
+        builder: (BuildContext context, GoRouterState state) =>
+            DummyScreen(key: home),
+        onExit: (BuildContext context) async {
+          return allow;
+        },
+      ),
+    ];
+
+    final GoRouter router = await createRouter(routes, tester);
+    expect(find.byKey(home), findsOneWidget);
+
+    // Not allow system pop.
+    expect(await router.routerDelegate.popRoute(), true);
+
+    allow = true;
+    expect(await router.routerDelegate.popRoute(), false);
+  });
+
+  testWidgets('android back button respects the last route with shell route.',
+      (WidgetTester tester) async {
+    bool allow = false;
+    final UniqueKey home = UniqueKey();
+    final List<RouteBase> routes = <RouteBase>[
+      ShellRoute(builder: (_, __, Widget child) => child, routes: <RouteBase>[
+        GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) =>
+              DummyScreen(key: home),
+          onExit: (BuildContext context) {
+            return allow;
+          },
+        ),
+      ])
+    ];
+
+    final GoRouter router = await createRouter(routes, tester);
+    expect(find.byKey(home), findsOneWidget);
+
+    // Not allow system pop.
+    expect(await router.routerDelegate.popRoute(), true);
+
+    allow = true;
+    expect(await router.routerDelegate.popRoute(), false);
+  });
 }


### PR DESCRIPTION
…nExit.

fixes https://github.com/flutter/flutter/issues/135094

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
