### PR TITLE
[go_router_builder] add support to go_router_builder for initializing a StatefulShellBranch with observers

### DIFF
--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.0
+
+* Adds support for passing observers to the StatefulShellBranch for the nested Navigator.
+
 ## 2.5.1
 
 - Updates examples to use uri.path instead of uri.toString() for accessing the current location.

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -146,6 +146,7 @@ class StatefulShellBranchConfig extends RouteBaseConfig {
     required this.navigatorKey,
     required super.routeDataClass,
     required super.parent,
+    required this.observers,
     this.restorationScopeId,
     this.initialLocation,
   }) : super._();
@@ -159,6 +160,9 @@ class StatefulShellBranchConfig extends RouteBaseConfig {
   /// The initial route.
   final String? initialLocation;
 
+  /// The navigator observers.
+  final String? observers;
+
   @override
   Iterable<String> classDeclarations() => <String>[];
 
@@ -168,7 +172,8 @@ class StatefulShellBranchConfig extends RouteBaseConfig {
   String get routeConstructorParameters =>
       '${navigatorKey == null ? '' : 'navigatorKey: $navigatorKey,'}'
       '${restorationScopeId == null ? '' : 'restorationScopeId: $restorationScopeId,'}'
-      '${initialLocation == null ? '' : 'initialLocation: $initialLocation,'}';
+      '${initialLocation == null ? '' : 'initialLocation: $initialLocation,'}'
+      '${observers == null ? '' : 'observers: $observers,'}';
 
   @override
   String get routeDataClassName => 'StatefulShellBranchData';
@@ -520,6 +525,10 @@ abstract class RouteBaseConfig {
           initialLocation: _generateParameterGetterCode(
             classElement,
             parameterName: r'$initialLocation',
+          ),
+          observers: _generateParameterGetterCode(
+            classElement,
+            parameterName: r'$observers',
           ),
         );
       case 'TypedGoRoute':

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -8,6 +8,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 
 environment:
   sdk: ^3.1.0
+  flutter: ">=3.10.0"
 
 dependencies:
   analyzer: ">=5.2.0 <7.0.0"
@@ -23,6 +24,8 @@ dependencies:
 dev_dependencies:
   build_test: ^2.1.7
   dart_style: 2.3.2
+  flutter:
+    sdk: flutter
   go_router: ^10.0.0
   test: ^1.20.0
 

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 2.5.1
+version: 2.6.0
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.10.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   analyzer: ">=5.2.0 <7.0.0"

--- a/packages/go_router_builder/test_inputs/statefull_shell_branch_with_observers_data.dart
+++ b/packages/go_router_builder/test_inputs/statefull_shell_branch_with_observers_data.dart
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+@TypedStatefulShellBranch<StatefulShellBranchWithObserversData>()
+class StatefulShellBranchWithObserversData extends StatefulShellBranchData {
+  const StatefulShellBranchWithObserversData();
+
+  static const String $initialLocation = '/main/second-tab';
+  static const List<NavigatorObserver> $observers = <NavigatorObserver>[];
+}

--- a/packages/go_router_builder/test_inputs/statefull_shell_branch_with_observers_data.dart.expect
+++ b/packages/go_router_builder/test_inputs/statefull_shell_branch_with_observers_data.dart.expect
@@ -1,0 +1,5 @@
+RouteBase get $statefulShellBranchWithObserversData =>
+    StatefulShellBranchData.$branch(
+      initialLocation: StatefulShellBranchWithObserversData.$initialLocation,
+      observers: StatefulShellBranchWithObserversData.$observers,
+    );


### PR DESCRIPTION
This pr added the ability to provide a list of NavigatorObservers to a StatefulShellBranch. 
The equivalent was never added to go_router_builder, so this pr provides that functionality.

With this change, you can provide NavigatorObservers directly to the StatefulShellBranch and fix https://github.com/flutter/flutter/issues/143869.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
