### PR TITLE
[web_view]Expose the allowsLinkPreview property in WKWebView for iOS

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.2
+
+* Adds support for the `allowsLinkPreview` property on iOS.
+
 ## 4.4.1
 
 * Exposes `JavaScriptLogLevel` from platform interface.

--- a/packages/webview_flutter/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/example/pubspec.yaml
@@ -29,6 +29,11 @@ dev_dependencies:
     sdk: flutter
   webview_flutter_platform_interface: ^2.3.0
 
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  webview_flutter_platform_interface:
+    path: ../../webview_flutter_platform_interface
+
 flutter:
   uses-material-design: true
   assets:

--- a/packages/webview_flutter/webview_flutter/lib/src/legacy/webview.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/legacy/webview.dart
@@ -92,6 +92,7 @@ class WebView extends StatefulWidget {
     this.onWebResourceError,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
+    this.allowsLinkPreview = true,
     this.userAgent,
     this.zoomEnabled = true,
     this.initialMediaPlaybackPolicy =
@@ -260,6 +261,13 @@ class WebView extends StatefulWidget {
   /// By default `gestureNavigationEnabled` is false.
   final bool gestureNavigationEnabled;
 
+  /// Whether pressing a link displays a preview of the destination for the link.
+  ///
+  /// Not supported on all platforms.
+  ///
+  /// By default `allowsLinkPreview` is true.
+  final bool allowsLinkPreview;
+
   /// The value used for the HTTP User-Agent: request header.
   ///
   /// When null the platform's webview default is used for the User-Agent header.
@@ -380,6 +388,7 @@ WebSettings _webSettingsFromWidget(WebView widget) {
     hasProgressTracking: widget.onProgress != null,
     debuggingEnabled: widget.debuggingEnabled,
     gestureNavigationEnabled: widget.gestureNavigationEnabled,
+    allowsLinkPreview: widget.allowsLinkPreview,
     allowsInlineMediaPlayback: widget.allowsInlineMediaPlayback,
     userAgent: WebSetting<String?>.of(widget.userAgent),
     zoomEnabled: widget.zoomEnabled,
@@ -397,6 +406,7 @@ WebSettings _clearUnchangedWebSettings(
   assert(newValue.hasNavigationDelegate != null);
   assert(newValue.debuggingEnabled != null);
   assert(newValue.zoomEnabled != null);
+  assert(newValue.allowsLinkPreview != null);
 
   JavascriptMode? javascriptMode;
   bool? hasNavigationDelegate;
@@ -404,6 +414,7 @@ WebSettings _clearUnchangedWebSettings(
   bool? debuggingEnabled;
   WebSetting<String?> userAgent = const WebSetting<String?>.absent();
   bool? zoomEnabled;
+  bool? allowsLinkPreview;
   if (currentValue.javascriptMode != newValue.javascriptMode) {
     javascriptMode = newValue.javascriptMode;
   }
@@ -422,6 +433,9 @@ WebSettings _clearUnchangedWebSettings(
   if (currentValue.zoomEnabled != newValue.zoomEnabled) {
     zoomEnabled = newValue.zoomEnabled;
   }
+  if (currentValue.allowsLinkPreview != newValue.allowsLinkPreview) {
+    allowsLinkPreview = newValue.allowsLinkPreview;
+  }
 
   return WebSettings(
     javascriptMode: javascriptMode,
@@ -430,6 +444,7 @@ WebSettings _clearUnchangedWebSettings(
     debuggingEnabled: debuggingEnabled,
     userAgent: userAgent,
     zoomEnabled: zoomEnabled,
+    allowsLinkPreview: allowsLinkPreview,
   );
 }
 

--- a/packages/webview_flutter/webview_flutter/lib/src/webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/webview_controller.dart
@@ -354,6 +354,11 @@ class WebViewController {
     return platform.setUserAgent(userAgent);
   }
 
+  /// Whether to display a preview of the destination for the link
+  Future<void> setAllowsLinkPreview(bool allow) {
+    return platform.setAllowsLinkPreview(allow);
+  }
+
   /// Sets a callback that notifies the host application on any log messages
   /// written to the JavaScript console.
   ///

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.4.1
+version: 4.4.2
 
 environment:
   sdk: ">=2.19.0 <4.0.0"
@@ -22,6 +22,11 @@ dependencies:
   webview_flutter_android: ^3.12.0
   webview_flutter_platform_interface: ^2.6.0
   webview_flutter_wkwebview: ^3.9.0
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter/test/legacy/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/legacy/webview_flutter_test.dart
@@ -1114,6 +1114,58 @@ void main() {
     });
   });
 
+  group('allowsLinkPreview', () {
+    testWidgets('defaults to true', (WidgetTester tester) async {
+      await tester.pumpWidget(const WebView());
+
+      final CreationParams params = captureBuildArgs(
+        mockWebViewPlatform,
+        creationParams: true,
+      ).single as CreationParams;
+
+      expect(params.webSettings!.allowsLinkPreview, true);
+    });
+
+    testWidgets('can be disabled', (WidgetTester tester) async {
+      await tester.pumpWidget(const WebView(
+        allowsLinkPreview: false,
+      ));
+
+      final CreationParams params = captureBuildArgs(
+        mockWebViewPlatform,
+        creationParams: true,
+      ).single as CreationParams;
+
+      expect(params.webSettings!.allowsLinkPreview, false);
+    });
+
+    testWidgets('can be changed', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(WebView(key: key));
+
+      await tester.pumpWidget(WebView(
+        key: key,
+        allowsLinkPreview: false,
+      ));
+
+      final WebSettings enabledSettings =
+          verify(mockWebViewPlatformController.updateSettings(captureAny))
+              .captured
+              .last as WebSettings;
+      expect(enabledSettings.allowsLinkPreview, false);
+
+      await tester.pumpWidget(WebView(
+        key: key,
+      ));
+
+      final WebSettings disabledSettings =
+          verify(mockWebViewPlatformController.updateSettings(captureAny))
+              .captured
+              .last as WebSettings;
+      expect(disabledSettings.allowsLinkPreview, true);
+    });
+  });
+
   group('Custom platform implementation', () {
     setUp(() {
       WebView.platform = MyWebViewPlatform();
@@ -1143,6 +1195,7 @@ void main() {
               debuggingEnabled: false,
               userAgent: const WebSetting<String?>.of(null),
               gestureNavigationEnabled: true,
+              allowsLinkPreview: true,
               zoomEnabled: true,
             ),
           )));
@@ -1326,6 +1379,7 @@ class MatchesWebSettings extends Matcher {
         _webSettings!.gestureNavigationEnabled ==
             webSettings.gestureNavigationEnabled &&
         _webSettings!.userAgent == webSettings.userAgent &&
+        _webSettings!.allowsLinkPreview == webSettings.allowsLinkPreview &&
         _webSettings!.zoomEnabled == webSettings.zoomEnabled;
   }
 }

--- a/packages/webview_flutter/webview_flutter/test/webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_controller_test.dart
@@ -336,6 +336,18 @@ void main() {
     );
   });
 
