### PR TITLE
[ci] Allow dependencies on local_auth_ios

### DIFF
--- a/script/configs/allowed_unpinned_deps.yaml
+++ b/script/configs/allowed_unpinned_deps.yaml
@@ -6,6 +6,10 @@
 
 ## Explicit allowances
 
+# Temporary during transition to local_auth_darwin. Can be removed once
+# the default endorsement changes.
+- local_auth_ios
+
 # Owned by individual Flutter Team members.
 # Ideally we would not do this, since there's no clear plan for what
 # would happen if the individuals left the Flutter Team, and the


### PR DESCRIPTION
We aren't quite ready to switch the endorsement to `local_auth_darwin`, so allow `local_auth_ios` for now.
