### PR TITLE
[google_sign_in] Enable FedCM for web. Use token expiration.

### DIFF
--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.12.1
+
+* Enables FedCM on browsers that support this authentication mechanism.
+* Uses the expiration timestamps of Credential and Token responses to improve
+  the accuracy of `isSignedIn` and `canAccessScopes` methods.
+* Deprecates `signIn()` method.
+  * Users should migrate to `renderButton` and `silentSignIn`, as described in
+    the README.
+
 ## 0.12.0+5
 
 * Migrates to `dart:ui_web` APIs.

--- a/packages/google_sign_in/google_sign_in_web/example/integration_test/src/jwt_examples.dart
+++ b/packages/google_sign_in/google_sign_in_web/example/integration_test/src/jwt_examples.dart
@@ -24,6 +24,11 @@ final CredentialResponse minimalCredential =
   'credential': minimalJwtToken,
 });
 
+final CredentialResponse expiredCredential =
+    jsifyAs<CredentialResponse>(<String, Object?>{
+  'credential': expiredJwtToken,
+});
+
 /// A JWT token with predefined values.
 ///
 /// 'email': 'adultman@example.com',
@@ -55,10 +60,29 @@ const String minimalJwtToken =
 
 /// The payload of a JWT token that contains only non-nullable values.
 ///
-/// "email": "adultman@example.com",
-/// "sub": "123456"
+/// 'email': 'adultman@example.com',
+/// 'sub': '123456'
 const String minimalPayload =
     'eyJlbWFpbCI6ImFkdWx0bWFuQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2In0';
+
+/// A JWT token with minimal set of predefined values and an expiration timestamp.
+///
+/// 'email': 'adultman@example.com',
+/// 'sub': '123456',
+/// 'exp': 1430330400
+///
+/// Signed with HS256 and the private key: 'symmetric-encryption-is-weak'
+const String expiredJwtToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.$expiredPayload.--gb5tnVSSsLg4zjjVH0FUUvT4rbehIcnBhB-8Iekm4';
+
+/// The payload of a JWT token that contains only non-nullable values, and an
+/// expiration timestamp of 1430330400 (Wednesday, April 29, 2015 6:00:00 PM UTC)
+///
+/// 'email': 'adultman@example.com',
+/// 'sub': '123456',
+/// 'exp': 1430330400
+const String expiredPayload =
+    'eyJlbWFpbCI6ImFkdWx0bWFuQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2IiwiZXhwIjoxNDMwMzMwNDAwfQ';
 
 // More encrypted JWT Tokens may be created on https://jwt.io.
 //

--- a/packages/google_sign_in/google_sign_in_web/example/integration_test/utils_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/example/integration_test/utils_test.dart
@@ -85,6 +85,30 @@ void main() {
     });
   });
 