+  test('setAllowsLinkPreview', () async {
+    final MockPlatformWebViewController mockPlatformWebViewController =
+        MockPlatformWebViewController();
+
+    final WebViewController webViewController = WebViewController.fromPlatform(
+      mockPlatformWebViewController,
+    );
+
+    await webViewController.setAllowsLinkPreview(false);
+    verify(mockPlatformWebViewController.setAllowsLinkPreview(false));
+  });
+
   test('setUserAgent', () async {
     final MockPlatformWebViewController mockPlatformWebViewController =
         MockPlatformWebViewController();

--- a/packages/webview_flutter/webview_flutter/test/webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_controller_test.mocks.dart
@@ -343,6 +343,17 @@ class MockPlatformWebViewController extends _i1.Mock
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setAllowsLinkPreview(bool? allow) => (super.noSuchMethod(
+        Invocation.method(
+          #setAllowsLinkPreview,
+          [allow],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
   @override
   _i5.Future<void> setOnPlatformPermissionRequest(
           void Function(_i2.PlatformWebViewPermissionRequest)?

--- a/packages/webview_flutter/webview_flutter/test/webview_widget_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_widget_test.mocks.dart
@@ -361,6 +361,17 @@ class MockPlatformWebViewController extends _i1.Mock
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> setAllowsLinkPreview(bool? allow) => (super.noSuchMethod(
+        Invocation.method(
+          #setAllowsLinkPreview,
+          [allow],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
   @override
   _i7.Future<void> setOnPlatformPermissionRequest(
           void Function(_i2.PlatformWebViewPermissionRequest)?

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+* Adds support for the `allowsLinkPreview` property on iOS.
+
 ## 2.6.0
 
 * Adds support to register a callback to intercept messages that are written to

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/legacy/types/web_settings.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/legacy/types/web_settings.dart
@@ -82,6 +82,7 @@ class WebSettings {
     this.hasProgressTracking,
     this.debuggingEnabled,
     this.gestureNavigationEnabled,
+    this.allowsLinkPreview,
     this.allowsInlineMediaPlayback,
     this.zoomEnabled,
     required this.userAgent,
@@ -125,8 +126,13 @@ class WebSettings {
   /// See also: [WebView.gestureNavigationEnabled]
   final bool? gestureNavigationEnabled;
 
+  /// Determines whether pressing a link displays a preview of the destination for the link in iOS.
+  ///
+  /// See also: [WebView.allowsLinkPreview]
+  final bool? allowsLinkPreview;
+
   @override
   String toString() {
-    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, hasProgressTracking: $hasProgressTracking, debuggingEnabled: $debuggingEnabled, gestureNavigationEnabled: $gestureNavigationEnabled, userAgent: $userAgent, allowsInlineMediaPlayback: $allowsInlineMediaPlayback)';
+    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, hasProgressTracking: $hasProgressTracking, debuggingEnabled: $debuggingEnabled, gestureNavigationEnabled: $gestureNavigationEnabled, allowsLinkPreview: $allowsLinkPreview, userAgent: $userAgent, allowsInlineMediaPlayback: $allowsInlineMediaPlayback)';
   }
 }

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
@@ -261,6 +261,11 @@ abstract class PlatformWebViewController extends PlatformInterface {
         'setUserAgent is not implemented on the current platform');
   }
 
+  /// Whether to display a preview of the destination for the link
+  ///
+  /// This is not supported by all platforms, so it defaults to a noop
+  Future<void> setAllowsLinkPreview(bool allow) async {}
+
   /// Sets a callback that notifies the host application that web content is
   /// requesting permission to access the specified resources.
   Future<void> setOnPlatformPermissionRequest(

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/webview_flutt
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.6.0
+version: 2.6.1
 
 environment:
   sdk: ">=2.19.0 <4.0.0"

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.3
+
+* Adds support for the `allowsLinkPreview` property on iOS.
+
 ## 3.9.2
 
 * Fixes error caused by calling `WKWebViewConfiguration.limitsNavigationsToAppBoundDomains` on

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
@@ -353,6 +353,22 @@ static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
   XCTAssertNil(error);
 }
 
+- (void)testSetAllowsLinkPreview {
+  FWFWebView *mockWebView = OCMClassMock([FWFWebView class]);
+
+  FWFInstanceManager *instanceManager = [[FWFInstanceManager alloc] init];
+  [instanceManager addDartCreatedInstance:mockWebView withIdentifier:0];
+
+  FWFWebViewHostApiImpl *hostAPI = [[FWFWebViewHostApiImpl alloc]
+      initWithBinaryMessenger:OCMProtocolMock(@protocol(FlutterBinaryMessenger))
+              instanceManager:instanceManager];
+
+  FlutterError *error;
+  [hostAPI setAllowsLinkPreviewForWebViewWithIdentifier:@0 isAllowed:@NO error:&error];
+  OCMVerify([mockWebView setAllowsLinkPreview:NO]);
+  XCTAssertNil(error);
+}
+
 - (void)testEvaluateJavaScript {
   FWFWebView *mockWebView = OCMClassMock([FWFWebView class]);
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/lib/legacy/web_view.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/lib/legacy/web_view.dart
@@ -68,6 +68,7 @@ class WebView extends StatefulWidget {
     this.onWebResourceError,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
+    this.allowsLinkPreview = true,
     this.userAgent,
     this.zoomEnabled = true,
     this.initialMediaPlaybackPolicy =
@@ -204,6 +205,13 @@ class WebView extends StatefulWidget {
   ///
   /// By default `gestureNavigationEnabled` is false.
   final bool gestureNavigationEnabled;
+
+  /// Whether pressing a link displays a preview of the destination for the link.
+  ///
+  /// Not supported on all platforms.
+  ///
+  /// By default `allowsLinkPreview` is true, to match the default on iOS.
+  final bool allowsLinkPreview;
 
   /// The value used for the HTTP User-Agent: request header.
   ///
@@ -618,6 +626,7 @@ WebSettings _webSettingsFromWidget(WebView widget) {
     hasProgressTracking: widget.onProgress != null,
     debuggingEnabled: widget.debuggingEnabled,
     gestureNavigationEnabled: widget.gestureNavigationEnabled,
+    allowsLinkPreview: widget.allowsLinkPreview,
     allowsInlineMediaPlayback: widget.allowsInlineMediaPlayback,
     userAgent: WebSetting<String?>.of(widget.userAgent),
     zoomEnabled: widget.zoomEnabled,

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/pubspec.yaml
@@ -25,6 +25,11 @@ dev_dependencies:
   integration_test:
     sdk: flutter
 
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  webview_flutter_platform_interface:
+    path: ../../webview_flutter_platform_interface
+
 flutter:
   uses-material-design: true
   assets:

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFGeneratedWebKitApis.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFGeneratedWebKitApis.h
@@ -744,6 +744,12 @@ NSObject<FlutterMessageCodec> *FWFWKWebViewHostApiGetCodec(void);
 - (void)setAllowsBackForwardForWebViewWithIdentifier:(NSNumber *)identifier
                                            isAllowed:(NSNumber *)allow
                                                error:(FlutterError *_Nullable *_Nonnull)error;
+- (void)setAllowsLinkPreviewForWebViewWithIdentifier:(NSNumber *)identifier
+                                           isAllowed:(NSNumber *)allow
+                                               error:(FlutterError *_Nullable *_Nonnull)error;
+- (void)setUserAgentForWebViewWithIdentifier:(NSNumber *)identifier
+                                   userAgent:(nullable NSString *)userAgent
+                                       error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)setCustomUserAgentForWebViewWithIdentifier:(NSNumber *)identifier
                                          userAgent:(nullable NSString *)userAgent
                                              error:(FlutterError *_Nullable *_Nonnull)error;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFGeneratedWebKitApis.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFGeneratedWebKitApis.m
@@ -2462,6 +2462,32 @@ void FWFWKWebViewHostApiSetup(id<FlutterBinaryMessenger> binaryMessenger,
   {
     FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
            initWithName:
+               @"dev.flutter.pigeon.webview_flutter_wkwebview.WKWebViewHostApi.setAllowsLinkPreview"
+        binaryMessenger:binaryMessenger
+                  codec:FWFWKWebViewHostApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector
+                     (setAllowsLinkPreviewForWebViewWithIdentifier:isAllowed:error:)],
+                @"FWFWKWebViewHostApi api (%@) doesn't respond to "
+                @"@selector(setAllowsLinkPreviewForWebViewWithIdentifier:isAllowed:error:)",
+                api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray *args = message;
+        NSNumber *arg_identifier = GetNullableObjectAtIndex(args, 0);
+        NSNumber *arg_allow = GetNullableObjectAtIndex(args, 1);
+        FlutterError *error;
+        [api setAllowsLinkPreviewForWebViewWithIdentifier:arg_identifier
+                                                isAllowed:arg_allow
+                                                    error:&error];
+        callback(wrapResult(nil, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
+           initWithName:
                @"dev.flutter.pigeon.webview_flutter_wkwebview.WKWebViewHostApi.setCustomUserAgent"
         binaryMessenger:binaryMessenger
                   codec:FWFWKWebViewHostApiGetCodec()];

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewHostApi.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewHostApi.m
@@ -276,6 +276,14 @@
 }
 
 - (void)
+    setAllowsLinkPreviewForWebViewWithIdentifier:(nonnull NSNumber *)identifier
+                                       isAllowed:(nonnull NSNumber *)allow
+                                           error:(FlutterError *_Nullable __autoreleasing *_Nonnull)
+                                                     error {
+  [[self webViewForIdentifier:identifier] setAllowsLinkPreview:allow.boolValue];
+}
+
+- (void)
     setNavigationDelegateForWebViewWithIdentifier:(nonnull NSNumber *)identifier
                                delegateIdentifier:(nullable NSNumber *)navigationDelegateIdentifier
                                             error:

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/common/web_kit.g.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/common/web_kit.g.dart
@@ -2513,6 +2513,29 @@ class WKWebViewHostApi {
     }
   }
 
+  Future<void> setAllowsLinkPreview(int arg_identifier, bool arg_allow) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.webview_flutter_wkwebview.WKWebViewHostApi.setAllowsLinkPreview',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel
+        .send(<Object?>[arg_identifier, arg_allow]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<void> setCustomUserAgent(
       int arg_identifier, String? arg_userAgent) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/legacy/web_kit_webview_widget.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/legacy/web_kit_webview_widget.dart
@@ -422,6 +422,10 @@ class WebKitWebViewPlatformController extends WebViewPlatformController {
         webView.setAllowsBackForwardNavigationGestures(
           setting.gestureNavigationEnabled!,
         ),
+      if (setting.allowsLinkPreview != null)
+        webView.setAllowsLinkPreview(
+          setting.allowsLinkPreview!,
+        ),
     ]);
   }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/web_kit/web_kit.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/web_kit/web_kit.dart
@@ -1087,6 +1087,18 @@ class WKWebView extends UIView {
     );
   }
 
+  /// Whether pressing a link displays a preview of the destination for the link.
+  ///
+  /// In iOS, this property is available on devices that support 3D Touch. In iOS 10 and later, the default value is true; in previous versions of iOS, the default value is false.
+  ///
+  /// Sets [WKWebView.allowsLinkPreview](https://developer.apple.com/documentation/webkit/wkwebview/1415000-allowslinkpreview?language=objc).
+  Future<void> setAllowsLinkPreview(bool allow) {
+    return _webViewApi.setAllowsLinkPreviewForInstances(
+      this,
+      allow,
+    );
+  }
+
   /// The custom user agent string.
   ///
   /// The default value of this property is null.

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/web_kit/web_kit_api_impls.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/web_kit/web_kit_api_impls.dart
@@ -1031,6 +1031,17 @@ class WKWebViewHostApiImpl extends WKWebViewHostApi {
     );
   }
 
+  /// Calls [setAllowsLinkPreview] with the ids of the provided object instances.
+  Future<void> setAllowsLinkPreviewForInstances(
+    WKWebView instance,
+    bool allow,
+  ) {
+    return setAllowsLinkPreview(
+      instanceManager.getIdentifier(instance)!,
+      allow,
+    );
+  }
+
   /// Calls [setCustomUserAgent] with the ids of the provided object instances.
   Future<void> setCustomUserAgentForInstances(
     WKWebView instance,

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
@@ -486,6 +486,11 @@ class WebKitWebViewController extends PlatformWebViewController {
   }
 
   @override
+  Future<void> setAllowsLinkPreview(bool allow) {
+    return _webView.setAllowsLinkPreview(allow);
+  }
+
+  @override
   Future<void> enableZoom(bool enabled) async {
     if (_zoomEnabled == enabled) {
       return;

--- a/packages/webview_flutter/webview_flutter_wkwebview/pigeons/web_kit.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pigeons/web_kit.dart
@@ -688,6 +688,9 @@ abstract class WKWebViewHostApi {
   @ObjCSelector('setAllowsBackForwardForWebViewWithIdentifier:isAllowed:')
   void setAllowsBackForwardNavigationGestures(int identifier, bool allow);
 
+  @ObjCSelector('setAllowsLinkPreviewForWebViewWithIdentifier:isAllowed:')
+  void setAllowsLinkPreview(int identifier, bool allow);
+
   @ObjCSelector('setCustomUserAgentForWebViewWithIdentifier:userAgent:')
   void setCustomUserAgent(int identifier, String? userAgent);
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.9.2
+version: 3.9.3
 
 environment:
   sdk: ">=2.19.0 <4.0.0"
@@ -28,6 +28,11 @@ dev_dependencies:
     sdk: flutter
   mockito: 5.4.1
   pigeon: ^10.1.4
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface
 
 topics:
   - html

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/legacy/web_kit_webview_widget_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/legacy/web_kit_webview_widget_test.mocks.dart
@@ -624,6 +624,17 @@ class MockWKWebView extends _i1.Mock implements _i4.WKWebView {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setAllowsLinkPreview(bool? allow) => (super.noSuchMethod(
+        Invocation.method(
+          #setAllowsLinkPreview,
+          [allow],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
   @override
   _i5.Future<void> setCustomUserAgent(String? userAgent) => (super.noSuchMethod(
         Invocation.method(

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/src/common/test_web_kit.g.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/src/common/test_web_kit.g.dart
@@ -1154,6 +1154,8 @@ abstract class TestWKWebViewHostApi {
 
   void setAllowsBackForwardNavigationGestures(int identifier, bool allow);
 
+  void setAllowsLinkPreview(int identifier, bool allow);
+
   void setCustomUserAgent(int identifier, String? userAgent);
 
   Future<Object?> evaluateJavaScript(int identifier, String javaScriptString);
@@ -1554,6 +1556,32 @@ abstract class TestWKWebViewHostApi {
               'Argument for dev.flutter.pigeon.webview_flutter_wkwebview.WKWebViewHostApi.setAllowsBackForwardNavigationGestures was null, expected non-null bool.');
           api.setAllowsBackForwardNavigationGestures(
               arg_identifier!, arg_allow!);
+          return <Object?>[];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.webview_flutter_wkwebview.WKWebViewHostApi.setAllowsLinkPreview',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.webview_flutter_wkwebview.WKWebViewHostApi.setAllowsLinkPreview was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_identifier = (args[0] as int?);
+          assert(arg_identifier != null,
+              'Argument for dev.flutter.pigeon.webview_flutter_wkwebview.WKWebViewHostApi.setAllowsLinkPreview was null, expected non-null int.');
+          final bool? arg_allow = (args[1] as bool?);
+          assert(arg_allow != null,
+              'Argument for dev.flutter.pigeon.webview_flutter_wkwebview.WKWebViewHostApi.setAllowsLinkPreview was null, expected non-null bool.');
+          api.setAllowsLinkPreview(arg_identifier!, arg_allow!);
           return <Object?>[];
         });
       }

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/src/ui_kit/ui_kit_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/src/ui_kit/ui_kit_test.mocks.dart
@@ -293,6 +293,23 @@ class MockTestWKWebViewHostApi extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  void setAllowsLinkPreview(
+    int? identifier,
+    bool? allow,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #setAllowsLinkPreview,
+          [
+            identifier,
+            allow,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
   @override
   void setCustomUserAgent(
     int? identifier,

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/src/web_kit/web_kit_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/src/web_kit/web_kit_test.dart
@@ -833,6 +833,14 @@ void main() {
         ));
       });
 
+      test('setAllowsLinkPreview', () {
+        webView.setAllowsLinkPreview(false);
+        verify(mockPlatformHostApi.setAllowsLinkPreview(
+          webViewInstanceId,
+          false,
+        ));
+      });
+
       test('setCustomUserAgent', () {
         webView.setCustomUserAgent('hello');
         verify(mockPlatformHostApi.setCustomUserAgent(

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/src/web_kit/web_kit_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/src/web_kit/web_kit_test.mocks.dart
@@ -522,6 +522,23 @@ class MockTestWKWebViewHostApi extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  void setAllowsLinkPreview(
+    int? identifier,
+    bool? allow,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #setAllowsLinkPreview,
+          [
+            identifier,
+            allow,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
   @override
   void setCustomUserAgent(
     int? identifier,

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.mocks.dart
@@ -732,6 +732,17 @@ class MockWKWebView extends _i1.Mock implements _i5.WKWebView {
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> setAllowsLinkPreview(bool? allow) => (super.noSuchMethod(
+        Invocation.method(
+          #setAllowsLinkPreview,
+          [allow],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
   @override
   _i6.Future<void> setCustomUserAgent(String? userAgent) => (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
Based off of flutter/plugins#5110
Also exposed it through the webview_controller
This comes from breaking https://github.com/flutter/packages/pull/5029 up into two

This PR fixes this issue:
- https://github.com/flutter/flutter/issues/69748
- (duplicate) https://github.com/flutter/flutter/issues/100783

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

