### PR TITLE
[tool] Don't lint Flutter shim podspecs

### DIFF
--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -102,8 +102,10 @@ class PodspecCheckCommand extends PackageLoopingCommand {
   Future<List<File>> _podspecsToLint(RepositoryPackage package) async {
     final List<File> podspecs =
         await getFilesForPackage(package).where((File entity) {
-      final String filePath = entity.path;
-      return path.extension(filePath) == '.podspec';
+      final String filename = entity.basename;
+      return path.extension(filename) == '.podspec' &&
+          filename != 'Flutter.podspec' &&
+          filename != 'FlutterMacOS.podspec';
     }).toList();
 
     podspecs.sort((File a, File b) => a.basename.compareTo(b.basename));

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -171,6 +171,60 @@ void main() {
       expect(output, contains('Bar'));
     });
 
+    test('skips shim podspecs for the Flutter framework', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin1',
+        packagesDir,
+        extraFiles: <String>[
+          'example/ios/Flutter/Flutter.podspec',
+          'example/macos/Flutter/ephemeral/FlutterMacOS.podspec',
+        ],
+      );
+      _writeFakePodspec(plugin, 'macos');
+
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['podspec-check']);
+
+      expect(output, isNot(contains('FlutterMacOS.podspec')));
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall('which', const <String>['pod'], packagesDir.path),
+          ProcessCall(
+              'pod',
+              <String>[
+                'lib',
+                'lint',
+                plugin
+                    .platformDirectory(FlutterPlatform.macos)
+                    .childFile('plugin1.podspec')
+                    .path,
+                '--configuration=Debug',
+                '--skip-tests',
+                '--allow-warnings',
+                '--use-modular-headers',
+                '--use-libraries'
+              ],
+              packagesDir.path),
+          ProcessCall(
+              'pod',
+              <String>[
+                'lib',
+                'lint',
+                plugin
+                    .platformDirectory(FlutterPlatform.macos)
+                    .childFile('plugin1.podspec')
+                    .path,
+                '--configuration=Debug',
+                '--skip-tests',
+                '--allow-warnings',
+                '--use-modular-headers',
+              ],
+              packagesDir.path),
+        ]),
+      );
+    });
+
     test('fails if pod is missing', () async {
       final RepositoryPackage plugin = createFakePlugin('plugin1', packagesDir);
       _writeFakePodspec(plugin, 'ios');


### PR DESCRIPTION
The Flutter build process creates podspecs that are just shims pointing to the local Flutter framework, and which don't pass the linter since they aren't intended for publishing. When finding podspecs to lint, skip those.

This avoids incorrect failures when running on a tree that isn't clean (in particular, where macOS and/or iOS builds have happened), which is very common locally.
