### PR TITLE
LinkedText

### DIFF
--- a/packages/linked_text/.gitignore
+++ b/packages/linked_text/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/linked_text/CHANGELOG.md
+++ b/packages/linked_text/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/packages/linked_text/README.md
+++ b/packages/linked_text/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/packages/linked_text/analysis_options.yaml
+++ b/packages/linked_text/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/packages/linked_text/example/linked_text_example.dart
+++ b/packages/linked_text/example/linked_text_example.dart
@@ -1,0 +1,6 @@
+import 'package:linked_text/linked_text.dart';
+
+void main() {
+  var awesome = Awesome();
+  print('awesome: ${awesome.isAwesome}');
+}

--- a/packages/linked_text/lib/linked_text.dart
+++ b/packages/linked_text/lib/linked_text.dart
@@ -1,8 +1,7 @@
-/// Support for doing something awesome.
-///
-/// More dartdocs go here.
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 library;
 
-export 'src/linked_text_base.dart';
-
-// TODO: Export any libraries intended for clients of this package.
+export 'src/linked_text.dart';
+export 'src/text_linker.dart';

--- a/packages/linked_text/lib/linked_text.dart
+++ b/packages/linked_text/lib/linked_text.dart
@@ -1,0 +1,8 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library;
+
+export 'src/linked_text_base.dart';
+
+// TODO: Export any libraries intended for clients of this package.

