### PR TITLE
[ci] Add flags to formatter command to decide which formatters to run

### DIFF
--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -33,6 +33,7 @@ const int _exitGitFailed = 6;
 const int _exitDependencyMissing = 7;
 const int _exitSwiftFormatFailed = 8;
 const int _exitKotlinFormatFailed = 9;
+const int _exitUnsupportedPlatform = 10;
 
 final Uri _javaFormatterUrl = Uri.https('github.com',
     '/google/google-java-format/releases/download/google-java-format-1.3/google-java-format-1.3-all-deps.jar');
@@ -48,17 +49,29 @@ class FormatCommand extends PackageCommand {
     super.platform,
   }) {
     argParser.addFlag('fail-on-change', hide: true);
-    argParser.addOption(_clangFormatArg,
+    argParser.addFlag(_dartArg, help: 'Format Dart files', defaultsTo: true);
+    argParser.addFlag(_clangFormatArg,
+        help: 'Format with "clang-format"', defaultsTo: true);
+    argParser.addFlag(_kotlinArg,
+        help: 'Format Kotlin files', defaultsTo: true);
+    argParser.addFlag(_javaArg, help: 'Format Java files', defaultsTo: true);
+    argParser.addFlag(_swiftArg, help: 'Format Swift files');
+    argParser.addOption(_clangFormatPathArg,
         defaultsTo: 'clang-format', help: 'Path to "clang-format" executable.');
-    argParser.addOption(_javaArg,
+    argParser.addOption(_javaPathArg,
         defaultsTo: 'java', help: 'Path to "java" executable.');
-    argParser.addOption(_swiftFormatArg,
-        help: 'Path to "swift-format" executable.');
+    argParser.addOption(_swiftFormatPathArg,
+        defaultsTo: 'swift-format', help: 'Path to "swift-format" executable.');
   }
 
+  static const String _dartArg = 'dart';
   static const String _clangFormatArg = 'clang-format';
+  static const String _kotlinArg = 'kotlin';
   static const String _javaArg = 'java';
-  static const String _swiftFormatArg = 'swift-format';
+  static const String _swiftArg = 'swift';
+  static const String _clangFormatPathArg = 'clang-format-path';
+  static const String _javaPathArg = 'java-path';
+  static const String _swiftFormatPathArg = 'swift-format-path';
 
   @override
   final String name = 'format';
@@ -80,13 +93,25 @@ class FormatCommand extends PackageCommand {
     // due to the startup overhead of the formatters.
     final Iterable<String> files =
         await _getFilteredFilePaths(getFiles(), relativeTo: packagesDir);
-    await _formatDart(files);
-    await _formatJava(files, javaFormatterPath);
-    await _formatKotlin(files, kotlinFormatterPath);
-    await _formatCppAndObjectiveC(files);
-    final String? swiftFormat = getNullableStringArg(_swiftFormatArg);
-    if (swiftFormat != null) {
-      await _formatSwift(swiftFormat, files);
+    if (getBoolArg(_dartArg)) {
+      await _formatDart(files);
+    }
+    if (getBoolArg(_javaArg)) {
+      await _formatJava(files, javaFormatterPath);
+    }
+    if (getBoolArg(_kotlinArg)) {
+      await _formatKotlin(files, kotlinFormatterPath);
+    }
+    if (getBoolArg(_clangFormatArg)) {
+      await _formatCppAndObjectiveC(files);
+    }
+    if (getBoolArg(_swiftArg)) {
+      /// swift-format can run on Linux, but in CI it is only built for macOS.
+      if (!platform.isMacOS) {
+        printError('swift-format is only supported on macOS');
+        throw ToolExit(_exitUnsupportedPlatform);
+      }
+      await _formatSwift(files);
     }
 
     if (getBoolArg('fail-on-change')) {
@@ -158,7 +183,8 @@ class FormatCommand extends PackageCommand {
     }
   }
 
-  Future<void> _formatSwift(String swiftFormat, Iterable<String> files) async {
+  Future<void> _formatSwift(Iterable<String> files) async {
+    final String swiftFormat = await _findValidSwiftFormat();
     final Iterable<String> swiftFiles =
         _getPathsWithExtensions(files, <String>{'.swift'});
     if (swiftFiles.isNotEmpty) {
@@ -173,7 +199,7 @@ class FormatCommand extends PackageCommand {
   }
 
   Future<String> _findValidClangFormat() async {
-    final String clangFormat = getStringArg(_clangFormatArg);
+    final String clangFormat = getStringArg(_clangFormatPathArg);
     if (await _hasDependency(clangFormat)) {
       return clangFormat;
     }
@@ -188,7 +214,18 @@ class FormatCommand extends PackageCommand {
       }
     }
     printError('Unable to run "clang-format". Make sure that it is in your '
-        'path, or provide a full path with --clang-format.');
+        'path, or provide a full path with --$_clangFormatPathArg.');
+    throw ToolExit(_exitDependencyMissing);
+  }
+
+  Future<String> _findValidSwiftFormat() async {
+    final String swiftFormat = getStringArg(_swiftFormatPathArg);
+    if (await _hasDependency(swiftFormat)) {
+      return swiftFormat;
+    }
+
+    printError('Unable to run "swift-format". Make sure that it is in your '
+        'path, or provide a full path with --$_swiftFormatPathArg.');
     throw ToolExit(_exitDependencyMissing);
   }
 
@@ -196,11 +233,11 @@ class FormatCommand extends PackageCommand {
     final Iterable<String> javaFiles =
         _getPathsWithExtensions(files, <String>{'.java'});
     if (javaFiles.isNotEmpty) {
-      final String java = getStringArg('java');
+      final String java = getStringArg(_javaPathArg);
       if (!await _hasDependency(java)) {
         printError(
             'Unable to run "java". Make sure that it is in your path, or '
-            'provide a full path with --java.');
+            'provide a full path with --$_javaPathArg.');
         throw ToolExit(_exitDependencyMissing);
       }
 
@@ -220,11 +257,11 @@ class FormatCommand extends PackageCommand {
     final Iterable<String> kotlinFiles =
         _getPathsWithExtensions(files, <String>{'.kt'});
     if (kotlinFiles.isNotEmpty) {
-      final String java = getStringArg('java');
+      final String java = getStringArg(_javaPathArg);
       if (!await _hasDependency(java)) {
         printError(
             'Unable to run "java". Make sure that it is in your path, or '
-            'provide a full path with --java.');
+            'provide a full path with --$_javaPathArg.');
         throw ToolExit(_exitDependencyMissing);
       }
 

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -33,7 +33,6 @@ const int _exitGitFailed = 6;
 const int _exitDependencyMissing = 7;
 const int _exitSwiftFormatFailed = 8;
 const int _exitKotlinFormatFailed = 9;
-const int _exitUnsupportedPlatform = 10;
 
 final Uri _javaFormatterUrl = Uri.https('github.com',
     '/google/google-java-format/releases/download/google-java-format-1.3/google-java-format-1.3-all-deps.jar');
@@ -106,11 +105,6 @@ class FormatCommand extends PackageCommand {
       await _formatCppAndObjectiveC(files);
     }
     if (getBoolArg(_swiftArg)) {
-      /// swift-format can run on Linux, but in CI it is only built for macOS.
-      if (!platform.isMacOS) {
-        printError('swift-format is only supported on macOS');
-        throw ToolExit(_exitUnsupportedPlatform);
-      }
       await _formatSwift(files);
     }
 

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -169,6 +169,16 @@ void main() {
         ]));
   });
 
+  test('skips dart if --no-dart flag is provided', () async {
+    const List<String> files = <String>[
+      'lib/a.dart',
+    ];
+    createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+
+    await runCapturingPrint(runner, <String>['format', '--no-dart']);
+    expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
+  });
+
   test('formats .java files', () async {
     const List<String> files = <String>[
       'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
@@ -250,7 +260,7 @@ void main() {
         ]));
   });
 
-  test('honors --java flag', () async {
+  test('honors --java-path flag', () async {
     const List<String> files = <String>[
       'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
       'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
@@ -278,6 +288,16 @@ void main() {
               ],
               packagesDir.path),
         ]));
+  });
+
+  test('skips Java if --no-java flag is provided', () async {
+    const List<String> files = <String>[
+      'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
+    ];
+    createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+
+    await runCapturingPrint(runner, <String>['format', '--no-java']);
+    expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
   });
 
   test('formats c-ish files', () async {
@@ -377,7 +397,7 @@ void main() {
         ]));
   });
 
