### PR TITLE
[ci] Finalize migration to x64 specific Windows platform

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -50,14 +50,6 @@ platform_properties:
         [
           {"dependency": "chrome_and_driver", "version": "version:114.0"}
         ]
-  windows:
-    properties:
-      dependencies: >
-        [
-          {"dependency": "certs", "version": "version:9563bb"}
-        ]
-      device_type: none
-      os: Windows
   windows_x64:
     properties:
       dependencies: >
@@ -901,23 +893,9 @@ targets:
       package_sharding: "--shardIndex 4 --shardCount 5"
 
   ### Windows desktop tasks ###
-  - name: Windows custom_package_tests master - packages
-    recipe: packages/packages
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_custom_package_tests.yaml
-      channel: master
-      version_file: flutter_master.version
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-
   - name: Windows_x64 custom_package_tests master - packages
     recipe: packages/packages
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       target_file: windows_custom_package_tests.yaml
@@ -927,83 +905,34 @@ targets:
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
-
-  - name: Windows dart_unit_tests_shard_1 master
-    recipe: packages/packages
-    timeout: 60
-    properties:
-      target_file: windows_dart_unit_tests.yaml
-      channel: master
-      version_file: flutter_master.version
-      package_sharding: "--shardIndex 0 --shardCount 2"
 
   - name: Windows_x64 dart_unit_tests_shard_1 master
     recipe: packages/packages
     timeout: 60
-    bringup: true
     properties:
       target_file: windows_dart_unit_tests.yaml
       channel: master
       version_file: flutter_master.version
       package_sharding: "--shardIndex 0 --shardCount 2"
-
-  - name: Windows dart_unit_tests_shard_2 master
-    recipe: packages/packages
-    timeout: 60
-    properties:
-      target_file: windows_dart_unit_tests.yaml
-      channel: master
-      version_file: flutter_master.version
-      package_sharding: "--shardIndex 1 --shardCount 2"
 
   - name: Windows_x64 dart_unit_tests_shard_2 master
     recipe: packages/packages
     timeout: 60
-    bringup: true
     properties:
       target_file: windows_dart_unit_tests.yaml
       channel: master
       version_file: flutter_master.version
       package_sharding: "--shardIndex 1 --shardCount 2"
 
-  - name: Windows win32-platform_tests_shard_1 master
-    recipe: packages/packages
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_build_and_platform_tests.yaml
-      channel: master
-      version_file: flutter_master.version
-      package_sharding: "--shardIndex 0 --shardCount 2"
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-
   - name: Windows_x64 win32-platform_tests_shard_1 master
     recipe: packages/packages
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       target_file: windows_build_and_platform_tests.yaml
       channel: master
       version_file: flutter_master.version
       package_sharding: "--shardIndex 0 --shardCount 2"
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-
-  - name: Windows win32-platform_tests_shard_2 master
-    recipe: packages/packages
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_build_and_platform_tests.yaml
-      channel: master
-      version_file: flutter_master.version
-      package_sharding: "--shardIndex 1 --shardCount 2"
       dependencies: >
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -1012,27 +941,12 @@ targets:
   - name: Windows_x64 win32-platform_tests_shard_2 master
     recipe: packages/packages
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       target_file: windows_build_and_platform_tests.yaml
       channel: master
       version_file: flutter_master.version
       package_sharding: "--shardIndex 1 --shardCount 2"
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-
-  - name: Windows win32-platform_tests_shard_1 stable
-    recipe: packages/packages
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_build_and_platform_tests.yaml
-      channel: stable
-      version_file: flutter_stable.version
-      package_sharding: "--shardIndex 0 --shardCount 2"
       dependencies: >
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -1041,7 +955,6 @@ targets:
   - name: Windows_x64 win32-platform_tests_shard_1 stable
     recipe: packages/packages
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       target_file: windows_build_and_platform_tests.yaml
@@ -1053,43 +966,15 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
 
-  - name: Windows win32-platform_tests_shard_2 stable
-    recipe: packages/packages
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_build_and_platform_tests.yaml
-      channel: stable
-      version_file: flutter_stable.version
-      package_sharding: "--shardIndex 1 --shardCount 2"
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-
   - name: Windows_x64 win32-platform_tests_shard_2 stable
     recipe: packages/packages
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       target_file: windows_build_and_platform_tests.yaml
       channel: stable
       version_file: flutter_stable.version
       package_sharding: "--shardIndex 1 --shardCount 2"
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-
-  - name: Windows windows-build_all_packages master
-    recipe: packages/packages
-    timeout: 30
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_build_all_packages.yaml
-      channel: master
-      version_file: flutter_master.version
       dependencies: >
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -1098,25 +983,11 @@ targets:
   - name: Windows_x64 windows-build_all_packages master
     recipe: packages/packages
     timeout: 30
-    bringup: true
     properties:
       add_recipes_cq: "true"
       target_file: windows_build_all_packages.yaml
       channel: master
       version_file: flutter_master.version
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-
-  - name: Windows windows-build_all_packages stable
-    recipe: packages/packages
-    timeout: 30
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_build_all_packages.yaml
-      channel: stable
-      version_file: flutter_stable.version
       dependencies: >
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -1125,7 +996,6 @@ targets:
   - name: Windows_x64 windows-build_all_packages stable
     recipe: packages/packages
     timeout: 30
-    bringup: true
     properties:
       add_recipes_cq: "true"
       target_file: windows_build_all_packages.yaml
@@ -1136,19 +1006,9 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
 
-  - name: Windows repo_tools_tests
-    recipe: packages/packages
-    timeout: 30
-    properties:
-      add_recipes_cq: "true"
-      target_file: repo_tools_tests.yaml
-      channel: master
-      version_file: flutter_master.version
-
   - name: Windows_x64 repo_tools_tests
     recipe: packages/packages
     timeout: 30
-    bringup: true
     properties:
       add_recipes_cq: "true"
       target_file: repo_tools_tests.yaml


### PR DESCRIPTION
_⚠️ Do not merge until after https://github.com/flutter/packages/pull/5133 has both landed and propagated through the infra system_

_⚠️ This pull request is stacked on top of https://github.com/flutter/packages/pull/5133. The base will be updated to `main` once the previous pull request has landed._

https://github.com/flutter/packages/pull/5133 began to migrate the Windows CI tests to use a new x64 specific Windows platform. This completes the migration by removing the old Windows tests and removing `bringup` from the new x64 specific tests.

Here are the resulting changes from both steps of the migration: https://github.com/flutter/packages/compare/main...loic-sharma:flutter-packages:windows_x64_ci_finalize

Prepares for https://github.com/flutter/flutter/issues/129813

Previous stacked pull request: https://github.com/flutter/packages/pull/5133
Next stacked pull request: https://github.com/flutter/packages/pull/5142

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
