### PR TITLE
[google_maps_flutter] Add hint for cloud-based map styling on iOS

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter/README.md
@@ -66,6 +66,9 @@ For details, see [the Android README](https://pub.dev/packages/google_maps_flutt
 Cloud-based map styling works on Android only if `AndroidMapRenderer.latest` map renderer has been initialized.
 For details, see [the Android README](https://pub.dev/packages/google_maps_flutter_android#map-renderer).
 
+Cloud-based map styling works on iOS only with GoogleMaps iOS SDK > 8.3.0. For this to be installed you need
+to set the minimum deployment target of your app to 14.0 or higher.
+
 ### iOS
 
 To set up, specify your API key in the application delegate `ios/Runner/AppDelegate.m`:


### PR DESCRIPTION
I added a hint to the readme, that iOS apps need to have a minimum deployment target >= 14.0 to use cloud-based map styling. This is necessary because the feature was introduced with GoogleMaps SDK 8.3.0 which is not available for iOS < 14.0.

Relevant part of [GoogleMaps iOS SDK Changelog](https://developers.google.com/maps/documentation/ios-sdk/release-notes#2021-10-18)

There is no Github Issue but a [StackOverflow Question](https://stackoverflow.com/questions/77024839/flutter-googlemap-widget-cloudmapid-property-not-working-in-emulator/77782406) that I answered.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
