### PR TITLE
[pigeon] Allows kotlin generator to skip error class generation

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 17.0.1
+## 17.1.0
 
 * [kotlin] Adds `includeErrorClass` to `KotlinOptions`.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 17.0.1
 
+* [kotlin] Adds `includeErrorClass` to `KotlinOptions`.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 
 ## 17.0.0

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '17.0.1';
+const String pigeonVersion = '17.1.0';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '17.0.0';
+const String pigeonVersion = '17.0.1';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -776,6 +776,7 @@ class KotlinGeneratorAdapter implements GeneratorAdapter {
         options.kotlinOptions ?? const KotlinOptions();
     kotlinOptions = kotlinOptions.merge(KotlinOptions(
       errorClassName: kotlinOptions.errorClassName ?? 'FlutterError',
+      includeErrorClass: kotlinOptions.includeErrorClass,
       copyrightHeader: options.copyrightHeader != null
           ? _lineReader(
               path.posix.join(options.basePath ?? '', options.copyrightHeader))

--- a/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/CoreTests.gen.kt
+++ b/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/CoreTests.gen.kt
@@ -20,7 +20,7 @@ private fun wrapResult(result: Any?): List<Any?> {
 }
 
 private fun wrapError(exception: Throwable): List<Any?> {
-  if (exception is CoreTestsError) {
+  if (exception is FlutterError) {
     return listOf(exception.code, exception.message, exception.details)
   } else {
     return listOf(
@@ -30,23 +30,10 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): CoreTestsError {
-  return CoreTestsError(
+private fun createConnectionError(channelName: String): FlutterError {
+  return FlutterError(
       "channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 }
-
-/**
- * Error class for passing custom error details to Flutter via a thrown PlatformException.
- *
- * @property code The error code.
- * @property message The error message.
- * @property details The error details. Must be a datatype supported by the api codec.
- */
-class CoreTestsError(
-    val code: String,
-    override val message: String? = null,
-    val details: Any? = null
-) : Throwable()
 
 enum class AnEnum(val raw: Int) {
   ONE(0),
@@ -2399,8 +2386,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(null) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
@@ -2417,8 +2403,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(null) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0]
           callback(Result.success(output))
@@ -2436,8 +2421,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(null) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
@@ -2454,12 +2438,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(everythingArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2483,8 +2466,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(everythingArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as AllNullableTypes?
           callback(Result.success(output))
@@ -2511,12 +2493,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aNullableBoolArg, aNullableIntArg, aNullableStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2537,12 +2518,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aBoolArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2563,12 +2543,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(anIntArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2589,12 +2568,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aDoubleArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2615,12 +2593,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2641,12 +2618,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aListArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2667,12 +2643,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aListArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2693,12 +2668,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aMapArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2719,12 +2693,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(anEnumArg.raw)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -2745,8 +2718,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aBoolArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as Boolean?
           callback(Result.success(output))
@@ -2764,8 +2736,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(anIntArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0].let { if (it is Int) it.toLong() else it as Long? }
           callback(Result.success(output))
@@ -2783,8 +2754,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aDoubleArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as Double?
           callback(Result.success(output))
@@ -2802,8 +2772,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as String?
           callback(Result.success(output))
@@ -2821,8 +2790,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aListArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as ByteArray?
           callback(Result.success(output))
@@ -2840,8 +2808,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aListArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as List<Any?>?
           callback(Result.success(output))
@@ -2862,8 +2829,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aMapArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as Map<String?, Any?>?
           callback(Result.success(output))
@@ -2881,8 +2847,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(anEnumArg?.raw)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = (it[0] as Int?)?.let { AnEnum.ofRaw(it) }
           callback(Result.success(output))
@@ -2903,8 +2868,7 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(null) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
@@ -2921,12 +2885,11 @@ class FlutterIntegrationCoreApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -3083,12 +3046,11 @@ class FlutterSmallApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(msgArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))
@@ -3108,12 +3070,11 @@ class FlutterSmallApi(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(aStringArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(CoreTestsError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
           callback(
               Result.failure(
-                  CoreTestsError(
+                  FlutterError(
                       "null-error",
                       "Flutter api returned null value for non-null return value.",
                       "")))

--- a/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/TestPlugin.kt
+++ b/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/TestPlugin.kt
@@ -39,7 +39,7 @@ class TestPlugin : FlutterPlugin, HostIntegrationCoreApi {
   }
 
   override fun throwFlutterError(): Any? {
-    throw CoreTestsError("code", "message", "details")
+    throw FlutterError("code", "message", "details")
   }
 
   override fun echoInt(anInt: Long): Long {
@@ -170,7 +170,7 @@ class TestPlugin : FlutterPlugin, HostIntegrationCoreApi {
   }
 
   override fun throwAsyncFlutterError(callback: (Result<Any?>) -> Unit) {
-    callback(Result.failure(CoreTestsError("code", "message", "details")))
+    callback(Result.failure(FlutterError("code", "message", "details")))
   }
 
   override fun echoAsyncAllTypes(everything: AllTypes, callback: (Result<AllTypes>) -> Unit) {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 17.0.0 # This must match the version in lib/generator_tools.dart
+version: 17.0.1 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ^3.1.0

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 17.0.1 # This must match the version in lib/generator_tools.dart
+version: 17.1.0 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ^3.1.0

--- a/packages/pigeon/tool/shared/generation.dart
+++ b/packages/pigeon/tool/shared/generation.dart
@@ -81,6 +81,13 @@ Future<int> generateTestPigeons({required String baseDir}) async {
     final Set<GeneratorLanguage> skipLanguages =
         _unsupportedFiles[input] ?? <GeneratorLanguage>{};
 
+    final bool kotlinErrorClassGenerationTestFiles =
+        input == 'core_tests' || input == 'background_platform_channels';
+
+    final String kotlinErrorName = kotlinErrorClassGenerationTestFiles
+        ? 'FlutterError'
+        : '${pascalCaseName}Error';
+
     // Generate the default language test plugin output.
     int generateCode = await runPigeon(
       input: './pigeons/$input.dart',
@@ -90,7 +97,8 @@ Future<int> generateTestPigeons({required String baseDir}) async {
           ? null
           : '$outputBase/android/src/main/kotlin/com/example/test_plugin/$pascalCaseName.gen.kt',
       kotlinPackage: 'com.example.test_plugin',
-      kotlinErrorClassName: '${pascalCaseName}Error',
+      kotlinErrorClassName: kotlinErrorName,
+      kotlinIncludeErrorClass: input != 'core_tests',
       // iOS
       swiftOut: skipLanguages.contains(GeneratorLanguage.swift)
           ? null
@@ -176,6 +184,7 @@ Future<int> runPigeon({
   String? kotlinOut,
   String? kotlinPackage,
   String? kotlinErrorClassName,
+  bool kotlinIncludeErrorClass = true,
   String? swiftOut,
   String? cppHeaderOut,
   String? cppSourceOut,
@@ -217,7 +226,10 @@ Future<int> runPigeon({
     javaOptions: JavaOptions(package: javaPackage),
     kotlinOut: kotlinOut,
     kotlinOptions: KotlinOptions(
-        package: kotlinPackage, errorClassName: kotlinErrorClassName),
+      package: kotlinPackage,
+      errorClassName: kotlinErrorClassName,
+      includeErrorClass: kotlinIncludeErrorClass,
+    ),
     objcHeaderOut: objcHeaderOut,
     objcSourceOut: objcSourceOut,
     objcOptions: ObjcOptions(prefix: objcPrefix),


### PR DESCRIPTION
Allows kotlin generator to skip error class generation by creating `includeErrorClass` argument.

This may be considered only a partial fix, as it requires another pigeon file with the class generated rather than creating a new file with the class.

This solution seems to me to solve the problem well enough as creating another file is a non-trivial task and there is already a working solution - renaming the error class per file.

fixes: https://github.com/flutter/flutter/issues/142099

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests


