### PR TITLE
[google_sign_in] Clean up pre-Pigeon code

### DIFF
--- a/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 5.7.4
 
+* Improves type handling in Objective-C code.
 * Updates minimum iOS version to 12.0 and minimum Flutter version to 3.16.6.
 
 ## 5.7.3

--- a/packages/google_sign_in/google_sign_in_ios/darwin/Classes/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/Classes/FLTGoogleSignInPlugin.m
@@ -111,9 +111,9 @@ static FlutterError *getFlutterError(NSError *error) {
 
 - (void)initializeSignInWithParameters:(nonnull FSIInitParams *)params
                                  error:(FlutterError *_Nullable __autoreleasing *_Nonnull)error {
-  GIDConfiguration *configuration = [self configurationWithClientIdArgument:params.clientId
-                                                     serverClientIdArgument:params.serverClientId
-                                                       hostedDomainArgument:params.hostedDomain];
+  GIDConfiguration *configuration = [self configurationWithClientIdentifier:params.clientId
+                                                     serverClientIdentifier:params.serverClientId
+                                                               hostedDomain:params.hostedDomain];
   self.requestedScopes = [NSSet setWithArray:params.scopes];
   if (configuration != nil) {
     self.configuration = configuration;
@@ -141,9 +141,9 @@ static FlutterError *getFlutterError(NSError *error) {
     // If neither are available, do not set the configuration - GIDSignIn will automatically use
     // settings from the Info.plist (which is the recommended method).
     if (!self.configuration && self.googleServiceProperties) {
-      self.configuration = [self configurationWithClientIdArgument:nil
-                                            serverClientIdArgument:nil
-                                              hostedDomainArgument:nil];
+      self.configuration = [self configurationWithClientIdentifier:nil
+                                            serverClientIdentifier:nil
+                                                      hostedDomain:nil];
     }
     if (self.configuration) {
       self.signIn.configuration = self.configuration;
@@ -270,30 +270,19 @@ static FlutterError *getFlutterError(NSError *error) {
 #endif
 }
 
-/// @return @c nil if GoogleService-Info.plist not found and clientId is not provided.
-- (GIDConfiguration *)configurationWithClientIdArgument:(id)clientIDArg
-                                 serverClientIdArgument:(id)serverClientIDArg
-                                   hostedDomainArgument:(id)hostedDomainArg {
-  NSString *clientID;
-  BOOL hasDynamicClientId = [clientIDArg isKindOfClass:[NSString class]];
-  if (hasDynamicClientId) {
-    clientID = clientIDArg;
-  } else if (self.googleServiceProperties) {
-    clientID = self.googleServiceProperties[kClientIdKey];
-  } else {
-    // We couldn't resolve a clientId, without which we cannot create a GIDConfiguration.
+/// @return @c nil if GoogleService-Info.plist not found and runtimeClientIdentifier is not
+/// provided.
+- (GIDConfiguration *)configurationWithClientIdentifier:(NSString *)runtimeClientIdentifier
+                                 serverClientIdentifier:(NSString *)runtimeServerClientIdentifier
+                                           hostedDomain:(id)hostedDomain {
+  NSString *clientID = runtimeClientIdentifier ?: self.googleServiceProperties[kClientIdKey];
+  if (!clientID) {
+    // Creating a GIDConfiguration requires a client identifier.
     return nil;
   }
+  NSString *serverClientID =
+      runtimeServerClientIdentifier ?: self.googleServiceProperties[kServerClientIdKey];
 
-  BOOL hasDynamicServerClientId = [serverClientIDArg isKindOfClass:[NSString class]];
-  NSString *serverClientID = hasDynamicServerClientId
-                                 ? serverClientIDArg
-                                 : self.googleServiceProperties[kServerClientIdKey];
-
-  NSString *hostedDomain = nil;
-  if (hostedDomainArg != [NSNull null]) {
-    hostedDomain = hostedDomainArg;
-  }
   return [[GIDConfiguration alloc] initWithClientID:clientID
                                      serverClientID:serverClientID
                                        hostedDomain:hostedDomain

--- a/packages/google_sign_in/google_sign_in_ios/darwin/Classes/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/Classes/FLTGoogleSignInPlugin.m
@@ -274,7 +274,7 @@ static FlutterError *getFlutterError(NSError *error) {
 /// provided.
 - (GIDConfiguration *)configurationWithClientIdentifier:(NSString *)runtimeClientIdentifier
                                  serverClientIdentifier:(NSString *)runtimeServerClientIdentifier
-                                           hostedDomain:(id)hostedDomain {
+                                           hostedDomain:(NSString *)hostedDomain {
   NSString *clientID = runtimeClientIdentifier ?: self.googleServiceProperties[kClientIdKey];
   if (!clientID) {
     // Creating a GIDConfiguration requires a client identifier.

--- a/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_ios
 description: iOS implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.7.3
+version: 5.7.4
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
Internal native helper code was still using `id` arguments, doing type checking, and handling `NSNull`, none of which is relevant now that the calling code has been converted to Pigeon and is already strongly typed as `NSString`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
