### PR TITLE
[url_launcher] Fix launch mode types in new APIs

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,4 +1,11 @@
+## 6.2.1
+
+* Fixes incorrect types in `supportsLaunchMode` and
+  `supportsCloseForLaunchMode`.
+
 ## 6.2.0
+
+_Retracted due to incorrect types in new APIs._
 
 * Adds `supportsLaunchMode` for checking whether the current platform supports a
   given launch mode, to allow clients that will only work with specific modes

--- a/packages/url_launcher/url_launcher/README.md
+++ b/packages/url_launcher/url_launcher/README.md
@@ -67,7 +67,7 @@ See [`-[UIApplication canOpenURL:]`](https://developer.apple.com/documentation/u
 Add any URL schemes passed to `canLaunchUrl` as `<queries>` entries in your
 `AndroidManifest.xml`, otherwise it will return false in most cases starting
 on Android 11 (API 30) or higher. Checking for
-`supportsLaunchMode(PreferredLaunchMode.inAppBrowserView)` also requires
+`supportsLaunchMode(LaunchMode.inAppBrowserView)` also requires
 a `<queries>` entry to return anything but false. A `<queries>`
 element must be added to your manifest as a child of the root element.
 
@@ -222,9 +222,9 @@ On some platforms, web URLs can be launched either in an in-app web view, or
 in the default browser. The default behavior depends on the platform (see
 [`launchUrl`](https://pub.dev/documentation/url_launcher/latest/url_launcher/launchUrl.html)
 for details), but a specific mode can be used on supported platforms by
-passing a `PreferredLaunchMode`.
+passing a `LaunchMode`.
 
-Platforms that do no support a requested `PreferredLaunchMode` will
+Platforms that do no support a requested `LaunchMode` will
 automatically fall back to a supported mode (usually `platformDefault`). If
 your application needs to avoid that fallback behavior, however, you can check
 if the current platform supports a given mode with `supportsLaunchMode` before

--- a/packages/url_launcher/url_launcher/lib/src/url_launcher_uri.dart
+++ b/packages/url_launcher/url_launcher/lib/src/url_launcher_uri.dart
@@ -4,7 +4,11 @@
 
 import 'dart:async';
 
-import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+// PreferredLaunchMode is hidden to prevent accidentally using it in APIs at
+// this layer. If it is ever needed in this file, it should be imported
+// separately with a prefix.
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart'
+    hide PreferredLaunchMode;
 
 import '../url_launcher_string.dart';
 import 'type_conversion.dart';
@@ -81,8 +85,8 @@ Future<void> closeInAppWebView() async {
 /// Calling [launchUrl] with an unsupported mode will fall back to a supported
 /// mode, so calling this method is only necessary for cases where the caller
 /// needs to know which mode will be used.
-Future<bool> supportsLaunchMode(PreferredLaunchMode mode) {
-  return UrlLauncherPlatform.instance.supportsMode(mode);
+Future<bool> supportsLaunchMode(LaunchMode mode) {
+  return UrlLauncherPlatform.instance.supportsMode(convertLaunchMode(mode));
 }
 
 /// Returns true if [closeInAppWebView] is supported for [mode] in the current
@@ -90,6 +94,6 @@ Future<bool> supportsLaunchMode(PreferredLaunchMode mode) {
 ///
 /// If this returns false, [closeInAppWebView] will not work when launching
 /// URLs with [mode].
-Future<bool> supportsCloseForLaunchMode(PreferredLaunchMode mode) {
-  return UrlLauncherPlatform.instance.supportsMode(mode);
+Future<bool> supportsCloseForLaunchMode(LaunchMode mode) {
+  return UrlLauncherPlatform.instance.supportsMode(convertLaunchMode(mode));
 }

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.2.0
+version: 6.2.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/url_launcher/url_launcher/test/src/url_launcher_uri_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/url_launcher_uri_test.dart
@@ -251,7 +251,7 @@ void main() {
 
   group('supportsLaunchMode', () {
     test('handles returning true', () async {
-      const PreferredLaunchMode mode = PreferredLaunchMode.inAppBrowserView;
+      const LaunchMode mode = LaunchMode.inAppBrowserView;
       mock.setResponse(true);
 
       expect(await supportsLaunchMode(mode), true);
@@ -259,7 +259,7 @@ void main() {
     });
 
     test('handles returning false', () async {
-      const PreferredLaunchMode mode = PreferredLaunchMode.inAppBrowserView;
+      const LaunchMode mode = LaunchMode.inAppBrowserView;
       mock.setResponse(false);
 
       expect(await supportsLaunchMode(mode), false);
@@ -269,7 +269,7 @@ void main() {
 
   group('supportsCloseForLaunchMode', () {
     test('handles returning true', () async {
-      const PreferredLaunchMode mode = PreferredLaunchMode.inAppBrowserView;
+      const LaunchMode mode = LaunchMode.inAppBrowserView;
       mock.setResponse(true);
 
       expect(await supportsCloseForLaunchMode(mode), true);
@@ -277,7 +277,7 @@ void main() {
     });
 
     test('handles returning false', () async {
-      const PreferredLaunchMode mode = PreferredLaunchMode.inAppBrowserView;
+      const LaunchMode mode = LaunchMode.inAppBrowserView;
       mock.setResponse(false);
 
       expect(await supportsCloseForLaunchMode(mode), false);

--- a/packages/url_launcher/url_launcher/test/src/url_launcher_uri_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/url_launcher_uri_test.dart
@@ -251,37 +251,35 @@ void main() {
 
   group('supportsLaunchMode', () {
     test('handles returning true', () async {
-      const LaunchMode mode = LaunchMode.inAppBrowserView;
       mock.setResponse(true);
 
-      expect(await supportsLaunchMode(mode), true);
-      expect(mock.launchMode, mode);
+      expect(await supportsLaunchMode(LaunchMode.inAppBrowserView), true);
+      expect(mock.launchMode, PreferredLaunchMode.inAppBrowserView);
     });
 
     test('handles returning false', () async {
-      const LaunchMode mode = LaunchMode.inAppBrowserView;
       mock.setResponse(false);
 
-      expect(await supportsLaunchMode(mode), false);
-      expect(mock.launchMode, mode);
+      expect(await supportsLaunchMode(LaunchMode.inAppBrowserView), false);
+      expect(mock.launchMode, PreferredLaunchMode.inAppBrowserView);
     });
   });
 
   group('supportsCloseForLaunchMode', () {
     test('handles returning true', () async {
-      const LaunchMode mode = LaunchMode.inAppBrowserView;
       mock.setResponse(true);
 
-      expect(await supportsCloseForLaunchMode(mode), true);
-      expect(mock.launchMode, mode);
+      expect(
+          await supportsCloseForLaunchMode(LaunchMode.inAppBrowserView), true);
+      expect(mock.launchMode, PreferredLaunchMode.inAppBrowserView);
     });
 
     test('handles returning false', () async {
-      const LaunchMode mode = LaunchMode.inAppBrowserView;
       mock.setResponse(false);
 
-      expect(await supportsCloseForLaunchMode(mode), false);
-      expect(mock.launchMode, mode);
+      expect(
+          await supportsCloseForLaunchMode(LaunchMode.inAppBrowserView), false);
+      expect(mock.launchMode, PreferredLaunchMode.inAppBrowserView);
     });
   });
 }


### PR DESCRIPTION
The new query APIs added in 6.2.0 accidentally used `PreferredLaunchMode`, which is only intended for the platform interface layer, rather than `LaunchMode`, which is the app-facing analog (they are separate to allow controlling when each is updated separately).

Technically this is a breaking change, but 6.2.0 was out for less than 24 hours, so extremely few people will be affected (they would have to have updated, written code against the new API, and worked around the lack of type export), and a breaking change to fix this would have much more disruptive effects on the ecosystem.

Fixes https://github.com/flutter/flutter/issues/137278

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
