### PR TITLE
[path_provider] Fix integration tests

### DIFF
--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -36,14 +36,14 @@ void main() {
       _verifySampleFile(result, 'library');
     } else if (Platform.isAndroid) {
       final Future<Directory?> result = getLibraryDirectory();
-      expect(result, throwsA(isInstanceOf<UnsupportedError>()));
+      await expectLater(result, throwsA(isInstanceOf<UnsupportedError>()));
     }
   });
 
   testWidgets('getExternalStorageDirectory', (WidgetTester tester) async {
     if (Platform.isIOS) {
       final Future<Directory?> result = getExternalStorageDirectory();
-      expect(result, throwsA(isInstanceOf<UnsupportedError>()));
+      await expectLater(result, throwsA(isInstanceOf<UnsupportedError>()));
     } else if (Platform.isAndroid) {
       final Directory? result = await getExternalStorageDirectory();
       _verifySampleFile(result, 'externalStorage');
@@ -53,7 +53,7 @@ void main() {
   testWidgets('getExternalCacheDirectories', (WidgetTester tester) async {
     if (Platform.isIOS) {
       final Future<List<Directory>?> result = getExternalCacheDirectories();
-      expect(result, throwsA(isInstanceOf<UnsupportedError>()));
+      await expectLater(result, throwsA(isInstanceOf<UnsupportedError>()));
     } else if (Platform.isAndroid) {
       final List<Directory>? directories = await getExternalCacheDirectories();
       expect(directories, isNotNull);
@@ -79,7 +79,7 @@ void main() {
         (WidgetTester tester) async {
       if (Platform.isIOS) {
         final Future<List<Directory>?> result = getExternalStorageDirectories();
-        expect(result, throwsA(isInstanceOf<UnsupportedError>()));
+        await expectLater(result, throwsA(isInstanceOf<UnsupportedError>()));
       } else if (Platform.isAndroid) {
         final List<Directory>? directories =
             await getExternalStorageDirectories(type: type);
@@ -92,17 +92,12 @@ void main() {
   }
 
   testWidgets('getDownloadsDirectory', (WidgetTester tester) async {
-    if (Platform.isAndroid) {
-      final Future<Directory?> result = getDownloadsDirectory();
-      expect(result, throwsA(isInstanceOf<UnsupportedError>()));
-    } else {
-      final Directory? result = await getDownloadsDirectory();
-      // On recent versions of macOS, actually using the downloads directory
-      // requires a user prompt (so will fail on CI), and on some platforms the
-      // directory may not exist. Instead of verifying that it exists, just
-      // check that it returned a path.
-      expect(result?.path, isNotEmpty);
-    }
+    final Directory? result = await getDownloadsDirectory();
+    // On recent versions of macOS, actually using the downloads directory
+    // requires a user prompt (so will fail on CI), and on some platforms the
+    // directory may not exist. Instead of verifying that it exists, just
+    // check that it returned a path.
+    expect(result?.path, isNotEmpty);
   });
 }
 


### PR DESCRIPTION
- Fix the `throwsA` test to properly await.
- Updates the `getDownloadsDirectory` test to not assume that Android will throw, since that is no longer true.