### PR TITLE
[gsi_web] Do not initialize CodeClient if scopes are empty.

### DIFF
--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.12.2
+## 0.12.3
+
+* Re-publishes 0.12.2 with a small fix to the auth code initialization.
+
+## 0.12.2 (withdrawn)
 
 * Adds server auth code retrieval to google_sign_in_web.
 * Adds `web_only` library to access web-only methods more easily.

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.12.3
+## 0.12.2+1
 
-* Re-publishes 0.12.2 with a small fix to the auth code initialization.
+* Re-publishes `0.12.2` with a small fix to the CodeClient initialization.
 
 ## 0.12.2 (withdrawn)
 

--- a/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
@@ -52,13 +52,15 @@ class GisSdkClient {
       onError: _onTokenError,
     );
 
-    _codeClient = _initializeCodeClient(
-      clientId,
-      hostedDomain: hostedDomain,
-      onResponse: _onCodeResponse,
-      onError: _onCodeError,
-      scopes: initialScopes,
-    );
+    if (initialScopes.isNotEmpty) {
+      _codeClient = _initializeCodeClient(
+        clientId,
+        hostedDomain: hostedDomain,
+        onResponse: _onCodeResponse,
+        onError: _onCodeError,
+        scopes: initialScopes,
+      );
+    }
   }
 
   void _logIfEnabled(String message, [List<Object?>? more]) {
@@ -291,7 +293,12 @@ class GisSdkClient {
   /// Requests a server auth code per:
   /// https://developers.google.com/identity/oauth2/web/guides/use-code-model#initialize_a_code_client
   Future<String?> requestServerAuthCode() async {
-    _codeClient.requestCode();
+    assert(_codeClient != null,
+        'CodeClient not initialized correctly. Ensure the `scopes` list passed to `init()` or `initWithParams()` is not empty!');
+    if (_codeClient == null) {
+      return null;
+    }
+    _codeClient!.requestCode();
     final CodeResponse response = await _codeResponses.stream.first;
     return response.code;
   }
@@ -461,7 +468,8 @@ class GisSdkClient {
 
   // The Google Identity Services client for oauth requests.
   late TokenClient _tokenClient;
-  late CodeClient _codeClient;
+  // CodeClient will not be created if `initialScopes` is empty.
+  CodeClient? _codeClient;
 
   // Streams of credential and token responses.
   late StreamController<CredentialResponse> _credentialResponses;

--- a/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/gis_client.dart
@@ -293,6 +293,7 @@ class GisSdkClient {
   /// Requests a server auth code per:
   /// https://developers.google.com/identity/oauth2/web/guides/use-code-model#initialize_a_code_client
   Future<String?> requestServerAuthCode() async {
+    // TODO(dit): Enable granular authorization, https://github.com/flutter/flutter/issues/139406
     assert(_codeClient != null,
         'CodeClient not initialized correctly. Ensure the `scopes` list passed to `init()` or `initWithParams()` is not empty!');
     if (_codeClient == null) {

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.12.2
+version: 0.12.3
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.12.3
+version: 0.12.2+1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
When initializing a `CodeClient`, it is mandatory to pass at least one `scope` (or the JS initialization will crash).

This PR ensures that the `CodeClient` is not created unless `initialScopes.isNotEmpty`, and lets the user know when attempting to use said client that it hasn't been initialized properly.

## Issues

* Fixes: https://github.com/flutter/flutter/issues/139382
* Fixes: https://github.com/flutter/flutter/issues/62474
* Closes: https://github.com/flutter/cocoon/pull/3304 (makes this PR unneeded)

## Tests

* Tested locally with `cocoon`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
