### PR TITLE
[camera] Options to scan for physical and/or logical cameras on iOS

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Updates support matrix in README to indicate that iOS 11 is no longer supported.
 * Clients on versions of Flutter that still support iOS 11 can continue to use this
   package with iOS 11, but will not receive any further updates to the iOS implementation.
+* Update availableDevices method to specify if it will return physical and/or logical devices.
 
 ## 0.10.5+9
 

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -19,12 +19,15 @@ dependencies:
   path_provider: ^2.0.0
   video_player: ^2.7.0
 
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
 dependency_overrides:
+
+  camera_avfoundation:
+    path: ../../../camera/camera_avfoundation
   camera_platform_interface:
-    git:
-      url: https://github.com/rickcasson/packages
-      path: packages/camera/camera_platform_interface
-      ref: camera-updates
+    path: ../../../camera/camera_platform_interface
 
 dev_dependencies:
   build_runner: ^2.1.10

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -24,10 +24,14 @@ dependencies:
 # See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
 dependency_overrides:
 
+  camera_android:
+    path: ../../../camera/camera_android
   camera_avfoundation:
     path: ../../../camera/camera_avfoundation
   camera_platform_interface:
     path: ../../../camera/camera_platform_interface
+  camera_web:
+    path: ../../../camera/camera_web
 
 dev_dependencies:
   build_runner: ^2.1.10

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -19,6 +19,13 @@ dependencies:
   path_provider: ^2.0.0
   video_player: ^2.7.0
 
+dependency_overrides:
+  camera_platform_interface:
+    git:
+      url: https://github.com/rickcasson/packages
+      path: packages/camera/camera_platform_interface
+      ref: camera-updates
+
 dev_dependencies:
   build_runner: ^2.1.10
   flutter_driver:

--- a/packages/camera/camera/lib/camera.dart
+++ b/packages/camera/camera/lib/camera.dart
@@ -4,7 +4,6 @@
 
 export 'package:camera_platform_interface/camera_platform_interface.dart'
     show
-        AppleCaptureDeviceType,
         CameraDescription,
         CameraException,
         CameraLensDirection,

--- a/packages/camera/camera/lib/camera.dart
+++ b/packages/camera/camera/lib/camera.dart
@@ -4,6 +4,7 @@
 
 export 'package:camera_platform_interface/camera_platform_interface.dart'
     show
+        AppleCaptureDeviceType,
         CameraDescription,
         CameraException,
         CameraLensDirection,

--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -24,8 +24,12 @@ typedef onLatestImageAvailable = void Function(CameraImage image);
 /// Completes with a list of available cameras.
 ///
 /// May throw a [CameraException].
-Future<List<CameraDescription>> availableCameras() async {
-  return CameraPlatform.instance.availableCameras();
+Future<List<CameraDescription>> availableCameras({
+  bool physicalCameras = true,
+  bool logicalCameras = false,
+}) async {
+  return CameraPlatform.instance.availableCameras(
+      logicalCameras: logicalCameras, physicalCameras: physicalCameras);
 }
 
 // TODO(stuartmorgan): Remove this once the package requires 2.10, where the

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -22,8 +22,10 @@ flutter:
 
 dependencies:
   camera_android: ^0.10.7
-  camera_avfoundation: ^0.9.13
-  camera_platform_interface: ^2.5.0
+  camera_avfoundation:
+    path: ../camera_avfoundation
+  camera_platform_interface:
+    path: ../camera_platform_interface
   camera_web: ^0.3.1
   flutter:
     sdk: flutter

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -22,17 +22,8 @@ flutter:
 
 dependencies:
   camera_android: ^0.10.7
-  camera_avfoundation:
-    git:
-      url: https://github.com/rickcasson/packages
-      path: packages/camera/camera_avfoundation
-      ref: camera-updates
-
-  camera_platform_interface:
-    git:
-      url: https://github.com/rickcasson/packages
-      path: packages/camera/camera_platform_interface
-      ref: camera-updates
+  camera_avfoundation: ^0.9.13
+  camera_platform_interface: ^2.5.0
   camera_web: ^0.3.1
   flutter:
     sdk: flutter

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -38,6 +38,13 @@ dependencies:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.2
 
+dependency_overrides:
+  camera_platform_interface:
+    git:
+      url: https://github.com/rickcasson/packages
+      path: packages/camera/camera_platform_interface
+      ref: camera-updates
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -34,10 +34,14 @@ dependencies:
 # See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
 dependency_overrides:
 
+  camera_android:
+    path: ../../camera/camera_android
   camera_avfoundation:
     path: ../../camera/camera_avfoundation
   camera_platform_interface:
     path: ../../camera/camera_platform_interface
+  camera_web:
+    path: ../../camera/camera_web
 
 dev_dependencies:
   flutter_test:

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -38,12 +38,15 @@ dependencies:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.2
 
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
 dependency_overrides:
+
+  camera_avfoundation:
+    path: ../../camera/camera_avfoundation
   camera_platform_interface:
-    git:
-      url: https://github.com/rickcasson/packages
-      path: packages/camera/camera_platform_interface
-      ref: camera-updates
+    path: ../../camera/camera_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -23,9 +23,16 @@ flutter:
 dependencies:
   camera_android: ^0.10.7
   camera_avfoundation:
-    path: ../camera_avfoundation
+    git:
+      url: https://github.com/rickcasson/packages
+      path: packages/camera/camera_avfoundation
+      ref: camera-updates
+
   camera_platform_interface:
-    path: ../camera_platform_interface
+    git:
+      url: https://github.com/rickcasson/packages
+      path: packages/camera/camera_platform_interface
+      ref: camera-updates
   camera_web: ^0.3.1
   flutter:
     sdk: flutter

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -1426,7 +1426,8 @@ class MockCameraPlatform extends Mock
   }
 
   @override
-  Future<List<CameraDescription>> availableCameras() =>
+  Future<List<CameraDescription>> availableCameras(
+          {bool physicalCameras = true, bool logicalCameras = false}) =>
       Future<List<CameraDescription>>.value(mockAvailableCameras);
 
   @override

--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates compileSdk version to 34.
+* Add placeholder physicalCameras and logicalCameras options to availableDevices method.
 
 ## 0.10.8+16
 

--- a/packages/camera/camera_android/example/pubspec.yaml
+++ b/packages/camera/camera_android/example/pubspec.yaml
@@ -35,4 +35,4 @@ flutter:
 # FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
 # See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
 dependency_overrides:
-   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}}
+   {camera_android: {path: ../../../camera/camera_android}, camera_platform_interface: {path: ../../../camera/camera_platform_interface}}

--- a/packages/camera/camera_android/example/pubspec.yaml
+++ b/packages/camera/camera_android/example/pubspec.yaml
@@ -31,3 +31,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}}

--- a/packages/camera/camera_android/lib/src/android_camera.dart
+++ b/packages/camera/camera_android/lib/src/android_camera.dart
@@ -69,7 +69,10 @@ class AndroidCamera extends CameraPlatform {
           .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
-  Future<List<CameraDescription>> availableCameras() async {
+  Future<List<CameraDescription>> availableCameras({
+    bool physicalCameras = true,
+    bool logicalCameras = false,
+  }) async {
     try {
       final List<Map<dynamic, dynamic>>? cameras = await _channel
           .invokeListMethod<Map<dynamic, dynamic>>('availableCameras');

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -32,3 +32,8 @@ dev_dependencies:
 
 topics:
   - camera
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../camera/camera_platform_interface}}

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Add placeholder physicalCameras and logicalCameras options to availableDevices method.
+
 ## 0.5.0+28
 
 * Wraps CameraX classes needed to implement setting focus and exposure points and exposure offset.

--- a/packages/camera/camera_android_camerax/example/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/example/pubspec.yaml
@@ -28,3 +28,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}}

--- a/packages/camera/camera_android_camerax/example/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/example/pubspec.yaml
@@ -32,4 +32,4 @@ flutter:
 # FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
 # See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
 dependency_overrides:
-   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}}
+   {camera_android_camerax: {path: ../../../camera/camera_android_camerax}, camera_platform_interface: {path: ../../../camera/camera_platform_interface}}

