### PR TITLE
[ci] Run 'flutter build --config-only for iOS and macOS during fetch deps

### DIFF
--- a/script/tool/lib/src/fetch_deps_command.dart
+++ b/script/tool/lib/src/fetch_deps_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:file/file.dart';
-
 import 'common/core.dart';
 import 'common/gradle.dart';
 import 'common/output_utils.dart';
@@ -216,44 +214,15 @@ class FetchDepsCommand extends PackageLoopingCommand {
     }
 
     for (final RepositoryPackage example in package.getExamples()) {
-      final Directory platformDir =
-          example.platformDirectory(getPlatformByName(platform));
-
-      // Running `pod install` requires `flutter pub get` or `flutter build` to
-      // have been run at some point to create the necessary native build files.
-      // See https://github.com/flutter/flutter/blob/fb7a763c640d247d090cbb373e4b3a0459ac171b/packages/flutter_tools/templates/cocoapods/Podfile-macos#L13-L15
-      // and https://github.com/flutter/flutter/blob/fb7a763c640d247d090cbb373e4b3a0459ac171b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift#L14-L16
-      final File generatedXCConfig = platform == platformMacOS
-          ? platformDir
-              .childDirectory('Flutter')
-              .childDirectory('ephemeral')
-              .childFile('Flutter-Generated.xcconfig')
-          : platformDir
-              .childDirectory('Flutter')
-              .childFile('Generated.xcconfig');
-      if (!generatedXCConfig.existsSync()) {
-        final int exitCode = await processRunner.runAndStream(
-          flutterCommand,
-          <String>['pub', 'get'],
-          workingDir: example.directory,
-        );
-        if (exitCode != 0) {
-          printError('Unable to prepare native project files.');
-          return PackageResult.fail(<String>['Unable to configure project.']);
-        }
-      }
-
+      // Create the necessary native build files, which will run pub get and pod install if needed.
       final int exitCode = await processRunner.runAndStream(
-        'pod',
-        <String>['install'],
-        workingDir: platformDir,
-        environment: <String, String>{
-          'LANG': 'en_US.UTF-8',
-        },
+        flutterCommand,
+        <String>['build', platform, '--config-only'],
+        workingDir: example.directory,
       );
       if (exitCode != 0) {
-        printError('Unable to "pod install"');
-        return PackageResult.fail(<String>['Unable to "pod install"']);
+        printError('Unable to prepare native project files.');
+        return PackageResult.fail(<String>['Unable to configure project.']);
       }
     }
 

--- a/script/tool/test/fetch_deps_command_test.dart
+++ b/script/tool/test/fetch_deps_command_test.dart
@@ -385,65 +385,17 @@ void main() {
     });
 
     group('ios', () {
-      test('runs pub get before pod install', () async {
-        final RepositoryPackage plugin =
-            createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
-          'example/ios/Flutter/Generated.xcconfig',
-        ], platformSupport: <String, PlatformDetails>{
-          platformIOS: const PlatformDetails(PlatformSupport.inline)
-        });
-
-        final Directory iOSDir =
-            plugin.getExamples().first.platformDirectory(FlutterPlatform.ios);
-
-        final List<String> output =
-            await runCapturingPrint(runner, <String>['fetch-deps', '--ios']);
-
-        expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            const ProcessCall(
-              'flutter',
-              <String>['precache', '--ios'],
-              null,
-            ),
-            ProcessCall(
-              'flutter',
-              const <String>['pub', 'get'],
-              plugin.directory.path,
-            ),
-            ProcessCall(
-              'pod',
-              const <String>['install'],
-              iOSDir.path,
-            ),
-          ]),
-        );
-
-        expect(
-            output,
-            containsAllInOrder(<Matcher>[
-              contains('Running for plugin1'),
-              contains('No issues found!'),
-            ]));
-      });
-
       test('runs on all examples', () async {
         final List<String> examples = <String>['example1', 'example2'];
         final RepositoryPackage plugin = createFakePlugin(
             'plugin1', packagesDir,
             examples: examples,
-            extraFiles: <String>[
-              'example/example1/ios/Flutter/Generated.xcconfig',
-              'example/example2/ios/Flutter/Generated.xcconfig',
-            ],
             platformSupport: <String, PlatformDetails>{
               platformIOS: const PlatformDetails(PlatformSupport.inline)
             });
 
-        final Iterable<Directory> exampleIOSDirs = plugin.getExamples().map(
-            (RepositoryPackage example) =>
-                example.platformDirectory(FlutterPlatform.ios));
+        final Iterable<Directory> exampleDirs = plugin.getExamples().map(
+            (RepositoryPackage example) => example.directory);
 
         final List<String> output = await runCapturingPrint(
             runner, <String>['fetch-deps', '--no-dart', '--ios']);
@@ -456,10 +408,10 @@ void main() {
               <String>['precache', '--ios'],
               null,
             ),
-            for (final Directory directory in exampleIOSDirs)
+            for (final Directory directory in exampleDirs)
               ProcessCall(
-                'pod',
-                const <String>['install'],
+                'flutter',
+                const <String>['build', 'ios', '--config-only'],
                 directory.path,
               ),
           ]),
