### PR TITLE
[flutter_markdown] Code decoration

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.17+4
 
-* Fixes an incorrect behavior of code block decoration.
+* Fixes an overlapping content of a code block for its decoration.
 
 ## 0.6.17+3
 

--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.17+4
 
-* Fixes an overlapping content of a code block for its decoration.
+* Fixes an issue where a code block would overlap its container decoration.
 
 ## 0.6.17+3
 

--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.17+4
+
+* Fixes an incorrect behavior of code block decoration.
+
 ## 0.6.17+3
 
 * Fixes an incorrect note about SDK versions in the 0.6.17+2 CHANGELOG.md entry.

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -443,18 +443,10 @@ class MarkdownBuilder implements md.NodeVisitor {
         );
       } else if (tag == 'pre') {
         child = Container(
+          clipBehavior: Clip.hardEdge,
           decoration: styleSheet.codeblockDecoration!,
           child: child,
         );
-        if (styleSheet.codeblockDecoration is BoxDecoration) {
-          BoxDecoration b = styleSheet.codeblockDecoration as BoxDecoration;
-          if (b.borderRadius != null) {
-            child = ClipRRect(
-              borderRadius: b.borderRadius!,
-              child: child,
-            );
-          }
-        }
       } else if (tag == 'hr') {
         child = Container(decoration: styleSheet.horizontalRuleDecoration);
       }

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -444,7 +444,7 @@ class MarkdownBuilder implements md.NodeVisitor {
       } else if (tag == 'pre') {
         child = Container(
           clipBehavior: Clip.hardEdge,
-          decoration: styleSheet.codeblockDecoration!,
+          decoration: styleSheet.codeblockDecoration,
           child: child,
         );
       } else if (tag == 'hr') {

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -442,7 +442,7 @@ class MarkdownBuilder implements md.NodeVisitor {
           ),
         );
       } else if (tag == 'pre') {
-        child = DecoratedBox(
+        child = Container(
           decoration: styleSheet.codeblockDecoration!,
           child: child,
         );

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -446,6 +446,15 @@ class MarkdownBuilder implements md.NodeVisitor {
           decoration: styleSheet.codeblockDecoration!,
           child: child,
         );
+        if (styleSheet.codeblockDecoration is BoxDecoration) {
+          BoxDecoration b = styleSheet.codeblockDecoration as BoxDecoration;
+          if (b.borderRadius != null) {
+            child = ClipRRect(
+              borderRadius: b.borderRadius!,
+              child: child,
+            );
+          }
+        }
       } else if (tag == 'hr') {
         child = Container(decoration: styleSheet.horizontalRuleDecoration);
       }

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.6.17+3
+version: 0.6.17+4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Because of using `DecoratedBox` for code block the content is above the decoration. This PR replaces `DecoratedBox` with `Container`.

![image](https://github.com/flutter/packages/assets/1847552/3203ecaf-23d3-44bd-ad73-f1369aa38020)

Issue: https://github.com/flutter/flutter/issues/135858

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