--- a/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
+++ b/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
@@ -177,7 +177,10 @@ class AndroidCameraCameraX extends CameraPlatform {
 
   /// Returns list of all available cameras and their descriptions.
   @override
-  Future<List<CameraDescription>> availableCameras() async {
+  Future<List<CameraDescription>> availableCameras({
+    bool physicalCameras = true,
+    bool logicalCameras = false,
+  }) async {
     final List<CameraDescription> cameraDescriptions = <CameraDescription>[];
 
     processCameraProvider ??= await proxy.getProcessCameraProvider();

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -36,3 +36,8 @@ dev_dependencies:
 
 topics:
   - camera
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../camera/camera_platform_interface}}

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Add physicalCameras and logicalCameras options to availableDevices method.
+
 ## 0.9.14
 
 * Adds support to HEIF format.

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/AvailableCamerasTest.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/AvailableCamerasTest.m
@@ -17,30 +17,116 @@
 - (void)testAvailableCamerasShouldReturnAllCamerasOnMultiCameraIPhone {
   CameraPlugin *camera = [[CameraPlugin alloc] initWithRegistry:nil messenger:nil];
   XCTestExpectation *expectation =
-      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
-
-  // iPhone 13 Cameras:
+  [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+  
   AVCaptureDevice *wideAngleCamera = OCMClassMock([AVCaptureDevice class]);
   OCMStub([wideAngleCamera uniqueID]).andReturn(@"0");
+  OCMStub([wideAngleCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInWideAngleCamera);
   OCMStub([wideAngleCamera position]).andReturn(AVCaptureDevicePositionBack);
-
+  
   AVCaptureDevice *frontFacingCamera = OCMClassMock([AVCaptureDevice class]);
   OCMStub([frontFacingCamera uniqueID]).andReturn(@"1");
+  OCMStub([frontFacingCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInWideAngleCamera);
   OCMStub([frontFacingCamera position]).andReturn(AVCaptureDevicePositionFront);
-
-  AVCaptureDevice *ultraWideCamera = OCMClassMock([AVCaptureDevice class]);
-  OCMStub([ultraWideCamera uniqueID]).andReturn(@"2");
-  OCMStub([ultraWideCamera position]).andReturn(AVCaptureDevicePositionBack);
-
+  
   AVCaptureDevice *telephotoCamera = OCMClassMock([AVCaptureDevice class]);
-  OCMStub([telephotoCamera uniqueID]).andReturn(@"3");
+  OCMStub([telephotoCamera uniqueID]).andReturn(@"2");
+  OCMStub([telephotoCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInTelephotoCamera);
   OCMStub([telephotoCamera position]).andReturn(AVCaptureDevicePositionBack);
-
-  NSMutableArray *requiredTypes =
-      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
-          mutableCopy];
+  
+  AVCaptureDevice *trueDepthCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([trueDepthCamera uniqueID]).andReturn(@"3");
+  OCMStub([trueDepthCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInTrueDepthCamera);
+  OCMStub([trueDepthCamera position]).andReturn(AVCaptureDevicePositionFront);
+  
+  AVCaptureDevice *dualCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([dualCamera uniqueID]).andReturn(@"4");
+  OCMStub([dualCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInDualCamera);
+  OCMStub([dualCamera position]).andReturn(AVCaptureDevicePositionBack);
+  
+  // iPhone 13 Cameras:
+  AVCaptureDevice *ultraWideCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([ultraWideCamera uniqueID]).andReturn(@"5");
   if (@available(iOS 13.0, *)) {
-    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+    OCMStub([ultraWideCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInUltraWideCamera);
+  }
+  OCMStub([ultraWideCamera position]).andReturn(AVCaptureDevicePositionBack);
+  
+  AVCaptureDevice *dualWideCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([dualWideCamera uniqueID]).andReturn(@"6");
+  if (@available(iOS 13.0, *)) {
+    OCMStub([dualWideCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInDualWideCamera);
+  }
+  OCMStub([dualWideCamera position]).andReturn(AVCaptureDevicePositionBack);
+  
+  AVCaptureDevice *tripleCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([tripleCamera uniqueID]).andReturn(@"7");
+  if (@available(iOS 13.0, *)) {
+    OCMStub([tripleCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInTripleCamera);
+  }
+  OCMStub([tripleCamera position]).andReturn(AVCaptureDevicePositionBack);
+    
+  // iPhone 15.4 Cameras:
+  AVCaptureDevice *liDARDepthCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([liDARDepthCamera uniqueID]).andReturn(@"8");
+  if (@available(iOS 15.4, *)) {
+    OCMStub([liDARDepthCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInLiDARDepthCamera);
+  }
+  OCMStub([liDARDepthCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  // iPhone 17 Cameras:
+  AVCaptureDevice *externalCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([externalCamera uniqueID]).andReturn(@"9");
+  if (@available(iOS 17.0, *)) {
+    OCMStub([externalCamera deviceType]).andReturn(AVCaptureDeviceTypeExternal);
+  }
+  OCMStub([externalCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  AVCaptureDevice *continuityCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([continuityCamera uniqueID]).andReturn(@"10");
+  if (@available(iOS 17.0, *)) {
+    OCMStub([continuityCamera deviceType]).andReturn(AVCaptureDeviceTypeContinuityCamera);
+  }
+  OCMStub([continuityCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  NSMutableArray *requiredTypes = [NSMutableArray new];
+  if (@available(iOS 17.0, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera,
+             AVCaptureDeviceTypeBuiltInUltraWideCamera,
+             AVCaptureDeviceTypeExternal, 
+             AVCaptureDeviceTypeBuiltInDualCamera,
+             AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+             AVCaptureDeviceTypeBuiltInDualWideCamera,
+             AVCaptureDeviceTypeBuiltInTripleCamera,
+             AVCaptureDeviceTypeBuiltInLiDARDepthCamera,
+             AVCaptureDeviceTypeContinuityCamera ]];
+  } else if (@available(iOS 15.4, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera,
+             AVCaptureDeviceTypeBuiltInUltraWideCamera,
+             AVCaptureDeviceTypeBuiltInDualCamera,
+             AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+             AVCaptureDeviceTypeBuiltInDualWideCamera,
+             AVCaptureDeviceTypeBuiltInTripleCamera,
+             AVCaptureDeviceTypeBuiltInLiDARDepthCamera ]];
+  } else if (@available(iOS 13.0, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera,
+             AVCaptureDeviceTypeBuiltInUltraWideCamera,
+             AVCaptureDeviceTypeBuiltInDualCamera,
+             AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+             AVCaptureDeviceTypeBuiltInDualWideCamera,
+             AVCaptureDeviceTypeBuiltInTripleCamera ]];
+  } else {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera,
+             AVCaptureDeviceTypeBuiltInDualCamera,
+             AVCaptureDeviceTypeBuiltInTrueDepthCamera ]];
   }
 
   id discoverySessionMock = OCMClassMock([AVCaptureDeviceDiscoverySession class]);
@@ -49,11 +135,18 @@
                                                        position:AVCaptureDevicePositionUnspecified])
       .andReturn(discoverySessionMock);
 
-  NSMutableArray *cameras = [NSMutableArray array];
-  [cameras addObjectsFromArray:@[ wideAngleCamera, frontFacingCamera, telephotoCamera ]];
+  NSMutableArray *cameras =
+      [@[ wideAngleCamera, frontFacingCamera, telephotoCamera, dualCamera, trueDepthCamera ] mutableCopy];
   if (@available(iOS 13.0, *)) {
-    [cameras addObject:ultraWideCamera];
+    [cameras addObjectsFromArray: @[ ultraWideCamera, dualWideCamera, tripleCamera ]];
   }
+  if (@available(iOS 15.4, *)) {
+    [cameras addObject:liDARDepthCamera];
+  }
+  if (@available(iOS 17.0, *)) {
+    [cameras addObjectsFromArray: @[ externalCamera, continuityCamera ]];
+  }
+
   OCMStub([discoverySessionMock devices]).andReturn([NSArray arrayWithArray:cameras]);
 
   MockFLTThreadSafeFlutterResult *resultObject =
@@ -61,16 +154,20 @@
 
   // Set up method call
   FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"availableCameras"
-                                                              arguments:nil];
+                                                              arguments:@{@"physicalCameras" : @TRUE, @"logicalCameras" : @TRUE}];
 
   [camera handleMethodCallAsync:call result:resultObject];
 
   // Verify the result
   NSDictionary *dictionaryResult = (NSDictionary *)resultObject.receivedResult;
-  if (@available(iOS 13.0, *)) {
-    XCTAssertTrue([dictionaryResult count] == 4);
+  if (@available(iOS 17.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 11);
+  } else if (@available(iOS 15.4, *)) {
+    XCTAssertTrue([dictionaryResult count] == 9);
+  } else if (@available(iOS 13.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 8);
   } else {
-    XCTAssertTrue([dictionaryResult count] == 3);
+    XCTAssertTrue([dictionaryResult count] == 5);
   }
 }
 - (void)testAvailableCamerasShouldReturnOneCameraOnSingleCameraIPhone {
@@ -81,17 +178,30 @@
   // iPhone 8 Cameras:
   AVCaptureDevice *wideAngleCamera = OCMClassMock([AVCaptureDevice class]);
   OCMStub([wideAngleCamera uniqueID]).andReturn(@"0");
+  OCMStub([wideAngleCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInWideAngleCamera);
   OCMStub([wideAngleCamera position]).andReturn(AVCaptureDevicePositionBack);
 
   AVCaptureDevice *frontFacingCamera = OCMClassMock([AVCaptureDevice class]);
   OCMStub([frontFacingCamera uniqueID]).andReturn(@"1");
+  OCMStub([frontFacingCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInWideAngleCamera);
   OCMStub([frontFacingCamera position]).andReturn(AVCaptureDevicePositionFront);
 
-  NSMutableArray *requiredTypes =
-      [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
-          mutableCopy];
-  if (@available(iOS 13.0, *)) {
-    [requiredTypes addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+  NSMutableArray *requiredTypes = [NSMutableArray new];
+  if (@available(iOS 17.0, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera,
+             AVCaptureDeviceTypeBuiltInUltraWideCamera,
+             AVCaptureDeviceTypeExternal ]];
+  } else if (@available(iOS 13.0, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera,
+             AVCaptureDeviceTypeBuiltInUltraWideCamera ]];
+  } else {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera ]];
   }
 
   id discoverySessionMock = OCMClassMock([AVCaptureDeviceDiscoverySession class]);
@@ -100,8 +210,7 @@
                                                        position:AVCaptureDevicePositionUnspecified])
       .andReturn(discoverySessionMock);
 
-  NSMutableArray *cameras = [NSMutableArray array];
-  [cameras addObjectsFromArray:@[ wideAngleCamera, frontFacingCamera ]];
+  NSMutableArray *cameras = [@[ wideAngleCamera, frontFacingCamera ] mutableCopy];
   OCMStub([discoverySessionMock devices]).andReturn([NSArray arrayWithArray:cameras]);
 
   MockFLTThreadSafeFlutterResult *resultObject =
@@ -109,13 +218,207 @@
 
   // Set up method call
   FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"availableCameras"
-                                                              arguments:nil];
+                                                              arguments:@{@"physicalCameras" : @TRUE, @"logicalCameras" : @FALSE}];
 
   [camera handleMethodCallAsync:call result:resultObject];
 
   // Verify the result
   NSDictionary *dictionaryResult = (NSDictionary *)resultObject.receivedResult;
   XCTAssertTrue([dictionaryResult count] == 2);
+}
+- (void)testAvailableCamerasShouldReturnOnlyPhysicalDevices {
+  CameraPlugin *camera = [[CameraPlugin alloc] initWithRegistry:nil messenger:nil];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+
+  AVCaptureDevice *wideAngleCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([wideAngleCamera uniqueID]).andReturn(@"0");
+  OCMStub([wideAngleCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  AVCaptureDevice *frontFacingCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([frontFacingCamera uniqueID]).andReturn(@"1");
+  OCMStub([frontFacingCamera position]).andReturn(AVCaptureDevicePositionFront);
+    
+  AVCaptureDevice *ultraWideCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([ultraWideCamera uniqueID]).andReturn(@"2");
+  if (@available(iOS 13.0, *)) {
+    OCMStub([ultraWideCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInUltraWideCamera);
+  }
+  OCMStub([ultraWideCamera position]).andReturn(AVCaptureDevicePositionBack);
+    
+  AVCaptureDevice *externalCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([externalCamera uniqueID]).andReturn(@"3");
+  if (@available(iOS 17.0, *)) {
+    OCMStub([externalCamera deviceType]).andReturn(AVCaptureDeviceTypeExternal);
+  }
+  OCMStub([externalCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  NSMutableArray *requiredTypes = [NSMutableArray new];
+  if (@available(iOS 17.0, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera,
+             AVCaptureDeviceTypeBuiltInUltraWideCamera,
+             AVCaptureDeviceTypeExternal ]];
+  } else if (@available(iOS 13.0, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera,
+             AVCaptureDeviceTypeBuiltInUltraWideCamera ]];
+  } else {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+             AVCaptureDeviceTypeBuiltInTelephotoCamera ]];
+  }
+
+  id discoverySessionMock = OCMClassMock([AVCaptureDeviceDiscoverySession class]);
+  OCMStub([discoverySessionMock discoverySessionWithDeviceTypes:requiredTypes
+                                                      mediaType:AVMediaTypeVideo
+                                                       position:AVCaptureDevicePositionUnspecified])
+      .andReturn(discoverySessionMock);
+
+  NSMutableArray *cameras =
+      [@[ wideAngleCamera, frontFacingCamera ] mutableCopy];
+  if (@available(iOS 13.0, *)) {
+    [cameras addObjectsFromArray: @[ ultraWideCamera ]];
+  }
+  if (@available(iOS 17.0, *)) {
+    [cameras addObjectsFromArray: @[ externalCamera ]];
+  }
+  OCMStub([discoverySessionMock devices]).andReturn([NSArray arrayWithArray:cameras]);
+
+  MockFLTThreadSafeFlutterResult *resultObject =
+      [[MockFLTThreadSafeFlutterResult alloc] initWithExpectation:expectation];
+
+  // Set up method call
+  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"availableCameras"
+                                                              arguments:@{@"physicalCameras" : @TRUE, @"logicalCameras" : @FALSE}];
+
+  [camera handleMethodCallAsync:call result:resultObject];
+
+  // Verify the result
+  NSDictionary *dictionaryResult = (NSDictionary *)resultObject.receivedResult;
+  if (@available(iOS 17.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 4);
+  } else if (@available(iOS 13.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 3);
+  } else {
+    XCTAssertTrue([dictionaryResult count] == 2);
+  }
+}
+- (void)testAvailableCamerasShouldReturnOnlyLogicalDevices {
+  CameraPlugin *camera = [[CameraPlugin alloc] initWithRegistry:nil messenger:nil];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+  
+  AVCaptureDevice *trueDepthCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([trueDepthCamera uniqueID]).andReturn(@"0");
+  OCMStub([trueDepthCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInTrueDepthCamera);
+  OCMStub([trueDepthCamera position]).andReturn(AVCaptureDevicePositionFront);
+  
+  AVCaptureDevice *dualCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([dualCamera uniqueID]).andReturn(@"1");
+  OCMStub([dualCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInDualCamera);
+  OCMStub([dualCamera position]).andReturn(AVCaptureDevicePositionBack);
+  
+  // iPhone 13 Cameras:
+  AVCaptureDevice *dualWideCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([dualWideCamera uniqueID]).andReturn(@"2");
+  if (@available(iOS 13.0, *)) {
+    OCMStub([dualWideCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInDualWideCamera);
+  }
+  OCMStub([dualWideCamera position]).andReturn(AVCaptureDevicePositionBack);
+  
+  AVCaptureDevice *tripleCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([tripleCamera uniqueID]).andReturn(@"3");
+  if (@available(iOS 13.0, *)) {
+    OCMStub([tripleCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInTripleCamera);
+  }
+  OCMStub([tripleCamera position]).andReturn(AVCaptureDevicePositionBack);
+    
+  // iPhone 15.4 Cameras:
+  AVCaptureDevice *liDARDepthCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([liDARDepthCamera uniqueID]).andReturn(@"4");
+  if (@available(iOS 15.4, *)) {
+    OCMStub([liDARDepthCamera deviceType]).andReturn(AVCaptureDeviceTypeBuiltInLiDARDepthCamera);
+  }
+  OCMStub([liDARDepthCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  // iPhone 17 Cameras:
+  AVCaptureDevice *continuityCamera = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([continuityCamera uniqueID]).andReturn(@"5");
+  if (@available(iOS 17.0, *)) {
+    OCMStub([continuityCamera deviceType]).andReturn(AVCaptureDeviceTypeContinuityCamera);
+  }
+  OCMStub([continuityCamera position]).andReturn(AVCaptureDevicePositionBack);
+
+  NSMutableArray *requiredTypes = [NSMutableArray new];
+  if (@available(iOS 17.0, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInDualCamera,
+             AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+             AVCaptureDeviceTypeBuiltInDualWideCamera,
+             AVCaptureDeviceTypeBuiltInTripleCamera,
+             AVCaptureDeviceTypeBuiltInLiDARDepthCamera,
+             AVCaptureDeviceTypeContinuityCamera ]];
+  } else if (@available(iOS 15.4, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInDualCamera,
+             AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+             AVCaptureDeviceTypeBuiltInDualWideCamera,
+             AVCaptureDeviceTypeBuiltInTripleCamera,
+             AVCaptureDeviceTypeBuiltInLiDARDepthCamera ]];
+  } else if (@available(iOS 13.0, *)) {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInDualCamera,
+             AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+             AVCaptureDeviceTypeBuiltInDualWideCamera,
+             AVCaptureDeviceTypeBuiltInTripleCamera ]];
+  } else {
+      [requiredTypes addObjectsFromArray:
+          @[ AVCaptureDeviceTypeBuiltInDualCamera,
+             AVCaptureDeviceTypeBuiltInTrueDepthCamera ]];
+  }
+
+  id discoverySessionMock = OCMClassMock([AVCaptureDeviceDiscoverySession class]);
+  OCMStub([discoverySessionMock discoverySessionWithDeviceTypes:requiredTypes
+                                                      mediaType:AVMediaTypeVideo
+                                                       position:AVCaptureDevicePositionUnspecified])
+      .andReturn(discoverySessionMock);
+
+  NSMutableArray *cameras =
+      [@[ trueDepthCamera, dualCamera ] mutableCopy];
+  if (@available(iOS 13.0, *)) {
+    [cameras addObjectsFromArray: @[ dualWideCamera, tripleCamera ]];
+  }
+  if (@available(iOS 15.4, *)) {
+    [cameras addObjectsFromArray: @[ liDARDepthCamera ]];
+  }
+  if (@available(iOS 17.0, *)) {
+    [cameras addObjectsFromArray: @[ continuityCamera ]];
+  }
+  OCMStub([discoverySessionMock devices]).andReturn([NSArray arrayWithArray:cameras]);
+
+  MockFLTThreadSafeFlutterResult *resultObject =
+      [[MockFLTThreadSafeFlutterResult alloc] initWithExpectation:expectation];
+
+  // Set up method call
+  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"availableCameras"
+                                                              arguments:@{@"physicalCameras" : @FALSE, @"logicalCameras" : @TRUE}];
+
+  [camera handleMethodCallAsync:call result:resultObject];
+
+  // Verify the result
+  NSDictionary *dictionaryResult = (NSDictionary *)resultObject.receivedResult;
+  if (@available(iOS 17.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 6);
+  } else if (@available(iOS 15.4, *)) {
+    XCTAssertTrue([dictionaryResult count] == 5);
+  } else if (@available(iOS 13.0, *)) {
+    XCTAssertTrue([dictionaryResult count] == 4);
+  } else {
+    XCTAssertTrue([dictionaryResult count] == 2);
+  }
 }
 
 @end

--- a/packages/camera/camera_avfoundation/example/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/example/pubspec.yaml
@@ -29,3 +29,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_avfoundation: {path: ../../../camera/camera_avfoundation}, camera_platform_interface: {path: ../../../camera/camera_platform_interface}}

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -104,13 +104,13 @@
 - (void)handleMethodCallAsync:(FlutterMethodCall *)call
                        result:(FLTThreadSafeFlutterResult *)result {
   if ([@"availableCameras" isEqualToString:call.method]) {
-    NSMutableArray *discoveryDevices =
-            NSMutableArray *discoveryDevices =
-                    [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera,
-                        AVCaptureDeviceTypeBuiltInDualCamera,
-                        AVCaptureDeviceTypeBuiltInDualWideCamera,
-                        AVCaptureDeviceTypeBuiltInTripleCamera ]
-                            mutableCopy];
+      NSMutableArray *discoveryDevices =
+            [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+                AVCaptureDeviceTypeBuiltInTelephotoCamera,
+                AVCaptureDeviceTypeBuiltInDualCamera,
+                AVCaptureDeviceTypeBuiltInDualWideCamera,
+                AVCaptureDeviceTypeBuiltInTripleCamera ]
+                    mutableCopy];
     if (@available(iOS 13.0, *)) {
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
     }

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -108,11 +108,20 @@
             [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
                 AVCaptureDeviceTypeBuiltInTelephotoCamera,
                 AVCaptureDeviceTypeBuiltInDualCamera,
-                AVCaptureDeviceTypeBuiltInDualWideCamera,
-                AVCaptureDeviceTypeBuiltInTripleCamera ]
+                AVCaptureDeviceTypeBuiltInTrueDepthCamera]
                     mutableCopy];
     if (@available(iOS 13.0, *)) {
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInDualWideCamera];
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInTripleCamera];
+      [discoveryDevices addObject:AVCaptureDeviceTypeDeskViewCamera];
+    }
+    if (@available(iOS 15.4, *)) {
+      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+    }
+    if (@available(iOS 17.0, *)) {
+      [discoveryDevices addObject:AVCaptureDeviceTypeExternal];
+      [discoveryDevices addObject:AVCaptureDeviceTypeContinuityCamera];
     }
     AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
         discoverySessionWithDeviceTypes:discoveryDevices
