### PR TITLE
[ci] Move tool_runner.sh

### DIFF
--- a/.ci/scripts/analyze_legacy.sh
+++ b/.ci/scripts/analyze_legacy.sh
@@ -9,12 +9,12 @@ set -e
 # work in legacy versions.
 #
 # This requires the --lib-only flag below.
-./script/tool_runner.sh remove-dev-dependencies
+.ci/scripts/tool_runner.sh remove-dev-dependencies
 
 # This uses --run-on-dirty-packages rather than --packages-for-branch
 # since only the packages changed by 'make-deps-path-based' need to be
 # re-checked.
-./script/tool_runner.sh analyze --lib-only \
+.ci/scripts/tool_runner.sh analyze --lib-only \
     --skip-if-not-supporting-flutter-version="$CHANNEL" \
     --custom-analysis=script/configs/custom_analysis.yaml
 

--- a/.ci/scripts/analyze_pathified.sh
+++ b/.ci/scripts/analyze_pathified.sh
@@ -6,7 +6,7 @@ set -e
 
 # Pathify the dependencies on changed packages (excluding major version
 # changes, which won't affect clients).
-./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
+.ci/scripts/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
 # This uses --run-on-dirty-packages rather than --packages-for-branch
 # since only the packages changed by 'make-deps-path-based' need to be
 # re-checked.

--- a/.ci/scripts/check_federated_safety.sh
+++ b/.ci/scripts/check_federated_safety.sh
@@ -7,5 +7,5 @@ set -e
 if [[ $LUCI_PR == "" ]]; then
   echo "This check is only run in presubmit"
 else
-  ./script/tool_runner.sh federation-safety-check
+  .ci/scripts/tool_runner.sh federation-safety-check
 fi

--- a/.ci/scripts/check_version.sh
+++ b/.ci/scripts/check_version.sh
@@ -10,7 +10,7 @@ set -e
 # missing version/CHANGELOG detection since PR-level overrides aren't available
 # in post-submit.
 if [[ $LUCI_PR == "" ]]; then
-  ./script/tool_runner.sh version-check --ignore-platform-interface-breaks
+  .ci/scripts/tool_runner.sh version-check --ignore-platform-interface-breaks
 else
-  ./script/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$PR_OVERRIDE_LABELS"
+  .ci/scripts/tool_runner.sh version-check --check-for-missing-changes --pr-labels="$PR_OVERRIDE_LABELS"
 fi

--- a/.ci/scripts/dart_unit_tests_pathified.sh
+++ b/.ci/scripts/dart_unit_tests_pathified.sh
@@ -6,7 +6,7 @@ set -e
 
 # Pathify the dependencies on changed packages (excluding major version
 # changes, which won't affect clients).
-./script/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
+.ci/scripts/tool_runner.sh make-deps-path-based --target-dependencies-with-non-breaking-updates
 # This uses --run-on-dirty-packages rather than --packages-for-branch
 # since only the packages changed by 'make-deps-path-based' need to be
 # re-checked.

--- a/.ci/scripts/tool_runner.sh
+++ b/.ci/scripts/tool_runner.sh
@@ -12,7 +12,7 @@ set -e
 # For local use, directly run `dart run <tool path>`.
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
+readonly REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 readonly TOOL_PATH="$REPO_DIR/script/tool/bin/flutter_plugin_tools.dart"
 
 # Ensure that the tool dependencies have been fetched.

--- a/.ci/scripts/tool_runner.sh
+++ b/.ci/scripts/tool_runner.sh
@@ -5,9 +5,11 @@
 
 set -e
 
-# WARNING! Do not remove this script, or change its behavior, unless you have
-# verified that it will not break the flutter/flutter analysis run of this
-# repository: https://github.com/flutter/flutter/blob/master/dev/bots/test.dart
+# This file runs the repo tooling (see TOOL_PATH) in a configuration that's
+# common to almost all of the CI usage, avoiding the need to pass the same
+# flags (e.g., --packages-for-branch) in every CI invocation.
+#
+# For local use, directly run `dart run <tool path>`.
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"

