### PR TITLE
[rfw] Enable subscribing to the root of a DynamicContent

### DIFF
--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 1.0.21
+
+* Adds support for subscribing to the root of a `DynamicContent` object.
+
 ## 1.0.20
 
-* Adds OverflowBox material widget.
-* Updates ButtonBar material widget implementation.
+* Adds `OverflowBox` material widget.
+* Updates `ButtonBar` material widget implementation.
 
 ## 1.0.19
 

--- a/packages/rfw/pubspec.yaml
+++ b/packages/rfw/pubspec.yaml
@@ -2,7 +2,7 @@ name: rfw
 description: "Remote Flutter widgets: a library for rendering declarative widget description files at runtime."
 repository: https://github.com/flutter/packages/tree/main/packages/rfw
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+rfw%22
-version: 1.0.20
+version: 1.0.21
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/rfw/test/runtime_test.dart
+++ b/packages/rfw/test/runtime_test.dart
@@ -1074,4 +1074,18 @@ void main() {
     });
     expect(tested, isTrue);
   });
+
+  testWidgets('DynamicContent subscriptions', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+    final DynamicContent data = DynamicContent(<String, Object?>{
+      'a': <Object>[0, 1],
+      'b': <Object>['q', 'r'],
+    });
+    data.subscribe(<Object>[], (Object value) { log.add('root: $value'); });
+    data.subscribe(<Object>['a', 0], (Object value) { log.add('leaf: $value'); });
+    data.update('a', <Object>[2, 3]);
+    expect(log, <String>['leaf: 2', 'root: {a: [2, 3], b: [q, r]}']);
+    data.update('c', 'test');
+    expect(log, <String>['leaf: 2', 'root: {a: [2, 3], b: [q, r]}', 'root: {a: [2, 3], b: [q, r], c: test}']);
+  });
 }

--- a/packages/rfw/test_coverage/bin/test_coverage.dart
+++ b/packages/rfw/test_coverage/bin/test_coverage.dart
@@ -20,9 +20,10 @@ import 'package:meta/meta.dart';
 
 // Please update these targets when you update this package.
 // Please ensure that test coverage continues to be 100%.
-const int targetLines = 3223;
+// Don't forget to update the lastUpdate date too!
+const int targetLines = 3273;
 const String targetPercent = '100';
-const String lastUpdate = '2023-06-29';
+const String lastUpdate = '2024-01-30';
 
 @immutable
 /* final */ class LcovLine {
@@ -196,14 +197,14 @@ Future<void> main(List<String> arguments) async {
       print(
         'Total lines of covered code has increased, and coverage script is now out of date.\n'
         'Coverage is now $coveredPercent%, $coveredLines/$totalLines lines, whereas previously there were only $targetLines lines.\n'
-        'Update the "\$targetLines" constant at the top of rfw/test_coverage/bin/test_coverage.dart (to $coveredLines).',
+        'Update the "targetLines" constant at the top of rfw/test_coverage/bin/test_coverage.dart (to $coveredLines).',
       );
     }
     if (targetLines > totalLines) {
       print(
         'Total lines of code has reduced, and coverage script is now out of date.\n'
         'Coverage is now $coveredPercent%, $coveredLines/$totalLines lines, but previously there were $targetLines lines.\n'
-        'Update the "\$targetLines" constant at the top of rfw/test_coverage/bin/test_coverage.dart (to $totalLines).',
+        'Update the "targetLines" constant at the top of rfw/test_coverage/bin/test_coverage.dart (to $totalLines).',
       );
       exit(1);
     }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/141069

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
