### PR TITLE
[go_router] Fixes missing state.extra in onException()

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.1.3
+
+- Fixes missing state.extra in onException().
+
 ## 11.1.2
 
 - Fixes a bug where the known routes and initial route were logged even when `debugLogDiagnostics` was set to `false`.

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -188,9 +188,14 @@ class RouteConfiguration {
   }
 
   /// The match used when there is an error during parsing.
-  static RouteMatchList _errorRouteMatchList(Uri uri, GoException exception) {
+  static RouteMatchList _errorRouteMatchList(
+    Uri uri,
+    GoException exception, {
+    Object? extra,
+  }) {
     return RouteMatchList(
       matches: const <RouteMatch>[],
+      extra: extra,
       error: exception,
       uri: uri,
       pathParameters: const <String, String>{},
@@ -277,7 +282,10 @@ class RouteConfiguration {
 
     if (matches == null) {
       return _errorRouteMatchList(
-          uri, GoException('no routes for location: $uri'));
+        uri,
+        GoException('no routes for location: $uri'),
+        extra: extra,
+      );
     }
     return RouteMatchList(
         matches: matches,

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 11.1.2
+version: 11.1.3
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/exception_handling_test.dart
+++ b/packages/go_router/test/exception_handling_test.dart
@@ -77,6 +77,21 @@ void main() {
       expect(find.text('redirected /some-other-location'), findsOneWidget);
     });
 
+    testWidgets('can redirect with extra', (WidgetTester tester) async {
+      final GoRouter router = await createRouter(<RouteBase>[
+        GoRoute(
+            path: '/error',
+            builder: (_, GoRouterState state) => Text('extra: ${state.extra}')),
+      ], tester,
+          onException: (_, GoRouterState state, GoRouter router) =>
+              router.go('/error', extra: state.extra));
+      expect(find.text('extra: null'), findsOneWidget);
+
+      router.go('/some-other-location', extra: 'X');
+      await tester.pumpAndSettle();
+      expect(find.text('extra: X'), findsOneWidget);
+    });
+
     testWidgets('stays on the same page if noop.', (WidgetTester tester) async {
       final GoRouter router = await createRouter(
         <RouteBase>[


### PR DESCRIPTION
<!-- *Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.* -->
This will help in knowing the extra Object passed when the _non-existing-location_ was asked.

*List which issues are fixed by this PR. You must list at least one issue.*
- The issue looks small, I will create it if needed by the maintainers

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
- No breaking changes

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