--- a/.ci/scripts/xvfb_tool_runner.sh
+++ b/.ci/scripts/xvfb_tool_runner.sh
@@ -4,4 +4,4 @@
 # found in the LICENSE file.
 set -e
 
-xvfb-run ./script/tool_runner.sh "$@"
+xvfb-run .ci/scripts/tool_runner.sh "$@"

--- a/.ci/targets/analyze.yaml
+++ b/.ci/targets/analyze.yaml
@@ -5,11 +5,11 @@ tasks:
   - name: analyze repo tools
     script: .ci/scripts/analyze_repo_tools.sh
   - name: download Dart deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["fetch-deps"]
     infra_step: true
   - name: analyze
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     # DO NOT change the custom-analysis argument here without changing the Dart repo.
     # See the comment in script/configs/custom_analysis.yaml for details.
     args: ["analyze", "--custom-analysis=script/configs/custom_analysis.yaml"]

--- a/.ci/targets/analyze_downgraded.yaml
+++ b/.ci/targets/analyze_downgraded.yaml
@@ -6,5 +6,5 @@ tasks:
   # new APIs but forget to update minimum versions of dependencies to where
   # those APIs are introduced.
   - name: analyze - downgraded
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["analyze", "--downgrade", "--custom-analysis=script/configs/custom_analysis.yaml"]

--- a/.ci/targets/android_device_tests.yaml
+++ b/.ci/targets/android_device_tests.yaml
@@ -3,11 +3,11 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: download Dart and Android deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     infra_step: true
     args: ["fetch-deps", "--android", "--supporting-target-platforms-only"]
   - name: Firebase Test Lab
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args:
       - "firebase-test-lab"
       - "--device"

--- a/.ci/targets/android_legacy_emulator_tests.yaml
+++ b/.ci/targets/android_legacy_emulator_tests.yaml
@@ -3,14 +3,14 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: download Dart and Android deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     infra_step: true
     args: ["fetch-deps", "--android", "--supporting-target-platforms-only", "--exclude=script/configs/exclude_integration_android_legacy_emulator.yaml"]
   # Only these two tests are run because they are the only ones that use the
   # emulator. Other tests would just duplicate android_platform_test.yaml tests.
   - name: native integration tests
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["native-test", "--android", "--no-unit", "--exclude=script/configs/exclude_integration_android_legacy_emulator.yaml"]
   - name: drive examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["drive-examples", "--android", "--exclude=script/configs/exclude_integration_android_legacy_emulator.yaml,script/configs/exclude_integration_android.yaml,script/configs/exclude_integration_android_emulator.yaml"]

--- a/.ci/targets/android_platform_tests.yaml
+++ b/.ci/targets/android_platform_tests.yaml
@@ -3,25 +3,25 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: download Dart and Android deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     infra_step: true
     args: ["fetch-deps", "--android", "--supporting-target-platforms-only", "--exclude=script/configs/still_requires_api_33_avd.yaml"]
   - name: build examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["build-examples", "--apk", "--exclude=script/configs/still_requires_api_33_avd.yaml"]
   - name: lint
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["lint-android", "--exclude=script/configs/still_requires_api_33_avd.yaml"]
   # Native unit and native integration are split into two steps to allow for
   # different exclusions.
   # TODO(stuartmorgan): Eliminate the native unit test exclusion, and combine
   # these steps.
   - name: native unit tests
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["native-test", "--android", "--no-integration", "--exclude=script/configs/exclude_native_unit_android.yaml,script/configs/still_requires_api_33_avd.yaml"]
   - name: native integration tests
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["native-test", "--android", "--no-unit", "--exclude=script/configs/still_requires_api_33_avd.yaml"]
   - name: drive examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["drive-examples", "--android", "--exclude=script/configs/exclude_integration_android.yaml,script/configs/exclude_integration_android_emulator.yaml,script/configs/still_requires_api_33_avd.yaml"]

