### PR TITLE
[url_launcher] Add explicit imports of UIKit

### DIFF
--- a/packages/url_launcher/url_launcher_ios/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_ios/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 6.2.5
 
+* Adds explicit imports for UIKit.
 * Updates minimum iOS version to 12.0 and minimum Flutter version to 3.16.6.
 
 ## 6.2.4

--- a/packages/url_launcher/url_launcher_ios/ios/Classes/Launcher.swift
+++ b/packages/url_launcher/url_launcher_ios/ios/Classes/Launcher.swift
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import UIKit
+
 /// Protocol for UIApplication methods relating to launching URLs.
 ///
 /// This protocol exists to allow injecting an alternate implementation for testing.

--- a/packages/url_launcher/url_launcher_ios/ios/Classes/URLLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_ios/ios/Classes/URLLauncherPlugin.swift
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import Flutter
+import UIKit
 
 public final class URLLauncherPlugin: NSObject, FlutterPlugin, UrlLauncherApi {
 

--- a/packages/url_launcher/url_launcher_ios/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_ios
 description: iOS implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.2.4
+version: 6.2.5
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
When trying to compile url_launcher_ios as an independent library (for instance, when using Bazel/Blaze) compilation fails due to a missing UIKit import. Presumably this is not a problem when using the Flutter build tools because UIKit is included implicitly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.