### PR TITLE
[flutter_image] Replace deprecated APIs

### DIFF
--- a/packages/flutter_image/CHANGELOG.md
+++ b/packages/flutter_image/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.11
+
+* Replaces deprecated loadBuffer API usage.
+
 ## 4.1.10
 
 * Fixes image asset link to use image within package.

--- a/packages/flutter_image/lib/network.dart
+++ b/packages/flutter_image/lib/network.dart
@@ -99,9 +99,9 @@ class NetworkImageWithRetry extends ImageProvider<NetworkImageWithRetry> {
   }
 
   @override
-  ImageStreamCompleter loadBuffer(
+  ImageStreamCompleter loadImage(
     NetworkImageWithRetry key,
-    DecoderBufferCallback decode,
+    ImageDecoderCallback decode,
   ) {
     return OneFrameImageStreamCompleter(_loadWithRetry(key, decode),
         informationCollector: () sync* {

--- a/packages/flutter_image/pubspec.yaml
+++ b/packages/flutter_image/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Image utilities for Flutter: improved network providers, effects, etc.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_image
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_image%22
-version: 4.1.10
+version: 4.1.11
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/flutter_image/test/network_test.dart
+++ b/packages/flutter_image/test/network_test.dart
@@ -140,9 +140,9 @@ void assertThatImageLoadingFails(
   NetworkImageWithRetry subject,
   List<FlutterErrorDetails> errorLog,
 ) {
-  final ImageStreamCompleter completer = subject.loadBuffer(
+  final ImageStreamCompleter completer = subject.loadImage(
     subject,
-    PaintingBinding.instance.instantiateImageCodecFromBuffer,
+    PaintingBinding.instance.instantiateImageCodecWithSize,
   );
   completer.addListener(ImageStreamListener(
     (ImageInfo image, bool synchronousCall) {},
@@ -157,9 +157,9 @@ void assertThatImageLoadingFails(
 void assertThatImageLoadingSucceeds(
   NetworkImageWithRetry subject,
 ) {
-  final ImageStreamCompleter completer = subject.loadBuffer(
+  final ImageStreamCompleter completer = subject.loadImage(
     subject,
-    PaintingBinding.instance.instantiateImageCodecFromBuffer,
+    PaintingBinding.instance.instantiateImageCodecWithSize,
   );
   completer.addListener(ImageStreamListener(
     expectAsync2((ImageInfo image, bool synchronousCall) {


### PR DESCRIPTION
Now that it's available on every supported version, switch to `loadImage` instead of the deprecated `loadBuffer`.

Fixes https://github.com/flutter/flutter/issues/132856

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
