### PR TITLE
[image_picker] Remove input element after completion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,3 +74,4 @@ Twin Sun, LLC <google-contrib@twinsunsolutions.com>
 Amir Panahandeh <amirpanahandeh@gmail.com>
 Daniele Cambi <dancam.dev@gmail.com>
 Michele Benedetti <michelebenx98@gmail.com>
+Taskulu LDA <contributions@taskulu.com>

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 3.0.2
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Removes input element after completion
 
 ## 3.0.1
 

--- a/packages/image_picker/image_picker_for_web/example/integration_test/image_picker_for_web_test.dart
+++ b/packages/image_picker/image_picker_for_web/example/integration_test/image_picker_for_web_test.dart
@@ -52,7 +52,7 @@ void main() {
 
     expect(html.querySelector('flt-image-picker-inputs')?.children.isEmpty,
         isFalse);
-        
+
     // Mock the browser behavior of selecting a file...
     mockInput.dispatchEvent(html.Event('change'));
 

--- a/packages/image_picker/image_picker_for_web/example/integration_test/image_picker_for_web_test.dart
+++ b/packages/image_picker/image_picker_for_web/example/integration_test/image_picker_for_web_test.dart
@@ -50,6 +50,9 @@ void main() {
       source: ImageSource.camera,
     );
 
+    expect(html.querySelector('flt-image-picker-inputs')?.children.isEmpty,
+        isFalse);
+        
     // Mock the browser behavior of selecting a file...
     mockInput.dispatchEvent(html.Event('change'));
 
@@ -68,6 +71,8 @@ void main() {
         completion(
           DateTime.fromMillisecondsSinceEpoch(textFile.lastModified!),
         ));
+    expect(html.querySelector('flt-image-picker-inputs')?.children.isEmpty,
+        isTrue);
   });
 
   testWidgets('getMultiImageWithOptions can select multiple files', (

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -158,7 +158,7 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     ) as html.FileUploadInputElement;
     _injectAndActivate(input);
 
-    return _getSelectedXFiles(input).whenComplete(() => _remove(input));
+    return _getSelectedXFiles(input).whenComplete(input.remove);
   }
 
   // Deprecated methods follow...
@@ -320,9 +320,6 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     // TODO(dit): Reimplement this with the showPicker() API, https://github.com/flutter/flutter/issues/130365
     element.click();
   }
-
-  /// Removes the file input element
-  void _remove(html.Element element) => _target.children.clear();
 }
 
 // Some tools to override behavior for unit-testing

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -158,7 +158,7 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     ) as html.FileUploadInputElement;
     _injectAndActivate(input);
 
-    return _getSelectedXFiles(input);
+    return _getSelectedXFiles(input).whenComplete(() => _remove(input));
   }
 
   // Deprecated methods follow...
@@ -320,6 +320,9 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     // TODO(dit): Reimplement this with the showPicker() API, https://github.com/flutter/flutter/issues/130365
     element.click();
   }
+
+  /// Removes the file input element
+  void _remove(html.Element element) => _target.children.clear();
 }
 
 // Some tools to override behavior for unit-testing

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_for_web
 description: Web platform implementation of image_picker
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_for_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 3.0.1
+version: 3.0.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
This PR attempts to remove the input element added to the DOM after image selection is completed.

Fixes https://github.com/flutter/flutter/issues/139442

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