@@ -473,84 +425,17 @@ void main() {
             ]));
       });
 
-      test('runs pub get if example is not configured', () async {
-        final RepositoryPackage plugin = createFakePlugin(
-            'plugin1', packagesDir, platformSupport: <String, PlatformDetails>{
-          platformIOS: const PlatformDetails(PlatformSupport.inline)
-        });
-
-        final RepositoryPackage example = plugin.getExamples().first;
-
-        final List<String> output = await runCapturingPrint(
-            runner, <String>['fetch-deps', '--no-dart', '--ios']);
-
-        expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            const ProcessCall(
-              'flutter',
-              <String>['precache', '--ios'],
-              null,
-            ),
-            ProcessCall(
-              'flutter',
-              const <String>['pub', 'get'],
-              example.directory.path,
-            ),
-            ProcessCall(
-              'pod',
-              const <String>['install'],
-              example.platformDirectory(FlutterPlatform.ios).path,
-            ),
-          ]),
-        );
-
-        expect(
-            output,
-            containsAllInOrder(<Matcher>[
-              contains('Running for plugin1'),
-              contains('No issues found!'),
-            ]));
-      });
-
-      test('fails if pre-pod pub get fails', () async {
+      test('fails if flutter build --config-only fails', () async {
         createFakePlugin('plugin1', packagesDir,
             platformSupport: <String, PlatformDetails>{
               platformIOS: const PlatformDetails(PlatformSupport.inline)
             });
 
         processRunner
-                .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
-            <FakeProcessInfo>[
+            .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
+        <FakeProcessInfo>[
           FakeProcessInfo(MockProcess(), <String>['precache']),
-          FakeProcessInfo(MockProcess(exitCode: 1), <String>['pub', 'get']),
-        ];
-
-        Error? commandError;
-        final List<String> output = await runCapturingPrint(
-            runner, <String>['fetch-deps', '--no-dart', '--ios'],
-            errorHandler: (Error e) {
-          commandError = e;
-        });
-
-        expect(commandError, isA<ToolExit>());
-        expect(
-            output,
-            containsAllInOrder(
-              <Matcher>[
-                contains('Unable to configure project'),
-              ],
-            ));
-      });
-
-      test('fails if pod install fails', () async {
-        createFakePlugin('plugin1', packagesDir,
-            platformSupport: <String, PlatformDetails>{
-              platformIOS: const PlatformDetails(PlatformSupport.inline)
-            });
-
-        processRunner.mockProcessesForExecutable['pod'] = <FakeProcessInfo>[
-          FakeProcessInfo(MockProcess(exitCode: 1)),
+          FakeProcessInfo(MockProcess(exitCode: 1), <String>['build', 'ios', '--config-only']),
         ];
 
         Error? commandError;
@@ -605,65 +490,17 @@ void main() {
     });
 
     group('macos', () {
-      test('runs pub get before pod install', () async {
-        final RepositoryPackage plugin =
-            createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
-          'example/macos/Flutter/ephemeral/Flutter-Generated.xcconfig',
-        ], platformSupport: <String, PlatformDetails>{
-          platformMacOS: const PlatformDetails(PlatformSupport.inline)
-        });
-
-        final Directory macOSDir =
-            plugin.getExamples().first.platformDirectory(FlutterPlatform.macos);
-
-        final List<String> output =
-            await runCapturingPrint(runner, <String>['fetch-deps', '--macos']);
-
-        expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            const ProcessCall(
-              'flutter',
-              <String>['precache', '--macos'],
-              null,
-            ),
-            ProcessCall(
-              'flutter',
-              const <String>['pub', 'get'],
-              plugin.directory.path,
-            ),
-            ProcessCall(
-              'pod',
-              const <String>['install'],
-              macOSDir.path,
-            ),
-          ]),
-        );
-
-        expect(
-            output,
-            containsAllInOrder(<Matcher>[
-              contains('Running for plugin1'),
-              contains('No issues found!'),
-            ]));
-      });
-
       test('runs on all examples', () async {
         final List<String> examples = <String>['example1', 'example2'];
         final RepositoryPackage plugin = createFakePlugin(
             'plugin1', packagesDir,
             examples: examples,
-            extraFiles: <String>[
-              'example/example1/macos/Flutter/ephemeral/Flutter-Generated.xcconfig',
-              'example/example2/macos/Flutter/ephemeral/Flutter-Generated.xcconfig',
-            ],
             platformSupport: <String, PlatformDetails>{
               platformMacOS: const PlatformDetails(PlatformSupport.inline)
             });
 
-        final Iterable<Directory> examplemacOSDirs = plugin.getExamples().map(
-            (RepositoryPackage example) =>
-                example.platformDirectory(FlutterPlatform.macos));
+        final Iterable<Directory> exampleDirs = plugin.getExamples().map(
+                (RepositoryPackage example) => example.directory);
 
         final List<String> output = await runCapturingPrint(
             runner, <String>['fetch-deps', '--no-dart', '--macos']);
@@ -676,10 +513,10 @@ void main() {
               <String>['precache', '--macos'],
               null,
             ),
-            for (final Directory directory in examplemacOSDirs)
+            for (final Directory directory in exampleDirs)
               ProcessCall(
-                'pod',
-                const <String>['install'],
+                'flutter',
+                const <String>['build', 'macos', '--config-only'],
                 directory.path,
               ),
           ]),
@@ -693,92 +530,25 @@ void main() {
             ]));
       });
 