+  group('getCredentialResponseExpirationTimestamp', () {
+    testWidgets('Good payload -> data', (_) async {
+      final DateTime? expiration =
+          getCredentialResponseExpirationTimestamp(expiredCredential);
+
+      expect(expiration, isNotNull);
+      expect(expiration!.millisecondsSinceEpoch, 1430330400 * 1000);
+    });
+
+    testWidgets('No expiration -> null', (_) async {
+      expect(
+          getCredentialResponseExpirationTimestamp(minimalCredential), isNull);
+    });
+
+    testWidgets('Bad data -> null', (_) async {
+      final CredentialResponse bogus =
+          jsifyAs<CredentialResponse>(<String, Object?>{
+        'credential': 'some-bogus.thing-that-is-not.valid-jwt',
+      });
+
+      expect(getCredentialResponseExpirationTimestamp(bogus), isNull);
+    });
+  });
+
   group('getJwtTokenPayload', () {
     testWidgets('happy case -> data', (_) async {
       final Map<String, Object?>? data = getJwtTokenPayload(goodJwtToken);

--- a/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
@@ -41,6 +41,8 @@ class GisSdkClient {
     _initializeIdClient(
       clientId,
       onResponse: _onCredentialResponse,
+      hostedDomain: hostedDomain,
+      useFedCM: true,
     );
 
     _tokenClient = _initializeTokenClient(
@@ -102,6 +104,8 @@ class GisSdkClient {
   void _initializeIdClient(
     String clientId, {
     required CallbackFn onResponse,
+    String? hostedDomain,
+    bool? useFedCM,
   }) {
     // Initialize `id` for the silent-sign in code.
     final IdConfiguration idConfig = IdConfiguration(
@@ -109,6 +113,9 @@ class GisSdkClient {
       callback: allowInterop(onResponse),
       cancel_on_tap_outside: false,
       auto_select: true, // Attempt to sign-in silently.
+      hd: hostedDomain,
+      use_fedcm_for_prompt:
+          useFedCM, // Use the native browser prompt, when available.
     );
     id.initialize(idConfig);
   }
@@ -238,7 +245,15 @@ class GisSdkClient {
   ///   * If [_lastCredentialResponse] is null, we add [people.scopes] to the
   ///     [_initialScopes], so we can retrieve User Profile information back
   ///     from the People API (without idToken). See [people.requestUserData].
+  @Deprecated(
+      'Use `renderButton` instead. See: https://pub.dev/packages/google_sign_in_web#migrating-to-v011-and-v012-google-identity-services')
   Future<GoogleSignInUserData?> signIn() async {
+    // Warn users that this method will be removed.
+    domConsole.warn(
+        'The google_sign_in plugin `signIn` method is deprecated on the web, and will be removed in Q2 2024. Please use `renderButton` instead. See: ',
+        <String>[
+          'https://pub.dev/packages/google_sign_in_web#migrating-to-v011-and-v012-google-identity-services'
+        ]);
     // If we already know the user, use their `email` as a `hint`, so they don't
     // have to pick their user again in the Authorization popup.
     final GoogleSignInUserData? knownUser =

--- a/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
@@ -239,6 +239,8 @@ class GisSdkClient {
     return id.renderButton(parent, convertButtonConfiguration(options)!);
   }
 
+  // TODO(dit): Clean this up. https://github.com/flutter/flutter/issues/137727
+  //
   /// Starts an oauth2 "implicit" flow to authorize requests.
   ///
   /// The new GIS SDK does not return user authentication from this flow, so:
@@ -283,7 +285,7 @@ class GisSdkClient {
   //
   // It'll do a request to the People API (if needed).
   //
-  // @Deprecated
+  // TODO(dit): Clean this up. https://github.com/flutter/flutter/issues/137727
   Future<GoogleSignInUserData?> _computeUserDataForLastToken() async {
     // If the user hasn't authenticated, request their basic profile info
     // from the People API.
@@ -328,6 +330,16 @@ class GisSdkClient {
     if (_lastCredentialResponse != null) {
       final DateTime? expiration = utils
           .getCredentialResponseExpirationTimestamp(_lastCredentialResponse);
+      // All Google ID Tokens provide an "exp" date. If the method above cannot
+      // extract `expiration`, it's because `_lastCredentialResponse`'s contents
+      // are unexpected (or wrong) in any way.
+      //
+      // Users are considered to be signedIn when the last CredentialResponse
+      // exists and has an expiration date in the future.
+      //
+      // Users are not signed in in any other case.
+      //
+      // See: https://developers.google.com/identity/openid-connect/openid-connect#an-id-tokens-payload
       isSignedIn = expiration?.isAfter(DateTime.now()) ?? false;
     }
 
@@ -412,6 +424,6 @@ class GisSdkClient {
   //
   // (This is a synthetic _lastCredentialResponse)
   //
-  // @Deprecated
+  // TODO(dit): Clean this up. https://github.com/flutter/flutter/issues/137727
   GoogleSignInUserData? _requestedUserData;
 }

--- a/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
@@ -54,11 +54,11 @@ Map<String, Object?>? decodeJwtPayload(String? payload) {
 
 /// Returns the payload of a [CredentialResponse].
 Map<String, Object?>? getResponsePayload(CredentialResponse? response) {
-  if (response == null || response.credential == null) {
+  if (response?.credential == null) {
     return null;
   }
 
-  return getJwtTokenPayload(response.credential);
+  return getJwtTokenPayload(response!.credential);
 }
 
 /// Converts a [CredentialResponse] into a [GoogleSignInUserData].
@@ -71,6 +71,9 @@ GoogleSignInUserData? gisResponsesToUserData(
   if (payload == null) {
     return null;
   }
+
+  assert(credentialResponse?.credential != null,
+      'The CredentialResponse cannot be null and have a payload.');
 
   return GoogleSignInUserData(
     email: payload['email']! as String,
@@ -88,11 +91,10 @@ GoogleSignInUserData? gisResponsesToUserData(
 DateTime? getCredentialResponseExpirationTimestamp(
     CredentialResponse? credentialResponse) {
   final Map<String, Object?>? payload = getResponsePayload(credentialResponse);
-  if (payload == null || payload['exp'] == null) {
-    return null;
-  }
-
-  return DateTime.fromMillisecondsSinceEpoch((payload['exp']! as int) * 1000);
+  // Get the 'exp' field from the payload, if present.
+  final int? exp = (payload != null) ? payload['exp'] as int? : null;
+  // Return 'exp' (a timestamp in seconds since Epoch) as a DateTime.
+  return (exp != null) ? DateTime.fromMillisecondsSinceEpoch(exp * 1000) : null;
 }
 
 /// Converts responses from the GIS library into TokenData for the plugin.

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.12.0+5
+version: 0.12.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  google_identity_services_web: ^0.2.1
+  google_identity_services_web: ^0.2.2
   google_sign_in_platform_interface: ^2.4.0
   http: ">=0.13.0 <2.0.0"
   js: ^0.6.3


### PR DESCRIPTION
* Enables [**FedCM API**](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API) on compatible browsers.
  * The GIS JS SDK falls-back to the JS implementation on browsers that don't support the new standard. See [migration instructions](https://developers.google.com/identity/gsi/web/guides/fedcm-migration)).
* Uses the supplied token expiration information to **more accurately compute `isSignedIn()` and `canAccessScopes(scopes)`**.
  * This does not handle the case where users sign in/out in another tab or from outside the web app, that's still something that needs to be checked server-side.
* **Deprecates the `signIn()` method on the web.**
  * Users should migrate to a combination of `renderButton()` and `silentSignIn()`, as described [here](https://pub.dev/packages/google_sign_in_web#migrating-to-v011-and-v012-google-identity-services).

### Issues

* FedCM:
  * Fixes https://github.com/flutter/flutter/issues/133703 (once rebuilt/redeployed)
  * Fixes `b/301259123`
* Token expiration:
  * Unblocks `b/245740319`

### Testing

* Added a few unit tests
* Manually verified token expiration: https://dit-gis-test.web.app

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
