### PR TITLE
[camera] Remove `@throw` from iOS implementation

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.13+6
+
+* Fixes incorrect use of `NSError` that could cause crashes on launch.
+
 ## 0.9.13+5
 
 * Ignores audio samples until the first video sample arrives.

--- a/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					03BB76672665316900CE5A93 = {

--- a/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraPropertiesTests.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraPropertiesTests.m
@@ -19,7 +19,7 @@
   XCTAssertEqual(FLTFlashModeAuto, FLTGetFLTFlashModeForString(@"auto"));
   XCTAssertEqual(FLTFlashModeAlways, FLTGetFLTFlashModeForString(@"always"));
   XCTAssertEqual(FLTFlashModeTorch, FLTGetFLTFlashModeForString(@"torch"));
-  XCTAssertThrows(FLTGetFLTFlashModeForString(@"unkwown"));
+  XCTAssertEqual(FLTFlashModeInvalid, FLTGetFLTFlashModeForString(@"unknown"));
 }
 
 - (void)testFLTGetAVCaptureFlashModeForFLTFlashMode {
@@ -34,13 +34,13 @@
 - (void)testFLTGetStringForFLTExposureMode {
   XCTAssertEqualObjects(@"auto", FLTGetStringForFLTExposureMode(FLTExposureModeAuto));
   XCTAssertEqualObjects(@"locked", FLTGetStringForFLTExposureMode(FLTExposureModeLocked));
-  XCTAssertThrows(FLTGetStringForFLTExposureMode(-1));
+  XCTAssertNil(FLTGetStringForFLTExposureMode(-1));
 }
 
 - (void)testFLTGetFLTExposureModeForString {
   XCTAssertEqual(FLTExposureModeAuto, FLTGetFLTExposureModeForString(@"auto"));
   XCTAssertEqual(FLTExposureModeLocked, FLTGetFLTExposureModeForString(@"locked"));
-  XCTAssertThrows(FLTGetFLTExposureModeForString(@"unknown"));
+  XCTAssertEqual(FLTExposureModeInvalid, FLTGetFLTExposureModeForString(@"unknown"));
 }
 
 #pragma mark - focus mode tests
@@ -48,13 +48,13 @@
 - (void)testFLTGetStringForFLTFocusMode {
   XCTAssertEqualObjects(@"auto", FLTGetStringForFLTFocusMode(FLTFocusModeAuto));
   XCTAssertEqualObjects(@"locked", FLTGetStringForFLTFocusMode(FLTFocusModeLocked));
-  XCTAssertThrows(FLTGetStringForFLTFocusMode(-1));
+  XCTAssertNil(FLTGetStringForFLTFocusMode(-1));
 }
 
 - (void)testFLTGetFLTFocusModeForString {
   XCTAssertEqual(FLTFocusModeAuto, FLTGetFLTFocusModeForString(@"auto"));
   XCTAssertEqual(FLTFocusModeLocked, FLTGetFLTFocusModeForString(@"locked"));
-  XCTAssertThrows(FLTGetFLTFocusModeForString(@"unknown"));
+  XCTAssertEqual(FLTFocusModeInvalid, FLTGetFLTFocusModeForString(@"unknown"));
 }
 
 #pragma mark - resolution preset tests
@@ -67,7 +67,7 @@
   XCTAssertEqual(FLTResolutionPresetVeryHigh, FLTGetFLTResolutionPresetForString(@"veryHigh"));
   XCTAssertEqual(FLTResolutionPresetUltraHigh, FLTGetFLTResolutionPresetForString(@"ultraHigh"));
   XCTAssertEqual(FLTResolutionPresetMax, FLTGetFLTResolutionPresetForString(@"max"));
-  XCTAssertThrows(FLTGetFLTFlashModeForString(@"unknown"));
+  XCTAssertEqual(FLTResolutionPresetInvalid, FLTGetFLTResolutionPresetForString(@"unknown"));
 }
 
 #pragma mark - video format tests
@@ -89,7 +89,7 @@
   XCTAssertEqual(UIDeviceOrientationLandscapeLeft,
                  FLTGetUIDeviceOrientationForString(@"landscapeRight"));
   XCTAssertEqual(UIDeviceOrientationPortrait, FLTGetUIDeviceOrientationForString(@"portraitUp"));
