### PR TITLE
[go_router] Expose full `Uri` on `GoRouterState` in `GoRouterRedirect`

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.2.0
+
+- Exposes full `Uri` on `GoRouterState` in `GoRouterRedirect`
+
 ## 13.1.0
 
 - Adds `topRoute` to `GoRouterState`

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -293,11 +293,24 @@ class RouteConfiguration {
 
   /// Finds the routes that matched the given URL.
   RouteMatchList findMatch(String location, {Object? extra}) {
-    final Uri uri = Uri.parse(canonicalUri(location));
+    final Uri uri = Uri.parse(location);
+    // Remove the host and scheme from the uri to match
+    // TODO(ChopinDavid): Do we want to expose this as a getter on `Uri` itself? Or use an extension/helper method?
+    final Uri uriToMatch = Uri.parse(
+      canonicalUri(
+        location.substring(
+          uri.host.isNotEmpty
+              ? uri.toString().indexOf(uri.host) + uri.host.length
+              : uri.hasScheme
+                  ? uri.toString().indexOf(uri.scheme) + uri.scheme.length
+                  : 0,
+        ),
+      ),
+    );
 
     final Map<String, String> pathParameters = <String, String>{};
     final List<RouteMatchBase> matches =
-        _getLocRouteMatches(uri, pathParameters);
+        _getLocRouteMatches(uriToMatch, pathParameters);
 
     if (matches.isEmpty) {
       return _errorRouteMatchList(

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -293,24 +293,11 @@ class RouteConfiguration {
 
   /// Finds the routes that matched the given URL.
   RouteMatchList findMatch(String location, {Object? extra}) {
-    final Uri uri = Uri.parse(location);
-    // Remove the host and scheme from the uri to match
-    // TODO(ChopinDavid): Do we want to expose this as a getter on `Uri` itself? Or use an extension/helper method?
-    final Uri uriToMatch = Uri.parse(
-      canonicalUri(
-        location.substring(
-          uri.host.isNotEmpty
-              ? uri.toString().indexOf(uri.host) + uri.host.length
-              : uri.hasScheme
-                  ? uri.toString().indexOf(uri.scheme) + uri.scheme.length
-                  : 0,
-        ),
-      ),
-    );
+    final Uri uri = Uri.parse(canonicalUri(location));
 
     final Map<String, String> pathParameters = <String, String>{};
     final List<RouteMatchBase> matches =
-        _getLocRouteMatches(uriToMatch, pathParameters);
+        _getLocRouteMatches(uri, pathParameters);
 
     if (matches.isEmpty) {
       return _errorRouteMatchList(

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -105,16 +105,9 @@ class GoRouteInformationProvider extends RouteInformationProvider
     final bool replace;
     switch (type) {
       case RouteInformationReportingType.none:
-        const DeepCollectionEquality deepCollectionEquality =
-            DeepCollectionEquality();
-        if (deepCollectionEquality.equals(
-                _valueInEngine.uri.path, routeInformation.uri.path) &&
-            deepCollectionEquality.equals(_valueInEngine.uri.queryParameters,
-                routeInformation.uri.queryParameters) &&
-            deepCollectionEquality.equals(
-                _valueInEngine.uri.fragment, routeInformation.uri.fragment) &&
-            deepCollectionEquality.equals(
-                _valueInEngine.state, routeInformation.state)) {
+        if (!_valueHasChanged(
+            newLocationUri: routeInformation.uri,
+            newState: routeInformation.state)) {
           return;
         }
         replace = _valueInEngine == _kEmptyRouteInformation;
@@ -143,14 +136,9 @@ class GoRouteInformationProvider extends RouteInformationProvider
 
   void _setValue(String location, Object state) {
     final Uri uri = Uri.parse(location);
-    const DeepCollectionEquality deepCollectionEquality =
-        DeepCollectionEquality();
+
     final bool shouldNotify =
-        !deepCollectionEquality.equals(_value.uri.path, uri.path) ||
-            !deepCollectionEquality.equals(
-                _value.uri.queryParameters, uri.queryParameters) ||
-            !deepCollectionEquality.equals(_value.uri.fragment, uri.fragment) ||
-            !deepCollectionEquality.equals(_value.state, state);
+        _valueHasChanged(newLocationUri: uri, newState: state);
     _value = RouteInformation(uri: Uri.parse(location), state: state);
     if (shouldNotify) {
       notifyListeners();
@@ -245,6 +233,19 @@ class GoRouteInformationProvider extends RouteInformationProvider
       _valueInEngine = _kEmptyRouteInformation;
     }
     notifyListeners();
+  }
+
+  bool _valueHasChanged(
+      {required Uri newLocationUri, required Object? newState}) {
+    const DeepCollectionEquality deepCollectionEquality =
+        DeepCollectionEquality();
+    return !deepCollectionEquality.equals(
+            _value.uri.path, newLocationUri.path) ||
+        !deepCollectionEquality.equals(
+            _value.uri.queryParameters, newLocationUri.queryParameters) ||
+        !deepCollectionEquality.equals(
+            _value.uri.fragment, newLocationUri.fragment) ||
+        !deepCollectionEquality.equals(_value.state, newState);
   }
 
   @override

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -11,10 +11,6 @@ import 'package:flutter/widgets.dart';
 
 import 'match.dart';
 
-// TODO(chunhtai): remove this ignore and migrate the code
-// https://github.com/flutter/flutter/issues/124045.
-// ignore_for_file: deprecated_member_use
-
 /// The type of the navigation.
 ///
 /// This enum is used by [RouteInformationState] to denote the navigation
@@ -85,7 +81,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
     Listenable? refreshListenable,
   })  : _refreshListenable = refreshListenable,
         _value = RouteInformation(
-          location: initialLocation,
+          uri: Uri.parse(initialLocation),
           state: RouteInformationState<void>(
               extra: initialExtra, type: NavigatingType.go),
         ),
@@ -96,8 +92,8 @@ class GoRouteInformationProvider extends RouteInformationProvider
   final Listenable? _refreshListenable;
 
   static WidgetsBinding get _binding => WidgetsBinding.instance;
-  static const RouteInformation _kEmptyRouteInformation =
-      RouteInformation(location: '');
+  static final RouteInformation _kEmptyRouteInformation =
+      RouteInformation(uri: Uri.parse(''));
 
   @override
   void routerReportsNewRouteInformation(RouteInformation routeInformation,
@@ -109,7 +105,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
     final bool replace;
     switch (type) {
       case RouteInformationReportingType.none:
-        if (_valueInEngine.location == routeInformation.location &&
+        if (_valueInEngine.uri.path == routeInformation.uri.path &&
             const DeepCollectionEquality()
                 .equals(_valueInEngine.state, routeInformation.state)) {
           return;
@@ -122,10 +118,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
     }
     SystemNavigator.selectMultiEntryHistory();
     SystemNavigator.routeInformationUpdated(
-      // TODO(chunhtai): remove this ignore and migrate the code
-      // https://github.com/flutter/flutter/issues/124045.
-      // ignore: unnecessary_null_checks, unnecessary_non_null_assertion
-      location: routeInformation.location!,
+      uri: routeInformation.uri,
       state: routeInformation.state,
       replace: replace,
     );
@@ -146,8 +139,8 @@ class GoRouteInformationProvider extends RouteInformationProvider
 
   void _setValue(String location, Object state) {
     final bool shouldNotify =
-        _value.location != location || _value.state != state;
-    _value = RouteInformation(location: location, state: state);
+        _value.uri.path != location || _value.state != state;
+    _value = RouteInformation(uri: Uri.parse(location), state: state);
     if (shouldNotify) {
       notifyListeners();
     }
@@ -272,13 +265,6 @@ class GoRouteInformationProvider extends RouteInformationProvider
   Future<bool> didPushRouteInformation(RouteInformation routeInformation) {
     assert(hasListeners);
     _platformReportsNewRouteInformation(routeInformation);
-    return SynchronousFuture<bool>(true);
-  }
-
-  @override
-  Future<bool> didPushRoute(String route) {
-    assert(hasListeners);
-    _platformReportsNewRouteInformation(RouteInformation(location: route));
     return SynchronousFuture<bool>(true);
   }
 }

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -105,9 +105,16 @@ class GoRouteInformationProvider extends RouteInformationProvider
     final bool replace;
     switch (type) {
       case RouteInformationReportingType.none:
-        if (_valueInEngine.uri.path == routeInformation.uri.path &&
-            const DeepCollectionEquality()
-                .equals(_valueInEngine.state, routeInformation.state)) {
+        const DeepCollectionEquality deepCollectionEquality =
+            DeepCollectionEquality();
+        if (deepCollectionEquality.equals(
+                _valueInEngine.uri.path, routeInformation.uri.path) &&
+            deepCollectionEquality.equals(_valueInEngine.uri.queryParameters,
+                routeInformation.uri.queryParameters) &&
+            deepCollectionEquality.equals(
+                _valueInEngine.uri.fragment, routeInformation.uri.fragment) &&
+            deepCollectionEquality.equals(
+                _valueInEngine.state, routeInformation.state)) {
           return;
         }
         replace = _valueInEngine == _kEmptyRouteInformation;
@@ -135,8 +142,15 @@ class GoRouteInformationProvider extends RouteInformationProvider
   }
 
   void _setValue(String location, Object state) {
+    final Uri uri = Uri.parse(location);
+    const DeepCollectionEquality deepCollectionEquality =
+        DeepCollectionEquality();
     final bool shouldNotify =
-        _value.uri.path != location || _value.state != state;
+        !deepCollectionEquality.equals(_value.uri.path, uri.path) ||
+            !deepCollectionEquality.equals(
+                _value.uri.queryParameters, uri.queryParameters) ||
+            !deepCollectionEquality.equals(_value.uri.fragment, uri.fragment) ||
+            !deepCollectionEquality.equals(_value.state, state);
     _value = RouteInformation(uri: Uri.parse(location), state: state);
     if (shouldNotify) {
       notifyListeners();

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -130,9 +130,6 @@ class GoRouteInformationProvider extends RouteInformationProvider
   RouteInformation _value;
 
   @override
-  // TODO(chunhtai): remove this ignore once package minimum dart version is
-  // above 3.
-  // ignore: unnecessary_overrides
   void notifyListeners() {
     super.notifyListeners();
   }

--- a/packages/go_router/lib/src/information_provider.dart
+++ b/packages/go_router/lib/src/information_provider.dart
@@ -235,7 +235,7 @@ class GoRouteInformationProvider extends RouteInformationProvider
       _value = _valueInEngine = routeInformation;
     } else {
       _value = RouteInformation(
-        location: routeInformation.location,
+        uri: routeInformation.uri,
         state: RouteInformationState<void>(type: NavigatingType.go),
       );
       _valueInEngine = _kEmptyRouteInformation;

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -80,8 +80,6 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
 
     late final RouteMatchList initialMatches;
     initialMatches =
-        // TODO(chunhtai): remove this ignore and migrate the code
-        // https://github.com/flutter/flutter/issues/124045.
         // TODO(chunhtai): After the migration from routeInformation's location
         // to uri, empty path check might be required here; see
         // https://github.com/flutter/packages/pull/5113#discussion_r1374861070
@@ -89,10 +87,7 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
         configuration.findMatch(routeInformation.uri.toString(),
             extra: state.extra);
     if (initialMatches.isError) {
-      // TODO(chunhtai): remove this ignore and migrate the code
-      // https://github.com/flutter/flutter/issues/124045.
-      // ignore: deprecated_member_use
-      log('No initial matches: ${routeInformation.location}');
+      log('No initial matches: ${routeInformation.uri.path}');
     }
 
     return debugParserFuture = _redirect(
@@ -143,10 +138,7 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
       location = configuration.uri.toString();
     }
     return RouteInformation(
-      // TODO(chunhtai): remove this ignore and migrate the code
-      // https://github.com/flutter/flutter/issues/124045.
-      // ignore: deprecated_member_use
-      location: location,
+      uri: Uri.parse(location),
       state: _routeMatchListCodec.encode(configuration),
     );
   }

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -79,13 +79,11 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
     }
 
     late final RouteMatchList initialMatches;
-    initialMatches =
-        // TODO(chunhtai): After the migration from routeInformation's location
-        // to uri, empty path check might be required here; see
-        // https://github.com/flutter/packages/pull/5113#discussion_r1374861070
-        // ignore: deprecated_member_use, unnecessary_non_null_assertion
-        configuration.findMatch(routeInformation.uri.toString(),
-            extra: state.extra);
+    initialMatches = configuration.findMatch(
+        routeInformation.uri.path.isEmpty
+            ? '${routeInformation.uri}/'
+            : routeInformation.uri.toString(),
+        extra: state.extra);
     if (initialMatches.isError) {
       log('No initial matches: ${routeInformation.uri.path}');
     }

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -86,7 +86,8 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
         // to uri, empty path check might be required here; see
         // https://github.com/flutter/packages/pull/5113#discussion_r1374861070
         // ignore: deprecated_member_use, unnecessary_non_null_assertion
-        configuration.findMatch(routeInformation.location!, extra: state.extra);
+        configuration.findMatch(routeInformation.uri.toString(),
+            extra: state.extra);
     if (initialMatches.isError) {
       // TODO(chunhtai): remove this ignore and migrate the code
       // https://github.com/flutter/flutter/issues/124045.

--- a/packages/go_router/lib/src/path_utils.dart
+++ b/packages/go_router/lib/src/path_utils.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'misc/errors.dart';
 import 'route.dart';
 
 final RegExp _parameterRegExp = RegExp(r':(\w+)(\((?:\\.|[^\\()])+\))?');
@@ -120,6 +121,9 @@ String concatenatePaths(String parentPath, String childPath) {
 
 /// Normalizes the location string.
 String canonicalUri(String loc) {
+  if (loc.isEmpty) {
+    throw GoException('Location cannot be empty.');
+  }
   String canon = Uri.parse(loc).toString();
   canon = canon.endsWith('?') ? canon.substring(0, canon.length - 1) : canon;
 
@@ -131,9 +135,18 @@ String canonicalUri(String loc) {
       ? canon.substring(0, canon.length - 1)
       : canon;
 
+  // replace '/?', except for first occurrence, from path only
   // /login/?from=/ => /login?from=/
   // /?from=/ => /?from=/
-  canon = canon.replaceFirst('/?', '?', 1);
+  final Uri uri = Uri.parse(canon);
+  final int pathStartIndex = uri.host.isNotEmpty
+      ? uri.toString().indexOf(uri.host) + uri.host.length
+      : uri.hasScheme
+          ? uri.toString().indexOf(uri.scheme) + uri.scheme.length
+          : 0;
+  if (pathStartIndex < canon.length) {
+    canon = canon.replaceFirst('/?', '?', pathStartIndex + 1);
+  }
 
   return canon;
 }

--- a/packages/go_router/lib/src/path_utils.dart
+++ b/packages/go_router/lib/src/path_utils.dart
@@ -127,7 +127,9 @@ String canonicalUri(String loc) {
   // /profile/ => /profile
   // / => /
   // /login?from=/ => login?from=/
-  canon = canon.endsWith('/') && canon != '/' && !canon.contains('?')
+  canon = canon.endsWith('/') &&
+          Uri.parse(canon).path != '/' &&
+          !canon.contains('?')
       ? canon.substring(0, canon.length - 1)
       : canon;
 

--- a/packages/go_router/lib/src/path_utils.dart
+++ b/packages/go_router/lib/src/path_utils.dart
@@ -127,9 +127,7 @@ String canonicalUri(String loc) {
   // /profile/ => /profile
   // / => /
   // /login?from=/ => login?from=/
-  canon = canon.endsWith('/') &&
-          Uri.parse(canon).path != '/' &&
-          !canon.contains('?')
+  canon = canon.endsWith('/') && canon != '/' && !canon.contains('?')
       ? canon.substring(0, canon.length - 1)
       : canon;
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.12.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 13.1.0
+version: 13.2.0
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  flutter: ">=3.12.0"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.1.0 <4.0.0"
   flutter: ">=3.13.0"
 
 dependencies:

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -1301,10 +1301,7 @@ void main() {
       expect(find.byKey(const ValueKey<String>('home')), findsOneWidget);
 
       router.routeInformationProvider.didPushRouteInformation(
-          // TODO(chunhtai): remove this ignore and migrate the code
-          // https://github.com/flutter/flutter/issues/124045.
-          // ignore: deprecated_member_use
-          RouteInformation(location: location, state: state));
+          RouteInformation(uri: Uri.parse(location), state: state));
       await tester.pumpAndSettle();
       // Make sure it has all the imperative routes.
       expect(find.byKey(const ValueKey<String>('settings-1')), findsOneWidget);
@@ -2435,10 +2432,7 @@ void main() {
         routes,
         tester,
       );
-      // TODO(chunhtai): remove this ignore and migrate the code
-      // https://github.com/flutter/flutter/issues/124045.
-      // ignore: deprecated_member_use
-      expect(router.routeInformationProvider.value.location, '/dummy');
+      expect(router.routeInformationProvider.value.uri.path, '/dummy');
       TestWidgetsFlutterBinding.instance.platformDispatcher
           .clearDefaultRouteNameTestValue();
     });

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -258,6 +258,95 @@ void main() {
       expect(find.byType(DummyScreen), findsOneWidget);
     });
 
+    testWidgets(
+        'match top level route when location has scheme/host and has trailing /',
+        (WidgetTester tester) async {
+      final List<GoRoute> routes = <GoRoute>[
+        GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) =>
+              const HomeScreen(),
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+      router.go('https://www.domain.com/?bar=baz');
+      await tester.pumpAndSettle();
+      final List<RouteMatchBase> matches =
+          router.routerDelegate.currentConfiguration.matches;
+      expect(matches, hasLength(1));
+      expect(matches.first.matchedLocation, '/');
+      expect(find.byType(HomeScreen), findsOneWidget);
+    });
+
+    testWidgets(
+        'match top level route when location has scheme/host and has trailing / (2)',
+        (WidgetTester tester) async {
+      final List<GoRoute> routes = <GoRoute>[
+        GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) =>
+              const HomeScreen(),
+        ),
+        GoRoute(
+          path: '/login',
+          builder: (BuildContext context, GoRouterState state) =>
+              const LoginScreen(),
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+      router.go('https://www.domain.com/login/');
+      await tester.pumpAndSettle();
+      final List<RouteMatchBase> matches =
+          router.routerDelegate.currentConfiguration.matches;
+      expect(matches, hasLength(1));
+      expect(matches.first.matchedLocation, '/login');
+      expect(find.byType(LoginScreen), findsOneWidget);
+    });
+
+    testWidgets(
+        'match top level route when location has scheme/host and has trailing / (3)',
+        (WidgetTester tester) async {
+      final List<GoRoute> routes = <GoRoute>[
+        GoRoute(
+            path: '/profile',
+            builder: dummy,
+            redirect: (_, __) => '/profile/foo'),
+        GoRoute(path: '/profile/:kind', builder: dummy),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+      router.go('https://www.domain.com/profile/');
+      await tester.pumpAndSettle();
+      final List<RouteMatchBase> matches =
+          router.routerDelegate.currentConfiguration.matches;
+      expect(matches, hasLength(1));
+      expect(matches.first.matchedLocation, '/profile/foo');
+      expect(find.byType(DummyScreen), findsOneWidget);
+    });
+
+    testWidgets(
+        'match top level route when location has scheme/host and has trailing / (4)',
+        (WidgetTester tester) async {
+      final List<GoRoute> routes = <GoRoute>[
+        GoRoute(
+            path: '/profile',
+            builder: dummy,
+            redirect: (_, __) => '/profile/foo'),
+        GoRoute(path: '/profile/:kind', builder: dummy),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+      router.go('https://www.domain.com/profile/?bar=baz');
+      await tester.pumpAndSettle();
+      final List<RouteMatchBase> matches =
+          router.routerDelegate.currentConfiguration.matches;
+      expect(matches, hasLength(1));
+      expect(matches.first.matchedLocation, '/profile/foo');
+      expect(find.byType(DummyScreen), findsOneWidget);
+    });
+
     testWidgets('repeatedly pops imperative route does not crash',
         (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/123369.

--- a/packages/go_router/test/information_provider_test.dart
+++ b/packages/go_router/test/information_provider_test.dart
@@ -26,11 +26,8 @@ void main() {
           GoRouteInformationProvider(
               initialLocation: initialRoute, initialExtra: null);
       provider.addListener(expectAsync0(() {}));
-      // TODO(chunhtai): remove this ignore and migrate the code
-      // https://github.com/flutter/flutter/issues/124045.
-      // ignore_for_file: deprecated_member_use
       provider
-          .didPushRouteInformation(const RouteInformation(location: newRoute));
+          .didPushRouteInformation(RouteInformation(uri: Uri.parse(newRoute)));
     });
 
     testWidgets('didPushRouteInformation maintains uri scheme and host',
@@ -63,7 +60,8 @@ void main() {
           GoRouteInformationProvider(
               initialLocation: initialRoute, initialExtra: null);
       provider.addListener(expectAsync0(() {}));
-      provider.didPushRoute(expectedUriString);
+      provider.didPushRouteInformation(
+          RouteInformation(uri: Uri.parse(expectedUriString)));
       expect(provider.value.uri.scheme, 'https');
       expect(provider.value.uri.host, 'www.example.com');
       expect(provider.value.uri.path, '/some/path');

--- a/packages/go_router/test/information_provider_test.dart
+++ b/packages/go_router/test/information_provider_test.dart
@@ -32,5 +32,42 @@ void main() {
       provider
           .didPushRouteInformation(const RouteInformation(location: newRoute));
     });
+
+    testWidgets('didPushRouteInformation maintains uri scheme and host',
+        (WidgetTester tester) async {
+      const String expectedScheme = 'https';
+      const String expectedHost = 'www.example.com';
+      const String expectedPath = '/some/path';
+      const String expectedUriString =
+          '$expectedScheme://$expectedHost$expectedPath';
+      late final GoRouteInformationProvider provider =
+          GoRouteInformationProvider(
+              initialLocation: initialRoute, initialExtra: null);
+      provider.addListener(expectAsync0(() {}));
+      provider.didPushRouteInformation(
+          RouteInformation(uri: Uri.parse(expectedUriString)));
+      expect(provider.value.uri.scheme, 'https');
+      expect(provider.value.uri.host, 'www.example.com');
+      expect(provider.value.uri.path, '/some/path');
+      expect(provider.value.uri.toString(), expectedUriString);
+    });
+
+    testWidgets('didPushRoute maintains uri scheme and host',
+        (WidgetTester tester) async {
+      const String expectedScheme = 'https';
+      const String expectedHost = 'www.example.com';
+      const String expectedPath = '/some/path';
+      const String expectedUriString =
+          '$expectedScheme://$expectedHost$expectedPath';
+      late final GoRouteInformationProvider provider =
+          GoRouteInformationProvider(
+              initialLocation: initialRoute, initialExtra: null);
+      provider.addListener(expectAsync0(() {}));
+      provider.didPushRoute(expectedUriString);
+      expect(provider.value.uri.scheme, 'https');
+      expect(provider.value.uri.host, 'www.example.com');
+      expect(provider.value.uri.path, '/some/path');
+      expect(provider.value.uri.toString(), expectedUriString);
+    });
   });
 }

--- a/packages/go_router/test/parser_test.dart
+++ b/packages/go_router/test/parser_test.dart
@@ -10,10 +10,7 @@ import 'test_helpers.dart';
 
 RouteInformation createRouteInformation(String location, [Object? extra]) {
   return RouteInformation(
-      // TODO(chunhtai): remove this ignore and migrate the code
-      // https://github.com/flutter/flutter/issues/124045.
-      // ignore: deprecated_member_use
-      location: location,
+      uri: Uri.parse(location),
       state:
           RouteInformationState<void>(type: NavigatingType.go, extra: extra));
 }
@@ -115,7 +112,7 @@ void main() {
     final RouteMatchList matchesObj =
         await parser.parseRouteInformationWithDependencies(
             createRouteInformation(expectedUriString), context);
-    final List<RouteMatch> matches = matchesObj.matches;
+    final List<RouteMatchBase> matches = matchesObj.matches;
     expect(matches.length, 2);
     expect(matchesObj.uri.toString(), expectedUriString);
     expect(matchesObj.uri.scheme, expectedScheme);
@@ -160,11 +157,7 @@ void main() {
 
     final RouteInformation restoredRouteInformation =
         router.routeInformationParser.restoreRouteInformation(matchList)!;
-    // URL reflects the latest push.
-    // TODO(chunhtai): remove this ignore and migrate the code
-    // https://github.com/flutter/flutter/issues/124045.
-    // ignore: deprecated_member_use
-    expect(restoredRouteInformation.location, '/');
+    expect(restoredRouteInformation.uri.path, '/');
 
     // Can restore back to original RouteMatchList.
     final RouteMatchList parsedRouteMatch = await router.routeInformationParser

--- a/packages/go_router/test/parser_test.dart
+++ b/packages/go_router/test/parser_test.dart
@@ -84,6 +84,52 @@ void main() {
   });
 
   testWidgets(
+      "GoRouteInformationParser can parse deeplink route and maintain uri's scheme and host",
+      (WidgetTester tester) async {
+    const String expectedScheme = 'https';
+    const String expectedHost = 'www.example.com';
+    const String expectedPath = '/abc';
+    const String expectedUriString =
+        '$expectedScheme://$expectedHost$expectedPath';
+    final List<GoRoute> routes = <GoRoute>[
+      GoRoute(
+        path: '/',
+        builder: (_, __) => const Placeholder(),
+        routes: <GoRoute>[
+          GoRoute(
+            path: 'abc',
+            builder: (_, __) => const Placeholder(),
+          ),
+        ],
+      ),
+    ];
+    final GoRouteInformationParser parser = await createParser(
+      tester,
+      routes: routes,
+      redirectLimit: 100,
+      redirect: (_, __) => null,
+    );
+
+    final BuildContext context = tester.element(find.byType(Router<Object>));
+
+    final RouteMatchList matchesObj =
+        await parser.parseRouteInformationWithDependencies(
+            createRouteInformation(expectedUriString), context);
+    final List<RouteMatch> matches = matchesObj.matches;
+    expect(matches.length, 2);
+    expect(matchesObj.uri.toString(), expectedUriString);
+    expect(matchesObj.uri.scheme, expectedScheme);
+    expect(matchesObj.uri.host, expectedHost);
+    expect(matchesObj.uri.path, expectedPath);
+
+    expect(matches[0].matchedLocation, '/');
+    expect(matches[0].route, routes[0]);
+
+    expect(matches[1].matchedLocation, '/abc');
+    expect(matches[1].route, routes[0].routes[0]);
+  });
+
+  testWidgets(
       'GoRouteInformationParser can restore full route matches if optionURLReflectsImperativeAPIs is true',
       (WidgetTester tester) async {
     final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();


### PR DESCRIPTION
A number of developers have voiced the desire to be able to know whether a `GoRouterState` is the result of a deep-link or in-app navigation from within their `GoRouter`'s `redirect` method. This can be accomplished by exposing the `Uri`'s `scheme` and `host` on the `GoRouterState`. This way, we can know whether the `GoRouterState` is the result of a deep-link by checking `state.uri.scheme != null` or `state.uri.host != null`.

This PR would close [#103659](https://github.com/flutter/flutter/issues/103659#issuecomment-1865112881).

No tests were broken as a result of this change, and we have added coverage for this change through new tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
