### PR TITLE
[pigeon] Fix pigeon test generation missing wrapResponse method.

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 16.0.1
+
+* [dart] Fixes test generation for missing wrapResponse method if only host Api.
+
 ## 16.0.0
 
 * [java] Adds `VoidResult` type for `Void` returns.

--- a/packages/pigeon/lib/dart_generator.dart
+++ b/packages/pigeon/lib/dart_generator.dart
@@ -704,7 +704,7 @@ if (${_varNamePrefix}replyList == null) {
     if (hasHostApi) {
       _writeCreateConnectionError(indent);
     }
-    if (hasFlutterApi) {
+    if (hasFlutterApi || generatorOptions.testOutPath != null) {
       _writeWrapResponse(generatorOptions, root, indent);
     }
   }

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '16.0.0';
+const String pigeonVersion = '16.0.1';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -474,6 +474,7 @@ class DartGeneratorAdapter implements GeneratorAdapter {
     final DartOptions dartOptionsWithHeader = _dartOptionsWithCopyrightHeader(
       options.dartOptions,
       options.copyrightHeader,
+      testOutPath: options.dartTestOut,
       basePath: options.basePath ?? '',
     );
     const DartGenerator generator = DartGenerator();

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 16.0.0 # This must match the version in lib/generator_tools.dart
+version: 16.0.1 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -1746,4 +1746,36 @@ name: foobar
         contains(
             '\'Unable to establish connection on channel: "\$channelName".\''));
   });
+
+  test('generate wrapResponse if is generating tests', () {
+    final Root root = Root(
+      apis: <Api>[
+        Api(
+            name: 'Api',
+            location: ApiLocation.host,
+            dartHostTestHandler: 'ApiMock',
+            methods: <Method>[
+              Method(
+                  name: 'foo',
+                  returnType: const TypeDeclaration.voidDeclaration(),
+                  parameters: <Parameter>[])
+            ])
+      ],
+      classes: <Class>[],
+      enums: <Enum>[],
+    );
+
+    final StringBuffer mainCodeSink = StringBuffer();
+    const DartGenerator generator = DartGenerator();
+    generator.generate(
+      const DartOptions(
+        testOutPath: 'test.dart',
+      ),
+      root,
+      mainCodeSink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String mainCode = mainCodeSink.toString();
+    expect(mainCode, contains('List<Object?> wrapResponse('));
+  });
 }


### PR DESCRIPTION
Pigeon was not generating the wrapResponse method, and therefore failing compilation of the generated tests.

Fixes: https://github.com/flutter/flutter/issues/141499

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
