### PR TITLE
Bump `release` to use 3.16.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       # the change if it doesn't.
       run: |
         cd $HOME
-        git clone https://github.com/flutter/flutter.git --depth 1 -b 3.16.0 _flutter
+        git clone https://github.com/flutter/flutter.git --depth 1 -b 3.16.6 _flutter
         echo "$HOME/_flutter/bin" >> $GITHUB_PATH
         cd $GITHUB_WORKSPACE
     # Checks out a copy of the repo.


### PR DESCRIPTION
google_maps_flutter_ios now requires 3.16.6, so we need to bump the release script so that it can be published by CI.

Fixes the tree.