### PR TITLE
[ci] Disable Windows Arm64 stable CI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1107,20 +1107,6 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
 
-  - name: Windows_arm64 windows-build_all_packages stable
-    recipe: packages/packages
-    timeout: 30
-    bringup: true # https://github.com/flutter/flutter/issues/134083
-    properties:
-      add_recipes_cq: "true"
-      target_file: windows_build_all_packages.yaml
-      channel: stable
-      version_file: flutter_stable.version
-      dependencies: >
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-
   - name: Windows_x64 repo_tools_tests
     recipe: packages/packages
     timeout: 30


### PR DESCRIPTION
The Windows Arm64 build-only stable test is currently failing as the necessary build layout migration hasn't landed on stable yet: https://github.com/flutter/flutter/commit/792e26df9540cf2cf510ea0c11a53ba10a243424

This test can be re-added after the next Flutter stable release. This is tracked by https://github.com/flutter/flutter/issues/129813

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
