### PR TITLE
[animations] Adds ability to show a translucent modal route

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.9
 
+* Adds ability to show a translucent modal route by setting `opaqueRoute` to `false`.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
 
 ## 2.0.8

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -97,6 +97,7 @@ class OpenContainer<T extends Object?> extends StatefulWidget {
     this.transitionDuration = const Duration(milliseconds: 300),
     this.transitionType = ContainerTransitionType.fade,
     this.useRootNavigator = false,
+    this.opaqueRoute = true,
     this.routeSettings,
     this.clipBehavior = Clip.antiAlias,
   });
@@ -251,6 +252,15 @@ class OpenContainer<T extends Object?> extends StatefulWidget {
   /// Provides additional data to the [openBuilder] route pushed by the Navigator.
   final RouteSettings? routeSettings;
 
+  /// Whether the modal route obscures previous routes when the transition is complete.
+  ///
+  /// Defaults to true.
+  ///
+  /// See also:
+  ///
+  /// * [ModalRoute.opaque], which is used to implement this property.
+  final bool opaqueRoute;
+
   /// The [closedBuilder] will be clipped (or not) according to this option.
   ///
   /// Defaults to [Clip.antiAlias], and must not be null.
@@ -284,6 +294,7 @@ class _OpenContainerState<T> extends State<OpenContainer<T?>> {
       context,
       rootNavigator: widget.useRootNavigator,
     ).push(_OpenContainerRoute<T>(
+      opaque: widget.opaqueRoute,
       closedColor: widget.closedColor,
       openColor: widget.openColor,
       middleColor: middleColor,
@@ -415,6 +426,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     required this.transitionDuration,
     required this.transitionType,
     required this.useRootNavigator,
+    required this.opaque,
     required RouteSettings? routeSettings,
   })  : _elevationTween = Tween<double>(
           begin: closedElevation,
@@ -557,6 +569,9 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
   final ContainerTransitionType transitionType;
 
   final bool useRootNavigator;
+
+  @override
+  final bool opaque;
 
   final Tween<double> _elevationTween;
   final ShapeBorderTween _shapeTween;
@@ -873,9 +888,6 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
 
   @override
   Color? get barrierColor => null;
-
-  @override
-  bool get opaque => true;
 
   @override
   bool get barrierDismissible => false;

--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -2,7 +2,7 @@ name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
 repository: https://github.com/flutter/packages/tree/main/packages/animations
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+animations%22
-version: 2.0.8
+version: 2.0.9
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/animations/test/open_container_test.dart
+++ b/packages/animations/test/open_container_test.dart
@@ -1746,6 +1746,37 @@ void main() {
   });
 
   testWidgets(
+    'Verify that modal route is not opaque when "opaqueRoute: false"',
+    (WidgetTester tester) async {
+      final Widget openContainer = OpenContainer(
+        opaqueRoute: false,
+        closedBuilder: (BuildContext context, VoidCallback action) {
+          return GestureDetector(
+            onTap: action,
+            child: const Text('Closed'),
+          );
+        },
+        openBuilder: (BuildContext context, VoidCallback action) {
+          return GestureDetector(
+            onTap: action,
+            child: const Text('Open'),
+          );
+        },
+      );
+
+      await tester.pumpWidget(_boilerplate(child: openContainer));
+
+      await tester.tap(find.text('Closed'));
+      await tester.pumpAndSettle();
+
+      final ModalRoute<dynamic> modalRoute = ModalRoute.of(
+        tester.element(find.text('Open')),
+      )!;
+      expect(modalRoute.opaque, isFalse);
+    },
+  );
+
+  testWidgets(
     'Verify routeSettings passed to Navigator',
     (WidgetTester tester) async {
       const RouteSettings routeSettings = RouteSettings(
@@ -1781,6 +1812,7 @@ void main() {
         tester.element(find.text('Open')),
       )!;
       expect(modalRoute.settings, routeSettings);
+      expect(modalRoute.opaque, isTrue);
     },
   );
 }


### PR DESCRIPTION
Currently the `_OpenContainerRoute.opaque` property is fixed to `true`, this change will add the ability to set this value to `false` if needed. This way we will be able to push a translucent route.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