--- a/.ci/targets/android_platform_tests_api_33_avd.yaml
+++ b/.ci/targets/android_platform_tests_api_33_avd.yaml
@@ -5,26 +5,25 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: download Dart and Android deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     infra_step: true
     args: ["fetch-deps", "--android", "--supporting-target-platforms-only", "--filter-packages-to=script/configs/still_requires_api_33_avd.yaml"]
   - name: build examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["build-examples", "--apk", "--filter-packages-to=script/configs/still_requires_api_33_avd.yaml"]
   - name: lint
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["lint-android", "--filter-packages-to=script/configs/still_requires_api_33_avd.yaml"]
   # Native unit and native integration are split into two steps to allow for
   # different exclusions.
   # TODO(stuartmorgan): Eliminate the native unit test exclusion, and combine
   # these steps.
   - name: native unit tests
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["native-test", "--android", "--no-integration", "--exclude=script/configs/exclude_native_unit_android.yaml", "--filter-packages-to=script/configs/still_requires_api_33_avd.yaml"]
   - name: native integration tests
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["native-test", "--android", "--no-unit", "--filter-packages-to=script/configs/still_requires_api_33_avd.yaml"]
   - name: drive examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["drive-examples", "--android", "--exclude=script/configs/exclude_integration_android.yaml,script/configs/exclude_integration_android_emulator.yaml", "--filter-packages-to=script/configs/still_requires_api_33_avd.yaml"]
-    

--- a/.ci/targets/dart_unit_tests.yaml
+++ b/.ci/targets/dart_unit_tests.yaml
@@ -3,7 +3,7 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: Dart unit tests
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["dart-test", "--exclude=script/configs/dart_unit_tests_exceptions.yaml", "--platform=vm"]
     # Re-run tests with path-based dependencies to ensure that publishing
     # the changes won't break tests of other packages in the respository

--- a/.ci/targets/ios_platform_tests.yaml
+++ b/.ci/targets/ios_platform_tests.yaml
@@ -6,21 +6,21 @@ tasks:
     script: .ci/scripts/create_simulator.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: download Dart and iOS deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["fetch-deps", "--ios", "--supporting-target-platforms-only"]
     infra_step: true
   - name: build examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["build-examples", "--ios"]
   - name: xcode analyze
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["xcode-analyze", "--ios"]
   - name: xcode analyze deprecation
     # Ensure we don't accidentally introduce deprecated code.
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["xcode-analyze", "--ios", "--ios-min-version=13.0"]
   - name: native test
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     # Simulator name and version must match name and version in create_simulator.sh
     args: ["native-test", "--ios", "--ios-destination", "platform=iOS Simulator,name=Flutter-iPhone,OS=17.0"]
   - name: boot simulator
@@ -31,7 +31,7 @@ tasks:
     # `drive-examples` contains integration tests, which changes the UI of the application.
     # This UI change sometimes affects `xctest`.
     # So we run `drive-examples` after `native-test`; changing the order will result ci failure.
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["drive-examples", "--ios", "--exclude=script/configs/exclude_integration_ios.yaml"]
   - name: remove simulator
     script: .ci/scripts/remove_simulator.sh

--- a/.ci/targets/linux_custom_package_tests.yaml
+++ b/.ci/targets/linux_custom_package_tests.yaml
@@ -3,5 +3,5 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: custom tests
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["custom-test"]

--- a/.ci/targets/linux_platform_tests.yaml
+++ b/.ci/targets/linux_platform_tests.yaml
@@ -5,11 +5,11 @@ tasks:
     script: .ci/scripts/set_default_linux_apps.sh
     infra_step: true
   - name: download Dart deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["fetch-deps", "--linux", "--supporting-target-platforms-only"]
     infra_step: true
   - name: build examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["build-examples", "--linux"]
   - name: native test
     script: .ci/scripts/xvfb_tool_runner.sh

