### PR TITLE
[web] Updates package:web dependency to ^0.5.0.

### DIFF
--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.3.4
 
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates to web code to package `web: ^0.5.0`.
+* Updates SDK version to Dart `^3.3.0`.
 
 ## 0.3.3+8
 

--- a/packages/cross_file/lib/src/types/html.dart
+++ b/packages/cross_file/lib/src/types/html.dart
@@ -66,9 +66,7 @@ class XFile extends XFileBase {
         super(path) {
     if (path == null) {
       _browserBlob = _createBlobFromBytes(bytes, mimeType);
-      // TODO(kevmoo): drop ignore when pkg:web constraint excludes v0.3
-      // ignore: unnecessary_cast
-      _path = URL.createObjectURL(_browserBlob! as JSObject);
+      _path = URL.createObjectURL(_browserBlob!);
     } else {
       _path = path;
     }
@@ -131,9 +129,7 @@ class XFile extends XFileBase {
 
     // Attempt to re-hydrate the blob from the `path` via a (local) HttpRequest.
     // Note that safari hangs if the Blob is >=4GB, so bail out in that case.
-    // TODO(kevmoo): Remove ignore and fix when the MIN Dart SDK is 3.3
-    // ignore: unnecessary_non_null_assertion
-    if (isSafari() && _length != null && _length! >= _fourGigabytes) {
+    if (isSafari() && _length != null && _length >= _fourGigabytes) {
       throw Exception('Safari cannot handle XFiles larger than 4GB.');
     }
 

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -2,14 +2,14 @@ name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 repository: https://github.com/flutter/packages/tree/main/packages/cross_file
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+cross_file%22
-version: 0.3.3+8
+version: 0.3.4
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.3.0
 
 dependencies:
   meta: ^1.3.0
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.5.0
 
 dev_dependencies:
   path: ^1.8.1

--- a/packages/cross_file/test/x_file_html_test.dart
+++ b/packages/cross_file/test/x_file_html_test.dart
@@ -69,10 +69,10 @@ void main() {
     test('Stores data as a Blob', () async {
       // Read the blob from its path 'natively'
       final html.Response response =
-          (await html.window.fetch(file.path.toJS).toDart)! as html.Response;
+          await html.window.fetch(file.path.toJS).toDart;
 
-      final JSAny? arrayBuffer = await response.arrayBuffer().toDart;
-      final ByteBuffer data = (arrayBuffer! as JSArrayBuffer).toDart;
+      final JSAny arrayBuffer = await response.arrayBuffer().toDart;
+      final ByteBuffer data = (arrayBuffer as JSArrayBuffer).toDart;
       expect(data.asUint8List(), equals(bytes));
     });
 

--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.9.4
 
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates to web code to package `web: ^0.5.0`.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.16.0`.
 
 ## 0.9.3
 

--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.4
 
-* Updates to web code to package `web: ^0.5.0`.
+* Updates web code to package `web: ^0.5.0`.
 * Updates SDK version to Dart `^3.3.0`. Flutter `^3.16.0`.
 
 ## 0.9.3

--- a/packages/file_selector/file_selector_web/example/integration_test/dom_helper_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/dom_helper_test.dart
@@ -18,11 +18,10 @@ void main() {
 
     FileList? createFileList(List<File> files) {
       final DataTransfer dataTransfer = DataTransfer();
+      // Tear-offs of external extension type interop member 'add' are disallowed.
+      // ignore: prefer_foreach
       for (final File e in files) {
-        // TODO(srujzs): This is necessary in order to support package:web 0.4.0.
-        // This was not needed with 0.3.0, hence the lint.
-        // ignore: unnecessary_cast
-        dataTransfer.items.add(e as JSAny);
+        dataTransfer.items.add(e);
       }
       return dataTransfer.files;
     }
@@ -46,9 +45,7 @@ void main() {
     });
 
     group('getFiles', () {
-      final File mockFile1 = File(
-          <String>['123456'].map((String e) => e.toJS).toList().toJS,
-          'file1.txt');
+      final File mockFile1 = File(<JSAny>['123456'.toJS].toJS, 'file1.txt');
       final File mockFile2 = File(<JSAny>[].toJS, 'file2.txt');
 
       testWidgets('works', (_) async {
@@ -111,10 +108,7 @@ void main() {
       testWidgets('sets the <input /> attributes and clicks it', (_) async {
         const String accept = '.jpg,.png';
         const bool multiple = true;
-        bool wasClicked = false;
-
-        //ignore: unawaited_futures
-        input.onClick.first.then((_) => wasClicked = true);
+        final Future<bool> wasClicked = input.onClick.first.then((_) => true);
 
         final Future<List<XFile>> futureFile = domHelper.getFiles(
           accept: accept,
@@ -122,21 +116,19 @@ void main() {
           input: input,
         );
 
-        expect(input.matches('body'), true);
+        expect(input.isConnected, true,
+            reason: 'input must be injected into the DOM');
         expect(input.accept, accept);
         expect(input.multiple, multiple);
-        expect(
-          wasClicked,
-          true,
-          reason:
-              'The <input /> should be clicked otherwise no dialog will be shown',
-        );
+        expect(await wasClicked, true,
+            reason:
+                'The <input /> should be clicked otherwise no dialog will be shown');
 
         setFilesAndTriggerChange(<File>[]);
         await futureFile;
 
         // It should be already removed from the DOM after the file is resolved.
-        expect(input.parentElement, isNull);
+        expect(input.isConnected, isFalse);
       });
     });
   });

--- a/packages/file_selector/file_selector_web/example/integration_test/dom_helper_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/dom_helper_test.dart
@@ -46,13 +46,10 @@ void main() {
     });
 
     group('getFiles', () {
-      final File mockFile1 =
-          // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
-          // ignore: always_specify_types
-          File(<Object>['123456'].jsify as JSArray, 'file1.txt');
-      // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
-      // ignore: always_specify_types
-      final File mockFile2 = File(<Object>[].jsify as JSArray, 'file2.txt');
+      final File mockFile1 = File(
+          <String>['123456'].map((String e) => e.toJS).toList().toJS,
+          'file1.txt');
+      final File mockFile2 = File(<JSAny>[].toJS, 'file2.txt');
 
       testWidgets('works', (_) async {
         final Future<List<XFile>> futureFiles = domHelper.getFiles(

--- a/packages/file_selector/file_selector_web/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.16.0
+  flutter: ^3.19.0
 
 dependencies:
   file_selector_platform_interface: ^2.6.0

--- a/packages/file_selector/file_selector_web/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   file_selector_platform_interface: ^2.6.0

--- a/packages/file_selector/file_selector_web/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: file_selector_web_integration_tests
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  sdk: ^3.3.0
+  flutter: ^3.16.0
 
 dependencies:
   file_selector_platform_interface: ^2.6.0
@@ -11,7 +11,7 @@ dependencies:
     path: ../
   flutter:
     sdk: flutter
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/file_selector/file_selector_web/lib/src/dom_helper.dart
+++ b/packages/file_selector/file_selector_web/lib/src/dom_helper.dart
@@ -14,11 +14,11 @@ import 'package:web/helpers.dart';
 class DomHelper {
   /// Default constructor, initializes the container DOM element.
   DomHelper() {
-    final Element body = querySelector('body')!;
+    final Element body = document.querySelector('body')!;
     body.appendChild(_container);
   }
 
-  final Element _container = createElementTag('file-selector');
+  final Element _container = document.createElement('file-selector');
 
   /// Sets the <input /> attributes and waits for a file to be selected.
   Future<List<XFile>> getFiles({
@@ -28,7 +28,7 @@ class DomHelper {
   }) {
     final Completer<List<XFile>> completer = Completer<List<XFile>>();
     final HTMLInputElement inputElement =
-        input ?? (createElementTag('input') as HTMLInputElement)
+        input ?? (document.createElement('input') as HTMLInputElement)
           ..type = 'file';
 
     _container.appendChild(
@@ -72,10 +72,7 @@ class DomHelper {
   }
 
   XFile _convertFileToXFile(File file) => XFile(
-        // TODO(srujzs): This is necessary in order to support package:web 0.4.0.
-        // This was not needed with 0.3.0, hence the lint.
-        // ignore: unnecessary_cast
-        URL.createObjectURL(file as JSObject),
+        URL.createObjectURL(file),
         name: file.name,
         length: file.size,
         lastModified: DateTime.fromMillisecondsSinceEpoch(file.lastModified),

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.9.4
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.16.0
+  flutter: ^3.19.0
 
 flutter:
   plugin:

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.9.4
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 flutter:
   plugin:

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -2,11 +2,11 @@ name: file_selector_web
 description: Web platform implementation of file_selector
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.3
+version: 0.9.4
 
 environment:
-  sdk: ^3.2.0
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0
+  flutter: ^3.16.0
 
 flutter:
   plugin:
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_identity_services_web/CHANGELOG.md
+++ b/packages/google_identity_services_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.1
 
-* Updates to web code to package `web: ^0.5.0`.
+* Updates web code to package `web: ^0.5.0`.
 * Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 0.3.0+2

--- a/packages/google_identity_services_web/CHANGELOG.md
+++ b/packages/google_identity_services_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+- Next Dart/Flutter
+- Latest pkg:web
+
 ## 0.3.0+2
 
 * Adds `fedcm_auto` to `CredentialSelectBy` enum.

--- a/packages/google_identity_services_web/CHANGELOG.md
+++ b/packages/google_identity_services_web/CHANGELOG.md
@@ -1,7 +1,7 @@
-## NEXT
+## 0.3.1
 
-- Next Dart/Flutter
-- Latest pkg:web
+* Updates to web code to package `web: ^0.5.0`.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 0.3.0+2
 

--- a/packages/google_identity_services_web/example/integration_test/js_interop_id_test.dart
+++ b/packages/google_identity_services_web/example/integration_test/js_interop_id_test.dart
@@ -66,9 +66,7 @@ void main() async {
       expectConfigValue('login_uri', 'https://www.example.com/login');
       expectConfigValue('native_callback', utils.isAJs('function'));
       expectConfigValue('cancel_on_tap_outside', isFalse);
-      // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
-      // ignore: always_specify_types
-      expectConfigValue('allowed_parent_origin', isA<JSArray>());
+      expectConfigValue('allowed_parent_origin', isA<JSArray<JSString>>());
       expectConfigValue('prompt_parent_id', 'some_dom_id');
       expectConfigValue('nonce', 's0m3_r4ndOM_vALu3');
       expectConfigValue('context', 'signin');

--- a/packages/google_identity_services_web/example/pubspec.yaml
+++ b/packages/google_identity_services_web/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   google_identity_services_web:
     path: ../
   http: ">=0.13.0 <2.0.0"
-  web: ">=0.3.0 <0.5.0"
+  web: ">=0.3.0 <0.6.0"
 
 dev_dependencies:
   build_runner: ^2.1.10 # To extract README excerpts only.

--- a/packages/google_identity_services_web/example/pubspec.yaml
+++ b/packages/google_identity_services_web/example/pubspec.yaml
@@ -1,7 +1,6 @@
 name: google_identity_services_web_example
 description: An example for the google_identity_services_web package, OneTap.
 publish_to: 'none'
-version: 0.0.1
 
 environment:
   flutter: ">=3.16.0"
@@ -13,7 +12,7 @@ dependencies:
   google_identity_services_web:
     path: ../
   http: ">=0.13.0 <2.0.0"
-  web: ">=0.3.0 <0.6.0"
+  web: ^0.5.0
 
 dev_dependencies:
   build_runner: ^2.1.10 # To extract README excerpts only.

--- a/packages/google_identity_services_web/lib/src/js_interop/google_accounts_id.dart
+++ b/packages/google_identity_services_web/lib/src/js_interop/google_accounts_id.dart
@@ -338,9 +338,7 @@ abstract class IdConfiguration {
     JSString? context,
     JSString? state_cookie_domain,
     JSString? ux_mode,
-    // TODO(srujzs): Remove once typed JSArrays (JSArray<T>) get to `stable`.
-    // ignore: always_specify_types
-    JSArray? allowed_parent_origin,
+    JSArray<JSString>? allowed_parent_origin,
     JSFunction? intermediate_iframe_close_callback,
     JSBoolean? itp_support,
     JSString? login_hint,

--- a/packages/google_identity_services_web/lib/src/js_interop/package_web_tweaks.dart
+++ b/packages/google_identity_services_web/lib/src/js_interop/package_web_tweaks.dart
@@ -2,34 +2,102 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Provides some useful tweaks to `package:web`.
-library package_web_tweaks;
+// ignore_for_file: public_member_api_docs
+
+@JS()
+library;
 
 import 'dart:js_interop';
+
 import 'package:web/web.dart' as web;
 
 /// This extension gives web.window a nullable getter to the `trustedTypes`
 /// property, which needs to be used to check for feature support.
 extension NullableTrustedTypesGetter on web.Window {
-  ///
   @JS('trustedTypes')
-  external web.TrustedTypePolicyFactory? get nullableTrustedTypes;
-}
+  external TrustedTypePolicyFactory? get nullableTrustedTypes;
 
-/// This extension allows a trusted type policy to create a script URL without
-/// the `args` parameter (which in Chrome currently fails).
-extension CreateScriptUrlWithoutArgs on web.TrustedTypePolicy {
-  ///
-  @JS('createScriptURL')
-  external web.TrustedScriptURL createScriptURLNoArgs(
-    String input,
-  );
+  external TrustedTypePolicyFactory get trustedTypes;
 }
 
 /// This extension allows setting a TrustedScriptURL as the src of a script element,
 /// which currently only accepts a string.
 extension TrustedTypeSrcAttribute on web.HTMLScriptElement {
-  ///
   @JS('src')
-  external set srcTT(web.TrustedScriptURL value);
+  external set srcTT(TrustedScriptURL value);
+}
+
+// TODO(kevmoo): drop all of this once https://github.com/dart-lang/web/pull/173
+// lands and pkg:web rolls to 0.5.1
+
+typedef CreateHTMLCallback = JSFunction;
+typedef CreateScriptCallback = JSFunction;
+typedef CreateScriptURLCallback = JSFunction;
+extension type TrustedHTML._(JSObject _) implements JSObject {
+  external static TrustedHTML fromLiteral(JSObject templateStringsArray);
+  external String toJSON();
+}
+extension type TrustedScript._(JSObject _) implements JSObject {
+  external static TrustedScript fromLiteral(JSObject templateStringsArray);
+  external String toJSON();
+}
+extension type TrustedScriptURL._(JSObject _) implements JSObject {
+  external static TrustedScriptURL fromLiteral(JSObject templateStringsArray);
+  external String toJSON();
+}
+extension type TrustedTypePolicyFactory._(JSObject _) implements JSObject {
+  external TrustedTypePolicy createPolicy(
+    String policyName, [
+    TrustedTypePolicyOptions policyOptions,
+  ]);
+  external bool isHTML(JSAny? value);
+  external bool isScript(JSAny? value);
+  external bool isScriptURL(JSAny? value);
+  external String? getAttributeType(
+    String tagName,
+    String attribute, [
+    String elementNs,
+    String attrNs,
+  ]);
+  external String? getPropertyType(
+    String tagName,
+    String property, [
+    String elementNs,
+  ]);
+  external TrustedHTML get emptyHTML;
+  external TrustedScript get emptyScript;
+  external TrustedTypePolicy? get defaultPolicy;
+}
+extension type TrustedTypePolicy._(JSObject _) implements JSObject {
+  external TrustedHTML createHTML(
+    String input,
+    JSAny? arguments,
+  );
+  external TrustedScript createScript(
+    String input,
+    JSAny? arguments,
+  );
+  external TrustedScriptURL createScriptURL(
+    String input,
+    JSAny? arguments,
+  );
+  @JS('createScriptURL')
+  external TrustedScriptURL createScriptURLNoArgs(
+    String input,
+  );
+  external String get name;
+}
+extension type TrustedTypePolicyOptions._(JSObject _) implements JSObject {
+  external factory TrustedTypePolicyOptions({
+    CreateHTMLCallback createHTML,
+    CreateScriptCallback createScript,
+    CreateScriptURLCallback createScriptURL,
+  });
+
+  external set createHTML(CreateHTMLCallback value);
+  external CreateHTMLCallback get createHTML;
+  external set createScript(CreateScriptCallback value);
+  external CreateScriptCallback get createScript;
+  external set createScriptURL(CreateScriptURLCallback value);
+  external CreateScriptURLCallback get createScriptURL;
 }

--- a/packages/google_identity_services_web/lib/src/js_interop/package_web_tweaks.dart
+++ b/packages/google_identity_services_web/lib/src/js_interop/package_web_tweaks.dart
@@ -11,13 +11,22 @@ import 'package:web/web.dart' as web;
 /// This extension gives web.window a nullable getter to the `trustedTypes`
 /// property, which needs to be used to check for feature support.
 extension NullableTrustedTypesGetter on web.Window {
-  /// Bindings to window.trustedTypes.
+  /// (Nullable) Bindings to window.trustedTypes.
   ///
   /// This may be null if the browser doesn't support the Trusted Types API.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API
   @JS('trustedTypes')
-  external TrustedTypePolicyFactory? get trustedTypes;
+  external TrustedTypePolicyFactory? get nullableTrustedTypes;
+
+  /// Bindings to window.trustedTypes.
+  ///
+  /// This will crash if accessed in a browser that doesn't support the
+  /// Trusted Types API.
+  ///
+  /// See: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API
+  @JS('trustedTypes')
+  external TrustedTypePolicyFactory get trustedTypes;
 }
 
 /// This extension allows setting a TrustedScriptURL as the src of a script element,

--- a/packages/google_identity_services_web/lib/src/js_interop/package_web_tweaks.dart
+++ b/packages/google_identity_services_web/lib/src/js_interop/package_web_tweaks.dart
@@ -2,102 +2,66 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
-
-@JS()
-library;
-
 import 'dart:js_interop';
 
 import 'package:web/web.dart' as web;
 
+// TODO(kevmoo): Make this file unnecessary, https://github.com/dart-lang/web/issues/175
+
 /// This extension gives web.window a nullable getter to the `trustedTypes`
 /// property, which needs to be used to check for feature support.
 extension NullableTrustedTypesGetter on web.Window {
+  /// Bindings to window.trustedTypes.
+  ///
+  /// This may be null if the browser doesn't support the Trusted Types API.
+  ///
+  /// See: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API
   @JS('trustedTypes')
-  external TrustedTypePolicyFactory? get nullableTrustedTypes;
-
-  external TrustedTypePolicyFactory get trustedTypes;
+  external TrustedTypePolicyFactory? get trustedTypes;
 }
 
 /// This extension allows setting a TrustedScriptURL as the src of a script element,
 /// which currently only accepts a string.
 extension TrustedTypeSrcAttribute on web.HTMLScriptElement {
   @JS('src')
-  external set srcTT(TrustedScriptURL value);
+  external set trustedSrc(TrustedScriptURL value);
 }
 
-// TODO(kevmoo): drop all of this once https://github.com/dart-lang/web/pull/173
-// lands and pkg:web rolls to 0.5.1
+// TODO(kevmoo): drop all of this once `pkg:web` publishes `0.5.1`.
 
-typedef CreateHTMLCallback = JSFunction;
-typedef CreateScriptCallback = JSFunction;
-typedef CreateScriptURLCallback = JSFunction;
-extension type TrustedHTML._(JSObject _) implements JSObject {
-  external static TrustedHTML fromLiteral(JSObject templateStringsArray);
-  external String toJSON();
-}
-extension type TrustedScript._(JSObject _) implements JSObject {
-  external static TrustedScript fromLiteral(JSObject templateStringsArray);
-  external String toJSON();
-}
-extension type TrustedScriptURL._(JSObject _) implements JSObject {
-  external static TrustedScriptURL fromLiteral(JSObject templateStringsArray);
-  external String toJSON();
-}
+/// Bindings to a JS TrustedScriptURL.
+///
+/// See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedScriptURL
+extension type TrustedScriptURL._(JSObject _) implements JSObject {}
+
+/// Bindings to a JS TrustedTypePolicyFactory.
+///
+/// See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicyFactory
 extension type TrustedTypePolicyFactory._(JSObject _) implements JSObject {
+  ///
   external TrustedTypePolicy createPolicy(
     String policyName, [
     TrustedTypePolicyOptions policyOptions,
   ]);
-  external bool isHTML(JSAny? value);
-  external bool isScript(JSAny? value);
-  external bool isScriptURL(JSAny? value);
-  external String? getAttributeType(
-    String tagName,
-    String attribute, [
-    String elementNs,
-    String attrNs,
-  ]);
-  external String? getPropertyType(
-    String tagName,
-    String property, [
-    String elementNs,
-  ]);
-  external TrustedHTML get emptyHTML;
-  external TrustedScript get emptyScript;
-  external TrustedTypePolicy? get defaultPolicy;
 }
+
+/// Bindings to a JS TrustedTypePolicy.
+///
+/// See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicy
 extension type TrustedTypePolicy._(JSObject _) implements JSObject {
-  external TrustedHTML createHTML(
-    String input,
-    JSAny? arguments,
-  );
-  external TrustedScript createScript(
-    String input,
-    JSAny? arguments,
-  );
-  external TrustedScriptURL createScriptURL(
-    String input,
-    JSAny? arguments,
-  );
+  ///
   @JS('createScriptURL')
   external TrustedScriptURL createScriptURLNoArgs(
     String input,
   );
-  external String get name;
 }
-extension type TrustedTypePolicyOptions._(JSObject _) implements JSObject {
-  external factory TrustedTypePolicyOptions({
-    CreateHTMLCallback createHTML,
-    CreateScriptCallback createScript,
-    CreateScriptURLCallback createScriptURL,
-  });
 
-  external set createHTML(CreateHTMLCallback value);
-  external CreateHTMLCallback get createHTML;
-  external set createScript(CreateScriptCallback value);
-  external CreateScriptCallback get createScript;
-  external set createScriptURL(CreateScriptURLCallback value);
-  external CreateScriptURLCallback get createScriptURL;
+/// Bindings to a JS TrustedTypePolicyOptions (anonymous).
+///
+/// See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#policyoptions
+extension type TrustedTypePolicyOptions._(JSObject _) implements JSObject {
+  ///
+  external factory TrustedTypePolicyOptions({
+    JSFunction createScriptURL,
+  });
 }

--- a/packages/google_identity_services_web/lib/src/js_loader.dart
+++ b/packages/google_identity_services_web/lib/src/js_loader.dart
@@ -26,7 +26,7 @@ Future<void> loadWebSdk({
 
   // If TrustedTypes are available, prepare a trusted URL.
   TrustedScriptURL? trustedUrl;
-  if (web.window.trustedTypes != null) {
+  if (web.window.nullableTrustedTypes != null) {
     web.console.debug(
       'TrustedTypes available. Creating policy: $trustedTypePolicyName'.toJS,
     );

--- a/packages/google_identity_services_web/lib/src/js_loader.dart
+++ b/packages/google_identity_services_web/lib/src/js_loader.dart
@@ -26,7 +26,7 @@ Future<void> loadWebSdk({
 
   // If TrustedTypes are available, prepare a trusted URL.
   TrustedScriptURL? trustedUrl;
-  if (web.window.nullableTrustedTypes != null) {
+  if (web.window.trustedTypes != null) {
     web.console.debug(
       'TrustedTypes available. Creating policy: $trustedTypePolicyName'.toJS,
     );
@@ -47,7 +47,7 @@ Future<void> loadWebSdk({
         ..async = true
         ..defer = true;
   if (trustedUrl != null) {
-    script.srcTT = trustedUrl;
+    script.trustedSrc = trustedUrl;
   } else {
     script.src = _url;
   }

--- a/packages/google_identity_services_web/lib/src/js_loader.dart
+++ b/packages/google_identity_services_web/lib/src/js_loader.dart
@@ -25,15 +25,15 @@ Future<void> loadWebSdk({
   onGoogleLibraryLoad = () => completer.complete();
 
   // If TrustedTypes are available, prepare a trusted URL.
-  web.TrustedScriptURL? trustedUrl;
+  TrustedScriptURL? trustedUrl;
   if (web.window.nullableTrustedTypes != null) {
     web.console.debug(
       'TrustedTypes available. Creating policy: $trustedTypePolicyName'.toJS,
     );
     try {
-      final web.TrustedTypePolicy policy = web.window.trustedTypes.createPolicy(
+      final TrustedTypePolicy policy = web.window.trustedTypes.createPolicy(
           trustedTypePolicyName,
-          web.TrustedTypePolicyOptions(
+          TrustedTypePolicyOptions(
             createScriptURL: ((JSString url) => _url).toJS,
           ));
       trustedUrl = policy.createScriptURLNoArgs(_url);

--- a/packages/google_identity_services_web/pubspec.yaml
+++ b/packages/google_identity_services_web/pubspec.yaml
@@ -5,11 +5,11 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.3.0+2
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
+  sdk: ^3.3.0
 
 dependencies:
   meta: ^1.3.0
-  web: ">=0.3.0 <0.6.0"
+  web: ^0.5.0
 
 dev_dependencies:
   path: ^1.8.1

--- a/packages/google_identity_services_web/pubspec.yaml
+++ b/packages/google_identity_services_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_identity_services_web
 description: A Dart JS-interop layer for Google Identity Services. Google's new sign-in SDK for Web that supports multiple types of credentials.
 repository: https://github.com/flutter/packages/tree/main/packages/google_identity_services_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_identiy_services_web%22
-version: 0.3.0+2
+version: 0.3.1
 
 environment:
   sdk: ^3.3.0

--- a/packages/google_identity_services_web/pubspec.yaml
+++ b/packages/google_identity_services_web/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   meta: ^1.3.0
-  web: ">=0.3.0 <0.5.0"
+  web: ">=0.3.0 <0.6.0"
 
 dev_dependencies:
   path: ^1.8.1

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.12.4
+## 0.12.3+3
 
-* Gets ready to update to web code to package `web: ^0.5.0`.
 * Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
+* Prepares update to package `web: ^0.5.0`.
 
 ## 0.12.3+2
 

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.4
+
+* Gets ready to update to web code to package `web: ^0.5.0`.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
+
 ## 0.12.3+2
 
 * Fixes new lint warnings.

--- a/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   mockito: 5.4.4
-  web: ">=0.3.0 <0.5.0"
+  web: ">=0.3.0 <0.6.0"
 
 flutter:
   uses-material-design: true

--- a/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: google_sign_in_web_integration_tests
 publish_to: none
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.12.4
+version: 0.12.3+3
 
 environment:
   sdk: ^3.3.0

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_identity_services_web: ^0.3.0
   google_sign_in_platform_interface: ^2.4.0
   http: ">=0.13.0 <2.0.0"
-  web: ">=0.3.0 <0.5.0"
+  web: ">=0.3.0 <0.6.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,11 +3,11 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.12.3+2
+version: 0.12.4
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 flutter:
   plugin:
@@ -25,7 +25,7 @@ dependencies:
   google_identity_services_web: ^0.3.0
   google_sign_in_platform_interface: ^2.4.0
   http: ">=0.13.0 <2.0.0"
-  web: ">=0.3.0 <0.6.0"
+  web: ">=0.3.0 <0.6.0" # because google_identity_services
 
 dev_dependencies:
   flutter_test:

--- a/packages/image_picker/image_picker_for_web/example/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/example/pubspec.yaml
@@ -17,4 +17,3 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  js: ^0.6.3

--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.13
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
-* Updates to the latest version of `package:googleapis`.
+* Updates dependency on `package:googleapis` to `^12.0.0`.
 
 ## 1.0.12
 

--- a/packages/metrics_center/CHANGELOG.md
+++ b/packages/metrics_center/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.0.13
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates to the latest version of `package:googleapis`.
 
 ## 1.0.12
 

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -1,5 +1,5 @@
 name: metrics_center
-version: 1.0.12
+version: 1.0.13
 description:
   Support multiple performance metrics sources/formats and destinations.
 repository: https://github.com/flutter/packages/tree/main/packages/metrics_center
@@ -12,7 +12,7 @@ dependencies:
   _discoveryapis_commons: ^1.0.0
   crypto: ^3.0.1
   gcloud: ^0.8.2
-  googleapis: ^3.0.0
+  googleapis: '>=3.0.0 <13.0.0'
   googleapis_auth: ^1.1.0
   http: ">=0.13.0 <2.0.0"
 

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   _discoveryapis_commons: ^1.0.0
   crypto: ^3.0.1
   gcloud: ^0.8.2
-  googleapis: '>=3.0.0 <13.0.0'
+  googleapis: ^12.0.0
   googleapis_auth: ^1.1.0
   http: ">=0.13.0 <2.0.0"
 

--- a/packages/metrics_center/test/gcs_lock_test.mocks.dart
+++ b/packages/metrics_center/test/gcs_lock_test.mocks.dart
@@ -60,9 +60,20 @@ class _FakeStreamedResponse_2 extends _i1.SmartFake
         );
 }
 
-class _FakeBucketAccessControlsResource_3 extends _i1.SmartFake
+class _FakeAnywhereCacheResource_3 extends _i1.SmartFake
+    implements _i4.AnywhereCacheResource {
+  _FakeAnywhereCacheResource_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeBucketAccessControlsResource_4 extends _i1.SmartFake
     implements _i4.BucketAccessControlsResource {
-  _FakeBucketAccessControlsResource_3(
+  _FakeBucketAccessControlsResource_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -71,9 +82,9 @@ class _FakeBucketAccessControlsResource_3 extends _i1.SmartFake
         );
 }
 
-class _FakeBucketsResource_4 extends _i1.SmartFake
+class _FakeBucketsResource_5 extends _i1.SmartFake
     implements _i4.BucketsResource {
-  _FakeBucketsResource_4(
+  _FakeBucketsResource_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -82,9 +93,9 @@ class _FakeBucketsResource_4 extends _i1.SmartFake
         );
 }
 
-class _FakeChannelsResource_5 extends _i1.SmartFake
+class _FakeChannelsResource_6 extends _i1.SmartFake
     implements _i4.ChannelsResource {
-  _FakeChannelsResource_5(
+  _FakeChannelsResource_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -93,9 +104,9 @@ class _FakeChannelsResource_5 extends _i1.SmartFake
         );
 }
 
-class _FakeDefaultObjectAccessControlsResource_6 extends _i1.SmartFake
+class _FakeDefaultObjectAccessControlsResource_7 extends _i1.SmartFake
     implements _i4.DefaultObjectAccessControlsResource {
-  _FakeDefaultObjectAccessControlsResource_6(
+  _FakeDefaultObjectAccessControlsResource_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -104,9 +115,20 @@ class _FakeDefaultObjectAccessControlsResource_6 extends _i1.SmartFake
         );
 }
 
-class _FakeNotificationsResource_7 extends _i1.SmartFake
+class _FakeManagedFoldersResource_8 extends _i1.SmartFake
+    implements _i4.ManagedFoldersResource {
+  _FakeManagedFoldersResource_8(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNotificationsResource_9 extends _i1.SmartFake
     implements _i4.NotificationsResource {
-  _FakeNotificationsResource_7(
+  _FakeNotificationsResource_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -115,9 +137,9 @@ class _FakeNotificationsResource_7 extends _i1.SmartFake
         );
 }
 
-class _FakeObjectAccessControlsResource_8 extends _i1.SmartFake
+class _FakeObjectAccessControlsResource_10 extends _i1.SmartFake
     implements _i4.ObjectAccessControlsResource {
-  _FakeObjectAccessControlsResource_8(
+  _FakeObjectAccessControlsResource_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -126,9 +148,9 @@ class _FakeObjectAccessControlsResource_8 extends _i1.SmartFake
         );
 }
 
-class _FakeObjectsResource_9 extends _i1.SmartFake
+class _FakeObjectsResource_11 extends _i1.SmartFake
     implements _i4.ObjectsResource {
-  _FakeObjectsResource_9(
+  _FakeObjectsResource_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -137,9 +159,20 @@ class _FakeObjectsResource_9 extends _i1.SmartFake
         );
 }
 
-class _FakeProjectsResource_10 extends _i1.SmartFake
+class _FakeOperationsResource_12 extends _i1.SmartFake
+    implements _i4.OperationsResource {
+  _FakeOperationsResource_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeProjectsResource_13 extends _i1.SmartFake
     implements _i4.ProjectsResource {
-  _FakeProjectsResource_10(
+  _FakeProjectsResource_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -148,8 +181,9 @@ class _FakeProjectsResource_10 extends _i1.SmartFake
         );
 }
 
-class _FakeObject_11 extends _i1.SmartFake implements _i4.Object {
-  _FakeObject_11(
+class _FakeGoogleLongrunningOperation_14 extends _i1.SmartFake
+    implements _i4.GoogleLongrunningOperation {
+  _FakeGoogleLongrunningOperation_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -158,8 +192,8 @@ class _FakeObject_11 extends _i1.SmartFake implements _i4.Object {
         );
 }
 
-class _FakeObject_12 extends _i1.SmartFake implements Object {
-  _FakeObject_12(
+class _FakeObject_15 extends _i1.SmartFake implements _i4.Object {
+  _FakeObject_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -168,8 +202,8 @@ class _FakeObject_12 extends _i1.SmartFake implements Object {
         );
 }
 
-class _FakePolicy_13 extends _i1.SmartFake implements _i4.Policy {
-  _FakePolicy_13(
+class _FakeObject_16 extends _i1.SmartFake implements Object {
+  _FakeObject_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -178,8 +212,8 @@ class _FakePolicy_13 extends _i1.SmartFake implements _i4.Policy {
         );
 }
 
-class _FakeObjects_14 extends _i1.SmartFake implements _i4.Objects {
-  _FakeObjects_14(
+class _FakePolicy_17 extends _i1.SmartFake implements _i4.Policy {
+  _FakePolicy_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -188,9 +222,19 @@ class _FakeObjects_14 extends _i1.SmartFake implements _i4.Objects {
         );
 }
 
-class _FakeRewriteResponse_15 extends _i1.SmartFake
+class _FakeObjects_18 extends _i1.SmartFake implements _i4.Objects {
+  _FakeObjects_18(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRewriteResponse_19 extends _i1.SmartFake
     implements _i4.RewriteResponse {
-  _FakeRewriteResponse_15(
+  _FakeRewriteResponse_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -199,9 +243,9 @@ class _FakeRewriteResponse_15 extends _i1.SmartFake
         );
 }
 
-class _FakeTestIamPermissionsResponse_16 extends _i1.SmartFake
+class _FakeTestIamPermissionsResponse_20 extends _i1.SmartFake
     implements _i4.TestIamPermissionsResponse {
-  _FakeTestIamPermissionsResponse_16(
+  _FakeTestIamPermissionsResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,8 +254,8 @@ class _FakeTestIamPermissionsResponse_16 extends _i1.SmartFake
         );
 }
 
-class _FakeChannel_17 extends _i1.SmartFake implements _i4.Channel {
-  _FakeChannel_17(
+class _FakeChannel_21 extends _i1.SmartFake implements _i4.Channel {
+  _FakeChannel_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -474,10 +518,19 @@ class MockStorageApi extends _i1.Mock implements _i4.StorageApi {
   }
 
   @override
+  _i4.AnywhereCacheResource get anywhereCache => (super.noSuchMethod(
+        Invocation.getter(#anywhereCache),
+        returnValue: _FakeAnywhereCacheResource_3(
+          this,
+          Invocation.getter(#anywhereCache),
+        ),
+      ) as _i4.AnywhereCacheResource);
+
+  @override
   _i4.BucketAccessControlsResource get bucketAccessControls =>
       (super.noSuchMethod(
         Invocation.getter(#bucketAccessControls),
-        returnValue: _FakeBucketAccessControlsResource_3(
+        returnValue: _FakeBucketAccessControlsResource_4(
           this,
           Invocation.getter(#bucketAccessControls),
         ),
@@ -486,7 +539,7 @@ class MockStorageApi extends _i1.Mock implements _i4.StorageApi {
   @override
   _i4.BucketsResource get buckets => (super.noSuchMethod(
         Invocation.getter(#buckets),
-        returnValue: _FakeBucketsResource_4(
+        returnValue: _FakeBucketsResource_5(
           this,
           Invocation.getter(#buckets),
         ),
@@ -495,7 +548,7 @@ class MockStorageApi extends _i1.Mock implements _i4.StorageApi {
   @override
   _i4.ChannelsResource get channels => (super.noSuchMethod(
         Invocation.getter(#channels),
-        returnValue: _FakeChannelsResource_5(
+        returnValue: _FakeChannelsResource_6(
           this,
           Invocation.getter(#channels),
         ),
@@ -505,16 +558,25 @@ class MockStorageApi extends _i1.Mock implements _i4.StorageApi {
   _i4.DefaultObjectAccessControlsResource get defaultObjectAccessControls =>
       (super.noSuchMethod(
         Invocation.getter(#defaultObjectAccessControls),
-        returnValue: _FakeDefaultObjectAccessControlsResource_6(
+        returnValue: _FakeDefaultObjectAccessControlsResource_7(
           this,
           Invocation.getter(#defaultObjectAccessControls),
         ),
       ) as _i4.DefaultObjectAccessControlsResource);
 
   @override
+  _i4.ManagedFoldersResource get managedFolders => (super.noSuchMethod(
+        Invocation.getter(#managedFolders),
+        returnValue: _FakeManagedFoldersResource_8(
+          this,
+          Invocation.getter(#managedFolders),
+        ),
+      ) as _i4.ManagedFoldersResource);
+
+  @override
   _i4.NotificationsResource get notifications => (super.noSuchMethod(
         Invocation.getter(#notifications),
-        returnValue: _FakeNotificationsResource_7(
+        returnValue: _FakeNotificationsResource_9(
           this,
           Invocation.getter(#notifications),
         ),
@@ -524,7 +586,7 @@ class MockStorageApi extends _i1.Mock implements _i4.StorageApi {
   _i4.ObjectAccessControlsResource get objectAccessControls =>
       (super.noSuchMethod(
         Invocation.getter(#objectAccessControls),
-        returnValue: _FakeObjectAccessControlsResource_8(
+        returnValue: _FakeObjectAccessControlsResource_10(
           this,
           Invocation.getter(#objectAccessControls),
         ),
@@ -533,16 +595,25 @@ class MockStorageApi extends _i1.Mock implements _i4.StorageApi {
   @override
   _i4.ObjectsResource get objects => (super.noSuchMethod(
         Invocation.getter(#objects),
-        returnValue: _FakeObjectsResource_9(
+        returnValue: _FakeObjectsResource_11(
           this,
           Invocation.getter(#objects),
         ),
       ) as _i4.ObjectsResource);
 
   @override
+  _i4.OperationsResource get operations => (super.noSuchMethod(
+        Invocation.getter(#operations),
+        returnValue: _FakeOperationsResource_12(
+          this,
+          Invocation.getter(#operations),
+        ),
+      ) as _i4.OperationsResource);
+
+  @override
   _i4.ProjectsResource get projects => (super.noSuchMethod(
         Invocation.getter(#projects),
-        returnValue: _FakeProjectsResource_10(
+        returnValue: _FakeProjectsResource_13(
           this,
           Invocation.getter(#projects),
         ),
@@ -554,6 +625,48 @@ class MockStorageApi extends _i1.Mock implements _i4.StorageApi {
 /// See the documentation for Mockito's code generation for more information.
 class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
   @override
+  _i6.Future<_i4.GoogleLongrunningOperation> bulkRestore(
+    _i4.BulkRestoreObjectsRequest? request,
+    String? bucket, {
+    String? $fields,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #bulkRestore,
+          [
+            request,
+            bucket,
+          ],
+          {#$fields: $fields},
+        ),
+        returnValue: _i6.Future<_i4.GoogleLongrunningOperation>.value(
+            _FakeGoogleLongrunningOperation_14(
+          this,
+          Invocation.method(
+            #bulkRestore,
+            [
+              request,
+              bucket,
+            ],
+            {#$fields: $fields},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i6.Future<_i4.GoogleLongrunningOperation>.value(
+                _FakeGoogleLongrunningOperation_14(
+          this,
+          Invocation.method(
+            #bulkRestore,
+            [
+              request,
+              bucket,
+            ],
+            {#$fields: $fields},
+          ),
+        )),
+      ) as _i6.Future<_i4.GoogleLongrunningOperation>);
+
+  @override
   _i6.Future<_i4.Object> compose(
     _i4.ComposeRequest? request,
     String? destinationBucket,
@@ -562,7 +675,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? ifGenerationMatch,
     String? ifMetagenerationMatch,
     String? kmsKeyName,
-    String? provisionalUserProject,
     String? userProject,
     String? $fields,
   }) =>
@@ -579,12 +691,11 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #ifGenerationMatch: ifGenerationMatch,
             #ifMetagenerationMatch: ifMetagenerationMatch,
             #kmsKeyName: kmsKeyName,
-            #provisionalUserProject: provisionalUserProject,
             #userProject: userProject,
             #$fields: $fields,
           },
         ),
-        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #compose,
@@ -598,13 +709,12 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifGenerationMatch: ifGenerationMatch,
               #ifMetagenerationMatch: ifMetagenerationMatch,
               #kmsKeyName: kmsKeyName,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #compose,
@@ -618,7 +728,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifGenerationMatch: ifGenerationMatch,
               #ifMetagenerationMatch: ifMetagenerationMatch,
               #kmsKeyName: kmsKeyName,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
@@ -644,7 +753,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? ifSourceMetagenerationMatch,
     String? ifSourceMetagenerationNotMatch,
     String? projection,
-    String? provisionalUserProject,
     String? sourceGeneration,
     String? userProject,
     String? $fields,
@@ -671,13 +779,12 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #ifSourceMetagenerationMatch: ifSourceMetagenerationMatch,
             #ifSourceMetagenerationNotMatch: ifSourceMetagenerationNotMatch,
             #projection: projection,
-            #provisionalUserProject: provisionalUserProject,
             #sourceGeneration: sourceGeneration,
             #userProject: userProject,
             #$fields: $fields,
           },
         ),
-        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #copy,
@@ -700,14 +807,13 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifSourceMetagenerationMatch: ifSourceMetagenerationMatch,
               #ifSourceMetagenerationNotMatch: ifSourceMetagenerationNotMatch,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #sourceGeneration: sourceGeneration,
               #userProject: userProject,
               #$fields: $fields,
             },
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #copy,
@@ -730,7 +836,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifSourceMetagenerationMatch: ifSourceMetagenerationMatch,
               #ifSourceMetagenerationNotMatch: ifSourceMetagenerationNotMatch,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #sourceGeneration: sourceGeneration,
               #userProject: userProject,
               #$fields: $fields,
@@ -748,7 +853,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? ifGenerationNotMatch,
     String? ifMetagenerationMatch,
     String? ifMetagenerationNotMatch,
-    String? provisionalUserProject,
     String? userProject,
     String? $fields,
   }) =>
@@ -765,7 +869,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #ifGenerationNotMatch: ifGenerationNotMatch,
             #ifMetagenerationMatch: ifMetagenerationMatch,
             #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
-            #provisionalUserProject: provisionalUserProject,
             #userProject: userProject,
             #$fields: $fields,
           },
@@ -784,7 +887,7 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? ifMetagenerationMatch,
     String? ifMetagenerationNotMatch,
     String? projection,
-    String? provisionalUserProject,
+    bool? softDeleted,
     String? userProject,
     String? $fields,
     _i10.DownloadOptions? downloadOptions = _i10.DownloadOptions.metadata,
@@ -803,13 +906,13 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #ifMetagenerationMatch: ifMetagenerationMatch,
             #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
             #projection: projection,
-            #provisionalUserProject: provisionalUserProject,
+            #softDeleted: softDeleted,
             #userProject: userProject,
             #$fields: $fields,
             #downloadOptions: downloadOptions,
           },
         ),
-        returnValue: _i6.Future<Object>.value(_FakeObject_12(
+        returnValue: _i6.Future<Object>.value(_FakeObject_16(
           this,
           Invocation.method(
             #get,
@@ -824,14 +927,14 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifMetagenerationMatch: ifMetagenerationMatch,
               #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
+              #softDeleted: softDeleted,
               #userProject: userProject,
               #$fields: $fields,
               #downloadOptions: downloadOptions,
             },
           ),
         )),
-        returnValueForMissingStub: _i6.Future<Object>.value(_FakeObject_12(
+        returnValueForMissingStub: _i6.Future<Object>.value(_FakeObject_16(
           this,
           Invocation.method(
             #get,
@@ -846,7 +949,7 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifMetagenerationMatch: ifMetagenerationMatch,
               #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
+              #softDeleted: softDeleted,
               #userProject: userProject,
               #$fields: $fields,
               #downloadOptions: downloadOptions,
@@ -860,7 +963,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? bucket,
     String? object, {
     String? generation,
-    String? provisionalUserProject,
     String? userProject,
     String? $fields,
   }) =>
@@ -873,12 +975,11 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
           ],
           {
             #generation: generation,
-            #provisionalUserProject: provisionalUserProject,
             #userProject: userProject,
             #$fields: $fields,
           },
         ),
-        returnValue: _i6.Future<_i4.Policy>.value(_FakePolicy_13(
+        returnValue: _i6.Future<_i4.Policy>.value(_FakePolicy_17(
           this,
           Invocation.method(
             #getIamPolicy,
@@ -888,13 +989,12 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             ],
             {
               #generation: generation,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i4.Policy>.value(_FakePolicy_13(
+        returnValueForMissingStub: _i6.Future<_i4.Policy>.value(_FakePolicy_17(
           this,
           Invocation.method(
             #getIamPolicy,
@@ -904,7 +1004,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             ],
             {
               #generation: generation,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
@@ -925,7 +1024,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? name,
     String? predefinedAcl,
     String? projection,
-    String? provisionalUserProject,
     String? userProject,
     String? $fields,
     _i10.UploadOptions? uploadOptions = _i10.UploadOptions.defaultOptions,
@@ -948,14 +1046,13 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #name: name,
             #predefinedAcl: predefinedAcl,
             #projection: projection,
-            #provisionalUserProject: provisionalUserProject,
             #userProject: userProject,
             #$fields: $fields,
             #uploadOptions: uploadOptions,
             #uploadMedia: uploadMedia,
           },
         ),
-        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #insert,
@@ -973,7 +1070,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #name: name,
               #predefinedAcl: predefinedAcl,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
               #uploadOptions: uploadOptions,
@@ -981,7 +1077,7 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             },
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #insert,
@@ -999,7 +1095,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #name: name,
               #predefinedAcl: predefinedAcl,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
               #uploadOptions: uploadOptions,
@@ -1014,12 +1109,14 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? bucket, {
     String? delimiter,
     String? endOffset,
+    bool? includeFoldersAsPrefixes,
     bool? includeTrailingDelimiter,
+    String? matchGlob,
     int? maxResults,
     String? pageToken,
     String? prefix,
     String? projection,
-    String? provisionalUserProject,
+    bool? softDeleted,
     String? startOffset,
     String? userProject,
     bool? versions,
@@ -1032,19 +1129,21 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
           {
             #delimiter: delimiter,
             #endOffset: endOffset,
+            #includeFoldersAsPrefixes: includeFoldersAsPrefixes,
             #includeTrailingDelimiter: includeTrailingDelimiter,
+            #matchGlob: matchGlob,
             #maxResults: maxResults,
             #pageToken: pageToken,
             #prefix: prefix,
             #projection: projection,
-            #provisionalUserProject: provisionalUserProject,
+            #softDeleted: softDeleted,
             #startOffset: startOffset,
             #userProject: userProject,
             #versions: versions,
             #$fields: $fields,
           },
         ),
-        returnValue: _i6.Future<_i4.Objects>.value(_FakeObjects_14(
+        returnValue: _i6.Future<_i4.Objects>.value(_FakeObjects_18(
           this,
           Invocation.method(
             #list,
@@ -1052,12 +1151,14 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             {
               #delimiter: delimiter,
               #endOffset: endOffset,
+              #includeFoldersAsPrefixes: includeFoldersAsPrefixes,
               #includeTrailingDelimiter: includeTrailingDelimiter,
+              #matchGlob: matchGlob,
               #maxResults: maxResults,
               #pageToken: pageToken,
               #prefix: prefix,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
+              #softDeleted: softDeleted,
               #startOffset: startOffset,
               #userProject: userProject,
               #versions: versions,
@@ -1066,7 +1167,7 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<_i4.Objects>.value(_FakeObjects_14(
+            _i6.Future<_i4.Objects>.value(_FakeObjects_18(
           this,
           Invocation.method(
             #list,
@@ -1074,12 +1175,14 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             {
               #delimiter: delimiter,
               #endOffset: endOffset,
+              #includeFoldersAsPrefixes: includeFoldersAsPrefixes,
               #includeTrailingDelimiter: includeTrailingDelimiter,
+              #matchGlob: matchGlob,
               #maxResults: maxResults,
               #pageToken: pageToken,
               #prefix: prefix,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
+              #softDeleted: softDeleted,
               #startOffset: startOffset,
               #userProject: userProject,
               #versions: versions,
@@ -1099,9 +1202,9 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? ifGenerationNotMatch,
     String? ifMetagenerationMatch,
     String? ifMetagenerationNotMatch,
+    bool? overrideUnlockedRetention,
     String? predefinedAcl,
     String? projection,
-    String? provisionalUserProject,
     String? userProject,
     String? $fields,
   }) =>
@@ -1119,14 +1222,14 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #ifGenerationNotMatch: ifGenerationNotMatch,
             #ifMetagenerationMatch: ifMetagenerationMatch,
             #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+            #overrideUnlockedRetention: overrideUnlockedRetention,
             #predefinedAcl: predefinedAcl,
             #projection: projection,
-            #provisionalUserProject: provisionalUserProject,
             #userProject: userProject,
             #$fields: $fields,
           },
         ),
-        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #patch,
@@ -1141,15 +1244,15 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifGenerationNotMatch: ifGenerationNotMatch,
               #ifMetagenerationMatch: ifMetagenerationMatch,
               #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+              #overrideUnlockedRetention: overrideUnlockedRetention,
               #predefinedAcl: predefinedAcl,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #patch,
@@ -1164,9 +1267,90 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifGenerationNotMatch: ifGenerationNotMatch,
               #ifMetagenerationMatch: ifMetagenerationMatch,
               #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+              #overrideUnlockedRetention: overrideUnlockedRetention,
               #predefinedAcl: predefinedAcl,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
+              #userProject: userProject,
+              #$fields: $fields,
+            },
+          ),
+        )),
+      ) as _i6.Future<_i4.Object>);
+
+  @override
+  _i6.Future<_i4.Object> restore(
+    _i4.Object? request,
+    String? bucket,
+    String? object,
+    String? generation, {
+    bool? copySourceAcl,
+    String? ifGenerationMatch,
+    String? ifGenerationNotMatch,
+    String? ifMetagenerationMatch,
+    String? ifMetagenerationNotMatch,
+    String? projection,
+    String? userProject,
+    String? $fields,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #restore,
+          [
+            request,
+            bucket,
+            object,
+            generation,
+          ],
+          {
+            #copySourceAcl: copySourceAcl,
+            #ifGenerationMatch: ifGenerationMatch,
+            #ifGenerationNotMatch: ifGenerationNotMatch,
+            #ifMetagenerationMatch: ifMetagenerationMatch,
+            #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+            #projection: projection,
+            #userProject: userProject,
+            #$fields: $fields,
+          },
+        ),
+        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_15(
+          this,
+          Invocation.method(
+            #restore,
+            [
+              request,
+              bucket,
+              object,
+              generation,
+            ],
+            {
+              #copySourceAcl: copySourceAcl,
+              #ifGenerationMatch: ifGenerationMatch,
+              #ifGenerationNotMatch: ifGenerationNotMatch,
+              #ifMetagenerationMatch: ifMetagenerationMatch,
+              #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+              #projection: projection,
+              #userProject: userProject,
+              #$fields: $fields,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_15(
+          this,
+          Invocation.method(
+            #restore,
+            [
+              request,
+              bucket,
+              object,
+              generation,
+            ],
+            {
+              #copySourceAcl: copySourceAcl,
+              #ifGenerationMatch: ifGenerationMatch,
+              #ifGenerationNotMatch: ifGenerationNotMatch,
+              #ifMetagenerationMatch: ifMetagenerationMatch,
+              #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+              #projection: projection,
               #userProject: userProject,
               #$fields: $fields,
             },
@@ -1193,7 +1377,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? ifSourceMetagenerationNotMatch,
     String? maxBytesRewrittenPerCall,
     String? projection,
-    String? provisionalUserProject,
     String? rewriteToken,
     String? sourceGeneration,
     String? userProject,
@@ -1222,7 +1405,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #ifSourceMetagenerationNotMatch: ifSourceMetagenerationNotMatch,
             #maxBytesRewrittenPerCall: maxBytesRewrittenPerCall,
             #projection: projection,
-            #provisionalUserProject: provisionalUserProject,
             #rewriteToken: rewriteToken,
             #sourceGeneration: sourceGeneration,
             #userProject: userProject,
@@ -1230,7 +1412,7 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
           },
         ),
         returnValue:
-            _i6.Future<_i4.RewriteResponse>.value(_FakeRewriteResponse_15(
+            _i6.Future<_i4.RewriteResponse>.value(_FakeRewriteResponse_19(
           this,
           Invocation.method(
             #rewrite,
@@ -1254,7 +1436,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifSourceMetagenerationNotMatch: ifSourceMetagenerationNotMatch,
               #maxBytesRewrittenPerCall: maxBytesRewrittenPerCall,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #rewriteToken: rewriteToken,
               #sourceGeneration: sourceGeneration,
               #userProject: userProject,
@@ -1263,7 +1444,7 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<_i4.RewriteResponse>.value(_FakeRewriteResponse_15(
+            _i6.Future<_i4.RewriteResponse>.value(_FakeRewriteResponse_19(
           this,
           Invocation.method(
             #rewrite,
@@ -1287,7 +1468,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifSourceMetagenerationNotMatch: ifSourceMetagenerationNotMatch,
               #maxBytesRewrittenPerCall: maxBytesRewrittenPerCall,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #rewriteToken: rewriteToken,
               #sourceGeneration: sourceGeneration,
               #userProject: userProject,
@@ -1303,7 +1483,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? bucket,
     String? object, {
     String? generation,
-    String? provisionalUserProject,
     String? userProject,
     String? $fields,
   }) =>
@@ -1317,12 +1496,11 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
           ],
           {
             #generation: generation,
-            #provisionalUserProject: provisionalUserProject,
             #userProject: userProject,
             #$fields: $fields,
           },
         ),
-        returnValue: _i6.Future<_i4.Policy>.value(_FakePolicy_13(
+        returnValue: _i6.Future<_i4.Policy>.value(_FakePolicy_17(
           this,
           Invocation.method(
             #setIamPolicy,
@@ -1333,13 +1511,12 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             ],
             {
               #generation: generation,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i4.Policy>.value(_FakePolicy_13(
+        returnValueForMissingStub: _i6.Future<_i4.Policy>.value(_FakePolicy_17(
           this,
           Invocation.method(
             #setIamPolicy,
@@ -1350,7 +1527,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             ],
             {
               #generation: generation,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
@@ -1364,7 +1540,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? object,
     List<String>? permissions, {
     String? generation,
-    String? provisionalUserProject,
     String? userProject,
     String? $fields,
   }) =>
@@ -1378,13 +1553,12 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
           ],
           {
             #generation: generation,
-            #provisionalUserProject: provisionalUserProject,
             #userProject: userProject,
             #$fields: $fields,
           },
         ),
         returnValue: _i6.Future<_i4.TestIamPermissionsResponse>.value(
-            _FakeTestIamPermissionsResponse_16(
+            _FakeTestIamPermissionsResponse_20(
           this,
           Invocation.method(
             #testIamPermissions,
@@ -1395,7 +1569,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             ],
             {
               #generation: generation,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
@@ -1403,7 +1576,7 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
         )),
         returnValueForMissingStub:
             _i6.Future<_i4.TestIamPermissionsResponse>.value(
-                _FakeTestIamPermissionsResponse_16(
+                _FakeTestIamPermissionsResponse_20(
           this,
           Invocation.method(
             #testIamPermissions,
@@ -1414,7 +1587,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             ],
             {
               #generation: generation,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
@@ -1432,9 +1604,9 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? ifGenerationNotMatch,
     String? ifMetagenerationMatch,
     String? ifMetagenerationNotMatch,
+    bool? overrideUnlockedRetention,
     String? predefinedAcl,
     String? projection,
-    String? provisionalUserProject,
     String? userProject,
     String? $fields,
   }) =>
@@ -1452,14 +1624,14 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #ifGenerationNotMatch: ifGenerationNotMatch,
             #ifMetagenerationMatch: ifMetagenerationMatch,
             #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+            #overrideUnlockedRetention: overrideUnlockedRetention,
             #predefinedAcl: predefinedAcl,
             #projection: projection,
-            #provisionalUserProject: provisionalUserProject,
             #userProject: userProject,
             #$fields: $fields,
           },
         ),
-        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValue: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #update,
@@ -1474,15 +1646,15 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifGenerationNotMatch: ifGenerationNotMatch,
               #ifMetagenerationMatch: ifMetagenerationMatch,
               #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+              #overrideUnlockedRetention: overrideUnlockedRetention,
               #predefinedAcl: predefinedAcl,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_11(
+        returnValueForMissingStub: _i6.Future<_i4.Object>.value(_FakeObject_15(
           this,
           Invocation.method(
             #update,
@@ -1497,9 +1669,9 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #ifGenerationNotMatch: ifGenerationNotMatch,
               #ifMetagenerationMatch: ifMetagenerationMatch,
               #ifMetagenerationNotMatch: ifMetagenerationNotMatch,
+              #overrideUnlockedRetention: overrideUnlockedRetention,
               #predefinedAcl: predefinedAcl,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #userProject: userProject,
               #$fields: $fields,
             },
@@ -1518,7 +1690,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
     String? pageToken,
     String? prefix,
     String? projection,
-    String? provisionalUserProject,
     String? startOffset,
     String? userProject,
     bool? versions,
@@ -1539,14 +1710,13 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
             #pageToken: pageToken,
             #prefix: prefix,
             #projection: projection,
-            #provisionalUserProject: provisionalUserProject,
             #startOffset: startOffset,
             #userProject: userProject,
             #versions: versions,
             #$fields: $fields,
           },
         ),
-        returnValue: _i6.Future<_i4.Channel>.value(_FakeChannel_17(
+        returnValue: _i6.Future<_i4.Channel>.value(_FakeChannel_21(
           this,
           Invocation.method(
             #watchAll,
@@ -1562,7 +1732,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #pageToken: pageToken,
               #prefix: prefix,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #startOffset: startOffset,
               #userProject: userProject,
               #versions: versions,
@@ -1571,7 +1740,7 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<_i4.Channel>.value(_FakeChannel_17(
+            _i6.Future<_i4.Channel>.value(_FakeChannel_21(
           this,
           Invocation.method(
             #watchAll,
@@ -1587,7 +1756,6 @@ class MockObjectsResource extends _i1.Mock implements _i4.ObjectsResource {
               #pageToken: pageToken,
               #prefix: prefix,
               #projection: projection,
-              #provisionalUserProject: provisionalUserProject,
               #startOffset: startOffset,
               #userProject: userProject,
               #versions: versions,

--- a/packages/pointer_interceptor/pointer_interceptor_web/CHANGELOG.md
+++ b/packages/pointer_interceptor/pointer_interceptor_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.10.2
 
-* Updates to web code to package `web: ^0.5.0`.
+* Updates web code to package `web: ^0.5.0`.
 * Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 0.10.1+2

--- a/packages/pointer_interceptor/pointer_interceptor_web/CHANGELOG.md
+++ b/packages/pointer_interceptor/pointer_interceptor_web/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.10.2-wip
+## 0.10.2
 
-* allow latest pkg web
+* Updates to web code to package `web: ^0.5.0`.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 0.10.1+2
 

--- a/packages/pointer_interceptor/pointer_interceptor_web/CHANGELOG.md
+++ b/packages/pointer_interceptor/pointer_interceptor_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2-wip
+
+* allow latest pkg web
+
 ## 0.10.1+2
 
 * Fixes "width and height missing" warning on web.

--- a/packages/pointer_interceptor/pointer_interceptor_web/example/pubspec.yaml
+++ b/packages/pointer_interceptor/pointer_interceptor_web/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: "Demonstrates how to use the pointer_interceptor_web plugin."
 publish_to: 'none'
 
 environment:
-  sdk: ^3.2.0
-  flutter: '>=3.16.0'
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   cupertino_icons: ^1.0.2
@@ -13,7 +13,7 @@ dependencies:
   pointer_interceptor_platform_interface: ^0.10.0
   pointer_interceptor_web:
     path: ../../pointer_interceptor_web
-  web: '>=0.3.0 <0.6.0'
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/pointer_interceptor/pointer_interceptor_web/example/pubspec.yaml
+++ b/packages/pointer_interceptor/pointer_interceptor_web/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   pointer_interceptor_platform_interface: ^0.10.0
   pointer_interceptor_web:
     path: ../../pointer_interceptor_web
-  web: '>=0.3.0 <0.5.0'
+  web: '>=0.3.0 <0.6.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/pointer_interceptor/pointer_interceptor_web/pubspec.yaml
+++ b/packages/pointer_interceptor/pointer_interceptor_web/pubspec.yaml
@@ -2,11 +2,11 @@ name: pointer_interceptor_web
 description: Web implementation of the pointer_interceptor plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/pointer_interceptor/pointer_interceptor_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apointer_interceptor
-version: 0.10.2-wip
+version: 0.10.2
 
 environment:
-  sdk: ^3.2.0
-  flutter: '>=3.16.0'
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 flutter:
   plugin:
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.7
   pointer_interceptor_platform_interface: ^0.10.0
-  web: '>=0.3.0 <0.6.0'
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/pointer_interceptor/pointer_interceptor_web/pubspec.yaml
+++ b/packages/pointer_interceptor/pointer_interceptor_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: pointer_interceptor_web
 description: Web implementation of the pointer_interceptor plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/pointer_interceptor/pointer_interceptor_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apointer_interceptor
-version: 0.10.1+2
+version: 0.10.2-wip
 
 environment:
   sdk: ^3.2.0
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.7
   pointer_interceptor_platform_interface: ^0.10.0
-  web: '>=0.3.0 <0.5.0'
+  web: '>=0.3.0 <0.6.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.0
 
-* Updates minimum supported SDK version to Dart 3.3.
+* Updates to web code to package `web: ^0.5.0`.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 2.2.2
 

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.2.3-wip
+## 2.3.0
 
-* Things...latest pkg:web, bump sdk
+* Updates minimum supported SDK version to Dart 3.3.
 
 ## 2.2.2
 

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3-wip
+
+* Things...latest pkg:web, bump sdk
+
 ## 2.2.2
 
 * Updates minimum supported SDK version to Dart 3.2.

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.0
 
-* Updates to web code to package `web: ^0.5.0`.
+* Updates web code to package `web: ^0.5.0`.
 * Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 2.2.2

--- a/packages/shared_preferences/shared_preferences_web/example/integration_test/shared_preferences_web_test.dart
+++ b/packages/shared_preferences/shared_preferences_web/example/integration_test/shared_preferences_web_test.dart
@@ -9,8 +9,7 @@ import 'package:shared_preferences_platform_interface/shared_preferences_platfor
 import 'package:shared_preferences_platform_interface/types.dart';
 import 'package:shared_preferences_web/shared_preferences_web.dart';
 import 'package:shared_preferences_web/src/keys_extension.dart';
-
-import 'package:web/helpers.dart' as html;
+import 'package:web/web.dart' as html;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/shared_preferences/shared_preferences_web/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   shared_preferences_platform_interface: ^2.3.0
   shared_preferences_web:
     path: ../
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/shared_preferences/shared_preferences_web/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/example/pubspec.yaml
@@ -18,4 +18,3 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  js: ^0.6.3

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -2,11 +2,11 @@ name: shared_preferences_web
 description: Web platform implementation of shared_preferences
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.2.2
+version: 2.3.0
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   shared_preferences_platform_interface: ^2.3.0
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.4
+
+* Updates minimum supported SDK version to Flutter 3.19.0/Dart 3.3.0.
+* Require `package:web` `^0.5.0`.
+* Remove use of Wasm-incompatible `dart:js_util`.
+
 ## 2.2.3
 
 * Fixes new lint warnings.

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,8 +1,7 @@
-## 2.2.4
+## 2.3.0
 
-* Updates minimum supported SDK version to Flutter 3.19.0/Dart 3.3.0.
-* Require `package:web` `^0.5.0`.
-* Remove use of Wasm-incompatible `dart:js_util`.
+* Updates to web code to package `web: ^0.5.0`.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 2.2.3
 

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.0
 
-* Updates to web code to package `web: ^0.5.0`.
+* Updates web code to package `web: ^0.5.0`.
 * Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 2.2.3

--- a/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_util';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:ui_web' as ui_web;
 
 import 'package:flutter/widgets.dart';
@@ -10,7 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_web/src/link.dart';
-import 'package:web/helpers.dart' as html;
+import 'package:web/web.dart' as html;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -177,7 +178,7 @@ html.Element _findSingleAnchor() {
   html.NodeList anchors = html.document.querySelectorAll('a');
   for (int i = 0; i < anchors.length; i++) {
     final html.Element anchor = anchors.item(i)! as html.Element;
-    if (hasProperty(anchor, linkViewIdProperty)) {
+    if (anchor.hasProperty(linkViewIdProperty.toJS).toDart) {
       foundAnchors.add(anchor);
     }
   }
@@ -189,7 +190,7 @@ html.Element _findSingleAnchor() {
     anchors = shadowRoot.querySelectorAll('a');
     for (int i = 0; i < anchors.length; i++) {
       final html.Element anchor = anchors.item(i)! as html.Element;
-      if (hasProperty(anchor, linkViewIdProperty)) {
+      if (anchor.hasProperty(linkViewIdProperty.toJS).toDart) {
         foundAnchors.add(anchor);
       }
     }

--- a/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
@@ -3,14 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:js_interop';
-import 'dart:js_util';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mockito/mockito.dart' show Mock, any, verify, when;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 import 'package:url_launcher_web/url_launcher_web.dart';
-import 'package:web/helpers.dart' as html;
+import 'package:web/web.dart' as html;
 
 abstract class MyWindow {
   html.Window? open(Object? a, Object? b, Object? c);
@@ -33,6 +32,7 @@ void main() {
   group('UrlLauncherPlugin', () {
     late MockWindow mockWindow;
     late MockNavigator mockNavigator;
+    late html.Window jsMockWindow;
 
     late UrlLauncherPlugin plugin;
 
@@ -40,10 +40,9 @@ void main() {
       mockWindow = MockWindow();
       mockNavigator = MockNavigator();
 
-      final html.Window jsMockWindow =
-          createDartExport(mockWindow) as html.Window;
+      jsMockWindow = createJSInteropWrapper(mockWindow) as html.Window;
       final html.Navigator jsMockNavigator =
-          createDartExport(mockNavigator) as html.Navigator;
+          createJSInteropWrapper(mockNavigator) as html.Navigator;
 
       when(mockWindow.navigator).thenReturn(jsMockNavigator);
 
@@ -53,7 +52,7 @@ void main() {
       when(mockNavigator.userAgent).thenReturn(
           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36');
 
-      plugin = UrlLauncherPlugin(debugWindow: mockWindow as html.Window);
+      plugin = UrlLauncherPlugin(debugWindow: jsMockWindow);
     });
 
     group('canLaunch', () {
@@ -185,7 +184,7 @@ void main() {
           when(mockNavigator.userAgent).thenReturn(
               'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5.1 Safari/605.1.15');
           // Recreate the plugin, so it grabs the overrides from this group
-          plugin = UrlLauncherPlugin(debugWindow: mockWindow as html.Window);
+          plugin = UrlLauncherPlugin(debugWindow: jsMockWindow);
         });
 
         testWidgets('http urls should be launched in a new window',

--- a/packages/url_launcher/url_launcher_web/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: regular_integration_tests
 publish_to: none
 
 environment:
-  sdk: ^3.2.0
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_web/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/example/pubspec.yaml
@@ -18,4 +18,4 @@ dev_dependencies:
   url_launcher_platform_interface: ^2.2.0
   url_launcher_web:
     path: ../
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.5.0

--- a/packages/url_launcher/url_launcher_web/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/link.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:js_util';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:ui_web' as ui_web;
 
 import 'package:flutter/foundation.dart';
@@ -12,7 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher_platform_interface/link.dart';
-import 'package:web/helpers.dart' as html;
+import 'package:web/web.dart' as html;
 
 /// The unique identifier for the view type to be used for link platform views.
 const String linkViewType = '__url_launcher::link';
@@ -172,7 +173,7 @@ class LinkViewController extends PlatformViewController {
 
   Future<void> _initialize() async {
     _element = html.document.createElement('a') as html.HTMLElement;
-    setProperty(_element, linkViewIdProperty, viewId);
+    _element[linkViewIdProperty] = viewId.toJS;
     _element.style
       ..opacity = '0'
       ..display = 'block'
@@ -283,11 +284,7 @@ class LinkViewController extends PlatformViewController {
 int? getViewIdFromTarget(html.Event event) {
   final html.Element? linkElement = getLinkElementFromTarget(event);
   if (linkElement != null) {
-    // TODO(stuartmorgan): Remove this ignore (and change to getProperty<int>)
-    // once the templated version is available on stable. On master (2.8) this
-    // is already not necessary.
-    // ignore: return_of_invalid_type
-    return getProperty(linkElement, linkViewIdProperty);
+    return linkElement.getProperty<JSNumber>(linkViewIdProperty.toJS).toDartInt;
   }
   return null;
 }
@@ -316,5 +313,5 @@ html.Element? getLinkElementFromTarget(html.Event event) {
 bool isLinkElement(html.Element? element) {
   return element != null &&
       element.tagName == 'A' &&
-      hasProperty(element, linkViewIdProperty);
+      element.hasProperty(linkViewIdProperty.toJS).toDart;
 }

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,11 +2,11 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.2.3
+version: 2.2.4
 
 environment:
-  sdk: ^3.2.0
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0-0
+  flutter: ">=3.19.0-0"
 
 flutter:
   plugin:
@@ -22,7 +22,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   url_launcher_platform_interface: ^2.2.0
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.2.4
+version: 2.3.0
 
 environment:
   sdk: ^3.3.0

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.2.4
 
 environment:
-  sdk: ^3.3.0-0
-  flutter: ">=3.19.0-0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.1.4
+## 2.2.0
 
-* Updates minimum supported SDK version to Flutter 3.16/Dart 3.3.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 2.1.3
 

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,6 +1,6 @@
-## NEXT
+## 2.1.4
 
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.3.
 
 ## 2.1.3
 

--- a/packages/video_player/video_player_web/example/integration_test/utils.dart
+++ b/packages/video_player/video_player_web/example/integration_test/utils.dart
@@ -3,11 +3,10 @@
 // found in the LICENSE file.
 
 @JS()
-library integration_test_utils;
+library;
 
 import 'dart:html';
-
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 // Returns the URL to load an asset from this example app as a network source.
 //

--- a/packages/video_player/video_player_web/example/integration_test/utils.dart
+++ b/packages/video_player/video_player_web/example/integration_test/utils.dart
@@ -2,11 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@JS()
-library;
-
-import 'dart:html';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'package:web/web.dart' as web;
 
 // Returns the URL to load an asset from this example app as a network source.
 //
@@ -21,35 +19,40 @@ String getUrlForAssetAsNetworkSource(String assetKey) {
       '?raw=true';
 }
 
-@JS()
-@anonymous
-class _Descriptor {
+extension type Descriptor._(JSObject _) implements JSObject {
   // May also contain "configurable" and "enumerable" bools.
   // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description
-  external factory _Descriptor({
+  external factory Descriptor({
     // bool configurable,
     // bool enumerable,
-    bool writable,
-    Object value,
+    JSBoolean writable,
+    JSAny value,
   });
 }
 
-@JS('Object.defineProperty')
-external void _defineProperty(
+void _defineProperty(
   Object object,
   String property,
-  _Descriptor description,
-);
+  Descriptor description,
+) {
+  (globalContext['Object'] as JSObject?)?.callMethod(
+    'defineProperty'.toJS,
+    object as JSObject,
+    property.toJS,
+    description,
+  );
+}
 
 /// Forces a VideoElement to report "Infinity" duration.
 ///
 /// Uses JS Object.defineProperty to set the value of a readonly property.
-void setInfinityDuration(VideoElement element) {
+void setInfinityDuration(Object videoElement) {
+  assert(videoElement is web.HTMLVideoElement);
   _defineProperty(
-      element,
+      videoElement,
       'duration',
-      _Descriptor(
-        writable: true,
-        value: double.infinity,
+      Descriptor(
+        writable: true.toJS,
+        value: double.infinity.toJS,
       ));
 }

--- a/packages/video_player/video_player_web/example/pubspec.yaml
+++ b/packages/video_player/video_player_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_web/example/pubspec.yaml
+++ b/packages/video_player/video_player_web/example/pubspec.yaml
@@ -2,14 +2,13 @@ name: video_player_for_web_integration_tests
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  sdk: ^3.3.0
+  flutter: ^3.19.0
 
 dependencies:
   flutter:
     sdk: flutter
-  js: ^0.6.0
-  video_player_platform_interface: ">=6.1.0 <7.0.0"
+  video_player_platform_interface: ^6.1.0
   video_player_web:
     path: ../
 

--- a/packages/video_player/video_player_web/example/pubspec.yaml
+++ b/packages/video_player/video_player_web/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   video_player_platform_interface: ^6.1.0
   video_player_web:
     path: ../
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,11 +2,11 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.1.3
+version: 2.2.0
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ^3.3.0
+  flutter: ^3.19.0
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.2.0
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 flutter:
   plugin:

--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.2.0
 
 * Updates to web code to package `web: ^0.5.0`.
-* Updates SDK version to Dart `^3.3.0`. Flutter `^3.16.0`.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.19.0`.
 
 ## 1.1.1
 

--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.2.0
 
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates to web code to package `web: ^0.5.0`.
+* Updates SDK version to Dart `^3.3.0`. Flutter `^3.16.0`.
 
 ## 1.1.1
 

--- a/packages/web_benchmarks/lib/client.dart
+++ b/packages/web_benchmarks/lib/client.dart
@@ -7,7 +7,7 @@ import 'dart:convert' show json;
 import 'dart:js_interop';
 import 'dart:math' as math;
 
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 import 'src/common.dart';
 import 'src/recorder.dart';
@@ -157,9 +157,7 @@ void _printResultsToScreen(Profile profile) {
   profile.scoreData.forEach((String scoreKey, Timeseries timeseries) {
     body.appendHtml('<h2>$scoreKey</h2>');
     body.appendHtml('<pre>${timeseries.computeStats()}</pre>');
-    // TODO(kevmoo): remove `NodeGlue` cast when we no longer need to support
-    // pkg:web 0.3.0
-    NodeGlue(body).append(TimeseriesVisualization(timeseries).render());
+    body.appendChild(TimeseriesVisualization(timeseries).render());
   });
 }
 
@@ -168,7 +166,7 @@ class TimeseriesVisualization {
   /// Creates a visualization for a [Timeseries].
   TimeseriesVisualization(this._timeseries) {
     _stats = _timeseries.computeStats();
-    _canvas = CanvasElement();
+    _canvas = HTMLCanvasElement();
     _screenWidth = window.screen.width;
     _canvas.width = _screenWidth;
     _canvas.height = (_kCanvasHeight * window.devicePixelRatio).round();
@@ -192,7 +190,7 @@ class TimeseriesVisualization {
 
   final Timeseries _timeseries;
   late TimeseriesStats _stats;
-  late CanvasElement _canvas;
+  late HTMLCanvasElement _canvas;
   late CanvasRenderingContext2D _ctx;
   late int _screenWidth;
 
@@ -215,7 +213,7 @@ class TimeseriesVisualization {
   }
 
   /// Renders the timeseries into a `<canvas>` and returns the canvas element.
-  CanvasElement render() {
+  HTMLCanvasElement render() {
     _ctx.translate(0, _kCanvasHeight * window.devicePixelRatio);
     _ctx.scale(1, -window.devicePixelRatio);
 
@@ -320,6 +318,7 @@ class LocalBenchmarkServerClient {
   /// DevTools Protocol.
   Future<void> startPerformanceTracing(String? benchmarkName) async {
     _checkNotManualMode();
+    // ignore: deprecated_member_use
     await HttpRequest.request(
       '/start-performance-tracing?label=$benchmarkName',
       method: 'POST',
@@ -330,6 +329,7 @@ class LocalBenchmarkServerClient {
   /// Stops the performance tracing session started by [startPerformanceTracing].
   Future<void> stopPerformanceTracing() async {
     _checkNotManualMode();
+    // ignore: deprecated_member_use
     await HttpRequest.request(
       '/stop-performance-tracing',
       method: 'POST',
@@ -358,6 +358,7 @@ class LocalBenchmarkServerClient {
   /// The server will halt the devicelab task and log the error.
   Future<void> reportError(dynamic error, StackTrace stackTrace) async {
     _checkNotManualMode();
+    // ignore: deprecated_member_use
     await HttpRequest.request(
       '/on-error',
       method: 'POST',
@@ -372,6 +373,7 @@ class LocalBenchmarkServerClient {
   /// Reports a message about the demo to the benchmark server.
   Future<void> printToConsole(String report) async {
     _checkNotManualMode();
+    // ignore: deprecated_member_use
     await HttpRequest.request(
       '/print-to-console',
       method: 'POST',

--- a/packages/web_benchmarks/lib/client.dart
+++ b/packages/web_benchmarks/lib/client.dart
@@ -318,7 +318,6 @@ class LocalBenchmarkServerClient {
   /// DevTools Protocol.
   Future<void> startPerformanceTracing(String? benchmarkName) async {
     _checkNotManualMode();
-    // ignore: deprecated_member_use
     await HttpRequest.request(
       '/start-performance-tracing?label=$benchmarkName',
       method: 'POST',
@@ -329,7 +328,6 @@ class LocalBenchmarkServerClient {
   /// Stops the performance tracing session started by [startPerformanceTracing].
   Future<void> stopPerformanceTracing() async {
     _checkNotManualMode();
-    // ignore: deprecated_member_use
     await HttpRequest.request(
       '/stop-performance-tracing',
       method: 'POST',
@@ -358,7 +356,6 @@ class LocalBenchmarkServerClient {
   /// The server will halt the devicelab task and log the error.
   Future<void> reportError(dynamic error, StackTrace stackTrace) async {
     _checkNotManualMode();
-    // ignore: deprecated_member_use
     await HttpRequest.request(
       '/on-error',
       method: 'POST',
@@ -373,7 +370,6 @@ class LocalBenchmarkServerClient {
   /// Reports a message about the demo to the benchmark server.
   Future<void> printToConsole(String report) async {
     _checkNotManualMode();
-    // ignore: deprecated_member_use
     await HttpRequest.request(
       '/print-to-console',
       method: 'POST',

--- a/packages/web_benchmarks/lib/src/recorder.dart
+++ b/packages/web_benchmarks/lib/src/recorder.dart
@@ -15,7 +15,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
-import 'package:web/helpers.dart' as html;
+import 'package:web/web.dart' as html;
 
 import 'common.dart';
 

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.2.0
 
 environment:
   sdk: ^3.3.0
-  flutter: ^3.19.0
+  flutter: ">=3.19.0"
 
 dependencies:
   collection: ^1.18.0

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -2,11 +2,11 @@ name: web_benchmarks
 description: A benchmark harness for performance-testing Flutter apps in Chrome.
 repository: https://github.com/flutter/packages/tree/main/packages/web_benchmarks
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+web_benchmarks%22
-version: 1.1.1
+version: 1.2.0
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0
+  flutter: ^3.19.0
 
 dependencies:
   collection: ^1.18.0
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
+  http: ^1.0.0
   logging: ^1.0.2
   meta: ^1.7.0
   path: ^1.8.0
@@ -21,7 +22,7 @@ dependencies:
   shelf: ^1.2.0
   shelf_static: ^1.1.0
   test: ^1.19.5
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.5.0
   webkit_inspection_protocol: ^1.0.0
 
 topics:


### PR DESCRIPTION
This PR updates the packages that are using `package:web` to version `^0.5.0`.

Ancilliary changes:

* Bump `environment` to `flutter: ">=3.19.0"` and `sdk: ^3.3.0`.
* Bump version to next `Y`
* Clean-up code that was kept for compatibility with versions of `web: <0.5.0`.

The main exception to this is `package:google_sign_in_web`, which depends on a version of `google_identity_services_web` that has a dependency on package:web that is `<0.5.0`, so that package needs to have a range until `google_identity_services_web` gets published with the new ^0.5.0 dependency.

Co-Authored-By: David Iglesias<ditman@gmail.com>