### PR TITLE
[ci] Reduce tasks slightly

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -107,20 +107,6 @@ platform_properties:
         }
 
 targets:
-  ### Linux-host general tasks ###
-  - name: Linux repo_tools_tests
-    recipe: packages/packages
-    timeout: 30
-    properties:
-      add_recipes_cq: "true"
-      target_file: repo_tools_tests.yaml
-      channel: master
-      version_file: flutter_master.version
-      env_variables: >-
-        {
-          "CHANNEL": "master"
-        }
-
   - name: Linux repo_checks
     recipe: packages/packages
     timeout: 30
@@ -281,19 +267,10 @@ targets:
           "CHANNEL": "stable"
         }
 
-  - name: Linux analyze_downgraded master
-    recipe: packages/packages
-    timeout: 30
-    properties:
-      add_recipes_cq: "true"
-      target_file: analyze_downgraded.yaml
-      channel: master
-      version_file: flutter_master.version
-      env_variables: >-
-        {
-          "CHANNEL": "master"
-        }
-
+  # This is only run on stable since it's extremely likely that stable will
+  # resolve to packages that are older (or at least as old) than on master, so
+  # running a second copy with master is very unlikely to catch anything that
+  # this doesn't.
   - name: Linux analyze_downgraded stable
     recipe: packages/packages
     timeout: 30

--- a/.ci/targets/repo_checks.yaml
+++ b/.ci/targets/repo_checks.yaml
@@ -2,6 +2,8 @@ tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
+  - name: tool unit tests
+    script: .ci/scripts/plugin_tools_tests.sh
   - name: format
     script: script/tool_runner.sh
     # Skip Swift formatting on Linux builders.


### PR DESCRIPTION
Help buy a bit of time until we eliminate the max number of tasks for `release` to wait for, and be more efficient with CI resources:
- Folds the very fast repo-tooling-unit-test step into the existing repo checks task, cutting down on machine overhead.
- Removes the `master` version of downgraded analysis, since it's hard to imagine a plausible scenario where it fails but the `stable` version does not, so we don't need to spend resources on both.

See https://github.com/flutter/flutter/issues/141196