--- a/.ci/targets/macos_platform_tests.yaml
+++ b/.ci/targets/macos_platform_tests.yaml
@@ -3,22 +3,22 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: download Dart and macOS deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["fetch-deps", "--macos", "--supporting-target-platforms-only"]
     infra_step: true
   - name: build examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["build-examples", "--macos"]
   - name: xcode analyze
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["xcode-analyze", "--macos"]
   - name: xcode analyze deprecation
     # Ensure we don't accidentally introduce deprecated code.
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["xcode-analyze", "--macos", "--macos-min-version=12.3"]
   - name: native test
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["native-test", "--macos"]
   - name: drive examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["drive-examples", "--macos", "--exclude=script/configs/exclude_integration_macos.yaml"]

--- a/.ci/targets/macos_repo_checks.yaml
+++ b/.ci/targets/macos_repo_checks.yaml
@@ -6,12 +6,12 @@ tasks:
     script: .ci/scripts/update_pods.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: Swift format
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     # Non-Swift languages are formatted on Linux builders.
     # Skip them on Mac builder to avoid duplication.
     args: ["format", "--fail-on-change", "--no-dart", "--no-clang-format", "--no-kotlin", "--no-java" ]
     always: true
   - name: validate iOS and macOS podspecs
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["podspec-check"]
     always: true

--- a/.ci/targets/repo_checks.yaml
+++ b/.ci/targets/repo_checks.yaml
@@ -5,18 +5,18 @@ tasks:
   - name: tool unit tests
     script: .ci/scripts/plugin_tools_tests.sh
   - name: format
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     # Skip Swift formatting on Linux builders.
     args: ["format", "--fail-on-change", "--no-swift"]
     always: true
   - name: license validation
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["license-check"]
     always: true
     # The major and minor version here should match the lowest version analyzed
     # in legacy version analysis (.ci.yaml analyze_legacy).
   - name: pubspec validation
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args:
       - "pubspec-check"
       - "--min-min-flutter-version=3.10.0"
@@ -24,7 +24,7 @@ tasks:
       - "--allow-pinned-dependencies=script/configs/allowed_pinned_deps.yaml"
     always: true
   - name: README validation
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["readme-check"]
     always: true
     # Re-run with --require-excerpts, skipping packages that still need
@@ -32,23 +32,23 @@ tasks:
     # has been fixed, this can be removed --require-excerpts added to the
     # run above.
   - name: README snippet configuration validation
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["readme-check", "--require-excerpts", "--exclude=script/configs/temp_exclude_excerpt.yaml"]
     always: true
   - name: README snippet validation
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["update-excerpts", "--fail-on-change"]
     always: true
   - name: Gradle validation
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["gradle-check"]
     always: true
   - name: Repository-level package metadata validation
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["check-repo-package-info"]
     always: true
   - name: Dependabot coverage validation
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["dependabot-check"]
     always: true
   - name: CHANGELOG and version validation
@@ -59,6 +59,6 @@ tasks:
     always: true
   # This is the slowest test, so prefer keeping it last.
   - name: publishability
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["publish-check", "--allow-pre-release"]
     always: true

--- a/.ci/targets/web_dart_unit_tests.yaml
+++ b/.ci/targets/web_dart_unit_tests.yaml
@@ -3,5 +3,5 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: Dart unit tests - web
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["dart-test", "--exclude=script/configs/dart_unit_tests_exceptions.yaml", "--platform=chrome"]

--- a/.ci/targets/web_platform_tests.yaml
+++ b/.ci/targets/web_platform_tests.yaml
@@ -3,12 +3,12 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: download Dart deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["fetch-deps", "--web", "--supporting-target-platforms-only"]
     infra_step: true
   - name: build examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["build-examples", "--web"]
   - name: drive examples
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["drive-examples", "--web", "--run-chromedriver", "--exclude=script/configs/exclude_integration_web.yaml"]