@@ -134,11 +143,47 @@
           lensFacing = @"external";
           break;
       }
+      NSString *deviceType;
+      switch ([device deviceType]) {
+        case AVCaptureDeviceTypeBuiltInWideAngleCamera:
+          deviceType = @"builtInWideAngleCamera";
+          break;
+        case AVCaptureDeviceTypeBuiltInUltraWideCamera:
+          deviceType = @"builtInUltraWideCamera";
+          break;
+        case AVCaptureDeviceTypeBuiltInTelephotoCamera:
+          deviceType = @"builtInTelephotoCamera";
+          break;
+        case AVCaptureDeviceTypeBuiltInDualCamera:
+          deviceType = @"builtInDualCamera";
+          break;
+        case AVCaptureDeviceTypeBuiltInDualWideCamera:
+          deviceType = @"builtInDualWideCamera";
+          break;
+        case AVCaptureDeviceTypeBuiltInTripleCamera:
+          deviceType = @"builtInTripleCamera";
+          break;
+        case AVCaptureDeviceTypeContinuityCamera:
+          deviceType = @"continuityCamera";
+          break;
+        case AVCaptureDeviceTypeExternal:
+          deviceType = @"external";
+          break;
+        case AVCaptureDeviceTypeDeskViewCamera:
+          deviceType = @"deskViewCamera";
+          break;
+        case AVCaptureDeviceTypeBuiltInLiDARDepthCamera:
+          deviceType = @"builtInLiDARDepthCamera";
+          break;
+        case AVCaptureDeviceTypeBuiltInTrueDepthCamera:
+          deviceType = @"builtInTrueDepthCamera";
+          break;
+      }
       [reply addObject:@{
         @"name" : [device uniqueID],
         @"lensFacing" : lensFacing,
         @"sensorOrientation" : @90,
-        @"deviceType" : [device deviceType],
+        @"deviceType" : deviceType,
       }];
     }
     [result sendSuccessWithData:reply];

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -104,23 +104,66 @@
 - (void)handleMethodCallAsync:(FlutterMethodCall *)call
                        result:(FLTThreadSafeFlutterResult *)result {
   if ([@"availableCameras" isEqualToString:call.method]) {
-      NSMutableArray *discoveryDevices =
-            [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
-                AVCaptureDeviceTypeBuiltInTelephotoCamera,
-                AVCaptureDeviceTypeBuiltInDualCamera,
-                AVCaptureDeviceTypeBuiltInTrueDepthCamera]
-                    mutableCopy];
-    if (@available(iOS 13.0, *)) {
-      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
-      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInDualWideCamera];
-      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInTripleCamera];
-    }
-    if (@available(iOS 15.4, *)) {
-      [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
-    }
+    BOOL physicalCameras = [call.arguments[@"physicalCameras"] boolValue];
+    BOOL logicalCameras = [call.arguments[@"logicalCameras"] boolValue];
+    NSMutableArray *discoveryDevices = [NSMutableArray new];
     if (@available(iOS 17.0, *)) {
-      [discoveryDevices addObject:AVCaptureDeviceTypeContinuityCamera];
-      [discoveryDevices addObject:AVCaptureDeviceTypeExternal];
+      if (physicalCameras) {
+        [discoveryDevices addObjectsFromArray:
+            @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+               AVCaptureDeviceTypeBuiltInTelephotoCamera,
+               AVCaptureDeviceTypeBuiltInUltraWideCamera,
+               AVCaptureDeviceTypeExternal ]];
+      }
+      if (logicalCameras) {
+        [discoveryDevices addObjectsFromArray:
+            @[ AVCaptureDeviceTypeBuiltInDualCamera,
+               AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+               AVCaptureDeviceTypeBuiltInDualWideCamera,
+               AVCaptureDeviceTypeBuiltInTripleCamera,
+               AVCaptureDeviceTypeBuiltInLiDARDepthCamera,
+               AVCaptureDeviceTypeContinuityCamera ]];
+      }
+    } else if (@available(iOS 15.4, *)) {
+      if (physicalCameras) {
+        [discoveryDevices addObjectsFromArray:
+            @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+               AVCaptureDeviceTypeBuiltInTelephotoCamera,
+               AVCaptureDeviceTypeBuiltInUltraWideCamera ]];
+      }
+      if (logicalCameras) {
+        [discoveryDevices addObjectsFromArray:
+            @[ AVCaptureDeviceTypeBuiltInDualCamera,
+               AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+               AVCaptureDeviceTypeBuiltInDualWideCamera,
+               AVCaptureDeviceTypeBuiltInTripleCamera,
+               AVCaptureDeviceTypeBuiltInLiDARDepthCamera ]];
+      }
+    } else if (@available(iOS 13.0, *)) {
+      if (physicalCameras) {
+        [discoveryDevices addObjectsFromArray:
+            @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+               AVCaptureDeviceTypeBuiltInTelephotoCamera,
+               AVCaptureDeviceTypeBuiltInUltraWideCamera ]];
+      }
+      if (logicalCameras) {
+        [discoveryDevices addObjectsFromArray:
+            @[ AVCaptureDeviceTypeBuiltInDualCamera,
+               AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+               AVCaptureDeviceTypeBuiltInDualWideCamera,
+               AVCaptureDeviceTypeBuiltInTripleCamera ]];
+      }
+    } else {
+      if (physicalCameras) {
+        [discoveryDevices addObjectsFromArray:
+            @[ AVCaptureDeviceTypeBuiltInWideAngleCamera,
+               AVCaptureDeviceTypeBuiltInTelephotoCamera ]];
+      }
+      if (logicalCameras) {
+        [discoveryDevices addObjectsFromArray:
+            @[ AVCaptureDeviceTypeBuiltInDualCamera,
+               AVCaptureDeviceTypeBuiltInTrueDepthCamera ]];
+      }
     }
     AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
         discoverySessionWithDeviceTypes:discoveryDevices

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -105,8 +105,12 @@
                        result:(FLTThreadSafeFlutterResult *)result {
   if ([@"availableCameras" isEqualToString:call.method]) {
     NSMutableArray *discoveryDevices =
-        [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera ]
-            mutableCopy];
+            NSMutableArray *discoveryDevices =
+                    [@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera,
+                        AVCaptureDeviceTypeBuiltInDualCamera,
+                        AVCaptureDeviceTypeBuiltInDualWideCamera,
+                        AVCaptureDeviceTypeBuiltInTripleCamera ]
+                            mutableCopy];
     if (@available(iOS 13.0, *)) {
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
     }