-  XCTAssertThrows(FLTGetUIDeviceOrientationForString(@"unknown"));
+  XCTAssertEqual(UIDeviceOrientationUnknown, FLTGetUIDeviceOrientationForString(@"unknown"));
 }
 
 - (void)testFLTGetStringForUIDeviceOrientation {

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraProperties.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraProperties.h
@@ -17,6 +17,9 @@ typedef NS_ENUM(NSInteger, FLTFlashMode) {
   FLTFlashModeAuto,
   FLTFlashModeAlways,
   FLTFlashModeTorch,
+  // This should never occur; it indicates an unknown value was received over
+  // the platform channel.
+  FLTFlashModeInvalid,
 };
 
 /**
@@ -39,6 +42,9 @@ extern AVCaptureFlashMode FLTGetAVCaptureFlashModeForFLTFlashMode(FLTFlashMode m
 typedef NS_ENUM(NSInteger, FLTExposureMode) {
   FLTExposureModeAuto,
   FLTExposureModeLocked,
+  // This should never occur; it indicates an unknown value was received over
+  // the platform channel.
+  FLTExposureModeInvalid,
 };
 
 /**
@@ -61,6 +67,9 @@ extern FLTExposureMode FLTGetFLTExposureModeForString(NSString *mode);
 typedef NS_ENUM(NSInteger, FLTFocusMode) {
   FLTFocusModeAuto,
   FLTFocusModeLocked,
+  // This should never occur; it indicates an unknown value was received over
+  // the platform channel.
+  FLTFocusModeInvalid,
 };
 
 /**
@@ -100,6 +109,9 @@ typedef NS_ENUM(NSInteger, FLTResolutionPreset) {
   FLTResolutionPresetVeryHigh,
   FLTResolutionPresetUltraHigh,
   FLTResolutionPresetMax,
+  // This should never occur; it indicates an unknown value was received over
+  // the platform channel.
+  FLTResolutionPresetInvalid,
 };
 
 /**

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraProperties.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraProperties.m
@@ -16,13 +16,7 @@ FLTFlashMode FLTGetFLTFlashModeForString(NSString *mode) {
   } else if ([mode isEqualToString:@"torch"]) {
     return FLTFlashModeTorch;
   } else {
-    NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain
-                                         code:NSURLErrorUnknown
-                                     userInfo:@{
-                                       NSLocalizedDescriptionKey : [NSString
-                                           stringWithFormat:@"Unknown flash mode %@", mode]
-                                     }];
-    @throw error;
+    return FLTFlashModeInvalid;
   }
 }
 
@@ -48,14 +42,11 @@ NSString *FLTGetStringForFLTExposureMode(FLTExposureMode mode) {
       return @"auto";
     case FLTExposureModeLocked:
       return @"locked";
+    case FLTExposureModeInvalid:
+      // This value should never actually be used.
+      return nil;
   }
-  NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain
-                                       code:NSURLErrorUnknown
-                                   userInfo:@{
-                                     NSLocalizedDescriptionKey : [NSString
-                                         stringWithFormat:@"Unknown string for exposure mode"]
-                                   }];
-  @throw error;
+  return nil;
 }
 
 FLTExposureMode FLTGetFLTExposureModeForString(NSString *mode) {
@@ -64,13 +55,7 @@ FLTExposureMode FLTGetFLTExposureModeForString(NSString *mode) {
   } else if ([mode isEqualToString:@"locked"]) {
     return FLTExposureModeLocked;
   } else {
-    NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain
-                                         code:NSURLErrorUnknown
-                                     userInfo:@{
-                                       NSLocalizedDescriptionKey : [NSString
-                                           stringWithFormat:@"Unknown exposure mode %@", mode]
-                                     }];
-    @throw error;
+    return FLTExposureModeInvalid;
   }
 }
 
@@ -82,14 +67,11 @@ NSString *FLTGetStringForFLTFocusMode(FLTFocusMode mode) {
       return @"auto";
     case FLTFocusModeLocked:
       return @"locked";
+    case FLTFocusModeInvalid:
+      // This value should never actually be used.
+      return nil;
   }
-  NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain
-                                       code:NSURLErrorUnknown
-                                   userInfo:@{
-                                     NSLocalizedDescriptionKey : [NSString
-                                         stringWithFormat:@"Unknown string for focus mode"]
-                                   }];
-  @throw error;
+  return nil;
 }
 
 FLTFocusMode FLTGetFLTFocusModeForString(NSString *mode) {
@@ -98,13 +80,7 @@ FLTFocusMode FLTGetFLTFocusModeForString(NSString *mode) {
   } else if ([mode isEqualToString:@"locked"]) {
     return FLTFocusModeLocked;
   } else {
-    NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain
-                                         code:NSURLErrorUnknown
-                                     userInfo:@{
-                                       NSLocalizedDescriptionKey : [NSString
-                                           stringWithFormat:@"Unknown focus mode %@", mode]
-                                     }];
-    @throw error;
+    return FLTFocusModeInvalid;
   }
 }
 
@@ -120,14 +96,7 @@ UIDeviceOrientation FLTGetUIDeviceOrientationForString(NSString *orientation) {
   } else if ([orientation isEqualToString:@"portraitUp"]) {
     return UIDeviceOrientationPortrait;
   } else {
-    NSError *error = [NSError
-        errorWithDomain:NSCocoaErrorDomain
-                   code:NSURLErrorUnknown
-               userInfo:@{
-                 NSLocalizedDescriptionKey :
-                     [NSString stringWithFormat:@"Unknown device orientation %@", orientation]
-               }];
-    @throw error;
+    return UIDeviceOrientationUnknown;
   }
 }
 
@@ -163,13 +132,7 @@ FLTResolutionPreset FLTGetFLTResolutionPresetForString(NSString *preset) {
   } else if ([preset isEqualToString:@"max"]) {
     return FLTResolutionPresetMax;
   } else {
-    NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain
-                                         code:NSURLErrorUnknown
-                                     userInfo:@{
-                                       NSLocalizedDescriptionKey : [NSString
-                                           stringWithFormat:@"Unknown resolution preset %@", preset]
-                                     }];
-    @throw error;
+    return FLTResolutionPresetInvalid;
   }
 }
 

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m
@@ -118,10 +118,16 @@ NSString *const errorMethod = @"error";
                              error:(NSError **)error {
   self = [super init];
   NSAssert(self, @"super init cannot be nil");
-  @try {
-    _resolutionPreset = FLTGetFLTResolutionPresetForString(resolutionPreset);
-  } @catch (NSError *e) {
-    *error = e;
+  _resolutionPreset = FLTGetFLTResolutionPresetForString(resolutionPreset);
+  if (_resolutionPreset == FLTResolutionPresetInvalid) {
+    *error = [NSError
+        errorWithDomain:NSCocoaErrorDomain
+                   code:NSURLErrorUnknown
+               userInfo:@{
+                 NSLocalizedDescriptionKey :
+                     [NSString stringWithFormat:@"Unknown resolution preset %@", resolutionPreset]
+               }];
+    return nil;
   }
   _enableAudio = enableAudio;
   _captureSessionQueue = captureSessionQueue;
@@ -162,7 +168,9 @@ NSString *const errorMethod = @"error";
   _motionManager = [[CMMotionManager alloc] init];
   [_motionManager startAccelerometerUpdates];
 
-  [self setCaptureSessionPreset:_resolutionPreset];
+  if (![self setCaptureSessionPreset:_resolutionPreset withError:error]) {
+    return nil;
+  }
   [self updateOrientation];
 
   return self;
@@ -337,7 +345,7 @@ NSString *const errorMethod = @"error";
   return file;
 }
 
-- (void)setCaptureSessionPreset:(FLTResolutionPreset)resolutionPreset {
+- (BOOL)setCaptureSessionPreset:(FLTResolutionPreset)resolutionPreset withError:(NSError **)error {
   switch (resolutionPreset) {
     case FLTResolutionPresetMax:
     case FLTResolutionPresetUltraHigh:
@@ -382,17 +390,17 @@ NSString *const errorMethod = @"error";
         _videoCaptureSession.sessionPreset = AVCaptureSessionPresetLow;
         _previewSize = CGSizeMake(352, 288);
       } else {
-        NSError *error =
-            [NSError errorWithDomain:NSCocoaErrorDomain
-                                code:NSURLErrorUnknown
-                            userInfo:@{
-                              NSLocalizedDescriptionKey :
-                                  @"No capture session available for current capture session."
-                            }];
-        @throw error;
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                     code:NSURLErrorUnknown
+                                 userInfo:@{
+                                   NSLocalizedDescriptionKey :
+                                       @"No capture session available for current capture session."
+                                 }];
+        return NO;
       }
   }
   _audioCaptureSession.sessionPreset = _videoCaptureSession.sessionPreset;
+  return YES;
 }
 
 - (void)captureOutput:(AVCaptureOutput *)output
@@ -726,11 +734,17 @@ NSString *const errorMethod = @"error";
 
 - (void)lockCaptureOrientationWithResult:(FLTThreadSafeFlutterResult *)result
                              orientation:(NSString *)orientationStr {
-  UIDeviceOrientation orientation;
-  @try {
-    orientation = FLTGetUIDeviceOrientationForString(orientationStr);
-  } @catch (NSError *e) {
-    [result sendError:e];
+  UIDeviceOrientation orientation = FLTGetUIDeviceOrientationForString(orientationStr);
+  // "Unknown" should never be sent, so is used to represent an unexpected
+  // value.
+  if (orientation == UIDeviceOrientationUnknown) {
+    [result sendError:[NSError errorWithDomain:NSCocoaErrorDomain
+                                          code:NSURLErrorUnknown
+                                      userInfo:@{
+                                        NSLocalizedDescriptionKey : [NSString
+                                            stringWithFormat:@"Unknown device orientation %@",
+                                                             orientationStr]
+                                      }]];
     return;
   }
 
@@ -749,11 +763,14 @@ NSString *const errorMethod = @"error";
 }
 
 - (void)setFlashModeWithResult:(FLTThreadSafeFlutterResult *)result mode:(NSString *)modeStr {
-  FLTFlashMode mode;
-  @try {
-    mode = FLTGetFLTFlashModeForString(modeStr);
-  } @catch (NSError *e) {
-    [result sendError:e];
+  FLTFlashMode mode = FLTGetFLTFlashModeForString(modeStr);
+  if (mode == FLTFlashModeInvalid) {
+    [result sendError:[NSError errorWithDomain:NSCocoaErrorDomain
+                                          code:NSURLErrorUnknown
+                                      userInfo:@{
+                                        NSLocalizedDescriptionKey : [NSString
+                                            stringWithFormat:@"Unknown flash mode %@", modeStr]
+                                      }]];
     return;
   }
   if (mode == FLTFlashModeTorch) {
@@ -800,11 +817,14 @@ NSString *const errorMethod = @"error";
 }
 
 - (void)setExposureModeWithResult:(FLTThreadSafeFlutterResult *)result mode:(NSString *)modeStr {
-  FLTExposureMode mode;
-  @try {
-    mode = FLTGetFLTExposureModeForString(modeStr);
-  } @catch (NSError *e) {
-    [result sendError:e];
+  FLTExposureMode mode = FLTGetFLTExposureModeForString(modeStr);
+  if (mode == FLTExposureModeInvalid) {
+    [result sendError:[NSError errorWithDomain:NSCocoaErrorDomain
+                                          code:NSURLErrorUnknown
+                                      userInfo:@{
+                                        NSLocalizedDescriptionKey : [NSString
+                                            stringWithFormat:@"Unknown exposure mode %@", modeStr]
+                                      }]];
     return;
   }
   _exposureMode = mode;
@@ -830,11 +850,14 @@ NSString *const errorMethod = @"error";
 }
 
 - (void)setFocusModeWithResult:(FLTThreadSafeFlutterResult *)result mode:(NSString *)modeStr {
-  FLTFocusMode mode;
-  @try {
-    mode = FLTGetFLTFocusModeForString(modeStr);
-  } @catch (NSError *e) {
-    [result sendError:e];
+  FLTFocusMode mode = FLTGetFLTFocusModeForString(modeStr);
+  if (mode == FLTFocusModeInvalid) {
+    [result sendError:[NSError errorWithDomain:NSCocoaErrorDomain
+                                          code:NSURLErrorUnknown
+                                      userInfo:@{
+                                        NSLocalizedDescriptionKey : [NSString
+                                            stringWithFormat:@"Unknown focus mode %@", modeStr]
+                                      }]];
     return;
   }
   _focusMode = mode;

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m
@@ -845,6 +845,11 @@ NSString *const errorMethod = @"error";
         [_captureDevice setExposureMode:AVCaptureExposureModeAutoExpose];
       }
       break;
+    case FLTExposureModeInvalid:
+      // This state is not intended to be reachable; it exists only for error handling during
+      // message deserialization.
+      NSAssert(false, @"");
+      break;
   }
   [_captureDevice unlockForConfiguration];
 }
@@ -883,6 +888,11 @@ NSString *const errorMethod = @"error";
       } else if ([captureDevice isFocusModeSupported:AVCaptureFocusModeAutoFocus]) {
         [captureDevice setFocusMode:AVCaptureFocusModeAutoFocus];
       }
+      break;
+    case FLTFocusModeInvalid:
+      // This state is not intended to be reachable; it exists only for error handling during
+      // message deserialization.
+      NSAssert(false, @"");
       break;
   }
   [captureDevice unlockForConfiguration];

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.13+5
+version: 0.9.13+6
 
 environment:
   sdk: ">=2.19.0 <4.0.0"


### PR DESCRIPTION
Using `@throw` in iOS code violates the style guide, so it shouldn't be done in the plugin as mechanism for communicating errors. More importantly, `NSError` is not intended to be used with `@throw`/`@catch`, and is causing issues when compiled with the iOS 17 SDK.

This removes all use of `@throw`, and all `@catch (NSError* e)`, in favor of other methods of communicating errors. It explicitly does not try to fix all the other strange things about this code (having an `NSError` out-param in an init method, using Cocoa and NSURL error domains and codes for some reason), and instead preserves existing behavior as much as possible. In practice, none of these codepaths should ever actually happen (they indicate programming errors within the plugin, not unexpected runtime behavior), and all of this code will go away when converting to Pigeon anyway, so there's not much value in trying to unwind this structure further.

Fixes https://github.com/flutter/flutter/issues/135195

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
