### PR TITLE
[ci][web] Ignore always_specify_types for JSArray.

### DIFF
--- a/packages/file_selector/file_selector_web/example/integration_test/dom_helper_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/dom_helper_test.dart
@@ -47,7 +47,11 @@ void main() {
 
     group('getFiles', () {
       final File mockFile1 =
+          // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
+          // ignore: always_specify_types
           File(<Object>['123456'].jsify as JSArray, 'file1.txt');
+      // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
+      // ignore: always_specify_types
       final File mockFile2 = File(<Object>[].jsify as JSArray, 'file2.txt');
 
       testWidgets('works', (_) async {

--- a/packages/google_identity_services_web/example/integration_test/js_interop_id_test.dart
+++ b/packages/google_identity_services_web/example/integration_test/js_interop_id_test.dart
@@ -66,6 +66,8 @@ void main() async {
       expectConfigValue('login_uri', 'https://www.example.com/login');
       expectConfigValue('native_callback', utils.isAJs('function'));
       expectConfigValue('cancel_on_tap_outside', isFalse);
+      // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
+      // ignore: always_specify_types
       expectConfigValue('allowed_parent_origin', isA<JSArray>());
       expectConfigValue('prompt_parent_id', 'some_dom_id');
       expectConfigValue('nonce', 's0m3_r4ndOM_vALu3');

--- a/packages/google_identity_services_web/lib/src/js_interop/google_accounts_id.dart
+++ b/packages/google_identity_services_web/lib/src/js_interop/google_accounts_id.dart
@@ -338,6 +338,8 @@ abstract class IdConfiguration {
     JSString? context,
     JSString? state_cookie_domain,
     JSString? ux_mode,
+    // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
+    // ignore: always_specify_types
     JSArray? allowed_parent_origin,
     JSFunction? intermediate_iframe_close_callback,
     JSBoolean? itp_support,

--- a/packages/google_sign_in/google_sign_in_web/lib/src/flexible_size_html_element_view.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/flexible_size_html_element_view.dart
@@ -73,6 +73,8 @@ class _FlexHtmlElementView extends State<FlexHtmlElementView> {
 
   /// The function called whenever an observed resize occurs.
   void _onResizeEntries(
+    // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
+    // ignore: always_specify_types
     JSArray resizes,
     web.ResizeObserver observer,
   ) {
@@ -88,6 +90,8 @@ class _FlexHtmlElementView extends State<FlexHtmlElementView> {
   /// When mutations are received, this function attaches a Resize Observer to
   /// the first child of the mutation, which will drive
   void _onMutationRecords(
+    // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
+    // ignore: always_specify_types
     JSArray mutations,
     web.MutationObserver observer,
   ) {


### PR DESCRIPTION
The definition of `JSArray` (and `JSPromise`) from `dart:js_interop` is changing to `JSArray<T>`, and our analyzer complains about our usage of it with default `T`s, blocking Dart SDK rolls.

This PR ignores the `always_specify_types` lint in the usages of `JSArray`, so this code passes analysis both with the current version of `dart:js_interop` and the next one.

## Issues

* Fixes https://github.com/flutter/flutter/issues/140076
* Cleanup https://github.com/flutter/flutter/issues/140095

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
