### PR TITLE
[pigeon] Don't wrap non-nullable primitives in Obj-C

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 13.0.0
+
+* **Breaking Change** [objc] Eliminates boxing of non-nullable primitive types
+  (bool, int, double). Changes required:
+  * Implementations of host API methods that take non-nullable
+    primitives will need to be updated to match the new signatures.
+  * Calls to Flutter API methods that take non-nullable primitives will need to
+    be updated to pass unboxed values.
+  * Calls to non-nullable primitive property methods on generated data classes
+    will need to be updated.
+  * **WARNING**: Current versions of `Xcode` do not appear to warn about
+    implicit `NSNumber *` to `BOOL` conversions, so code that is no longer
+    correct after this breaking change may compile without warning. For example,
+    `myGeneratedClass.aBoolProperty = @NO` can silently set `aBoolProperty` to
+    `YES`. Any data class or Flutter API interactions involving `bool`s should
+    be carefully audited by hand when updating.
+
+
+
 ## 12.0.1
 
 * [swift] Adds protocol for Flutter APIs.

--- a/packages/pigeon/example/app/macos/Runner/messages.g.h
+++ b/packages/pigeon/example/app/macos/Runner/messages.g.h
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSUInteger, PGNCode) {
 @property(nonatomic, copy, nullable) NSString *name;
 @property(nonatomic, copy, nullable) NSString *description;
 @property(nonatomic, assign) PGNCode code;
-@property(nonatomic, strong) NSDictionary<NSString *, NSString *> *data;
+@property(nonatomic, copy) NSDictionary<NSString *, NSString *> *data;
 @end
 
 /// The codec used by PGNExampleHostApi.
@@ -46,8 +46,8 @@ NSObject<FlutterMessageCodec> *PGNExampleHostApiGetCodec(void);
 /// @return `nil` only when `error != nil`.
 - (nullable NSString *)getHostLanguageWithError:(FlutterError *_Nullable *_Nonnull)error;
 /// @return `nil` only when `error != nil`.
-- (nullable NSNumber *)addNumber:(NSNumber *)a
-                        toNumber:(NSNumber *)b
+- (nullable NSNumber *)addNumber:(NSInteger)a
+                        toNumber:(NSInteger)b
                            error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)sendMessageMessage:(PGNMessageData *)message
                 completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;

--- a/packages/pigeon/example/app/macos/Runner/messages.g.m
+++ b/packages/pigeon/example/app/macos/Runner/messages.g.m
@@ -63,7 +63,6 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.description = GetNullableObjectAtIndex(list, 1);
   pigeonResult.code = [GetNullableObjectAtIndex(list, 2) integerValue];
   pigeonResult.data = GetNullableObjectAtIndex(list, 3);
