### PR TITLE
Drop quiver usage in several packages

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Drop unused dependency on `package:quiver`.
 
 ## 0.10.5+5
 

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.10.5+6
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
 * Drop unused dependency on `package:quiver`.

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.5+5
+version: 0.10.5+6
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -28,7 +28,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.2
-  quiver: ^3.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/camera/camera_android/example/pubspec.yaml
+++ b/packages/camera/camera_android/example/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider: ^2.0.0
-  quiver: ^3.0.0
   video_player: ^2.1.4
 
 dev_dependencies:

--- a/packages/camera/camera_avfoundation/example/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/example/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider: ^2.0.0
-  quiver: ^3.0.0
   video_player: ^2.1.4
 
 dev_dependencies:

--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.4.3
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
 * Drop dependency on `package:quiver`.

--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Drop dependency on `package:quiver`.
 
 ## 2.4.2
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/widgets.dart';
-import 'package:quiver/core.dart';
 
 /// Default configuration options to use when signing in.
 ///
@@ -132,8 +131,8 @@ class GoogleSignInUserData {
   @override
   // TODO(stuartmorgan): Make this class immutable in the next breaking change.
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => hashObjects(
-      <String?>[displayName, email, id, photoUrl, idToken, serverAuthCode]);
+  int get hashCode =>
+      Object.hash(displayName, email, id, photoUrl, idToken, serverAuthCode);
 
   @override
   // TODO(stuartmorgan): Make this class immutable in the next breaking change.
@@ -176,7 +175,7 @@ class GoogleSignInTokenData {
   @override
   // TODO(stuartmorgan): Make this class immutable in the next breaking change.
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => hash3(idToken, accessToken, serverAuthCode);
+  int get hashCode => Object.hash(idToken, accessToken, serverAuthCode);
 
   @override
   // TODO(stuartmorgan): Make this class immutable in the next breaking change.

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.0
-  quiver: ^3.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_sign_i
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.4.2
+version: 2.4.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
camera: was NOT used at all. Superfluous usage!
google_sign_in_platform_interface: dropping usage was trivial with
  new dart:core APIs

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