--- a/.ci/targets/windows_build_and_platform_tests.yaml
+++ b/.ci/targets/windows_build_and_platform_tests.yaml
@@ -3,7 +3,7 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: download Dart deps
-    script: script/tool_runner.sh
+    script: .ci/scripts/tool_runner.sh
     args: ["fetch-deps", "--windows", "--supporting-target-platforms-only"]
     infra_step: true
   - name: build examples (Win32)

--- a/packages/video_player/video_player_android/CONTRIBUTING.md
+++ b/packages/video_player/video_player_android/CONTRIBUTING.md
@@ -7,7 +7,7 @@ command in this directory:
 flutter pub upgrade
 flutter pub run pigeon --input pigeons/messages.dart
 # git commit your changes so that your working environment is clean
-(cd ../../../; ./script/tool_runner.sh format --clang-format=clang-format-7)
+dart run ../../../script/tool/bin/flutter_plugin_tools.dart format --current-package
 ```
 
 If you update pigeon itself and want to test the changes here,

--- a/packages/video_player/video_player_avfoundation/CONTRIBUTING.md
+++ b/packages/video_player/video_player_avfoundation/CONTRIBUTING.md
@@ -7,7 +7,7 @@ command in this directory:
 flutter pub upgrade
 flutter pub run pigeon --input pigeons/messages.dart
 # git commit your changes so that your working environment is clean
-(cd ../../../; ./script/tool_runner.sh format --clang-format=clang-format-7)
+dart run ../../../script/tool/bin/flutter_plugin_tools.dart format --current-package
 ```
 
 If you update pigeon itself and want to test the changes here,

--- a/script/configs/custom_analysis.yaml
+++ b/script/configs/custom_analysis.yaml
@@ -7,8 +7,10 @@
 # options.
 
 # DO NOT move or delete this file without updating
-# https://github.com/dart-lang/sdk/blob/master/tools/bots/flutter/analyze_flutter_plugins.sh
-# which references this file from source, but out-of-repo.
+# https://github.com/dart-lang/sdk/blob/main/tools/bots/flutter/analyze_flutter_packages.sh
+# and
+# https://github.com/flutter/flutter/blob/main/dev/bots/test.dart
+# which reference this file from source, but out-of-repo.
 # Contact stuartmorgan or devoncarew for assistance if necessary.
 
 # Opts out of unawaited_futures, matching flutter/flutter's disabling due

