### PR TITLE
[camera_avfoundation] Add capture device type to CameraDescription on iOS

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.14
+
+* Add missing all missing `AVCaptureDevice.DeviceType` objects when checking for available cameras.
+
 ## 0.9.13+11
 
 * Fixes a memory leak of sample buffer when pause and resume the video recording.

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.14
 
-* Add missing all missing `AVCaptureDevice.DeviceType` objects when checking for available cameras.
+* Adds missing `AVCaptureDevice.DeviceType` objects when checking for available cameras.
 
 ## 0.9.13+11
 

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.15
+
+* Add `AppleCaptureDeviceType` to CameraDescription when discovering available cameras.
+
 ## 0.9.14
 
 * Adds missing `AVCaptureDevice.DeviceType` objects when checking for available cameras.

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/AvailableCamerasTest.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/AvailableCamerasTest.m
@@ -19,7 +19,6 @@
   XCTestExpectation *expectation =
       [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
 
-  // iPhone 13 Cameras:
   AVCaptureDevice *wideAngleCamera = OCMClassMock([AVCaptureDevice class]);
   OCMStub([wideAngleCamera uniqueID]).andReturn(@"0");
   OCMStub([wideAngleCamera position]).andReturn(AVCaptureDevicePositionBack);
@@ -28,19 +27,60 @@
   OCMStub([frontFacingCamera uniqueID]).andReturn(@"1");
   OCMStub([frontFacingCamera position]).andReturn(AVCaptureDevicePositionFront);
 
-  AVCaptureDevice *ultraWideCamera = OCMClassMock([AVCaptureDevice class]);
-  OCMStub([ultraWideCamera uniqueID]).andReturn(@"2");
-  OCMStub([ultraWideCamera position]).andReturn(AVCaptureDevicePositionBack);
-
   AVCaptureDevice *telephotoCamera = OCMClassMock([AVCaptureDevice class]);
-  OCMStub([telephotoCamera uniqueID]).andReturn(@"3");
+  OCMStub([telephotoCamera uniqueID]).andReturn(@"2");
   OCMStub([telephotoCamera position]).andReturn(AVCaptureDevicePositionBack);
 
+  AVCaptureDevice *trueDepthCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([trueDepthCamera uniqueID]).andReturn(@"3");
+  OCMStub([trueDepthCamera position]).andReturn(AVCaptureDevicePositionFront);
+
+  // iPhone 13 Cameras:
+  AVCaptureDevice *ultraWideCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([ultraWideCamera uniqueID]).andReturn(@"4");
+  OCMStub([ultraWideCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  AVCaptureDevice *dualWideCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([dualWideCamera uniqueID]).andReturn(@"5");
+  OCMStub([dualWideCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  AVCaptureDevice *tripleCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([tripleCamera uniqueID]).andReturn(@"6");
+  OCMStub([tripleCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  // iPhone 15.4 Cameras:
+  AVCaptureDevice *liDARDepthCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([liDARDepthCamera uniqueID]).andReturn(@"7");
+  OCMStub([liDARDepthCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  // iPhone 17 Cameras:
+  AVCaptureDevice *externalCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([externalCamera uniqueID]).andReturn(@"8");
+  OCMStub([externalCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  AVCaptureDevice *continuityCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([continuityCamera uniqueID]).andReturn(@"9");
+  OCMStub([continuityCamera position]).andReturn(AVCaptureDevicePositionBack);
+
   NSMutableArray *requiredTypes =
-      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
+      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+          AVCaptureDeviceTypeBuiltInTelephotoCamera,
+          AVCaptureDeviceTypeBuiltInDualCamera,
+          AVCaptureDeviceTypeBuiltInTrueDepthCamera ]
           mutableCopy];
   if (@available(iOS 13.0, *)) {
-    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+    [requiredTypes addObjectsFromArray:
+        @[ AVCaptureDeviceTypeBuiltInUltraWideCamera,
+           AVCaptureDeviceTypeBuiltInDualWideCamera,
+           AVCaptureDeviceTypeBuiltInTripleCamera ]];
+  }
+  if (@available(iOS 15.4, *)) {
+    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+  }
+  if (@available(iOS 17.0, *)) {
+    [requiredTypes addObjectsFromArray:
+        @[ AVCaptureDeviceTypeExternal,
+           AVCaptureDeviceTypeContinuityCamera ]];
   }
 
   id discoverySessionMock = OCMClassMock([AVCaptureDeviceDiscoverySession class]);
@@ -49,11 +89,18 @@
                                                        position:AVCaptureDevicePositionUnspecified])
       .andReturn(discoverySessionMock);
 
-  NSMutableArray *cameras = [NSMutableArray array];
-  [cameras addObjectsFromArray:@[ wideAngleCamera, frontFacingCamera, telephotoCamera ]];
+  NSMutableArray *cameras =
+      [@[ wideAngleCamera, frontFacingCamera, telephotoCamera, trueDepthCamera ] mutableCopy];
   if (@available(iOS 13.0, *)) {
-    [cameras addObject:ultraWideCamera];
+    [cameras addObjectsFromArray: @[ ultraWideCamera, dualWideCamera, tripleCamera ]];
   }
+  if (@available(iOS 15.4, *)) {
+    [cameras addObject:liDARDepthCamera];
+  }
+  if (@available(iOS 17.0, *)) {
+    [cameras addObjectsFromArray: @[ externalCamera, continuityCamera ]];
+  }
+
   OCMStub([discoverySessionMock devices]).andReturn([NSArray arrayWithArray:cameras]);
 
   MockFLTThreadSafeFlutterResult *resultObject =
@@ -67,10 +114,14 @@
 
   // Verify the result
   NSDictionary *dictionaryResult = (NSDictionary *)resultObject.receivedResult;
-  if (@available(iOS 13.0, *)) {
-    XCTAssertTrue([dictionaryResult count] == 4);
+  if (@available(iOS 17.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 10);
+  } else if (@available(iOS 15.4, *)) {
+    XCTAssertTrue([dictionaryResult count] == 8);
+  } else if (@available(iOS 13.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 7);
   } else {
-    XCTAssertTrue([dictionaryResult count] == 3);
+    XCTAssertTrue([dictionaryResult count] == 4);
   }
 }
 - (void)testAvailableCamerasShouldReturnOneCameraOnSingleCameraIPhone {
@@ -88,10 +139,24 @@
   OCMStub([frontFacingCamera position]).andReturn(AVCaptureDevicePositionFront);
 
   NSMutableArray *requiredTypes =
-      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
+      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+          AVCaptureDeviceTypeBuiltInTelephotoCamera,
+          AVCaptureDeviceTypeBuiltInDualCamera,
+          AVCaptureDeviceTypeBuiltInTrueDepthCamera ]
           mutableCopy];
   if (@available(iOS 13.0, *)) {
-    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+    [requiredTypes addObjectsFromArray:
+        @[ AVCaptureDeviceTypeBuiltInUltraWideCamera,
+           AVCaptureDeviceTypeBuiltInDualWideCamera,
+           AVCaptureDeviceTypeBuiltInTripleCamera ]];
+  }
+  if (@available(iOS 15.4, *)) {
+    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+  }
+  if (@available(iOS 17.0, *)) {
+    [requiredTypes addObjectsFromArray:
+        @[ AVCaptureDeviceTypeExternal,
+           AVCaptureDeviceTypeContinuityCamera ]];
   }
 
   id discoverySessionMock = OCMClassMock([AVCaptureDeviceDiscoverySession class]);
@@ -100,8 +165,7 @@
                                                        position:AVCaptureDevicePositionUnspecified])
       .andReturn(discoverySessionMock);
 
-  NSMutableArray *cameras = [NSMutableArray array];
-  [cameras addObjectsFromArray:@[ wideAngleCamera, frontFacingCamera ]];
+  NSMutableArray *cameras = [@[ wideAngleCamera, frontFacingCamera ] mutableCopy];
   OCMStub([discoverySessionMock devices]).andReturn([NSArray arrayWithArray:cameras]);
 
   MockFLTThreadSafeFlutterResult *resultObject =

--- a/packages/camera/camera_avfoundation/example/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  camera_platform_interface: ^2.4.0
+  camera_platform_interface: ^2.7.3
   flutter:
     sdk: flutter
   path_provider: ^2.0.0

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -144,10 +144,35 @@
           lensFacing = @"external";
           break;
       }
+      NSString *deviceType;
+      if ([device deviceType] == AVCaptureDeviceTypeBuiltInWideAngleCamera) {
+        deviceType = @"builtInWideAngleCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTelephotoCamera) {
+        deviceType = @"builtInTelephotoCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInUltraWideCamera) {
+        deviceType = @"builtInUltraWideCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInDualCamera) {
+        deviceType = @"builtInDualCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInDualWideCamera) {
+        deviceType = @"builtInDualWideCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTripleCamera) {
+        deviceType = @"builtInTripleCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeContinuityCamera) {
+        deviceType = @"continuityCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeExternal) {
+        deviceType = @"external";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInLiDARDepthCamera) {
+        deviceType = @"builtInLiDARDepthCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTrueDepthCamera) {
+        deviceType = @"builtInTrueDepthCamera";
+      } else {
+        deviceType = @"unknown";
+      }
       [reply addObject:@{
         @"name" : [device uniqueID],
         @"lensFacing" : lensFacing,
         @"sensorOrientation" : @90,
+        @"deviceType" : deviceType,
       }];
     }
     [result sendSuccessWithData:reply];

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -105,10 +105,24 @@
                        result:(FLTThreadSafeFlutterResult *)result {
   if ([@"availableCameras" isEqualToString:call.method]) {
     NSMutableArray *discoveryDevices =
-        [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
-            mutableCopy];
+        [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+            AVCaptureDeviceTypeBuiltInTelephotoCamera,
+            AVCaptureDeviceTypeBuiltInDualCamera,
+            AVCaptureDeviceTypeBuiltInTrueDepthCamera]
+         mutableCopy];
     if (@available(iOS 13.0, *)) {
-      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+      [discoveryDevices addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInUltraWideCamera,
+             AVCaptureDeviceTypeBuiltInDualWideCamera,
+             AVCaptureDeviceTypeBuiltInTripleCamera ]];
+    }
+    if (@available(iOS 15.4, *)) {
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+    }
+    if (@available(iOS 17.0, *)) {
+      [discoveryDevices addObjectsFromArray:
+          @[ AVCaptureDeviceTypeExternal,
+             AVCaptureDeviceTypeContinuityCamera ]];
     }
     AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
         discoverySessionWithDeviceTypes:discoveryDevices

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -84,6 +84,8 @@ class AVFoundationCamera extends CameraPlatform {
           lensDirection:
               parseCameraLensDirection(camera['lensFacing']! as String),
           sensorOrientation: camera['sensorOrientation']! as int,
+          appleCaptureDeviceType:
+              parseAppleCaptureDeviceType(camera['deviceType']! as String),
         );
       }).toList();
     } on PlatformException catch (e) {

--- a/packages/camera/camera_avfoundation/lib/src/utils.dart
+++ b/packages/camera/camera_avfoundation/lib/src/utils.dart
@@ -18,6 +18,33 @@ CameraLensDirection parseCameraLensDirection(String string) {
   throw ArgumentError('Unknown CameraLensDirection value');
 }
 
+/// Parses the [type] into an [AppleCaptureDeviceType].
+AppleCaptureDeviceType? parseAppleCaptureDeviceType(String type) {
+  switch (type) {
+    case 'builtInWideAngleCamera':
+      return AppleCaptureDeviceType.builtInWideAngleCamera;
+    case 'builtInUltraWideCamera':
+      return AppleCaptureDeviceType.builtInUltraWideCamera;
+    case 'builtInTelephotoCamera':
+      return AppleCaptureDeviceType.builtInTelephotoCamera;
+    case 'builtInDualCamera':
+      return AppleCaptureDeviceType.builtInDualCamera;
+    case 'builtInDualWideCamera':
+      return AppleCaptureDeviceType.builtInDualWideCamera;
+    case 'builtInTripleCamera':
+      return AppleCaptureDeviceType.builtInTripleCamera;
+    case 'continuityCamera':
+      return AppleCaptureDeviceType.continuityCamera;
+    case 'external':
+      return AppleCaptureDeviceType.external;
+    case 'builtInLiDARDepthCamera':
+      return AppleCaptureDeviceType.builtInLiDARDepthCamera;
+    case 'builtInTrueDepthCamera':
+      return AppleCaptureDeviceType.builtInTrueDepthCamera;
+  }
+  throw ArgumentError('Unknown AppleCaptureDeviceType value');
+}
+
 /// Returns the device orientation as a String.
 String serializeDeviceOrientation(DeviceOrientation orientation) {
   switch (orientation) {

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.14
+version: 0.9.15
 
 environment:
   sdk: ^3.2.3
@@ -17,7 +17,7 @@ flutter:
         dartPluginClass: AVFoundationCamera
 
 dependencies:
-  camera_platform_interface: ^2.4.0
+  camera_platform_interface: ^2.7.3
   flutter:
     sdk: flutter
   stream_transform: ^2.0.0

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.13+11
+version: 0.9.14
 
 environment:
   sdk: ^3.2.3

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -62,7 +62,9 @@ void main() {
         const CameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0),
+            sensorOrientation: 0,
+            appleCaptureDeviceType:
+                AppleCaptureDeviceType.builtInWideAngleCamera),
         ResolutionPreset.high,
       );
 
@@ -98,6 +100,8 @@ void main() {
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
+            appleCaptureDeviceType:
+                AppleCaptureDeviceType.builtInWideAngleCamera,
           ),
           ResolutionPreset.high,
         ),