-  NSAssert(pigeonResult.data != nil, @"");
   return pigeonResult;
 }
 + (nullable PGNMessageData *)nullableFromList:(NSArray *)list {
@@ -71,10 +70,10 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 - (NSArray *)toList {
   return @[
-    (self.name ?: [NSNull null]),
-    (self.description ?: [NSNull null]),
+    self.name ?: [NSNull null],
+    self.description ?: [NSNull null],
     @(self.code),
-    (self.data ?: [NSNull null]),
+    self.data ?: [NSNull null],
   ];
 }
 @end

--- a/packages/pigeon/example/app/macos/Runner/messages.g.m
+++ b/packages/pigeon/example/app/macos/Runner/messages.g.m
@@ -160,8 +160,8 @@ void SetUpPGNExampleHostApi(id<FlutterBinaryMessenger> binaryMessenger,
           api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_a = GetNullableObjectAtIndex(args, 0);
-        NSNumber *arg_b = GetNullableObjectAtIndex(args, 1);
+        NSInteger arg_a = [GetNullableObjectAtIndex(args, 0) integerValue];
+        NSInteger arg_b = [GetNullableObjectAtIndex(args, 1) integerValue];
         FlutterError *error;
         NSNumber *output = [api addNumber:arg_a toNumber:arg_b error:&error];
         callback(wrapResult(output, error));

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '12.0.1';
+const String pigeonVersion = '13.0.0';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -232,19 +232,17 @@ class ObjcHeaderGenerator extends StructuredGenerator<ObjcOptions> {
           field,
           classes,
           enums,
-          (TypeDeclaration x) => _objcTypePtrForPrimitiveDartType(prefix, x),
+          (TypeDeclaration x) => _objcTypeStringForPrimitiveDartType(prefix, x,
+              beforeString: true),
           customResolver: customEnumNames.contains(field.type.baseName)
               ? (String x) => _enumName(x, prefix: prefix)
               : (String x) => '${_className(prefix, x)} *');
       late final String propertyType;
       addDocumentationComments(
           indent, field.documentationComments, _docCommentSpec);
-      if (customEnumNames.contains(field.type.baseName) &&
-          !field.type.isNullable) {
-        propertyType = 'assign';
-      } else {
-        propertyType = _propertyTypeForDartType(field);
-      }
+      propertyType = _propertyTypeForDartType(field,
+          isNullable: field.type.isNullable,
+          isEnum: customEnumNames.contains(field.type.baseName));
       final String nullability = field.type.isNullable ? ', nullable' : '';
       final String fieldType = isEnum(root, field.type) && field.type.isNullable
           ? _enumName(field.type.baseName,
@@ -314,7 +312,7 @@ class ObjcHeaderGenerator extends StructuredGenerator<ObjcOptions> {
     indent.writeln(
         '- (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger;');
     for (final Method func in api.methods) {
-      final _ObjcPtr returnType =
+      final _ObjcType returnType =
           _objcTypeForDartType(generatorOptions.prefix, func.returnType);
       final String callbackType =
           _callbackForType(root, func.returnType, returnType, generatorOptions);
@@ -354,8 +352,13 @@ class ObjcHeaderGenerator extends StructuredGenerator<ObjcOptions> {
 
     indent.writeln('@protocol $apiName');
     for (final Method func in api.methods) {
-      final _ObjcPtr returnTypeName =
-          _objcTypeForDartType(generatorOptions.prefix, func.returnType);
+      final _ObjcType returnTypeName = _objcTypeForDartType(
+        generatorOptions.prefix,
+        func.returnType,
+        // Nullability is required since the return must be nil if NSError is
+        // set.
+        forceNullability: true,
+      );
 
       String? lastArgName;
       String? lastArgType;
@@ -375,7 +378,7 @@ class ObjcHeaderGenerator extends StructuredGenerator<ObjcOptions> {
           lastArgType = 'void (^)($enumReturnType, FlutterError *_Nullable)';
         } else {
           lastArgType =
-              'void (^)(${returnTypeName.withPtr}_Nullable, FlutterError *_Nullable)';
+              'void (^)(${returnTypeName.beforeString}_Nullable, FlutterError *_Nullable)';
         }
       } else {
         if (func.returnType.isVoid) {
@@ -383,7 +386,7 @@ class ObjcHeaderGenerator extends StructuredGenerator<ObjcOptions> {
         } else if (isEnum(root, func.returnType)) {
           returnType = enumReturnType;
         } else {
-          returnType = 'nullable ${returnTypeName.withPtr.trim()}';
+          returnType = 'nullable $returnTypeName';
         }
 
         lastArgType = 'FlutterError *_Nullable *_Nonnull';
@@ -730,17 +733,17 @@ class ObjcSourceGenerator extends StructuredGenerator<ObjcOptions> {
                 '$className $argName = [GetNullableObjectAtIndex(args, $count) integerValue];');
           }
         } else {
-          final _ObjcPtr argType =
+          final _ObjcType argType =
               _objcTypeForDartType(generatorOptions.prefix, arg.type);
           indent.writeln(
-              '${argType.withPtr}$argName = GetNullableObjectAtIndex(args, $count);');
+              '${argType.beforeString}$argName = GetNullableObjectAtIndex(args, $count);');
         }
         count++;
       }
     }
 
     void writeAsyncBindings(Iterable<String> selectorComponents,
-        String callSignature, _ObjcPtr returnType) {
+        String callSignature, _ObjcType returnType) {
       if (func.returnType.isVoid) {
         const String callback = 'callback(wrapResult(nil, error));';
         if (func.arguments.isEmpty) {
@@ -758,7 +761,7 @@ class ObjcSourceGenerator extends StructuredGenerator<ObjcOptions> {
         }
       } else {
         const String callback = 'callback(wrapResult(output, error));';
-        String returnTypeString = '${returnType.withPtr}_Nullable output';
+        String returnTypeString = '${returnType.beforeString}_Nullable output';
         const String numberOutput = 'NSNumber *output =';
         const String enumConversionExpression =
             'enumValue == nil ? nil : [NSNumber numberWithInteger:enumValue.value];';
@@ -789,7 +792,7 @@ class ObjcSourceGenerator extends StructuredGenerator<ObjcOptions> {
       }
     }
 
-    void writeSyncBindings(String call, _ObjcPtr returnType) {
+    void writeSyncBindings(String call, _ObjcType returnType) {
       indent.writeln('FlutterError *error;');
       if (func.returnType.isVoid) {
         indent.writeln('$call;');
@@ -801,7 +804,7 @@ class ObjcSourceGenerator extends StructuredGenerator<ObjcOptions> {
           indent.writeln(
               'NSNumber *output = enumBox == nil ? nil : [NSNumber numberWithInteger:enumBox.value];');
         } else {
-          indent.writeln('${returnType.withPtr}output = $call;');
+          indent.writeln('${returnType.beforeString}output = $call;');
         }
         indent.writeln('callback(wrapResult(output, error));');
       }
@@ -816,7 +819,7 @@ class ObjcSourceGenerator extends StructuredGenerator<ObjcOptions> {
     indent.write(
         '[$channel setMessageHandler:^(id _Nullable message, FlutterReply callback) ');
     indent.addScoped('{', '}];', () {
-      final _ObjcPtr returnType =
+      final _ObjcType returnType =
           _objcTypeForDartType(generatorOptions.prefix, func.returnType);
       final Iterable<String> selectorComponents =
           _getSelectorComponents(func, lastSelectorComponent);
@@ -1042,8 +1045,12 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
     Method func, {
     required String dartPackageName,
   }) {
-    final _ObjcPtr returnType =
-        _objcTypeForDartType(languageOptions.prefix, func.returnType);
+    final _ObjcType returnType = _objcTypeForDartType(
+      languageOptions.prefix,
+      func.returnType,
+      // Nullability is required since the return must be nil if NSError is set.
+      forceNullability: true,
+    );
     final String callbackType =
         _callbackForType(root, func.returnType, returnType, languageOptions);
 
@@ -1116,7 +1123,8 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
                 indent.writeln(
                     '$enumName *output = outputAsNumber == nil ? nil : [[$enumName alloc] initWithValue:[outputAsNumber integerValue]];');
               } else {
-                indent.writeln('${returnType.withPtr}output = $nullCheck;');
+                indent
+                    .writeln('${returnType.beforeString}output = $nullCheck;');
               }
               indent.writeln('completion(output, nil);');
             }
@@ -1159,7 +1167,8 @@ void _writeObjcSourceClassInitializerDeclaration(
           field,
           classes,
           enums,
-          (TypeDeclaration x) => _objcTypePtrForPrimitiveDartType(prefix, x),
+          (TypeDeclaration x) => _objcTypeStringForPrimitiveDartType(prefix, x,
+              beforeString: true),
           customResolver: customEnumNames.contains(field.type.baseName)
               ? (String x) => field.type.isNullable
                   ? _enumName(x, suffix: ' *', prefix: prefix, box: true)
@@ -1186,38 +1195,63 @@ String _className(String? prefix, String className) {
 
 /// Calculates callback block signature for async methods.
 String _callbackForType(
-    Root root, TypeDeclaration type, _ObjcPtr objcType, ObjcOptions options) {
+    Root root, TypeDeclaration type, _ObjcType objcType, ObjcOptions options) {
   if (type.isVoid) {
     return 'void (^)(FlutterError *_Nullable)';
   } else if (isEnum(root, type)) {
     return 'void (^)(${_enumName(objcType.baseName, suffix: ' *_Nullable', prefix: options.prefix, box: true)}, FlutterError *_Nullable)';
   } else {
-    return 'void (^)(${objcType.withPtr}_Nullable, FlutterError *_Nullable)';
+    return 'void (^)(${objcType.beforeString}_Nullable, FlutterError *_Nullable)';
   }
 }
 
-/// Represents an ObjC pointer (ex 'id', 'NSString *').
-class _ObjcPtr {
-  const _ObjcPtr({required this.baseName}) : hasAsterisk = baseName != 'id';
+/// Represents an Objective-C type, including pointer (id, NSString*, etc.) and
+/// primitive (BOOL, NSInteger, etc.) types.
+class _ObjcType {
+  const _ObjcType({required this.baseName, bool isPointer = true})
+      : hasAsterisk = isPointer && baseName != 'id';
   final String baseName;
   final bool hasAsterisk;
-  String get withPtr => '$baseName${hasAsterisk ? ' *' : ' '}';
-  String get ptr => hasAsterisk ? '*' : '';
+
+  @override
+  String toString() => hasAsterisk ? '$baseName *' : baseName;
+
+  /// Returns a version of the string form that can be used directly before
+  /// another string (e.g., a variable name) and handle spacing correctly for
+  /// a right-aligned pointer format.
+  String get beforeString => hasAsterisk ? toString() : '$this ';
 }
 
 /// Maps between Dart types to ObjC pointer types (ex 'String' => 'NSString *').
-const Map<String, _ObjcPtr> _objcTypeForDartTypeMap = <String, _ObjcPtr>{
-  'bool': _ObjcPtr(baseName: 'NSNumber'),
-  'int': _ObjcPtr(baseName: 'NSNumber'),
-  'String': _ObjcPtr(baseName: 'NSString'),
-  'double': _ObjcPtr(baseName: 'NSNumber'),
-  'Uint8List': _ObjcPtr(baseName: 'FlutterStandardTypedData'),
-  'Int32List': _ObjcPtr(baseName: 'FlutterStandardTypedData'),
-  'Int64List': _ObjcPtr(baseName: 'FlutterStandardTypedData'),
-  'Float64List': _ObjcPtr(baseName: 'FlutterStandardTypedData'),
-  'List': _ObjcPtr(baseName: 'NSArray'),
-  'Map': _ObjcPtr(baseName: 'NSDictionary'),
-  'Object': _ObjcPtr(baseName: 'id'),
+const Map<String, _ObjcType> _objcTypeForNullableDartTypeMap =
+    <String, _ObjcType>{
+  'bool': _ObjcType(baseName: 'NSNumber'),
+  'int': _ObjcType(baseName: 'NSNumber'),
+  'String': _ObjcType(baseName: 'NSString'),
+  'double': _ObjcType(baseName: 'NSNumber'),
+  'Uint8List': _ObjcType(baseName: 'FlutterStandardTypedData'),
+  'Int32List': _ObjcType(baseName: 'FlutterStandardTypedData'),
+  'Int64List': _ObjcType(baseName: 'FlutterStandardTypedData'),
+  'Float64List': _ObjcType(baseName: 'FlutterStandardTypedData'),
+  'List': _ObjcType(baseName: 'NSArray'),
+  'Map': _ObjcType(baseName: 'NSDictionary'),
+  'Object': _ObjcType(baseName: 'id'),
+};
+
+/// Maps between Dart types to ObjC pointer types (ex 'String' => 'NSString *').
+const Map<String, _ObjcType> _objcTypeForNonNullableDartTypeMap =
+    <String, _ObjcType>{
+  'bool': _ObjcType(baseName: 'BOOL', isPointer: false),
+  'int': _ObjcType(baseName: 'NSInteger', isPointer: false),
+  'String': _ObjcType(baseName: 'NSString'),
+  'double': _ObjcType(baseName: 'double', isPointer: false),
+  'Uint8List': _ObjcType(baseName: 'FlutterStandardTypedData'),
+  'Int32List': _ObjcType(baseName: 'FlutterStandardTypedData'),
+  'Int64List': _ObjcType(baseName: 'FlutterStandardTypedData'),
+  'Float64List': _ObjcType(baseName: 'FlutterStandardTypedData'),
+  'List': _ObjcType(baseName: 'NSArray'),
+  'Map': _ObjcType(baseName: 'NSDictionary'),
+  'Object': _ObjcType(baseName: 'id'),
 };
 
 /// Converts list of [TypeDeclaration] to a code string representing the type
@@ -1226,52 +1260,71 @@ const Map<String, _ObjcPtr> _objcTypeForDartTypeMap = <String, _ObjcPtr>{
 String _flattenTypeArguments(String? classPrefix, List<TypeDeclaration> args) {
   final String result = args
       .map<String>((TypeDeclaration e) =>
-          _objcTypeForDartType(classPrefix, e).withPtr.trim())
+          _objcTypeForDartType(classPrefix, e).toString())
       .join(', ');
   return result;
 }
 
-String? _objcTypePtrForPrimitiveDartType(
-    String? classPrefix, TypeDeclaration type) {
-  return _objcTypeForDartTypeMap.containsKey(type.baseName)
-      ? _objcTypeForDartType(classPrefix, type).withPtr
-      : null;
+_ObjcType? _objcTypeForPrimitiveDartType(TypeDeclaration type,
+    {bool forceNullability = false}) {
+  return forceNullability || type.isNullable
+      ? _objcTypeForNullableDartTypeMap[type.baseName]
+      : _objcTypeForNonNullableDartTypeMap[type.baseName];
 }
 
-/// Returns the objc type for a dart [type], prepending the [classPrefix] for
-/// generated classes.  For example:
-/// _objcTypeForDartType(null, 'int') => 'NSNumber'.
-_ObjcPtr _objcTypeForDartType(String? classPrefix, TypeDeclaration field) {
-  return _objcTypeForDartTypeMap.containsKey(field.baseName)
-      ? field.typeArguments.isEmpty
-          ? _objcTypeForDartTypeMap[field.baseName]!
-          : _ObjcPtr(
+String? _objcTypeStringForPrimitiveDartType(
+    String? classPrefix, TypeDeclaration type,
+    {required bool beforeString, bool forceNullability = false}) {
+  final _ObjcType? objcType;
+  if (forceNullability || type.isNullable) {
+    objcType = _objcTypeForNullableDartTypeMap.containsKey(type.baseName)
+        ? _objcTypeForDartType(classPrefix, type)
+        : null;
+  } else {
+    objcType = _objcTypeForNonNullableDartTypeMap.containsKey(type.baseName)
+        ? _objcTypeForDartType(classPrefix, type)
+        : null;
+  }
+  return beforeString ? objcType?.beforeString : objcType?.toString();
+}
+
+/// Returns the Objective-C type for a Dart [field], prepending the
+/// [classPrefix] for generated classes.
+_ObjcType _objcTypeForDartType(String? classPrefix, TypeDeclaration field,
+    {bool forceNullability = false}) {
+  final _ObjcType? primitiveType =
+      _objcTypeForPrimitiveDartType(field, forceNullability: forceNullability);
+  return primitiveType == null
+      ? _ObjcType(baseName: _className(classPrefix, field.baseName))
+      : field.typeArguments.isEmpty
+          ? primitiveType
+          : _ObjcType(
               baseName:
-                  '${_objcTypeForDartTypeMap[field.baseName]!.baseName}<${_flattenTypeArguments(classPrefix, field.typeArguments)}>')
-      : _ObjcPtr(baseName: _className(classPrefix, field.baseName));
+                  '${primitiveType.baseName}<${_flattenTypeArguments(classPrefix, field.typeArguments)}>');
 }
 
 /// Maps a type to a properties memory semantics (ie strong, copy).
-String _propertyTypeForDartType(NamedType field) {
-  const Map<String, String> propertyTypeForDartTypeMap = <String, String>{
-    'String': 'copy',
-    'bool': 'strong',
-    'int': 'strong',
-    'double': 'strong',
-    'Uint8List': 'strong',
-    'Int32List': 'strong',
-    'Int64List': 'strong',
-    'Float64List': 'strong',
-    'List': 'strong',
-    'Map': 'strong',
-  };
-
-  final String? result = propertyTypeForDartTypeMap[field.type.baseName];
-  if (result == null) {
-    return 'strong';
-  } else {
-    return result;
+String _propertyTypeForDartType(NamedType field,
+    {required bool isNullable, required bool isEnum}) {
+  if (isEnum) {
+    // Only the nullable versions are objects.
+    return isNullable ? 'strong' : 'assign';
   }
+  switch (field.type.baseName) {
+    case 'List':
+    case 'Map':
+    case 'String':
+      // Standard Objective-C practice is to copy strings and collections to
+      // avoid unexpected mutation if set to mutable versions.
+      return 'copy';
+    case 'double':
+    case 'bool':
+    case 'int':
+      // Only the nullable versions are objects.
+      return isNullable ? 'strong' : 'assign';
+  }
+  // Anything else is a standard object, and should therefore be strong.
+  return 'strong';
 }
 
 /// Generates the name of the codec that will be generated.
@@ -1348,8 +1401,9 @@ String _makeObjcSignature({
         return '${arg.type.isNullable ? 'nullable ' : ''}${_enumName(arg.type.baseName, suffix: arg.type.isNullable ? ' *' : '', prefix: options.prefix, box: arg.type.isNullable)}';
       } else {
         final String nullable = arg.type.isNullable ? 'nullable ' : '';
-        final _ObjcPtr argType = _objcTypeForDartType(options.prefix, arg.type);
-        return '$nullable${argType.withPtr.trim()}';
+        final _ObjcType argType =
+            _objcTypeForDartType(options.prefix, arg.type);
+        return '$nullable$argType';
       }
     }),
     lastArgType,

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/MultipleArityTest.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/MultipleArityTest.m
@@ -25,8 +25,8 @@
   MultipleArityFlutterApi *api =
       [[MultipleArityFlutterApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation *expectation = [self expectationWithDescription:@"subtraction"];
-  [api subtractX:@(30)
-               y:@(10)
+  [api subtractX:30
+               y:10
       completion:^(NSNumber *_Nonnull result, FlutterError *_Nullable error) {
         XCTAssertNil(error);
         XCTAssertEqual(20, result.intValue);

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/NullFieldsTest.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/NullFieldsTest.m
@@ -29,7 +29,7 @@
 @implementation NullFieldsTest
 
 - (void)testMakeWithValues {
-  NullFieldsSearchRequest *request = [NullFieldsSearchRequest makeWithQuery:@"hello" identifier:@1];
+  NullFieldsSearchRequest *request = [NullFieldsSearchRequest makeWithQuery:@"hello" identifier:1];
 
   NullFieldsSearchReplyTypeBox *typeWrapper =
       [[NullFieldsSearchReplyTypeBox alloc] initWithValue:NullFieldsSearchReplyTypeSuccess];
@@ -48,7 +48,7 @@
 }
 
 - (void)testMakeRequestWithNulls {
-  NullFieldsSearchRequest *request = [NullFieldsSearchRequest makeWithQuery:nil identifier:@1];
+  NullFieldsSearchRequest *request = [NullFieldsSearchRequest makeWithQuery:nil identifier:1];
   XCTAssertNil(request.query);
 }
 
@@ -121,13 +121,13 @@
 }
 
 - (void)testRequestToListWithValuess {
-  NullFieldsSearchRequest *request = [NullFieldsSearchRequest makeWithQuery:@"hello" identifier:@1];
+  NullFieldsSearchRequest *request = [NullFieldsSearchRequest makeWithQuery:@"hello" identifier:1];
   NSArray *list = [request toList];
   XCTAssertEqual(@"hello", list[0]);
 }
 
 - (void)testRequestToListWithNulls {
-  NullFieldsSearchRequest *request = [NullFieldsSearchRequest makeWithQuery:nil identifier:@1];
+  NullFieldsSearchRequest *request = [NullFieldsSearchRequest makeWithQuery:nil identifier:1];
   NSArray *list = [request toList];
   XCTAssertEqual([NSNull null], list[0]);
 }
@@ -139,7 +139,7 @@
       makeWithResult:@"result"
                error:@"error"
              indices:@[ @1, @2, @3 ]
-             request:[NullFieldsSearchRequest makeWithQuery:@"hello" identifier:@1]
+             request:[NullFieldsSearchRequest makeWithQuery:@"hello" identifier:1]
                 type:typeWrapper];
   NSArray *list = [reply toList];
   NSArray *indices = @[ @1, @2, @3 ];

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/PrimitiveTest.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/PrimitiveTest.m
@@ -21,7 +21,7 @@
       [[EchoBinaryMessenger alloc] initWithCodec:PrimitiveFlutterApiGetCodec()];
   PrimitiveFlutterApi *api = [[PrimitiveFlutterApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-  [api anIntValue:@1
+  [api anIntValue:1
        completion:^(NSNumber *_Nonnull result, FlutterError *_Nullable err) {
          XCTAssertEqualObjects(@1, result);
          [expectation fulfill];
@@ -34,10 +34,11 @@
       [[EchoBinaryMessenger alloc] initWithCodec:PrimitiveFlutterApiGetCodec()];
   PrimitiveFlutterApi *api = [[PrimitiveFlutterApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-  NSNumber *arg = @YES;
+  BOOL arg = YES;
   [api aBoolValue:arg
        completion:^(NSNumber *_Nonnull result, FlutterError *_Nullable err) {
-         XCTAssertEqualObjects(arg, result);
+         XCTAssertNotNil(result);
+         XCTAssertEqual(arg, result.boolValue);
          [expectation fulfill];
        }];
   [self waitForExpectations:@[ expectation ] timeout:1.0];
@@ -48,10 +49,11 @@
       [[EchoBinaryMessenger alloc] initWithCodec:PrimitiveFlutterApiGetCodec()];
   PrimitiveFlutterApi *api = [[PrimitiveFlutterApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-  NSNumber *arg = @(1.5);
+  NSInteger arg = 1.5;
   [api aDoubleValue:arg
          completion:^(NSNumber *_Nonnull result, FlutterError *_Nullable err) {
-           XCTAssertEqualObjects(arg, result);
+           XCTAssertNotNil(result);
+           XCTAssertEqual(arg, result.integerValue);
            [expectation fulfill];
          }];
   [self waitForExpectations:@[ expectation ] timeout:1.0];

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/AlternateLanguageTestPlugin.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/AlternateLanguageTestPlugin.m
@@ -50,17 +50,16 @@
   return nil;
 }
 
-- (nullable NSNumber *)echoInt:(NSNumber *)anInt error:(FlutterError *_Nullable *_Nonnull)error {
-  return anInt;
+- (nullable NSNumber *)echoInt:(NSInteger)anInt error:(FlutterError *_Nullable *_Nonnull)error {
+  return @(anInt);
 }
 
-- (nullable NSNumber *)echoDouble:(NSNumber *)aDouble
-                            error:(FlutterError *_Nullable *_Nonnull)error {
-  return aDouble;
+- (nullable NSNumber *)echoDouble:(double)aDouble error:(FlutterError *_Nullable *_Nonnull)error {
+  return @(aDouble);
 }
 
-- (nullable NSNumber *)echoBool:(NSNumber *)aBool error:(FlutterError *_Nullable *_Nonnull)error {
-  return aBool;
+- (nullable NSNumber *)echoBool:(BOOL)aBool error:(FlutterError *_Nullable *_Nonnull)error {
+  return @(aBool);
 }
 
 - (nullable NSString *)echoString:(NSString *)aString
@@ -196,19 +195,19 @@
   completion(everything, nil);
 }
 
-- (void)echoAsyncInt:(NSNumber *)anInt
+- (void)echoAsyncInt:(NSInteger)anInt
           completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
-  completion(anInt, nil);
+  completion(@(anInt), nil);
 }
 
-- (void)echoAsyncDouble:(NSNumber *)aDouble
+- (void)echoAsyncDouble:(double)aDouble
              completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
-  completion(aDouble, nil);
+  completion(@(aDouble), nil);
 }
 
-- (void)echoAsyncBool:(NSNumber *)aBool
+- (void)echoAsyncBool:(BOOL)aBool
            completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
-  completion(aBool, nil);
+  completion(@(aBool), nil);
 }
 
 - (void)echoAsyncString:(NSString *)aString
@@ -331,7 +330,7 @@
                                        }];
 }
 
-- (void)callFlutterEchoBool:(NSNumber *)aBool
+- (void)callFlutterEchoBool:(BOOL)aBool
                  completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   [self.flutterAPI echoBool:aBool
                  completion:^(NSNumber *value, FlutterError *error) {
@@ -339,7 +338,7 @@
                  }];
 }
 
-- (void)callFlutterEchoInt:(NSNumber *)anInt
+- (void)callFlutterEchoInt:(NSInteger)anInt
                 completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   [self.flutterAPI echoInt:anInt
                 completion:^(NSNumber *value, FlutterError *error) {
@@ -347,7 +346,7 @@
                 }];
 }
 
-- (void)callFlutterEchoDouble:(NSNumber *)aDouble
+- (void)callFlutterEchoDouble:(double)aDouble
                    completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   [self.flutterAPI echoDouble:aDouble
                    completion:^(NSNumber *value, FlutterError *error) {

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.h
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.h
@@ -35,10 +35,10 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 @interface AllTypes : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)makeWithABool:(NSNumber *)aBool
-                        anInt:(NSNumber *)anInt
-                      anInt64:(NSNumber *)anInt64
-                      aDouble:(NSNumber *)aDouble
++ (instancetype)makeWithABool:(BOOL)aBool
+                        anInt:(NSInteger)anInt
+                      anInt64:(NSInteger)anInt64
+                      aDouble:(double)aDouble
                    aByteArray:(FlutterStandardTypedData *)aByteArray
                   a4ByteArray:(FlutterStandardTypedData *)a4ByteArray
                   a8ByteArray:(FlutterStandardTypedData *)a8ByteArray
@@ -48,16 +48,16 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
                        anEnum:(AnEnum)anEnum
                       aString:(NSString *)aString
                      anObject:(id)anObject;
-@property(nonatomic, strong) NSNumber *aBool;
-@property(nonatomic, strong) NSNumber *anInt;
-@property(nonatomic, strong) NSNumber *anInt64;
-@property(nonatomic, strong) NSNumber *aDouble;
+@property(nonatomic, assign) BOOL aBool;
+@property(nonatomic, assign) NSInteger anInt;
+@property(nonatomic, assign) NSInteger anInt64;
+@property(nonatomic, assign) double aDouble;
 @property(nonatomic, strong) FlutterStandardTypedData *aByteArray;
 @property(nonatomic, strong) FlutterStandardTypedData *a4ByteArray;
 @property(nonatomic, strong) FlutterStandardTypedData *a8ByteArray;
 @property(nonatomic, strong) FlutterStandardTypedData *aFloatArray;
-@property(nonatomic, strong) NSArray *aList;
-@property(nonatomic, strong) NSDictionary *aMap;
+@property(nonatomic, copy) NSArray *aList;
+@property(nonatomic, copy) NSDictionary *aMap;
 @property(nonatomic, assign) AnEnum anEnum;
 @property(nonatomic, copy) NSString *aString;
 @property(nonatomic, strong) id anObject;
@@ -90,12 +90,12 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 @property(nonatomic, strong, nullable) FlutterStandardTypedData *aNullable4ByteArray;
 @property(nonatomic, strong, nullable) FlutterStandardTypedData *aNullable8ByteArray;
 @property(nonatomic, strong, nullable) FlutterStandardTypedData *aNullableFloatArray;
-@property(nonatomic, strong, nullable) NSArray *aNullableList;
-@property(nonatomic, strong, nullable) NSDictionary *aNullableMap;
-@property(nonatomic, strong, nullable) NSArray<NSArray<NSNumber *> *> *nullableNestedList;
-@property(nonatomic, strong, nullable)
+@property(nonatomic, copy, nullable) NSArray *aNullableList;
+@property(nonatomic, copy, nullable) NSDictionary *aNullableMap;
+@property(nonatomic, copy, nullable) NSArray<NSArray<NSNumber *> *> *nullableNestedList;
+@property(nonatomic, copy, nullable)
     NSDictionary<NSString *, NSString *> *nullableMapWithAnnotations;
-@property(nonatomic, strong, nullable) NSDictionary<NSString *, id> *nullableMapWithObject;
+@property(nonatomic, copy, nullable) NSDictionary<NSString *, id> *nullableMapWithObject;
 @property(nonatomic, strong, nullable) AnEnumBox *aNullableEnum;
 @property(nonatomic, copy, nullable) NSString *aNullableString;
 @property(nonatomic, strong, nullable) id aNullableObject;
@@ -118,7 +118,7 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 /// A data class containing a List, used in unit tests.
 @interface TestMessage : NSObject
 + (instancetype)makeWithTestList:(nullable NSArray *)testList;
-@property(nonatomic, strong, nullable) NSArray *testList;
+@property(nonatomic, copy, nullable) NSArray *testList;
 @end
 
 /// The codec used by HostIntegrationCoreApi.
@@ -144,16 +144,15 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 /// Returns passed in int.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable NSNumber *)echoInt:(NSNumber *)anInt error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSNumber *)echoInt:(NSInteger)anInt error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns passed in double.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable NSNumber *)echoDouble:(NSNumber *)aDouble
-                            error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSNumber *)echoDouble:(double)aDouble error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the passed in boolean.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable NSNumber *)echoBool:(NSNumber *)aBool error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSNumber *)echoBool:(BOOL)aBool error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the passed in string.
 ///
 /// @return `nil` only when `error != nil`.
@@ -241,13 +240,13 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 /// test basic asynchronous calling.
 - (void)noopAsyncWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 /// Returns passed in int asynchronously.
-- (void)echoAsyncInt:(NSNumber *)anInt
+- (void)echoAsyncInt:(NSInteger)anInt
           completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns passed in double asynchronously.
-- (void)echoAsyncDouble:(NSNumber *)aDouble
+- (void)echoAsyncDouble:(double)aDouble
              completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed in boolean asynchronously.
-- (void)echoAsyncBool:(NSNumber *)aBool
+- (void)echoAsyncBool:(BOOL)aBool
            completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed string asynchronously.
 - (void)echoAsyncString:(NSString *)aString
@@ -326,11 +325,11 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
                                           aString:(nullable NSString *)aNullableString
                                        completion:(void (^)(AllNullableTypes *_Nullable,
                                                             FlutterError *_Nullable))completion;
-- (void)callFlutterEchoBool:(NSNumber *)aBool
+- (void)callFlutterEchoBool:(BOOL)aBool
                  completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
-- (void)callFlutterEchoInt:(NSNumber *)anInt
+- (void)callFlutterEchoInt:(NSInteger)anInt
                 completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
-- (void)callFlutterEchoDouble:(NSNumber *)aDouble
+- (void)callFlutterEchoDouble:(double)aDouble
                    completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 - (void)callFlutterEchoString:(NSString *)aString
                    completion:(void (^)(NSString *_Nullable, FlutterError *_Nullable))completion;
@@ -403,13 +402,13 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void);
                             completion:(void (^)(AllNullableTypes *_Nullable,
                                                  FlutterError *_Nullable))completion;
 /// Returns the passed boolean, to test serialization and deserialization.
-- (void)echoBool:(NSNumber *)aBool
+- (void)echoBool:(BOOL)aBool
       completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed int, to test serialization and deserialization.
-- (void)echoInt:(NSNumber *)anInt
+- (void)echoInt:(NSInteger)anInt
      completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed double, to test serialization and deserialization.
-- (void)echoDouble:(NSNumber *)aDouble
+- (void)echoDouble:(double)aDouble
         completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed string, to test serialization and deserialization.
 - (void)echoString:(NSString *)aString

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.m
@@ -65,10 +65,10 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 @end
 
 @implementation AllTypes
-+ (instancetype)makeWithABool:(NSNumber *)aBool
-                        anInt:(NSNumber *)anInt
-                      anInt64:(NSNumber *)anInt64
-                      aDouble:(NSNumber *)aDouble
++ (instancetype)makeWithABool:(BOOL)aBool
+                        anInt:(NSInteger)anInt
+                      anInt64:(NSInteger)anInt64
+                      aDouble:(double)aDouble
                    aByteArray:(FlutterStandardTypedData *)aByteArray
                   a4ByteArray:(FlutterStandardTypedData *)a4ByteArray
                   a8ByteArray:(FlutterStandardTypedData *)a8ByteArray
@@ -465,7 +465,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_anInt = GetNullableObjectAtIndex(args, 0);
+        NSInteger arg_anInt = [GetNullableObjectAtIndex(args, 0) integerValue];
         FlutterError *error;
         NSNumber *output = [api echoInt:arg_anInt error:&error];
         callback(wrapResult(output, error));
@@ -487,7 +487,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aDouble = GetNullableObjectAtIndex(args, 0);
+        double arg_aDouble = [GetNullableObjectAtIndex(args, 0) doubleValue];
         FlutterError *error;
         NSNumber *output = [api echoDouble:arg_aDouble error:&error];
         callback(wrapResult(output, error));
@@ -509,7 +509,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aBool = GetNullableObjectAtIndex(args, 0);
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
         FlutterError *error;
         NSNumber *output = [api echoBool:arg_aBool error:&error];
         callback(wrapResult(output, error));
@@ -665,7 +665,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         FlutterError *error;
         AnEnumBox *enumBox = [api echoEnum:arg_anEnum error:&error];
         NSNumber *output = enumBox == nil ? nil : [NSNumber numberWithInteger:enumBox.value];
@@ -1024,7 +1024,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
           api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_anInt = GetNullableObjectAtIndex(args, 0);
+        NSInteger arg_anInt = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api echoAsyncInt:arg_anInt
                completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                  callback(wrapResult(output, error));
@@ -1048,7 +1048,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aDouble = GetNullableObjectAtIndex(args, 0);
+        double arg_aDouble = [GetNullableObjectAtIndex(args, 0) doubleValue];
         [api echoAsyncDouble:arg_aDouble
                   completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                     callback(wrapResult(output, error));
@@ -1072,7 +1072,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aBool = GetNullableObjectAtIndex(args, 0);
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
         [api echoAsyncBool:arg_aBool
                 completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                   callback(wrapResult(output, error));
@@ -1218,7 +1218,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api echoAsyncEnum:arg_anEnum
                 completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                   NSNumber *output =
@@ -1718,7 +1718,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aBool = GetNullableObjectAtIndex(args, 0);
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
         [api callFlutterEchoBool:arg_aBool
                       completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                         callback(wrapResult(output, error));
@@ -1741,7 +1741,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_anInt = GetNullableObjectAtIndex(args, 0);
+        NSInteger arg_anInt = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api callFlutterEchoInt:arg_anInt
                      completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                        callback(wrapResult(output, error));
@@ -1764,7 +1764,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aDouble = GetNullableObjectAtIndex(args, 0);
+        double arg_aDouble = [GetNullableObjectAtIndex(args, 0) doubleValue];
         [api callFlutterEchoDouble:arg_aDouble
                         completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                           callback(wrapResult(output, error));
@@ -1881,7 +1881,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api callFlutterEchoEnum:arg_anEnum
                       completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                         NSNumber *output =
@@ -2327,7 +2327,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoBool:(NSNumber *)arg_aBool
+- (void)echoBool:(BOOL)arg_aBool
       completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
       messageChannelWithName:
@@ -2353,7 +2353,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoInt:(NSNumber *)arg_anInt
+- (void)echoInt:(NSInteger)arg_anInt
      completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
       messageChannelWithName:
@@ -2379,7 +2379,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoDouble:(NSNumber *)arg_aDouble
+- (void)echoDouble:(double)arg_aDouble
         completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
       messageChannelWithName:

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.m
@@ -96,7 +96,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 + (AllTypes *)fromList:(NSArray *)list {
   AllTypes *pigeonResult = [[AllTypes alloc] init];
-  pigeonResult.aBool = [GetNullableObjectAtIndex(list, 0) booleanValue];
+  pigeonResult.aBool = [GetNullableObjectAtIndex(list, 0) boolValue];
   pigeonResult.anInt = [GetNullableObjectAtIndex(list, 1) integerValue];
   pigeonResult.anInt64 = [GetNullableObjectAtIndex(list, 2) integerValue];
   pigeonResult.aDouble = [GetNullableObjectAtIndex(list, 3) doubleValue];
@@ -496,7 +496,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) boolValue];
         FlutterError *error;
         NSNumber *output = [api echoBool:arg_aBool error:&error];
         callback(wrapResult(output, error));
@@ -652,7 +652,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         FlutterError *error;
         AnEnumBox *enumBox = [api echoEnum:arg_anEnum error:&error];
         NSNumber *output = enumBox == nil ? nil : [NSNumber numberWithInteger:enumBox.value];
@@ -1059,7 +1059,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) boolValue];
         [api echoAsyncBool:arg_aBool
                 completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                   callback(wrapResult(output, error));
@@ -1205,7 +1205,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api echoAsyncEnum:arg_anEnum
                 completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                   NSNumber *output =
@@ -1705,7 +1705,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) boolValue];
         [api callFlutterEchoBool:arg_aBool
                       completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                         callback(wrapResult(output, error));
@@ -1868,7 +1868,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api callFlutterEchoEnum:arg_anEnum
                       completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                         NSNumber *output =

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.m
@@ -96,31 +96,19 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 + (AllTypes *)fromList:(NSArray *)list {
   AllTypes *pigeonResult = [[AllTypes alloc] init];
-  pigeonResult.aBool = GetNullableObjectAtIndex(list, 0);
-  NSAssert(pigeonResult.aBool != nil, @"");
-  pigeonResult.anInt = GetNullableObjectAtIndex(list, 1);
-  NSAssert(pigeonResult.anInt != nil, @"");
-  pigeonResult.anInt64 = GetNullableObjectAtIndex(list, 2);
-  NSAssert(pigeonResult.anInt64 != nil, @"");
-  pigeonResult.aDouble = GetNullableObjectAtIndex(list, 3);
-  NSAssert(pigeonResult.aDouble != nil, @"");
+  pigeonResult.aBool = [GetNullableObjectAtIndex(list, 0) booleanValue];
+  pigeonResult.anInt = [GetNullableObjectAtIndex(list, 1) integerValue];
+  pigeonResult.anInt64 = [GetNullableObjectAtIndex(list, 2) integerValue];
+  pigeonResult.aDouble = [GetNullableObjectAtIndex(list, 3) doubleValue];
   pigeonResult.aByteArray = GetNullableObjectAtIndex(list, 4);
-  NSAssert(pigeonResult.aByteArray != nil, @"");
   pigeonResult.a4ByteArray = GetNullableObjectAtIndex(list, 5);
-  NSAssert(pigeonResult.a4ByteArray != nil, @"");
   pigeonResult.a8ByteArray = GetNullableObjectAtIndex(list, 6);
-  NSAssert(pigeonResult.a8ByteArray != nil, @"");
   pigeonResult.aFloatArray = GetNullableObjectAtIndex(list, 7);
-  NSAssert(pigeonResult.aFloatArray != nil, @"");
   pigeonResult.aList = GetNullableObjectAtIndex(list, 8);
-  NSAssert(pigeonResult.aList != nil, @"");
   pigeonResult.aMap = GetNullableObjectAtIndex(list, 9);
-  NSAssert(pigeonResult.aMap != nil, @"");
   pigeonResult.anEnum = [GetNullableObjectAtIndex(list, 10) integerValue];
   pigeonResult.aString = GetNullableObjectAtIndex(list, 11);
-  NSAssert(pigeonResult.aString != nil, @"");
   pigeonResult.anObject = GetNullableObjectAtIndex(list, 12);
-  NSAssert(pigeonResult.anObject != nil, @"");
   return pigeonResult;
 }
 + (nullable AllTypes *)nullableFromList:(NSArray *)list {
@@ -128,19 +116,19 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 - (NSArray *)toList {
   return @[
-    (self.aBool ?: [NSNull null]),
-    (self.anInt ?: [NSNull null]),
-    (self.anInt64 ?: [NSNull null]),
-    (self.aDouble ?: [NSNull null]),
-    (self.aByteArray ?: [NSNull null]),
-    (self.a4ByteArray ?: [NSNull null]),
-    (self.a8ByteArray ?: [NSNull null]),
-    (self.aFloatArray ?: [NSNull null]),
-    (self.aList ?: [NSNull null]),
-    (self.aMap ?: [NSNull null]),
+    @(self.aBool),
+    @(self.anInt),
+    @(self.anInt64),
+    @(self.aDouble),
+    self.aByteArray ?: [NSNull null],
+    self.a4ByteArray ?: [NSNull null],
+    self.a8ByteArray ?: [NSNull null],
+    self.aFloatArray ?: [NSNull null],
+    self.aList ?: [NSNull null],
+    self.aMap ?: [NSNull null],
     @(self.anEnum),
-    (self.aString ?: [NSNull null]),
-    (self.anObject ?: [NSNull null]),
+    self.aString ?: [NSNull null],
+    self.anObject ?: [NSNull null],
   ];
 }
 @end
@@ -212,23 +200,23 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 - (NSArray *)toList {
   return @[
-    (self.aNullableBool ?: [NSNull null]),
-    (self.aNullableInt ?: [NSNull null]),
-    (self.aNullableInt64 ?: [NSNull null]),
-    (self.aNullableDouble ?: [NSNull null]),
-    (self.aNullableByteArray ?: [NSNull null]),
-    (self.aNullable4ByteArray ?: [NSNull null]),
-    (self.aNullable8ByteArray ?: [NSNull null]),
-    (self.aNullableFloatArray ?: [NSNull null]),
-    (self.aNullableList ?: [NSNull null]),
-    (self.aNullableMap ?: [NSNull null]),
-    (self.nullableNestedList ?: [NSNull null]),
-    (self.nullableMapWithAnnotations ?: [NSNull null]),
-    (self.nullableMapWithObject ?: [NSNull null]),
+    self.aNullableBool ?: [NSNull null],
+    self.aNullableInt ?: [NSNull null],
+    self.aNullableInt64 ?: [NSNull null],
+    self.aNullableDouble ?: [NSNull null],
+    self.aNullableByteArray ?: [NSNull null],
+    self.aNullable4ByteArray ?: [NSNull null],
+    self.aNullable8ByteArray ?: [NSNull null],
+    self.aNullableFloatArray ?: [NSNull null],
+    self.aNullableList ?: [NSNull null],
+    self.aNullableMap ?: [NSNull null],
+    self.nullableNestedList ?: [NSNull null],
+    self.nullableMapWithAnnotations ?: [NSNull null],
+    self.nullableMapWithObject ?: [NSNull null],
     (self.aNullableEnum == nil ? [NSNull null]
                                : [NSNumber numberWithInteger:self.aNullableEnum.value]),
-    (self.aNullableString ?: [NSNull null]),
-    (self.aNullableObject ?: [NSNull null]),
+    self.aNullableString ?: [NSNull null],
+    self.aNullableObject ?: [NSNull null],
   ];
 }
 @end
@@ -245,7 +233,6 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   AllClassesWrapper *pigeonResult = [[AllClassesWrapper alloc] init];
   pigeonResult.allNullableTypes =
       [AllNullableTypes nullableFromList:(GetNullableObjectAtIndex(list, 0))];
-  NSAssert(pigeonResult.allNullableTypes != nil, @"");
   pigeonResult.allTypes = [AllTypes nullableFromList:(GetNullableObjectAtIndex(list, 1))];
   return pigeonResult;
 }
@@ -276,7 +263,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 - (NSArray *)toList {
   return @[
-    (self.testList ?: [NSNull null]),
+    self.testList ?: [NSNull null],
   ];
 }
 @end
@@ -2334,7 +2321,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
           @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoBool"
              binaryMessenger:self.binaryMessenger
                        codec:FlutterIntegrationCoreApiGetCodec()];
-  [channel sendMessage:@[ arg_aBool ?: [NSNull null] ]
+  [channel sendMessage:@[ @(arg_aBool) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {
@@ -2360,7 +2347,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
           @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoInt"
              binaryMessenger:self.binaryMessenger
                        codec:FlutterIntegrationCoreApiGetCodec()];
-  [channel sendMessage:@[ arg_anInt ?: [NSNull null] ]
+  [channel sendMessage:@[ @(arg_anInt) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {
@@ -2386,7 +2373,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
           @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoDouble"
              binaryMessenger:self.binaryMessenger
                        codec:FlutterIntegrationCoreApiGetCodec()];
-  [channel sendMessage:@[ arg_aDouble ?: [NSNull null] ]
+  [channel sendMessage:@[ @(arg_aDouble) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/AlternateLanguageTestPlugin.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/AlternateLanguageTestPlugin.m
@@ -50,17 +50,16 @@
   return nil;
 }
 
-- (nullable NSNumber *)echoInt:(NSNumber *)anInt error:(FlutterError *_Nullable *_Nonnull)error {
-  return anInt;
+- (nullable NSNumber *)echoInt:(NSInteger)anInt error:(FlutterError *_Nullable *_Nonnull)error {
+  return @(anInt);
 }
 
-- (nullable NSNumber *)echoDouble:(NSNumber *)aDouble
-                            error:(FlutterError *_Nullable *_Nonnull)error {
-  return aDouble;
+- (nullable NSNumber *)echoDouble:(double)aDouble error:(FlutterError *_Nullable *_Nonnull)error {
+  return @(aDouble);
 }
 
-- (nullable NSNumber *)echoBool:(NSNumber *)aBool error:(FlutterError *_Nullable *_Nonnull)error {
-  return aBool;
+- (nullable NSNumber *)echoBool:(BOOL)aBool error:(FlutterError *_Nullable *_Nonnull)error {
+  return @(aBool);
 }
 
 - (nullable NSString *)echoString:(NSString *)aString
@@ -196,19 +195,19 @@
   completion(everything, nil);
 }
 
-- (void)echoAsyncInt:(NSNumber *)anInt
+- (void)echoAsyncInt:(NSInteger)anInt
           completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
-  completion(anInt, nil);
+  completion(@(anInt), nil);
 }
 
-- (void)echoAsyncDouble:(NSNumber *)aDouble
+- (void)echoAsyncDouble:(double)aDouble
              completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
-  completion(aDouble, nil);
+  completion(@(aDouble), nil);
 }
 
-- (void)echoAsyncBool:(NSNumber *)aBool
+- (void)echoAsyncBool:(BOOL)aBool
            completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
-  completion(aBool, nil);
+  completion(@(aBool), nil);
 }
 
 - (void)echoAsyncString:(NSString *)aString
@@ -331,7 +330,7 @@
                                        }];
 }
 
-- (void)callFlutterEchoBool:(NSNumber *)aBool
+- (void)callFlutterEchoBool:(BOOL)aBool
                  completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   [self.flutterAPI echoBool:aBool
                  completion:^(NSNumber *value, FlutterError *error) {
@@ -339,7 +338,7 @@
                  }];
 }
 
-- (void)callFlutterEchoInt:(NSNumber *)anInt
+- (void)callFlutterEchoInt:(NSInteger)anInt
                 completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   [self.flutterAPI echoInt:anInt
                 completion:^(NSNumber *value, FlutterError *error) {
@@ -347,7 +346,7 @@
                 }];
 }
 
-- (void)callFlutterEchoDouble:(NSNumber *)aDouble
+- (void)callFlutterEchoDouble:(double)aDouble
                    completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   [self.flutterAPI echoDouble:aDouble
                    completion:^(NSNumber *value, FlutterError *error) {

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/CoreTests.gen.h
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/CoreTests.gen.h
@@ -35,10 +35,10 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 @interface AllTypes : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)makeWithABool:(NSNumber *)aBool
-                        anInt:(NSNumber *)anInt
-                      anInt64:(NSNumber *)anInt64
-                      aDouble:(NSNumber *)aDouble
++ (instancetype)makeWithABool:(BOOL)aBool
+                        anInt:(NSInteger)anInt
+                      anInt64:(NSInteger)anInt64
+                      aDouble:(double)aDouble
                    aByteArray:(FlutterStandardTypedData *)aByteArray
                   a4ByteArray:(FlutterStandardTypedData *)a4ByteArray
                   a8ByteArray:(FlutterStandardTypedData *)a8ByteArray
@@ -48,16 +48,16 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
                        anEnum:(AnEnum)anEnum
                       aString:(NSString *)aString
                      anObject:(id)anObject;
-@property(nonatomic, strong) NSNumber *aBool;
-@property(nonatomic, strong) NSNumber *anInt;
-@property(nonatomic, strong) NSNumber *anInt64;
-@property(nonatomic, strong) NSNumber *aDouble;
+@property(nonatomic, assign) BOOL aBool;
+@property(nonatomic, assign) NSInteger anInt;
+@property(nonatomic, assign) NSInteger anInt64;
+@property(nonatomic, assign) double aDouble;
 @property(nonatomic, strong) FlutterStandardTypedData *aByteArray;
 @property(nonatomic, strong) FlutterStandardTypedData *a4ByteArray;
 @property(nonatomic, strong) FlutterStandardTypedData *a8ByteArray;
 @property(nonatomic, strong) FlutterStandardTypedData *aFloatArray;
-@property(nonatomic, strong) NSArray *aList;
-@property(nonatomic, strong) NSDictionary *aMap;
+@property(nonatomic, copy) NSArray *aList;
+@property(nonatomic, copy) NSDictionary *aMap;
 @property(nonatomic, assign) AnEnum anEnum;
 @property(nonatomic, copy) NSString *aString;
 @property(nonatomic, strong) id anObject;
@@ -90,12 +90,12 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 @property(nonatomic, strong, nullable) FlutterStandardTypedData *aNullable4ByteArray;
 @property(nonatomic, strong, nullable) FlutterStandardTypedData *aNullable8ByteArray;
 @property(nonatomic, strong, nullable) FlutterStandardTypedData *aNullableFloatArray;
-@property(nonatomic, strong, nullable) NSArray *aNullableList;
-@property(nonatomic, strong, nullable) NSDictionary *aNullableMap;
-@property(nonatomic, strong, nullable) NSArray<NSArray<NSNumber *> *> *nullableNestedList;
-@property(nonatomic, strong, nullable)
+@property(nonatomic, copy, nullable) NSArray *aNullableList;
+@property(nonatomic, copy, nullable) NSDictionary *aNullableMap;
+@property(nonatomic, copy, nullable) NSArray<NSArray<NSNumber *> *> *nullableNestedList;
+@property(nonatomic, copy, nullable)
     NSDictionary<NSString *, NSString *> *nullableMapWithAnnotations;
-@property(nonatomic, strong, nullable) NSDictionary<NSString *, id> *nullableMapWithObject;
+@property(nonatomic, copy, nullable) NSDictionary<NSString *, id> *nullableMapWithObject;
 @property(nonatomic, strong, nullable) AnEnumBox *aNullableEnum;
 @property(nonatomic, copy, nullable) NSString *aNullableString;
 @property(nonatomic, strong, nullable) id aNullableObject;
@@ -118,7 +118,7 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 /// A data class containing a List, used in unit tests.
 @interface TestMessage : NSObject
 + (instancetype)makeWithTestList:(nullable NSArray *)testList;
-@property(nonatomic, strong, nullable) NSArray *testList;
+@property(nonatomic, copy, nullable) NSArray *testList;
 @end
 
 /// The codec used by HostIntegrationCoreApi.
@@ -144,16 +144,15 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 /// Returns passed in int.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable NSNumber *)echoInt:(NSNumber *)anInt error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSNumber *)echoInt:(NSInteger)anInt error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns passed in double.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable NSNumber *)echoDouble:(NSNumber *)aDouble
-                            error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSNumber *)echoDouble:(double)aDouble error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the passed in boolean.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable NSNumber *)echoBool:(NSNumber *)aBool error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSNumber *)echoBool:(BOOL)aBool error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the passed in string.
 ///
 /// @return `nil` only when `error != nil`.
@@ -241,13 +240,13 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 /// test basic asynchronous calling.
 - (void)noopAsyncWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 /// Returns passed in int asynchronously.
-- (void)echoAsyncInt:(NSNumber *)anInt
+- (void)echoAsyncInt:(NSInteger)anInt
           completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns passed in double asynchronously.
-- (void)echoAsyncDouble:(NSNumber *)aDouble
+- (void)echoAsyncDouble:(double)aDouble
              completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed in boolean asynchronously.
-- (void)echoAsyncBool:(NSNumber *)aBool
+- (void)echoAsyncBool:(BOOL)aBool
            completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed string asynchronously.
 - (void)echoAsyncString:(NSString *)aString
@@ -326,11 +325,11 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
                                           aString:(nullable NSString *)aNullableString
                                        completion:(void (^)(AllNullableTypes *_Nullable,
                                                             FlutterError *_Nullable))completion;
-- (void)callFlutterEchoBool:(NSNumber *)aBool
+- (void)callFlutterEchoBool:(BOOL)aBool
                  completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
-- (void)callFlutterEchoInt:(NSNumber *)anInt
+- (void)callFlutterEchoInt:(NSInteger)anInt
                 completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
-- (void)callFlutterEchoDouble:(NSNumber *)aDouble
+- (void)callFlutterEchoDouble:(double)aDouble
                    completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 - (void)callFlutterEchoString:(NSString *)aString
                    completion:(void (^)(NSString *_Nullable, FlutterError *_Nullable))completion;
@@ -403,13 +402,13 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void);
                             completion:(void (^)(AllNullableTypes *_Nullable,
                                                  FlutterError *_Nullable))completion;
 /// Returns the passed boolean, to test serialization and deserialization.
-- (void)echoBool:(NSNumber *)aBool
+- (void)echoBool:(BOOL)aBool
       completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed int, to test serialization and deserialization.
-- (void)echoInt:(NSNumber *)anInt
+- (void)echoInt:(NSInteger)anInt
      completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed double, to test serialization and deserialization.
-- (void)echoDouble:(NSNumber *)aDouble
+- (void)echoDouble:(double)aDouble
         completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed string, to test serialization and deserialization.
 - (void)echoString:(NSString *)aString

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/CoreTests.gen.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/CoreTests.gen.m
@@ -65,10 +65,10 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 @end
 
 @implementation AllTypes
-+ (instancetype)makeWithABool:(NSNumber *)aBool
-                        anInt:(NSNumber *)anInt
-                      anInt64:(NSNumber *)anInt64
-                      aDouble:(NSNumber *)aDouble
++ (instancetype)makeWithABool:(BOOL)aBool
+                        anInt:(NSInteger)anInt
+                      anInt64:(NSInteger)anInt64
+                      aDouble:(double)aDouble
                    aByteArray:(FlutterStandardTypedData *)aByteArray
                   a4ByteArray:(FlutterStandardTypedData *)a4ByteArray
                   a8ByteArray:(FlutterStandardTypedData *)a8ByteArray
@@ -465,7 +465,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_anInt = GetNullableObjectAtIndex(args, 0);
+        NSInteger arg_anInt = [GetNullableObjectAtIndex(args, 0) integerValue];
         FlutterError *error;
         NSNumber *output = [api echoInt:arg_anInt error:&error];
         callback(wrapResult(output, error));
@@ -487,7 +487,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aDouble = GetNullableObjectAtIndex(args, 0);
+        double arg_aDouble = [GetNullableObjectAtIndex(args, 0) doubleValue];
         FlutterError *error;
         NSNumber *output = [api echoDouble:arg_aDouble error:&error];
         callback(wrapResult(output, error));
@@ -509,7 +509,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aBool = GetNullableObjectAtIndex(args, 0);
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
         FlutterError *error;
         NSNumber *output = [api echoBool:arg_aBool error:&error];
         callback(wrapResult(output, error));
@@ -665,7 +665,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         FlutterError *error;
         AnEnumBox *enumBox = [api echoEnum:arg_anEnum error:&error];
         NSNumber *output = enumBox == nil ? nil : [NSNumber numberWithInteger:enumBox.value];
@@ -1024,7 +1024,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
           api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_anInt = GetNullableObjectAtIndex(args, 0);
+        NSInteger arg_anInt = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api echoAsyncInt:arg_anInt
                completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                  callback(wrapResult(output, error));
@@ -1048,7 +1048,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aDouble = GetNullableObjectAtIndex(args, 0);
+        double arg_aDouble = [GetNullableObjectAtIndex(args, 0) doubleValue];
         [api echoAsyncDouble:arg_aDouble
                   completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                     callback(wrapResult(output, error));
@@ -1072,7 +1072,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aBool = GetNullableObjectAtIndex(args, 0);
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
         [api echoAsyncBool:arg_aBool
                 completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                   callback(wrapResult(output, error));
@@ -1218,7 +1218,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api echoAsyncEnum:arg_anEnum
                 completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                   NSNumber *output =
@@ -1718,7 +1718,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aBool = GetNullableObjectAtIndex(args, 0);
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
         [api callFlutterEchoBool:arg_aBool
                       completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                         callback(wrapResult(output, error));
@@ -1741,7 +1741,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_anInt = GetNullableObjectAtIndex(args, 0);
+        NSInteger arg_anInt = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api callFlutterEchoInt:arg_anInt
                      completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                        callback(wrapResult(output, error));
@@ -1764,7 +1764,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_aDouble = GetNullableObjectAtIndex(args, 0);
+        double arg_aDouble = [GetNullableObjectAtIndex(args, 0) doubleValue];
         [api callFlutterEchoDouble:arg_aDouble
                         completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                           callback(wrapResult(output, error));
@@ -1881,7 +1881,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api callFlutterEchoEnum:arg_anEnum
                       completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                         NSNumber *output =
@@ -2327,7 +2327,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoBool:(NSNumber *)arg_aBool
+- (void)echoBool:(BOOL)arg_aBool
       completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
       messageChannelWithName:
@@ -2353,7 +2353,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoInt:(NSNumber *)arg_anInt
+- (void)echoInt:(NSInteger)arg_anInt
      completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
       messageChannelWithName:
@@ -2379,7 +2379,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoDouble:(NSNumber *)arg_aDouble
+- (void)echoDouble:(double)arg_aDouble
         completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
       messageChannelWithName:

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/CoreTests.gen.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/CoreTests.gen.m
@@ -96,7 +96,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 + (AllTypes *)fromList:(NSArray *)list {
   AllTypes *pigeonResult = [[AllTypes alloc] init];
-  pigeonResult.aBool = [GetNullableObjectAtIndex(list, 0) booleanValue];
+  pigeonResult.aBool = [GetNullableObjectAtIndex(list, 0) boolValue];
   pigeonResult.anInt = [GetNullableObjectAtIndex(list, 1) integerValue];
   pigeonResult.anInt64 = [GetNullableObjectAtIndex(list, 2) integerValue];
   pigeonResult.aDouble = [GetNullableObjectAtIndex(list, 3) doubleValue];
@@ -496,7 +496,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) boolValue];
         FlutterError *error;
         NSNumber *output = [api echoBool:arg_aBool error:&error];
         callback(wrapResult(output, error));
@@ -652,7 +652,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         FlutterError *error;
         AnEnumBox *enumBox = [api echoEnum:arg_anEnum error:&error];
         NSNumber *output = enumBox == nil ? nil : [NSNumber numberWithInteger:enumBox.value];
@@ -1059,7 +1059,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) boolValue];
         [api echoAsyncBool:arg_aBool
                 completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                   callback(wrapResult(output, error));
@@ -1205,7 +1205,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api echoAsyncEnum:arg_anEnum
                 completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                   NSNumber *output =
@@ -1705,7 +1705,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) booleanValue];
+        BOOL arg_aBool = [GetNullableObjectAtIndex(args, 0) boolValue];
         [api callFlutterEchoBool:arg_aBool
                       completion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
                         callback(wrapResult(output, error));
@@ -1868,7 +1868,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum *arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api callFlutterEchoEnum:arg_anEnum
                       completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                         NSNumber *output =

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/CoreTests.gen.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/CoreTests.gen.m
@@ -96,31 +96,19 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 + (AllTypes *)fromList:(NSArray *)list {
   AllTypes *pigeonResult = [[AllTypes alloc] init];
-  pigeonResult.aBool = GetNullableObjectAtIndex(list, 0);
-  NSAssert(pigeonResult.aBool != nil, @"");
-  pigeonResult.anInt = GetNullableObjectAtIndex(list, 1);
-  NSAssert(pigeonResult.anInt != nil, @"");
-  pigeonResult.anInt64 = GetNullableObjectAtIndex(list, 2);
-  NSAssert(pigeonResult.anInt64 != nil, @"");
-  pigeonResult.aDouble = GetNullableObjectAtIndex(list, 3);
-  NSAssert(pigeonResult.aDouble != nil, @"");
+  pigeonResult.aBool = [GetNullableObjectAtIndex(list, 0) booleanValue];
+  pigeonResult.anInt = [GetNullableObjectAtIndex(list, 1) integerValue];
+  pigeonResult.anInt64 = [GetNullableObjectAtIndex(list, 2) integerValue];
+  pigeonResult.aDouble = [GetNullableObjectAtIndex(list, 3) doubleValue];
   pigeonResult.aByteArray = GetNullableObjectAtIndex(list, 4);
-  NSAssert(pigeonResult.aByteArray != nil, @"");
   pigeonResult.a4ByteArray = GetNullableObjectAtIndex(list, 5);
-  NSAssert(pigeonResult.a4ByteArray != nil, @"");
   pigeonResult.a8ByteArray = GetNullableObjectAtIndex(list, 6);
-  NSAssert(pigeonResult.a8ByteArray != nil, @"");
   pigeonResult.aFloatArray = GetNullableObjectAtIndex(list, 7);
-  NSAssert(pigeonResult.aFloatArray != nil, @"");
   pigeonResult.aList = GetNullableObjectAtIndex(list, 8);
-  NSAssert(pigeonResult.aList != nil, @"");
   pigeonResult.aMap = GetNullableObjectAtIndex(list, 9);
-  NSAssert(pigeonResult.aMap != nil, @"");
   pigeonResult.anEnum = [GetNullableObjectAtIndex(list, 10) integerValue];
   pigeonResult.aString = GetNullableObjectAtIndex(list, 11);
-  NSAssert(pigeonResult.aString != nil, @"");
   pigeonResult.anObject = GetNullableObjectAtIndex(list, 12);
-  NSAssert(pigeonResult.anObject != nil, @"");
   return pigeonResult;
 }
 + (nullable AllTypes *)nullableFromList:(NSArray *)list {
@@ -128,19 +116,19 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 - (NSArray *)toList {
   return @[
-    (self.aBool ?: [NSNull null]),
-    (self.anInt ?: [NSNull null]),
-    (self.anInt64 ?: [NSNull null]),
-    (self.aDouble ?: [NSNull null]),
-    (self.aByteArray ?: [NSNull null]),
-    (self.a4ByteArray ?: [NSNull null]),
-    (self.a8ByteArray ?: [NSNull null]),
-    (self.aFloatArray ?: [NSNull null]),
-    (self.aList ?: [NSNull null]),
-    (self.aMap ?: [NSNull null]),
+    @(self.aBool),
+    @(self.anInt),
+    @(self.anInt64),
+    @(self.aDouble),
+    self.aByteArray ?: [NSNull null],
+    self.a4ByteArray ?: [NSNull null],
+    self.a8ByteArray ?: [NSNull null],
+    self.aFloatArray ?: [NSNull null],
+    self.aList ?: [NSNull null],
+    self.aMap ?: [NSNull null],
     @(self.anEnum),
-    (self.aString ?: [NSNull null]),
-    (self.anObject ?: [NSNull null]),
+    self.aString ?: [NSNull null],
+    self.anObject ?: [NSNull null],
   ];
 }
 @end
@@ -212,23 +200,23 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 - (NSArray *)toList {
   return @[
-    (self.aNullableBool ?: [NSNull null]),
-    (self.aNullableInt ?: [NSNull null]),
-    (self.aNullableInt64 ?: [NSNull null]),
-    (self.aNullableDouble ?: [NSNull null]),
-    (self.aNullableByteArray ?: [NSNull null]),
-    (self.aNullable4ByteArray ?: [NSNull null]),
-    (self.aNullable8ByteArray ?: [NSNull null]),
-    (self.aNullableFloatArray ?: [NSNull null]),
-    (self.aNullableList ?: [NSNull null]),
-    (self.aNullableMap ?: [NSNull null]),
-    (self.nullableNestedList ?: [NSNull null]),
-    (self.nullableMapWithAnnotations ?: [NSNull null]),
-    (self.nullableMapWithObject ?: [NSNull null]),
+    self.aNullableBool ?: [NSNull null],
+    self.aNullableInt ?: [NSNull null],
+    self.aNullableInt64 ?: [NSNull null],
+    self.aNullableDouble ?: [NSNull null],
+    self.aNullableByteArray ?: [NSNull null],
+    self.aNullable4ByteArray ?: [NSNull null],
+    self.aNullable8ByteArray ?: [NSNull null],
+    self.aNullableFloatArray ?: [NSNull null],
+    self.aNullableList ?: [NSNull null],
+    self.aNullableMap ?: [NSNull null],
+    self.nullableNestedList ?: [NSNull null],
+    self.nullableMapWithAnnotations ?: [NSNull null],
+    self.nullableMapWithObject ?: [NSNull null],
     (self.aNullableEnum == nil ? [NSNull null]
                                : [NSNumber numberWithInteger:self.aNullableEnum.value]),
-    (self.aNullableString ?: [NSNull null]),
-    (self.aNullableObject ?: [NSNull null]),
+    self.aNullableString ?: [NSNull null],
+    self.aNullableObject ?: [NSNull null],
   ];
 }
 @end
@@ -245,7 +233,6 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   AllClassesWrapper *pigeonResult = [[AllClassesWrapper alloc] init];
   pigeonResult.allNullableTypes =
       [AllNullableTypes nullableFromList:(GetNullableObjectAtIndex(list, 0))];
-  NSAssert(pigeonResult.allNullableTypes != nil, @"");
   pigeonResult.allTypes = [AllTypes nullableFromList:(GetNullableObjectAtIndex(list, 1))];
   return pigeonResult;
 }
@@ -276,7 +263,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 - (NSArray *)toList {
   return @[
-    (self.testList ?: [NSNull null]),
+    self.testList ?: [NSNull null],
   ];
 }
 @end
@@ -2334,7 +2321,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
           @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoBool"
              binaryMessenger:self.binaryMessenger
                        codec:FlutterIntegrationCoreApiGetCodec()];
-  [channel sendMessage:@[ arg_aBool ?: [NSNull null] ]
+  [channel sendMessage:@[ @(arg_aBool) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {
@@ -2360,7 +2347,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
           @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoInt"
              binaryMessenger:self.binaryMessenger
                        codec:FlutterIntegrationCoreApiGetCodec()];
-  [channel sendMessage:@[ arg_anInt ?: [NSNull null] ]
+  [channel sendMessage:@[ @(arg_anInt) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {
@@ -2386,7 +2373,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
           @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoDouble"
              binaryMessenger:self.binaryMessenger
                        codec:FlutterIntegrationCoreApiGetCodec()];
-  [channel sendMessage:@[ arg_aDouble ?: [NSNull null] ]
+  [channel sendMessage:@[ @(arg_aDouble) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/pigeon/platform_tests/test_plugin/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/pigeon/platform_tests/test_plugin/example/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1400;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33A341DA291ED36900D34E0F = {

--- a/packages/pigeon/platform_tests/test_plugin/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/pigeon/platform_tests/test_plugin/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 12.0.1 # This must match the version in lib/generator_tools.dart
+version: 13.0.0 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.19.0 <4.0.0"

--- a/packages/pigeon/test/objc_generator_test.dart
+++ b/packages/pigeon/test/objc_generator_test.dart
@@ -1194,7 +1194,7 @@ void main() {
     expect(
         code,
         contains(
-            '@property(nonatomic, strong, nullable) NSDictionary<NSString *, id> *'));
+            '@property(nonatomic, copy, nullable) NSDictionary<NSString *, id> *'));
   });
 
   test('gen map argument with object', () {
@@ -1978,7 +1978,7 @@ void main() {
       expect(
           code,
           contains(
-              '- (nullable NSNumber *)addX:(NSNumber *)x y:(NSNumber *)y error:(FlutterError *_Nullable *_Nonnull)error;'));
+              '- (nullable NSNumber *)addX:(NSInteger)x y:(NSInteger)y error:(FlutterError *_Nullable *_Nonnull)error;'));
     }
     {
       final StringBuffer sink = StringBuffer();
@@ -1997,10 +1997,14 @@ void main() {
       );
       final String code = sink.toString();
       expect(code, contains('NSArray *args = message;'));
-      expect(code,
-          contains('NSNumber *arg_x = GetNullableObjectAtIndex(args, 0);'));
-      expect(code,
-          contains('NSNumber *arg_y = GetNullableObjectAtIndex(args, 1);'));
+      expect(
+          code,
+          contains(
+              'NSInteger arg_x = [GetNullableObjectAtIndex(args, 0) integerValue];'));
+      expect(
+          code,
+          contains(
+              'NSInteger arg_y = [GetNullableObjectAtIndex(args, 1) integerValue];'));
       expect(code,
           contains('NSNumber *output = [api addX:arg_x y:arg_y error:&error]'));
     }
@@ -2045,7 +2049,7 @@ void main() {
       expect(
           code,
           contains(
-              '- (void)addX:(NSNumber *)x y:(NSNumber *)y completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;'));
+              '- (void)addX:(NSInteger)x y:(NSInteger)y completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;'));
     }
     {
       final StringBuffer sink = StringBuffer();
@@ -2064,10 +2068,14 @@ void main() {
       );
       final String code = sink.toString();
       expect(code, contains('NSArray *args = message;'));
-      expect(code,
-          contains('NSNumber *arg_x = GetNullableObjectAtIndex(args, 0);'));
-      expect(code,
-          contains('NSNumber *arg_y = GetNullableObjectAtIndex(args, 1);'));
+      expect(
+          code,
+          contains(
+              'NSInteger arg_x = [GetNullableObjectAtIndex(args, 0) integerValue];'));
+      expect(
+          code,
+          contains(
+              'NSInteger arg_y = [GetNullableObjectAtIndex(args, 1) integerValue];'));
       expect(code, contains('[api addX:arg_x y:arg_y completion:'));
     }
   });
@@ -2110,7 +2118,7 @@ void main() {
       expect(
           code,
           contains(
-              '- (void)addX:(NSNumber *)x y:(NSNumber *)y completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;'));
+              '- (void)addX:(NSInteger)x y:(NSInteger)y completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;'));
     }
     {
       final StringBuffer sink = StringBuffer();
@@ -2131,11 +2139,9 @@ void main() {
       expect(
           code,
           contains(
-              '- (void)addX:(NSNumber *)arg_x y:(NSNumber *)arg_y completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {'));
+              '- (void)addX:(NSInteger)arg_x y:(NSInteger)arg_y completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {'));
       expect(
-          code,
-          contains(
-              '[channel sendMessage:@[arg_x ?: [NSNull null], arg_y ?: [NSNull null]] reply:'));
+          code, contains('[channel sendMessage:@[@(arg_x), @(arg_y)] reply:'));
     }
   });
 


### PR DESCRIPTION
Updates the Objective-C generator to use `BOOL`, `NSInteger`, and `double` for non-nullable versions of those primitives, instead of boxing them with `NSNumber*`. This makes the code more idiomatic, brings them into alignment with enum behavior, and importantly helps minimize the chances of clients having issues with silent conversion of `NSNumber*` to `BOOL` in the long term (although it may cause some such issues in the short term when people update; the changelog contains a prominent warning about this).

As an incidental fix, this also fixes the use of `strong` for collections and strings, which is not best practice, since I was already changing related code.

Fixes https://github.com/flutter/flutter/issues/116680
Fixes https://github.com/flutter/flutter/issues/127401

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
