### PR TITLE
Disable `presubmit: false` targets for recipes CQ

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1130,7 +1130,6 @@ targets:
     timeout: 60
     properties:
       channel: stable
-      add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: macos_platform_tests.yaml
       env_variables: >-
@@ -1275,7 +1274,6 @@ targets:
     timeout: 60
     properties:
       channel: stable
-      add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 0 --shardCount 5"
@@ -1291,7 +1289,6 @@ targets:
     timeout: 60
     properties:
       channel: stable
-      add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 1 --shardCount 5"
@@ -1307,7 +1304,6 @@ targets:
     timeout: 60
     properties:
       channel: stable
-      add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 2 --shardCount 5"
@@ -1323,7 +1319,6 @@ targets:
     timeout: 60
     properties:
       channel: stable
-      add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 3 --shardCount 5"
@@ -1339,7 +1334,6 @@ targets:
     timeout: 60
     properties:
       channel: stable
-      add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 4 --shardCount 5"


### PR DESCRIPTION
These targets are not enabled in presubmit, but enabled in CQ. This caused latest changes not surfaced from CQ side: CQ runs are based on out dated try runs. For example: `Mac_arm64 ios_platform_tests_shard_1 stable` is using the old build executed on 12/13: https://ci.chromium.org/ui/p/flutter/builders/try/Mac_arm64%20ios_platform_tests_shard_1%20stable

This PR disables CQ for targets that are with `presubmit: false`, to unblock recipes CL: https://flutter-review.googlesource.com/c/recipes/+/53301