### PR TITLE
[camera]fix a sample buffer memory leak on pause resume recording

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.9.13+11
 
-* Remove development team from example app.
+* Fixes a memory leak of sample buffer when pause and resume the video recording.
+* Removes development team from example app.
 * Updates minimum iOS version to 12.0 and minimum Flutter version to 3.16.6.
 
 ## 0.9.13+10

--- a/packages/camera/camera_avfoundation/ios/Classes/QueueUtils.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/QueueUtils.h
@@ -7,7 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Queue-specific context data to be associated with the capture session queue.
-extern const char* FLTCaptureSessionQueueSpecific;
+extern const char *FLTCaptureSessionQueueSpecific;
 
 /// Ensures the given block to be run on the main queue.
 /// If caller site is already on the main queue, the block will be run

--- a/packages/camera/camera_avfoundation/ios/Classes/QueueUtils.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/QueueUtils.h
@@ -7,7 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Queue-specific context data to be associated with the capture session queue.
-extern const char *FLTCaptureSessionQueueSpecific;
+extern const char* FLTCaptureSessionQueueSpecific;
 
 /// Ensures the given block to be run on the main queue.
 /// If caller site is already on the main queue, the block will be run

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.13+10
+version: 0.9.13+11
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
This memory leak happens when pause/resume the recording. Depending on camera resolution, about 1-2MB leaks for every resume, so it can add up pretty fast if we frequently pause/resume. 

We only reference this sample buffer inside the scope of this method (e.g. directly piping into file IO), so no need to retain it again, as it's already retained and will be released afterwards by apple. (We did keep around the pixel buffer, but we already manually [retain](https://github.com/flutter/packages/blob/d7ee75ad59ad7bc45e659d0599e935e9e7981ea1/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m#L403) and [release](https://github.com/flutter/packages/blob/d7ee75ad59ad7bc45e659d0599e935e9e7981ea1/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m#L415) that)

Bug was introduced in https://github.com/flutter/plugins/pull/1370. 


*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/132013

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
