### PR TITLE
[ci] Fix legacy Android task names

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -533,7 +533,7 @@ targets:
           {"dependency": "android_virtual_device", "version": "33"}
         ]
 
-  - name: linux_android_legacy android_platform_tests_legacy_api_shard_1 master
+  - name: Linux_android_legacy android_platform_tests_legacy_api_shard_1 master
     recipe: packages/packages
     timeout: 60
     bringup: true # New target
@@ -543,7 +543,7 @@ targets:
       version_file: flutter_master.version
       package_sharding: "--shardIndex 0 --shardCount 6"
 
-  - name: linux_android_legacy android_platform_tests_legacy_api_shard_2 master
+  - name: Linux_android_legacy android_platform_tests_legacy_api_shard_2 master
     recipe: packages/packages
     timeout: 60
     bringup: true # New target
@@ -553,7 +553,7 @@ targets:
       version_file: flutter_master.version
       package_sharding: "--shardIndex 1 --shardCount 6"
 
-  - name: linux_android_legacy android_platform_tests_legacy_api_shard_3 master
+  - name: Linux_android_legacy android_platform_tests_legacy_api_shard_3 master
     recipe: packages/packages
     timeout: 60
     bringup: true # New target
@@ -563,7 +563,7 @@ targets:
       version_file: flutter_master.version
       package_sharding: "--shardIndex 2 --shardCount 6"
 
-  - name: linux_android_legacy android_platform_tests_legacy_api_shard_4 master
+  - name: Linux_android_legacy android_platform_tests_legacy_api_shard_4 master
     recipe: packages/packages
     timeout: 60
     bringup: true # New target
@@ -573,7 +573,7 @@ targets:
       version_file: flutter_master.version
       package_sharding: "--shardIndex 3 --shardCount 6"
 
-  - name: linux_android_legacy android_platform_tests_legacy_api_shard_5 master
+  - name: Linux_android_legacy android_platform_tests_legacy_api_shard_5 master
     recipe: packages/packages
     timeout: 60
     bringup: true # New target
@@ -583,7 +583,7 @@ targets:
       version_file: flutter_master.version
       package_sharding: "--shardIndex 4 --shardCount 6"
 
-  - name: linux_android_legacy android_platform_tests_legacy_api_shard_6 master
+  - name: Linux_android_legacy android_platform_tests_legacy_api_shard_6 master
     recipe: packages/packages
     timeout: 60
     bringup: true # New target


### PR DESCRIPTION
Uses a capital for the first letter of the task names for consistency with the other tasks (which affects sorting in the GitHub PR UI).

Part of https://github.com/flutter/flutter/issues/130010
