### PR TITLE
[camera_platform_interface] Add appleCaptureDeviceType to CameraDescription

### DIFF
--- a/packages/camera/camera/lib/camera.dart
+++ b/packages/camera/camera/lib/camera.dart
@@ -4,7 +4,6 @@
 
 export 'package:camera_platform_interface/camera_platform_interface.dart'
     show
-        AppleCaptureDeviceType,
         CameraDescription,
         CameraException,
         CameraLensDirection,

--- a/packages/camera/camera/lib/camera.dart
+++ b/packages/camera/camera/lib/camera.dart
@@ -4,6 +4,7 @@
 
 export 'package:camera_platform_interface/camera_platform_interface.dart'
     show
+        AppleCaptureDeviceType,
         CameraDescription,
         CameraException,
         CameraLensDirection,

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.7.3
+
+* Adds optional appleCaptureDeviceType to CameraDescription.
+
 ## 2.7.2
 
 * Updates minimum required plugin_platform_interface version to 2.1.7.

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
@@ -16,6 +16,40 @@ enum CameraLensDirection {
   external,
 }
 
+/// Capture device types used on Apple Device. Mirror of AVCaptureDevice.DeviceType:
+/// https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype
+enum AppleCaptureDeviceType {
+  /// A built-in wide-angle camera device type.
+  builtInWideAngleCamera,
+
+  /// A built-in camera device type with a shorter focal length than a wide-angle camera.
+  builtInUltraWideCamera,
+
+  /// A built-in camera device type with a longer focal length than a wide-angle camera.
+  builtInTelephotoCamera,
+
+  /// A built-in camera device type that consists of a wide-angle and telephoto camera.
+  builtInDualCamera,
+
+  /// A built-in camera device type that consists of two cameras of fixed focal length, one ultrawide angle and one wide angle.
+  builtInDualWideCamera,
+
+  /// A built-in camera device type that consists of three cameras of fixed focal length, one ultrawide angle, one wide angle, and one telephoto.
+  builtInTripleCamera,
+
+  /// A Continuity Camera device type.
+  continuityCamera,
+
+  /// An external device type.
+  external,
+
+  /// A device that consists of two cameras, one LiDAR and one YUV.
+  builtInLiDARDepthCamera,
+
+  /// A device that consists of two cameras, one Infrared and one YUV.
+  builtInTrueDepthCamera,
+}
+
 /// Properties of a camera device.
 @immutable
 class CameraDescription {
@@ -24,6 +58,7 @@ class CameraDescription {
     required this.name,
     required this.lensDirection,
     required this.sensorOrientation,
+    this.appleCaptureDeviceType,
   });
 
   /// The name of the camera device.
@@ -41,20 +76,24 @@ class CameraDescription {
   /// is from top to bottom in the sensor's coordinate system.
   final int sensorOrientation;
 
+  /// The type of the capture device on Apple devices.
+  final AppleCaptureDeviceType? appleCaptureDeviceType;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is CameraDescription &&
           runtimeType == other.runtimeType &&
           name == other.name &&
-          lensDirection == other.lensDirection;
+          lensDirection == other.lensDirection &&
+          appleCaptureDeviceType == other.appleCaptureDeviceType;
 
   @override
-  int get hashCode => Object.hash(name, lensDirection);
+  int get hashCode => Object.hash(name, lensDirection, appleCaptureDeviceType);
 
   @override
   String toString() {
     return '${objectRuntimeType(this, 'CameraDescription')}('
-        '$name, $lensDirection, $sensorOrientation)';
+        '$name, $lensDirection, $sensorOrientation, $appleCaptureDeviceType)';
   }
 }

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.7.2
+version: 2.7.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/camera/camera_platform_interface/test/types/camera_description_test.dart
+++ b/packages/camera/camera_platform_interface/test/types/camera_description_test.dart
@@ -24,17 +24,43 @@ void main() {
     });
   });
 
