### PR TITLE
[camera] Add `isDisposed` getter to `CameraController`

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.5+10
+
+* Adds `isDisposed` getter to `CameraController`.
+
 ## 0.10.5+9
 
 * Updates minimum required plugin_platform_interface version to 2.1.7.

--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -279,6 +279,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     assert(_isDisposed);
   }
 
+  /// Whether [CameraController.dispose] has been called.
+  bool get isDisposed => _isDisposed;
+
   /// The camera identifier with which the controller is associated.
   int get cameraId => _cameraId;
 

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.5+9
+version: 0.10.5+10
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/camera/camera/test/camera_preview_test.dart
+++ b/packages/camera/camera/test/camera_preview_test.dart
@@ -27,6 +27,9 @@ class FakeController extends ValueNotifier<CameraValue>
   }
 
   @override
+  bool get isDisposed => false;
+
+  @override
   int get cameraId => CameraController.kUninitializedCameraId;
 
   @override

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -124,7 +124,13 @@ void main() {
       expect(cameraController.value.previewSize, const Size(75, 75));
       expect(cameraController.value.isInitialized, isTrue);
 
-      await cameraController.dispose();
+      expect(cameraController.isDisposed, isFalse);
+
+      final Future<void> disposeFuture = cameraController.dispose();
+
+      expect(cameraController.isDisposed, isTrue);
+
+      await disposeFuture;
 
       verify(CameraPlatform.instance.dispose(13)).called(1);
     });


### PR DESCRIPTION
Add `isDisposed` getter to `CameraController`

Solves https://github.com/flutter/flutter/issues/141513

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
