### PR TITLE
[tool] Ignore GeneratedPluginRegistrant.swift for `format`

### DIFF
--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -346,6 +346,8 @@ class FormatCommand extends PackageCommand {
                 pathFragmentForDirectories(<String>['example', 'build'])) &&
             // Ignore files in Pods, which are not part of the repository.
             !path.contains(pathFragmentForDirectories(<String>['Pods'])) &&
+            // See https://github.com/flutter/flutter/issues/144039
+            !path.endsWith('GeneratedPluginRegistrant.swift') &&
             // Ignore .dart_tool/, which can have various intermediate files.
             !path.contains(pathFragmentForDirectories(<String>['.dart_tool'])))
         .toList();

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -737,6 +737,52 @@ void main() {
         ]));
   });
 
+  test('skips GeneratedPluginRegistrant.swift', () async {
+    const String sourceFile = 'macos/Classes/Foo.swift';
+    final RepositoryPackage plugin = createFakePlugin(
+      'a_plugin',
+      packagesDir,
+      extraFiles: <String>[
+        sourceFile,
+        'example/macos/Flutter/GeneratedPluginRegistrant.swift',
+      ],
+    );
+
+    await runCapturingPrint(runner, <String>[
+      'format',
+      '--swift',
+      '--swift-format-path=/path/to/swift-format'
+    ]);
+
+    expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          const ProcessCall(
+            '/path/to/swift-format',
+            <String>['--version'],
+            null,
+          ),
+          ProcessCall(
+            '/path/to/swift-format',
+            <String>[
+              '-i',
+              ...getPackagesDirRelativePaths(plugin, <String>[sourceFile])
+            ],
+            packagesDir.path,
+          ),
+          ProcessCall(
+            '/path/to/swift-format',
+            <String>[
+              'lint',
+              '--parallel',
+              '--strict',
+              ...getPackagesDirRelativePaths(plugin, <String>[sourceFile]),
+            ],
+            packagesDir.path,
+          ),
+        ]));
+  });
+
   test('fails if files are changed with --fail-on-change', () async {
     const List<String> files = <String>[
       'linux/foo_plugin.cc',


### PR DESCRIPTION
This file fails `swift-format lint`, so including it in `format` causes lots of warnings when run locally.
