### PR TITLE
[tool] Use ^ for Dart SDK

### DIFF
--- a/script/tool/lib/src/update_min_sdk_command.dart
+++ b/script/tool/lib/src/update_min_sdk_command.dart
@@ -69,16 +69,8 @@ class UpdateMinSdkCommand extends PackageLoopingCommand {
         YamlEditor(package.pubspecFile.readAsStringSync());
     if (dartRange != null &&
         (dartRange.min ?? Version.none) < _dartMinVersion) {
-      Version upperBound = _dartMinVersion.nextMajor;
-      // pub special-cases 3.0.0 as an upper bound to be treated as 4.0.0, and
-      // using 3.0.0 is now an error at upload time, so special case it here.
-      if (upperBound.major == 3) {
-        upperBound = upperBound.nextMajor;
-      }
-      editablePubspec.update(
-          <String>[environmentKey, dartSdkKey],
-          VersionRange(min: _dartMinVersion, includeMin: true, max: upperBound)
-              .toString());
+      editablePubspec
+          .update(<String>[environmentKey, dartSdkKey], '^$_dartMinVersion');
       print('${indentation}Updating Dart minimum to $_dartMinVersion');
     }
     if (flutterRange != null &&

--- a/script/tool/test/update_min_sdk_command_test.dart
+++ b/script/tool/test/update_min_sdk_command_test.dart
@@ -38,98 +38,91 @@ void main() {
     expect(commandError, isA<ArgumentError>());
   });
 
-  test('updates Dart when only Dart is present', () async {
+  test('updates Dart when only Dart is present, with manual range', () async {
     final RepositoryPackage package = createFakePackage(
         'a_package', packagesDir,
-        dartConstraint: '>=2.12.0 <4.0.0');
+        dartConstraint: '>=3.0.0 <4.0.0');
 
     await runCapturingPrint(runner, <String>[
       'update-min-sdk',
       '--flutter-min',
-      '3.3.0', // Corresponds to Dart 2.18.0
+      '3.13.0', // Corresponds to Dart 3.1.0
     ]);
 
     final String dartVersion =
         package.parsePubspec().environment?['sdk'].toString() ?? '';
-    expect(dartVersion, '>=2.18.0 <4.0.0');
+    expect(dartVersion, '^3.1.0');
+  });
+
+  test('updates Dart when only Dart is present, with carrot', () async {
+    final RepositoryPackage package =
+        createFakePackage('a_package', packagesDir, dartConstraint: '^3.0.0');
+
+    await runCapturingPrint(runner, <String>[
+      'update-min-sdk',
+      '--flutter-min',
+      '3.13.0', // Corresponds to Dart 3.1.0
+    ]);
+
+    final String dartVersion =
+        package.parsePubspec().environment?['sdk'].toString() ?? '';
+    expect(dartVersion, '^3.1.0');
   });
 
   test('does not update Dart if it is already higher', () async {
-    final RepositoryPackage package = createFakePackage(
-        'a_package', packagesDir,
-        dartConstraint: '>=2.19.0 <4.0.0');
+    final RepositoryPackage package =
+        createFakePackage('a_package', packagesDir, dartConstraint: '^3.2.0');
 
     await runCapturingPrint(runner, <String>[
       'update-min-sdk',
       '--flutter-min',
-      '3.3.0', // Corresponds to Dart 2.18.0
+      '3.13.0', // Corresponds to Dart 3.1.0
     ]);
 
     final String dartVersion =
         package.parsePubspec().environment?['sdk'].toString() ?? '';
-    expect(dartVersion, '>=2.19.0 <4.0.0');
+    expect(dartVersion, '^3.2.0');
   });
 
   test('updates both Dart and Flutter when both are present', () async {
     final RepositoryPackage package = createFakePackage(
         'a_package', packagesDir,
         isFlutter: true,
-        dartConstraint: '>=2.12.0 <4.0.0',
-        flutterConstraint: '>=2.10.0');
+        dartConstraint: '>=3.0.0 <4.0.0',
+        flutterConstraint: '>=3.10.0');
 
     await runCapturingPrint(runner, <String>[
       'update-min-sdk',
       '--flutter-min',
-      '3.3.0', // Corresponds to Dart 2.18.0
+      '3.13.0', // Corresponds to Dart 3.1.0
     ]);
 
     final String dartVersion =
         package.parsePubspec().environment?['sdk'].toString() ?? '';
     final String flutterVersion =
         package.parsePubspec().environment?['flutter'].toString() ?? '';
-    expect(dartVersion, '>=2.18.0 <4.0.0');
-    expect(flutterVersion, '>=3.3.0');
-  });
-
-  test('handles Flutter 3.10.0', () async {
-    final RepositoryPackage package = createFakePackage(
-        'a_package', packagesDir,
-        isFlutter: true,
-        dartConstraint: '>=2.12.0 <4.0.0',
-        flutterConstraint: '>=2.10.0');
-
-    await runCapturingPrint(runner, <String>[
-      'update-min-sdk',
-      '--flutter-min',
-      '3.10.0', // Corresponds to Dart 3.0.0
-    ]);
-
-    final String dartVersion =
-        package.parsePubspec().environment?['sdk'].toString() ?? '';
-    final String flutterVersion =
-        package.parsePubspec().environment?['flutter'].toString() ?? '';
-    expect(dartVersion, '>=3.0.0 <4.0.0');
-    expect(flutterVersion, '>=3.10.0');
+    expect(dartVersion, '^3.1.0');
+    expect(flutterVersion, '>=3.13.0');
   });
 
   test('does not update Flutter if it is already higher', () async {
     final RepositoryPackage package = createFakePackage(
         'a_package', packagesDir,
         isFlutter: true,
-        dartConstraint: '>=2.19.0 <4.0.0',
-        flutterConstraint: '>=3.7.0');
+        dartConstraint: '^3.2.0',
+        flutterConstraint: '>=3.16.0');
 
     await runCapturingPrint(runner, <String>[
       'update-min-sdk',
       '--flutter-min',
-      '3.3.0', // Corresponds to Dart 2.18.0
+      '3.13.0', // Corresponds to Dart 3.1.0
     ]);
 
     final String dartVersion =
         package.parsePubspec().environment?['sdk'].toString() ?? '';
     final String flutterVersion =
         package.parsePubspec().environment?['flutter'].toString() ?? '';
-    expect(dartVersion, '>=2.19.0 <4.0.0');
-    expect(flutterVersion, '>=3.7.0');
+    expect(dartVersion, '^3.2.0');
+    expect(flutterVersion, '>=3.16.0');
   });
 }


### PR DESCRIPTION
The update-min-sdk command has been using explicitly ranges for the Dart SDK, because that used to be required. Current versions of `pub` no longer require that, and using `^` for Dart ranges is okay, so this updates the tooling to use that format in the future.

Also removes the special casing that changed the upper bound from 3 to 4, since we have passed the point where we are generating upper bounds less than 4 anyway.

To minimize churn, this doesn't update the existing pubspecs. We can incrementally adopt this going forward as we roll dependencies forward.

Fixes https://github.com/flutter/flutter/issues/139806
