### PR TITLE
[tools] Ignore analysis options files in .symlinks

### DIFF
--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -66,7 +66,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
   /// Checks that there are no unexpected analysis_options.yaml files.
   bool _hasUnexpecetdAnalysisOptions(RepositoryPackage package) {
     final List<FileSystemEntity> files =
-        package.directory.listSync(recursive: true);
+        package.directory.listSync(recursive: true, followLinks: false);
     for (final FileSystemEntity file in files) {
       if (file.basename != 'analysis_options.yaml' &&
           file.basename != '.analysis_options') {

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -273,6 +273,23 @@ void main() {
           ]));
     });
 
+    test('ignores analysis options in the plugin .symlinks directory',
+        () async {
+      final RepositoryPackage plugin = createFakePlugin('foo', packagesDir,
+          extraFiles: <String>['analysis_options.yaml']);
+      final RepositoryPackage includingPackage =
+          createFakePlugin('bar', packagesDir);
+      // Simulate the local state of having built 'bar' if it includes 'foo'.
+      includingPackage.directory
+          .childDirectory('example')
+          .childDirectory('ios')
+          .childLink('.symlinks')
+          .createSync(plugin.directory.path, recursive: true);
+
+      await runCapturingPrint(
+          runner, <String>['analyze', '--custom-analysis', 'foo']);
+    });
+
     test('takes an allow config file', () async {
       final RepositoryPackage plugin = createFakePlugin('foo', packagesDir,
           extraFiles: <String>['analysis_options.yaml']);


### PR DESCRIPTION
When running `analyze` in a local tree that has done builds, there can be false positives of the "unexpected analysis options" check due to the .symlinks directory making other packages' analysis options show up in the check. This avoids following links to prevent those false positives.