### PR TITLE
Update release step to 3.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       # the change if it doesn't.
       run: |
         cd $HOME
-        git clone https://github.com/flutter/flutter.git --depth 1 -b 3.13.0 _flutter
+        git clone https://github.com/flutter/flutter.git --depth 1 -b 3.16.0 _flutter
         echo "$HOME/_flutter/bin" >> $GITHUB_PATH
         cd $GITHUB_WORKSPACE
     # Checks out a copy of the repo.


### PR DESCRIPTION
The last commit failed to publish because it requires 3.16, and `release` is still using 3.13.