### PR TITLE
[flutter_lints] Replace "flutter pub add --dev" with "dev:"

### DIFF
--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+* Replaces `flutter pub add --dev` with `dev:` in README.md.
+
 ## 3.0.0
 
 * Updated `package:lints` dependency to version 3.0.0, with the following changes:

--- a/packages/flutter_lints/README.md
+++ b/packages/flutter_lints/README.md
@@ -19,7 +19,7 @@ package. Entities created before that version can use these lints by following
 these instructions:
 
 1. Depend on this package as a **dev_dependency** by running
-  `flutter pub add --dev flutter_lints`.
+  `flutter pub add dev:flutter_lints`.
 2. Create an `analysis_options.yaml` file at the root of the package (alongside
    the `pubspec.yaml` file) and `include: package:flutter_lints/flutter.yaml`
    from it.

--- a/packages/flutter_lints/pubspec.yaml
+++ b/packages/flutter_lints/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_lints
 description: Recommended lints for Flutter apps, packages, and plugins to encourage good coding practices.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_lints
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_lints%22
-version: 3.0.0
+version: 3.0.1
 
 environment:
   sdk: ^3.0.0


### PR DESCRIPTION
This pull request is to replace `—dev` with `dev:`, as this is the newer way and is used in the Flutter documentation.
https://dart.dev/tools/pub/cmd/pub-add#dev-dependency
https://docs.flutter.dev/data-and-backend/serialization/json#setting-up-json_serializable-in-a-project

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
