### PR TITLE
Update to avoid deprecated library

### DIFF
--- a/packages/file_selector/file_selector_web/example/integration_test/dom_helper_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/dom_helper_test.dart
@@ -8,7 +8,7 @@ import 'package:file_selector_platform_interface/file_selector_platform_interfac
 import 'package:file_selector_web/src/dom_helper.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 void main() {
   group('dom_helper', () {

--- a/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
@@ -9,7 +9,7 @@ import 'package:file_selector_web/file_selector_web.dart';
 import 'package:file_selector_web/src/dom_helper.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 void main() {
   group('FileSelectorWeb', () {

--- a/packages/shared_preferences/shared_preferences_web/example/integration_test/shared_preferences_web_test.dart
+++ b/packages/shared_preferences/shared_preferences_web/example/integration_test/shared_preferences_web_test.dart
@@ -10,7 +10,7 @@ import 'package:shared_preferences_platform_interface/types.dart';
 import 'package:shared_preferences_web/shared_preferences_web.dart';
 import 'package:shared_preferences_web/src/keys_extension.dart';
 
-import 'package:web/helpers.dart' as html;
+import 'package:web/web.dart' as html;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_web/src/link.dart';
-import 'package:web/helpers.dart' as html;
+import 'package:web/web.dart' as html;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
@@ -10,7 +10,7 @@ import 'package:integration_test/integration_test.dart';
 import 'package:mockito/mockito.dart' show Mock, any, verify, when;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 import 'package:url_launcher_web/url_launcher_web.dart';
-import 'package:web/helpers.dart' as html;
+import 'package:web/web.dart' as html;
 
 abstract class MyWindow {
   html.Window? open(Object? a, Object? b, Object? c);


### PR DESCRIPTION
Similar to https://github.com/flutter/devtools/pull/7037, update to avoid deprecated library.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
