### PR TITLE
[pigeon] Fix Kotlin generator to use provided errorClassName

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 14.0.1
+## 15.0.0
 
+* **Breaking Change** [kotlin] Updates Flutter API to use new errorClassName.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
-* [kotlin] Updates Flutter API to use new errorClassName.
 
 ## 14.0.0
 

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 14.0.1
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
-* Fixes Kotlin generator to use provided errorClassName
+* [kotlin] Updates Flutter API to use new errorClassName.
 
 ## 14.0.0
 

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 14.0.1
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Fixes Kotlin generator to use provided errorClassName
 
 ## 14.0.0
 

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '14.0.1';
+const String pigeonVersion = '15.0.0';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '14.0.0';
+const String pigeonVersion = '14.0.1';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/kotlin_generator.dart
+++ b/packages/pigeon/lib/kotlin_generator.dart
@@ -682,8 +682,8 @@ class KotlinGenerator extends StructuredGenerator<KotlinOptions> {
     indent.newln();
     indent.write('private fun wrapError(exception: Throwable): List<Any?> ');
     indent.addScoped('{', '}', () {
-      indent.write(
-          'if (exception is ${_getErrorClassName(generatorOptions)}) ');
+      indent
+          .write('if (exception is ${_getErrorClassName(generatorOptions)}) ');
       indent.addScoped('{', '}', () {
         indent.write('return ');
         indent.addScoped('listOf(', ')', () {
@@ -723,7 +723,8 @@ class KotlinGenerator extends StructuredGenerator<KotlinOptions> {
     indent.addln(' : Throwable()');
   }
 
-  void _writeCreateConnectionError(KotlinOptions generatorOptions, Indent indent) {
+  void _writeCreateConnectionError(
+      KotlinOptions generatorOptions, Indent indent) {
     final String errorClassName = _getErrorClassName(generatorOptions);
     indent.newln();
     indent.write(
@@ -765,7 +766,8 @@ HostDatatype _getHostDatatype(Root root, NamedType field) {
 /// Calculates the name of the codec that will be generated for [api].
 String _getCodecName(Api api) => '${api.name}Codec';
 
-String _getErrorClassName(KotlinOptions generatorOptions) => generatorOptions.errorClassName ?? 'FlutterError';
+String _getErrorClassName(KotlinOptions generatorOptions) =>
+    generatorOptions.errorClassName ?? 'FlutterError';
 
 String _getArgumentName(int count, NamedType argument) =>
     argument.name.isEmpty ? 'arg$count' : argument.name;

--- a/packages/pigeon/lib/kotlin_generator.dart
+++ b/packages/pigeon/lib/kotlin_generator.dart
@@ -358,6 +358,7 @@ class KotlinGenerator extends StructuredGenerator<KotlinOptions> {
         });
       });
 
+      final String errorClassName = _getErrorClassName(generatorOptions);
       for (final Method func in api.methods) {
         final String returnType = func.returnType.isVoid
             ? 'Unit'
@@ -396,12 +397,12 @@ class KotlinGenerator extends StructuredGenerator<KotlinOptions> {
             indent.writeScoped('if (it is List<*>) {', '} ', () {
               indent.writeScoped('if (it.size > 1) {', '} ', () {
                 indent.writeln(
-                    'callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))');
+                    'callback(Result.failure($errorClassName(it[0] as String, it[1] as String, it[2] as String?)))');
               }, addTrailingNewline: false);
               if (!func.returnType.isNullable && !func.returnType.isVoid) {
                 indent.addScoped('else if (it[0] == null) {', '} ', () {
                   indent.writeln(
-                      'callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))');
+                      'callback(Result.failure($errorClassName("null-error", "Flutter api returned null value for non-null return value.", "")))');
                 }, addTrailingNewline: false);
               }
               indent.addScoped('else {', '}', () {
@@ -682,7 +683,7 @@ class KotlinGenerator extends StructuredGenerator<KotlinOptions> {
     indent.write('private fun wrapError(exception: Throwable): List<Any?> ');
     indent.addScoped('{', '}', () {
       indent.write(
-          'if (exception is ${generatorOptions.errorClassName ?? "FlutterError"}) ');
+          'if (exception is ${_getErrorClassName(generatorOptions)}) ');
       indent.addScoped('{', '}', () {
         indent.write('return ');
         indent.addScoped('listOf(', ')', () {
@@ -713,7 +714,7 @@ class KotlinGenerator extends StructuredGenerator<KotlinOptions> {
     indent.writeln(
         ' * @property details The error details. Must be a datatype supported by the api codec.');
     indent.writeln(' */');
-    indent.write('class ${generatorOptions.errorClassName ?? "FlutterError"} ');
+    indent.write('class ${_getErrorClassName(generatorOptions)} ');
     indent.addScoped('(', ')', () {
       indent.writeln('val code: String,');
       indent.writeln('override val message: String? = null,');
@@ -722,13 +723,14 @@ class KotlinGenerator extends StructuredGenerator<KotlinOptions> {
     indent.addln(' : Throwable()');
   }
 
-  void _writeCreateConnectionError(Indent indent) {
+  void _writeCreateConnectionError(KotlinOptions generatorOptions, Indent indent) {
+    final String errorClassName = _getErrorClassName(generatorOptions);
     indent.newln();
     indent.write(
-        'private fun createConnectionError(channelName: String): FlutterError ');
+        'private fun createConnectionError(channelName: String): $errorClassName ');
     indent.addScoped('{', '}', () {
       indent.write(
-          'return FlutterError("channel-error",  "Unable to establish connection on channel: \'\$channelName\'.", "")');
+          'return $errorClassName("channel-error",  "Unable to establish connection on channel: \'\$channelName\'.", "")');
     });
   }
 
@@ -749,7 +751,7 @@ class KotlinGenerator extends StructuredGenerator<KotlinOptions> {
       _writeWrapError(generatorOptions, indent);
     }
     if (hasFlutterApi) {
-      _writeCreateConnectionError(indent);
+      _writeCreateConnectionError(generatorOptions, indent);
     }
     _writeErrorClass(generatorOptions, indent);
   }
@@ -762,6 +764,8 @@ HostDatatype _getHostDatatype(Root root, NamedType field) {
 
 /// Calculates the name of the codec that will be generated for [api].
 String _getCodecName(Api api) => '${api.name}Codec';
+
+String _getErrorClassName(KotlinOptions generatorOptions) => generatorOptions.errorClassName ?? 'FlutterError';
 
 String _getArgumentName(int count, NamedType argument) =>
     argument.name.isEmpty ? 'arg$count' : argument.name;

--- a/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/CoreTests.gen.kt
+++ b/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/CoreTests.gen.kt
@@ -20,7 +20,7 @@ private fun wrapResult(result: Any?): List<Any?> {
 }
 
 private fun wrapError(exception: Throwable): List<Any?> {
-  if (exception is FlutterError) {
+  if (exception is CoreTestsError) {
     return listOf(exception.code, exception.message, exception.details)
   } else {
     return listOf(
@@ -30,8 +30,8 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): FlutterError {
-  return FlutterError(
+private fun createConnectionError(channelName: String): CoreTestsError {
+  return CoreTestsError(
       "channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 }
 
@@ -42,7 +42,7 @@ private fun createConnectionError(channelName: String): FlutterError {
  * @property message The error message.
  * @property details The error details. Must be a datatype supported by the api codec.
  */
-class FlutterError(
+class CoreTestsError(
     val code: String,
     override val message: String? = null,
     val details: Any? = null
@@ -2397,7 +2397,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(null) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
@@ -2414,7 +2415,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(null) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0]
           callback(Result.success(output))
@@ -2432,7 +2434,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(null) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
@@ -2449,11 +2452,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(everythingArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2477,7 +2481,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(everythingArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as AllNullableTypes?
           callback(Result.success(output))
@@ -2504,11 +2509,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aNullableBoolArg, aNullableIntArg, aNullableStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2529,11 +2535,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aBoolArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2554,11 +2561,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(anIntArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2579,11 +2587,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aDoubleArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2604,11 +2613,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2629,11 +2639,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aListArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2654,11 +2665,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aListArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2679,11 +2691,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aMapArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2704,11 +2717,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(anEnumArg.raw)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2729,7 +2743,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aBoolArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as Boolean?
           callback(Result.success(output))
@@ -2747,7 +2762,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(anIntArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0].let { if (it is Int) it.toLong() else it as Long? }
           callback(Result.success(output))
@@ -2765,7 +2781,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aDoubleArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as Double?
           callback(Result.success(output))
@@ -2783,7 +2800,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as String?
           callback(Result.success(output))
@@ -2801,7 +2819,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aListArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as ByteArray?
           callback(Result.success(output))
@@ -2819,7 +2838,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aListArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as List<Any?>?
           callback(Result.success(output))
@@ -2840,7 +2860,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aMapArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as Map<String?, Any?>?
           callback(Result.success(output))
@@ -2858,7 +2879,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(anEnumArg?.raw)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = (it[0] as Int?)?.let { AnEnum.ofRaw(it) }
           callback(Result.success(output))
@@ -2879,7 +2901,8 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(null) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
@@ -2896,11 +2919,12 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -3057,11 +3081,12 @@ class FlutterSmallApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(msgArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -3081,11 +3106,12 @@ class FlutterSmallApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  FlutterError(
+                  CoreTestsError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))

--- a/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/TestPlugin.kt
+++ b/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/TestPlugin.kt
@@ -39,7 +39,7 @@ class TestPlugin : FlutterPlugin, HostIntegrationCoreApi {
   }
 
   override fun throwFlutterError(): Any? {
-    throw FlutterError("code", "message", "details")
+    throw CoreTestsError("code", "message", "details")
   }
 
   override fun echoInt(anInt: Long): Long {
@@ -170,7 +170,7 @@ class TestPlugin : FlutterPlugin, HostIntegrationCoreApi {
   }
 
   override fun throwAsyncFlutterError(callback: (Result<Any?>) -> Unit) {
-    callback(Result.failure(FlutterError("code", "message", "details")))
+    callback(Result.failure(CoreTestsError("code", "message", "details")))
   }
 
   override fun echoAsyncAllTypes(everything: AllTypes, callback: (Result<AllTypes>) -> Unit) {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 14.0.0 # This must match the version in lib/generator_tools.dart
+version: 14.0.1 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 14.0.1 # This must match the version in lib/generator_tools.dart
+version: 15.0.0 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/pigeon/test/kotlin_generator_test.dart
+++ b/packages/pigeon/test/kotlin_generator_test.dart
@@ -1635,4 +1635,168 @@ void main() {
         contains(
             'callback(Result.failure(createConnectionError(channelName)))'));
   });
+
+  test('gen host uses default error class', () {
+    final Root root = Root(
+      apis: <Api>[
+        Api(
+          name: 'Api',
+          location: ApiLocation.host,
+          methods: <Method>[
+            Method(
+              name: 'method',
+              returnType: const TypeDeclaration.voidDeclaration(),
+              parameters: <Parameter>[
+                Parameter(
+                  name: 'field',
+                  type: const TypeDeclaration(
+                    baseName: 'int',
+                    isNullable: true,
+                  ),
+                ),
+              ],
+            )
+          ],
+        )
+      ],
+      classes: <Class>[],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const KotlinOptions kotlinOptions = KotlinOptions();
+    const KotlinGenerator generator = KotlinGenerator();
+    generator.generate(
+      kotlinOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(code, contains('FlutterError'));
+  });
+
+  test('gen flutter uses default error class', () {
+    final Root root = Root(
+      apis: <Api>[
+        Api(
+          name: 'Api',
+          location: ApiLocation.flutter,
+          methods: <Method>[
+            Method(
+              name: 'method',
+              returnType: const TypeDeclaration.voidDeclaration(),
+              parameters: <Parameter>[
+                Parameter(
+                  name: 'field',
+                  type: const TypeDeclaration(
+                    baseName: 'int',
+                    isNullable: true,
+                  ),
+                ),
+              ],
+            )
+          ],
+        )
+      ],
+      classes: <Class>[],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const KotlinOptions kotlinOptions = KotlinOptions();
+    const KotlinGenerator generator = KotlinGenerator();
+    generator.generate(
+      kotlinOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(code, contains('FlutterError'));
+  });
+
+  test('gen host uses error class', () {
+    final Root root = Root(
+      apis: <Api>[
+        Api(
+          name: 'Api',
+          location: ApiLocation.host,
+          methods: <Method>[
+            Method(
+              name: 'method',
+              returnType: const TypeDeclaration.voidDeclaration(),
+              parameters: <Parameter>[
+                Parameter(
+                  name: 'field',
+                  type: const TypeDeclaration(
+                    baseName: 'int',
+                    isNullable: true,
+                  ),
+                ),
+              ],
+            )
+          ],
+        )
+      ],
+      classes: <Class>[],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const String errorClassName = 'FooError';
+    const KotlinOptions kotlinOptions = KotlinOptions(
+      errorClassName: errorClassName
+    );
+    const KotlinGenerator generator = KotlinGenerator();
+    generator.generate(
+      kotlinOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(code, contains(errorClassName));
+    expect(code, isNot(contains('FlutterError')));
+  });
+
+  test('gen flutter uses error class', () {
+    final Root root = Root(
+      apis: <Api>[
+        Api(
+          name: 'Api',
+          location: ApiLocation.flutter,
+          methods: <Method>[
+            Method(
+              name: 'method',
+              returnType: const TypeDeclaration.voidDeclaration(),
+              parameters: <Parameter>[
+                Parameter(
+                  name: 'field',
+                  type: const TypeDeclaration(
+                    baseName: 'int',
+                    isNullable: true,
+                  ),
+                ),
+              ],
+            )
+          ],
+        )
+      ],
+      classes: <Class>[],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const String errorClassName = 'FooError';
+    const KotlinOptions kotlinOptions = KotlinOptions(
+        errorClassName: errorClassName
+    );
+    const KotlinGenerator generator = KotlinGenerator();
+    generator.generate(
+      kotlinOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(code, contains(errorClassName));
+    expect(code, isNot(contains('FlutterError')));
+  });
 }

--- a/packages/pigeon/test/kotlin_generator_test.dart
+++ b/packages/pigeon/test/kotlin_generator_test.dart
@@ -1742,9 +1742,8 @@ void main() {
     );
     final StringBuffer sink = StringBuffer();
     const String errorClassName = 'FooError';
-    const KotlinOptions kotlinOptions = KotlinOptions(
-      errorClassName: errorClassName
-    );
+    const KotlinOptions kotlinOptions =
+        KotlinOptions(errorClassName: errorClassName);
     const KotlinGenerator generator = KotlinGenerator();
     generator.generate(
       kotlinOptions,
@@ -1785,9 +1784,8 @@ void main() {
     );
     final StringBuffer sink = StringBuffer();
     const String errorClassName = 'FooError';
-    const KotlinOptions kotlinOptions = KotlinOptions(
-        errorClassName: errorClassName
-    );
+    const KotlinOptions kotlinOptions =
+        KotlinOptions(errorClassName: errorClassName);
     const KotlinGenerator generator = KotlinGenerator();
     generator.generate(
       kotlinOptions,

--- a/packages/pigeon/tool/shared/generation.dart
+++ b/packages/pigeon/tool/shared/generation.dart
@@ -89,8 +89,7 @@ Future<int> generateTestPigeons({required String baseDir}) async {
           ? null
           : '$outputBase/android/src/main/kotlin/com/example/test_plugin/$pascalCaseName.gen.kt',
       kotlinPackage: 'com.example.test_plugin',
-      kotlinErrorClassName:
-          input == 'core_tests' ? null : '${pascalCaseName}Error',
+      kotlinErrorClassName: '${pascalCaseName}Error',
       // iOS
       swiftOut: skipLanguages.contains(GeneratorLanguages.swift)
           ? null


### PR DESCRIPTION
Fix bug with Pigeon Kotlin code generator not using the provided `errorClassName`.

fixes: https://github.com/flutter/flutter/issues/139031

Replace https://github.com/flutter/packages/pull/5480 as I can't push to that pr.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
