### PR TITLE
[camera_avfoundation] testSampleBufferCallbackQueueMustBeCaptureSessionQueue assertions added

### DIFF
--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.h
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.h
@@ -15,7 +15,8 @@ extern FLTCam *FLTCreateCamWithCaptureSessionQueue(dispatch_queue_t captureSessi
 /// @param captureSessionQueue the capture session queue
 /// @param error the error
 /// @return an FLTCam object.
-extern FLTCam *FLTCreateCamWithCaptureSessionQueueWithError(dispatch_queue_t captureSessionQueue, NSError** error);
+extern FLTCam *FLTCreateCamWithCaptureSessionQueueWithError(dispatch_queue_t captureSessionQueue,
+                                                            NSError **error);
 
 /// Creates a test sample buffer.
 /// @return a test sample buffer.

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.h
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.h
@@ -11,6 +11,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return an FLTCam object.
 extern FLTCam *FLTCreateCamWithCaptureSessionQueue(dispatch_queue_t captureSessionQueue);
 
+/// Creates an `FLTCam` that runs its capture session operations on a given queue.
+/// @param captureSessionQueue the capture session queue
+/// @param error the error
+/// @return an FLTCam object.
+extern FLTCam *FLTCreateCamWithCaptureSessionQueueWithError(dispatch_queue_t captureSessionQueue, NSError** error);
+
 /// Creates a test sample buffer.
 /// @return a test sample buffer.
 extern CMSampleBufferRef FLTCreateTestSampleBuffer(void);

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.m
@@ -7,11 +7,12 @@
 @import AVFoundation;
 
 FLTCam *FLTCreateCamWithCaptureSessionQueue(dispatch_queue_t captureSessionQueue) {
-  NSError* error = nil;
+  NSError *error = nil;
   return FLTCreateCamWithCaptureSessionQueueWithError(captureSessionQueue, &error);
 }
 
-FLTCam *FLTCreateCamWithCaptureSessionQueueWithError(dispatch_queue_t captureSessionQueue, NSError** error) {
+FLTCam *FLTCreateCamWithCaptureSessionQueueWithError(dispatch_queue_t captureSessionQueue,
+                                                     NSError **error) {
   id inputMock = OCMClassMock([AVCaptureDeviceInput class]);
   OCMStub([inputMock deviceInputWithDevice:[OCMArg any] error:[OCMArg setTo:nil]])
       .andReturn(inputMock);

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.m
@@ -7,6 +7,11 @@
 @import AVFoundation;
 
 FLTCam *FLTCreateCamWithCaptureSessionQueue(dispatch_queue_t captureSessionQueue) {
+  NSError* error = nil;
+  return FLTCreateCamWithCaptureSessionQueueWithError(captureSessionQueue, &error);
+}
+
+FLTCam *FLTCreateCamWithCaptureSessionQueueWithError(dispatch_queue_t captureSessionQueue, NSError** error) {
   id inputMock = OCMClassMock([AVCaptureDeviceInput class]);
   OCMStub([inputMock deviceInputWithDevice:[OCMArg any] error:[OCMArg setTo:nil]])
       .andReturn(inputMock);
@@ -26,7 +31,7 @@ FLTCam *FLTCreateCamWithCaptureSessionQueue(dispatch_queue_t captureSessionQueue
                         videoCaptureSession:videoSessionMock
                         audioCaptureSession:audioSessionMock
                         captureSessionQueue:captureSessionQueue
-                                      error:nil];
+                                      error:error];
 }
 
 CMSampleBufferRef FLTCreateTestSampleBuffer(void) {

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSampleBufferTests.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSampleBufferTests.m
@@ -18,7 +18,13 @@
 
 - (void)testSampleBufferCallbackQueueMustBeCaptureSessionQueue {
   dispatch_queue_t captureSessionQueue = dispatch_queue_create("testing", NULL);
-  FLTCam *cam = FLTCreateCamWithCaptureSessionQueue(captureSessionQueue);
+  NSError *error = nil;
+  FLTCam *cam = FLTCreateCamWithCaptureSessionQueue(captureSessionQueue, &error);
+  XCTAssertNotNil(cam, @"FLTCreateCamWithCaptureSessionQueue must not be nil, error: %@", error);
+  XCTAssertNotNil(cam.captureVideoOutput.sampleBufferCallbackQueue, @"sampleBufferCallbackQueue must not be nil, error: %@", error);
+  if (error) {
+    XCTAssertNil(error, @"FLTCreateCamWithCaptureSessionQueue error: %@", error.description);
+  }
   XCTAssertEqual(captureSessionQueue, cam.captureVideoOutput.sampleBufferCallbackQueue,
                  @"Sample buffer callback queue must be the capture session queue.");
 }

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSampleBufferTests.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSampleBufferTests.m
@@ -21,7 +21,8 @@
   NSError *error = nil;
   FLTCam *cam = FLTCreateCamWithCaptureSessionQueueWithError(captureSessionQueue, &error);
   XCTAssertNotNil(cam, @"FLTCreateCamWithCaptureSessionQueue must not be nil, error: %@", error);
-  XCTAssertNotNil(cam.captureVideoOutput.sampleBufferCallbackQueue, @"sampleBufferCallbackQueue must not be nil, error: %@", error);
+  XCTAssertNotNil(cam.captureVideoOutput.sampleBufferCallbackQueue,
+                  @"sampleBufferCallbackQueue must not be nil, error: %@", error);
   if (error) {
     XCTAssertNil(error, @"FLTCreateCamWithCaptureSessionQueue error: %@", error.description);
   }

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSampleBufferTests.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSampleBufferTests.m
@@ -19,7 +19,7 @@
 - (void)testSampleBufferCallbackQueueMustBeCaptureSessionQueue {
   dispatch_queue_t captureSessionQueue = dispatch_queue_create("testing", NULL);
   NSError *error = nil;
-  FLTCam *cam = FLTCreateCamWithCaptureSessionQueue(captureSessionQueue, &error);
+  FLTCam *cam = FLTCreateCamWithCaptureSessionQueueWithError(captureSessionQueue, &error);
   XCTAssertNotNil(cam, @"FLTCreateCamWithCaptureSessionQueue must not be nil, error: %@", error);
   XCTAssertNotNil(cam.captureVideoOutput.sampleBufferCallbackQueue, @"sampleBufferCallbackQueue must not be nil, error: %@", error);
   if (error) {


### PR DESCRIPTION
CI/CD test reports `@"Sample buffer callback queue must be the capture session queue."` in `testSampleBufferCallbackQueueMustBeCaptureSessionQueue`.

Test should expect that `cam.captureVideoOutput.sampleBufferCallbackQueue` is `not nil`.

It is actually `nil` on CI/CD, and `not nil` when running on development host machine (Sonoma, XCode 15.0.1).
