### PR TITLE
[flutter_migrate] Implement lineTerminator in the MemoryStdout fake

### DIFF
--- a/packages/flutter_migrate/test/src/fakes.dart
+++ b/packages/flutter_migrate/test/src/fakes.dart
@@ -133,6 +133,15 @@ class MemoryStdout extends MemoryIOSink implements io.Stdout {
   bool _hasTerminal = true;
 
   @override
+  // ignore: override_on_non_overriding_member
+  String get lineTerminator => '\n';
+  @override
+  // ignore: override_on_non_overriding_member
+  set lineTerminator(String value) {
+    throw UnimplementedError('Setting the line terminator is not supported');
+  }
+
+  @override
   io.IOSink get nonBlocking => this;
 
   @override


### PR DESCRIPTION
https://dart-review.googlesource.com/c/sdk/+/326761/24/sdk/lib/io/stdio.dart#380 added a `lineTerminator` field to `Stdout`.

See https://github.com/flutter/flutter/issues/143614