### PR TITLE
[webview_flutter_wkwebview] skip other navigation requests on iOS

### DIFF
--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
@@ -888,7 +888,7 @@ class WebKitNavigationDelegate extends PlatformNavigationDelegate {
         WKWebView webView,
         WKNavigationAction action,
       ) async {
-        if (weakThis.target?._onNavigationRequest != null) {
+        if (weakThis.target?._onNavigationRequest != null && action.navigationType != WKNavigationType.other) {
           final NavigationDecision decision =
               await weakThis.target!._onNavigationRequest!(NavigationRequest(
             url: action.request.url,


### PR DESCRIPTION
In flutters webview package you can set a navigation delegate which is triggered when the user clicks on a link in the webview. This can be used to load these pages in an in-app browser or external browser for example but I can imagine it has other use-cases as well.

On Android this seems to work well but on iOS the delegate is triggered onload without any user action involved. It seems like this is an implementation issue. Currently, we the `decidePolicyForNavigationAction` handler is used to trigger the navigation delegate in flutter. This is fine but it seems like this handler is more generic on iOS and is also triggered whenever an URL is loaded. The fix has been discussed already:

See: https://github.com/flutter/flutter/issues/73242#issuecomment-1358461716

Now that https://github.com/flutter/plugins/pull/6863 has added support for `WKNavigationAction.navigationType` we can actually solve this issue by excluding `other` navigation types. This is what this PR does, it excludes the `other` navigation type so that both Android and iOS behave similarly.

Issue: https://github.com/flutter/flutter/issues/73242

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
