### PR TITLE
[camerax] Change `buildPreview` to return `Texture` versus `FutureBuilder`

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.5.0+29
 
 * Modifies `buildPreview` to return `Texture` that maps to camera preview, building in the assumption
-  that `createCamera` should have been called before building the preview.
+  that `createCamera` should have been called before building the preview. Fixes
+  https://github.com/flutter/flutter/issues/140567.
 
 ## 0.5.0+28
 

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0+29
+
+* Modifies `buildPreview` to return `Texture` that maps to camera preview, building in the assumption
+  that `createCamera` should have been called before building the preview.
+
 ## 0.5.0+28
 
 * Wraps CameraX classes needed to implement setting focus and exposure points and exposure offset.

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.5.0+28
+version: 0.5.0+29
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Changes the `buildPreview` implementation to return a `Texture` versus a `FutureBuilder` that would ultimately return that same `Texture`.

The `FutureBuilder` depended on checking a condition that should be true by default assuming `createCamera` was called prior. This seems to be an assumption made consistently across other platform implementations (including `camera_android`-- see [source](https://github.com/flutter/packages/blob/7b1ae1f4cceea02f330716e701c6dcd9f0ca3f7e/packages/camera/camera_android/lib/src/android_camera.dart#L520)), so this PR is achieving consistency with them.

Fixes https://github.com/flutter/flutter/issues/140567. Thanks to @davidmartos96 for the push to investigate deeper on that issue!

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
