### PR TITLE
[ci] Exclude quick_actions from Android emulators

### DIFF
--- a/.ci/targets/android_platform_tests.yaml
+++ b/.ci/targets/android_platform_tests.yaml
@@ -21,7 +21,7 @@ tasks:
     args: ["native-test", "--android", "--no-integration", "--exclude=script/configs/exclude_native_unit_android.yaml,script/configs/still_requires_api_33_avd.yaml"]
   - name: native integration tests
     script: script/tool_runner.sh
-    args: ["native-test", "--android", "--no-unit", "--exclude=script/configs/still_requires_api_33_avd.yaml"]
+    args: ["native-test", "--android", "--no-unit", "--exclude=script/configs/exclude_native_integration_android_emulator.yaml,script/configs/still_requires_api_33_avd.yaml"]
   - name: drive examples
     script: script/tool_runner.sh
     args: ["drive-examples", "--android", "--exclude=script/configs/exclude_integration_android.yaml,script/configs/exclude_integration_android_emulator.yaml,script/configs/still_requires_api_33_avd.yaml"]

--- a/script/configs/exclude_native_integration_android_emulator.yaml
+++ b/script/configs/exclude_native_integration_android_emulator.yaml
@@ -1,0 +1,3 @@
+# Incredibly flaky, see https://github.com/flutter/flutter/issues/141136
+# TODO(stuartmorgan): Remove once the flake is fixed.
+- quick_actions_android


### PR DESCRIPTION
To address extreme flake in the tree.

See https://github.com/flutter/flutter/issues/141136