### PR TITLE
[ci] Fix indentation in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@
 'p: camera':
   - changed-files:
     - any-glob-to-any-file:
-     - packages/camera/**/*
+      - packages/camera/**/*
 
 'p: cross_file':
   - changed-files:


### PR DESCRIPTION
Fixes an indentation bug in the config file that causes the task to fail.
