### PR TITLE
[image_picker_ios] Update UITests for Xcode 15/iOS 17

### DIFF
--- a/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromGalleryUITests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromGalleryUITests.m
@@ -11,6 +11,8 @@ const int kElementWaitingTime = 30;
 
 @property(nonatomic, strong) XCUIApplication *app;
 
+@property(nonatomic, assign) BOOL interceptedPermissionInterruption;
+
 @end
 
 @implementation ImagePickerFromGalleryUITests
@@ -21,14 +23,18 @@ const int kElementWaitingTime = 30;
 
   self.continueAfterFailure = NO;
   self.app = [[XCUIApplication alloc] init];
+  if (@available(iOS 13.4, *)) {
+    [self.app resetAuthorizationStatusForResource:XCUIProtectedResourcePhotos];
+  }
   [self.app launch];
+  self.interceptedPermissionInterruption = NO;
   __weak typeof(self) weakSelf = self;
   [self addUIInterruptionMonitorWithDescription:@"Permission popups"
                                         handler:^BOOL(XCUIElement *_Nonnull interruptingElement) {
                                           if (@available(iOS 14, *)) {
                                             XCUIElement *allPhotoPermission =
                                                 interruptingElement
-                                                    .buttons[@"Allow Access to All Photos"];
+                                                    .buttons[weakSelf.allowAccessPermissionText];
                                             if (![allPhotoPermission waitForExistenceWithTimeout:
                                                                          kElementWaitingTime]) {
                                               os_log_error(OS_LOG_DEFAULT, "%@",
@@ -50,6 +56,7 @@ const int kElementWaitingTime = 30;
                                             }
                                             [ok tap];
                                           }
+                                          weakSelf.interceptedPermissionInterruption = YES;
                                           return YES;
                                         }];
 }
@@ -57,6 +64,46 @@ const int kElementWaitingTime = 30;
 - (void)tearDown {
   [super tearDown];
   [self.app terminate];
+}
+
+- (NSString *)allowAccessPermissionText {
+  NSString *fullAccessButtonText = @"Allow Access to All Photos";
+  if (@available(iOS 17, *)) {
+    fullAccessButtonText = @"Allow Full Access";
+  }
+  return fullAccessButtonText;
+}
+
+- (void)handlePermissionInterruption {
+  // addUIInterruptionMonitorWithDescription is only invoked when trying to interact with an element
+  // (the app in this case) the alert is blocking. We expect a permission popup here so do a swipe
+  // up action (which should be harmless).
+  [self.app swipeUp];
+
+  if (@available(iOS 17, *)) {
+    // addUIInterruptionMonitorWithDescription does not work consistently on Xcode 15 simulators, so
+    // use a backup method of accepting permissions popup.
+
+    if (self.interceptedPermissionInterruption == YES) {
+      return;
+    }
+
+    // If cancel button exists, permission has already been given.
+    XCUIElement *cancelButton = self.app.buttons[@"Cancel"].firstMatch;
+    if ([cancelButton waitForExistenceWithTimeout:kElementWaitingTime]) {
+      return;
+    }
+
+    XCUIApplication *springboardApp =
+        [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+    XCUIElement *allowButton = springboardApp.buttons[self.allowAccessPermissionText];
+    if (![allowButton waitForExistenceWithTimeout:kElementWaitingTime]) {
+      os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
+      XCTFail(@"Failed due to not able to find allow button with %@ seconds",
+              @(kElementWaitingTime));
+    }
+    [allowButton tap];
+  }
 }
 
 - (void)testCancel {
@@ -80,9 +127,7 @@ const int kElementWaitingTime = 30;
 
   [pickButton tap];
 
-  // There is a known bug where the permission popups interruption won't get fired until a tap
-  // happened in the app. We expect a permission popup so we do a tap here.
-  [self.app tap];
+  [self handlePermissionInterruption];
 
   // Find and tap on the `Cancel` button.
   XCUIElement *cancelButton = self.app.buttons[@"Cancel"].firstMatch;
@@ -151,9 +196,7 @@ const int kElementWaitingTime = 30;
   }
   [pickButton tap];
 
-  // There is a known bug where the permission popups interruption won't get fired until a tap
-  // happened in the app. We expect a permission popup so we do a tap here.
-  [self.app tap];
+  [self handlePermissionInterruption];
 
   // Find an image and tap on it. (IOS 14 UI, images are showing directly)
   XCUIElement *aImage;

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromGalleryUITests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromGalleryUITests.m
@@ -19,11 +19,11 @@ const int kElementWaitingTime = 30;
 
 - (void)setUp {
   [super setUp];
-  // Delete the app if already exists, to test permission popups
 
   self.continueAfterFailure = NO;
   self.app = [[XCUIApplication alloc] init];
   if (@available(iOS 13.4, *)) {
+    // Reset the authorization status for Photos to test permission popups
     [self.app resetAuthorizationStatusForResource:XCUIProtectedResourcePhotos];
   }
   [self.app launch];
@@ -99,7 +99,7 @@ const int kElementWaitingTime = 30;
     XCUIElement *allowButton = springboardApp.buttons[self.allowAccessPermissionText];
     if (![allowButton waitForExistenceWithTimeout:kElementWaitingTime]) {
       os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
-      XCTFail(@"Failed due to not able to find allow button with %@ seconds",
+      XCTFail(@"Failed due to not able to find Allow Access button with %@ seconds",
               @(kElementWaitingTime));
     }
     [allowButton tap];


### PR DESCRIPTION
With Xcode 15, XCTest's `addUIInterruptionMonitorWithDescription` sometimes doesn't work. To fix, I added a fallback to query for the buttons in the permissions dialog.

Also, the Allow text in the permissions dialog is different in iOS 17 than previous versions.

Fixes https://github.com/flutter/flutter/issues/136747

Example passing on Xcode 15 with iOS 17 simulator: https://ci.chromium.org/ui/p/flutter/builders/try/Mac_arm64%20ios_platform_tests_shard_3%20master/7604/overview

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