--- a/packages/linked_text/lib/src/linked_text.dart
+++ b/packages/linked_text/lib/src/linked_text.dart
@@ -1,0 +1,333 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+
+import './text_linker.dart';
+
+/// Singature for a function that builds the [Widget] output by [LinkedText].
+///
+/// Typically a [Text.rich] containing a [TextSpan] whose children are the
+/// [linkedSpans].
+typedef LinkedTextWidgetBuilder = Widget Function (
+  BuildContext context,
+  Iterable<InlineSpan> linkedSpans,
+);
+
+/// A widget that displays text with parts of it made interactive.
+///
+/// By default, any URLs in the text are made interactive, and clicking one
+/// calls the provided callback.
+///
+/// Works with either a flat [String] (`text`) or a list of [InlineSpan]s
+/// (`spans`). When using `spans`, only [TextSpan]s will be converted to links.
+///
+/// {@tool dartpad}
+/// This example shows how to create a [LinkedText] that turns URLs into
+/// working links.
+///
+/// ** See code in examples/api/lib/widgets/linked_text/linked_text.0.dart **
+/// {@end-tool}
+///
+/// {@tool dartpad}
+/// This example shows how to use [LinkedText] to link Twitter handles by
+/// passing in a custom [RegExp].
+///
+/// ** See code in examples/api/lib/widgets/linked_text/linked_text.1.dart **
+/// {@end-tool}
+///
+/// {@tool dartpad}
+/// This example shows how to use [LinkedText] to link URLs in a TextSpan tree
+/// instead of in a flat string.
+///
+/// ** See code in examples/api/lib/widgets/linked_text/linked_text.2.dart **
+/// {@end-tool}
+class LinkedText extends StatefulWidget {
+  /// Creates an instance of [LinkedText] from the given [text] or [spans],
+  /// turning any URLs into interactive links.
+  ///
+  /// See also:
+  ///
+  ///  * [LinkedText.regExp], which matches based on any given [RegExp].
+  ///  * [LinkedText.textLinkers], which uses [TextLinker]s to allow full
+  ///    control over matching and building different types of links.
+  LinkedText({
+    super.key,
+    required ValueChanged<Uri> onTapUri,
+    this.builder = _defaultBuilder,
+    List<InlineSpan>? spans,
+    String? text,
+  }) : assert((text == null) != (spans == null), 'Must specify exactly one to link: either text or spans.'),
+       spans = spans ?? <InlineSpan>[
+         TextSpan(
+           text: text,
+         ),
+       ],
+       onTap = _getOnTap(onTapUri),
+       regExp = defaultUriRegExp,
+       textLinkers = null;
+
+  /// Creates an instance of [LinkedText] from the given [text] or [spans],
+  /// turning anything matched by [regExp] into interactive links.
+  ///
+  /// {@tool dartpad}
+  /// This example shows how to use [LinkedText] to link Twitter handles by
+  /// passing in a custom [RegExp].
+  ///
+  /// ** See code in examples/api/lib/widgets/linked_text/linked_text.1.dart **
+  /// {@end-tool}
+  ///
+  /// See also:
+  ///
+  ///  * [LinkedText.new], which matches [Uri]s.
+  ///  * [LinkedText.textLinkers], which uses [TextLinker]s to allow full
+  ///    control over matching and building different types of links.
+  LinkedText.regExp({
+    super.key,
+    required this.onTap,
+    required this.regExp,
+    this.builder = _defaultBuilder,
+    List<InlineSpan>? spans,
+    String? text,
+  }) : assert((text == null) != (spans == null), 'Must specify exactly one to link: either text or spans.'),
+       spans = spans ?? <InlineSpan>[
+         TextSpan(
+           text: text,
+         ),
+       ],
+       textLinkers = null;
+
+  /// Creates an instance of [LinkedText] where the given [textLinkers] are
+  /// applied.
+  ///
+  /// Useful for independently matching different types of strings with
+  /// different behaviors. For example, highlighting both URLs and Twitter
+  /// handles with different style and/or behavior.
+  ///
+  /// {@tool dartpad}
+  /// This example shows how to use [LinkedText] to link both URLs and Twitter
+  /// handles in the same text.
+  ///
+  /// ** See code in examples/api/lib/widgets/linked_text/linked_text.3.dart **
+  /// {@end-tool}
+  ///
+  /// See also:
+  ///
+  ///  * [LinkedText.new], which matches [Uri]s.
+  ///  * [LinkedText.regExp], which matches based on any given [RegExp].
+  LinkedText.textLinkers({
+    super.key,
+    this.builder = _defaultBuilder,
+    String? text,
+    List<InlineSpan>? spans,
+    required List<TextLinker> textLinkers,
+  }) : assert((text == null) != (spans == null), 'Must specify exactly one to link: either text or spans.'),
+       assert(textLinkers.isNotEmpty),
+       textLinkers = textLinkers, // ignore: prefer_initializing_formals
+       spans = spans ?? <InlineSpan>[
+         TextSpan(
+           text: text,
+         ),
+       ],
+       onTap = null,
+       regExp = null;
+
+  /// The spans on which to create links.
+  ///
+  /// It's also possible to specify a plain string by using the `text`
+  /// parameter instead.
+  final List<InlineSpan> spans;
+
+  /// Builds the [Widget] that is output by [LinkedText].
+  ///
+  /// By default, builds a [Text.rich] with a single [TextSpan] whose children
+  /// are the linked [TextSpan]s, and whose style is [DefaultTextStyle].
+  final LinkedTextWidgetBuilder builder;
+
+  /// Handles tapping on a link.
+  ///
+  /// This is irrelevant when using [LinkedText.textLinkers], where this is
+  /// controlled with an [InlineLinkBuilder] instead.
+  final ValueChanged<String>? onTap;
+
+  /// Matches the text that should be turned into a link.
+  ///
+  /// This is irrelevant when using [LinkedText.textLinkers], where each
+  /// [TextLinker] specifies its own [TextLinker.regExp].
+  ///
+  /// {@tool dartpad}
+  /// This example shows how to use [LinkedText] to link Twitter handles by
+  /// passing in a custom [RegExp].
+  ///
+  /// ** See code in examples/api/lib/widgets/linked_text/linked_text.1.dart **
+  /// {@end-tool}
+  final RegExp? regExp;
+
+  /// Defines what parts of the text to match and how to link them.
+  ///
+  /// [TextLinker]s are applied in the order given. Overlapping matches are not
+  /// supported and will produce an error.
+  ///
+  /// {@tool dartpad}
+  /// This example shows how to use [LinkedText] to link both URLs and Twitter
+  /// handles in the same text with [TextLinker]s.
+  ///
+  /// ** See code in examples/api/lib/widgets/linked_text/linked_text.3.dart **
+  /// {@end-tool}
+  final List<TextLinker>? textLinkers;
+
+  /// The default [RegExp], which matches [Uri]s by default.
+  ///
+  /// Matches with and without a host, but only "http" or "https". Ignores email
+  /// addresses.
+  static final RegExp defaultUriRegExp = RegExp(r'(?<!@[a-zA-Z0-9-]*)(?<![\/\.a-zA-Z0-9-])((https?:\/\/)?(([a-zA-Z0-9-]*\.)*[a-zA-Z0-9-]+(\.[a-zA-Z]+)+))(?::\d{1,5})?(?:\/[^\s]*)?(?:\?[^\s#]*)?(?:#[^\s]*)?(?![a-zA-Z0-9-]*@)');
+
+  /// Returns a generic [ValueChanged]<String> given a callback specifically for
+  /// tapping on a [Uri].
+  static ValueChanged<String> _getOnTap(ValueChanged<Uri> onTapUri) {
+    return (String linkString) {
+      Uri uri = Uri.parse(linkString);
+      if (uri.host.isEmpty) {
+        // defaultUriRegExp matches Uris without a host, but packages like
+        // url_launcher require a host to launch a Uri. So add the host.
+        uri = Uri.parse('https://$linkString');
+      }
+      onTapUri(uri);
+    };
+  }
+
+  /// The default value of [builder].
+  ///
+  /// Builds a [Text.rich] with a single [TextSpan] whose children are the
+  /// linked [TextSpan]s, and whose style is [DefaultTextStyle]. If there are no
+  /// linked [TextSpan]s to display, builds a [SizedBox.shrink].
+  static Widget _defaultBuilder(BuildContext context, Iterable<InlineSpan> linkedSpans) {
+    if (linkedSpans.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Text.rich(
+      TextSpan(
+        style: DefaultTextStyle.of(context).style,
+        children: linkedSpans.toList(),
+      ),
+    );
+  }
+
+  /// The style used for the link by default if none is given.
+  @visibleForTesting
+  static TextStyle defaultLinkStyle = _InlineLinkSpan.defaultLinkStyle;
+
+  @override
+  State<LinkedText> createState() => _LinkedTextState();
+}
+
+class _LinkedTextState extends State<LinkedText> {
+  final List<GestureRecognizer> _recognizers = <GestureRecognizer>[];
+  late Iterable<InlineSpan> _linkedSpans;
+  late final List<TextLinker> _textLinkers;
+
+  void _disposeRecognizers() {
+    for (final GestureRecognizer recognizer in _recognizers) {
+      recognizer.dispose();
+    }
+    _recognizers.clear();
+  }
+
+  void _linkSpans() {
+    _disposeRecognizers();
+    final Iterable<InlineSpan> linkedSpans = TextLinker.linkSpans(
+      widget.spans,
+      _textLinkers,
+    );
+    _linkedSpans = linkedSpans;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _textLinkers = widget.textLinkers ?? <TextLinker>[
+       TextLinker(
+         regExp: widget.regExp ?? LinkedText.defaultUriRegExp,
+         linkBuilder: (String displayString, String linkString) {
+           final TapGestureRecognizer recognizer = TapGestureRecognizer()
+               ..onTap = () => widget.onTap!(linkString);
+           // Keep track of created recognizers so that they can be disposed.
+           _recognizers.add(recognizer);
+           return _InlineLinkSpan(
+             recognizer: recognizer,
+             style: LinkedText.defaultLinkStyle,
+             text: displayString,
+           );
+         },
+       ),
+     ];
+    _linkSpans();
+  }
+
+  @override
+  void didUpdateWidget(LinkedText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.spans != oldWidget.spans || widget.textLinkers != oldWidget.textLinkers) {
+      _linkSpans();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposeRecognizers();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context, _linkedSpans);
+  }
+}
+
+/// An inline, interactive text link.
+///
+/// See also:
+///
+///  * [LinkedText], which creates links with this class by default.
+class _InlineLinkSpan extends TextSpan {
+  /// Create an instance of [_InlineLinkSpan].
+  _InlineLinkSpan({
+    required String text,
+    TextStyle? style,
+    super.recognizer,
+  }) : super(
+    style: style ?? defaultLinkStyle,
+    mouseCursor: SystemMouseCursors.click,
+    text: text,
+  );
+
+  static Color get _linkColor {
+    return switch (defaultTargetPlatform) {
+      // This value was taken from Safari on an iPhone 14 Pro iOS 16.4
+      // simulator.
+      TargetPlatform.iOS => const Color(0xff1717f0),
+      // This value was taken from Chrome on macOS 13.4.1.
+      TargetPlatform.macOS => const Color(0xff0000ee),
+      // This value was taken from Chrome on Android 14.
+      TargetPlatform.android || TargetPlatform.fuchsia => const Color(0xff0e0eef),
+      // This value was taken from the Chrome browser running on GNOME 43.3 on
+      // Debian.
+      TargetPlatform.linux => const Color(0xff0026e8),
+      // This value was taken from the Edge browser running on Windows 10.
+      TargetPlatform.windows => const Color(0xff1e2b8b),
+    };
+  }
+
+  /// The style used for the link by default if none is given.
+  @visibleForTesting
+  static TextStyle defaultLinkStyle = TextStyle(
+    color: _linkColor,
+    decorationColor: _linkColor,
+    decoration: TextDecoration.underline,
+  );
+}

