### PR TITLE
[flutter_lints] rev flutter_lints to 3.0; increase dep on package:lints

### DIFF
--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 3.0.0
+
+* Updated `package:lints` dependency to version 3.0.0, with the following changes:
+    * added `collection_methods_unrelated_type`
+    * added `dangling_library_doc_comments`
+    * added `implicit_call_tearoffs`
+    * added `secure_pubspec_urls`
+    * added `type_literal_in_constant_pattern`
+    * added `unnecessary_to_list_in_spreads`
+    * added `use_string_in_part_of_directives`
+    * added `use_super_parameters`
+    * removed `iterable_contains_unrelated_type`
+    * removed `list_remove_unrelated_type`
+    * removed `no_wildcard_variable_uses`
+    * removed `prefer_equal_for_default_values`
+    * removed `prefer_void_to_null`
+* Updates minimum supported SDK version to Flutter 3.10 / Dart 3.0.
+
 ## 2.0.3
 
 * Adds pub topics to package metadata.

--- a/packages/flutter_lints/pubspec.yaml
+++ b/packages/flutter_lints/pubspec.yaml
@@ -2,13 +2,13 @@ name: flutter_lints
 description: Recommended lints for Flutter apps, packages, and plugins to encourage good coding practices.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_lints
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_lints%22
-version: 2.0.3
+version: 3.0.0
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   # Code is not allowed in this package. Do not add any dependencies or dev_dependencies.
 
 topics:


### PR DESCRIPTION
- rev package:flutter_lints to 3.0 in order to increase the dep. on package:lints (to its recently released 3.0.0 version)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [-] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
