### PR TITLE
[flutter_adaptive_scaffold] Replace deprecated APIs

### DIFF
--- a/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/adaptive_layout_test.dart
@@ -14,7 +14,7 @@ void main() {
       (WidgetTester tester) async {
     MediaQuery slot(double width) {
       return MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
+        data: MediaQueryData.fromView(tester.view)
             .copyWith(size: Size(width, 800)),
         child: Directionality(
           textDirection: TextDirection.ltr,
@@ -120,11 +120,11 @@ void main() {
   testWidgets(
       'slot layout properly switches between items with the appropriate animation',
       (WidgetTester tester) async {
-    await tester.pumpWidget(slot(300));
+    await tester.pumpWidget(slot(300, tester));
     expect(begin, findsOneWidget);
     expect(end, findsNothing);
 
-    await tester.pumpWidget(slot(500));
+    await tester.pumpWidget(slot(500, tester));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
     expect(tester.widget<SlideTransition>(slideOut('0')).position.value,
@@ -146,7 +146,7 @@ void main() {
   testWidgets('AnimatedSwitcher does not spawn duplicate keys on rapid resize',
       (WidgetTester tester) async {
     // Populate the smaller slot layout and let the animation settle.
-    await tester.pumpWidget(slot(300));
+    await tester.pumpWidget(slot(300, tester));
     await tester.pumpAndSettle();
     expect(begin, findsOneWidget);
     expect(end, findsNothing);
@@ -157,12 +157,12 @@ void main() {
     for (int i = 0; i < 2; i++) {
       // Resize between the two slot layouts, but do not pump the animation
       // until completion.
-      await tester.pumpWidget(slot(500));
+      await tester.pumpWidget(slot(500, tester));
       await tester.pump(const Duration(milliseconds: 100));
       expect(begin, findsOneWidget);
       expect(end, findsOneWidget);
 
-      await tester.pumpWidget(slot(300));
+      await tester.pumpWidget(slot(300, tester));
       await tester.pump(const Duration(milliseconds: 100));
       expect(begin, findsOneWidget);
       expect(end, findsOneWidget);
@@ -171,18 +171,18 @@ void main() {
 
   testWidgets('slot layout can tolerate rapid changes in breakpoints',
       (WidgetTester tester) async {
-    await tester.pumpWidget(slot(300));
+    await tester.pumpWidget(slot(300, tester));
     expect(begin, findsOneWidget);
     expect(end, findsNothing);
 
-    await tester.pumpWidget(slot(500));
+    await tester.pumpWidget(slot(500, tester));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
     expect(tester.widget<SlideTransition>(slideOut('0')).position.value,
         offsetMoreOrLessEquals(const Offset(-0.1, 0), epsilon: 0.05));
     expect(tester.widget<SlideTransition>(slideIn('400')).position.value,
         offsetMoreOrLessEquals(const Offset(-0.9, 0), epsilon: 0.05));
-    await tester.pumpWidget(slot(300));
+    await tester.pumpWidget(slot(300, tester));
     await tester.pumpAndSettle();
     expect(begin, findsOneWidget);
     expect(end, findsNothing);
@@ -415,10 +415,9 @@ AnimatedWidget leftInOut(Widget child, Animation<double> animation) {
   );
 }
 
-MediaQuery slot(double width) {
+MediaQuery slot(double width, WidgetTester tester) {
   return MediaQuery(
-    data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
-        .copyWith(size: Size(width, 800)),
+    data: MediaQueryData.fromView(tester.view).copyWith(size: Size(width, 800)),
     child: Directionality(
       textDirection: TextDirection.ltr,
       child: SlotLayout(

--- a/packages/flutter_adaptive_scaffold/test/breakpoint_test.dart
+++ b/packages/flutter_adaptive_scaffold/test/breakpoint_test.dart
@@ -12,19 +12,19 @@ void main() {
       (WidgetTester tester) async {
     // Pump a small layout on a mobile device. The small slot
     // should give the mobile slot layout, not the desktop layout.
-    await tester.pumpWidget(SimulatedLayout.small.slot);
+    await tester.pumpWidget(SimulatedLayout.small.slot(tester));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('Breakpoints.smallMobile')), findsOneWidget);
     expect(find.byKey(const Key('Breakpoints.smallDesktop')), findsNothing);
 
     // Do the same with a medium layout on a mobile
-    await tester.pumpWidget(SimulatedLayout.medium.slot);
+    await tester.pumpWidget(SimulatedLayout.medium.slot(tester));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('Breakpoints.mediumMobile')), findsOneWidget);
     expect(find.byKey(const Key('Breakpoints.mediumDesktop')), findsNothing);
 
     // Large layout on mobile
-    await tester.pumpWidget(SimulatedLayout.large.slot);
+    await tester.pumpWidget(SimulatedLayout.large.slot(tester));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('Breakpoints.largeMobile')), findsOneWidget);
     expect(find.byKey(const Key('Breakpoints.largeDesktop')), findsNothing);
@@ -34,19 +34,19 @@ void main() {
       (WidgetTester tester) async {
     // Pump a small layout on a desktop device. The small slot
     // should give the mobile slot layout, not the desktop layout.
-    await tester.pumpWidget(SimulatedLayout.small.slot);
+    await tester.pumpWidget(SimulatedLayout.small.slot(tester));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('Breakpoints.smallDesktop')), findsOneWidget);
     expect(find.byKey(const Key('Breakpoints.smallMobile')), findsNothing);
 
     // Do the same with a medium layout on a desktop
-    await tester.pumpWidget(SimulatedLayout.medium.slot);
+    await tester.pumpWidget(SimulatedLayout.medium.slot(tester));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('Breakpoints.mediumDesktop')), findsOneWidget);
     expect(find.byKey(const Key('Breakpoints.mediumMobile')), findsNothing);
 
     // Large layout on desktop
-    await tester.pumpWidget(SimulatedLayout.large.slot);
+    await tester.pumpWidget(SimulatedLayout.large.slot(tester));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('Breakpoints.largeDesktop')), findsOneWidget);
     expect(find.byKey(const Key('Breakpoints.largeMobile')), findsNothing);

--- a/packages/flutter_adaptive_scaffold/test/simulated_layout.dart
+++ b/packages/flutter_adaptive_scaffold/test/simulated_layout.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'test_breakpoints.dart';
 
@@ -149,9 +150,9 @@ enum SimulatedLayout {
     );
   }
 
-  MediaQuery get slot {
+  MediaQuery slot(WidgetTester tester) {
     return MediaQuery(
-      data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
+      data: MediaQueryData.fromView(tester.view)
           .copyWith(size: Size(_width, _height)),
       child: Theme(
         data: ThemeData(),


### PR DESCRIPTION
Replaces the use of deprecated `MediaQueryData.fromWindow` and `window` in tests.

Fixes https://github.com/flutter/flutter/issues/143397
Part of https://github.com/flutter/flutter/issues/143399

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