--- a/packages/linked_text/lib/src/linked_text_base.dart
+++ b/packages/linked_text/lib/src/linked_text_base.dart
@@ -1,6 +1,0 @@
-// TODO: Put public facing types in this file.
-
-/// Checks if you are awesome. Spoiler: you are.
-class Awesome {
-  bool get isAwesome => true;
-}

--- a/packages/linked_text/lib/src/linked_text_base.dart
+++ b/packages/linked_text/lib/src/linked_text_base.dart
@@ -1,0 +1,6 @@
+// TODO: Put public facing types in this file.
+
+/// Checks if you are awesome. Spoiler: you are.
+class Awesome {
+  bool get isAwesome => true;
+}

--- a/packages/linked_text/lib/src/text_linker.dart
+++ b/packages/linked_text/lib/src/text_linker.dart
@@ -1,0 +1,419 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// Signature for a function that builds an [InlineSpan] link.
+///
+/// The link displays [displayString] and links to [linkString] when tapped.
+/// These are distinct because sometimes a link may be split across multiple
+/// [TextSpan]s.
+///
+/// For example, consider the [TextSpan]s
+/// `[TextSpan(text: 'http://'), TextSpan(text: 'google.com'), TextSpan(text: '/')]`.
+/// This builder would be called three times, with the following parameters:
+///
+///  1. `displayString: 'http://', linkString: 'http://google.com/'`
+///  2. `displayString: 'google.com', linkString: 'http://google.com/'`
+///  3. `displayString: '/', linkString: 'http://google.com/'`
+///
+/// {@template flutter.painting.LinkBuilder.recognizer}
+/// It's necessary for the owning widget to manage the lifecycle of any
+/// [GestureRecognizer]s created in this function, such as for handling a tap on
+/// the link. See [TextSpan.recognizer] for more.
+/// {@endtemplate}
+///
+/// {@tool dartpad}
+/// This example shows how to use [TextLinker] to link both URLs and Twitter
+/// handles in a [TextSpan] tree. It also illustrates the difference between
+/// `displayString` and `linkString`.
+///
+/// ** See code in examples/api/lib/painting/text_linker/text_linker.1.dart **
+/// {@end-tool}
+typedef InlineLinkBuilder = InlineSpan Function(
+  String displayString,
+  String linkString,
+);
+
+/// Specifies a way to find and style parts of some text.
+///
+/// [TextLinker]s can be applied to some text using the [linkSpans] method.
+///
+/// {@tool dartpad}
+/// This example shows how to use [TextLinker] to link both URLs and Twitter
+/// handles in the same text.
+///
+/// ** See code in examples/api/lib/painting/text_linker/text_linker.0.dart **
+/// {@end-tool}
+///
+/// {@tool dartpad}
+/// This example shows how to use [TextLinker] to link both URLs and Twitter
+/// handles in a [TextSpan] tree instead of a flat string.
+///
+/// ** See code in examples/api/lib/painting/text_linker/text_linker.1.dart **
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [LinkedText.textLinkers], which uses [TextLinker]s to allow full control
+///    over matching and building different types of links.
+///  * [LinkedText.new], which is simpler than using [TextLinker] and
+///    automatically manages the lifecycle of any [GestureRecognizer]s.
+class TextLinker {
+  /// Creates an instance of [TextLinker] with a [RegExp] and an [InlineLinkBuilder
+  /// [InlineLinkBuilder].
+  ///
+  /// Does not manage the lifecycle of any [GestureRecognizer]s created in the
+  /// [InlineLinkBuilder], so it's the responsibility of the caller to do so.
+  /// See [TextSpan.recognizer] for more.
+  TextLinker({
+    required this.regExp,
+    required this.linkBuilder,
+  });
+
+  /// Builds an [InlineSpan] to display the text that it's passed.
+  ///
+  /// {@macro flutter.painting.LinkBuilder.recognizer}
+  final InlineLinkBuilder linkBuilder;
+
+  /// Matches text that should be turned into a link with [linkBuilder].
+  final RegExp regExp;
+
+  /// Applies the given [TextLinker]s to the given [InlineSpan]s and returns the
+  /// new resulting spans and any created [GestureRecognizer]s.
+  static Iterable<InlineSpan> linkSpans(Iterable<InlineSpan> spans, Iterable<TextLinker> textLinkers) {
+    final _LinkedSpans linkedSpans = _LinkedSpans(
+      spans: spans,
+      textLinkers: textLinkers,
+    );
+    return linkedSpans.linkedSpans;
+  }
+
+  // Turns all matches from the regExp into a list of TextRanges.
+  static Iterable<TextRange> _textRangesFromText(String text, RegExp regExp) {
+    final Iterable<RegExpMatch> matches = regExp.allMatches(text);
+    return matches.map((RegExpMatch match) {
+      return TextRange(
+        start: match.start,
+        end: match.end,
+      );
+    });
+  }
+
+  /// Apply this [TextLinker] to a [String].
+  Iterable<_TextLinkerMatch> _link(String text) {
+    final Iterable<TextRange> textRanges = _textRangesFromText(text, regExp);
+    return textRanges.map((TextRange textRange) {
+      return _TextLinkerMatch(
+        textRange: textRange,
+        linkBuilder: linkBuilder,
+        linkString: text.substring(textRange.start, textRange.end),
+      );
+    });
+  }
+
+  @override
+  String toString() => '${objectRuntimeType(this, 'TextLinker')}($regExp)';
+}
+
+/// A matched replacement on some string.
+///
+/// Produced by applying a [TextLinker]'s [RegExp] to a string.
+class _TextLinkerMatch {
+  _TextLinkerMatch({
+    required this.textRange,
+    required this.linkBuilder,
+    required this.linkString,
+  }) : assert(textRange.end - textRange.start == linkString.length);
+
+  final InlineLinkBuilder linkBuilder;
+  final TextRange textRange;
+
+  /// The string that [textRange] matches.
+  final String linkString;
+
+  /// Get all [_TextLinkerMatch]s obtained from applying the given
+  /// `textLinker`s with the given `text`.
+  static List<_TextLinkerMatch> fromTextLinkers(Iterable<TextLinker> textLinkers, String text) {
+    return textLinkers
+        .fold<List<_TextLinkerMatch>>(
+          <_TextLinkerMatch>[],
+          (List<_TextLinkerMatch> previousValue, TextLinker value) {
+            return previousValue..addAll(value._link(text));
+        });
+  }
+
+  @override
+  String toString() => '${objectRuntimeType(this, '_TextLinkerMatch')}($textRange, $linkBuilder, $linkString)';
+}
+
+/// Used to cache information about a span's recursive text.
+///
+/// Avoids repeatedly calling [TextSpan.toPlainText].
+class _TextCache {
+  factory _TextCache({
+    required InlineSpan span,
+  }) {
+    if (span is! TextSpan) {
+      return _TextCache._(
+        text: '',
+        lengths: <InlineSpan, int>{span: 0},
+      );
+    }
+
+    _TextCache childrenTextCache = _TextCache._empty();
+    for (final InlineSpan child in span.children ?? <InlineSpan>[]) {
+      final _TextCache childTextCache = _TextCache(
+        span: child,
+      );
+      childrenTextCache = childrenTextCache._merge(childTextCache);
+    }
+
+    final String text = (span.text ?? '') + childrenTextCache.text;
+    return _TextCache._(
+      text: text,
+      lengths: <InlineSpan, int>{
+        span: text.length,
+        ...childrenTextCache._lengths,
+      },
+    );
+  }
+
+  factory _TextCache.fromMany({
+    required Iterable<InlineSpan> spans,
+  }) {
+    _TextCache textCache = _TextCache._empty();
+    for (final InlineSpan span in spans) {
+      final _TextCache spanTextCache = _TextCache(
+        span: span,
+      );
+      textCache = textCache._merge(spanTextCache);
+    }
+    return textCache;
+  }
+
+  _TextCache._empty(
+  ) : text = '',
+      _lengths = <InlineSpan, int>{};
+
+  const _TextCache._({
+    required this.text,
+    required Map<InlineSpan, int> lengths,
+  }) : _lengths = lengths;
+
+  /// The flattened text of all spans in the span tree.
+  final String text;
+
+  /// A [Map] containing the lengths of all spans in the span tree.
+  ///
+  /// The length is defined as the length of the flattened text at the point in
+  /// the tree where the node resides.
+  ///
+  /// The length of [text] is the length of the root node in [_lengths].
+  final Map<InlineSpan, int> _lengths;
+
+  /// Merges the given _TextCache with this one by appending it to the end.
+  ///
+  /// Returns a new _TextCache and makes no modifications to either passed in.
+  _TextCache _merge(_TextCache other) {
+    return _TextCache._(
+      text: text + other.text,
+      lengths: Map<InlineSpan, int>.from(_lengths)..addAll(other._lengths),
+    );
+  }
+
+  int? getLength(InlineSpan span) => _lengths[span];
+
+  @override
+  String toString() => '${objectRuntimeType(this, '_TextCache')}($text, $_lengths)';
+}
+
+/// Signature for the output of linking an InlineSpan to some
+/// _TextLinkerMatches.
+typedef _LinkSpanRecursion = (
+  /// The output of linking the input InlineSpan.
+  InlineSpan linkedSpan,
+  /// The provided _TextLinkerMatches, but with those completely used during
+  /// linking removed.
+  Iterable<_TextLinkerMatch> unusedTextLinkerMatches,
+);
+
+/// Signature for the output of linking a List of InlineSpans to some
+/// _TextLinkerMatches.
+typedef _LinkSpansRecursion = (
+  /// The output of linking the input InlineSpans.
+  Iterable<InlineSpan> linkedSpans,
+  /// The provided _TextLinkerMatches, but with those completely used during
+  /// linking removed.
+  Iterable<_TextLinkerMatch> unusedTextLinkerMatches,
+);
+
+/// Applies some [TextLinker]s to some [InlineSpan]s and produces a new list of
+/// [linkedSpans] as well as the [recognizers] created for each generated link.
+class _LinkedSpans {
+  factory _LinkedSpans({
+    required Iterable<InlineSpan> spans,
+    required Iterable<TextLinker> textLinkers,
+  }) {
+    // Flatten the spans and store all string lengths, so that matches across
+    // span boundaries can be matched in the flat string. This is calculated
+    // once in the beginning to avoid recomputing.
+    final _TextCache textCache = _TextCache.fromMany(spans: spans);
+
+    final Iterable<_TextLinkerMatch> textLinkerMatches =
+        _cleanTextLinkerMatches(
+          _TextLinkerMatch.fromTextLinkers(textLinkers, textCache.text),
+        );
+
+    final (Iterable<InlineSpan> linkedSpans, Iterable<_TextLinkerMatch> _) =
+        _linkSpansRecurse(
+          spans,
+          textCache,
+          textLinkerMatches,
+        );
+
+    return _LinkedSpans._(
+      linkedSpans: linkedSpans,
+    );
+  }
+
+  const _LinkedSpans._({
+    required this.linkedSpans,
+  });
+
+  final Iterable<InlineSpan> linkedSpans;
+
+  static List<_TextLinkerMatch> _cleanTextLinkerMatches(Iterable<_TextLinkerMatch> textLinkerMatches) {
+    final List<_TextLinkerMatch> nextTextLinkerMatches = textLinkerMatches.toList();
+
+    // Sort by start.
+    nextTextLinkerMatches.sort((_TextLinkerMatch a, _TextLinkerMatch b) {
+      return a.textRange.start.compareTo(b.textRange.start);
+    });
+
+    // Validate that there are no overlapping matches.
+    int lastEnd = 0;
+    for (final _TextLinkerMatch textLinkerMatch in nextTextLinkerMatches) {
+      if (textLinkerMatch.textRange.start < lastEnd) {
+        throw ArgumentError('Matches must not overlap. Overlapping text was "${textLinkerMatch.linkString}" located at ${textLinkerMatch.textRange.start}-${textLinkerMatch.textRange.end}.');
+      }
+      lastEnd = textLinkerMatch.textRange.end;
+    }
+
+    // Remove empty ranges.
+    nextTextLinkerMatches.removeWhere((_TextLinkerMatch textLinkerMatch) {
+      return textLinkerMatch.textRange.start == textLinkerMatch.textRange.end;
+    });
+
+    return nextTextLinkerMatches;
+  }
+
+  // `index` is the index of the start of `span` in the overall flattened tree
+  // string.
+  static _LinkSpansRecursion _linkSpansRecurse(Iterable<InlineSpan> spans, _TextCache textCache, Iterable<_TextLinkerMatch> textLinkerMatches, [int index = 0]) {
+    final List<InlineSpan> output = <InlineSpan>[];
+    Iterable<_TextLinkerMatch> nextTextLinkerMatches = textLinkerMatches;
+    int nextIndex = index;
+    for (final InlineSpan span in spans) {
+      final (InlineSpan childSpan, Iterable<_TextLinkerMatch> childTextLinkerMatches) = _linkSpanRecurse(
+        span,
+        textCache,
+        nextTextLinkerMatches,
+        nextIndex,
+      );
+      output.add(childSpan);
+      nextTextLinkerMatches = childTextLinkerMatches;
+      nextIndex += textCache.getLength(span)!;
+    }
+
+    return (output, nextTextLinkerMatches);
+  }
+
+  // `index` is the index of the start of `span` in the overall flattened tree
+  // string.
+  static _LinkSpanRecursion _linkSpanRecurse(InlineSpan span, _TextCache textCache, Iterable<_TextLinkerMatch> textLinkerMatches, [int index = 0]) {
+    if (span is! TextSpan) {
+      return (span, textLinkerMatches);
+    }
+
+    final List<InlineSpan> nextChildren = <InlineSpan>[];
+    List<_TextLinkerMatch> nextTextLinkerMatches = <_TextLinkerMatch>[...textLinkerMatches];
+    int lastLinkEnd = index;
+    if (span.text?.isNotEmpty ?? false) {
+      final int textEnd = index + span.text!.length;
+      for (final _TextLinkerMatch textLinkerMatch in textLinkerMatches) {
+        if (textLinkerMatch.textRange.start >= textEnd) {
+          // Because ranges is ordered, there are no more relevant ranges for this
+          // text.
+          break;
+        }
+        if (textLinkerMatch.textRange.end <= index) {
+          // This range ends before this span and is therefore irrelevant to it.
+          // It should have been removed from ranges.
+          assert(false, 'Invalid ranges.');
+          nextTextLinkerMatches.removeAt(0);
+          continue;
+        }
+        if (textLinkerMatch.textRange.start > index) {
+          // Add the unlinked text before the range.
+          nextChildren.add(TextSpan(
+            text: span.text!.substring(
+              lastLinkEnd - index,
+              textLinkerMatch.textRange.start - index,
+            ),
+          ));
+        }
+        // Add the link itself.
+        final int linkStart = math.max(textLinkerMatch.textRange.start, index);
+        lastLinkEnd = math.min(textLinkerMatch.textRange.end, textEnd);
+        final InlineSpan nextChild = textLinkerMatch.linkBuilder(
+          span.text!.substring(linkStart - index, lastLinkEnd - index),
+          textLinkerMatch.linkString,
+        );
+        nextChildren.add(nextChild);
+        if (textLinkerMatch.textRange.end > textEnd) {
+          // If we only partially used this range, keep it in nextRanges. Since
+          // overlapping ranges have been removed, this must be the last relevant
+          // range for this span.
+          break;
+        }
+        nextTextLinkerMatches.removeAt(0);
+      }
+
+      // Add any extra text after any ranges.
+      final String remainingText = span.text!.substring(lastLinkEnd - index);
+      if (remainingText.isNotEmpty) {
+        nextChildren.add(TextSpan(
+          text: remainingText,
+        ));
+      }
+    }
+
+    // Recurse on the children.
+    if (span.children?.isNotEmpty ?? false) {
+      final (
+        Iterable<InlineSpan> childrenSpans,
+        Iterable<_TextLinkerMatch> childrenTextLinkerMatches,
+      ) = _linkSpansRecurse(
+        span.children!,
+        textCache,
+        nextTextLinkerMatches,
+        index + (span.text?.length ?? 0),
+      );
+      nextTextLinkerMatches = childrenTextLinkerMatches.toList();
+      nextChildren.addAll(childrenSpans);
+    }
+
+    return (
+      TextSpan(
+        style: span.style,
+        children: nextChildren,
+      ),
+      nextTextLinkerMatches,
+    );
+  }
+}

