### PR TITLE
Expose registered widget libraries and local widget library widgets.

### DIFF
--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.18
+
+* Exposes `WidgetLibrary`s registered in `Runtime`.
+* Exposes widgets map in `LocalWidgetLibrary`.
+
 ## 1.0.17
 
 * Adds support for tracking source locations of `BlobNode`s and

--- a/packages/rfw/lib/src/flutter/runtime.dart
+++ b/packages/rfw/lib/src/flutter/runtime.dart
@@ -4,10 +4,13 @@
 
 // This file is hand-formatted.
 
+import 'dart:collection';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import '../dart/model.dart';
+import '../../formats.dart';
+
 import 'content.dart';
 
 /// Signature of builders for local widgets.
@@ -169,6 +172,22 @@ class LocalWidgetLibrary extends WidgetLibrary {
   LocalWidgetBuilder? findConstructor(String name) {
     return _widgets[name];
   }
+
+  /// The widgets defined by this [LocalWidgetLibrary].
+  ///
+  /// The returned map is an immutable view of the map provided to the constructor.
+  /// They keys are the unqualified widget names, and the values are the corresponding
+  /// [LocalWidgetBuilder]s.
+  ///
+  /// The map never changes during the lifetime of the [LocalWidgetLibrary], but a new
+  /// instance of an [UnmodifiableMapView] is returned each time this getter is used.
+  ///
+  /// See also:
+  ///
+  ///  * [createCoreWidgets], a function that creates a [Map] of local widgets.
+  UnmodifiableMapView<String, LocalWidgetBuilder> get widgets {
+    return UnmodifiableMapView<String, LocalWidgetBuilder>(_widgets);
+  }
 }
 
 class _ResolvedConstructor {
@@ -224,6 +243,24 @@ class Runtime extends ChangeNotifier {
   void clearLibraries() {
     _libraries.clear();
     _clearCache();
+  }
+
+  /// The widget libraries imported in this [Runtime].
+  ///
+  /// The returned map is an immutable view of the map updated by calls to
+  /// [update] and [clearLibraries].
+  /// 
+  /// The keys are instances [LibraryName] which encode fully qualified library
+  /// names, and the values are the corresponding [WidgetLibrary]s.
+  /// 
+  /// The returned map is an immutable copy of the registered libraries
+  /// at the time of this call. 
+  ///
+  /// See also:
+  ///
+  ///  * [update] and [clearLibraries], functions that populate this map.
+  UnmodifiableMapView<LibraryName, WidgetLibrary> get libraries {
+    return UnmodifiableMapView<LibraryName, WidgetLibrary>(Map<LibraryName, WidgetLibrary>.from(_libraries));
   }
 
   final Map<FullyQualifiedWidgetName, _ResolvedConstructor?> _cachedConstructors = <FullyQualifiedWidgetName, _ResolvedConstructor?>{};

--- a/packages/rfw/pubspec.yaml
+++ b/packages/rfw/pubspec.yaml
@@ -2,7 +2,7 @@ name: rfw
 description: "Remote Flutter widgets: a library for rendering declarative widget description files at runtime."
 repository: https://github.com/flutter/packages/tree/main/packages/rfw
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+rfw%22
-version: 1.0.17
+version: 1.0.18
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/rfw/test/runtime_test.dart
+++ b/packages/rfw/test/runtime_test.dart
@@ -349,6 +349,18 @@ void main() {
 
   testWidgets('Runtime', (WidgetTester tester) async {
     final Runtime runtime = Runtime()
+          ..update(const LibraryName(<String>['core']), createCoreWidgets());
+    expect(runtime.libraries.length, 1);
+    final LibraryName libraryName = runtime.libraries.entries.first.key;
+    expect('$libraryName', 'core');
+    final WidgetLibrary widgetLibrary = runtime.libraries.entries.first.value;
+    expect(widgetLibrary, isA<LocalWidgetLibrary>());
+    widgetLibrary as LocalWidgetLibrary;
+    expect(widgetLibrary.widgets.length, greaterThan(1));
+  });
+
+  testWidgets('Runtime', (WidgetTester tester) async {
+    final Runtime runtime = Runtime()
       ..update(const LibraryName(<String>['core']), createCoreWidgets());
     final DynamicContent data = DynamicContent();
     await tester.pumpWidget(

--- a/packages/rfw/test_coverage/bin/test_coverage.dart
+++ b/packages/rfw/test_coverage/bin/test_coverage.dart
@@ -20,7 +20,7 @@ import 'package:meta/meta.dart';
 
 // Please update these targets when you update this package.
 // Please ensure that test coverage continues to be 100%.
-const int targetLines = 3219;
+const int targetLines = 3223;
 const String targetPercent = '100';
 const String lastUpdate = '2023-06-29';
 


### PR DESCRIPTION
This exposes the necessary information to allow rfwpg to display registered libraries and widgets in a list or tree.