-  test('honors --clang-format flag', () async {
+  test('honors --clang-format-path flag', () async {
     const List<String> files = <String>[
       'windows/foo_plugin.cpp',
     ];
@@ -434,6 +454,16 @@ void main() {
         ]));
   });
 
+  test('skips clang-format if --no-clang-format flag is provided', () async {
+    const List<String> files = <String>[
+      'linux/foo_plugin.cc',
+    ];
+    createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+
+    await runCapturingPrint(runner, <String>['format', '--no-clang-format']);
+    expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
+  });
+
   group('kotlin-format', () {
     test('formats .kt files', () async {
       const List<String> files = <String>[
@@ -487,6 +517,16 @@ void main() {
           containsAllInOrder(<Matcher>[
             contains('Failed to format Kotlin files: exit code 1.'),
           ]));
+    });
+
+    test('skips Kotlin if --no-kotlin flag is provided', () async {
+      const List<String> files = <String>[
+        'android/src/main/kotlin/io/flutter/plugins/a_plugin/a.kt',
+      ];
+      createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+
+      await runCapturingPrint(runner, <String>['format', '--no-kotlin']);
+      expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
     });
   });
 


### PR DESCRIPTION
Get ready for a world where `swift-format` is available on the `PATH` https://flutter-review.googlesource.com/c/recipes/+/54020

1. Add `format --clang-format --java --kotlin --swift --dart` flags to decide whether to run specific formatters, as opposed to using the `path`.  Keep `swift-format` optional but default the others to run.  This matches the current behavior on Linux.
2. Add `*-path` variants of each.

This will allow us to run `format --swift --no-clang-format --no-java --no-kotlin --no-dart`  on the macOS bot so it doesn't duplicate same `format` call run on Linux.

Part of https://github.com/flutter/flutter/issues/41129

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
