### PR TITLE
[video_player] get position update interval from params

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Updates support matrix in README to indicate that iOS 11 is no longer supported.
 * Clients on versions of Flutter that still support iOS 11 can continue to use this
   package with iOS 11, but will not receive any further updates to the iOS implementation.
+* Adds the parameter `positionUpdateInterval` which enables control of the interval of how often the `position` value is updated.
 
 ## 2.8.2
 

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -167,20 +167,27 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   /// The name of the asset is given by the [dataSource] argument and must not be
   /// null. The [package] argument must be non-null when the asset comes from a
   /// package and null otherwise.
-  MiniController.asset(this.dataSource, {this.package})
-      : dataSourceType = DataSourceType.asset,
+  MiniController.asset(
+    this.dataSource, {
+    this.package,
+    this.positionUpdateInterval = _defaultPositionUpdateInterval,
+  })  : dataSourceType = DataSourceType.asset,
         super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [MiniController] playing a video from obtained from
   /// the network.
-  MiniController.network(this.dataSource)
-      : dataSourceType = DataSourceType.network,
+  MiniController.network(
+    this.dataSource, {
+    this.positionUpdateInterval = _defaultPositionUpdateInterval,
+  })  : dataSourceType = DataSourceType.network,
         package = null,
         super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [MiniController] playing a video from obtained from a file.
-  MiniController.file(File file)
-      : dataSource = Uri.file(file.absolute.path).toString(),
+  MiniController.file(
+    File file, {
+    this.positionUpdateInterval = _defaultPositionUpdateInterval,
+  })  : dataSource = Uri.file(file.absolute.path).toString(),
         dataSourceType = DataSourceType.file,
         package = null,
         super(const VideoPlayerValue(duration: Duration.zero));
@@ -196,6 +203,10 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   /// Only set for [asset] videos. The package that the asset was loaded from.
   final String? package;
 
+  /// The interval at which the [position] of the video is updated.
+  /// Defaults to 500ms.
+  final Duration positionUpdateInterval;
+
   Timer? _timer;
   Completer<void>? _creatingCompleter;
   StreamSubscription<dynamic>? _eventSubscription;
@@ -209,6 +220,9 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   /// on the plugin.
   @visibleForTesting
   int get textureId => _textureId;
+
+  static const Duration _defaultPositionUpdateInterval =
+      Duration(milliseconds: 500);
 
   /// Attempts to open the given [dataSource] and load metadata about the video.
   Future<void> initialize() async {
@@ -315,7 +329,7 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
       await _platform.play(_textureId);
 
       _timer = Timer.periodic(
-        const Duration(milliseconds: 500),
+        positionUpdateInterval,
         (Timer timer) async {
           final Duration? newPosition = await position;
           if (newPosition == null) {

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -167,20 +167,27 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   /// The name of the asset is given by the [dataSource] argument and must not be
   /// null. The [package] argument must be non-null when the asset comes from a
   /// package and null otherwise.
-  MiniController.asset(this.dataSource, {this.package})
-      : dataSourceType = DataSourceType.asset,
+  MiniController.asset(
+    this.dataSource, {
+    this.package,
+    this.positionUpdateInterval = _defaultPositionUpdateInterval,
+  })  : dataSourceType = DataSourceType.asset,
         super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [MiniController] playing a video from obtained from
   /// the network.
-  MiniController.network(this.dataSource)
-      : dataSourceType = DataSourceType.network,
+  MiniController.network(
+    this.dataSource, {
+    this.positionUpdateInterval = _defaultPositionUpdateInterval,
+  })  : dataSourceType = DataSourceType.network,
         package = null,
         super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [MiniController] playing a video from obtained from a file.
-  MiniController.file(File file)
-      : dataSource = Uri.file(file.absolute.path).toString(),
+  MiniController.file(
+    File file, {
+    this.positionUpdateInterval = _defaultPositionUpdateInterval,
+  })  : dataSource = Uri.file(file.absolute.path).toString(),
         dataSourceType = DataSourceType.file,
         package = null,
         super(const VideoPlayerValue(duration: Duration.zero));
@@ -196,6 +203,10 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   /// Only set for [asset] videos. The package that the asset was loaded from.
   final String? package;
 
+  /// The interval at which the [position] of the video is updated.
+  /// Defaults to 500ms.
+  final Duration positionUpdateInterval;
+
   Timer? _timer;
   Completer<void>? _creatingCompleter;
   StreamSubscription<dynamic>? _eventSubscription;
@@ -209,6 +220,9 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   /// on the plugin.
   @visibleForTesting
   int get textureId => _textureId;
+
+  static const Duration _defaultPositionUpdateInterval =
+      Duration(milliseconds: 500);
 
   /// Attempts to open the given [dataSource] and load metadata about the video.
   Future<void> initialize() async {
@@ -315,7 +329,7 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
       await _platform.play(_textureId);
 
       _timer = Timer.periodic(
-        const Duration(milliseconds: 500),
+        positionUpdateInterval,
         (Timer timer) async {
           final Duration? newPosition = await position;
           if (newPosition == null) {


### PR DESCRIPTION
Added a parameter `positionUpdateInterval`, which specifies how often should the value of `value.position` updated. This is useful in cases where a timeline depends on the video's current position to slide smoothly

fixes https://github.com/flutter/flutter/issues/90080

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
