### PR TITLE
[camera] Fix Android autofocus state reading

### DIFF
--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.8+12
+
+* Fixes handling of autofocus state when taking a picture.
+
 ## 0.10.8+11
 
 * Downgrades AGP version for compatibility with legacy projects.

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
@@ -31,7 +31,7 @@ class CameraCaptureCallback extends CaptureCallback {
   CaptureResult.Key<Integer> aeStateKey = CaptureResult.CONTROL_AE_STATE;
 
   @VisibleForTesting @NonNull
-  CaptureResult.Key<Integer> afStateKey = CaptureResult.CONTROL_AE_STATE;
+  CaptureResult.Key<Integer> afStateKey = CaptureResult.CONTROL_AF_STATE;
 
   private CameraCaptureCallback(
       @NonNull CameraCaptureStateListener cameraStateListener,

--- a/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraCaptureCallbackTest.java
+++ b/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraCaptureCallbackTest.java
@@ -69,4 +69,22 @@ public class CameraCaptureCallbackTest {
     verify(mockCaptureProps, times(1)).setLastSensorExposureTime(2L);
     verify(mockCaptureProps, times(1)).setLastSensorSensitivity(3);
   }
+
+  @Test
+  public void onCaptureCompleted_checksBothAutoFocusAndAutoExposure() {
+    CameraCaptureSession mockSession = mock(CameraCaptureSession.class);
+    CaptureRequest mockRequest = mock(CaptureRequest.class);
+    TotalCaptureResult mockResult = mock(TotalCaptureResult.class);
+
+    cameraCaptureCallback.onCaptureCompleted(mockSession, mockRequest, mockResult);
+
+    // This is inherently somewhat fragile since it is testing internal implementation details,
+    // but it is important to test that the code is actually using both of the expected states
+    // since it's easy to typo one of these constants as the other. Ideally this would be tested
+    // via the state machine output (CameraCaptureCallbackStatesTest.java), but testing the state
+    // machine requires overriding the keys, so can't test that the right real keys are used in
+    // production.
+    verify(mockResult, times(1)).get(CaptureResult.CONTROL_AE_STATE);
+    verify(mockResult, times(1)).get(CaptureResult.CONTROL_AF_STATE);
+  }
 }

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 
-version: 0.10.8+11
+version: 0.10.8+12
 
 environment:
   sdk: ">=2.19.0 <4.0.0"


### PR DESCRIPTION
Fixes a typo introduced during a testability refactor that caused the capture state machine to read the wrong value for autofocus state, breaking the state machine.

Fixes https://github.com/flutter/flutter/issues/135554
Part of https://github.com/flutter/flutter/issues/84957

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
