### PR TITLE
[various] Clean up `deprecated_member_use` ignores

### DIFF
--- a/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
@@ -14,9 +14,6 @@ void main() {
       (WidgetTester tester) async {
     MediaQuery slot(double width) {
       return MediaQuery(
-        // TODO(stuartmorgan): Replace with .fromView once this package requires
-        // Flutter 3.8+.
-        // ignore: deprecated_member_use
         data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
             .copyWith(size: Size(width, 800)),
         child: Directionality(
@@ -420,9 +417,6 @@ AnimatedWidget leftInOut(Widget child, Animation<double> animation) {
 
 MediaQuery slot(double width) {
   return MediaQuery(
-    // TODO(stuartmorgan): Replace with .fromView once this package requires
-    // Flutter 3.8+.
-    // ignore: deprecated_member_use
     data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
         .copyWith(size: Size(width, 800)),
     child: Directionality(

--- a/packages/flutter_adaptive_scaffold/test/simulated_layout.dart
+++ b/packages/flutter_adaptive_scaffold/test/simulated_layout.dart
@@ -151,9 +151,6 @@ enum SimulatedLayout {
 
   MediaQuery get slot {
     return MediaQuery(
-      // TODO(stuartmorgan): Replace with .fromView once this package requires
-      // Flutter 3.8+.
-      // ignore: deprecated_member_use
       data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
           .copyWith(size: Size(_width, _height)),
       child: Theme(

--- a/packages/flutter_image/lib/network.dart
+++ b/packages/flutter_image/lib/network.dart
@@ -101,9 +101,6 @@ class NetworkImageWithRetry extends ImageProvider<NetworkImageWithRetry> {
   @override
   ImageStreamCompleter loadBuffer(
     NetworkImageWithRetry key,
-    // TODO(LongCatIsLooong): migrate to use new `loadImage` API.
-    // https://github.com/flutter/flutter/issues/132856
-    // ignore: deprecated_member_use
     DecoderBufferCallback decode,
   ) {
     return OneFrameImageStreamCompleter(_loadWithRetry(key, decode),

--- a/packages/flutter_image/test/network_test.dart
+++ b/packages/flutter_image/test/network_test.dart
@@ -142,9 +142,6 @@ void assertThatImageLoadingFails(
 ) {
   final ImageStreamCompleter completer = subject.loadBuffer(
     subject,
-    // TODO(LongCatIsLooong): migrate to use new `instantiateImageCodecWithSize` API.
-    // https://github.com/flutter/flutter/issues/132856
-    // ignore: deprecated_member_use
     PaintingBinding.instance.instantiateImageCodecFromBuffer,
   );
   completer.addListener(ImageStreamListener(
@@ -162,9 +159,6 @@ void assertThatImageLoadingSucceeds(
 ) {
   final ImageStreamCompleter completer = subject.loadBuffer(
     subject,
-    // TODO(LongCatIsLooong): migrate to use new `instantiateImageCodecWithSize` API.
-    // https://github.com/flutter/flutter/issues/132856
-    // ignore: deprecated_member_use
     PaintingBinding.instance.instantiateImageCodecFromBuffer,
   );
   completer.addListener(ImageStreamListener(

--- a/packages/flutter_markdown/lib/src/_functions_io.dart
+++ b/packages/flutter_markdown/lib/src/_functions_io.dart
@@ -65,7 +65,7 @@ final MarkdownStyleSheet Function(BuildContext, MarkdownStyleSheetBaseTheme?)
 
   return result.copyWith(
     textScaleFactor:
-        MediaQuery.textScaleFactorOf(context), // ignore: deprecated_member_use
+        MediaQuery.textScaleFactorOf(context),
   );
 };
 

--- a/packages/flutter_markdown/lib/src/_functions_io.dart
+++ b/packages/flutter_markdown/lib/src/_functions_io.dart
@@ -64,8 +64,7 @@ final MarkdownStyleSheet Function(BuildContext, MarkdownStyleSheetBaseTheme?)
   }
 
   return result.copyWith(
-    textScaleFactor:
-        MediaQuery.textScaleFactorOf(context),
+    textScaleFactor: MediaQuery.textScaleFactorOf(context),
   );
 };
 

--- a/packages/flutter_markdown/lib/src/_functions_web.dart
+++ b/packages/flutter_markdown/lib/src/_functions_web.dart
@@ -66,8 +66,7 @@ final MarkdownStyleSheet Function(BuildContext, MarkdownStyleSheetBaseTheme?)
   }
 
   return result.copyWith(
-    textScaleFactor:
-        MediaQuery.textScaleFactorOf(context),
+    textScaleFactor: MediaQuery.textScaleFactorOf(context),
   );
 };
 

--- a/packages/flutter_markdown/lib/src/_functions_web.dart
+++ b/packages/flutter_markdown/lib/src/_functions_web.dart
@@ -67,7 +67,7 @@ final MarkdownStyleSheet Function(BuildContext, MarkdownStyleSheetBaseTheme?)
 
   return result.copyWith(
     textScaleFactor:
-        MediaQuery.textScaleFactorOf(context), // ignore: deprecated_member_use
+        MediaQuery.textScaleFactorOf(context),
   );
 };
 

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -867,7 +867,6 @@ class MarkdownBuilder implements md.NodeVisitor {
     if (selectable) {
       return SelectableText.rich(
         text!,
-        // ignore: deprecated_member_use
         textScaleFactor: styleSheet.textScaleFactor,
         textAlign: textAlign ?? TextAlign.start,
         onTap: onTapText,
@@ -876,7 +875,6 @@ class MarkdownBuilder implements md.NodeVisitor {
     } else {
       return Text.rich(
         text!,
-        // ignore: deprecated_member_use
         textScaleFactor: styleSheet.textScaleFactor,
         textAlign: textAlign ?? TextAlign.start,
         key: k,

--- a/packages/flutter_markdown/test/text_scale_factor_test.dart
+++ b/packages/flutter_markdown/test/text_scale_factor_test.dart
@@ -25,7 +25,7 @@ void defineTests() {
         );
 
         final RichText richText = tester.widget(find.byType(RichText));
-        expect(richText.textScaleFactor, 2.0); // ignore: deprecated_member_use
+        expect(richText.textScaleFactor, 2.0);
       },
     );
 
@@ -36,7 +36,6 @@ void defineTests() {
         await tester.pumpWidget(
           boilerplate(
             const MediaQuery(
-              // ignore: deprecated_member_use
               data: MediaQueryData(textScaleFactor: 2.0),
               child: MarkdownBody(
                 data: data,
@@ -46,7 +45,7 @@ void defineTests() {
         );
 
         final RichText richText = tester.widget(find.byType(RichText));
-        expect(richText.textScaleFactor, 2.0); // ignore: deprecated_member_use
+        expect(richText.textScaleFactor, 2.0);
       },
     );
 
@@ -57,7 +56,6 @@ void defineTests() {
         await tester.pumpWidget(
           boilerplate(
             const MediaQuery(
-              // ignore: deprecated_member_use
               data: MediaQueryData(textScaleFactor: 2.0),
               child: MarkdownBody(
                 data: data,
@@ -69,7 +67,6 @@ void defineTests() {
 
         final SelectableText selectableText =
             tester.widget(find.byType(SelectableText));
-        // ignore: deprecated_member_use
         expect(selectableText.textScaleFactor, 2.0);
       },
     );

--- a/packages/flutter_markdown/test/utils.dart
+++ b/packages/flutter_markdown/test/utils.dart
@@ -169,8 +169,6 @@ void expectLinkTap(MarkdownLink? actual, MarkdownLink expected) {
 }
 
 String dumpRenderView() {
-  // TODO(goderbauer): Migrate to rootElement once v3.9.0 is the oldest supported Flutter version.
-  // ignore: deprecated_member_use
   return WidgetsBinding.instance.renderViewElement!.toStringDeep().replaceAll(
         RegExp(r'SliverChildListDelegate#\d+', multiLine: true),
         'SliverChildListDelegate',

--- a/packages/flutter_migrate/lib/src/base/common.dart
+++ b/packages/flutter_migrate/lib/src/base/common.dart
@@ -150,7 +150,6 @@ Future<T> asyncGuard<T>(
       // ignore: avoid_catches_without_on_clauses, forwards to Future
       handleError(e, s);
     }
-    // ignore: deprecated_member_use
   }, onError: (Object e, StackTrace s) {
     handleError(e, s);
   });

--- a/packages/flutter_migrate/test/src/common.dart
+++ b/packages/flutter_migrate/test/src/common.dart
@@ -10,15 +10,15 @@ import 'package:flutter_migrate/src/base/file_system.dart';
 import 'package:flutter_migrate/src/base/io.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
-import 'package:test_api/test_api.dart' // ignore: deprecated_member_use
+import 'package:test_api/test_api.dart'
     as test_package show test;
-import 'package:test_api/test_api.dart' // ignore: deprecated_member_use
+import 'package:test_api/test_api.dart'
     hide
         test;
 
 import 'test_utils.dart';
 
-export 'package:test_api/test_api.dart' // ignore: deprecated_member_use
+export 'package:test_api/test_api.dart'
     hide
         isInstanceOf,
         test;

--- a/packages/flutter_migrate/test/src/common.dart
+++ b/packages/flutter_migrate/test/src/common.dart
@@ -10,18 +10,12 @@ import 'package:flutter_migrate/src/base/file_system.dart';
 import 'package:flutter_migrate/src/base/io.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
-import 'package:test_api/test_api.dart'
-    as test_package show test;
-import 'package:test_api/test_api.dart'
-    hide
-        test;
+import 'package:test_api/test_api.dart' as test_package show test;
+import 'package:test_api/test_api.dart' hide test;
 
 import 'test_utils.dart';
 
-export 'package:test_api/test_api.dart'
-    hide
-        isInstanceOf,
-        test;
+export 'package:test_api/test_api.dart' hide isInstanceOf, test;
 
 bool tryToDelete(FileSystemEntity fileEntity) {
   // This should not be necessary, but it turns out that

--- a/packages/flutter_migrate/test/src/test_flutter_command_runner.dart
+++ b/packages/flutter_migrate/test/src/test_flutter_command_runner.dart
@@ -5,10 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:flutter_migrate/src/base/command.dart';
 
-export 'package:test_api/test_api.dart'
-    hide
-        isInstanceOf,
-        test;
+export 'package:test_api/test_api.dart' hide isInstanceOf, test;
 
 CommandRunner<void> createTestCommandRunner([MigrateCommand? command]) {
   final CommandRunner<void> runner = TestCommandRunner();

--- a/packages/flutter_migrate/test/src/test_flutter_command_runner.dart
+++ b/packages/flutter_migrate/test/src/test_flutter_command_runner.dart
@@ -5,7 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:flutter_migrate/src/base/command.dart';
 
-export 'package:test_api/test_api.dart' // ignore: deprecated_member_use
+export 'package:test_api/test_api.dart'
     hide
         isInstanceOf,
         test;

--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates dependencies to require `analyzer` 5.2.0 or later.
+
 ## 2.4.1
 
 * Fixes new lint warnings.

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -447,9 +447,6 @@ abstract class RouteBaseConfig {
   ) {
     assert(!reader.isNull, 'reader should not be null');
     final InterfaceType type = reader.objectValue.type! as InterfaceType;
-    // TODO(stuartmorgan): Remove this ignore once 'analyze' can be set to
-    // 5.2+ (when Flutter 3.4+ is on stable).
-    // ignore: deprecated_member_use
     final String typeName = type.element.name;
     final DartType typeParamType = type.typeArguments.single;
     if (typeParamType is! InterfaceType) {
@@ -461,9 +458,6 @@ abstract class RouteBaseConfig {
     }
 
     // TODO(kevmoo): validate that this MUST be a subtype of `GoRouteData`
-    // TODO(stuartmorgan): Remove this ignore once 'analyze' can be set to
-    // 5.2+ (when Flutter 3.4+ is on stable).
-    // ignore: deprecated_member_use
     final InterfaceElement classElement = typeParamType.element;
 
     final RouteBaseConfig value;
@@ -701,16 +695,10 @@ $routeDataClassName.$dataConvertionFunctionName(
 String _enumMapConst(InterfaceType type) {
   assert(type.isEnum);
 
-  // TODO(stuartmorgan): Remove this ignore once 'analyze' can be set to
-  // 5.2+ (when Flutter 3.4+ is on stable).
-  // ignore: deprecated_member_use
   final String enumName = type.element.name;
 
   final StringBuffer buffer = StringBuffer('const ${enumMapName(type)} = {');
 
-  // TODO(stuartmorgan): Remove this ignore once 'analyze' can be set to
-  // 5.2+ (when Flutter 3.4+ is on stable).
-  // ignore: deprecated_member_use
   for (final FieldElement enumField in type.element.fields
       .where((FieldElement element) => element.isEnumConstant)) {
     buffer.writeln(

--- a/packages/go_router_builder/lib/src/type_helpers.dart
+++ b/packages/go_router_builder/lib/src/type_helpers.dart
@@ -87,9 +87,6 @@ String encodeField(PropertyAccessorElement element) {
 }
 
 /// Gets the name of the `const` map generated to help encode [Enum] types.
-// TODO(stuartmorgan): Remove this ignore once 'analyze' can be set to
-// 5.2+ (when Flutter 3.4+ is on stable).
-// ignore: deprecated_member_use
 String enumMapName(InterfaceType type) => '_\$${type.element.name}EnumMap';
 
 String _stateValueAccess(ParameterElement element, Set<String> pathParameters) {

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=4.4.0 <7.0.0"
+  analyzer: ">=5.2.0 <7.0.0"
   async: ^2.8.0
   build: ^2.0.0
   build_config: ^1.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
@@ -17,7 +17,6 @@ void main() {
       final Object json = descriptor.toJson();
 
       // Rehydrate a new bitmap descriptor...
-      // ignore: deprecated_member_use_from_same_package
       final BitmapDescriptor descriptorFromJson =
           BitmapDescriptor.fromJson(json);
 

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/html.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/html.dart
@@ -27,8 +27,6 @@ class PickedFile extends PickedFileBase {
 
   Future<Uint8List> get _bytes async {
     if (_initBytes != null) {
-      // TODO(stuartmorgan): Remove this directive, https://github.com/flutter/flutter/issues/143113
-      // ignore: deprecated_member_use
       return Future<Uint8List>.value(UnmodifiableUint8ListView(_initBytes!));
     }
     return http.readBytes(Uri.parse(path));

--- a/packages/ios_platform_images/lib/ios_platform_images.dart
+++ b/packages/ios_platform_images/lib/ios_platform_images.dart
@@ -71,7 +71,7 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
   @override
   ImageStreamCompleter loadBuffer(
     _FutureMemoryImage key,
-    DecoderBufferCallback decode, // ignore: deprecated_member_use
+    DecoderBufferCallback decode,
   ) {
     return _FutureImageStreamCompleter(
       codec: _loadAsync(key, decode),
@@ -81,7 +81,7 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
 
   Future<ui.Codec> _loadAsync(
     _FutureMemoryImage key,
-    DecoderBufferCallback decode, // ignore: deprecated_member_use
+    DecoderBufferCallback decode,
   ) {
     assert(key == this);
     return _futureBytes.then(ui.ImmutableBuffer.fromUint8List).then(decode);

--- a/packages/rfw/lib/src/flutter/core_widgets.dart
+++ b/packages/rfw/lib/src/flutter/core_widgets.dart
@@ -658,7 +658,7 @@ Map<String, LocalWidgetBuilder> get _coreWidgetsDefinitions => <String, LocalWid
       locale: ArgumentDecoders.locale(source, ['locale']),
       softWrap: source.v<bool>(['softWrap']),
       overflow: ArgumentDecoders.enumValue<TextOverflow>(TextOverflow.values, source, ['overflow']),
-      textScaleFactor: source.v<double>(['textScaleFactor']),  // ignore: deprecated_member_use
+      textScaleFactor: source.v<double>(['textScaleFactor']),
       maxLines: source.v<int>(['maxLines']),
       semanticsLabel: source.v<String>(['semanticsLabel']),
       textWidthBasis: ArgumentDecoders.enumValue<TextWidthBasis>(TextWidthBasis.values, source, ['textWidthBasis']),

--- a/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
@@ -238,9 +238,8 @@ void main() {
           _anonymize(TestWidgetsFlutterBinding.ensureInitialized())!
               as TestWidgetsFlutterBinding;
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      // TODO(goderbauer): Migrate to binding.renderViews when that is available in the oldest supported stable.
       final RenderView renderView =
-          binding.renderView; // ignore: deprecated_member_use
+          binding.renderView;
       renderView.automaticSystemUiAdjustment = true;
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);
@@ -270,9 +269,8 @@ void main() {
           _anonymize(TestWidgetsFlutterBinding.ensureInitialized())!
               as TestWidgetsFlutterBinding;
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      // TODO(goderbauer): Migrate to binding.renderViews when that is available in the oldest supported stable.
       final RenderView renderView =
-          binding.renderView; // ignore: deprecated_member_use
+          binding.renderView;
       expect(renderView.automaticSystemUiAdjustment, true);
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);

--- a/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
@@ -238,8 +238,7 @@ void main() {
           _anonymize(TestWidgetsFlutterBinding.ensureInitialized())!
               as TestWidgetsFlutterBinding;
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      final RenderView renderView =
-          binding.renderView;
+      final RenderView renderView = binding.renderView;
       renderView.automaticSystemUiAdjustment = true;
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);
@@ -269,8 +268,7 @@ void main() {
           _anonymize(TestWidgetsFlutterBinding.ensureInitialized())!
               as TestWidgetsFlutterBinding;
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      final RenderView renderView =
-          binding.renderView;
+      final RenderView renderView = binding.renderView;
       expect(renderView.automaticSystemUiAdjustment, true);
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);

--- a/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
@@ -86,9 +86,6 @@ abstract class LinkInfo {
 // TODO(ianh): Remove the first argument.
 Future<ByteData> pushRouteNameToFramework(Object? _, String routeName) {
   final Completer<ByteData> completer = Completer<ByteData>();
-  // TODO(chunhtai): remove this ignore and migrate the code
-  // https://github.com/flutter/flutter/issues/124045.
-  // ignore: deprecated_member_use
   SystemNavigator.routeInformationUpdated(location: routeName);
   ui.channelBuffers.push(
     'flutter/navigation',

--- a/packages/url_launcher/url_launcher_platform_interface/test/link_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/link_test.dart
@@ -83,9 +83,7 @@ class _RouteDelegate extends RouterDelegate<RouteInformation>
     if (_history.isEmpty) {
       return const Placeholder(key: Key('empty'));
     }
-    // TODO(chunhtai): remove this ignore and migrate the code
-    // https://github.com/flutter/flutter/issues/124045.
-    // ignore: unnecessary_string_interpolations, deprecated_member_use
+    // ignore: unnecessary_string_interpolations
     return Placeholder(key: Key('${_history.last.location}'));
   }
 }

--- a/packages/web_benchmarks/lib/src/recorder.dart
+++ b/packages/web_benchmarks/lib/src/recorder.dart
@@ -255,8 +255,7 @@ abstract class SceneBuilderRecorder extends Recorder {
           _profile.record('sceneBuildDuration', () {
             final Scene scene = sceneBuilder.build();
             _profile.record('windowRenderDuration', () {
-              // TODO(goderbauer): Migrate to PlatformDispatcher.implicitView once v3.9.0 is the oldest supported Flutter version.
-              window.render(scene); // ignore: deprecated_member_use
+              window.render(scene);
             }, reported: false);
           }, reported: false);
         }, reported: true);

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_api_impls.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_api_impls.dart
@@ -720,7 +720,6 @@ class WebViewClientFlutterApiImpl extends WebViewClientFlutterApi {
       webViewInstance != null,
       'InstanceManager does not contain a WebView with instanceId: $webViewInstanceId',
     );
-    // ignore: deprecated_member_use_from_same_package
     if (instance!.onReceivedError != null) {
       instance.onReceivedError!(
         webViewInstance!,


### PR DESCRIPTION
As of https://github.com/flutter/packages/pull/6111 `deprecated_member_use` is no longer on in the repository, so we no longer need (most; see below) of these annotations. Since we will not be annotating deprecated usage going forward, the associated comments with TODOs have also been removed, for consistency with the new process. This also opportunistically removes `deprecated_member_use_from_same_package` everywhere, since that has been disabled for a long time, so they were cruft.

I have ensured that issues are filed for all of these usages, with the new `p: deprecated api` tag, per the new process for tracking deprecated APIs that is now described in the Ecosystem gardener rotation handbook. (In summary: there will be a manual weekly process of checking for new deprecations and filing them, and the [update-stable-in-this-repo process](https://github.com/flutter/flutter/wiki/Updating-Packages-repo-for-a-stable-release) will involve causing anything that is unblocked to be re-triaged.)

The only annotations that are left are for cases where we have integration tests testing deprecated APIs in that package, as those are false positives; they are conceptually `deprecated_member_use_from_same_package` and aren't tech debt (or used by clients), but technically are from a different package since integration tests are in the example app. This will prevent them from showing up in the manual weekly check.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
