### PR TITLE
[go_router] fix(docs): typo in example extra_codec.dart

### DIFF
--- a/packages/go_router/example/lib/extra_codec.dart
+++ b/packages/go_router/example/lib/extra_codec.dart
@@ -116,7 +116,7 @@ class _MyExtraDecoder extends Converter<Object?, Object?> {
     if (inputAsList[0] == 'ComplexData2') {
       return ComplexData2(inputAsList[1]! as String);
     }
-    throw FormatException('Unable tp parse input: $input');
+    throw FormatException('Unable to parse input: $input');
   }
 }
 

--- a/packages/go_router/example/test/extra_codec_test.dart
+++ b/packages/go_router/example/test/extra_codec_test.dart
@@ -20,4 +20,20 @@ void main() {
     expect(find.text('The extra for this page is: ComplexData2(data: data)'),
         findsOneWidget);
   });
+
+  test('invalid extra throws', () {
+    const example.MyExtraCodec extraCodec = example.MyExtraCodec();
+    const List<Object?> invalidValue = <Object?>['invalid'];
+
+    expect(
+      () => extraCodec.decode(invalidValue),
+      throwsA(
+        predicate(
+          (Object? exception) =>
+              exception is FormatException &&
+              exception.message == 'Unable to parse input: $invalidValue',
+        ),
+      ),
+    );
+  });
 }


### PR DESCRIPTION
Replace 
```
    throw FormatException('Unable tp parse input: $input');
```

by
```
    throw FormatException('Unable to parse input: $input');
```

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
