### PR TITLE
[pigeon] Use dart:io output inheritance for tooling

### DIFF
--- a/packages/pigeon/tool/shared/generation.dart
+++ b/packages/pigeon/tool/shared/generation.dart
@@ -246,5 +246,6 @@ Future<int> formatAllFiles({required String repositoryRoot}) {
         '--packages=pigeon',
       ],
       workingDirectory: repositoryRoot,
+      streamOutput: false,
       logFailure: true);
 }

--- a/packages/pigeon/tool/shared/process_utils.dart
+++ b/packages/pigeon/tool/shared/process_utils.dart
@@ -3,27 +3,19 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show Process, stderr, stdout;
-
-Future<Process> _streamOutput(Future<Process> processFuture) async {
-  final Process process = await processFuture;
-  await Future.wait(<Future<Object?>>[
-    stdout.addStream(process.stdout),
-    stderr.addStream(process.stderr),
-  ]);
-  return process;
-}
+import 'dart:io' show Process, ProcessStartMode, stderr, stdout;
 
 Future<int> runProcess(String command, List<String> arguments,
     {String? workingDirectory,
     bool streamOutput = true,
     bool logFailure = false}) async {
-  final Future<Process> future = Process.start(
+  final Process process = await Process.start(
     command,
     arguments,
     workingDirectory: workingDirectory,
+    mode:
+        streamOutput ? ProcessStartMode.inheritStdio : ProcessStartMode.normal,
   );
-  final Process process = await (streamOutput ? _streamOutput(future) : future);
   final int exitCode = await process.exitCode;
   if (exitCode != 0 && logFailure) {
     // ignore: avoid_print


### PR DESCRIPTION
Applies the same change as https://github.com/flutter/packages/pull/5410 to the Pigeon tooling, avoiding the need to manually wire up output forwarding.

Also adjusts a call site in the tooling that was forwarding all output normally but then also logging all output on failure to only log all output on failure.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
