### PR TITLE
Add library annotations for js interop

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.7
+
+* Fixes an issue where `dart:js_interop` object literal factories did not
+  compile with dart2js.
+
 ## 0.5.6
 
 * Adds support for `MapConfiguration.style`.

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.7
+## 0.5.6+1
 
 * Fixes an issue where `dart:js_interop` object literal factories did not
   compile with dart2js.

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/dom_window_extension.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/dom_window_extension.dart
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(srujzs): Needed for https://github.com/dart-lang/sdk/issues/54801. Once
+// we publish a version with a min SDK constraint that contains this fix,
+// remove.
+@JS()
+library;
+
 import 'dart:js_interop';
 
 import 'package:web/web.dart' as web;

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/map_styler.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/map_styler.dart
@@ -2,14 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(srujzs): Needed for https://github.com/dart-lang/sdk/issues/54801. Once
+// we publish a version with a min SDK constraint that contains this fix,
+// remove.
+@JS()
+library;
+
 import 'dart:js_interop';
 
 /// The interop type for a Google Maps Map Styler.
 ///
 /// See: https://developers.google.com/maps/documentation/javascript/style-reference#stylers
 @JS()
-@staticInterop
-@anonymous
 extension type MapStyler._(JSObject _) implements JSObject {
   /// Create a new [MapStyler] instance.
   external factory MapStyler({

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.5.7
+version: 0.5.6+1
 
 environment:
   sdk: ^3.3.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.5.6
+version: 0.5.7
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
These are needed for 3.3 in order to address issue https://github.com/dart-lang/sdk/issues/54801. This commit also cleans up some unnecessary annotations.

Also publishes 0.5.7.

https://github.com/dart-lang/sdk/issues/55039