### PR TITLE
[tool] Add features to support GCB auto-publish flow

### DIFF
--- a/script/tool/lib/src/publish_command.dart
+++ b/script/tool/lib/src/publish_command.dart
@@ -60,7 +60,7 @@ class PublishCommand extends PackageLoopingCommand {
         _stdin = stdinput ?? io.stdin {
     argParser.addFlag(_alreadyTaggedFlag,
         help:
-            'Instead of tagging, validates that the current checkout is aleardy tagged with the expected version.\n'
+            'Instead of tagging, validates that the current checkout is already tagged with the expected version.\n'
             'This is primarily intended for use in CI publish steps triggered by tagging.',
         negatable: false);
     argParser.addMultiOption(_pubFlagsOption,
@@ -88,7 +88,7 @@ class PublishCommand extends PackageLoopingCommand {
     argParser.addFlag(_skipConfirmationFlag,
         help: 'Run the command without asking for Y/N inputs.\n'
             'This command will add a `--force` flag to the `pub publish` command if it is not added with $_pubFlagsOption\n');
-    argParser.addFlag(_tagForAutopublishFlag,
+    argParser.addFlag(_tagForAutoPublishFlag,
         help:
             'Runs the dry-run publish, and tags if it succeeds, but does not actually publish.\n'
             'This is intended for use with a separate publish step that is based on tag push events.',
@@ -101,7 +101,7 @@ class PublishCommand extends PackageLoopingCommand {
   static const String _allChangedFlag = 'all-changed';
   static const String _dryRunFlag = 'dry-run';
   static const String _skipConfirmationFlag = 'skip-confirmation';
-  static const String _tagForAutopublishFlag = 'tag-for-autopublish';
+  static const String _tagForAutoPublishFlag = 'tag-for-auto-publish';
 
   static const String _pubCredentialName = 'PUB_CREDENTIALS';
 
@@ -205,7 +205,7 @@ class PublishCommand extends PackageLoopingCommand {
       return PackageResult.fail(<String>['uncommitted changes']);
     }
 
-    final bool tagOnly = getBoolArg(_tagForAutopublishFlag);
+    final bool tagOnly = getBoolArg(_tagForAutoPublishFlag);
     if (!tagOnly) {
       if (!await _publish(package)) {
         return PackageResult.fail(<String>['publish failed']);

--- a/script/tool/lib/src/publish_command.dart
+++ b/script/tool/lib/src/publish_command.dart
@@ -58,6 +58,11 @@ class PublishCommand extends PackageLoopingCommand {
   })  : _pubVersionFinder =
             PubVersionFinder(httpClient: httpClient ?? http.Client()),
         _stdin = stdinput ?? io.stdin {
+    argParser.addFlag(_alreadyTaggedFlag,
+        help:
+            'Instead of tagging, validates that the current checkout is aleardy tagged with the expected version.\n'
+            'This is primarily intended for use in CI publish steps triggered by tagging.',
+        negatable: false);
     argParser.addMultiOption(_pubFlagsOption,
         help:
             'A list of options that will be forwarded on to pub. Separate multiple flags with commas.');
@@ -83,13 +88,20 @@ class PublishCommand extends PackageLoopingCommand {
     argParser.addFlag(_skipConfirmationFlag,
         help: 'Run the command without asking for Y/N inputs.\n'
             'This command will add a `--force` flag to the `pub publish` command if it is not added with $_pubFlagsOption\n');
+    argParser.addFlag(_tagForAutopublishFlag,
+        help:
+            'Runs the dry-run publish, and tags if it succeeds, but does not actually publish.\n'
+            'This is intended for use with a separate publish step that is based on tag push events.',
+        negatable: false);
   }
 
+  static const String _alreadyTaggedFlag = 'already-tagged';
   static const String _pubFlagsOption = 'pub-publish-flags';
   static const String _remoteOption = 'remote';
   static const String _allChangedFlag = 'all-changed';
   static const String _dryRunFlag = 'dry-run';
   static const String _skipConfirmationFlag = 'skip-confirmation';
+  static const String _tagForAutopublishFlag = 'tag-for-autopublish';
 
   static const String _pubCredentialName = 'PUB_CREDENTIALS';
 
@@ -193,15 +205,27 @@ class PublishCommand extends PackageLoopingCommand {
       return PackageResult.fail(<String>['uncommitted changes']);
     }
 
-    if (!await _publish(package)) {
-      return PackageResult.fail(<String>['publish failed']);
+    final bool tagOnly = getBoolArg(_tagForAutopublishFlag);
+    if (!tagOnly) {
+      if (!await _publish(package)) {
+        return PackageResult.fail(<String>['publish failed']);
+      }
     }
 
-    if (!await _tagRelease(package)) {
-      return PackageResult.fail(<String>['tagging failed']);
+    final String tag = _getTag(package);
+    if (getBoolArg(_alreadyTaggedFlag)) {
+      if (!(await _getCurrentTags()).contains(tag)) {
+        printError('The current checkout is not already tagged "$tag"');
+        return PackageResult.fail(<String>['missing tag']);
+      }
+    } else {
+      if (!await _tagRelease(package, tag)) {
+        return PackageResult.fail(<String>['tagging failed']);
+      }
     }
 
-    print('\nPublished ${package.directory.basename} successfully!');
+    final String action = tagOnly ? 'Tagged' : 'Published';
+    print('\n$action ${package.directory.basename} successfully!');
     return PackageResult.success();
   }
 
@@ -277,8 +301,7 @@ Safe to ignore if the package is deleted in this commit.
   // Tag the release with <package-name>-v<version>, and push it to the remote.
   //
   // Return `true` if successful, `false` otherwise.
-  Future<bool> _tagRelease(RepositoryPackage package) async {
-    final String tag = _getTag(package);
+  Future<bool> _tagRelease(RepositoryPackage package, String tag) async {
     print('Tagging release $tag...');
     if (!getBoolArg(_dryRunFlag)) {
       final io.ProcessResult result = await (await gitDir).runCommand(
@@ -299,6 +322,22 @@ Safe to ignore if the package is deleted in this commit.
       print('Release tagged!');
     }
     return success;
+  }
+
+  Future<Iterable<String>> _getCurrentTags() async {
+    // git tag --points-at HEAD
+    final io.ProcessResult tagsResult = await (await gitDir).runCommand(
+      <String>['tag', '--points-at', 'HEAD'],
+      throwOnError: false,
+    );
+    if (tagsResult.exitCode != 0) {
+      return <String>[];
+    }
+
+    return (tagsResult.stdout as String)
+        .split('\n')
+        .map((String line) => line.trim())
+        .where((String line) => line.isNotEmpty);
   }
 
   Future<bool> _checkGitStatus(RepositoryPackage package) async {

--- a/script/tool/test/common/package_command_test.dart
+++ b/script/tool/test/common/package_command_test.dart
@@ -222,11 +222,6 @@ void main() {
     test(
         'explicitly specifying the plugin (group) name of a federated plugin '
         'should include all plugins in the group', () async {
-      processRunner.mockProcessesForExecutable['git-diff'] = <FakeProcessInfo>[
-        FakeProcessInfo(MockProcess(stdout: '''
-packages/plugin1/plugin1/plugin1.dart
-''')),
-      ];
       final Directory pluginGroup = packagesDir.childDirectory('plugin1');
       final RepositoryPackage appFacingPackage =
           createFakePlugin('plugin1', pluginGroup);
@@ -235,8 +230,7 @@ packages/plugin1/plugin1/plugin1.dart
       final RepositoryPackage implementationPackage =
           createFakePlugin('plugin1_web', pluginGroup);
 
-      await runCapturingPrint(
-          runner, <String>['sample', '--base-sha=main', '--packages=plugin1']);
+      await runCapturingPrint(runner, <String>['sample', '--packages=plugin1']);
 
       expect(
           command.plugins,
@@ -245,6 +239,21 @@ packages/plugin1/plugin1/plugin1.dart
             platformInterfacePackage.path,
             implementationPackage.path
           ]));
+    });
+
+    test(
+        'specifying the app-facing package of a federated plugin with '
+        '--exact-match-only should only include only that package', () async {
+      final Directory pluginGroup = packagesDir.childDirectory('plugin1');
+      final RepositoryPackage appFacingPackage =
+          createFakePlugin('plugin1', pluginGroup);
+      createFakePlugin('plugin1_platform_interface', pluginGroup);
+      createFakePlugin('plugin1_web', pluginGroup);
+
+      await runCapturingPrint(runner,
+          <String>['sample', '--packages=plugin1', '--exact-match-only']);
+
+      expect(command.plugins, unorderedEquals(<String>[appFacingPackage.path]));
     });
 
     test(

--- a/script/tool/test/publish_command_test.dart
+++ b/script/tool/test/publish_command_test.dart
@@ -350,7 +350,7 @@ void main() {
       );
     });
 
-    test('skips publish with --tag-for-autopublish', () async {
+    test('skips publish with --tag-for-auto-publish', () async {
       const String packageName = 'a_package';
       createFakePackage(packageName, packagesDir);
 
@@ -358,7 +358,7 @@ void main() {
           await runCapturingPrint(commandRunner, <String>[
         'publish',
         '--packages=$packageName',
-        '--tag-for-autopublish',
+        '--tag-for-auto-publish',
       ]);
 
       // There should be no variant of any command containing "publish".
@@ -418,12 +418,12 @@ void main() {
               const ProcessCall('git-tag', <String>['foo-v0.0.1'], null))));
     });
 
-    test('when passed --tag-for-autopublish', () async {
+    test('when passed --tag-for-auto-publish', () async {
       createFakePlugin('foo', packagesDir, examples: <String>[]);
       await runCapturingPrint(commandRunner, <String>[
         'publish',
         '--packages=foo',
-        '--tag-for-autopublish',
+        '--tag-for-auto-publish',
       ]);
 
       expect(processRunner.recordedCalls,
@@ -478,13 +478,13 @@ void main() {
           ]));
     });
 
-    test('when passed --tag-for-autopublish', () async {
+    test('when passed --tag-for-auto-publish', () async {
       createFakePlugin('foo', packagesDir, examples: <String>[]);
       await runCapturingPrint(commandRunner, <String>[
         'publish',
         '--packages=foo',
         '--skip-confirmation',
-        '--tag-for-autopublish',
+        '--tag-for-auto-publish',
       ]);
 
       expect(

--- a/script/tool/test/publish_command_test.dart
+++ b/script/tool/test/publish_command_test.dart
@@ -349,6 +349,33 @@ void main() {
         ),
       );
     });
+
+    test('skips publish with --tag-for-autopublish', () async {
+      const String packageName = 'a_package';
+      createFakePackage(packageName, packagesDir);
+
+      final List<String> output =
+          await runCapturingPrint(commandRunner, <String>[
+        'publish',
+        '--packages=$packageName',
+        '--tag-for-autopublish',
+      ]);
+
+      // There should be no variant of any command containing "publish".
+      expect(
+          processRunner.recordedCalls
+              .map((ProcessCall call) => call.toString()),
+          isNot(contains(contains('publish'))));
+      // The output should indicate that it was tagged, not published.
+      expect(
+        output,
+        containsAllInOrder(
+          <Matcher>[
+            contains('Tagged a_package successfully!'),
+          ],
+        ),
+      );
+    });
   });
 
   group('Tags release', () {
@@ -389,6 +416,18 @@ void main() {
           processRunner.recordedCalls,
           isNot(contains(
               const ProcessCall('git-tag', <String>['foo-v0.0.1'], null))));
+    });
+
+    test('when passed --tag-for-autopublish', () async {
+      createFakePlugin('foo', packagesDir, examples: <String>[]);
+      await runCapturingPrint(commandRunner, <String>[
+        'publish',
+        '--packages=foo',
+        '--tag-for-autopublish',
+      ]);
+
+      expect(processRunner.recordedCalls,
+          contains(const ProcessCall('git-tag', <String>['foo-v0.0.1'], null)));
     });
   });
 
@@ -439,6 +478,21 @@ void main() {
           ]));
     });
 
+    test('when passed --tag-for-autopublish', () async {
+      createFakePlugin('foo', packagesDir, examples: <String>[]);
+      await runCapturingPrint(commandRunner, <String>[
+        'publish',
+        '--packages=foo',
+        '--skip-confirmation',
+        '--tag-for-autopublish',
+      ]);
+
+      expect(
+          processRunner.recordedCalls,
+          contains(const ProcessCall(
+              'git-push', <String>['upstream', 'foo-v0.0.1'], null)));
+    });
+
     test('to upstream by default, dry run', () async {
       final RepositoryPackage plugin =
           createFakePlugin('foo', packagesDir, examples: <String>[]);
@@ -485,6 +539,62 @@ void main() {
           containsAllInOrder(<Matcher>[
             contains('Published foo successfully!'),
           ]));
+    });
+  });
+
+  group('--already-tagged', () {
+    test('passes when HEAD has the expected tag', () async {
+      createFakePlugin('foo', packagesDir, examples: <String>[]);
+
+      processRunner.mockProcessesForExecutable['git-tag'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess()), // Skip the initializeRun call.
+        FakeProcessInfo(MockProcess(stdout: 'foo-v0.0.1\n'),
+            <String>['--points-at', 'HEAD'])
+      ];
+
+      await runCapturingPrint(commandRunner,
+          <String>['publish', '--packages=foo', '--already-tagged']);
+    });
+
+    test('fails if HEAD does not have the expected tag', () async {
+      createFakePlugin('foo', packagesDir, examples: <String>[]);
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(commandRunner,
+          <String>['publish', '--packages=foo', '--already-tagged'],
+          errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+          output,
+          containsAllInOrder(<Matcher>[
+            contains('The current checkout is not already tagged "foo-v0.0.1"'),
+            contains('missing tag'),
+          ]));
+    });
+
+    test('does not create or push tags', () async {
+      createFakePlugin('foo', packagesDir, examples: <String>[]);
+
+      processRunner.mockProcessesForExecutable['git-tag'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess()), // Skip the initializeRun call.
+        FakeProcessInfo(MockProcess(stdout: 'foo-v0.0.1\n'),
+            <String>['--points-at', 'HEAD'])
+      ];
+
+      await runCapturingPrint(commandRunner,
+          <String>['publish', '--packages=foo', '--already-tagged']);
+
+      expect(
+          processRunner.recordedCalls,
+          isNot(contains(
+              const ProcessCall('git-tag', <String>['foo-v0.0.1'], null))));
+      expect(
+          processRunner.recordedCalls
+              .map((ProcessCall call) => call.executable),
+          isNot(contains('git-push')));
     });
   });
 


### PR DESCRIPTION
Adds the flowing to the tool:
- A new `--exact-match-only` flag to be used with `--packages` to prevent group matching (i.e., a selection like `--packages=path_provider --exact-match-only` would only run on `packages/path_provider/path_provider`, not `packages/path_provider/*`).
- Two new `publish` command flags:
  - `--tag-for-auto-publish`, to do all the steps that `publish` currently does except for the real `pub publish`, so it would dry-run the publish and then create and push the tag if successful.
  - `--already-tagged`, to skip the step of adding and pushing a tag, and replace it with a check that `HEAD` already has the expected tag.

This set of additions supports a workflow where the current `release` step is changed to use `--tag-for-auto-publish`, and then the separate auto-publish system would publish each package with `... publish --already-tagged --packages=<some package> --exact-match-only`.

See https://github.com/flutter/packages/pull/5005#discussion_r1344542422 for previous discussion/context.

Part of https://github.com/flutter/flutter/issues/126827