### PR TITLE
[various] Disambiguate TestDefaultBinaryMessengerBinding

### DIFF
--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -32,15 +32,14 @@ void main() {
     // registerWith is called very early in initialization the bindings won't
     // have been initialized. While registerWith could initialize them, that
     // could slow down startup, so instead the handler should be set up lazily.
-    final ByteData? response =
-        await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
-            .handlePlatformMessage(
-                AVFoundationCamera.deviceEventChannelName,
-                const StandardMethodCodec().encodeMethodCall(const MethodCall(
-                    'orientation_changed',
-                    <String, Object>{'orientation': 'portraitDown'})),
-                (ByteData? data) {});
+    final ByteData? response = await TestDefaultBinaryMessengerBinding
+        .instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+            AVFoundationCamera.deviceEventChannelName,
+            const StandardMethodCodec().encodeMethodCall(const MethodCall(
+                'orientation_changed',
+                <String, Object>{'orientation': 'portraitDown'})),
+            (ByteData? data) {});
     expect(response, null);
   });
 
@@ -422,8 +421,7 @@ void main() {
       const DeviceOrientationChangedEvent event =
           DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
       for (int i = 0; i < 3; i++) {
-        await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .handlePlatformMessage(
                 AVFoundationCamera.deviceEventChannelName,
                 const StandardMethodCodec().encodeMethodCall(
@@ -1187,9 +1185,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/camera/camera_avfoundation/test/method_channel_mock.dart
+++ b/packages/camera/camera_avfoundation/test/method_channel_mock.dart
@@ -11,8 +11,7 @@ class MethodChannelMock {
     this.delay,
     required this.methods,
   }) : methodChannel = MethodChannel(channelName) {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, _handler);
   }
 
@@ -39,9 +38,3 @@ class MethodChannelMock {
     });
   }
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/camera/camera_platform_interface/test/utils/method_channel_mock.dart
+++ b/packages/camera/camera_platform_interface/test/utils/method_channel_mock.dart
@@ -11,8 +11,7 @@ class MethodChannelMock {
     this.delay,
     required this.methods,
   }) : methodChannel = MethodChannel(channelName) {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, _handler);
   }
 
@@ -39,9 +38,3 @@ class MethodChannelMock {
     });
   }
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/camera/camera_windows/test/utils/method_channel_mock.dart
+++ b/packages/camera/camera_windows/test/utils/method_channel_mock.dart
@@ -17,8 +17,7 @@ class MethodChannelMock {
     this.delay,
     required this.methods,
   }) : methodChannel = MethodChannel(channelName) {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, _handler);
   }
 
