### PR TITLE
Add Kotlin to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ use, and use auto-formatters:
     for more details, and exceptions.
 - [Java](https://google.github.io/styleguide/javaguide.html) formatted with
   `google-java-format`
+- [Kotlin](https://developer.android.com/kotlin/style-guide) formatted with
+  `ktfmt`
 - [Objective-C](https://google.github.io/styleguide/objcguide.html) formatted with
   `clang-format`
 - [Swift](https://google.github.io/swift/) formatted with `swift-format`


### PR DESCRIPTION
I never updated the contributing notes about languages when we added Kotlin to the repo.