### PR TITLE
[camera_avfoundation] Add all missing iOS capture device types

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.14
+
+* Add missing all missing `AVCaptureDevice.DeviceType` objects when checking for available cameras.
+
 ## 0.9.13+11
 
 * Fixes a memory leak of sample buffer when pause and resume the video recording.

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.14
 
-* Add missing all missing `AVCaptureDevice.DeviceType` objects when checking for available cameras.
+* Adds missing `AVCaptureDevice.DeviceType` objects when checking for available cameras.
 
 ## 0.9.13+11
 

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/AvailableCamerasTest.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/AvailableCamerasTest.m
@@ -19,7 +19,6 @@
   XCTestExpectation *expectation =
       [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
 
-  // iPhone 13 Cameras:
   AVCaptureDevice *wideAngleCamera = OCMClassMock([AVCaptureDevice class]);
   OCMStub([wideAngleCamera uniqueID]).andReturn(@"0");
   OCMStub([wideAngleCamera position]).andReturn(AVCaptureDevicePositionBack);
@@ -28,19 +27,60 @@
   OCMStub([frontFacingCamera uniqueID]).andReturn(@"1");
   OCMStub([frontFacingCamera position]).andReturn(AVCaptureDevicePositionFront);
 
-  AVCaptureDevice *ultraWideCamera = OCMClassMock([AVCaptureDevice class]);
-  OCMStub([ultraWideCamera uniqueID]).andReturn(@"2");
-  OCMStub([ultraWideCamera position]).andReturn(AVCaptureDevicePositionBack);
-
   AVCaptureDevice *telephotoCamera = OCMClassMock([AVCaptureDevice class]);
-  OCMStub([telephotoCamera uniqueID]).andReturn(@"3");
+  OCMStub([telephotoCamera uniqueID]).andReturn(@"2");
   OCMStub([telephotoCamera position]).andReturn(AVCaptureDevicePositionBack);
 
+  AVCaptureDevice *trueDepthCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([trueDepthCamera uniqueID]).andReturn(@"3");
+  OCMStub([trueDepthCamera position]).andReturn(AVCaptureDevicePositionFront);
+
+  // iPhone 13 Cameras:
+  AVCaptureDevice *ultraWideCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([ultraWideCamera uniqueID]).andReturn(@"4");
+  OCMStub([ultraWideCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  AVCaptureDevice *dualWideCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([dualWideCamera uniqueID]).andReturn(@"5");
+  OCMStub([dualWideCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  AVCaptureDevice *tripleCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([tripleCamera uniqueID]).andReturn(@"6");
+  OCMStub([tripleCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  // iPhone 15.4 Cameras:
+  AVCaptureDevice *liDARDepthCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([liDARDepthCamera uniqueID]).andReturn(@"7");
+  OCMStub([liDARDepthCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  // iPhone 17 Cameras:
+  AVCaptureDevice *externalCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([externalCamera uniqueID]).andReturn(@"8");
+  OCMStub([externalCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  AVCaptureDevice *continuityCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([continuityCamera uniqueID]).andReturn(@"9");
+  OCMStub([continuityCamera position]).andReturn(AVCaptureDevicePositionBack);
+
   NSMutableArray *requiredTypes =
-      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
+      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+          AVCaptureDeviceTypeBuiltInTelephotoCamera,
+          AVCaptureDeviceTypeBuiltInDualCamera,
+          AVCaptureDeviceTypeBuiltInTrueDepthCamera ]
           mutableCopy];
   if (@available(iOS 13.0, *)) {
-    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+    [requiredTypes addObjectsFromArray:
+        @[ AVCaptureDeviceTypeBuiltInUltraWideCamera,
+           AVCaptureDeviceTypeBuiltInDualWideCamera,
+           AVCaptureDeviceTypeBuiltInTripleCamera ]];
+  }
+  if (@available(iOS 15.4, *)) {
+    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+  }
+  if (@available(iOS 17.0, *)) {
+    [requiredTypes addObjectsFromArray:
+        @[ AVCaptureDeviceTypeExternal,
+           AVCaptureDeviceTypeContinuityCamera ]];
   }
 
   id discoverySessionMock = OCMClassMock([AVCaptureDeviceDiscoverySession class]);
@@ -49,11 +89,18 @@
                                                        position:AVCaptureDevicePositionUnspecified])
       .andReturn(discoverySessionMock);
 
-  NSMutableArray *cameras = [NSMutableArray array];
-  [cameras addObjectsFromArray:@[ wideAngleCamera, frontFacingCamera, telephotoCamera ]];
+  NSMutableArray *cameras =
+      [@[ wideAngleCamera, frontFacingCamera, telephotoCamera, trueDepthCamera ] mutableCopy];
   if (@available(iOS 13.0, *)) {
-    [cameras addObject:ultraWideCamera];
+    [cameras addObjectsFromArray: @[ ultraWideCamera, dualWideCamera, tripleCamera ]];
   }
+  if (@available(iOS 15.4, *)) {
+    [cameras addObject:liDARDepthCamera];
+  }
+  if (@available(iOS 17.0, *)) {
+    [cameras addObjectsFromArray: @[ externalCamera, continuityCamera ]];
+  }
+
   OCMStub([discoverySessionMock devices]).andReturn([NSArray arrayWithArray:cameras]);
 
   MockFLTThreadSafeFlutterResult *resultObject =
@@ -67,10 +114,14 @@
 
   // Verify the result
   NSDictionary *dictionaryResult = (NSDictionary *)resultObject.receivedResult;
-  if (@available(iOS 13.0, *)) {
-    XCTAssertTrue([dictionaryResult count] == 4);
+  if (@available(iOS 17.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 10);
+  } else if (@available(iOS 15.4, *)) {
+    XCTAssertTrue([dictionaryResult count] == 8);
+  } else if (@available(iOS 13.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 7);
   } else {
-    XCTAssertTrue([dictionaryResult count] == 3);
+    XCTAssertTrue([dictionaryResult count] == 4);
   }
 }
 - (void)testAvailableCamerasShouldReturnOneCameraOnSingleCameraIPhone {
@@ -88,10 +139,24 @@
   OCMStub([frontFacingCamera position]).andReturn(AVCaptureDevicePositionFront);
 
   NSMutableArray *requiredTypes =
-      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
+      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+          AVCaptureDeviceTypeBuiltInTelephotoCamera,
+          AVCaptureDeviceTypeBuiltInDualCamera,
+          AVCaptureDeviceTypeBuiltInTrueDepthCamera ]
           mutableCopy];
   if (@available(iOS 13.0, *)) {
-    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+    [requiredTypes addObjectsFromArray:
+        @[ AVCaptureDeviceTypeBuiltInUltraWideCamera,
+           AVCaptureDeviceTypeBuiltInDualWideCamera,
+           AVCaptureDeviceTypeBuiltInTripleCamera ]];
+  }
+  if (@available(iOS 15.4, *)) {
+    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+  }
+  if (@available(iOS 17.0, *)) {
+    [requiredTypes addObjectsFromArray:
+        @[ AVCaptureDeviceTypeExternal,
+           AVCaptureDeviceTypeContinuityCamera ]];
   }
 
   id discoverySessionMock = OCMClassMock([AVCaptureDeviceDiscoverySession class]);
@@ -100,8 +165,7 @@
                                                        position:AVCaptureDevicePositionUnspecified])
       .andReturn(discoverySessionMock);
 
-  NSMutableArray *cameras = [NSMutableArray array];
-  [cameras addObjectsFromArray:@[ wideAngleCamera, frontFacingCamera ]];
+  NSMutableArray *cameras = [@[ wideAngleCamera, frontFacingCamera ] mutableCopy];
   OCMStub([discoverySessionMock devices]).andReturn([NSArray arrayWithArray:cameras]);
 
   MockFLTThreadSafeFlutterResult *resultObject =

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -105,10 +105,24 @@
                        result:(FLTThreadSafeFlutterResult *)result {
   if ([@"availableCameras" isEqualToString:call.method]) {
     NSMutableArray *discoveryDevices =
-        [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
-            mutableCopy];
+        [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+            AVCaptureDeviceTypeBuiltInTelephotoCamera,
+            AVCaptureDeviceTypeBuiltInDualCamera,
+            AVCaptureDeviceTypeBuiltInTrueDepthCamera]
+         mutableCopy];
     if (@available(iOS 13.0, *)) {
-      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+      [discoveryDevices addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInUltraWideCamera,
+             AVCaptureDeviceTypeBuiltInDualWideCamera,
+             AVCaptureDeviceTypeBuiltInTripleCamera ]];
+    }
+    if (@available(iOS 15.4, *)) {
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+    }
+    if (@available(iOS 17.0, *)) {
+      [discoveryDevices addObjectsFromArray:
+          @[ AVCaptureDeviceTypeExternal,
+             AVCaptureDeviceTypeContinuityCamera ]];
     }
     AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
         discoverySessionWithDeviceTypes:discoveryDevices

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.13+11
+version: 0.9.14
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
Several of the physical and logical cameras were missing when discovering available capture devices on iOS,  so I completed the list based on Apple's developer documentation: https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype

@bibaswan-bhawal had previously made a PR (#5892) that added one of these types, but I think it would be helpful to have the complete list available.

*List which issues are fixed by this PR. You must list at least one issue.*
closes flutter/flutter#134151
closes flutter/flutter#130073

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
