### PR TITLE
[go_router] Update redirection.md code example for clarity

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Updates the redirection documentation for clarity.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 
 ## 13.2.0

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 13.2.1
 
-* Updates the redirection documentation for clarity.
+* Updates the `redirect` documentation for clarity.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 
 ## 13.2.0

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 13.2.1
 
 * Updates the redirection documentation for clarity.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.

--- a/packages/go_router/doc/redirection.md
+++ b/packages/go_router/doc/redirection.md
@@ -10,7 +10,7 @@ either the GoRouter or GoRoute constructor:
 
 ```dart
 redirect: (BuildContext context, GoRouterState state) {
-  if (AuthState.of(context).isSignedIn) {
+  if (!AuthState.of(context).isSignedIn) {
     return '/signin';
   } else {
     return null;

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 13.2.0
+version: 13.2.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Updates the redirection documentation for clarity.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 
 ## 2.5.3
@@ -270,7 +271,7 @@ GoogleMapController is now uniformly driven by implementing `DefaultLifecycleObs
 
 * Fix headline in the readme.
 
-## 1.0.0 - Out of developer preview  🎉.
+## 1.0.0 - Out of developer preview  🎉
 
 * Bump the minimal Flutter SDK to 1.22 where platform views are out of developer preview and performing better on iOS. Flutter 1.22 no longer requires adding the `io.flutter.embedded_views_preview` to `Info.plist` in iOS.
 
@@ -293,7 +294,7 @@ GoogleMapController is now uniformly driven by implementing `DefaultLifecycleObs
 
 ## 0.5.29+1
 
-* (ios) Pin dependency on GoogleMaps pod to `< 3.10`, to address https://github.com/flutter/flutter/issues/63447
+* (ios) Pin dependency on GoogleMaps pod to `< 3.10`, to address <https://github.com/flutter/flutter/issues/63447>
 
 ## 0.5.29
 
@@ -549,7 +550,7 @@ GoogleMapController is now uniformly driven by implementing `DefaultLifecycleObs
 ## 0.5.14+1
 
 * Example app update(comment out usage of the ImageStreamListener API which has a breaking change
-  that's not yet on master). See: https://github.com/flutter/flutter/issues/33438
+  that's not yet on master). See: <https://github.com/flutter/flutter/issues/33438>
 
 ## 0.5.14
 
@@ -648,7 +649,7 @@ GoogleMapController is now uniformly driven by implementing `DefaultLifecycleObs
 
 ## 0.2.0+5
 
-* Skip the Gradle Android permissions lint for MyLocation (https://github.com/flutter/flutter/issues/28339)
+* Skip the Gradle Android permissions lint for MyLocation (<https://github.com/flutter/flutter/issues/28339>)
 * Suppress unchecked cast warning for the PlatformViewFactory creation parameters.
 
 ## 0.2.0+4
@@ -666,7 +667,7 @@ GoogleMapController is now uniformly driven by implementing `DefaultLifecycleObs
 
 ## 0.2.0+1
 
-* Fixed a bug which the camera is not positioned correctly at map initialization(temporary workaround)(https://github.com/flutter/flutter/issues/27550).
+* Fixed a bug which the camera is not positioned correctly at map initialization(temporary workaround)(<https://github.com/flutter/flutter/issues/27550>).
 
 ## 0.2.0
 


### PR DESCRIPTION
The GoRouter redirect documentation describes an example scenario where the top level redirect may be used to send non-signed-in users to the signin page. The example code seems to be doing so for signed in users, however. 

This is a documentation-only change.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
