### PR TITLE
[google_sign_in] Add server auth code retrieval to gis_client

### DIFF
--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.2
+
+* Adds server auth code retrieval to google_sign_in_web.
+
 ## 0.12.1
 
 * Enables FedCM on browsers that support this authentication mechanism.

--- a/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
@@ -300,4 +300,11 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
   @override
   Stream<GoogleSignInUserData?>? get userDataEvents =>
       _userDataController.stream;
+
+  /// Requests server auth code from GIS Client per:
+  /// https://developers.google.com/identity/oauth2/web/guides/use-code-model#initialize_a_code_client
+  Future<String?> requestServerAuthCode() async {
+    await initialized;
+    return _gisClient.requestServerAuthCode();
+  }
 }

--- a/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
@@ -51,6 +51,14 @@ class GisSdkClient {
       onResponse: _onTokenResponse,
       onError: _onTokenError,
     );
+
+    _codeClient = _initializeCodeClient(
+      clientId,
+      hostedDomain: hostedDomain,
+      onResponse: _onCodeResponse,
+      onError: _onCodeError,
+      scopes: initialScopes,
+    );
   }
 
   void _logIfEnabled(String message, [List<Object?>? more]) {
@@ -63,6 +71,7 @@ class GisSdkClient {
   void _configureStreams() {
     _tokenResponses = StreamController<TokenResponse>.broadcast();
     _credentialResponses = StreamController<CredentialResponse>.broadcast();
+    _codeResponses = StreamController<CodeResponse>.broadcast();
 
     _tokenResponses.stream.listen((TokenResponse response) {
       _lastTokenResponse = response;
@@ -71,6 +80,13 @@ class GisSdkClient {
     }, onError: (Object error) {
       _logIfEnabled('Error on TokenResponse:', <Object>[error.toString()]);
       _lastTokenResponse = null;
+    });
+
+    _codeResponses.stream.listen((CodeResponse response) {
+      _lastCodeResponse = response;
+    }, onError: (Object error) {
+      _logIfEnabled('Error on CodeResponse:', <Object>[error.toString()]);
+      _lastCodeResponse = null;
     });
 
     _credentialResponses.stream.listen((CredentialResponse response) {
@@ -174,6 +190,44 @@ class GisSdkClient {
     _tokenResponses.addError(getProperty(error!, 'type'));
   }
 
+// Creates a `oauth2.CodeClient` used for authorization (scope) requests.
+  CodeClient _initializeCodeClient(
+    String clientId, {
+    String? hostedDomain,
+    required List<String> scopes,
+    required CodeClientCallbackFn onResponse,
+    required ErrorCallbackFn onError,
+  }) {
+    // Create a Token Client for authorization calls.
+    final CodeClientConfig codeConfig = CodeClientConfig(
+      client_id: clientId,
+      hosted_domain: hostedDomain,
+      callback: allowInterop(_onCodeResponse),
+      error_callback: allowInterop(_onCodeError),
+      scope: scopes.join(' '),
+      auto_select: true,
+      enable_serial_consent: true,
+      hint: 'hint',
+      redirect_uri: null,
+      select_account: true,
+      state: null,
+      ux_mode: UxMode.popup,
+    );
+    return oauth2.initCodeClient(codeConfig);
+  }
+
+  void _onCodeResponse(CodeResponse response) {
+    if (response.error != null) {
+      _codeResponses.addError(response.error!);
+    } else {
+      _codeResponses.add(response);
+    }
+  }
+
+  void _onCodeError(Object? error) {
+    _codeResponses.addError(getProperty(error!, 'type'));
+  }
+
   /// Attempts to sign-in the user using the OneTap UX flow.
   ///
   /// If the user consents, to OneTap, the [GoogleSignInUserData] will be
@@ -237,6 +291,14 @@ class GisSdkClient {
     GSIButtonConfiguration options,
   ) async {
     return id.renderButton(parent, convertButtonConfiguration(options)!);
+  }
+
+  /// Requests a server auth code per:
+  /// https://developers.google.com/identity/oauth2/web/guides/use-code-model#initialize_a_code_client
+  Future<String?> requestServerAuthCode() async {
+    _codeClient.requestCode();
+    final CodeResponse response = await _codeResponses.stream.first;
+    return response.code;
   }
 
   // TODO(dit): Clean this up. https://github.com/flutter/flutter/issues/137727
@@ -306,6 +368,7 @@ class GisSdkClient {
     return utils.gisResponsesToTokenData(
       _lastCredentialResponse,
       _lastTokenResponse,
+      _lastCodeResponse,
     );
   }
 
@@ -351,6 +414,7 @@ class GisSdkClient {
     _lastCredentialResponse = null;
     _lastTokenResponse = null;
     _requestedUserData = null;
+    _lastCodeResponse = null;
   }
 
   /// Requests the list of [scopes] passed in to the client.
@@ -402,16 +466,19 @@ class GisSdkClient {
 
   // The Google Identity Services client for oauth requests.
   late TokenClient _tokenClient;
+  late CodeClient _codeClient;
 
   // Streams of credential and token responses.
   late StreamController<CredentialResponse> _credentialResponses;
   late StreamController<TokenResponse> _tokenResponses;
+  late StreamController<CodeResponse> _codeResponses;
 
   // The last-seen credential and token responses
   CredentialResponse? _lastCredentialResponse;
   TokenResponse? _lastTokenResponse;
   // Expiration timestamp for the lastTokenResponse, which only has an `expires_in` field.
   DateTime? _lastTokenResponseExpiration;
+  CodeResponse? _lastCodeResponse;
 
   /// The StreamController onto which the GIS Client propagates user authentication events.
   ///

--- a/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
@@ -99,9 +99,10 @@ DateTime? getCredentialResponseExpirationTimestamp(
 
 /// Converts responses from the GIS library into TokenData for the plugin.
 GoogleSignInTokenData gisResponsesToTokenData(
-    CredentialResponse? credentialResponse, TokenResponse? tokenResponse) {
+    CredentialResponse? credentialResponse, TokenResponse? tokenResponse, CodeResponse? codeResponse) {
   return GoogleSignInTokenData(
     idToken: credentialResponse?.credential,
     accessToken: tokenResponse?.access_token,
+    serverAuthCode: codeResponse?.code,
   );
 }

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.12.1
+version: 0.12.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
This adds the ability for a Flutter web app to request a server auth code via gis.

Reference docs:
https://developers.google.com/identity/oauth2/web/guides/use-code-model https://developers.google.com/identity/oauth2/web/reference/js-reference#google.accounts.oauth2.initCodeClient

https://github.com/flutter/flutter/issues/62474

## Pre-launch Checklist

[✔️] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
[✔️] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
[✔️] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use dart format.)
[✔️] I signed the [CLA].
[✔️] The title of the PR starts with the name of the package surrounded by square brackets, e.g. [shared_preferences]
[✔️] I listed at least one issue that this PR fixes in the description above.
[✔️] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
[✔️] I updated CHANGELOG.md to add a description of the change, [following repository CHANGELOG style].
[✔️] I updated/added relevant documentation (doc comments with ///).
[✔️] I added new tests to check the change I am making, or this PR is [test-exempt].
[] All existing and new tests are passing.
