### PR TITLE
[camera_android] Downgrade to AGP 7.3.0 to fix build_alll_packages test failures

### DIFF
--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.8+11
+
+* Downgrade AGP version for compatibility with legacy projects.
+
 ## 0.10.8+10
 
 * Sets android.defaults.buildfeatures.buildconfig to true for compatibility with AGP 8.0+.

--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.10.8+11
 
-* Downgrade AGP version for compatibility with legacy projects.
+* Downgrades AGP version for compatibility with legacy projects.
 
 ## 0.10.8+10
 

--- a/packages/camera/camera_android/android/build.gradle
+++ b/packages/camera/camera_android/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:7.3.0'
     }
 }
 

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 
-version: 0.10.8+10
+version: 0.10.8+11
 
 environment:
   sdk: ">=2.19.0 <4.0.0"

--- a/script/configs/exclude_all_packages_app.yaml
+++ b/script/configs/exclude_all_packages_app.yaml
@@ -6,15 +6,8 @@
 # updating multiple packages for a breaking change in a common dependency in
 # cases where using a relaxed version constraint isn't possible.
 
-# An application cannot depend directly on multiple federated implementations
-# of the same plugin for the same platform, which means the app cannot
-# directly depend on both camera_android and camera_android_androidx.
-# Since camera_android is endorsed, it will be included transitively
-# already, so exclude it from the direct dependency list to allow including
-# camera_android_androidx to ensure that they don't conflict at build time
-# (if they did, it would be impossible to use camera_android_androidx while
-# camera_android is endorsed).
-- camera_android
+# NOTE: camera_android is semi-excluded via special casing in the repo tools.
+# See create_all_packages_app_command.dart.
 
 # This is a permament entry, as it should never be a direct app dependency.
 - plugin_platform_interface

--- a/script/tool/lib/src/create_all_packages_app_command.dart
+++ b/script/tool/lib/src/create_all_packages_app_command.dart
@@ -293,6 +293,20 @@ dependencies {}
       },
       dependencyOverrides: pluginDeps,
     );
+
+    // An application cannot depend directly on multiple federated
+    // implementations of the same plugin for the same platform, which means the
+    // app cannot directly depend on both camera_android and
+    // camera_android_androidx. Since camera_android is endorsed, it will be
+    // included transitively already, so exclude it from the direct dependency
+    // list to allow including camera_android_androidx to ensure that they don't
+    // conflict at build time (if they did, it would be impossible to use
+    // camera_android_androidx while camera_android is endorsed).
+    // This is special-cased here, rather than being done via the normal
+    // exclusion config file mechanism, because it still needs to be in the
+    // depenedency overrides list to ensure that the version from path is used.
+    pubspec.dependencies.remove('camera_android');
+
     app.pubspecFile.writeAsStringSync(_pubspecToString(pubspec));
   }
 


### PR DESCRIPTION
Fixes the current failures of the build_all_packages tests that were caused in https://github.com/flutter/packages/pull/4951/files. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
