### PR TITLE
[various] Standardize Obj-C doc comment style

### DIFF
--- a/packages/camera/camera_avfoundation/ios/Classes/CameraProperties.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraProperties.h
@@ -9,9 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - flash mode
 
-/**
- * Represents camera's flash mode. Mirrors `FlashMode` enum in flash_mode.dart.
- */
+/// Represents camera's flash mode. Mirrors `FlashMode` enum in flash_mode.dart.
 typedef NS_ENUM(NSInteger, FLTFlashMode) {
   FLTFlashModeOff,
   FLTFlashModeAuto,
@@ -22,23 +20,17 @@ typedef NS_ENUM(NSInteger, FLTFlashMode) {
   FLTFlashModeInvalid,
 };
 
-/**
- * Gets FLTFlashMode from its string representation.
- * @param mode a string representation of the FLTFlashMode.
- */
+/// Gets FLTFlashMode from its string representation.
+/// @param mode a string representation of the FLTFlashMode.
 extern FLTFlashMode FLTGetFLTFlashModeForString(NSString *mode);
 
-/**
- * Gets AVCaptureFlashMode from FLTFlashMode.
- * @param mode flash mode.
- */
+/// Gets AVCaptureFlashMode from FLTFlashMode.
+/// @param mode flash mode.
 extern AVCaptureFlashMode FLTGetAVCaptureFlashModeForFLTFlashMode(FLTFlashMode mode);
 
 #pragma mark - exposure mode
 
-/**
- * Represents camera's exposure mode. Mirrors ExposureMode in camera.dart.
- */
+/// Represents camera's exposure mode. Mirrors ExposureMode in camera.dart.
 typedef NS_ENUM(NSInteger, FLTExposureMode) {
   FLTExposureModeAuto,
   FLTExposureModeLocked,
@@ -47,23 +39,17 @@ typedef NS_ENUM(NSInteger, FLTExposureMode) {
   FLTExposureModeInvalid,
 };
 
-/**
- * Gets a string representation of exposure mode.
- * @param mode exposure mode
- */
+/// Gets a string representation of exposure mode.
+/// @param mode exposure mode
 extern NSString *FLTGetStringForFLTExposureMode(FLTExposureMode mode);
 
-/**
- * Gets FLTExposureMode from its string representation.
- * @param mode a string representation of the FLTExposureMode.
- */
+/// Gets FLTExposureMode from its string representation.
+/// @param mode a string representation of the FLTExposureMode.
 extern FLTExposureMode FLTGetFLTExposureModeForString(NSString *mode);
 
 #pragma mark - focus mode
 
-/**
- * Represents camera's focus mode. Mirrors FocusMode in camera.dart.
- */
+/// Represents camera's focus mode. Mirrors FocusMode in camera.dart.
 typedef NS_ENUM(NSInteger, FLTFocusMode) {
   FLTFocusModeAuto,
   FLTFocusModeLocked,
@@ -72,35 +58,25 @@ typedef NS_ENUM(NSInteger, FLTFocusMode) {
   FLTFocusModeInvalid,
 };
 
-/**
- * Gets a string representation from FLTFocusMode.
- * @param mode focus mode
- */
+/// Gets a string representation from FLTFocusMode.
+/// @param mode focus mode
 extern NSString *FLTGetStringForFLTFocusMode(FLTFocusMode mode);
 
-/**
- * Gets FLTFocusMode from its string representation.
- * @param mode a string representation of focus mode.
- */
+/// Gets FLTFocusMode from its string representation.
+/// @param mode a string representation of focus mode.
 extern FLTFocusMode FLTGetFLTFocusModeForString(NSString *mode);
 
 #pragma mark - device orientation
 
-/**
- * Gets UIDeviceOrientation from its string representation.
- */
+/// Gets UIDeviceOrientation from its string representation.
 extern UIDeviceOrientation FLTGetUIDeviceOrientationForString(NSString *orientation);
 
-/**
- * Gets a string representation of UIDeviceOrientation.
- */
+/// Gets a string representation of UIDeviceOrientation.
 extern NSString *FLTGetStringForUIDeviceOrientation(UIDeviceOrientation orientation);
 
 #pragma mark - resolution preset
 
-/**
- * Represents camera's resolution present. Mirrors ResolutionPreset in camera.dart.
- */
+/// Represents camera's resolution present. Mirrors ResolutionPreset in camera.dart.
 typedef NS_ENUM(NSInteger, FLTResolutionPreset) {
   FLTResolutionPresetVeryLow,
   FLTResolutionPresetLow,
@@ -114,22 +90,16 @@ typedef NS_ENUM(NSInteger, FLTResolutionPreset) {
   FLTResolutionPresetInvalid,
 };
 
-/**
- * Gets FLTResolutionPreset from its string representation.
- * @param preset a string representation of FLTResolutionPreset.
- */
+/// Gets FLTResolutionPreset from its string representation.
+/// @param preset a string representation of FLTResolutionPreset.
 extern FLTResolutionPreset FLTGetFLTResolutionPresetForString(NSString *preset);
 
 #pragma mark - video format
 
-/**
- * Gets VideoFormat from its string representation.
- */
+/// Gets VideoFormat from its string representation.
 extern OSType FLTGetVideoFormatFromString(NSString *videoFormatString);
 
-/**
- * Represents image format. Mirrors ImageFileFormat in camera.dart.
- */
+/// Represents image format. Mirrors ImageFileFormat in camera.dart.
 typedef NS_ENUM(NSInteger, FCPFileFormat) {
   FCPFileFormatJPEG,
   FCPFileFormatHEIF,
@@ -138,9 +108,7 @@ typedef NS_ENUM(NSInteger, FCPFileFormat) {
 
 #pragma mark - image extension
 
-/**
- * Gets a string representation of ImageFileFormat.
- */
+/// Gets a string representation of ImageFileFormat.
 extern FCPFileFormat FCPGetFileFormatFromString(NSString *fileFormatString);
 
 NS_ASSUME_NONNULL_END

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTCam.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTCam.h
@@ -14,9 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * A class that manages camera's state and performs camera operations.
- */
+/// A class that manages camera's state and performs camera operations.
 @interface FLTCam : NSObject <FlutterTexture>
 
 @property(readonly, nonatomic) AVCaptureDevice *captureDevice;
@@ -52,13 +50,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)close;
 - (void)startVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result;
 - (void)setImageFileFormat:(FCPFileFormat)fileFormat;
-/**
- * Starts recording a video with an optional streaming messenger.
- * If the messenger is non-null then it will be called for each
- * captured frame, allowing streaming concurrently with recording.
- *
- * @param messenger Nullable messenger for capturing each frame.
- */
+/// Starts recording a video with an optional streaming messenger.
+/// If the messenger is non-null then it will be called for each
+/// captured frame, allowing streaming concurrently with recording.
+///
+/// @param messenger Nullable messenger for capturing each frame.
 - (void)startVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result
                 messengerForStreaming:(nullable NSObject<FlutterBinaryMessenger> *)messenger;
 - (void)stopVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result;
@@ -72,28 +68,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setFocusModeWithResult:(FLTThreadSafeFlutterResult *)result mode:(NSString *)modeStr;
 - (void)applyFocusMode;
 
-/**
- * Acknowledges the receipt of one image stream frame.
- *
- * This should be called each time a frame is received. Failing to call it may
- * cause later frames to be dropped instead of streamed.
- */
+/// Acknowledges the receipt of one image stream frame.
+///
+/// This should be called each time a frame is received. Failing to call it may
+/// cause later frames to be dropped instead of streamed.
 - (void)receivedImageStreamData;
 
-/**
- * Applies FocusMode on the AVCaptureDevice.
- *
- * If the @c focusMode is set to FocusModeAuto the AVCaptureDevice is configured to use
- * AVCaptureFocusModeContinuousModeAutoFocus when supported, otherwise it is set to
- * AVCaptureFocusModeAutoFocus. If neither AVCaptureFocusModeContinuousModeAutoFocus nor
- * AVCaptureFocusModeAutoFocus are supported focus mode will not be set.
- * If @c focusMode is set to FocusModeLocked the AVCaptureDevice is configured to use
- * AVCaptureFocusModeAutoFocus. If AVCaptureFocusModeAutoFocus is not supported focus mode will not
- * be set.
- *
- * @param focusMode The focus mode that should be applied to the @captureDevice instance.
- * @param captureDevice The AVCaptureDevice to which the @focusMode will be applied.
- */
+/// Applies FocusMode on the AVCaptureDevice.
+///
+/// If the @c focusMode is set to FocusModeAuto the AVCaptureDevice is configured to use
+/// AVCaptureFocusModeContinuousModeAutoFocus when supported, otherwise it is set to
+/// AVCaptureFocusModeAutoFocus. If neither AVCaptureFocusModeContinuousModeAutoFocus nor
+/// AVCaptureFocusModeAutoFocus are supported focus mode will not be set.
+/// If @c focusMode is set to FocusModeLocked the AVCaptureDevice is configured to use
+/// AVCaptureFocusModeAutoFocus. If AVCaptureFocusModeAutoFocus is not supported focus mode will not
+/// be set.
+///
+/// @param focusMode The focus mode that should be applied to the @captureDevice instance.
+/// @param captureDevice The AVCaptureDevice to which the @focusMode will be applied.
 - (void)applyFocusMode:(FLTFocusMode)focusMode onDevice:(AVCaptureDevice *)captureDevice;
 - (void)pausePreviewWithResult:(FLTThreadSafeFlutterResult *)result;
 - (void)resumePreviewWithResult:(FLTThreadSafeFlutterResult *)result;

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTSavePhotoDelegate.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTSavePhotoDelegate.h
@@ -18,18 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^FLTSavePhotoDelegateCompletionHandler)(NSString *_Nullable path,
                                                       NSError *_Nullable error);
 
-/**
- Delegate object that handles photo capture results.
- */
+/// Delegate object that handles photo capture results.
 @interface FLTSavePhotoDelegate : NSObject <AVCapturePhotoCaptureDelegate>
 
-/**
- * Initialize a photo capture delegate.
- * @param path the path for captured photo file.
- * @param ioQueue the queue on which captured photos are written to disk.
- * @param completionHandler The completion handler block for save photo operations. Can
- * be called from either main queue or IO queue.
- */
+/// Initialize a photo capture delegate.
+/// @param path the path for captured photo file.
+/// @param ioQueue the queue on which captured photos are written to disk.
+/// @param completionHandler The completion handler block for save photo operations. Can
+/// be called from either main queue or IO queue.
 - (instancetype)initWithPath:(NSString *)path
                      ioQueue:(dispatch_queue_t)ioQueue
            completionHandler:(FLTSavePhotoDelegateCompletionHandler)completionHandler;

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTSavePhotoDelegate_Test.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTSavePhotoDelegate_Test.h
@@ -4,9 +4,7 @@
 
 #import "FLTSavePhotoDelegate.h"
 
-/**
- API exposed for unit tests.
- */
+/// API exposed for unit tests.
 @interface FLTSavePhotoDelegate ()
 
 /// The completion handler block for capture and save photo operations.

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeEventChannel.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeEventChannel.h
@@ -6,22 +6,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * A thread safe wrapper for FlutterEventChannel that can be called from any thread, by dispatching
- * its underlying engine calls to the main thread.
- */
+/// A thread safe wrapper for FlutterEventChannel that can be called from any thread, by dispatching
+/// its underlying engine calls to the main thread.
 @interface FLTThreadSafeEventChannel : NSObject
 
-/**
- * Creates a FLTThreadSafeEventChannel by wrapping a FlutterEventChannel object.
- * @param channel The FlutterEventChannel object to be wrapped.
- */
+/// Creates a FLTThreadSafeEventChannel by wrapping a FlutterEventChannel object.
+/// @param channel The FlutterEventChannel object to be wrapped.
 - (instancetype)initWithEventChannel:(FlutterEventChannel *)channel;
 
-/*
- * Registers a handler on the main thread for stream setup requests from the Flutter side.
- # The completion block runs on the main thread.
- */
+/// Registers a handler on the main thread for stream setup requests from the Flutter side.
+/// The completion block runs on the main thread.
 - (void)setStreamHandler:(nullable NSObject<FlutterStreamHandler> *)handler
               completion:(void (^)(void))completion;
 

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeFlutterResult.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeFlutterResult.h
@@ -6,56 +6,38 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * A thread safe wrapper for FlutterResult that can be called from any thread, by dispatching its
- * underlying engine calls to the main thread.
- */
+/// A thread safe wrapper for FlutterResult that can be called from any thread, by dispatching its
+/// underlying engine calls to the main thread.
 @interface FLTThreadSafeFlutterResult : NSObject
 
-/**
- * Gets the original FlutterResult object wrapped by this FLTThreadSafeFlutterResult instance.
- */
+/// Gets the original FlutterResult object wrapped by this FLTThreadSafeFlutterResult instance.
 @property(readonly, nonatomic) FlutterResult flutterResult;
 
-/**
- * Initializes with a FlutterResult object.
- * @param result The FlutterResult object that the result will be given to.
- */
+/// Initializes with a FlutterResult object.
+/// @param result The FlutterResult object that the result will be given to.
 - (instancetype)initWithResult:(FlutterResult)result;
 
-/**
- * Sends a successful result on the main thread without any data.
- */
+/// Sends a successful result on the main thread without any data.
 - (void)sendSuccess;
 
-/**
- * Sends a successful result on the main thread with data.
- * @param data Result data that is send to the Flutter Dart side.
- */
+/// Sends a successful result on the main thread with data.
+/// @param data Result data that is send to the Flutter Dart side.
 - (void)sendSuccessWithData:(id)data;
 
-/**
- * Sends an NSError as result on the main thread.
- * @param error Error that will be send as FlutterError.
- */
+/// Sends an NSError as result on the main thread.
+/// @param error Error that will be send as FlutterError.
 - (void)sendError:(NSError *)error;
 
-/**
- * Sends a FlutterError as result on the main thread.
- * @param flutterError FlutterError that will be sent to the Flutter Dart side.
- */
+/// Sends a FlutterError as result on the main thread.
+/// @param flutterError FlutterError that will be sent to the Flutter Dart side.
 - (void)sendFlutterError:(FlutterError *)flutterError;
 
-/**
- * Sends a FlutterError as result on the main thread.
- */
+/// Sends a FlutterError as result on the main thread.
 - (void)sendErrorWithCode:(NSString *)code
                   message:(nullable NSString *)message
                   details:(nullable id)details;
 
-/**
- * Sends FlutterMethodNotImplemented as result on the main thread.
- */
+/// Sends FlutterMethodNotImplemented as result on the main thread.
 - (void)sendNotImplemented;
 @end
 

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeFlutterResult.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeFlutterResult.m
@@ -47,9 +47,7 @@
   [self send:FlutterMethodNotImplemented];
 }
 
-/**
- * Sends result to flutterResult on the main thread.
- */
+/// Sends result to flutterResult on the main thread.
 - (void)send:(id _Nullable)result {
   FLTEnsureToRunOnMainQueue(^{
     // WARNING: Should not use weak self, because `FlutterResult`s are passed as arguments

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeMethodChannel.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeMethodChannel.h
@@ -6,21 +6,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * A thread safe wrapper for FlutterMethodChannel that can be called from any thread, by dispatching
- * its underlying engine calls to the main thread.
- */
+/// A thread safe wrapper for FlutterMethodChannel that can be called from any thread, by dispatching
+/// its underlying engine calls to the main thread.
 @interface FLTThreadSafeMethodChannel : NSObject
 
-/**
- * Creates a FLTThreadSafeMethodChannel by wrapping a FlutterMethodChannel object.
- * @param channel The FlutterMethodChannel object to be wrapped.
- */
+/// Creates a FLTThreadSafeMethodChannel by wrapping a FlutterMethodChannel object.
+/// @param channel The FlutterMethodChannel object to be wrapped.
 - (instancetype)initWithMethodChannel:(FlutterMethodChannel *)channel;
 
-/**
- * Invokes the specified flutter method on the main thread with the specified arguments.
- */
+/// Invokes the specified flutter method on the main thread with the specified arguments.
 - (void)invokeMethod:(NSString *)method arguments:(nullable id)arguments;
 
 @end

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeMethodChannel.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeMethodChannel.h
@@ -6,8 +6,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// A thread safe wrapper for FlutterMethodChannel that can be called from any thread, by dispatching
-/// its underlying engine calls to the main thread.
+/// A thread safe wrapper for FlutterMethodChannel that can be called from any thread, by
+/// dispatching its underlying engine calls to the main thread.
 @interface FLTThreadSafeMethodChannel : NSObject
 
 /// Creates a FLTThreadSafeMethodChannel by wrapping a FlutterMethodChannel object.

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeTextureRegistry.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeTextureRegistry.h
@@ -6,39 +6,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * A thread safe wrapper for FlutterTextureRegistry that can be called from any thread, by
- * dispatching its underlying engine calls to the main thread.
- */
+/// A thread safe wrapper for FlutterTextureRegistry that can be called from any thread, by
+/// dispatching its underlying engine calls to the main thread.
 @interface FLTThreadSafeTextureRegistry : NSObject
 
-/**
- * Creates a FLTThreadSafeTextureRegistry by wrapping an object conforming to
- * FlutterTextureRegistry.
- * @param registry The FlutterTextureRegistry object to be wrapped.
- */
+/// Creates a FLTThreadSafeTextureRegistry by wrapping an object conforming to
+/// FlutterTextureRegistry.
+/// @param registry The FlutterTextureRegistry object to be wrapped.
 - (instancetype)initWithTextureRegistry:(NSObject<FlutterTextureRegistry> *)registry;
 
-/**
- * Registers a `FlutterTexture` on the main thread for usage in Flutter and returns an id that can
- * be used to reference that texture when calling into Flutter with channels.
- *
- * On success the completion block completes with the pointer to the registered texture, else with
- * 0. The completion block runs on the main thread.
- */
+/// Registers a `FlutterTexture` on the main thread for usage in Flutter and returns an id that can
+/// be used to reference that texture when calling into Flutter with channels.
+///
+/// On success the completion block completes with the pointer to the registered texture, else with
+/// 0. The completion block runs on the main thread.
 - (void)registerTexture:(NSObject<FlutterTexture> *)texture
              completion:(void (^)(int64_t))completion;
 
-/**
- * Notifies the Flutter engine on the main thread that the given texture has been updated.
- */
+/// Notifies the Flutter engine on the main thread that the given texture has been updated.
 - (void)textureFrameAvailable:(int64_t)textureId;
 
-/**
- * Notifies the Flutter engine on the main thread to unregister a `FlutterTexture` that has been
- * previously registered with `registerTexture:`.
- * @param textureId The result that was previously returned from `registerTexture:`.
- */
+/// Notifies the Flutter engine on the main thread to unregister a `FlutterTexture` that has been
+/// previously registered with `registerTexture:`.
+/// @param textureId The result that was previously returned from `registerTexture:`.
 - (void)unregisterTexture:(int64_t)textureId;
 
 @end

--- a/packages/file_selector/file_selector_ios/ios/Classes/FFSFileSelectorPlugin_Test.h
+++ b/packages/file_selector/file_selector_ios/ios/Classes/FFSFileSelectorPlugin_Test.h
@@ -9,14 +9,10 @@
 // This header is available in the Test module. Import via "@import file_selector_ios.Test;".
 @interface FFSFileSelectorPlugin () <FFSFileSelectorApi, UIDocumentPickerDelegate>
 
-/**
- * Overrides the view controller used for presenting the document picker.
- */
+/// Overrides the view controller used for presenting the document picker.
 @property(nonatomic) UIViewController *_Nullable presentingViewControllerOverride;
 
-/**
- * Overrides the UIDocumentPickerViewController used for file picking.
- */
+/// Overrides the UIDocumentPickerViewController used for file picking.
 @property(nonatomic) UIDocumentPickerViewController *_Nullable documentPickerViewControllerOverride;
 
 @end

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController_Test.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController_Test.h
@@ -9,14 +9,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FLTGoogleMapController (Test)
 
-/**
- * Initializes a map controller with a concrete map view.
- *
- * @param mapView A map view that will be displayed by the controller
- * @param viewId A unique identifier for the controller.
- * @param args Parameters for initialising the map view.
- * @param registrar The plugin registrar passed from Flutter.
- */
+/// Initializes a map controller with a concrete map view.
+///
+/// @param mapView A map view that will be displayed by the controller
+/// @param viewId A unique identifier for the controller.
+/// @param args Parameters for initialising the map view.
+/// @param registrar The plugin registrar passed from Flutter.
 - (instancetype)initWithMapView:(GMSMapView *)mapView
                  viewIdentifier:(int64_t)viewId
                       arguments:(id _Nullable)args

--- a/packages/google_sign_in/google_sign_in_ios/darwin/Classes/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/Classes/FLTGoogleSignInPlugin.m
@@ -329,18 +329,16 @@ static FlutterError *getFlutterError(NSError *error) {
 #pragma clang diagnostic pop
 }
 
-/**
- * This method recursively iterate through the view hierarchy
- * to return the top most view controller.
- *
- * It supports the following scenarios:
- *
- * - The view controller is presenting another view.
- * - The view controller is a UINavigationController.
- * - The view controller is a UITabBarController.
- *
- * @return The top most view controller.
- */
+/// This method recursively iterate through the view hierarchy
+/// to return the top most view controller.
+///
+/// It supports the following scenarios:
+///
+/// - The view controller is presenting another view.
+/// - The view controller is a UINavigationController.
+/// - The view controller is a UITabBarController.
+///
+/// @return The top most view controller.
 - (UIViewController *)topViewControllerFromViewController:(UIViewController *)viewController {
   if ([viewController isKindOfClass:[UINavigationController class]]) {
     UINavigationController *navigationController = (UINavigationController *)viewController;

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
@@ -31,12 +31,10 @@
 
 @interface FLTImagePickerPlugin ()
 
-/**
- * The UIImagePickerController instances that will be used when a new
- * controller would normally be created. Each call to
- * createImagePickerController will remove the current first element from
- * the array.
- */
+/// The UIImagePickerController instances that will be used when a new
+/// controller would normally be created. Each call to
+/// createImagePickerController will remove the current first element from
+/// the array.
 @property(strong, nonatomic)
     NSMutableArray<UIImagePickerController *> *imagePickerControllerOverrides;
 
@@ -84,11 +82,9 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   return topController;
 }
 
-/**
- * Returns the UIImagePickerControllerCameraDevice to use given [source].
- *
- * @param source The source specification from Dart.
- */
+/// Returns the UIImagePickerControllerCameraDevice to use given [source].
+///
+/// @param source The source specification from Dart.
 - (UIImagePickerControllerCameraDevice)cameraDeviceForSource:(FLTSourceSpecification *)source {
   switch (source.camera) {
     case FLTSourceCameraFront:
@@ -287,12 +283,10 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
 
 #pragma mark -
 
-/**
- * If a call is still in progress, cancels it by returning an error and then clearing state.
- *
- * TODO(stuartmorgan): Eliminate this, and instead track context per image picker (e.g., using
- * associated objects).
- */
+/// If a call is still in progress, cancels it by returning an error and then clearing state.
+///
+/// TODO(stuartmorgan): Eliminate this, and instead track context per image picker (e.g., using
+/// associated objects).
 - (void)cancelInProgressCall {
   if (self.callContext) {
     [self sendCallResultWithError:[FlutterError errorWithCode:@"multiple_request"
@@ -687,12 +681,10 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   self.callContext = nil;
 }
 
-/**
- * Sends the given error via `callContext.result` as the result of the original platform channel
- * method call, clearing the in-progress call state.
- *
- * @param error The error to return.
- */
+/// Sends the given error via `callContext.result` as the result of the original platform channel
+/// method call, clearing the in-progress call state.
+///
+/// @param error The error to return.
 - (void)sendCallResultWithError:(FlutterError *)error {
   if (!self.callContext) {
     return;

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin_Test.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin_Test.h
@@ -10,95 +10,77 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * The return handler used for all method calls, which internally adapts the provided result list
- * to return either a list or a single element depending on the original call.
- */
+/// The return handler used for all method calls, which internally adapts the provided result list
+/// to return either a list or a single element depending on the original call.
 typedef void (^FlutterResultAdapter)(NSArray<NSString *> *_Nullable, FlutterError *_Nullable);
 
-/**
- * A container class for context to use when handling a method call from the Dart side.
- */
+/// A container class for context to use when handling a method call from the Dart side.
 @interface FLTImagePickerMethodCallContext : NSObject
 
-/**
- * Initializes a new context that calls |result| on completion of the operation.
- */
+/// Initializes a new context that calls |result| on completion of the operation.
 - (instancetype)initWithResult:(nonnull FlutterResultAdapter)result;
 
-/** The callback to provide results to the Dart caller. */
+/// The callback to provide results to the Dart caller.
 @property(nonatomic, copy, nonnull) FlutterResultAdapter result;
 
-/**
- * The maximum size to enforce on the results.
- *
- * If nil, no resizing is done.
- */
+/// The maximum size to enforce on the results.
+///
+/// If nil, no resizing is done.
 @property(nonatomic, strong, nullable) FLTMaxSize *maxSize;
 
-/**
- * The image quality to resample the results to.
- *
- * If nil, no resampling is done.
- */
+/// The image quality to resample the results to.
+///
+/// If nil, no resampling is done.
 @property(nonatomic, strong, nullable) NSNumber *imageQuality;
 
-/** Maximum number of images to select. 0 indicates no maximum. */
+/// Maximum number of images to select. 0 indicates no maximum.
 @property(nonatomic, assign) int maxImageCount;
 
-/** Whether the image should be picked with full metadata (requires gallery permissions) */
+/// Whether the image should be picked with full metadata (requires gallery permissions)
 @property(nonatomic, assign) BOOL requestFullMetadata;
 
-/** Whether the picker should include videos in the list*/
+/// Whether the picker should include videos in the list*/
 @property(nonatomic, assign) BOOL includeVideo;
 
 @end
 
 #pragma mark -
 
-/** Methods exposed for unit testing. */
+/// Methods exposed for unit testing.
 @interface FLTImagePickerPlugin () <FLTImagePickerApi,
                                     UINavigationControllerDelegate,
                                     UIImagePickerControllerDelegate,
                                     PHPickerViewControllerDelegate,
                                     UIAdaptivePresentationControllerDelegate>
 
-/**
- * The context of the Flutter method call that is currently being handled, if any.
- */
+/// The context of the Flutter method call that is currently being handled, if any.
 @property(strong, nonatomic, nullable) FLTImagePickerMethodCallContext *callContext;
 
 - (UIViewController *)viewControllerWithWindow:(nullable UIWindow *)window;
 
-/**
- * Validates the provided paths list, then sends it via `callContext.result` as the result of the
- * original platform channel method call, clearing the in-progress call state.
- *
- * @param pathList The paths to return. nil indicates a cancelled operation.
- */
+/// Validates the provided paths list, then sends it via `callContext.result` as the result of the
+/// original platform channel method call, clearing the in-progress call state.
+///
+/// @param pathList The paths to return. nil indicates a cancelled operation.
 - (void)sendCallResultWithSavedPathList:(nullable NSArray *)pathList;
 
-/**
- * Tells the delegate that the user cancelled the pick operation.
- *
- * Your delegate’s implementation of this method should dismiss the picker view
- * by calling the dismissModalViewControllerAnimated: method of the parent
- * view controller.
- *
- * Implementation of this method is optional, but expected.
- *
- * @param picker The controller object managing the image picker interface.
- */
+/// Tells the delegate that the user cancelled the pick operation.
+///
+/// Your delegate’s implementation of this method should dismiss the picker view
+/// by calling the dismissModalViewControllerAnimated: method of the parent
+/// view controller.
+///
+/// Implementation of this method is optional, but expected.
+///
+/// @param picker The controller object managing the image picker interface.
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker;
 
-/**
- * Sets UIImagePickerController instances that will be used when a new
- * controller would normally be created. Each call to
- * createImagePickerController will remove the current first element from
- * the array.
- *
- * Should be used for testing purposes only.
- */
+/// Sets UIImagePickerController instances that will be used when a new
+/// controller would normally be created. Each call to
+/// createImagePickerController will remove the current first element from
+/// the array.
+///
+/// Should be used for testing purposes only.
 - (void)setImagePickerControllerOverrides:
     (NSArray<UIImagePickerController *> *)imagePickerControllers;
 

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.h
@@ -14,17 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns either the saved path, or an error. Both cannot be set.
 typedef void (^FLTGetSavedPath)(NSString *_Nullable savedPath, FlutterError *_Nullable error);
 
-/*!
- @class FLTPHPickerSaveImageToPathOperation
-
- @brief The FLTPHPickerSaveImageToPathOperation class
-
- @discussion    This class was implemented to handle saved image paths and populate the pathList
- with the final result by using GetSavedPath type block.
-
- @superclass SuperClass: NSOperation\n
- @helps It helps FLTImagePickerPlugin class.
- */
+/// @class FLTPHPickerSaveImageToPathOperation
+///
+/// @brief The FLTPHPickerSaveImageToPathOperation class
+///
+/// @discussion    This class was implemented to handle saved image paths and populate the pathList
+/// with the final result by using GetSavedPath type block.
+///
+/// @superclass SuperClass: NSOperation\n
+/// @helps It helps FLTImagePickerPlugin class.
 @interface FLTPHPickerSaveImageToPathOperation : NSOperation
 
 - (instancetype)initWithResult:(PHPickerResult *)result

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
@@ -124,9 +124,7 @@ API_AVAILABLE(ios(14))
   }
 }
 
-/**
- * Processes the image.
- */
+/// Processes the image.
 - (void)processImage:(NSData *)pickerImageData API_AVAILABLE(ios(14)) {
   UIImage *localImage = [[UIImage alloc] initWithData:pickerImageData];
 
@@ -190,9 +188,7 @@ API_AVAILABLE(ios(14))
   }
 }
 
-/**
- * Processes the video.
- */
+/// Processes the video.
 - (void)processVideo API_AVAILABLE(ios(14)) {
   NSString *typeIdentifier = self.result.itemProvider.registeredTypeIdentifiers.firstObject;
   [self.result.itemProvider

--- a/packages/local_auth/local_auth_darwin/darwin/Classes/FLALocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_darwin/darwin/Classes/FLALocalAuthPlugin.m
@@ -8,9 +8,7 @@
 
 typedef void (^FLADAuthCompletion)(FLADAuthResultDetails *_Nullable, FlutterError *_Nullable);
 
-/**
- * A default context factory that wraps standard LAContext allocation.
- */
+/// A default context factory that wraps standard LAContext allocation.
 @interface FLADefaultAuthContextFactory : NSObject <FLADAuthContextFactory>
 @end
 
@@ -22,9 +20,7 @@ typedef void (^FLADAuthCompletion)(FLADAuthResultDetails *_Nullable, FlutterErro
 
 #pragma mark -
 
-/**
- * A data container for sticky auth state.
- */
+/// A data container for sticky auth state.
 @interface FLAStickyAuthState : NSObject
 @property(nonatomic, strong, nonnull) FLADAuthOptions *options;
 @property(nonatomic, strong, nonnull) FLADAuthStrings *strings;

--- a/packages/local_auth/local_auth_darwin/darwin/Classes/FLALocalAuthPlugin_Test.h
+++ b/packages/local_auth/local_auth_darwin/darwin/Classes/FLALocalAuthPlugin_Test.h
@@ -5,17 +5,13 @@
 #import <Flutter/Flutter.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 
-/**
- * Protocol for a source of LAContext instances. Used to allow context injection in unit tests.
- */
+/// Protocol for a source of LAContext instances. Used to allow context injection in unit tests.
 @protocol FLADAuthContextFactory <NSObject>
 - (LAContext *)createAuthContext;
 @end
 
 @interface FLALocalAuthPlugin ()
-/**
- * Returns an instance that uses the given factory to create LAContexts.
- */
+/// Returns an instance that uses the given factory to create LAContexts.
 - (instancetype)initWithContextFactory:(NSObject<FLADAuthContextFactory> *)factory
     NS_DESIGNATED_INITIALIZER;
 @end

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/AlternateLanguageTestPlugin.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/AlternateLanguageTestPlugin.m
@@ -10,9 +10,7 @@
 @property(nonatomic) FlutterIntegrationCoreApi *flutterAPI;
 @end
 
-/**
- * This plugin handles the native side of the integration tests in example/integration_test/.
- */
+/// This plugin handles the native side of the integration tests in example/integration_test/.
 @implementation AlternateLanguageTestPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   AlternateLanguageTestPlugin *plugin = [[AlternateLanguageTestPlugin alloc] init];

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/AlternateLanguageTestPlugin.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/macos/Classes/AlternateLanguageTestPlugin.m
@@ -10,9 +10,7 @@
 @property(nonatomic) FlutterIntegrationCoreApi *flutterAPI;
 @end
 
-/**
- * This plugin handles the native side of the integration tests in example/integration_test/.
- */
+/// This plugin handles the native side of the integration tests in example/integration_test/.
 @implementation AlternateLanguageTestPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   AlternateLanguageTestPlugin *plugin = [[AlternateLanguageTestPlugin alloc] init];

--- a/packages/video_player/video_player_avfoundation/darwin/Classes/AVAssetTrackUtils.h
+++ b/packages/video_player/video_player_avfoundation/darwin/Classes/AVAssetTrackUtils.h
@@ -4,11 +4,9 @@
 
 #import <AVFoundation/AVFoundation.h>
 
-/**
- * Returns a standardized transform
- * according to the orientation of the track.
- *
- * Note: https://stackoverflow.com/questions/64161544
- * `AVAssetTrack.preferredTransform` can have wrong `tx` and `ty`.
- */
+/// Returns a standardized transform
+/// according to the orientation of the track.
+///
+/// Note: https://stackoverflow.com/questions/64161544
+/// `AVAssetTrack.preferredTransform` can have wrong `tx` and `ty`.
 CGAffineTransform FVPGetStandardizedTransformForTrack(AVAssetTrack* track);

--- a/packages/video_player/video_player_avfoundation/darwin/Classes/FVPDisplayLink.h
+++ b/packages/video_player/video_player_avfoundation/darwin/Classes/FVPDisplayLink.h
@@ -13,19 +13,15 @@
 // A cross-platform display link abstraction.
 @interface FVPDisplayLink : NSObject
 
-/**
- * Whether the display link is currently running (i.e., firing events).
- *
- * Defaults to NO.
- */
+/// Whether the display link is currently running (i.e., firing events).
+///
+/// Defaults to NO.
 @property(nonatomic, assign) BOOL running;
 
-/**
- * Initializes a display link that calls the given callback when fired.
- *
- * The display link starts paused, so must be started, by setting 'running' to YES, before the
- * callback will fire.
- */
+/// Initializes a display link that calls the given callback when fired.
+///
+/// The display link starts paused, so must be started, by setting 'running' to YES, before the
+/// callback will fire.
 - (instancetype)initWithRegistrar:(id<FlutterPluginRegistrar>)registrar
                          callback:(void (^)(void))callback NS_DESIGNATED_INITIALIZER;
 

--- a/packages/video_player/video_player_avfoundation/darwin/Classes/FVPVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/darwin/Classes/FVPVideoPlayerPlugin.m
@@ -72,7 +72,7 @@
 }
 @end
 
-/** Non-test implementation of the diplay link factory. */
+/// Non-test implementation of the diplay link factory.
 @interface FVPDefaultDisplayLinkFactory : NSObject <FVPDisplayLinkFactory>
 @end
 

--- a/packages/video_player/video_player_avfoundation/darwin/Classes/ios/FVPDisplayLink.m
+++ b/packages/video_player/video_player_avfoundation/darwin/Classes/ios/FVPDisplayLink.m
@@ -7,17 +7,15 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
-/**
- * A proxy object to act as a CADisplayLink target, to avoid retain loops, since FVPDisplayLink
- * owns its CADisplayLink, but CADisplayLink retains its target.
- */
+/// A proxy object to act as a CADisplayLink target, to avoid retain loops, since FVPDisplayLink
+/// owns its CADisplayLink, but CADisplayLink retains its target.
 @interface FVPDisplayLinkTarget : NSObject
 @property(nonatomic) void (^callback)(void);
 
-/** Initializes a target object that runs the given callback when onDisplayLink: is called. */
+/// Initializes a target object that runs the given callback when onDisplayLink: is called.
 - (instancetype)initWithCallback:(void (^)(void))callback;
 
-/** Method to be called when a CADisplayLink fires. */
+/// Method to be called when a CADisplayLink fires.
 - (void)onDisplayLink:(CADisplayLink *)link;
 @end
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFDataConverters.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFDataConverters.h
@@ -8,209 +8,167 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Converts an FWFNSUrlRequestData to an NSURLRequest.
- *
- * @param data The data object containing information to create an NSURLRequest.
- *
- * @return An NSURLRequest or nil if data could not be converted.
- */
+/// Converts an FWFNSUrlRequestData to an NSURLRequest.
+///
+/// @param data The data object containing information to create an NSURLRequest.
+///
+/// @return An NSURLRequest or nil if data could not be converted.
 extern NSURLRequest *_Nullable FWFNativeNSURLRequestFromRequestData(FWFNSUrlRequestData *data);
 
-/**
- * Converts an FWFNSHttpCookieData to an NSHTTPCookie.
- *
- * @param data The data object containing information to create an NSHTTPCookie.
- *
- * @return An NSHTTPCookie or nil if data could not be converted.
- */
+/// Converts an FWFNSHttpCookieData to an NSHTTPCookie.
+///
+/// @param data The data object containing information to create an NSHTTPCookie.
+///
+/// @return An NSHTTPCookie or nil if data could not be converted.
 extern NSHTTPCookie *_Nullable FWFNativeNSHTTPCookieFromCookieData(FWFNSHttpCookieData *data);
 
-/**
- * Converts an FWFNSKeyValueObservingOptionsEnumData to an NSKeyValueObservingOptions.
- *
- * @param data The data object containing information to create an NSKeyValueObservingOptions.
- *
- * @return An NSKeyValueObservingOptions or -1 if data could not be converted.
- */
+/// Converts an FWFNSKeyValueObservingOptionsEnumData to an NSKeyValueObservingOptions.
+///
+/// @param data The data object containing information to create an NSKeyValueObservingOptions.
+///
+/// @return An NSKeyValueObservingOptions or -1 if data could not be converted.
 extern NSKeyValueObservingOptions FWFNativeNSKeyValueObservingOptionsFromEnumData(
     FWFNSKeyValueObservingOptionsEnumData *data);
 
-/**
- * Converts an FWFNSHTTPCookiePropertyKeyEnumData to an NSHTTPCookiePropertyKey.
- *
- * @param data The data object containing information to create an NSHTTPCookiePropertyKey.
- *
- * @return An NSHttpCookiePropertyKey or nil if data could not be converted.
- */
+/// Converts an FWFNSHTTPCookiePropertyKeyEnumData to an NSHTTPCookiePropertyKey.
+///
+/// @param data The data object containing information to create an NSHTTPCookiePropertyKey.
+///
+/// @return An NSHttpCookiePropertyKey or nil if data could not be converted.
 extern NSHTTPCookiePropertyKey _Nullable FWFNativeNSHTTPCookiePropertyKeyFromEnumData(
     FWFNSHttpCookiePropertyKeyEnumData *data);
 
-/**
- * Converts a WKUserScriptData to a WKUserScript.
- *
- * @param data The data object containing information to create a WKUserScript.
- *
- * @return A WKUserScript or nil if data could not be converted.
- */
+/// Converts a WKUserScriptData to a WKUserScript.
+///
+/// @param data The data object containing information to create a WKUserScript.
+///
+/// @return A WKUserScript or nil if data could not be converted.
 extern WKUserScript *FWFNativeWKUserScriptFromScriptData(FWFWKUserScriptData *data);
 
-/**
- * Converts an FWFWKUserScriptInjectionTimeEnumData to a WKUserScriptInjectionTime.
- *
- * @param data The data object containing information to create a WKUserScriptInjectionTime.
- *
- * @return A WKUserScriptInjectionTime or -1 if data could not be converted.
- */
+/// Converts an FWFWKUserScriptInjectionTimeEnumData to a WKUserScriptInjectionTime.
+///
+/// @param data The data object containing information to create a WKUserScriptInjectionTime.
+///
+/// @return A WKUserScriptInjectionTime or -1 if data could not be converted.
 extern WKUserScriptInjectionTime FWFNativeWKUserScriptInjectionTimeFromEnumData(
     FWFWKUserScriptInjectionTimeEnumData *data);
 
-/**
- * Converts an FWFWKAudiovisualMediaTypeEnumData to a WKAudiovisualMediaTypes.
- *
- * @param data The data object containing information to create a WKAudiovisualMediaTypes.
- *
- * @return A WKAudiovisualMediaType or -1 if data could not be converted.
- */
+/// Converts an FWFWKAudiovisualMediaTypeEnumData to a WKAudiovisualMediaTypes.
+///
+/// @param data The data object containing information to create a WKAudiovisualMediaTypes.
+///
+/// @return A WKAudiovisualMediaType or -1 if data could not be converted.
 extern WKAudiovisualMediaTypes FWFNativeWKAudiovisualMediaTypeFromEnumData(
     FWFWKAudiovisualMediaTypeEnumData *data);
 
-/**
- * Converts an FWFWKWebsiteDataTypeEnumData to a WKWebsiteDataType.
- *
- * @param data The data object containing information to create a WKWebsiteDataType.
- *
- * @return A WKWebsiteDataType or nil if data could not be converted.
- */
+/// Converts an FWFWKWebsiteDataTypeEnumData to a WKWebsiteDataType.
+///
+/// @param data The data object containing information to create a WKWebsiteDataType.
+///
+/// @return A WKWebsiteDataType or nil if data could not be converted.
 extern NSString *_Nullable FWFNativeWKWebsiteDataTypeFromEnumData(
     FWFWKWebsiteDataTypeEnumData *data);
 
-/**
- * Converts a WKNavigationAction to an FWFWKNavigationActionData.
- *
- * @param action The object containing information to create a WKNavigationActionData.
- *
- * @return A FWFWKNavigationActionData.
- */
+/// Converts a WKNavigationAction to an FWFWKNavigationActionData.
+///
+/// @param action The object containing information to create a WKNavigationActionData.
+///
+/// @return A FWFWKNavigationActionData.
 extern FWFWKNavigationActionData *FWFWKNavigationActionDataFromNativeWKNavigationAction(
     WKNavigationAction *action);
 
-/**
- * Converts a NSURLRequest to an FWFNSUrlRequestData.
- *
- * @param request The object containing information to create a WKNavigationActionData.
- *
- * @return A FWFNSUrlRequestData.
- */
+/// Converts a NSURLRequest to an FWFNSUrlRequestData.
+///
+/// @param request The object containing information to create a WKNavigationActionData.
+///
+/// @return A FWFNSUrlRequestData.
 extern FWFNSUrlRequestData *FWFNSUrlRequestDataFromNativeNSURLRequest(NSURLRequest *request);
 
-/**
- * Converts a WKFrameInfo to an FWFWKFrameInfoData.
- *
- * @param info The object containing information to create a FWFWKFrameInfoData.
- *
- * @return A FWFWKFrameInfoData.
- */
+/// Converts a WKFrameInfo to an FWFWKFrameInfoData.
+///
+/// @param info The object containing information to create a FWFWKFrameInfoData.
+///
+/// @return A FWFWKFrameInfoData.
 extern FWFWKFrameInfoData *FWFWKFrameInfoDataFromNativeWKFrameInfo(WKFrameInfo *info);
 
-/**
- * Converts an FWFWKNavigationActionPolicyEnumData to a WKNavigationActionPolicy.
- *
- * @param data The data object containing information to create a WKNavigationActionPolicy.
- *
- * @return A WKNavigationActionPolicy or -1 if data could not be converted.
- */
+/// Converts an FWFWKNavigationActionPolicyEnumData to a WKNavigationActionPolicy.
+///
+/// @param data The data object containing information to create a WKNavigationActionPolicy.
+///
+/// @return A WKNavigationActionPolicy or -1 if data could not be converted.
 extern WKNavigationActionPolicy FWFNativeWKNavigationActionPolicyFromEnumData(
     FWFWKNavigationActionPolicyEnumData *data);
 
-/**
- * Converts a NSError to an FWFNSErrorData.
- *
- * @param error The object containing information to create a FWFNSErrorData.
- *
- * @return A FWFNSErrorData.
- */
+/// Converts a NSError to an FWFNSErrorData.
+///
+/// @param error The object containing information to create a FWFNSErrorData.
+///
+/// @return A FWFNSErrorData.
 extern FWFNSErrorData *FWFNSErrorDataFromNativeNSError(NSError *error);
 
-/**
- * Converts an NSKeyValueChangeKey to a FWFNSKeyValueChangeKeyEnumData.
- *
- * @param key The data object containing information to create a FWFNSKeyValueChangeKeyEnumData.
- *
- * @return A FWFNSKeyValueChangeKeyEnumData.
- */
+/// Converts an NSKeyValueChangeKey to a FWFNSKeyValueChangeKeyEnumData.
+///
+/// @param key The data object containing information to create a FWFNSKeyValueChangeKeyEnumData.
+///
+/// @return A FWFNSKeyValueChangeKeyEnumData.
 extern FWFNSKeyValueChangeKeyEnumData *FWFNSKeyValueChangeKeyEnumDataFromNativeNSKeyValueChangeKey(
     NSKeyValueChangeKey key);
 
-/**
- * Converts a WKScriptMessage to an FWFWKScriptMessageData.
- *
- * @param message The object containing information to create a FWFWKScriptMessageData.
- *
- * @return A FWFWKScriptMessageData.
- */
+/// Converts a WKScriptMessage to an FWFWKScriptMessageData.
+///
+/// @param message The object containing information to create a FWFWKScriptMessageData.
+///
+/// @return A FWFWKScriptMessageData.
 extern FWFWKScriptMessageData *FWFWKScriptMessageDataFromNativeWKScriptMessage(
     WKScriptMessage *message);
 
-/**
- * Converts a WKNavigationType to an FWFWKNavigationType.
- *
- * @param type The object containing information to create a FWFWKNavigationType
- *
- * @return A FWFWKNavigationType.
- */
+/// Converts a WKNavigationType to an FWFWKNavigationType.
+///
+/// @param type The object containing information to create a FWFWKNavigationType
+///
+/// @return A FWFWKNavigationType.
 extern FWFWKNavigationType FWFWKNavigationTypeFromNativeWKNavigationType(WKNavigationType type);
 
-/**
- * Converts a WKSecurityOrigin to an FWFWKSecurityOriginData.
- *
- * @param origin The object containing information to create an FWFWKSecurityOriginData.
- *
- * @return An FWFWKSecurityOriginData.
- */
+/// Converts a WKSecurityOrigin to an FWFWKSecurityOriginData.
+///
+/// @param origin The object containing information to create an FWFWKSecurityOriginData.
+///
+/// @return An FWFWKSecurityOriginData.
 extern FWFWKSecurityOriginData *FWFWKSecurityOriginDataFromNativeWKSecurityOrigin(
     WKSecurityOrigin *origin);
 
-/**
- * Converts an FWFWKPermissionDecisionData to a WKPermissionDecision.
- *
- * @param data The data object containing information to create a WKPermissionDecision.
- *
- * @return A WKPermissionDecision or -1 if data could not be converted.
- */
+/// Converts an FWFWKPermissionDecisionData to a WKPermissionDecision.
+///
+/// @param data The data object containing information to create a WKPermissionDecision.
+///
+/// @return A WKPermissionDecision or -1 if data could not be converted.
 API_AVAILABLE(ios(15.0))
 extern WKPermissionDecision FWFNativeWKPermissionDecisionFromData(
     FWFWKPermissionDecisionData *data);
 
-/**
- * Converts an WKMediaCaptureType to a FWFWKMediaCaptureTypeData.
- *
- * @param type The data object containing information to create a FWFWKMediaCaptureTypeData.
- *
- * @return A FWFWKMediaCaptureTypeData or nil if data could not be converted.
- */
+/// Converts an WKMediaCaptureType to a FWFWKMediaCaptureTypeData.
+///
+/// @param type The data object containing information to create a FWFWKMediaCaptureTypeData.
+///
+/// @return A FWFWKMediaCaptureTypeData or nil if data could not be converted.
 API_AVAILABLE(ios(15.0))
 extern FWFWKMediaCaptureTypeData *FWFWKMediaCaptureTypeDataFromNativeWKMediaCaptureType(
     WKMediaCaptureType type);
 
-/**
- * Converts an FWFNSUrlSessionAuthChallengeDisposition to an NSURLSessionAuthChallengeDisposition.
- *
- * @param value The object containing information to create an NSURLSessionAuthChallengeDisposition.
- *
- * @return A NSURLSessionAuthChallengeDisposition or -1 if data could not be converted.
- */
+/// Converts an FWFNSUrlSessionAuthChallengeDisposition to an NSURLSessionAuthChallengeDisposition.
+///
+/// @param value The object containing information to create an NSURLSessionAuthChallengeDisposition.
+///
+/// @return A NSURLSessionAuthChallengeDisposition or -1 if data could not be converted.
 extern NSURLSessionAuthChallengeDisposition
 FWFNativeNSURLSessionAuthChallengeDispositionFromFWFNSUrlSessionAuthChallengeDisposition(
     FWFNSUrlSessionAuthChallengeDisposition value);
 
-/**
- * Converts an FWFNSUrlCredentialPersistence to an NSURLCredentialPersistence.
- *
- * @param value The object containing information to create an NSURLCredentialPersistence.
- *
- * @return A NSURLCredentialPersistence or -1 if data could not be converted.
- */
+/// Converts an FWFNSUrlCredentialPersistence to an NSURLCredentialPersistence.
+///
+/// @param value The object containing information to create an NSURLCredentialPersistence.
+///
+/// @return A NSURLCredentialPersistence or -1 if data could not be converted.
 extern NSURLCredentialPersistence
 FWFNativeNSURLCredentialPersistenceFromFWFNSUrlCredentialPersistence(
     FWFNSUrlCredentialPersistence value);

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFDataConverters.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFDataConverters.h
@@ -157,7 +157,8 @@ extern FWFWKMediaCaptureTypeData *FWFWKMediaCaptureTypeDataFromNativeWKMediaCapt
 
 /// Converts an FWFNSUrlSessionAuthChallengeDisposition to an NSURLSessionAuthChallengeDisposition.
 ///
-/// @param value The object containing information to create an NSURLSessionAuthChallengeDisposition.
+/// @param value The object containing information to create an
+/// NSURLSessionAuthChallengeDisposition.
 ///
 /// @return A NSURLSessionAuthChallengeDisposition or -1 if data could not be converted.
 extern NSURLSessionAuthChallengeDisposition

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFHTTPCookieStoreHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFHTTPCookieStoreHostApi.h
@@ -10,11 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Host api implementation for WKHTTPCookieStore.
- *
- * Handles creating WKHTTPCookieStore that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKHTTPCookieStore.
+///
+/// Handles creating WKHTTPCookieStore that intercommunicate with a paired Dart object.
 @interface FWFHTTPCookieStoreHostApiImpl : NSObject <FWFWKHttpCookieStoreHostApi>
 - (instancetype)initWithInstanceManager:(FWFInstanceManager *)instanceManager;
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFInstanceManager.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFInstanceManager.h
@@ -14,11 +14,11 @@ typedef void (^FWFOnDeallocCallback)(long identifier);
 ///
 /// Added instances are added as a weak reference and a strong reference. When the strong reference
 /// is removed with `removeStrongReferenceWithIdentifier:` and the weak reference is deallocated,
-/// the `deallocCallback` is made with the instance's identifier. However, if the strong reference is
-/// removed and then the identifier is retrieved with the intention to pass the identifier to Dart
-/// (e.g. calling  `identifierForInstance:identifierWillBePassedToFlutter:` with
-/// `identifierWillBePassedToFlutter` set to YES), the strong reference to the instance is recreated.
-/// The strong reference will then need to be removed manually again.
+/// the `deallocCallback` is made with the instance's identifier. However, if the strong reference
+/// is removed and then the identifier is retrieved with the intention to pass the identifier to
+/// Dart (e.g. calling  `identifierForInstance:identifierWillBePassedToFlutter:` with
+/// `identifierWillBePassedToFlutter` set to YES), the strong reference to the instance is
+/// recreated. The strong reference will then need to be removed manually again.
 ///
 /// Accessing and inserting to an InstanceManager is thread safe.
 @interface FWFInstanceManager : NSObject
@@ -30,8 +30,8 @@ typedef void (^FWFOnDeallocCallback)(long identifier);
 /// Adds a new instance that was instantiated from Dart.
 ///
 /// If an instance or identifier has already been added, it will be replaced by the new values. The
-/// Dart InstanceManager is considered the source of truth and has the capability to overwrite stored
-/// pairs in response to hot restarts.
+/// Dart InstanceManager is considered the source of truth and has the capability to overwrite
+/// stored pairs in response to hot restarts.
 ///
 /// @param instance The instance to be stored.
 /// @param instanceIdentifier The identifier to be paired with instance. This value must be >= 0.
@@ -66,8 +66,8 @@ typedef void (^FWFOnDeallocCallback)(long identifier);
 /// `instance` will be recreated and will need to be removed again with
 /// `removeInstanceWithIdentifier:`.
 ///
-/// This method also expects the Dart `InstanceManager` to have, or recreate, a weak reference to the
-/// instance the identifier is associated with once it receives it.
+/// This method also expects the Dart `InstanceManager` to have, or recreate, a weak reference to
+/// the instance the identifier is associated with once it receives it.
 ///
 /// @param instance An instance that may be stored in the manager.
 ///

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFInstanceManager.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFInstanceManager.h
@@ -8,89 +8,76 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^FWFOnDeallocCallback)(long identifier);
 
-/**
- * Maintains instances used to communicate with the corresponding objects in Dart.
- *
- * When an instance is added with an identifier, either can be used to retrieve the other.
- *
- * Added instances are added as a weak reference and a strong reference. When the strong reference
- * is removed with `removeStrongReferenceWithIdentifier:` and the weak reference is deallocated,
- * the `deallocCallback` is made with the instance's identifier. However, if the strong reference is
- * removed and then the identifier is retrieved with the intention to pass the identifier to Dart
- * (e.g. calling  `identifierForInstance:identifierWillBePassedToFlutter:` with
- * `identifierWillBePassedToFlutter` set to YES), the strong reference to the instance is recreated.
- * The strong reference will then need to be removed manually again.
- *
- * Accessing and inserting to an InstanceManager is thread safe.
- */
+/// Maintains instances used to communicate with the corresponding objects in Dart.
+///
+/// When an instance is added with an identifier, either can be used to retrieve the other.
+///
+/// Added instances are added as a weak reference and a strong reference. When the strong reference
+/// is removed with `removeStrongReferenceWithIdentifier:` and the weak reference is deallocated,
+/// the `deallocCallback` is made with the instance's identifier. However, if the strong reference is
+/// removed and then the identifier is retrieved with the intention to pass the identifier to Dart
+/// (e.g. calling  `identifierForInstance:identifierWillBePassedToFlutter:` with
+/// `identifierWillBePassedToFlutter` set to YES), the strong reference to the instance is recreated.
+/// The strong reference will then need to be removed manually again.
+///
+/// Accessing and inserting to an InstanceManager is thread safe.
 @interface FWFInstanceManager : NSObject
 @property(readonly) FWFOnDeallocCallback deallocCallback;
 - (instancetype)initWithDeallocCallback:(FWFOnDeallocCallback)callback;
+
 // TODO(bparrishMines): Pairs should not be able to be overwritten and this feature
 // should be replaced with a call to clear the manager in the event of a hot restart.
-/**
- * Adds a new instance that was instantiated from Dart.
- *
- * If an instance or identifier has already been added, it will be replaced by the new values. The
- * Dart InstanceManager is considered the source of truth and has the capability to overwrite stored
- * pairs in response to hot restarts.
- *
- * @param instance The instance to be stored.
- * @param instanceIdentifier The identifier to be paired with instance. This value must be >= 0.
- */
+/// Adds a new instance that was instantiated from Dart.
+///
+/// If an instance or identifier has already been added, it will be replaced by the new values. The
+/// Dart InstanceManager is considered the source of truth and has the capability to overwrite stored
+/// pairs in response to hot restarts.
+///
+/// @param instance The instance to be stored.
+/// @param instanceIdentifier The identifier to be paired with instance. This value must be >= 0.
 - (void)addDartCreatedInstance:(NSObject *)instance withIdentifier:(long)instanceIdentifier;
 
-/**
- * Adds a new instance that was instantiated from the host platform.
- *
- * @param instance The instance to be stored.
- * @return The unique identifier stored with instance.
- */
+/// Adds a new instance that was instantiated from the host platform.
+///
+/// @param instance The instance to be stored.
+/// @return The unique identifier stored with instance.
 - (long)addHostCreatedInstance:(nonnull NSObject *)instance;
 
-/**
- * Removes `instanceIdentifier` and its associated strongly referenced instance, if present, from
- * the manager.
- *
- * @param instanceIdentifier The identifier paired to an instance.
- *
- * @return The removed instance if the manager contains the given instanceIdentifier, otherwise
- * nil.
- */
+/// Removes `instanceIdentifier` and its associated strongly referenced instance, if present, from
+/// the manager.
+///
+/// @param instanceIdentifier The identifier paired to an instance.
+///
+/// @return The removed instance if the manager contains the given instanceIdentifier, otherwise
+/// nil.
 - (nullable NSObject *)removeInstanceWithIdentifier:(long)instanceIdentifier;
 
-/**
- * Retrieves the instance associated with identifier.
- *
- * @param instanceIdentifier  The identifier paired to an instance.
- *
- * @return The  instance associated with `instanceIdentifier` if the manager contains the value,
- * otherwise nil.
- */
+/// Retrieves the instance associated with identifier.
+///
+/// @param instanceIdentifier  The identifier paired to an instance.
+///
+/// @return The  instance associated with `instanceIdentifier` if the manager contains the value,
+/// otherwise nil.
 - (nullable NSObject *)instanceForIdentifier:(long)instanceIdentifier;
 
-/**
- * Retrieves the identifier paired with an instance.
- *
- * If the manager contains `instance`, as a strong or weak reference, the strong reference to
- * `instance` will be recreated and will need to be removed again with
- * `removeInstanceWithIdentifier:`.
- *
- * This method also expects the Dart `InstanceManager` to have, or recreate, a weak reference to the
- * instance the identifier is associated with once it receives it.
- *
- * @param instance An instance that may be stored in the manager.
- *
- * @return The identifier associated with `instance` if the manager contains the value, otherwise
- * NSNotFound.
- */
+/// Retrieves the identifier paired with an instance.
+///
+/// If the manager contains `instance`, as a strong or weak reference, the strong reference to
+/// `instance` will be recreated and will need to be removed again with
+/// `removeInstanceWithIdentifier:`.
+///
+/// This method also expects the Dart `InstanceManager` to have, or recreate, a weak reference to the
+/// instance the identifier is associated with once it receives it.
+///
+/// @param instance An instance that may be stored in the manager.
+///
+/// @return The identifier associated with `instance` if the manager contains the value, otherwise
+/// NSNotFound.
 - (long)identifierWithStrongReferenceForInstance:(nonnull NSObject *)instance;
 
-/**
- * Returns whether this manager contains the given `instance`.
- *
- * @return Whether this manager contains the given `instance`.
- */
+/// Returns whether this manager contains the given `instance`.
+///
+/// @return Whether this manager contains the given `instance`.
 - (BOOL)containsInstance:(nonnull NSObject *)instance;
 @end
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFInstanceManager_Test.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFInstanceManager_Test.h
@@ -7,24 +7,18 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FWFInstanceManager ()
-/**
- * The next identifier that will be used for a host-created instance.
- */
+/// The next identifier that will be used for a host-created instance.
 @property long nextIdentifier;
 
-/**
- * The number of instances stored as a strong reference.
- *
- * Added for debugging purposes.
- */
+/// The number of instances stored as a strong reference.
+///
+/// Added for debugging purposes.
 - (NSUInteger)strongInstanceCount;
 
-/**
- * The number of instances stored as a weak reference.
- *
- * Added for debugging purposes. NSMapTables that store keys or objects as weak reference will be
- * reclaimed nondeterministically.
- */
+/// The number of instances stored as a weak reference.
+///
+/// Added for debugging purposes. NSMapTables that store keys or objects as weak reference will be
+/// reclaimed nondeterministically.
 - (NSUInteger)weakInstanceCount;
 @end
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFNavigationDelegateHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFNavigationDelegateHostApi.h
@@ -12,19 +12,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Flutter api implementation for WKNavigationDelegate.
- *
- * Handles making callbacks to Dart for a WKNavigationDelegate.
- */
+/// Flutter api implementation for WKNavigationDelegate.
+///
+/// Handles making callbacks to Dart for a WKNavigationDelegate.
 @interface FWFNavigationDelegateFlutterApiImpl : FWFWKNavigationDelegateFlutterApi
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Implementation of WKNavigationDelegate for FWFNavigationDelegateHostApiImpl.
- */
+/// Implementation of WKNavigationDelegate for FWFNavigationDelegateHostApiImpl.
 @interface FWFNavigationDelegate : FWFObject <WKNavigationDelegate>
 @property(readonly, nonnull, nonatomic) FWFNavigationDelegateFlutterApiImpl *navigationDelegateAPI;
 
@@ -32,11 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Host api implementation for WKNavigationDelegate.
- *
- * Handles creating WKNavigationDelegate that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKNavigationDelegate.
+///
+/// Handles creating WKNavigationDelegate that intercommunicate with a paired Dart object.
 @interface FWFNavigationDelegateHostApiImpl : NSObject <FWFWKNavigationDelegateHostApi>
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFObjectHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFObjectHostApi.h
@@ -9,11 +9,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Flutter api implementation for NSObject.
- *
- * Handles making callbacks to Dart for an NSObject.
- */
+/// Flutter api implementation for NSObject.
+///
+/// Handles making callbacks to Dart for an NSObject.
 @interface FWFObjectFlutterApiImpl : FWFNSObjectFlutterApi
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
@@ -25,9 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
                    completion:(void (^)(FlutterError *_Nullable))completion;
 @end
 
-/**
- * Implementation of NSObject for FWFObjectHostApiImpl.
- */
+/// Implementation of NSObject for FWFObjectHostApiImpl.
 @interface FWFObject : NSObject
 @property(readonly, nonnull, nonatomic) FWFObjectFlutterApiImpl *objectApi;
 
@@ -35,11 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Host api implementation for NSObject.
- *
- * Handles creating NSObject that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for NSObject.
+///
+/// Handles creating NSObject that intercommunicate with a paired Dart object.
 @interface FWFObjectHostApiImpl : NSObject <FWFNSObjectHostApi>
 - (instancetype)initWithInstanceManager:(FWFInstanceManager *)instanceManager;
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFPreferencesHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFPreferencesHostApi.h
@@ -10,11 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Host api implementation for WKPreferences.
- *
- * Handles creating WKPreferences that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKPreferences.
+///
+/// Handles creating WKPreferences that intercommunicate with a paired Dart object.
 @interface FWFPreferencesHostApiImpl : NSObject <FWFWKPreferencesHostApi>
 - (instancetype)initWithInstanceManager:(FWFInstanceManager *)instanceManager;
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFScriptMessageHandlerHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFScriptMessageHandlerHostApi.h
@@ -11,19 +11,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Flutter api implementation for WKScriptMessageHandler.
- *
- * Handles making callbacks to Dart for a WKScriptMessageHandler.
- */
+/// Flutter api implementation for WKScriptMessageHandler.
+///
+/// Handles making callbacks to Dart for a WKScriptMessageHandler.
 @interface FWFScriptMessageHandlerFlutterApiImpl : FWFWKScriptMessageHandlerFlutterApi
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Implementation of WKScriptMessageHandler for FWFScriptMessageHandlerHostApiImpl.
- */
+/// Implementation of WKScriptMessageHandler for FWFScriptMessageHandlerHostApiImpl.
 @interface FWFScriptMessageHandler : FWFObject <WKScriptMessageHandler>
 @property(readonly, nonnull, nonatomic)
     FWFScriptMessageHandlerFlutterApiImpl *scriptMessageHandlerAPI;
@@ -32,11 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Host api implementation for WKScriptMessageHandler.
- *
- * Handles creating WKScriptMessageHandler that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKScriptMessageHandler.
+///
+/// Handles creating WKScriptMessageHandler that intercommunicate with a paired Dart object.
 @interface FWFScriptMessageHandlerHostApiImpl : NSObject <FWFWKScriptMessageHandlerHostApi>
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFScrollViewDelegateHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFScrollViewDelegateHostApi.h
@@ -11,20 +11,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Flutter api implementation for UIScrollViewDelegate.
- *
- * Handles making callbacks to Dart for a UIScrollViewDelegate.
- */
+/// Flutter api implementation for UIScrollViewDelegate.
+///
+/// Handles making callbacks to Dart for a UIScrollViewDelegate.
 @interface FWFScrollViewDelegateFlutterApiImpl : FWFUIScrollViewDelegateFlutterApi
 
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Implementation of WKUIScrollViewDelegate for FWFUIScrollViewDelegateHostApiImpl.
- */
+/// Implementation of WKUIScrollViewDelegate for FWFUIScrollViewDelegateHostApiImpl.
 @interface FWFScrollViewDelegate : FWFObject <UIScrollViewDelegate>
 @property(readonly, nonnull, nonatomic) FWFScrollViewDelegateFlutterApiImpl *scrollViewDelegateAPI;
 
@@ -33,11 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/**
- * Host api implementation for UIScrollViewDelegate.
- *
- * Handles creating UIScrollView that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for UIScrollViewDelegate.
+///
+/// Handles creating UIScrollView that intercommunicate with a paired Dart object.
 @interface FWFScrollViewDelegateHostApiImpl : NSObject <FWFUIScrollViewDelegateHostApi>
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFScrollViewHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFScrollViewHostApi.h
@@ -10,11 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Host api implementation for UIScrollView.
- *
- * Handles creating UIScrollView that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for UIScrollView.
+///
+/// Handles creating UIScrollView that intercommunicate with a paired Dart object.
 @interface FWFScrollViewHostApiImpl : NSObject <FWFUIScrollViewHostApi>
 - (instancetype)initWithInstanceManager:(FWFInstanceManager *)instanceManager;
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFUIDelegateHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFUIDelegateHostApi.h
@@ -12,11 +12,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Flutter api implementation for WKUIDelegate.
- *
- * Handles making callbacks to Dart for a WKUIDelegate.
- */
+/// Flutter api implementation for WKUIDelegate.
+///
+/// Handles making callbacks to Dart for a WKUIDelegate.
 @interface FWFUIDelegateFlutterApiImpl : FWFWKUIDelegateFlutterApi
 @property(readonly, nonatomic)
     FWFWebViewConfigurationFlutterApiImpl *webViewConfigurationFlutterApi;
@@ -25,9 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Implementation of WKUIDelegate for FWFUIDelegateHostApiImpl.
- */
+/// Implementation of WKUIDelegate for FWFUIDelegateHostApiImpl.
 @interface FWFUIDelegate : FWFObject <WKUIDelegate>
 @property(readonly, nonnull, nonatomic) FWFUIDelegateFlutterApiImpl *UIDelegateAPI;
 
@@ -35,11 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Host api implementation for WKUIDelegate.
- *
- * Handles creating WKUIDelegate that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKUIDelegate.
+///
+/// Handles creating WKUIDelegate that intercommunicate with a paired Dart object.
 @interface FWFUIDelegateHostApiImpl : NSObject <FWFWKUIDelegateHostApi>
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFUIViewHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFUIViewHostApi.h
@@ -9,11 +9,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Host api implementation for UIView.
- *
- * Handles creating UIView that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for UIView.
+///
+/// Handles creating UIView that intercommunicate with a paired Dart object.
 @interface FWFUIViewHostApiImpl : NSObject <FWFUIViewHostApi>
 - (instancetype)initWithInstanceManager:(FWFInstanceManager *)instanceManager;
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFURLAuthenticationChallengeHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFURLAuthenticationChallengeHostApi.h
@@ -9,22 +9,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Flutter API implementation for `NSURLAuthenticationChallenge`.
- *
- * This class may handle instantiating and adding Dart instances that are attached to a native
- * instance or sending callback methods from an overridden native class.
- */
+/// Flutter API implementation for `NSURLAuthenticationChallenge`.
+///
+/// This class may handle instantiating and adding Dart instances that are attached to a native
+/// instance or sending callback methods from an overridden native class.
 @interface FWFURLAuthenticationChallengeFlutterApiImpl : NSObject
-/**
- * The Flutter API used to send messages back to Dart.
- */
+/// The Flutter API used to send messages back to Dart.
 @property FWFNSUrlAuthenticationChallengeFlutterApi *api;
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
-/**
- * Sends a message to Dart to create a new Dart instance and add it to the `InstanceManager`.
- */
+/// Sends a message to Dart to create a new Dart instance and add it to the `InstanceManager`.
 - (void)createWithInstance:(NSURLAuthenticationChallenge *)instance
            protectionSpace:(NSURLProtectionSpace *)protectionSpace
                 completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFURLCredentialHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFURLCredentialHostApi.h
@@ -10,12 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Host API implementation for `NSURLCredential`.
- *
- * This class may handle instantiating and adding native object instances that are attached to a
- * Dart instance or method calls on the associated native class or an instance of the class.
- */
+/// Host API implementation for `NSURLCredential`.
+///
+/// This class may handle instantiating and adding native object instances that are attached to a
+/// Dart instance or method calls on the associated native class or an instance of the class.
 @interface FWFURLCredentialHostApiImpl : NSObject <FWFNSUrlCredentialHostApi>
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFURLHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFURLHostApi.h
@@ -9,33 +9,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Host API implementation for `NSURL`.
- *
- * This class may handle instantiating and adding native object instances that are attached to a
- * Dart instance or method calls on the associated native class or an instance of the class.
- */
+/// Host API implementation for `NSURL`.
+///
+/// This class may handle instantiating and adding native object instances that are attached to a
+/// Dart instance or method calls on the associated native class or an instance of the class.
 @interface FWFURLHostApiImpl : NSObject <FWFNSUrlHostApi>
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Flutter API implementation for `NSURL`.
- *
- * This class may handle instantiating and adding Dart instances that are attached to a native
- * instance or sending callback methods from an overridden native class.
- */
+/// Flutter API implementation for `NSURL`.
+///
+/// This class may handle instantiating and adding Dart instances that are attached to a native
+/// instance or sending callback methods from an overridden native class.
 @interface FWFURLFlutterApiImpl : NSObject
-/**
- * The Flutter API used to send messages back to Dart.
- */
+/// The Flutter API used to send messages back to Dart.
 @property FWFNSUrlFlutterApi *api;
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
-/**
- * Sends a message to Dart to create a new Dart instance and add it to the `InstanceManager`.
- */
+
+/// Sends a message to Dart to create a new Dart instance and add it to the `InstanceManager`.
 - (void)create:(NSURL *)instance completion:(void (^)(FlutterError *_Nullable))completion;
 @end
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFURLProtectionSpaceHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFURLProtectionSpaceHostApi.h
@@ -9,22 +9,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Flutter API implementation for `NSURLProtectionSpace`.
- *
- * This class may handle instantiating and adding Dart instances that are attached to a native
- * instance or sending callback methods from an overridden native class.
- */
+/// Flutter API implementation for `NSURLProtectionSpace`.
+///
+/// This class may handle instantiating and adding Dart instances that are attached to a native
+/// instance or sending callback methods from an overridden native class.
 @interface FWFURLProtectionSpaceFlutterApiImpl : NSObject
-/**
- * The Flutter API used to send messages back to Dart.
- */
+/// The Flutter API used to send messages back to Dart.
 @property FWFNSUrlProtectionSpaceFlutterApi *api;
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
-/**
- * Sends a message to Dart to create a new Dart instance and add it to the `InstanceManager`.
- */
+/// Sends a message to Dart to create a new Dart instance and add it to the `InstanceManager`.
 - (void)createWithInstance:(NSURLProtectionSpace *)instance
                       host:(nullable NSString *)host
                      realm:(nullable NSString *)realm

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFUserContentControllerHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFUserContentControllerHostApi.h
@@ -10,11 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Host api implementation for WKUserContentController.
- *
- * Handles creating WKUserContentController that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKUserContentController.
+///
+/// Handles creating WKUserContentController that intercommunicate with a paired Dart object.
 @interface FWFUserContentControllerHostApiImpl : NSObject <FWFWKUserContentControllerHostApi>
 - (instancetype)initWithInstanceManager:(FWFInstanceManager *)instanceManager;
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewConfigurationHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewConfigurationHostApi.h
@@ -11,11 +11,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Flutter api implementation for WKWebViewConfiguration.
- *
- * Handles making callbacks to Dart for a WKWebViewConfiguration.
- */
+/// Flutter api implementation for WKWebViewConfiguration.
+///
+/// Handles making callbacks to Dart for a WKWebViewConfiguration.
 @interface FWFWebViewConfigurationFlutterApiImpl : FWFWKWebViewConfigurationFlutterApi
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;
@@ -24,9 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
                      completion:(void (^)(FlutterError *_Nullable))completion;
 @end
 
-/**
- * Implementation of WKWebViewConfiguration for FWFWebViewConfigurationHostApiImpl.
- */
+/// Implementation of WKWebViewConfiguration for FWFWebViewConfigurationHostApiImpl.
 @interface FWFWebViewConfiguration : WKWebViewConfiguration
 @property(readonly, nonnull, nonatomic) FWFObjectFlutterApiImpl *objectApi;
 
@@ -34,11 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
                         instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Host api implementation for WKWebViewConfiguration.
- *
- * Handles creating WKWebViewConfiguration that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKWebViewConfiguration.
+///
+/// Handles creating WKWebViewConfiguration that intercommunicate with a paired Dart object.
 @interface FWFWebViewConfigurationHostApiImpl : NSObject <FWFWKWebViewConfigurationHostApi>
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewFlutterWKWebViewExternalAPI.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewFlutterWKWebViewExternalAPI.h
@@ -8,28 +8,24 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * App and package facing native API provided by the `webview_flutter_wkwebview` plugin.
- *
- * This class follows the convention of breaking changes of the Dart API, which means that any
- * changes to the class that are not backwards compatible will only be made with a major version
- * change of the plugin. Native code other than this external API does not follow breaking change
- * conventions, so app or plugin clients should not use any other native APIs.
- */
+/// App and package facing native API provided by the `webview_flutter_wkwebview` plugin.
+///
+/// This class follows the convention of breaking changes of the Dart API, which means that any
+/// changes to the class that are not backwards compatible will only be made with a major version
+/// change of the plugin. Native code other than this external API does not follow breaking change
+/// conventions, so app or plugin clients should not use any other native APIs.
 @interface FWFWebViewFlutterWKWebViewExternalAPI : NSObject
-/**
- * Retrieves the `WKWebView` that is associated with `identifier`.
- *
- * See the Dart method `WebKitWebViewController.webViewIdentifier` to get the identifier of an
- * underlying `WKWebView`.
- *
- * @param identifier The associated identifier of the `WebView`.
- * @param registry The plugin registry the `FLTWebViewFlutterPlugin` should belong to. If
- *        the registry doesn't contain an attached instance of `FLTWebViewFlutterPlugin`,
- *        this method returns nil.
- * @return The `WKWebView` associated with `identifier` or nil if a `WKWebView` instance associated
- * with `identifier` could not be found.
- */
+/// Retrieves the `WKWebView` that is associated with `identifier`.
+///
+/// See the Dart method `WebKitWebViewController.webViewIdentifier` to get the identifier of an
+/// underlying `WKWebView`.
+///
+/// @param identifier The associated identifier of the `WebView`.
+/// @param registry The plugin registry the `FLTWebViewFlutterPlugin` should belong to. If
+///        the registry doesn't contain an attached instance of `FLTWebViewFlutterPlugin`,
+///        this method returns nil.
+/// @return The `WKWebView` associated with `identifier` or nil if a `WKWebView` instance associated
+/// with `identifier` could not be found.
 + (nullable WKWebView *)webViewForIdentifier:(long)identifier
                           withPluginRegistry:(id<FlutterPluginRegistry>)registry;
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewHostApi.h
@@ -11,18 +11,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * A set of Flutter and Dart assets used by a `FlutterEngine` to initialize execution.
- *
- * Default implementation delegates methods to FlutterDartProject.
- */
+/// A set of Flutter and Dart assets used by a `FlutterEngine` to initialize execution.
+///
+/// Default implementation delegates methods to FlutterDartProject.
 @interface FWFAssetManager : NSObject
 - (NSString *)lookupKeyForAsset:(NSString *)asset;
 @end
 
-/**
- * Implementation of WKWebView that can be used as a FlutterPlatformView.
- */
+/// Implementation of WKWebView that can be used as a FlutterPlatformView.
 @interface FWFWebView : WKWebView <FlutterPlatformView>
 @property(readonly, nonnull, nonatomic) FWFObjectFlutterApiImpl *objectApi;
 
@@ -32,11 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
               instanceManager:(FWFInstanceManager *)instanceManager;
 @end
 
-/**
- * Host api implementation for WKWebView.
- *
- * Handles creating WKWebViews that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKWebView.
+///
+/// Handles creating WKWebViews that intercommunicate with a paired Dart object.
 @interface FWFWebViewHostApiImpl : NSObject <FWFWKWebViewHostApi>
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger
                         instanceManager:(FWFInstanceManager *)instanceManager;

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebsiteDataStoreHostApi.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebsiteDataStoreHostApi.h
@@ -10,11 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Host api implementation for WKWebsiteDataStore.
- *
- * Handles creating WKWebsiteDataStore that intercommunicate with a paired Dart object.
- */
+/// Host api implementation for WKWebsiteDataStore.
+///
+/// Handles creating WKWebsiteDataStore that intercommunicate with a paired Dart object.
 @interface FWFWebsiteDataStoreHostApiImpl : NSObject <FWFWKWebsiteDataStoreHostApi>
 - (instancetype)initWithInstanceManager:(FWFInstanceManager *)instanceManager;
 @end


### PR DESCRIPTION
Standardizes Objective-C code on `///` for documentation comments, instead of a mix of that and `/** ... */`.

This does not add enforcement, since my expectation is that if we start from a homogeneous style we will be much less likely to diverge again (and if some do creep in, it's harmless).

This only changes comments, so is a no-op for package clients.

Fixes https://github.com/flutter/flutter/issues/143868