--- a/packages/linked_text/pubspec.yaml
+++ b/packages/linked_text/pubspec.yaml
@@ -1,0 +1,15 @@
+name: linked_text
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+# repository: https://github.com/my_org/my_repo
+
+environment:
+  sdk: ^3.4.0-14.0.dev
+
+# Add regular dependencies here.
+dependencies:
+  # path: ^1.8.0
+
+dev_dependencies:
+  lints: ^3.0.0
+  test: ^1.24.0

--- a/packages/linked_text/pubspec.yaml
+++ b/packages/linked_text/pubspec.yaml
@@ -1,15 +1,16 @@
 name: linked_text
-description: A starting point for Dart libraries or applications.
+description: Flutter plugin for creating links in text.
 version: 1.0.0
-# repository: https://github.com/my_org/my_repo
+repository: https://github.com/flutter/packages/tree/main/packages/linked_text
+issue_tracker: https://github.com/flutter/flutter/issues
 
 environment:
-  sdk: ^3.4.0-14.0.dev
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
-# Add regular dependencies here.
 dependencies:
-  # path: ^1.8.0
+  flutter:
+    sdk: flutter
 
 dev_dependencies:
-  lints: ^3.0.0
   test: ^1.24.0

--- a/packages/linked_text/test/linked_text_test.dart
+++ b/packages/linked_text/test/linked_text_test.dart
@@ -1,0 +1,16 @@
+import 'package:linked_text/linked_text.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    final awesome = Awesome();
+
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      expect(awesome.isAwesome, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
A new package that provides the ability to automatically add working links into text.

This was originally part of the framework (https://github.com/flutter/flutter/pull/125927), but is being moved to a package. The reason is a close dependency on the `url_launcher` package for most functionality, which the Flutter framework does not depend on. Specifically, building a fully functional link on the web platform requires url_launcher's `Link` widget, and that's something I want users to have out of the box.