@@ -129,6 +133,8 @@ void main() {
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
+            appleCaptureDeviceType:
+                AppleCaptureDeviceType.builtInWideAngleCamera,
           ),
           ResolutionPreset.high,
         ),
@@ -191,6 +197,7 @@ void main() {
           name: 'Test',
           lensDirection: CameraLensDirection.back,
           sensorOrientation: 0,
+          appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
         ),
         ResolutionPreset.high,
       );
@@ -238,6 +245,7 @@ void main() {
           name: 'Test',
           lensDirection: CameraLensDirection.back,
           sensorOrientation: 0,
+          appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
         ),
         ResolutionPreset.high,
       );
@@ -286,6 +294,7 @@ void main() {
           name: 'Test',
           lensDirection: CameraLensDirection.back,
           sensorOrientation: 0,
+          appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
         ),
         ResolutionPreset.high,
       );
@@ -459,6 +468,7 @@ void main() {
           name: 'Test',
           lensDirection: CameraLensDirection.back,
           sensorOrientation: 0,
+          appleCaptureDeviceType: AppleCaptureDeviceType.builtInWideAngleCamera,
         ),
         ResolutionPreset.high,
       );
@@ -487,12 +497,14 @@ void main() {
         <String, dynamic>{
           'name': 'Test 1',
           'lensFacing': 'front',
-          'sensorOrientation': 1
+          'sensorOrientation': 1,
+          'deviceType': 'builtInTrueDepthCamera'
         },
         <String, dynamic>{
           'name': 'Test 2',
           'lensFacing': 'back',
-          'sensorOrientation': 2
+          'sensorOrientation': 2,
+          'deviceType': 'builtInWideAngleCamera'
         }
       ];
       final MethodChannelMock channel = MethodChannelMock(
@@ -516,6 +528,8 @@ void main() {
           lensDirection:
               parseCameraLensDirection(typedData['lensFacing']! as String),
           sensorOrientation: typedData['sensorOrientation']! as int,
+          appleCaptureDeviceType:
+              parseAppleCaptureDeviceType(typedData['deviceType']! as String),
         );
         expect(cameras[i], cameraDescription);
       }