--- a/script/tool/lib/src/common/package_command.dart
+++ b/script/tool/lib/src/common/package_command.dart
@@ -689,13 +689,12 @@ abstract class PackageCommand extends Command<void> {
   bool _changesRequireFullTest(List<String> changedFiles) {
     const List<String> specialFiles = <String>[
       '.ci.yaml', // LUCI config.
-      '.cirrus.yml', // Cirrus config.
       '.clang-format', // ObjC and C/C++ formatting options.
       'analysis_options.yaml', // Dart analysis settings.
     ];
     const List<String> specialDirectories = <String>[
       '.ci/', // Support files for CI.
-      'script/', // This tool, and its wrapper scripts.
+      'script/', // This tool.
     ];
     // Directory entries must end with / to avoid over-matching, since the
     // check below is done via string prefixing.

--- a/script/tool/lib/src/common/package_state_utils.dart
+++ b/script/tool/lib/src/common/package_state_utils.dart
@@ -194,6 +194,8 @@ Future<bool> _isDevChange(List<String> pathComponents,
       // Entry point for the 'custom-test' command, which is only for CI and
       // local testing.
       pathComponents.first == 'run_tests.sh' ||
+      // CONTRIBUTING.md is dev-facing.
+      pathComponents.last == 'CONTRIBUTING.md' ||
       // Lints don't affect clients.
       pathComponents.contains('analysis_options.yaml') ||
       pathComponents.contains('lint-baseline.xml') ||

--- a/script/tool/test/common/package_command_test.dart
+++ b/script/tool/test/common/package_command_test.dart
@@ -524,32 +524,6 @@ packages/plugin1/plugin1/plugin1.dart
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
       });
 
-      test('all plugins should be tested if .cirrus.yml changes.', () async {
-        processRunner.mockProcessesForExecutable['git-diff'] =
-            <FakeProcessInfo>[
-          FakeProcessInfo(MockProcess(stdout: '''
-.cirrus.yml
-packages/plugin1/CHANGELOG
-''')),
-        ];
-        final RepositoryPackage plugin1 =
-            createFakePlugin('plugin1', packagesDir);
-        final RepositoryPackage plugin2 =
-            createFakePlugin('plugin2', packagesDir);
-
-        final List<String> output = await runCapturingPrint(runner,
-            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
-
-        expect(command.plugins,
-            unorderedEquals(<String>[plugin1.path, plugin2.path]));
-        expect(
-            output,
-            containsAllInOrder(<Matcher>[
-              contains('Running for all packages, since a file has changed '
-                  'that could affect the entire repository.')
-            ]));
-      });
-
       test('all plugins should be tested if .ci.yaml changes', () async {
         processRunner.mockProcessesForExecutable['git-diff'] =
             <FakeProcessInfo>[
@@ -606,7 +580,7 @@ packages/plugin1/CHANGELOG
         processRunner.mockProcessesForExecutable['git-diff'] =
             <FakeProcessInfo>[
           FakeProcessInfo(MockProcess(stdout: '''
-script/tool_runner.sh
+script/tool/bin/flutter_plugin_tools.dart
 packages/plugin1/CHANGELOG
 ''')),
         ];
@@ -929,12 +903,11 @@ packages/a_plugin/a_plugin_platform_interface/lib/foo.dart
         processRunner.mockProcessesForExecutable['git-diff'] =
             <FakeProcessInfo>[
           FakeProcessInfo(MockProcess(stdout: '''
-.cirrus.yml
 .ci.yaml
 .ci/Dockerfile
 .clang-format
 analysis_options.yaml
-script/tool_runner.sh
+script/tool/bin/flutter_plugin_tools.dart
 ''')),
         ];
         createFakePackage('a_package', packagesDir);

--- a/script/tool/test/common/package_state_utils_test.dart
+++ b/script/tool/test/common/package_state_utils_test.dart
@@ -62,6 +62,8 @@ void main() {
 
       const List<String> changedFiles = <String>[
         'packages/a_plugin/CHANGELOG.md',
+        // Dev-facing docs.
+        'packages/a_plugin/CONTRIBUTING.md',
         // Analysis.
         'packages/a_plugin/example/android/lint-baseline.xml',
         // Tests.

--- a/script/tool_runner.sh
+++ b/script/tool_runner.sh
@@ -19,5 +19,5 @@ readonly TOOL_PATH="$REPO_DIR/script/tool/bin/flutter_plugin_tools.dart"
 # The tool expects to be run from the repo root.
 cd "$REPO_DIR"
 # Run from the in-tree source.
-# PACKAGE_SHARDING is (optionally) set from Cirrus. See .cirrus.yml
+# PACKAGE_SHARDING is (optionally) set in CI configuration. See .ci.yaml
 dart run "$TOOL_PATH" "$@" --packages-for-branch --log-timing $PACKAGE_SHARDING


### PR DESCRIPTION
`script/tool_runner.sh` has only been intended for CI usage for quite a while, but it still lives in a prominent non-CI location which has been a source of confusion for developers (e.g., people looking at how CI is running things, and reasonably assuming that since the script isn't in a CI-specific location, it's for general use). While running it for simple cases works, it conflicts with any package selection, which is common thing to want to control when running locally.

This makes the following changes:
- Move the script into the .ci directory
- Adds explicit comments that it's not designed for local use, with a pointer to the corresponding local command
- Removes a stale reference to external-to-the-repo use of tool_runner.sh, as that usage no longer exists
  - Also consolidates and updates the links to the external scripts
- Updates a couple of CONTRIBUTING.md comments that still said to run tool_runner.sh
- Opportunistically cleans up some tooling references to .cirrus.yml, found while cleaning up comments in tool_runner.sh and checking for other references.
