### PR TITLE
[various] Update examples using video_player

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.5+7
+
+* Updates example app to use non-deprecated video_player method.
+
 ## 0.10.5+6
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -986,11 +986,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     }
 
     final VideoPlayerController vController = kIsWeb
-        // TODO(gabrielokura): remove the ignore once the following line can migrate to
-        // use VideoPlayerController.networkUrl after the issue is resolved.
-        // https://github.com/flutter/flutter/issues/121927
-        // ignore: deprecated_member_use
-        ? VideoPlayerController.network(videoFile!.path)
+        ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
         : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider: ^2.0.0
-  video_player: ^2.1.4
+  video_player: ^2.7.0
 
 dev_dependencies:
   build_runner: ^2.1.10

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -34,7 +34,6 @@ dev_dependencies:
     sdk: flutter
   mockito: 5.4.3
   plugin_platform_interface: ^2.0.0
-  video_player: ^2.0.0
 
 topics:
   - camera

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.5+6
+version: 0.10.5+7
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.8+15
+
+* Updates example app to use non-deprecated video_player method.
+
 ## 0.10.8+14
 
 * Fixes `pausePreview` null pointer error. `pausePreview` should not be called 

--- a/packages/camera/camera_android/example/lib/main.dart
+++ b/packages/camera/camera_android/example/lib/main.dart
@@ -994,11 +994,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     }
 
     final VideoPlayerController vController = kIsWeb
-        // TODO(gabrielokura): remove the ignore once the following line can migrate to
-        // use VideoPlayerController.networkUrl after the issue is resolved.
-        // https://github.com/flutter/flutter/issues/121927
-        // ignore: deprecated_member_use
-        ? VideoPlayerController.network(videoFile!.path)
+        ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
         : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {

--- a/packages/camera/camera_android/example/pubspec.yaml
+++ b/packages/camera/camera_android/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider: ^2.0.0
-  video_player: ^2.1.4
+  video_player: ^2.7.0
 
 dev_dependencies:
   build_runner: ^2.1.10

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 
-version: 0.10.8+14
+version: 0.10.8+15
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+24
+
+* Updates example app to use non-deprecated video_player method.
+
 ## 0.5.0+23
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.

--- a/packages/camera/camera_android_camerax/example/lib/main.dart
+++ b/packages/camera/camera_android_camerax/example/lib/main.dart
@@ -971,11 +971,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     }
 
     final VideoPlayerController vController = kIsWeb
-        // TODO(gabrielokura): remove the ignore once the following line can migrate to
-        // use VideoPlayerController.networkUrl after the issue is resolved.
-        // https://github.com/flutter/flutter/issues/121927
-        // ignore: deprecated_member_use
-        ? VideoPlayerController.network(videoFile!.path)
+        ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
         : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {

--- a/packages/camera/camera_android_camerax/example/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   camera_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
-  video_player: ^2.4.10
+  video_player: ^2.7.0
 
 dev_dependencies:
   espresso: ^0.2.0

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.5.0+23
+version: 0.5.0+24
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.9.13+8
 
+* Updates example app to use non-deprecated video_player method.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
 
 ## 0.9.13+7

--- a/packages/camera/camera_avfoundation/example/lib/main.dart
+++ b/packages/camera/camera_avfoundation/example/lib/main.dart
@@ -994,11 +994,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     }
 
     final VideoPlayerController vController = kIsWeb
-        // TODO(gabrielokura): remove the ignore once the following line can migrate to
-        // use VideoPlayerController.networkUrl after the issue is resolved.
-        // https://github.com/flutter/flutter/issues/121927
-        // ignore: deprecated_member_use
-        ? VideoPlayerController.network(videoFile!.path)
+        ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
         : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {

--- a/packages/camera/camera_avfoundation/example/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider: ^2.0.0
-  video_player: ^2.1.4
+  video_player: ^2.7.0
 
 dev_dependencies:
   build_runner: ^2.1.10

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.13+7
+version: 0.9.13+8
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.0.5
 
+* Updates example app to use non-deprecated video_player method.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
 
 ## 1.0.4

--- a/packages/image_picker/image_picker/example/lib/main.dart
+++ b/packages/image_picker/image_picker/example/lib/main.dart
@@ -62,11 +62,7 @@ class _MyHomePageState extends State<MyHomePage> {
       await _disposeVideoController();
       late VideoPlayerController controller;
       if (kIsWeb) {
-        // TODO(gabrielokura): remove the ignore once the following line can migrate to
-        // use VideoPlayerController.networkUrl after the issue is resolved.
-        // https://github.com/flutter/flutter/issues/121927
-        // ignore: deprecated_member_use
-        controller = VideoPlayerController.network(file.path);
+        controller = VideoPlayerController.networkUrl(Uri.parse(file.path));
       } else {
         controller = VideoPlayerController.file(File(file.path));
       }

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     path: ../
   image_picker_platform_interface: ^2.8.0
   mime: ^1.0.4
-  video_player: ^2.1.4
+  video_player: ^2.7.0
 
 dev_dependencies:
   build_runner: ^2.1.10

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 1.0.4
+version: 1.0.5
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Updates examples in other packages (image_picker, camera) that use the deprecated `VideoPlayerController.network` to use the newer `VideoPlayerController.networkUrl` instead.

Fixes https://github.com/flutter/flutter/issues/127754

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
