### PR TITLE
[video_player] Call `super.dispose` last in README example

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.5
+
+* Updates example to call `super.dispose()` last.
+
 ## 2.8.4
 
 * Removes `_ambiguate` methods from code.

--- a/packages/video_player/video_player/README.md
+++ b/packages/video_player/video_player/README.md
@@ -118,8 +118,8 @@ class _VideoAppState extends State<VideoApp> {
 
   @override
   void dispose() {
-    super.dispose();
     _controller.dispose();
+    super.dispose();
   }
 }
 ```

--- a/packages/video_player/video_player/example/lib/basic.dart
+++ b/packages/video_player/video_player/example/lib/basic.dart
@@ -66,8 +66,8 @@ class _VideoAppState extends State<VideoApp> {
 
   @override
   void dispose() {
-    super.dispose();
     _controller.dispose();
+    super.dispose();
   }
 }
 // #enddocregion basic-example

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.8.4
+version: 2.8.5
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
As per https://api.flutter.dev/flutter/widgets/State/dispose.html

> Implementations of this method should end with a call to the inherited method, as in super.dispose().