@@ -710,7 +724,9 @@ void main() {
       const CameraDescription camera2Description = CameraDescription(
           name: 'Test2',
           lensDirection: CameraLensDirection.front,
-          sensorOrientation: 0);
+          sensorOrientation: 0,
+          appleCaptureDeviceType:
+              AppleCaptureDeviceType.builtInWideAngleCamera);
 
       // Act
       await camera.setDescriptionWhileRecording(camera2Description);

--- a/packages/camera/camera_avfoundation/test/utils_test.dart
+++ b/packages/camera/camera_avfoundation/test/utils_test.dart
@@ -35,6 +35,51 @@ void main() {
       );
     });
 
+    test(
+        'Should return AppleCaptureDeviceType when valid value is supplied when parsing Apple capture device type',
+        () {
+      expect(
+        parseAppleCaptureDeviceType('builtInWideAngleCamera'),
+        AppleCaptureDeviceType.builtInWideAngleCamera,
+      );
+      expect(
+        parseAppleCaptureDeviceType('builtInUltraWideCamera'),
+        AppleCaptureDeviceType.builtInUltraWideCamera,
+      );
+      expect(
+        parseAppleCaptureDeviceType('builtInTelephotoCamera'),
+        AppleCaptureDeviceType.builtInTelephotoCamera,
+      );
+      expect(
+        parseAppleCaptureDeviceType('builtInDualCamera'),
+        AppleCaptureDeviceType.builtInDualCamera,
+      );
+      expect(
+        parseAppleCaptureDeviceType('builtInDualWideCamera'),
+        AppleCaptureDeviceType.builtInDualWideCamera,
+      );
+      expect(
+        parseAppleCaptureDeviceType('builtInTripleCamera'),
+        AppleCaptureDeviceType.builtInTripleCamera,
+      );
+      expect(
+        parseAppleCaptureDeviceType('continuityCamera'),
+        AppleCaptureDeviceType.continuityCamera,
+      );
+      expect(
+        parseAppleCaptureDeviceType('external'),
+        AppleCaptureDeviceType.external,
+      );
+      expect(
+        parseAppleCaptureDeviceType('builtInLiDARDepthCamera'),
+        AppleCaptureDeviceType.builtInLiDARDepthCamera,
+      );
+      expect(
+        parseAppleCaptureDeviceType('builtInTrueDepthCamera'),
+        AppleCaptureDeviceType.builtInTrueDepthCamera,
+      );
+    });
+
     test('serializeDeviceOrientation() should serialize correctly', () {
       expect(serializeDeviceOrientation(DeviceOrientation.portraitUp),
           'portraitUp');


### PR DESCRIPTION
When checking availableDevices, add the appropriate `AppleCaptureDeviceType` to the `CameraDescription`. This PR is dependant on both #5957 and #5958 

*List which issues are fixed by this PR. You must list at least one issue.*
Closes https://github.com/flutter/flutter/issues/142025

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.