### PR TITLE
[repo] Adjust error message layout for repo checks

### DIFF
--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -442,11 +442,10 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     }
 
     if (fromPubspec != fromChangeLog) {
-      printError('''
-${indentation}Versions in CHANGELOG.md and pubspec.yaml do not match.
-${indentation}The version in pubspec.yaml is $fromPubspec.
-${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
-''');
+      printError(
+          '${indentation}Versions in CHANGELOG.md and pubspec.yaml do not match.\n '
+          '${indentation}The version in pubspec.yaml is $fromPubspec.\n '
+          '${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.');
       return false;
     }
 
@@ -558,11 +557,12 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
       } else {
         printError(
             'No version change found, but the change to this package could '
-            'not be verified to be exempt from version changes according to '
-            'repository policy. If this is a false positive, please comment in '
-            'the PR to explain why the PR is exempt, and add (or ask your '
-            'reviewer to add) the "$_missingVersionChangeOverrideLabel" '
-            'label.');
+            'not be verified to be exempt\n'
+            'from version changes according to repository policy.\n'
+            'If this is a false positive, please comment in '
+            'the PR to explain why the PR\n'
+            'is exempt, and add (or ask your reviewer to add) the '
+            '"$_missingVersionChangeOverrideLabel" label.');
         return 'Missing version change';
       }
     }
@@ -572,13 +572,13 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
         logWarning('Ignoring lack of CHANGELOG update due to the '
             '"$_missingChangelogChangeOverrideLabel" label.');
       } else {
-        printError(
-            'No CHANGELOG change found. If this PR needs an exemption from '
-            'the standard policy of listing all changes in the CHANGELOG, '
+        printError('No CHANGELOG change found.\n'
+            'If this PR needs an exemption from the standard policy of listing '
+            'all changes in the CHANGELOG,\n'
             'comment in the PR to explain why the PR is exempt, and add (or '
-            'ask your reviewer to add) the '
-            '"$_missingChangelogChangeOverrideLabel" label. Otherwise, '
-            'please add a NEXT entry in the CHANGELOG as described in '
+            'ask your reviewer to add) the\n'
+            '"$_missingChangelogChangeOverrideLabel" label.\n'
+            'Otherwise, please add a NEXT entry in the CHANGELOG as described in '
             'the contributing guide.');
         return 'Missing CHANGELOG change';
       }

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -442,10 +442,11 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     }
 
     if (fromPubspec != fromChangeLog) {
-      printError(
-          '${indentation}Versions in CHANGELOG.md and pubspec.yaml do not match.\n '
-          '${indentation}The version in pubspec.yaml is $fromPubspec.\n '
-          '${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.');
+      printError('''
+${indentation}Versions in CHANGELOG.md and pubspec.yaml do not match.
+${indentation}The version in pubspec.yaml is $fromPubspec.
+${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
+''');
       return false;
     }
 

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -961,7 +961,7 @@ packages/plugin/example/lib/foo.dart
         expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('No CHANGELOG change found'),
+            contains('No CHANGELOG change found.\nIf'),
             contains('plugin:\n'
                 '    Missing CHANGELOG change'),
           ]),
@@ -1222,7 +1222,10 @@ packages/plugin/lib/plugin.dart
         expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('No version change found'),
+            contains(
+              'No version change found, but the change to this package could '
+              'not be verified to be exempt\n',
+            ),
             contains('plugin:\n'
                 '    Missing version change'),
           ]),


### PR DESCRIPTION
This tweaks the errors messages that provide info like how to override a repo check for versioning or changelog updates.
Basically added newlines, so the errors do not require scrolling far off to the right to get the message.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
