### PR TITLE
Add an optional parameter `initialPage` to `serveWebBenchmark`

### DIFF
--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.1.0+9
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Adds an optional parameter `initialPage` to `serveWebBenchmark`.
 
 ## 0.1.0+8
 

--- a/packages/web_benchmarks/lib/server.dart
+++ b/packages/web_benchmarks/lib/server.dart
@@ -47,6 +47,7 @@ Future<BenchmarkResults> serveWebBenchmark({
   int chromeDebugPort = defaultChromeDebugPort,
   bool headless = true,
   bool treeShakeIcons = true,
+  String initialPage = BenchmarkServer.defaultInitialPage,
 }) async {
   // Reduce logging level. Otherwise, package:webkit_inspection_protocol is way too spammy.
   Logger.root.level = Level.INFO;
@@ -59,5 +60,6 @@ Future<BenchmarkResults> serveWebBenchmark({
     chromeDebugPort: chromeDebugPort,
     headless: headless,
     treeShakeIcons: treeShakeIcons,
+    initialPage: initialPage,
   ).run();
 }

--- a/packages/web_benchmarks/lib/src/runner.dart
+++ b/packages/web_benchmarks/lib/src/runner.dart
@@ -55,7 +55,14 @@ class BenchmarkServer {
     required this.chromeDebugPort,
     required this.headless,
     required this.treeShakeIcons,
+    this.initialPage = defaultInitialPage,
   });
+
+  /// The default initial page to load upon opening the benchmark app in Chrome.
+  /// 
+  /// This value will be used by default if no value is passed to [initialPage].
+  /// See also, [initialPage] and [_benchmarkAppUrl].
+  static const String defaultInitialPage = 'index.html';
 
   final ProcessManager _processManager = const LocalProcessManager();
 
@@ -89,6 +96,14 @@ class BenchmarkServer {
   ///
   /// When false, '--no-tree-shake-icons' will be passed as a build argument.
   final bool treeShakeIcons;
+
+  /// The initial page to load upon opening the benchmark app in Chrome.
+  ///
+  /// The default value is [defaultInitialPage]. See also, [_benchmarkAppUrl].
+  final String initialPage;
+
+  String get _benchmarkAppUrl =>
+      'http://localhost:$benchmarkServerPort/$initialPage';
 
   /// Builds and serves the benchmark app, and collects benchmark results.
   Future<BenchmarkResults> run() async {
@@ -252,7 +267,7 @@ class BenchmarkServer {
           .path;
 
       final ChromeOptions options = ChromeOptions(
-        url: 'http://localhost:$benchmarkServerPort/index.html',
+        url: _benchmarkAppUrl,
         userDataDirectory: userDataDir,
         headless: headless,
         debugPort: chromeDebugPort,

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_benchmarks
 description: A benchmark harness for performance-testing Flutter apps in Chrome.
 repository: https://github.com/flutter/packages/tree/main/packages/web_benchmarks
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+web_benchmarks%22
-version: 0.1.0+8
+version: 0.1.0+9
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
We will use this new parameter from DevTools. This PR also preps the package for release.