-      test('runs pub get if example is not configured', () async {
-        final RepositoryPackage plugin = createFakePlugin(
-            'plugin1', packagesDir, platformSupport: <String, PlatformDetails>{
-          platformMacOS: const PlatformDetails(PlatformSupport.inline)
-        });
-
-        final RepositoryPackage example = plugin.getExamples().first;
-
-        final List<String> output = await runCapturingPrint(
-            runner, <String>['fetch-deps', '--no-dart', '--macos']);
-
-        expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            const ProcessCall(
-              'flutter',
-              <String>['precache', '--macos'],
-              null,
-            ),
-            ProcessCall(
-              'flutter',
-              const <String>['pub', 'get'],
-              example.directory.path,
-            ),
-            ProcessCall(
-              'pod',
-              const <String>['install'],
-              example.platformDirectory(FlutterPlatform.macos).path,
-            ),
-          ]),
-        );
-
-        expect(
-            output,
-            containsAllInOrder(<Matcher>[
-              contains('Running for plugin1'),
-              contains('No issues found!'),
-            ]));
-      });
-
-      test('fails if pre-pod pub get fails', () async {
+      test('fails if flutter build --config-only fails', () async {
         createFakePlugin('plugin1', packagesDir,
             platformSupport: <String, PlatformDetails>{
               platformMacOS: const PlatformDetails(PlatformSupport.inline)
             });
 
         processRunner
-                .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
-            <FakeProcessInfo>[
+            .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
+        <FakeProcessInfo>[
           FakeProcessInfo(MockProcess(), <String>['precache']),
-          FakeProcessInfo(MockProcess(exitCode: 1), <String>['pub', 'get']),
+          FakeProcessInfo(MockProcess(exitCode: 1), <String>['build', 'macos', '--config-only']),
         ];
 
         Error? commandError;
         final List<String> output = await runCapturingPrint(
             runner, <String>['fetch-deps', '--no-dart', '--macos'],
             errorHandler: (Error e) {
-          commandError = e;
-        });
-
-        expect(commandError, isA<ToolExit>());
-        expect(
-            output,
-            containsAllInOrder(
-              <Matcher>[
-                contains('Unable to configure project'),
-              ],
-            ));
-      });
-
-      test('fails if pod install fails', () async {
-        createFakePlugin('plugin1', packagesDir,
-            platformSupport: <String, PlatformDetails>{
-              platformMacOS: const PlatformDetails(PlatformSupport.inline)
+              commandError = e;
             });
-
-        processRunner.mockProcessesForExecutable['pod'] = <FakeProcessInfo>[
-          FakeProcessInfo(MockProcess(exitCode: 1)),
-        ];
-
-        Error? commandError;
-        final List<String> output = await runCapturingPrint(
-            runner, <String>['fetch-deps', '--no-dart', '--macos'],
-            errorHandler: (Error e) {
-          commandError = e;
-        });
 
         expect(commandError, isA<ToolExit>());
         expect(


### PR DESCRIPTION
For iOS and macOS move fetch deps from explicity running `pub get` and `pod install` to instead run `flutter build x --config-only` which smartly fetches deps and lays down the required native pieces.  I didn't guard it on whether certain files are present since the command already has similar guards, and runs pretty fast if the native code has already been generated.

This fixes an issue where `pod install` is run before the Flutter native bits and migrations are run.

Fixes issues seen in the Flutter roll https://github.com/flutter/packages/pull/5792#issuecomment-1876103613
```
Running command: "pod install" in /Volumes/Work/s/w/ir/x/w/packages/packages/camera/camera_avfoundation/example/ios
Analyzing dependencies
[!] CocoaPods could not find compatible versions for pod "Flutter":
  In Podfile:
    Flutter (from `Flutter`)

Specs satisfying the `Flutter (from `Flutter`)` dependency were found, but they required a higher minimum deployment target.

[!] Automatically assigning platform `iOS` with version `11.0` on target `Runner` because no platform was specified. Please specify a platform for this target in your Podfile. See `https://guides.cocoapods.org/syntax/podfile.html#platform`.
Unable to "pod install"
```

Caused by https://github.com/flutter/flutter/pull/140478

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
