### PR TITLE
[webview_flutter] Exposes missing `JavaScriptLogLevel` from platform interface

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 4.4.1
+
+* Exposes `JavaScriptLogLevel` from platform interface.
+
 ## 4.4.0
 
-* Adds support to register a callback to receive JavaScript console messages. See `WebViewController.setConsoleLogCallback`.
+* Adds support to register a callback to receive JavaScript console messages. See `WebViewController.setOnConsoleMessage`.
 
 ## 4.3.0
 

--- a/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
@@ -7,6 +7,7 @@ library webview_flutter;
 export 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart'
     show
         JavaScriptConsoleMessage,
+        JavaScriptLogLevel,
         JavaScriptMessage,
         JavaScriptMode,
         LoadRequestMethod,

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.4.0
+version: 4.4.1
 
 environment:
   sdk: ">=2.19.0 <4.0.0"

--- a/packages/webview_flutter/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_flutter_test.dart
@@ -10,6 +10,10 @@ void main() {
     test('ensure webview_flutter.dart exports classes from platform interface',
         () {
       // ignore: unnecessary_statements
+      main_file.JavaScriptConsoleMessage;
+      // ignore: unnecessary_statements
+      main_file.JavaScriptLogLevel;
+      // ignore: unnecessary_statements
       main_file.JavaScriptMessage;
       // ignore: unnecessary_statements
       main_file.JavaScriptMode;


### PR DESCRIPTION
`JavaScriptConsoleMessage` includes a field with type  `JavaScriptLogLevel` and was missing from https://github.com/flutter/packages/pull/4705.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
