### PR TITLE
[pointer_interceptor] Re-land: Add platform interface

### DIFF
--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/AUTHORS
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/AUTHORS
@@ -1,0 +1,6 @@
+# Below is a list of people and organizations that have contributed
+# to the project. Names should be added to the list like so:
+#
+#   Name/Organization <email address>
+
+Google Inc.

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/CHANGELOG.md
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.10.0
+
+* Initial release from migration to federated architecture.

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/LICENSE
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/LICENSE
@@ -1,0 +1,25 @@
+Copyright 2013 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/README.md
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/README.md
@@ -1,0 +1,26 @@
+# pointer_interceptor_platform_interface
+
+A common platform interface for the [`pointer_interceptor`][1] plugin.
+
+This interface allows platform-specific implementations of the `pointer_interceptor`
+plugin, as well as the plugin itself, to ensure they are supporting the
+same interface.
+
+# Usage
+
+To implement a new platform-specific implementation of `pointer_interceptor`, extend
+[`PointerInterceptorPlatform`][2] with an implementation that performs the
+platform-specific behavior, and when you register your plugin, set the default
+`PointerInterceptorPlatform` by calling
+`PointerInterceptorPlatform.instance = MyPointerInterceptorPlatform()`.
+
+# Note on breaking changes
+
+Strongly prefer non-breaking changes (such as adding a method to the interface)
+over breaking changes for this package.
+
+See https://flutter.dev/go/platform-interface-breaking-changes for a discussion
+on why a less-clean interface is preferable to a breaking change.
+
+[1]: https://pub.dev/packages/pointer_interceptor
+[2]: lib/src/pointer_interceptor_platform.dart

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/lib/pointer_interceptor_platform_interface.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/lib/pointer_interceptor_platform_interface.dart
@@ -1,0 +1,5 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'src/pointer_interceptor_platform.dart';

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/lib/src/default_pointer_interceptor.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/lib/src/default_pointer_interceptor.dart
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+import 'pointer_interceptor_platform.dart';
+
+/// A default no-op implementation of [PointerInterceptorPlatform].
+class DefaultPointerInterceptor extends PointerInterceptorPlatform {
+  @override
+  Widget buildWidget({
+    required Widget child,
+    bool debug = false,
+    Key? key,
+  }) {
+    return child;
+  }
+}

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/lib/src/pointer_interceptor_platform.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/lib/src/pointer_interceptor_platform.dart
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'default_pointer_interceptor.dart';
+
+/// Platform-specific implementations should set this with their own
+/// platform-specific class that extends [PointerInterceptorPlatform] when
+/// they register themselves.
+abstract class PointerInterceptorPlatform extends PlatformInterface {
+  /// Constructs a PointerInterceptorPlatform.
+  PointerInterceptorPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static PointerInterceptorPlatform _instance = DefaultPointerInterceptor();
+
+  static set instance(PointerInterceptorPlatform? instance) {
+    if (instance == null) {
+      throw AssertionError(
+          'Platform interfaces can only be set to a non-null instance');
+    }
+
+    PlatformInterface.verify(instance, _token);
+    _instance = instance;
+  }
+
+  /// The default instance of [PointerInterceptorPlatform] to use.
+  ///
+  /// Defaults to [DefaultPointerInterceptor], which does not do anything
+  static PointerInterceptorPlatform get instance => _instance;
+
+  /// Platform-specific implementations should override this function their own
+  /// implementation of a pointer interceptor widget.
+  Widget buildWidget({
+    required Widget child,
+    bool debug = false,
+    Key? key,
+  }) {
+    throw UnimplementedError('buildWidget() has not been implemented.');
+  }
+}

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/pubspec.yaml
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/pubspec.yaml
@@ -1,0 +1,24 @@
+name: pointer_interceptor_platform_interface
+description: "A common platform interface for the pointer_interceptor plugin."
+repository: https://github.com/flutter/packages/tree/main/packages/pointer_interceptor/pointer_interceptor_platform_interface
+issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pointer_interceptor%22
+
+version: 0.10.0
+
+environment:
+  sdk: '>=3.1.0 <4.0.0'
+  flutter: '>=3.13.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  plugin_platform_interface: ^2.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+topics:
+  - widgets
+  - platform views
+  - pointer-interceptor

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/pubspec.yaml
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
 
 topics:
   - widgets
-  - platform views
+  - platform-views
   - pointer-interceptor

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/test/default_pointer_interceptor_test.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/test/default_pointer_interceptor_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pointer_interceptor_platform_interface/pointer_interceptor_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('Default implementation of PointerInterceptor does not do anything', () {
+    final PointerInterceptorPlatform defaultPointerInterceptor =
+        PointerInterceptorPlatform.instance;
+
+    final Container testChild = Container();
+    expect(defaultPointerInterceptor.buildWidget(child: testChild), testChild);
+  });
+}

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/test/pointer_interceptor_platform_test.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/test/pointer_interceptor_platform_test.dart
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pointer_interceptor_platform_interface/pointer_interceptor_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+      'Default implementation of PointerInterceptorPlatform should throw unimplemented error',
+      () {
+    final PointerInterceptorPlatform unimplementedPointerInterceptorPlatform =
+        UnimplementedPointerInterceptorPlatform();
+
+    final Container testChild = Container();
+    expect(
+        () => unimplementedPointerInterceptorPlatform.buildWidget(
+            child: testChild),
+        throwsUnimplementedError);
+  });
+}
+
+class UnimplementedPointerInterceptorPlatform
+    extends PointerInterceptorPlatform {}


### PR DESCRIPTION
Addresses https://github.com/flutter/flutter/issues/30143 by adding an iOS implementation

This PR is Part 1 of https://github.com/flutter/packages/pull/5233

This reverts commit bc72d15c95a5bd664ad684c7e056e3e6b9a508c5 and then fixes the topic format