+  group('AppleCaptureDeviceType tests', () {
+    test('AppleCaptureDeviceType should contain 10 options', () {
+      const List<AppleCaptureDeviceType> values = AppleCaptureDeviceType.values;
+
+      expect(values.length, 10);
+    });
+
+    test('AppleCaptureDeviceType enum should have items in correct index', () {
+      const List<AppleCaptureDeviceType> values = AppleCaptureDeviceType.values;
+
+      expect(values[0], AppleCaptureDeviceType.builtInWideAngleCamera);
+      expect(values[1], AppleCaptureDeviceType.builtInUltraWideCamera);
+      expect(values[2], AppleCaptureDeviceType.builtInTelephotoCamera);
+      expect(values[3], AppleCaptureDeviceType.builtInDualCamera);
+      expect(values[4], AppleCaptureDeviceType.builtInDualWideCamera);
+      expect(values[5], AppleCaptureDeviceType.builtInTripleCamera);
+      expect(values[6], AppleCaptureDeviceType.continuityCamera);
+      expect(values[7], AppleCaptureDeviceType.external);
+      expect(values[8], AppleCaptureDeviceType.builtInLiDARDepthCamera);
+      expect(values[9], AppleCaptureDeviceType.builtInTrueDepthCamera);
+    });
+  });
+
   group('CameraDescription tests', () {
     test('Constructor should initialize all properties', () {
       const CameraDescription description = CameraDescription(
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
 
       expect(description.name, 'Test');
       expect(description.lensDirection, CameraLensDirection.front);
       expect(description.sensorOrientation, 90);
+      expect(description.appleCaptureDeviceType,
+          AppleCaptureDeviceType.builtInWideAngleCamera);
     });
 
     test('equals should return true if objects are the same', () {
@@ -42,11 +68,13 @@ void main() {
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
       const CameraDescription secondDescription = CameraDescription(
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
 
       expect(firstDescription == secondDescription, true);
@@ -57,11 +85,13 @@ void main() {
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
       const CameraDescription secondDescription = CameraDescription(
         name: 'Testing',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
 
       expect(firstDescription == secondDescription, false);
@@ -72,11 +102,13 @@ void main() {
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
       const CameraDescription secondDescription = CameraDescription(
         name: 'Test',
         lensDirection: CameraLensDirection.back,
         sensorOrientation: 90,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
 
       expect(firstDescription == secondDescription, false);
@@ -87,11 +119,63 @@ void main() {
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 0,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
       const CameraDescription secondDescription = CameraDescription(
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 90,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
+      );
+
+      expect(firstDescription == secondDescription, true);
+    });
+
+    test('equals should return false if apple capture device type is different',
+        () {
+      const CameraDescription firstDescription = CameraDescription(
+        name: 'Test',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 0,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
+      );
+      const CameraDescription secondDescription = CameraDescription(
+        name: 'Test',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 0,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInUltraWideCamera,
+      );
+
+      expect(firstDescription == secondDescription, false);
+    });
+
+    test('equals should return false if one apple capture device type is null',
+        () {
+      const CameraDescription firstDescription = CameraDescription(
+        name: 'Test',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 0,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
+      );
+      const CameraDescription secondDescription = CameraDescription(
+        name: 'Test',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 0,
+      );
+
+      expect(firstDescription == secondDescription, false);
+    });
+
+    test('equals should return true if apple capture device type is null', () {
+      const CameraDescription firstDescription = CameraDescription(
+        name: 'Test',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 0,
+      );
+      const CameraDescription secondDescription = CameraDescription(
+        name: 'Test',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 0,
       );
 
       expect(firstDescription == secondDescription, true);
@@ -103,9 +187,10 @@ void main() {
         name: 'Test',
         lensDirection: CameraLensDirection.front,
         sensorOrientation: 0,
+        appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
       );
-      final int expectedHashCode =
-          Object.hash(description.name, description.lensDirection);
+      final int expectedHashCode = Object.hash(description.name,
+          description.lensDirection, description.appleCaptureDeviceType);
 
       expect(description.hashCode, expectedHashCode);
     });


### PR DESCRIPTION
To more easily differentiate between the available cameras on iOS devices, the optional appleCaptureDeviceType parameter can become populated when discovering devices.

*List which issues are fixed by this PR. You must list at least one issue.*
Closes  flutter/flutter#142025

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.