@@ -45,9 +44,3 @@ class MethodChannelMock {
     });
   }
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -16,8 +16,7 @@ void main() {
   setUp(() {
     plugin = FileSelectorLinux();
     log = <MethodCall>[];
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       plugin.channel,
       (MethodCall methodCall) async {
@@ -527,9 +526,3 @@ void expectMethodCall(
 }) {
   expect(log, <Matcher>[isMethodCall(methodName, arguments: arguments)]);
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
@@ -16,8 +16,7 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
 
     setUp(() {
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
         plugin.channel,
         (MethodCall methodCall) async {
@@ -279,9 +278,3 @@ void expectMethodCall(
 }) {
   expect(log, <Matcher>[isMethodCall(methodName, arguments: arguments)]);
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -774,8 +774,7 @@ void main() {
         'Handles the Android back button when parentNavigatorKey is set to the root navigator',
         (WidgetTester tester) async {
       final List<MethodCall> log = <MethodCall>[];
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform,
               (MethodCall methodCall) async {
         log.add(methodCall);
@@ -817,8 +816,7 @@ void main() {
     testWidgets("Handles the Android back button when ShellRoute can't pop",
         (WidgetTester tester) async {
       final List<MethodCall> log = <MethodCall>[];
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform,
               (MethodCall methodCall) async {
         log.add(methodCall);
@@ -917,8 +915,7 @@ void main() {
       'Handles the Android back button when a second Shell has a GoRoute with parentNavigator key',
       (WidgetTester tester) async {
     final List<MethodCall> log = <MethodCall>[];
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform,
             (MethodCall methodCall) async {
       log.add(methodCall);
@@ -1008,8 +1005,7 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
     setUp(() {
       GoRouter.optionURLReflectsImperativeAPIs = false;
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.navigation,
               (MethodCall methodCall) async {
         log.add(methodCall);
@@ -1018,8 +1014,7 @@ void main() {
     });
     tearDown(() {
       GoRouter.optionURLReflectsImperativeAPIs = false;
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.navigation, null);
       log.clear();
     });
@@ -5158,9 +5153,3 @@ class IsRouteUpdateCall extends Matcher {
         .addDescriptionOf(replace);
   }
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
@@ -27,8 +27,7 @@ void main() {
     required Future<dynamic>? Function(MethodCall call) handler,
   }) {
     final MethodChannel channel = maps.ensureChannelInitialized(mapId);
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) {
@@ -42,8 +41,7 @@ void main() {
       int mapId, String method, Map<dynamic, dynamic> data) async {
     final ByteData byteData =
         const StandardMethodCodec().encodeMethodCall(MethodCall(method, data));
-    await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .handlePlatformMessage('plugins.flutter.dev/google_maps_android_$mapId',
             byteData, (ByteData? data) {});
   }
@@ -218,9 +216,3 @@ void main() {
     );
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
@@ -27,8 +27,7 @@ void main() {
     required Future<dynamic>? Function(MethodCall call) handler,
   }) {
     final MethodChannel channel = maps.ensureChannelInitialized(mapId);
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) {
@@ -42,8 +41,7 @@ void main() {
       int mapId, String method, Map<dynamic, dynamic> data) async {
     final ByteData byteData =
         const StandardMethodCodec().encodeMethodCall(MethodCall(method, data));
-    await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .handlePlatformMessage('plugins.flutter.dev/google_maps_ios_$mapId',
             byteData, (ByteData? data) {});
   }
@@ -179,9 +177,3 @@ void main() {
     );
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/method_channel/method_channel_google_maps_flutter_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/method_channel/method_channel_google_maps_flutter_test.dart
@@ -25,8 +25,7 @@ void main() {
       required Future<dynamic>? Function(MethodCall call) handler,
     }) {
       final MethodChannel channel = maps.ensureChannelInitialized(mapId);
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
         channel,
         (MethodCall methodCall) {
@@ -40,8 +39,7 @@ void main() {
         int mapId, String method, Map<dynamic, dynamic> data) async {
       final ByteData byteData = const StandardMethodCodec()
           .encodeMethodCall(MethodCall(method, data));
-      await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .handlePlatformMessage('plugins.flutter.io/google_maps_$mapId',
               byteData, (ByteData? data) {});
     }
@@ -125,9 +123,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/google_sign_in/google_sign_in_platform_interface/test/method_channel_google_sign_in_test.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/test/method_channel_google_sign_in_test.dart
@@ -50,8 +50,7 @@ void main() {
 
     setUp(() {
       responses = Map<String, dynamic>.from(kDefaultResponses);
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) {
         log.add(methodCall);
         final dynamic response = responses[methodCall.method];
@@ -173,9 +172,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/image_picker/image_picker_platform_interface/test/method_channel_image_picker_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/method_channel_image_picker_test.dart
@@ -18,8 +18,7 @@ void main() {
 
     setUp(() {
       returnValue = '';
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(picker.channel,
               (MethodCall methodCall) async {
         log.add(methodCall);
@@ -188,8 +187,7 @@ void main() {
       });
 
       test('handles a null image path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
 
@@ -357,8 +355,7 @@ void main() {
       });
 
       test('handles a null image path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
 
@@ -431,8 +428,7 @@ void main() {
       });
 
       test('handles a null video path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
 
@@ -476,8 +472,7 @@ void main() {
 
     group('#retrieveLostData', () {
       test('retrieveLostData get success response', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return <String, String>{
@@ -492,8 +487,7 @@ void main() {
       });
 
       test('retrieveLostData get error response', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return <String, String>{
@@ -510,8 +504,7 @@ void main() {
       });
 
       test('retrieveLostData get null response', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return null;
@@ -520,8 +513,7 @@ void main() {
       });
 
       test('retrieveLostData get both path and error should throw', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return <String, String>{
@@ -693,8 +685,7 @@ void main() {
       });
 
       test('handles a null image path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
 
@@ -862,8 +853,7 @@ void main() {
       });
 
       test('handles a null image path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
 
@@ -1007,8 +997,7 @@ void main() {
       });
 
       test('handles a null path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
         expect(
@@ -1082,8 +1071,7 @@ void main() {
       });
 
       test('handles a null video path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
 
@@ -1127,8 +1115,7 @@ void main() {
 
     group('#getLostData', () {
       test('getLostData get success response', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return <String, String>{
@@ -1143,8 +1130,7 @@ void main() {
       });
 
       test('getLostData should successfully retrieve multiple files', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return <String, dynamic>{
@@ -1162,8 +1148,7 @@ void main() {
       });
 
       test('getLostData get error response', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return <String, String>{
@@ -1180,8 +1165,7 @@ void main() {
       });
 
       test('getLostData get null response', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return null;
@@ -1190,8 +1174,7 @@ void main() {
       });
 
       test('getLostData get both path and error should throw', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(picker.channel,
                 (MethodCall methodCall) async {
           return <String, String>{
@@ -1389,8 +1372,7 @@ void main() {
       });
 
       test('handles a null image path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
 
@@ -1621,8 +1603,7 @@ void main() {
       });
 
       test('handles a null image path response gracefully', () async {
-        _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-            .defaultBinaryMessenger
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
                 picker.channel, (MethodCall methodCall) => null);
 
@@ -1670,9 +1651,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_manager_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_manager_test.dart
@@ -26,8 +26,8 @@ void main() {
   const String onBillingServiceDisconnectedCallback =
       'BillingClientStateListener#onBillingServiceDisconnected()';
 
-  setUpAll(() => _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-      .defaultBinaryMessenger
+  setUpAll(() => TestDefaultBinaryMessengerBinding
+      .instance.defaultBinaryMessenger
       .setMockMethodCallHandler(channel, stubPlatform.fakeMethodCallHandler));
 
   setUp(() {
@@ -110,9 +110,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -31,8 +31,8 @@ void main() {
   final StubInAppPurchasePlatform stubPlatform = StubInAppPurchasePlatform();
   late BillingClient billingClient;
 
-  setUpAll(() => _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-      .defaultBinaryMessenger
+  setUpAll(() => TestDefaultBinaryMessengerBinding
+      .instance.defaultBinaryMessenger
       .setMockMethodCallHandler(channel, stubPlatform.fakeMethodCallHandler));
 
   setUp(() {
@@ -642,9 +642,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_addition_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_addition_test.dart
@@ -22,8 +22,7 @@ void main() {
   const String endConnectionCall = 'BillingClient#endConnection()';
 
   setUpAll(() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, stubPlatform.fakeMethodCallHandler);
   });
 
@@ -175,9 +174,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
@@ -30,8 +30,7 @@ void main() {
       'BillingClientStateListener#onBillingServiceDisconnected()';
 
   setUpAll(() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, stubPlatform.fakeMethodCallHandler);
   });
 
@@ -852,9 +851,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
@@ -14,8 +14,7 @@ import '../store_kit_wrappers/sk_test_stub_objects.dart';
 
 class FakeStoreKitPlatform {
   FakeStoreKitPlatform() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, onMethodCall);
   }
 
@@ -233,9 +232,3 @@ class FakeStoreKitPlatform {
     return (call.arguments as Map<Object?, Object?>).cast<String, Object?>();
   }
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_addtion_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_addtion_test.dart
@@ -15,8 +15,7 @@ void main() {
   final FakeStoreKitPlatform fakeStoreKitPlatform = FakeStoreKitPlatform();
 
   setUpAll(() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
             SystemChannels.platform, fakeStoreKitPlatform.onMethodCall);
   });
@@ -41,9 +40,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_test.dart
@@ -21,8 +21,7 @@ void main() {
   late InAppPurchaseStoreKitPlatform iapStoreKitPlatform;
 
   setUpAll(() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
             SystemChannels.platform, fakeStoreKitPlatform.onMethodCall);
   });
@@ -573,9 +572,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
@@ -14,8 +14,7 @@ void main() {
   final FakeStoreKitPlatform fakeStoreKitPlatform = FakeStoreKitPlatform();
 
   setUpAll(() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
             SystemChannels.platform, fakeStoreKitPlatform.onMethodCall);
   });
@@ -203,8 +202,7 @@ void main() {
 
 class FakeStoreKitPlatform {
   FakeStoreKitPlatform() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, onMethodCall);
   }
   // get product request
@@ -331,9 +329,3 @@ class TestPaymentTransactionObserver extends SKTransactionObserverWrapper {
     return true;
   }
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_payment_queue_delegate_api_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_payment_queue_delegate_api_test.dart
@@ -13,8 +13,7 @@ void main() {
   final FakeStoreKitPlatform fakeStoreKitPlatform = FakeStoreKitPlatform();
 
   setUpAll(() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
             SystemChannels.platform, fakeStoreKitPlatform.onMethodCall);
   });
@@ -150,8 +149,7 @@ class TestPaymentQueueDelegate extends SKPaymentQueueDelegateWrapper {
 
 class FakeStoreKitPlatform {
   FakeStoreKitPlatform() {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, onMethodCall);
   }
 
@@ -170,9 +168,3 @@ class FakeStoreKitPlatform {
     return Future<dynamic>.error('method not mocked');
   }
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/local_auth/local_auth_platform_interface/test/default_method_channel_platform_test.dart
+++ b/packages/local_auth/local_auth_platform_interface/test/default_method_channel_platform_test.dart
@@ -29,8 +29,7 @@ void main() {
   });
 
   test('getAvailableBiometrics', () async {
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) {
       log.add(methodCall);
       return Future<dynamic>.value(<String>[]);
@@ -51,8 +50,7 @@ void main() {
     // existing unendorsed implementations, used 'undefined' as a special
     // return value from `getAvailableBiometrics` to indicate that nothing was
     // enrolled, but that the hardware does support biometrics.
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) {
       log.add(methodCall);
       return Future<dynamic>.value(<String>['undefined']);
@@ -72,8 +70,7 @@ void main() {
 
   group('Boolean returning methods', () {
     setUp(() {
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) {
         log.add(methodCall);
         return Future<dynamic>.value(true);
@@ -204,9 +201,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/path_provider/path_provider_platform_interface/test/method_channel_path_provider_test.dart
+++ b/packages/path_provider/path_provider_platform_interface/test/method_channel_path_provider_test.dart
@@ -26,8 +26,7 @@ void main() {
     setUp(() async {
       methodChannelPathProvider = MethodChannelPathProvider();
 
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(methodChannelPathProvider.methodChannel,
               (MethodCall methodCall) async {
         log.add(methodCall);
@@ -221,9 +220,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/quick_actions/quick_actions_platform_interface/test/method_channel_quick_actions_test.dart
+++ b/packages/quick_actions/quick_actions_platform_interface/test/method_channel_quick_actions_test.dart
@@ -18,8 +18,7 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
 
     setUp(() {
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(quickActions.channel,
               (MethodCall methodCall) async {
         log.add(methodCall);
@@ -150,9 +149,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/method_channel_shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/method_channel_shared_preferences_test.dart
@@ -59,8 +59,7 @@ void main() {
             .cast<String, Object?>();
       }
 
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
         log.add(methodCall);
         if (methodCall.method == 'getAll') {
@@ -301,9 +300,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/url_launcher/url_launcher_linux/test/url_launcher_linux_test.dart
+++ b/packages/url_launcher/url_launcher_linux/test/url_launcher_linux_test.dart
@@ -14,8 +14,7 @@ void main() {
     const MethodChannel channel =
         MethodChannel('plugins.flutter.io/url_launcher_linux');
     final List<MethodCall> log = <MethodCall>[];
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
       log.add(methodCall);
 
@@ -142,9 +141,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -48,8 +48,7 @@ void main() {
     const MethodChannel channel =
         MethodChannel('plugins.flutter.io/url_launcher');
     final List<MethodCall> log = <MethodCall>[];
-    _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-        .defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
       log.add(methodCall);
 
@@ -325,9 +324,3 @@ class ExtendsUrlLauncherPlatform extends UrlLauncherPlatform {
   @override
   final LinkDelegate? linkDelegate = null;
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -243,16 +243,15 @@ void main() {
 
     test('videoEventsFor', () async {
       const String mockChannel = 'flutter.io/videoPlayer/videoEvents123';
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMessageHandler(
         mockChannel,
         (ByteData? message) async {
           final MethodCall methodCall =
               const StandardMethodCodec().decodeMethodCall(message);
           if (methodCall.method == 'listen') {
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -264,8 +263,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -278,8 +277,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -288,8 +287,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -302,8 +301,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -312,8 +311,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -322,8 +321,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -333,8 +332,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -394,9 +393,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -243,16 +243,15 @@ void main() {
 
     test('videoEventsFor', () async {
       const String mockChannel = 'flutter.io/videoPlayer/videoEvents123';
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMessageHandler(
         mockChannel,
         (ByteData? message) async {
           final MethodCall methodCall =
               const StandardMethodCodec().decodeMethodCall(message);
           if (methodCall.method == 'listen') {
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -264,8 +263,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -274,8 +273,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -288,8 +287,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -298,8 +297,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -308,8 +307,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -319,8 +318,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -373,9 +372,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/webview_flutter/webview_flutter_android/test/legacy/surface_android_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/legacy/surface_android_test.dart
@@ -17,8 +17,7 @@ void main() {
     late List<MethodCall> log;
 
     setUpAll(() {
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
         SystemChannels.platform_views,
         (MethodCall call) async {
@@ -38,8 +37,7 @@ void main() {
     });
 
     tearDownAll(() {
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform_views, null);
     });
 
@@ -122,9 +120,3 @@ class TestWebViewPlatformCallbacksHandler
   @override
   void onWebResourceError(WebResourceError error) {}
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;


### PR DESCRIPTION
Removes the "ambiguate" method that was used to allow compatibility with both stable and master during the transition of `TestDefaultBinaryMessengerBinding.instance` from a nullable return to a non-nullable return, now that all versions we analyze are sufficiently new to have the non-nullable version.

Part of https://github.com/flutter/flutter/issues/111841