### PR TITLE
[tool] Handle Flutter dev dependencies

### DIFF
--- a/script/tool/lib/src/common/repository_package.dart
+++ b/script/tool/lib/src/common/repository_package.dart
@@ -112,8 +112,10 @@ class RepositoryPackage {
 
   /// Returns true if the package depends on Flutter.
   bool requiresFlutter() {
+    const String flutterDependency = 'flutter';
     final Pubspec pubspec = parsePubspec();
-    return pubspec.dependencies.containsKey('flutter');
+    return pubspec.dependencies.containsKey(flutterDependency) ||
+        pubspec.devDependencies.containsKey(flutterDependency);
   }
 
   /// True if this appears to be a federated plugin package, according to
@@ -151,7 +153,9 @@ class RepositoryPackage {
       return false;
     }
     // Check whether this is one of the enclosing package's examples.
-    return enclosingPackage.getExamples().any((RepositoryPackage p) => p.path == path);
+    return enclosingPackage
+        .getExamples()
+        .any((RepositoryPackage p) => p.path == path);
   }
 
   /// Returns the Flutter example packages contained in the package, if any.

--- a/script/tool/test/common/repository_package_test.dart
+++ b/script/tool/test/common/repository_package_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
 
 import '../util.dart';
@@ -218,6 +219,17 @@ void main() {
     test('returns true for Flutter package', () async {
       final RepositoryPackage package =
           createFakePackage('a_package', packagesDir, isFlutter: true);
+      expect(package.requiresFlutter(), true);
+    });
+
+    test('returns true for a dev dependency on Flutter', () async {
+      final RepositoryPackage package =
+          createFakePackage('a_package', packagesDir);
+      final File pubspecFile = package.pubspecFile;
+      final Pubspec pubspec = package.parsePubspec();
+      pubspec.devDependencies['flutter'] = SdkDependency('flutter');
+      pubspecFile.writeAsStringSync(pubspec.toString());
+
       expect(package.requiresFlutter(), true);
     });
 


### PR DESCRIPTION
A non-Flutter package can have Flutter-based tests (e.g., cupertino_icons), in which case we need to use `flutter test` rather than `dart test` just like we would for a package with a non-dev Flutter dependency. This updates the `requiresFlutter` check to include dev dependencies as well as normal dependencies.