### PR TITLE
[go_router] Fixes use of `Iterable`

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 12.1.2
+
+* Fixes an incorrect use of `extends` for Dart 3 compatibility.
+* Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+
 ## 12.1.1
 
 - Retains query parameters during refresh and first redirect.
@@ -75,7 +80,7 @@
 
 ## 10.1.1
 
-- Fixes mapping from `Page` to `RouteMatch`s. 
+- Fixes mapping from `Page` to `RouteMatch`s.
 - Updates minimum supported SDK version to Flutter 3.7/Dart 2.19.
 
 ## 10.1.0

--- a/packages/go_router/example/pubspec.yaml
+++ b/packages/go_router/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 3.0.1
 publish_to: none
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
-  flutter: ">=3.7.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   adaptive_navigation: ^0.0.4

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -247,7 +247,7 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
 /// The iterator starts with the navigator that hosts the top-most route. This
 /// navigator may not be the inner-most navigator if the top-most route is a
 /// pageless route, such as a dialog or bottom sheet.
-class _NavigatorStateIterator extends Iterator<NavigatorState> {
+class _NavigatorStateIterator implements Iterator<NavigatorState> {
   _NavigatorStateIterator(this.matchList, this.root)
       : index = matchList.matches.length - 1;
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,13 +1,13 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 12.1.1
+version: 12.1.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
-  flutter: ">=3.7.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   collection: ^1.15.0


### PR DESCRIPTION
Replaces an `extends Iterable` with `implements Iterable` for Dart 3.0 compatibility, and updates the minimum version of the Dart SDK to 3.0 to test it.

This helps unblock rolling the entire repo forward to Flutter 3.10/Dart 3.0 as a minimum version.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
