### PR TITLE
[go_router] Fixes deep-link with no path but trailing slash on cold start.

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.1.4
+
+* Fixes deep-link with no path but trailing slash on cold start.
+
 ## 12.1.3
 
 * Fixes a typo in `navigation.md`.

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -534,12 +534,14 @@ class GoRouter implements RouterConfig<RouteMatchList> {
     Uri platformDefaultUri = Uri.parse(
       WidgetsBinding.instance.platformDispatcher.defaultRouteName,
     );
-    if (platformDefaultUri.hasEmptyPath) {
+    if (platformDefaultUri.path.isEmpty || platformDefaultUri.path == '/') {
       // TODO(chunhtai): Clean up this once `RouteInformation.uri` is available
       // in packages repo.
       platformDefaultUri = Uri(
         path: '/',
-        queryParameters: platformDefaultUri.queryParameters,
+        queryParameters: platformDefaultUri.queryParameters.isEmpty
+            ? null
+            : platformDefaultUri.queryParameters,
       );
     }
     final String platformDefault = platformDefaultUri.toString();

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 12.1.3
+version: 12.1.4
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -2484,7 +2484,7 @@ void main() {
         routes,
         tester,
       );
-      expect(router.routeInformationProvider.value.uri.path, '/');
+      expect(router.routeInformationProvider.value.uri.toString(), '/');
       TestWidgetsFlutterBinding.instance.platformDispatcher
           .clearDefaultRouteNameTestValue();
     });
@@ -2499,7 +2499,7 @@ void main() {
         routes,
         tester,
       );
-      expect(router.routeInformationProvider.value.uri.path, '/');
+      expect(router.routeInformationProvider.value.uri.toString(), '/');
       TestWidgetsFlutterBinding.instance.platformDispatcher
           .clearDefaultRouteNameTestValue();
     });


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
- Please see the commit message of b649a48bf45ec9cdc9a075991b22ac7325813768

*List which issues are fixed by this PR. You must list at least one issue.*
- Cherry-pick b1f4a2d4d4f4e70b1157c642e119dddc66a8af2b to reproduce the bug

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
