### PR TITLE
Remove workarounds for `check_podspecs` needed for older version of Cocoapods

### DIFF
--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -142,9 +142,6 @@ class PodspecCheckCommand extends PackageLoopingCommand {
       podspecPath,
       '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
       '--skip-tests',
-      // TODO(vashworth): remove allow-warnings when https://github.com/flutter/flutter/issues/125812 is fixed.
-      // https://github.com/flutter/flutter/issues/125812
-      '--allow-warnings',
       '--use-modular-headers', // Flutter sets use_modular_headers! in its templates.
       if (libraryLint) '--use-libraries'
     ];

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -199,7 +199,6 @@ void main() {
                     .path,
                 '--configuration=Debug',
                 '--skip-tests',
-                '--allow-warnings',
                 '--use-modular-headers',
                 '--use-libraries'
               ],
@@ -215,7 +214,6 @@ void main() {
                     .path,
                 '--configuration=Debug',
                 '--skip-tests',
-                '--allow-warnings',
                 '--use-modular-headers',
               ],
               packagesDir.path),

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -143,7 +143,6 @@ void main() {
                     .path,
                 '--configuration=Debug',
                 '--skip-tests',
-                '--allow-warnings',
                 '--use-modular-headers',
                 '--use-libraries'
               ],
@@ -159,7 +158,6 @@ void main() {
                     .path,
                 '--configuration=Debug',
                 '--skip-tests',
-                '--allow-warnings',
                 '--use-modular-headers',
               ],
               packagesDir.path),


### PR DESCRIPTION
CI has been updated to Cocoapods 1.13, which fixes previous issues with the plugin_lint_mac test. Remove workarounds added previously.

See https://github.com/flutter/flutter/issues/125812.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
