### PR TITLE
[file_selector] Remove deprecated `primary` and `onPrimary` references from `ElevatedButton.styleFrom`

### DIFF
--- a/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
@@ -42,10 +42,8 @@ class GetMultipleDirectoriesPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
-                // ignore: deprecated_member_use
-                primary: Colors.blue,
-                // ignore: deprecated_member_use
-                onPrimary: Colors.white,
+                backgroundColor: Colors.blue,
+                foregroundColor: Colors.white,
               ),
               child: const Text(
                   'Press to ask user to choose multiple directories'),

--- a/packages/file_selector/file_selector_windows/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/get_multiple_directories_page.dart
@@ -42,10 +42,8 @@ class GetMultipleDirectoriesPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
-                // ignore: deprecated_member_use
-                primary: Colors.blue,
-                // ignore: deprecated_member_use
-                onPrimary: Colors.white,
+                backgroundColor: Colors.blue,
+                foregroundColor: Colors.white,
               ),
               child: const Text(
                   'Press to ask user to choose multiple directories'),


### PR DESCRIPTION
This PR is to remove deprecated `primary` and `onPrimary` references([deprecation PR](https://github.com/flutter/flutter/pull/105291)) from `ElevatedButton.styleFrom`.

`primary` should be replaced with `backgroundColor` and `onPrimary` should be replaced with `foregroundColor`.

No new tests needed. Please let me know if I incorrectly handled the CHANGELOG and version change.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