@@ -134,6 +138,7 @@
         @"name" : [device uniqueID],
         @"lensFacing" : lensFacing,
         @"sensorOrientation" : @90,
+        @"deviceType" : [device deviceType],
       }];
     }
     [result sendSuccessWithData:reply];

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -119,8 +119,8 @@
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
     }
     if (@available(iOS 17.0, *)) {
-      [discoveryDevices addObject:AVCaptureDeviceTypeExternal];
       [discoveryDevices addObject:AVCaptureDeviceTypeContinuityCamera];
+      [discoveryDevices addObject:AVCaptureDeviceTypeExternal];
     }
     AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
         discoverySessionWithDeviceTypes:discoveryDevices
@@ -142,29 +142,33 @@
           lensFacing = @"external";
           break;
       }
-      NSString *deviceType;
+      NSString *deviceType = @"unknown";
       if ([device deviceType] == AVCaptureDeviceTypeBuiltInWideAngleCamera) {
-          deviceType = @"builtInWideAngleCamera";
+        deviceType = @"builtInWideAngleCamera";
       } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTelephotoCamera) {
-          deviceType = @"builtInTelephotoCamera";
-      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInUltraWideCamera) {
-          deviceType = @"builtInUltraWideCamera";
+        deviceType = @"builtInTelephotoCamera";
       } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInDualCamera) {
-          deviceType = @"builtInDualCamera";
-      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInDualWideCamera) {
-        deviceType = @"builtInDualWideCamera";
-      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTripleCamera) {
-        deviceType = @"builtInTripleCamera";
-      } else if ([device deviceType] == AVCaptureDeviceTypeContinuityCamera) {
-        deviceType = @"continuityCamera";
-      } else if ([device deviceType] == AVCaptureDeviceTypeExternal) {
-        deviceType = @"external";
-      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInLiDARDepthCamera) {
-        deviceType = @"builtInLiDARDepthCamera";
+        deviceType = @"builtInDualCamera";
       } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTrueDepthCamera) {
         deviceType = @"builtInTrueDepthCamera";
-      } else {
-        deviceType = @"unknown";
+      } else if (@available(iOS 13.0, *)) {
+        if ([device deviceType] == AVCaptureDeviceTypeBuiltInUltraWideCamera) {
+          deviceType = @"builtInUltraWideCamera";
+        } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInDualWideCamera) {
+          deviceType = @"builtInDualWideCamera";
+        } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTripleCamera) {
+          deviceType = @"builtInTripleCamera";
+        } else if (@available(iOS 15.4, *)) {
+          if ([device deviceType] == AVCaptureDeviceTypeBuiltInLiDARDepthCamera) {
+            deviceType = @"builtInLiDARDepthCamera";
+          } else if (@available(iOS 17.0, *)) {
+            if ([device deviceType] == AVCaptureDeviceTypeContinuityCamera) {
+              deviceType = @"continuityCamera";
+            } else if ([device deviceType] == AVCaptureDeviceTypeExternal) {
+              deviceType = @"external";
+            }
+          }
+        }
       }
       [reply addObject:@{
         @"name" : [device uniqueID],

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -114,7 +114,6 @@
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInDualWideCamera];
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInTripleCamera];
-      [discoveryDevices addObject:AVCaptureDeviceTypeDeskViewCamera];
     }
     if (@available(iOS 15.4, *)) {
       [discoveryDevices addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
@@ -144,40 +143,28 @@
           break;
       }
       NSString *deviceType;
-      switch ([device deviceType]) {
-        case AVCaptureDeviceTypeBuiltInWideAngleCamera:
+      if ([device deviceType] == AVCaptureDeviceTypeBuiltInWideAngleCamera) {
           deviceType = @"builtInWideAngleCamera";
-          break;
-        case AVCaptureDeviceTypeBuiltInUltraWideCamera:
-          deviceType = @"builtInUltraWideCamera";
-          break;
-        case AVCaptureDeviceTypeBuiltInTelephotoCamera:
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTelephotoCamera) {
           deviceType = @"builtInTelephotoCamera";
-          break;
-        case AVCaptureDeviceTypeBuiltInDualCamera:
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInUltraWideCamera) {
+          deviceType = @"builtInUltraWideCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInDualCamera) {
           deviceType = @"builtInDualCamera";
-          break;
-        case AVCaptureDeviceTypeBuiltInDualWideCamera:
-          deviceType = @"builtInDualWideCamera";
-          break;
-        case AVCaptureDeviceTypeBuiltInTripleCamera:
-          deviceType = @"builtInTripleCamera";
-          break;
-        case AVCaptureDeviceTypeContinuityCamera:
-          deviceType = @"continuityCamera";
-          break;
-        case AVCaptureDeviceTypeExternal:
-          deviceType = @"external";
-          break;
-        case AVCaptureDeviceTypeDeskViewCamera:
-          deviceType = @"deskViewCamera";
-          break;
-        case AVCaptureDeviceTypeBuiltInLiDARDepthCamera:
-          deviceType = @"builtInLiDARDepthCamera";
-          break;
-        case AVCaptureDeviceTypeBuiltInTrueDepthCamera:
-          deviceType = @"builtInTrueDepthCamera";
-          break;
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInDualWideCamera) {
+        deviceType = @"builtInDualWideCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTripleCamera) {
+        deviceType = @"builtInTripleCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeContinuityCamera) {
+        deviceType = @"continuityCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeExternal) {
+        deviceType = @"external";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInLiDARDepthCamera) {
+        deviceType = @"builtInLiDARDepthCamera";
+      } else if ([device deviceType] == AVCaptureDeviceTypeBuiltInTrueDepthCamera) {
+        deviceType = @"builtInTrueDepthCamera";
+      } else {
+        deviceType = @"unknown";
       }
       [reply addObject:@{
         @"name" : [device uniqueID],

--- a/packages/camera/camera_avfoundation/lib/camera_avfoundation.dart
+++ b/packages/camera/camera_avfoundation/lib/camera_avfoundation.dart
@@ -3,3 +3,4 @@
 // found in the LICENSE file.
 
 export 'src/avfoundation_camera.dart';
+export 'src/avfoundation_camera_description.dart';

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -93,27 +93,6 @@ class AVFoundationCamera extends CameraPlatform {
     }
   }
 
-  /// Parses the [type] into an [AppleCaptureDeviceType].
-  AppleCaptureDeviceType? parseAppleCaptureDeviceType(String type) {
-    for (final AppleCaptureDeviceType element
-        in AppleCaptureDeviceType.values) {
-      if (element.name == type) {
-        return element;
-      }
-    }
-    // catch deprecated types
-    switch (type) {
-      case 'builtInDuoCamera':
-        return AppleCaptureDeviceType.builtInDualCamera;
-      case 'builtInMicrophone':
-        return AppleCaptureDeviceType.microphone;
-      case 'externalUnknown':
-        return AppleCaptureDeviceType.external;
-      default:
-        return null;
-    }
-  }
-
   @override
   Future<int> createCamera(
     CameraDescription cameraDescription,

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:camera_avfoundation/camera_avfoundation.dart';
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -69,23 +70,30 @@ class AVFoundationCamera extends CameraPlatform {
           .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
-  Future<List<CameraDescription>> availableCameras() async {
+  Future<List<CameraDescription>> availableCameras({
+    bool physicalCameras = true,
+    bool logicalCameras = false,
+  }) async {
     try {
       final List<Map<dynamic, dynamic>>? cameras = await _channel
-          .invokeListMethod<Map<dynamic, dynamic>>('availableCameras');
+          .invokeListMethod<Map<dynamic, dynamic>>(
+              'availableCameras', <String, dynamic>{
+        'physicalCameras': physicalCameras,
+        'logicalCameras': logicalCameras,
+      });
 
       if (cameras == null) {
         return <CameraDescription>[];
       }
 
       return cameras.map((Map<dynamic, dynamic> camera) {
-        return CameraDescription(
+        return AVCameraDescription(
           name: camera['name']! as String,
           lensDirection:
               parseCameraLensDirection(camera['lensFacing']! as String),
           sensorOrientation: camera['sensorOrientation']! as int,
-          appleCaptureDeviceType:
-              parseAppleCaptureDeviceType(camera['deviceType']! as String),
+          captureDeviceType:
+              parseAVCaptureDeviceType(camera['deviceType']! as String),
         );
       }).toList();
     } on PlatformException catch (e) {

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -84,10 +84,33 @@ class AVFoundationCamera extends CameraPlatform {
           lensDirection:
               parseCameraLensDirection(camera['lensFacing']! as String),
           sensorOrientation: camera['sensorOrientation']! as int,
+          appleCaptureDeviceType:
+              parseAppleCaptureDeviceType(camera['deviceType']! as String),
         );
       }).toList();
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
+    }
+  }
+
+  /// Parses the [type] into an [AppleCaptureDeviceType].
+  AppleCaptureDeviceType? parseAppleCaptureDeviceType(String type) {
+    for (final AppleCaptureDeviceType element
+        in AppleCaptureDeviceType.values) {
+      if (element.name == type) {
+        return element;
+      }
+    }
+    // catch deprecated types
+    switch (type) {
+      case 'builtInDuoCamera':
+        return AppleCaptureDeviceType.builtInDualCamera;
+      case 'builtInMicrophone':
+        return AppleCaptureDeviceType.microphone;
+      case 'externalUnknown':
+        return AppleCaptureDeviceType.external;
+      default:
+        return null;
     }
   }
 

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -70,7 +70,7 @@ class AVFoundationCamera extends CameraPlatform {
           .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
-  Future<List<CameraDescription>> availableCameras({
+  Future<List<AVCameraDescription>> availableCameras({
     bool physicalCameras = true,
     bool logicalCameras = false,
   }) async {
@@ -83,7 +83,7 @@ class AVFoundationCamera extends CameraPlatform {
       });
 
       if (cameras == null) {
-        return <CameraDescription>[];
+        return <AVCameraDescription>[];
       }
 
       return cameras.map((Map<dynamic, dynamic> camera) {

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera_description.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera_description.dart
@@ -1,0 +1,71 @@
+import 'package:camera_platform_interface/camera_platform_interface.dart';
+import 'package:flutter/foundation.dart';
+
+/// Capture device types used on Apple Device. Mirror of AVCaptureDevice.DeviceType:
+/// https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype
+enum AVCaptureDeviceType {
+  /// A built-in wide-angle camera device type.
+  builtInWideAngleCamera,
+
+  /// A built-in camera device type with a shorter focal length than a wide-angle camera.
+  builtInUltraWideCamera,
+
+  /// A built-in camera device type with a longer focal length than a wide-angle camera.
+  builtInTelephotoCamera,
+
+  /// A built-in camera device type that consists of a wide-angle and telephoto camera.
+  builtInDualCamera,
+
+  /// A built-in camera device type that consists of two cameras of fixed focal length, one ultrawide angle and one wide angle.
+  builtInDualWideCamera,
+
+  /// A built-in camera device type that consists of three cameras of fixed focal length, one ultrawide angle, one wide angle, and one telephoto.
+  builtInTripleCamera,
+
+  /// A Continuity Camera device type.
+  continuityCamera,
+
+  /// An external device type.
+  external,
+
+  /// A device that consists of two cameras, one LiDAR and one YUV.
+  builtInLiDARDepthCamera,
+
+  /// A device that consists of two cameras, one Infrared and one YUV.
+  builtInTrueDepthCamera,
+}
+
+/// Properties of an Apple camera device.
+@immutable
+class AVCameraDescription extends CameraDescription {
+  /// Creates a new camera description with the given properties.
+  const AVCameraDescription({
+    required super.name,
+    required super.lensDirection,
+    required super.sensorOrientation,
+    this.captureDeviceType,
+  });
+
+  /// The type of the capture device on Apple devices.
+  final AVCaptureDeviceType? captureDeviceType;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AVCameraDescription &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          lensDirection == other.lensDirection &&
+          sensorOrientation == other.sensorOrientation &&
+          captureDeviceType == other.captureDeviceType;
+
+  @override
+  int get hashCode =>
+      Object.hash(name, lensDirection, sensorOrientation, captureDeviceType);
+
+  @override
+  String toString() {
+    return '${objectRuntimeType(this, 'AVCameraDescription')}('
+        '$name, $lensDirection, $sensorOrientation, $captureDeviceType)';
+  }
+}

--- a/packages/camera/camera_avfoundation/lib/src/utils.dart
+++ b/packages/camera/camera_avfoundation/lib/src/utils.dart
@@ -5,6 +5,8 @@
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:flutter/services.dart';
 
+import '../camera_avfoundation.dart';
+
 /// Parses a string into a corresponding CameraLensDirection.
 CameraLensDirection parseCameraLensDirection(String string) {
   switch (string) {
@@ -18,29 +20,29 @@ CameraLensDirection parseCameraLensDirection(String string) {
   throw ArgumentError('Unknown CameraLensDirection value');
 }
 
-/// Parses the [type] into an [AppleCaptureDeviceType].
-AppleCaptureDeviceType? parseAppleCaptureDeviceType(String type) {
+/// Parses the [type] into an [AVCaptureDeviceType].
+AVCaptureDeviceType? parseAVCaptureDeviceType(String type) {
   switch (type) {
     case 'builtInWideAngleCamera':
-      return AppleCaptureDeviceType.builtInWideAngleCamera;
+      return AVCaptureDeviceType.builtInWideAngleCamera;
     case 'builtInUltraWideCamera':
-      return AppleCaptureDeviceType.builtInUltraWideCamera;
+      return AVCaptureDeviceType.builtInUltraWideCamera;
     case 'builtInTelephotoCamera':
-      return AppleCaptureDeviceType.builtInTelephotoCamera;
+      return AVCaptureDeviceType.builtInTelephotoCamera;
     case 'builtInDualCamera':
-      return AppleCaptureDeviceType.builtInDualCamera;
+      return AVCaptureDeviceType.builtInDualCamera;
     case 'builtInDualWideCamera':
-      return AppleCaptureDeviceType.builtInDualWideCamera;
+      return AVCaptureDeviceType.builtInDualWideCamera;
     case 'builtInTripleCamera':
-      return AppleCaptureDeviceType.builtInTripleCamera;
+      return AVCaptureDeviceType.builtInTripleCamera;
     case 'continuityCamera':
-      return AppleCaptureDeviceType.continuityCamera;
+      return AVCaptureDeviceType.continuityCamera;
     case 'external':
-      return AppleCaptureDeviceType.external;
+      return AVCaptureDeviceType.external;
     case 'builtInLiDARDepthCamera':
-      return AppleCaptureDeviceType.builtInLiDARDepthCamera;
+      return AVCaptureDeviceType.builtInLiDARDepthCamera;
     case 'builtInTrueDepthCamera':
-      return AppleCaptureDeviceType.builtInTrueDepthCamera;
+      return AVCaptureDeviceType.builtInTrueDepthCamera;
   }
   // unknown type
   return null;

--- a/packages/camera/camera_avfoundation/lib/src/utils.dart
+++ b/packages/camera/camera_avfoundation/lib/src/utils.dart
@@ -18,6 +18,37 @@ CameraLensDirection parseCameraLensDirection(String string) {
   throw ArgumentError('Unknown CameraLensDirection value');
 }
 
+/// Parses the [type] into an [AppleCaptureDeviceType].
+AppleCaptureDeviceType? parseAppleCaptureDeviceType(String type) {
+  switch (type) {
+    case 'builtInWideAngleCamera':
+      return AppleCaptureDeviceType.builtInWideAngleCamera;
+    case 'builtInUltraWideCamera':
+      return AppleCaptureDeviceType.builtInUltraWideCamera;
+    case 'builtInTelephotoCamera':
+      return AppleCaptureDeviceType.builtInTelephotoCamera;
+    case 'builtInDualCamera':
+      return AppleCaptureDeviceType.builtInDualCamera;
+    case 'builtInDualWideCamera':
+      return AppleCaptureDeviceType.builtInDualWideCamera;
+    case 'builtInTripleCamera':
+      return AppleCaptureDeviceType.builtInTripleCamera;
+    case 'continuityCamera':
+      return AppleCaptureDeviceType.continuityCamera;
+    case 'microphone':
+      return AppleCaptureDeviceType.microphone;
+    case 'external':
+      return AppleCaptureDeviceType.external;
+    case 'deskViewCamera':
+      return AppleCaptureDeviceType.deskViewCamera;
+    case 'builtInLiDARDepthCamera':
+      return AppleCaptureDeviceType.builtInLiDARDepthCamera;
+    case 'builtInTrueDepthCamera':
+      return AppleCaptureDeviceType.builtInTrueDepthCamera;
+  }
+  throw ArgumentError('Unknown AppleCaptureDeviceType value');
+}
+
 /// Returns the device orientation as a String.
 String serializeDeviceOrientation(DeviceOrientation orientation) {
   switch (orientation) {

--- a/packages/camera/camera_avfoundation/lib/src/utils.dart
+++ b/packages/camera/camera_avfoundation/lib/src/utils.dart
@@ -42,7 +42,8 @@ AppleCaptureDeviceType? parseAppleCaptureDeviceType(String type) {
     case 'builtInTrueDepthCamera':
       return AppleCaptureDeviceType.builtInTrueDepthCamera;
   }
-  throw ArgumentError('Unknown AppleCaptureDeviceType value');
+  // unknown type
+  return null;
 }
 
 /// Returns the device orientation as a String.

--- a/packages/camera/camera_avfoundation/lib/src/utils.dart
+++ b/packages/camera/camera_avfoundation/lib/src/utils.dart
@@ -39,8 +39,6 @@ AppleCaptureDeviceType? parseAppleCaptureDeviceType(String type) {
       return AppleCaptureDeviceType.microphone;
     case 'external':
       return AppleCaptureDeviceType.external;
-    case 'deskViewCamera':
-      return AppleCaptureDeviceType.deskViewCamera;
     case 'builtInLiDARDepthCamera':
       return AppleCaptureDeviceType.builtInLiDARDepthCamera;
     case 'builtInTrueDepthCamera':

--- a/packages/camera/camera_avfoundation/lib/src/utils.dart
+++ b/packages/camera/camera_avfoundation/lib/src/utils.dart
@@ -35,8 +35,6 @@ AppleCaptureDeviceType? parseAppleCaptureDeviceType(String type) {
       return AppleCaptureDeviceType.builtInTripleCamera;
     case 'continuityCamera':
       return AppleCaptureDeviceType.continuityCamera;
-    case 'microphone':
-      return AppleCaptureDeviceType.microphone;
     case 'external':
       return AppleCaptureDeviceType.external;
     case 'builtInLiDARDepthCamera':

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -29,3 +29,8 @@ dev_dependencies:
 
 topics:
   - camera
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../camera/camera_platform_interface}}

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -29,4 +29,3 @@ dev_dependencies:
 
 topics:
   - camera
-

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_description_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_description_test.dart
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:camera_avfoundation/camera_avfoundation.dart';
+import 'package:camera_platform_interface/camera_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('equals should return false if apple capture device type is different',
+      () {
+    const CameraDescription firstDescription = AVCameraDescription(
+      name: 'Test',
+      lensDirection: CameraLensDirection.front,
+      sensorOrientation: 0,
+      captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera,
+    );
+    const CameraDescription secondDescription = AVCameraDescription(
+      name: 'Test',
+      lensDirection: CameraLensDirection.front,
+      sensorOrientation: 0,
+      captureDeviceType: AVCaptureDeviceType.builtInUltraWideCamera,
+    );
+
+    expect(firstDescription == secondDescription, false);
+  });
+
+  test('equals should return false if one apple capture device type is null',
+      () {
+    const CameraDescription firstDescription = AVCameraDescription(
+      name: 'Test',
+      lensDirection: CameraLensDirection.front,
+      sensorOrientation: 0,
+      captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera,
+    );
+    const CameraDescription secondDescription = AVCameraDescription(
+      name: 'Test',
+      lensDirection: CameraLensDirection.front,
+      sensorOrientation: 0,
+    );
+
+    expect(firstDescription == secondDescription, false);
+  });
+
+  test('equals should return true if apple capture device type is null', () {
+    const CameraDescription firstDescription = AVCameraDescription(
+      name: 'Test',
+      lensDirection: CameraLensDirection.front,
+      sensorOrientation: 0,
+    );
+    const CameraDescription secondDescription = AVCameraDescription(
+      name: 'Test',
+      lensDirection: CameraLensDirection.front,
+      sensorOrientation: 0,
+    );
+
+    expect(firstDescription == secondDescription, true);
+  });
+}

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:async/async.dart';
-import 'package:camera_avfoundation/src/avfoundation_camera.dart';
+import 'package:camera_avfoundation/camera_avfoundation.dart';
 import 'package:camera_avfoundation/src/utils.dart';
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:flutter/services.dart';
@@ -43,6 +43,29 @@ void main() {
     expect(response, null);
   });
 
+  group('AVCaptureDeviceType tests', () {
+    test('AVCaptureDeviceType should contain 10 options', () {
+      const List<AVCaptureDeviceType> values = AVCaptureDeviceType.values;
+
+      expect(values.length, 10);
+    });
+
+    test('AVCaptureDeviceType enum should have items in correct index', () {
+      const List<AVCaptureDeviceType> values = AVCaptureDeviceType.values;
+
+      expect(values[0], AVCaptureDeviceType.builtInWideAngleCamera);
+      expect(values[1], AVCaptureDeviceType.builtInUltraWideCamera);
+      expect(values[2], AVCaptureDeviceType.builtInTelephotoCamera);
+      expect(values[3], AVCaptureDeviceType.builtInDualCamera);
+      expect(values[4], AVCaptureDeviceType.builtInDualWideCamera);
+      expect(values[5], AVCaptureDeviceType.builtInTripleCamera);
+      expect(values[6], AVCaptureDeviceType.continuityCamera);
+      expect(values[7], AVCaptureDeviceType.external);
+      expect(values[8], AVCaptureDeviceType.builtInLiDARDepthCamera);
+      expect(values[9], AVCaptureDeviceType.builtInTrueDepthCamera);
+    });
+  });
+
   group('Creation, Initialization & Disposal Tests', () {
     test('Should send creation data and receive back a camera id', () async {
       // Arrange
@@ -58,10 +81,11 @@ void main() {
 
       // Act
       final int cameraId = await camera.createCamera(
-        const CameraDescription(
+        const AVCameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0),
+            sensorOrientation: 0,
+            captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera),
         ResolutionPreset.high,
       );
 
@@ -93,10 +117,11 @@ void main() {
       // Act
       expect(
         () => camera.createCamera(
-          const CameraDescription(
+          const AVCameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
+            captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera,
           ),
           ResolutionPreset.high,
         ),
@@ -124,10 +149,11 @@ void main() {
       // Act
       expect(
         () => camera.createCamera(
-          const CameraDescription(
+          const AVCameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
+            captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera,
           ),
           ResolutionPreset.high,
         ),
@@ -186,10 +212,11 @@ void main() {
           });
       final AVFoundationCamera camera = AVFoundationCamera();
       final int cameraId = await camera.createCamera(
-        const CameraDescription(
+        const AVCameraDescription(
           name: 'Test',
           lensDirection: CameraLensDirection.back,
           sensorOrientation: 0,
+          captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera,
         ),
         ResolutionPreset.high,
       );
@@ -233,10 +260,11 @@ void main() {
 
       final AVFoundationCamera camera = AVFoundationCamera();
       final int cameraId = await camera.createCamera(
-        const CameraDescription(
+        const AVCameraDescription(
           name: 'Test',
           lensDirection: CameraLensDirection.back,
           sensorOrientation: 0,
+          captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera,
         ),
         ResolutionPreset.high,
       );
@@ -281,10 +309,11 @@ void main() {
       );
       camera = AVFoundationCamera();
       cameraId = await camera.createCamera(
-        const CameraDescription(
+        const AVCameraDescription(
           name: 'Test',
           lensDirection: CameraLensDirection.back,
           sensorOrientation: 0,
+          captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera,
         ),
         ResolutionPreset.high,
       );
@@ -453,10 +482,11 @@ void main() {
       );
       camera = AVFoundationCamera();
       cameraId = await camera.createCamera(
-        const CameraDescription(
+        const AVCameraDescription(
           name: 'Test',
           lensDirection: CameraLensDirection.back,
           sensorOrientation: 0,
+          captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera,
         ),
         ResolutionPreset.high,
       );
@@ -485,12 +515,14 @@ void main() {
         <String, dynamic>{
           'name': 'Test 1',
           'lensFacing': 'front',
-          'sensorOrientation': 1
+          'sensorOrientation': 1,
+          'deviceType': 'builtInTrueDepthCamera'
         },
         <String, dynamic>{
           'name': 'Test 2',
           'lensFacing': 'back',
-          'sensorOrientation': 2
+          'sensorOrientation': 2,
+          'deviceType': 'builtInWideAngleCamera'
         }
       ];
       final MethodChannelMock channel = MethodChannelMock(
@@ -503,17 +535,22 @@ void main() {
 
       // Assert
       expect(channel.log, <Matcher>[
-        isMethodCall('availableCameras', arguments: null),
+        isMethodCall('availableCameras', arguments: <String, Object?>{
+          'physicalCameras': true,
+          'logicalCameras': false
+        }),
       ]);
       expect(cameras.length, returnData.length);
       for (int i = 0; i < returnData.length; i++) {
         final Map<String, Object?> typedData =
             (returnData[i] as Map<dynamic, dynamic>).cast<String, Object?>();
-        final CameraDescription cameraDescription = CameraDescription(
+        final CameraDescription cameraDescription = AVCameraDescription(
           name: typedData['name']! as String,
           lensDirection:
               parseCameraLensDirection(typedData['lensFacing']! as String),
           sensorOrientation: typedData['sensorOrientation']! as int,
+          captureDeviceType:
+              parseAVCaptureDeviceType(typedData['deviceType']! as String),
         );
         expect(cameras[i], cameraDescription);
       }
@@ -705,10 +742,11 @@ void main() {
         channelName: _channelName,
         methods: <String, dynamic>{'setDescriptionWhileRecording': null},
       );
-      const CameraDescription camera2Description = CameraDescription(
+      const AVCameraDescription camera2Description = AVCameraDescription(
           name: 'Test2',
           lensDirection: CameraLensDirection.front,
-          sensorOrientation: 0);
+          sensorOrientation: 0,
+          captureDeviceType: AVCaptureDeviceType.builtInWideAngleCamera);
 
       // Act
       await camera.setDescriptionWhileRecording(camera2Description);

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.7.3
+
+* add options to get available physical or logical cameras
+
 ## 2.7.2
 
 * Updates minimum required plugin_platform_interface version to 2.1.7.

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -61,7 +61,10 @@ class MethodChannelCamera extends CameraPlatform {
           .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
-  Future<List<CameraDescription>> availableCameras() async {
+  Future<List<CameraDescription>> availableCameras({
+    bool physicalCameras = true,
+    bool logicalCameras = false,
+  }) async {
     try {
       final List<Map<dynamic, dynamic>>? cameras = await _channel
           .invokeListMethod<Map<dynamic, dynamic>>('availableCameras');

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -42,7 +42,10 @@ abstract class CameraPlatform extends PlatformInterface {
   /// Completes with a list of available cameras.
   ///
   /// This method returns an empty list when no cameras are available.
-  Future<List<CameraDescription>> availableCameras() {
+  Future<List<CameraDescription>> availableCameras({
+    bool physicalCameras = true,
+    bool logicalCameras = false,
+  }) {
     throw UnimplementedError('availableCameras() is not implemented.');
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
@@ -16,50 +16,14 @@ enum CameraLensDirection {
   external,
 }
 
-/// Capture device types used on Apple Device. Mirror of AVCaptureDevice.DeviceType:
-/// https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype
-enum AppleCaptureDeviceType {
-  /// A built-in wide-angle camera device type.
-  builtInWideAngleCamera,
-
-  /// A built-in camera device type with a shorter focal length than a wide-angle camera.
-  builtInUltraWideCamera,
-
-  /// A built-in camera device type with a longer focal length than a wide-angle camera.
-  builtInTelephotoCamera,
-
-  /// A built-in camera device type that consists of a wide-angle and telephoto camera.
-  builtInDualCamera,
-
-  /// A built-in camera device type that consists of two cameras of fixed focal length, one ultrawide angle and one wide angle.
-  builtInDualWideCamera,
-
-  /// A built-in camera device type that consists of three cameras of fixed focal length, one ultrawide angle, one wide angle, and one telephoto.
-  builtInTripleCamera,
-
-  /// A Continuity Camera device type.
-  continuityCamera,
-
-  /// An external device type.
-  external,
-
-  /// A device that consists of two cameras, one LiDAR and one YUV.
-  builtInLiDARDepthCamera,
-
-  /// A device that consists of two cameras, one Infrared and one YUV.
-  builtInTrueDepthCamera,
-}
-
 /// Properties of a camera device.
 @immutable
 class CameraDescription {
   /// Creates a new camera description with the given properties.
-  const CameraDescription({
-    required this.name,
-    required this.lensDirection,
-    required this.sensorOrientation,
-    this.appleCaptureDeviceType,
-  });
+  const CameraDescription(
+      {required this.name,
+      required this.lensDirection,
+      required this.sensorOrientation});
 
   /// The name of the camera device.
   final String name;
@@ -76,9 +40,6 @@ class CameraDescription {
   /// is from top to bottom in the sensor's coordinate system.
   final int sensorOrientation;
 
-  /// The type of the capture device on Apple devices.
-  final AppleCaptureDeviceType? appleCaptureDeviceType;
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -93,6 +54,6 @@ class CameraDescription {
   @override
   String toString() {
     return '${objectRuntimeType(this, 'CameraDescription')}('
-        '$name, $lensDirection, $sensorOrientation, $appleCaptureDeviceType)';
+        '$name, $lensDirection, $sensorOrientation)';
   }
 }

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
@@ -40,14 +40,8 @@ enum AppleCaptureDeviceType {
   /// A Continuity Camera device type.
   continuityCamera,
 
-  /// A microphone device type.
-  microphone,
-
   /// An external device type.
   external,
-
-  /// A virtual overhead camera that captures a user’s desk.
-  deskViewCamera,
 
   /// A device that consists of two cameras, one LiDAR and one YUV.
   builtInLiDARDepthCamera,

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
@@ -16,6 +16,46 @@ enum CameraLensDirection {
   external,
 }
 
+/// Capture device types used on Apple Device. Mirror of AVCaptureDevice.DeviceType:
+/// https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype
+enum AppleCaptureDeviceType {
+  /// A built-in wide-angle camera device type.
+  builtInWideAngleCamera,
+
+  /// A built-in camera device type with a shorter focal length than a wide-angle camera.
+  builtInUltraWideCamera,
+
+  /// A built-in camera device type with a longer focal length than a wide-angle camera.
+  builtInTelephotoCamera,
+
+  /// A built-in camera device type that consists of a wide-angle and telephoto camera.
+  builtInDualCamera,
+
+  /// A built-in camera device type that consists of two cameras of fixed focal length, one ultrawide angle and one wide angle.
+  builtInDualWideCamera,
+
+  /// A built-in camera device type that consists of three cameras of fixed focal length, one ultrawide angle, one wide angle, and one telephoto.
+  builtInTripleCamera,
+
+  /// A Continuity Camera device type.
+  continuityCamera,
+
+  /// A microphone device type.
+  microphone,
+
+  /// An external device type.
+  external,
+
+  /// A virtual overhead camera that captures a user’s desk.
+  deskViewCamera,
+
+  /// A device that consists of two cameras, one LiDAR and one YUV.
+  builtInLiDARDepthCamera,
+
+  /// A device that consists of two cameras, one Infrared and one YUV.
+  builtInTrueDepthCamera,
+}
+
 /// Properties of a camera device.
 @immutable
 class CameraDescription {
@@ -24,6 +64,7 @@ class CameraDescription {
     required this.name,
     required this.lensDirection,
     required this.sensorOrientation,
+    this.appleCaptureDeviceType,
   });
 
   /// The name of the camera device.
@@ -41,6 +82,9 @@ class CameraDescription {
   /// is from top to bottom in the sensor's coordinate system.
   final int sensorOrientation;
 
+  /// The type of the capture device on Apple devices.
+  final AppleCaptureDeviceType? appleCaptureDeviceType;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -55,6 +99,6 @@ class CameraDescription {
   @override
   String toString() {
     return '${objectRuntimeType(this, 'CameraDescription')}('
-        '$name, $lensDirection, $sensorOrientation)';
+        '$name, $lensDirection, $sensorOrientation, $appleCaptureDeviceType)';
   }
 }

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.7.2
+version: 2.7.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Add placeholder physicalCameras and logicalCameras options to availableDevices method.
+
 ## 0.3.2+4
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.

--- a/packages/camera/camera_web/example/pubspec.yaml
+++ b/packages/camera/camera_web/example/pubspec.yaml
@@ -20,3 +20,8 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   mocktail: 0.3.0
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}}

--- a/packages/camera/camera_web/example/pubspec.yaml
+++ b/packages/camera/camera_web/example/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 # FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
 # See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
 dependency_overrides:
-   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}}
+   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}, camera_web: {path: ../../../camera/camera_web}}

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -82,7 +82,10 @@ class CameraPlugin extends CameraPlatform {
   html.Window? window = html.window;
 
   @override
-  Future<List<CameraDescription>> availableCameras() async {
+  Future<List<CameraDescription>> availableCameras({
+    bool physicalCameras = true,
+    bool logicalCameras = false,
+  }) async {
     try {
       final html.MediaDevices? mediaDevices = window?.navigator.mediaDevices;
       final List<CameraDescription> cameras = <CameraDescription>[];

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -30,3 +30,8 @@ dev_dependencies:
 
 topics:
   - camera
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../camera/camera_platform_interface}}

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Add placeholder physicalCameras and logicalCameras options to availableDevices method.
+
 ## 0.2.1+9
 
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.

--- a/packages/camera/camera_windows/example/pubspec.yaml
+++ b/packages/camera/camera_windows/example/pubspec.yaml
@@ -27,3 +27,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}}

--- a/packages/camera/camera_windows/example/pubspec.yaml
+++ b/packages/camera/camera_windows/example/pubspec.yaml
@@ -31,4 +31,4 @@ flutter:
 # FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
 # See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
 dependency_overrides:
-   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}}
+   {camera_platform_interface: {path: ../../../camera/camera_platform_interface}, camera_windows: {path: ../../../camera/camera_windows}}

--- a/packages/camera/camera_windows/lib/camera_windows.dart
+++ b/packages/camera/camera_windows/lib/camera_windows.dart
@@ -41,7 +41,10 @@ class CameraWindows extends CameraPlatform {
           .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
-  Future<List<CameraDescription>> availableCameras() async {
+  Future<List<CameraDescription>> availableCameras({
+    bool physicalCameras = true,
+    bool logicalCameras = false,
+  }) async {
     try {
       final List<Map<dynamic, dynamic>>? cameras = await pluginChannel
           .invokeListMethod<Map<dynamic, dynamic>>('availableCameras');

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -30,3 +30,8 @@ dev_dependencies:
 
 topics:
   - camera
+
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins
+dependency_overrides:
+   {camera_platform_interface: {path: ../../camera/camera_platform_interface}}


### PR DESCRIPTION
Based on feedback from @stuartmorgan, I have refactored my original PRs (#5957 and #5958) to not disrupt the existing functionality of the availableDevices method, while still providing the option to access the extended list of iOS cameras (both physical and logical) based on Apple's documentation:
https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype

This changes hopefully make room to eventually add the ability to access logical cameras on Android (or other?) devices at some point, but the changes on iOS were more pressing for my project so I wanted to at least start there.

I've included external cameras as "physical devices" so this PR should fix the same issue as #5892.

*List which issues are fixed by this PR. You must list at least one issue.*
closes flutter/flutter#134151
closes flutter/flutter#130073
closes flutter/flutter#142025

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.