### PR TITLE
[ci] Disable maps tests in Android emulator

### DIFF
--- a/script/configs/exclude_integration_android_emulator.yaml
+++ b/script/configs/exclude_integration_android_emulator.yaml
@@ -5,4 +5,5 @@
 - camera_android_camerax
 # Frequent flaky failures, see https://github.com/flutter/flutter/issues/130986
 # TODO(stuartmorgan): Remove once the flake is fixed.
+- google_maps_flutter
 - google_maps_flutter_android


### PR DESCRIPTION
When the emulator tests for Android were brought up, `google_maps_fluter_android` was excluded due to flake. We're also seeing high flake from `google_maps_flutter` on Android, so disabling that as well.

We continue to have coverage of these tests via FTL, so it's only the relatively new emulator version that is being disabled here.

See https://github.com/flutter/flutter/issues/130986