### PR TITLE
Fix issue link in repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These packages are also available on [pub](https://pub.dartlang.org/flutter/pack
 ## Issues
 
 Please file any issues, bugs, or feature requests in the [main flutter
-repo](https://github.com/flutter/flutter/issues/new).
+repo](https://github.com/flutter/flutter/issues/new/choose).
 Issues pertaining to this repository are [labeled
 "package"](https://github.com/flutter/flutter/issues?q=is%3Aopen+is%3Aissue+label%3Apackage).
 


### PR DESCRIPTION
Currently the link to file an issue bypasses all of the templates; update it to link to the template chooser instead.