### PR TITLE
[pigeon] Fixes double prefixes added to enum names for Objc HostApis and FlutterApis

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.1.3
+
+* [objc] Fixes double prefixes added to enum names.
+
 ## 17.1.2
 
 * [swift] Separates message call code generation into separate methods.

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '17.1.2';
+const String pigeonVersion = '17.1.3';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/objc_generator.dart
+++ b/packages/pigeon/lib/objc_generator.dart
@@ -359,7 +359,7 @@ class ObjcHeaderGenerator extends StructuredGenerator<ObjcOptions> {
       String? lastArgType;
       String? returnType;
       final String enumReturnType = _enumName(
-        returnTypeName.baseName,
+        func.returnType.baseName,
         suffix: ' *_Nullable',
         prefix: generatorOptions.prefix,
         box: true,
@@ -765,7 +765,7 @@ static FlutterError *createConnectionError(NSString *channelName) {
         } else if (arg.type.isEnum) {
           indent.writeln('NSNumber *${argName}AsNumber = $valueGetter;');
           indent.writeln(
-              '${_enumName(arg.type.baseName, suffix: ' *', prefix: '', box: true)}$argName = ${argName}AsNumber == nil ? nil : [[${_enumName(arg.type.baseName, prefix: generatorOptions.prefix, box: true)} alloc] initWithValue:[${argName}AsNumber integerValue]];');
+              '${_enumName(arg.type.baseName, suffix: ' *', prefix: generatorOptions.prefix, box: true)}$argName = ${argName}AsNumber == nil ? nil : [[${_enumName(arg.type.baseName, prefix: generatorOptions.prefix, box: true)} alloc] initWithValue:[${argName}AsNumber integerValue]];');
         } else {
           indent.writeln('${objcArgType.beforeString}$argName = $valueGetter;');
         }
@@ -799,7 +799,7 @@ static FlutterError *createConnectionError(NSString *channelName) {
 
         if (func.returnType.isEnum) {
           returnTypeString =
-              '${_enumName(returnType.baseName, suffix: ' *_Nullable', prefix: generatorOptions.prefix, box: true)} enumValue';
+              '${_enumName(func.returnType.baseName, suffix: ' *_Nullable', prefix: generatorOptions.prefix, box: true)} enumValue';
         }
         if (func.parameters.isEmpty) {
           indent.writeScoped(
@@ -1132,7 +1132,7 @@ static FlutterError *createConnectionError(NSString *channelName) {
               indent.writeln('completion(nil);');
             } else {
               if (func.returnType.isEnum) {
-                final String enumName = _enumName(returnType.baseName,
+                final String enumName = _enumName(func.returnType.baseName,
                     prefix: languageOptions.prefix, box: true);
                 indent.writeln('NSNumber *outputAsNumber = $nullCheck;');
                 indent.writeln(
@@ -1212,7 +1212,7 @@ String _callbackForType(
   if (type.isVoid) {
     return 'void (^)(FlutterError *_Nullable)';
   } else if (type.isEnum) {
-    return 'void (^)(${_enumName(objcType.baseName, suffix: ' *_Nullable', prefix: options.prefix, box: true)}, FlutterError *_Nullable)';
+    return 'void (^)(${_enumName(type.baseName, suffix: ' *_Nullable', prefix: options.prefix, box: true)}, FlutterError *_Nullable)';
   } else {
     return 'void (^)(${objcType.beforeString}_Nullable, FlutterError *_Nullable)';
   }

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/AllDatatypesTest.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/AllDatatypesTest.m
@@ -17,14 +17,14 @@
 @implementation AllDatatypesTest
 
 - (void)testAllNull {
-  AllNullableTypes *everything = [[AllNullableTypes alloc] init];
+  FLTAllNullableTypes *everything = [[FLTAllNullableTypes alloc] init];
   EchoBinaryMessenger *binaryMessenger =
-      [[EchoBinaryMessenger alloc] initWithCodec:FlutterIntegrationCoreApiGetCodec()];
-  FlutterIntegrationCoreApi *api =
-      [[FlutterIntegrationCoreApi alloc] initWithBinaryMessenger:binaryMessenger];
+      [[EchoBinaryMessenger alloc] initWithCodec:FLTFlutterIntegrationCoreApiGetCodec()];
+  FLTFlutterIntegrationCoreApi *api =
+      [[FLTFlutterIntegrationCoreApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [api echoAllNullableTypes:everything
-                 completion:^(AllNullableTypes *_Nonnull result, FlutterError *_Nullable error) {
+                 completion:^(FLTAllNullableTypes *_Nonnull result, FlutterError *_Nullable error) {
                    XCTAssertNil(result.aNullableBool);
                    XCTAssertNil(result.aNullableInt);
                    XCTAssertNil(result.aNullableDouble);
@@ -41,7 +41,7 @@
 }
 
 - (void)testAllEquals {
-  AllNullableTypes *everything = [[AllNullableTypes alloc] init];
+  FLTAllNullableTypes *everything = [[FLTAllNullableTypes alloc] init];
   everything.aNullableBool = @NO;
   everything.aNullableInt = @(1);
   everything.aNullableDouble = @(2.0);
@@ -58,12 +58,12 @@
   everything.aNullableMap = @{@"hello" : @(1234)};
   everything.nullableMapWithObject = @{@"hello" : @(1234), @"goodbye" : @"world"};
   EchoBinaryMessenger *binaryMessenger =
-      [[EchoBinaryMessenger alloc] initWithCodec:FlutterIntegrationCoreApiGetCodec()];
-  FlutterIntegrationCoreApi *api =
-      [[FlutterIntegrationCoreApi alloc] initWithBinaryMessenger:binaryMessenger];
+      [[EchoBinaryMessenger alloc] initWithCodec:FLTFlutterIntegrationCoreApiGetCodec()];
+  FLTFlutterIntegrationCoreApi *api =
+      [[FLTFlutterIntegrationCoreApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [api echoAllNullableTypes:everything
-                 completion:^(AllNullableTypes *_Nonnull result, FlutterError *_Nullable error) {
+                 completion:^(FLTAllNullableTypes *_Nonnull result, FlutterError *_Nullable error) {
                    XCTAssertEqual(result.aNullableBool, everything.aNullableBool);
                    XCTAssertEqual(result.aNullableInt, everything.aNullableInt);
                    XCTAssertEqual(result.aNullableDouble, everything.aNullableDouble);

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/AsyncHandlersTest.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/AsyncHandlersTest.m
@@ -10,7 +10,7 @@
 #import "MockBinaryMessenger.h"
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-@interface MockHostSmallApi : NSObject <HostSmallApi>
+@interface MockHostSmallApi : NSObject <FLTHostSmallApi>
 @property(nonatomic, copy) NSString *output;
 @property(nonatomic, retain) FlutterError *voidVoidError;
 @end
@@ -42,11 +42,11 @@
 
 - (void)testAsyncHost2Flutter {
   MockBinaryMessenger *binaryMessenger =
-      [[MockBinaryMessenger alloc] initWithCodec:FlutterIntegrationCoreApiGetCodec()];
+      [[MockBinaryMessenger alloc] initWithCodec:FLTFlutterIntegrationCoreApiGetCodec()];
   NSString *value = @"Test";
   binaryMessenger.result = value;
-  FlutterIntegrationCoreApi *flutterApi =
-      [[FlutterIntegrationCoreApi alloc] initWithBinaryMessenger:binaryMessenger];
+  FLTFlutterIntegrationCoreApi *flutterApi =
+      [[FLTFlutterIntegrationCoreApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation *expectation = [self expectationWithDescription:@"echo callback"];
   [flutterApi echoAsyncString:value
                    completion:^(NSString *_Nonnull output, FlutterError *_Nullable error) {
@@ -58,9 +58,9 @@
 
 - (void)testAsyncFlutter2HostVoidVoid {
   MockBinaryMessenger *binaryMessenger =
-      [[MockBinaryMessenger alloc] initWithCodec:HostSmallApiGetCodec()];
+      [[MockBinaryMessenger alloc] initWithCodec:FLTHostSmallApiGetCodec()];
   MockHostSmallApi *mockHostSmallApi = [[MockHostSmallApi alloc] init];
-  SetUpHostSmallApi(binaryMessenger, mockHostSmallApi);
+  SetUpFLTHostSmallApi(binaryMessenger, mockHostSmallApi);
   NSString *channelName = @"dev.flutter.pigeon.pigeon_integration_tests.HostSmallApi.voidVoid";
   XCTAssertNotNil(binaryMessenger.handlers[channelName]);
 
@@ -75,12 +75,12 @@
 
 - (void)testAsyncFlutter2HostVoidVoidError {
   MockBinaryMessenger *binaryMessenger =
-      [[MockBinaryMessenger alloc] initWithCodec:HostSmallApiGetCodec()];
+      [[MockBinaryMessenger alloc] initWithCodec:FLTHostSmallApiGetCodec()];
   MockHostSmallApi *mockHostSmallApi = [[MockHostSmallApi alloc] init];
   mockHostSmallApi.voidVoidError = [FlutterError errorWithCode:@"code"
                                                        message:@"message"
                                                        details:nil];
-  SetUpHostSmallApi(binaryMessenger, mockHostSmallApi);
+  SetUpFLTHostSmallApi(binaryMessenger, mockHostSmallApi);
   NSString *channelName = @"dev.flutter.pigeon.pigeon_integration_tests.HostSmallApi.voidVoid";
   XCTAssertNotNil(binaryMessenger.handlers[channelName]);
 
@@ -96,11 +96,11 @@
 
 - (void)testAsyncFlutter2Host {
   MockBinaryMessenger *binaryMessenger =
-      [[MockBinaryMessenger alloc] initWithCodec:HostSmallApiGetCodec()];
+      [[MockBinaryMessenger alloc] initWithCodec:FLTHostSmallApiGetCodec()];
   MockHostSmallApi *mockHostSmallApi = [[MockHostSmallApi alloc] init];
   NSString *value = @"Test";
   mockHostSmallApi.output = value;
-  SetUpHostSmallApi(binaryMessenger, mockHostSmallApi);
+  SetUpFLTHostSmallApi(binaryMessenger, mockHostSmallApi);
   NSString *channelName = @"dev.flutter.pigeon.pigeon_integration_tests.HostSmallApi.echo";
   XCTAssertNotNil(binaryMessenger.handlers[channelName]);
 
@@ -117,9 +117,9 @@
 
 - (void)testAsyncFlutter2HostError {
   MockBinaryMessenger *binaryMessenger =
-      [[MockBinaryMessenger alloc] initWithCodec:HostSmallApiGetCodec()];
+      [[MockBinaryMessenger alloc] initWithCodec:FLTHostSmallApiGetCodec()];
   MockHostSmallApi *mockHostSmallApi = [[MockHostSmallApi alloc] init];
-  SetUpHostSmallApi(binaryMessenger, mockHostSmallApi);
+  SetUpFLTHostSmallApi(binaryMessenger, mockHostSmallApi);
   NSString *channelName = @"dev.flutter.pigeon.pigeon_integration_tests.HostSmallApi.echo";
   XCTAssertNotNil(binaryMessenger.handlers[channelName]);
 

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/ListTest.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/RunnerTests/ListTest.m
@@ -17,18 +17,18 @@
 @implementation ListTest
 
 - (void)testListInList {
-  TestMessage *top = [[TestMessage alloc] init];
-  TestMessage *inside = [[TestMessage alloc] init];
+  FLTTestMessage *top = [[FLTTestMessage alloc] init];
+  FLTTestMessage *inside = [[FLTTestMessage alloc] init];
   inside.testList = @[ @1, @2, @3 ];
   top.testList = @[ inside ];
   EchoBinaryMessenger *binaryMessenger =
-      [[EchoBinaryMessenger alloc] initWithCodec:FlutterSmallApiGetCodec()];
-  FlutterSmallApi *api = [[FlutterSmallApi alloc] initWithBinaryMessenger:binaryMessenger];
+      [[EchoBinaryMessenger alloc] initWithCodec:FLTFlutterSmallApiGetCodec()];
+  FLTFlutterSmallApi *api = [[FLTFlutterSmallApi alloc] initWithBinaryMessenger:binaryMessenger];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [api echoWrappedList:top
-            completion:^(TestMessage *_Nonnull result, FlutterError *_Nullable err) {
+            completion:^(FLTTestMessage *_Nonnull result, FlutterError *_Nullable err) {
               XCTAssertEqual(1u, result.testList.count);
-              XCTAssertTrue([result.testList[0] isKindOfClass:[TestMessage class]]);
+              XCTAssertTrue([result.testList[0] isKindOfClass:[FLTTestMessage class]]);
               XCTAssertEqualObjects(inside.testList, [result.testList[0] testList]);
               [expectation fulfill];
             }];

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/AlternateLanguageTestPlugin.h
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/AlternateLanguageTestPlugin.h
@@ -6,5 +6,5 @@
 
 #import "CoreTests.gen.h"
 
-@interface AlternateLanguageTestPlugin : NSObject <FlutterPlugin, HostIntegrationCoreApi>
+@interface AlternateLanguageTestPlugin : NSObject <FlutterPlugin, FLTHostIntegrationCoreApi>
 @end

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/AlternateLanguageTestPlugin.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/AlternateLanguageTestPlugin.m
@@ -7,16 +7,16 @@
 #import "CoreTests.gen.h"
 
 @interface AlternateLanguageTestPlugin ()
-@property(nonatomic) FlutterIntegrationCoreApi *flutterAPI;
+@property(nonatomic) FLTFlutterIntegrationCoreApi *flutterAPI;
 @end
 
 /// This plugin handles the native side of the integration tests in example/integration_test/.
 @implementation AlternateLanguageTestPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   AlternateLanguageTestPlugin *plugin = [[AlternateLanguageTestPlugin alloc] init];
-  SetUpHostIntegrationCoreApi([registrar messenger], plugin);
+  SetUpFLTHostIntegrationCoreApi([registrar messenger], plugin);
   plugin.flutterAPI =
-      [[FlutterIntegrationCoreApi alloc] initWithBinaryMessenger:[registrar messenger]];
+      [[FLTFlutterIntegrationCoreApi alloc] initWithBinaryMessenger:[registrar messenger]];
 }
 
 #pragma mark HostIntegrationCoreApi implementation
@@ -24,13 +24,13 @@
 - (void)noopWithError:(FlutterError *_Nullable *_Nonnull)error {
 }
 
-- (nullable AllTypes *)echoAllTypes:(AllTypes *)everything
-                              error:(FlutterError *_Nullable *_Nonnull)error {
+- (nullable FLTAllTypes *)echoAllTypes:(FLTAllTypes *)everything
+                                 error:(FlutterError *_Nullable *_Nonnull)error {
   return everything;
 }
 
-- (nullable AllNullableTypes *)echoAllNullableTypes:(nullable AllNullableTypes *)everything
-                                              error:(FlutterError *_Nullable *_Nonnull)error {
+- (nullable FLTAllNullableTypes *)echoAllNullableTypes:(nullable FLTAllNullableTypes *)everything
+                                                 error:(FlutterError *_Nullable *_Nonnull)error {
   return everything;
 }
 
@@ -84,13 +84,14 @@
   return aMap;
 }
 
-- (nullable AllClassesWrapper *)echoClassWrapper:(AllClassesWrapper *)wrapper
-                                           error:(FlutterError *_Nullable *_Nonnull)error {
+- (nullable FLTAllClassesWrapper *)echoClassWrapper:(FLTAllClassesWrapper *)wrapper
+                                              error:(FlutterError *_Nullable *_Nonnull)error {
   return wrapper;
 }
 
-- (AnEnumBox *_Nullable)echoEnum:(AnEnum)anEnum error:(FlutterError *_Nullable *_Nonnull)error {
-  return [[AnEnumBox alloc] initWithValue:anEnum];
+- (FLTAnEnumBox *_Nullable)echoEnum:(FLTAnEnum)anEnum
+                              error:(FlutterError *_Nullable *_Nonnull)error {
+  return [[FLTAnEnumBox alloc] initWithValue:anEnum];
 }
 
 - (nullable NSString *)echoNamedDefaultString:(NSString *)aString
@@ -108,25 +109,25 @@
   return @(anInt);
 }
 
-- (nullable NSString *)extractNestedNullableStringFrom:(AllClassesWrapper *)wrapper
+- (nullable NSString *)extractNestedNullableStringFrom:(FLTAllClassesWrapper *)wrapper
                                                  error:(FlutterError *_Nullable *_Nonnull)error {
   return wrapper.allNullableTypes.aNullableString;
 }
 
-- (nullable AllClassesWrapper *)
+- (nullable FLTAllClassesWrapper *)
     createNestedObjectWithNullableString:(nullable NSString *)nullableString
                                    error:(FlutterError *_Nullable *_Nonnull)error {
-  AllNullableTypes *innerObject = [[AllNullableTypes alloc] init];
+  FLTAllNullableTypes *innerObject = [[FLTAllNullableTypes alloc] init];
   innerObject.aNullableString = nullableString;
-  return [AllClassesWrapper makeWithAllNullableTypes:innerObject allTypes:nil];
+  return [FLTAllClassesWrapper makeWithAllNullableTypes:innerObject allTypes:nil];
 }
 
-- (nullable AllNullableTypes *)sendMultipleNullableTypesABool:(nullable NSNumber *)aNullableBool
-                                                        anInt:(nullable NSNumber *)aNullableInt
-                                                      aString:(nullable NSString *)aNullableString
-                                                        error:(FlutterError *_Nullable *_Nonnull)
-                                                                  error {
-  AllNullableTypes *someTypes = [[AllNullableTypes alloc] init];
+- (nullable FLTAllNullableTypes *)
+    sendMultipleNullableTypesABool:(nullable NSNumber *)aNullableBool
+                             anInt:(nullable NSNumber *)aNullableInt
+                           aString:(nullable NSString *)aNullableString
+                             error:(FlutterError *_Nullable *_Nonnull)error {
+  FLTAllNullableTypes *someTypes = [[FLTAllNullableTypes alloc] init];
   someTypes.aNullableBool = aNullableBool;
   someTypes.aNullableInt = aNullableInt;
   someTypes.aNullableString = aNullableString;
@@ -175,8 +176,8 @@
   return aNullableMap;
 }
 
-- (AnEnumBox *_Nullable)echoNullableEnum:(nullable AnEnumBox *)AnEnumBoxed
-                                   error:(FlutterError *_Nullable *_Nonnull)error {
+- (FLTAnEnumBox *_Nullable)echoNullableEnum:(nullable FLTAnEnumBox *)AnEnumBoxed
+                                      error:(FlutterError *_Nullable *_Nonnull)error {
   return AnEnumBoxed;
 }
 
@@ -207,13 +208,13 @@
   completion(nil, [FlutterError errorWithCode:@"code" message:@"message" details:@"details"]);
 }
 
-- (void)echoAsyncAllTypes:(AllTypes *)everything
-               completion:(void (^)(AllTypes *_Nullable, FlutterError *_Nullable))completion {
+- (void)echoAsyncAllTypes:(FLTAllTypes *)everything
+               completion:(void (^)(FLTAllTypes *_Nullable, FlutterError *_Nullable))completion {
   completion(everything, nil);
 }
 
-- (void)echoAsyncNullableAllNullableTypes:(nullable AllNullableTypes *)everything
-                               completion:(void (^)(AllNullableTypes *_Nullable,
+- (void)echoAsyncNullableAllNullableTypes:(nullable FLTAllNullableTypes *)everything
+                               completion:(void (^)(FLTAllNullableTypes *_Nullable,
                                                     FlutterError *_Nullable))completion {
   completion(everything, nil);
 }
@@ -260,9 +261,9 @@
   completion(aMap, nil);
 }
 
-- (void)echoAsyncEnum:(AnEnum)anEnum
-           completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion {
-  completion([[AnEnumBox alloc] initWithValue:anEnum], nil);
+- (void)echoAsyncEnum:(FLTAnEnum)anEnum
+           completion:(void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion {
+  completion([[FLTAnEnumBox alloc] initWithValue:anEnum], nil);
 }
 
 - (void)echoAsyncNullableInt:(nullable NSNumber *)anInt
@@ -308,8 +309,9 @@
   completion(aMap, nil);
 }
 
-- (void)echoAsyncNullableEnum:(nullable AnEnumBox *)AnEnumBoxed
-                   completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion {
+- (void)echoAsyncNullableEnum:(nullable FLTAnEnumBox *)AnEnumBoxed
+                   completion:
+                       (void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion {
   completion(AnEnumBoxed, nil);
 }
 
@@ -332,10 +334,11 @@
   }];
 }
 
-- (void)callFlutterEchoAllTypes:(AllTypes *)everything
-                     completion:(void (^)(AllTypes *_Nullable, FlutterError *_Nullable))completion {
+- (void)callFlutterEchoAllTypes:(FLTAllTypes *)everything
+                     completion:
+                         (void (^)(FLTAllTypes *_Nullable, FlutterError *_Nullable))completion {
   [self.flutterAPI echoAllTypes:everything
-                     completion:^(AllTypes *value, FlutterError *error) {
+                     completion:^(FLTAllTypes *value, FlutterError *error) {
                        completion(value, error);
                      }];
 }
@@ -343,14 +346,15 @@
 - (void)callFlutterSendMultipleNullableTypesABool:(nullable NSNumber *)aNullableBool
                                             anInt:(nullable NSNumber *)aNullableInt
                                           aString:(nullable NSString *)aNullableString
-                                       completion:(void (^)(AllNullableTypes *_Nullable,
+                                       completion:(void (^)(FLTAllNullableTypes *_Nullable,
                                                             FlutterError *_Nullable))completion {
-  [self.flutterAPI sendMultipleNullableTypesABool:aNullableBool
-                                            anInt:aNullableInt
-                                          aString:aNullableString
-                                       completion:^(AllNullableTypes *value, FlutterError *error) {
-                                         completion(value, error);
-                                       }];
+  [self.flutterAPI
+      sendMultipleNullableTypesABool:aNullableBool
+                               anInt:aNullableInt
+                             aString:aNullableString
+                          completion:^(FLTAllNullableTypes *value, FlutterError *error) {
+                            completion(value, error);
+                          }];
 }
 
 - (void)callFlutterEchoBool:(BOOL)aBool
@@ -411,19 +415,19 @@
                 }];
 }
 
-- (void)callFlutterEchoEnum:(AnEnum)anEnum
-                 completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion {
+- (void)callFlutterEchoEnum:(FLTAnEnum)anEnum
+                 completion:(void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion {
   [self.flutterAPI echoEnum:anEnum
-                 completion:^(AnEnumBox *value, FlutterError *error) {
+                 completion:^(FLTAnEnumBox *value, FlutterError *error) {
                    completion(value, error);
                  }];
 }
 
-- (void)callFlutterEchoAllNullableTypes:(nullable AllNullableTypes *)everything
-                             completion:(void (^)(AllNullableTypes *_Nullable,
+- (void)callFlutterEchoAllNullableTypes:(nullable FLTAllNullableTypes *)everything
+                             completion:(void (^)(FLTAllNullableTypes *_Nullable,
                                                   FlutterError *_Nullable))completion {
   [self.flutterAPI echoAllNullableTypes:everything
-                             completion:^(AllNullableTypes *value, FlutterError *error) {
+                             completion:^(FLTAllNullableTypes *value, FlutterError *error) {
                                completion(value, error);
                              }];
 }
@@ -491,11 +495,11 @@
                         }];
 }
 
-- (void)callFlutterEchoNullableEnum:(nullable AnEnumBox *)AnEnumBoxed
-                         completion:
-                             (void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion {
+- (void)callFlutterEchoNullableEnum:(nullable FLTAnEnumBox *)AnEnumBoxed
+                         completion:(void (^)(FLTAnEnumBox *_Nullable,
+                                              FlutterError *_Nullable))completion {
   [self.flutterAPI echoNullableEnum:AnEnumBoxed
-                         completion:^(AnEnumBox *value, FlutterError *error) {
+                         completion:^(FLTAnEnumBox *value, FlutterError *error) {
                            completion(value, error);
                          }];
 }

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.h
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.h
@@ -14,27 +14,27 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, AnEnum) {
-  AnEnumOne = 0,
-  AnEnumTwo = 1,
-  AnEnumThree = 2,
-  AnEnumFortyTwo = 3,
-  AnEnumFourHundredTwentyTwo = 4,
+typedef NS_ENUM(NSUInteger, FLTAnEnum) {
+  FLTAnEnumOne = 0,
+  FLTAnEnumTwo = 1,
+  FLTAnEnumThree = 2,
+  FLTAnEnumFortyTwo = 3,
+  FLTAnEnumFourHundredTwentyTwo = 4,
 };
 
-/// Wrapper for AnEnum to allow for nullability.
-@interface AnEnumBox : NSObject
-@property(nonatomic, assign) AnEnum value;
-- (instancetype)initWithValue:(AnEnum)value;
+/// Wrapper for FLTAnEnum to allow for nullability.
+@interface FLTAnEnumBox : NSObject
+@property(nonatomic, assign) FLTAnEnum value;
+- (instancetype)initWithValue:(FLTAnEnum)value;
 @end
 
-@class AllTypes;
-@class AllNullableTypes;
-@class AllClassesWrapper;
-@class TestMessage;
+@class FLTAllTypes;
+@class FLTAllNullableTypes;
+@class FLTAllClassesWrapper;
+@class FLTTestMessage;
 
 /// A class containing all supported types.
-@interface AllTypes : NSObject
+@interface FLTAllTypes : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)makeWithABool:(BOOL)aBool
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
                   aFloatArray:(FlutterStandardTypedData *)aFloatArray
                         aList:(NSArray *)aList
                          aMap:(NSDictionary *)aMap
-                       anEnum:(AnEnum)anEnum
+                       anEnum:(FLTAnEnum)anEnum
                       aString:(NSString *)aString
                      anObject:(id)anObject;
 @property(nonatomic, assign) BOOL aBool;
@@ -60,13 +60,13 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 @property(nonatomic, strong) FlutterStandardTypedData *aFloatArray;
 @property(nonatomic, copy) NSArray *aList;
 @property(nonatomic, copy) NSDictionary *aMap;
-@property(nonatomic, assign) AnEnum anEnum;
+@property(nonatomic, assign) FLTAnEnum anEnum;
 @property(nonatomic, copy) NSString *aString;
 @property(nonatomic, strong) id anObject;
 @end
 
 /// A class containing all supported nullable types.
-@interface AllNullableTypes : NSObject
+@interface FLTAllNullableTypes : NSObject
 + (instancetype)makeWithANullableBool:(nullable NSNumber *)aNullableBool
                          aNullableInt:(nullable NSNumber *)aNullableInt
                        aNullableInt64:(nullable NSNumber *)aNullableInt64
@@ -81,7 +81,7 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
            nullableMapWithAnnotations:
                (nullable NSDictionary<NSString *, NSString *> *)nullableMapWithAnnotations
                 nullableMapWithObject:(nullable NSDictionary<NSString *, id> *)nullableMapWithObject
-                        aNullableEnum:(nullable AnEnumBox *)aNullableEnum
+                        aNullableEnum:(nullable FLTAnEnumBox *)aNullableEnum
                       aNullableString:(nullable NSString *)aNullableString
                       aNullableObject:(nullable id)aNullableObject;
 @property(nonatomic, strong, nullable) NSNumber *aNullableBool;
@@ -98,7 +98,7 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 @property(nonatomic, copy, nullable)
     NSDictionary<NSString *, NSString *> *nullableMapWithAnnotations;
 @property(nonatomic, copy, nullable) NSDictionary<NSString *, id> *nullableMapWithObject;
-@property(nonatomic, strong, nullable) AnEnumBox *aNullableEnum;
+@property(nonatomic, strong, nullable) FLTAnEnumBox *aNullableEnum;
 @property(nonatomic, copy, nullable) NSString *aNullableString;
 @property(nonatomic, strong, nullable) id aNullableObject;
 @end
@@ -108,35 +108,35 @@ typedef NS_ENUM(NSUInteger, AnEnum) {
 /// This is needed to test nested nullable and non-nullable classes,
 /// `AllNullableTypes` is non-nullable here as it is easier to instantiate
 /// than `AllTypes` when testing doesn't require both (ie. testing null classes).
-@interface AllClassesWrapper : NSObject
+@interface FLTAllClassesWrapper : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)makeWithAllNullableTypes:(AllNullableTypes *)allNullableTypes
-                                allTypes:(nullable AllTypes *)allTypes;
-@property(nonatomic, strong) AllNullableTypes *allNullableTypes;
-@property(nonatomic, strong, nullable) AllTypes *allTypes;
++ (instancetype)makeWithAllNullableTypes:(FLTAllNullableTypes *)allNullableTypes
+                                allTypes:(nullable FLTAllTypes *)allTypes;
+@property(nonatomic, strong) FLTAllNullableTypes *allNullableTypes;
+@property(nonatomic, strong, nullable) FLTAllTypes *allTypes;
 @end
 
 /// A data class containing a List, used in unit tests.
-@interface TestMessage : NSObject
+@interface FLTTestMessage : NSObject
 + (instancetype)makeWithTestList:(nullable NSArray *)testList;
 @property(nonatomic, copy, nullable) NSArray *testList;
 @end
 
-/// The codec used by HostIntegrationCoreApi.
-NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
+/// The codec used by FLTHostIntegrationCoreApi.
+NSObject<FlutterMessageCodec> *FLTHostIntegrationCoreApiGetCodec(void);
 
 /// The core interface that each host language plugin must implement in
 /// platform_test integration tests.
-@protocol HostIntegrationCoreApi
+@protocol FLTHostIntegrationCoreApi
 /// A no-op function taking no arguments and returning no value, to sanity
 /// test basic calling.
 - (void)noopWithError:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the passed object, to test serialization and deserialization.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable AllTypes *)echoAllTypes:(AllTypes *)everything
-                              error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable FLTAllTypes *)echoAllTypes:(FLTAllTypes *)everything
+                                 error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns an error, to test error handling.
 - (nullable id)throwErrorWithError:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns an error from a void function, to test error handling.
@@ -182,12 +182,13 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 /// Returns the passed map to test nested class serialization and deserialization.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable AllClassesWrapper *)echoClassWrapper:(AllClassesWrapper *)wrapper
-                                           error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable FLTAllClassesWrapper *)echoClassWrapper:(FLTAllClassesWrapper *)wrapper
+                                              error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the passed enum to test serialization and deserialization.
 ///
 /// @return `nil` only when `error != nil`.
-- (AnEnumBox *_Nullable)echoEnum:(AnEnum)anEnum error:(FlutterError *_Nullable *_Nonnull)error;
+- (FLTAnEnumBox *_Nullable)echoEnum:(FLTAnEnum)anEnum
+                              error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the default string.
 ///
 /// @return `nil` only when `error != nil`.
@@ -204,27 +205,27 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 - (nullable NSNumber *)echoRequiredInt:(NSInteger)anInt
                                  error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the passed object, to test serialization and deserialization.
-- (nullable AllNullableTypes *)echoAllNullableTypes:(nullable AllNullableTypes *)everything
-                                              error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable FLTAllNullableTypes *)echoAllNullableTypes:(nullable FLTAllNullableTypes *)everything
+                                                 error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the inner `aString` value from the wrapped object, to test
 /// sending of nested objects.
-- (nullable NSString *)extractNestedNullableStringFrom:(AllClassesWrapper *)wrapper
+- (nullable NSString *)extractNestedNullableStringFrom:(FLTAllClassesWrapper *)wrapper
                                                  error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns the inner `aString` value from the wrapped object, to test
 /// sending of nested objects.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable AllClassesWrapper *)
+- (nullable FLTAllClassesWrapper *)
     createNestedObjectWithNullableString:(nullable NSString *)nullableString
                                    error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns passed in arguments of multiple types.
 ///
 /// @return `nil` only when `error != nil`.
-- (nullable AllNullableTypes *)sendMultipleNullableTypesABool:(nullable NSNumber *)aNullableBool
-                                                        anInt:(nullable NSNumber *)aNullableInt
-                                                      aString:(nullable NSString *)aNullableString
-                                                        error:(FlutterError *_Nullable *_Nonnull)
-                                                                  error;
+- (nullable FLTAllNullableTypes *)
+    sendMultipleNullableTypesABool:(nullable NSNumber *)aNullableBool
+                             anInt:(nullable NSNumber *)aNullableInt
+                           aString:(nullable NSString *)aNullableString
+                             error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns passed in int.
 - (nullable NSNumber *)echoNullableInt:(nullable NSNumber *)aNullableInt
                                  error:(FlutterError *_Nullable *_Nonnull)error;
@@ -251,8 +252,8 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 - (nullable NSDictionary<NSString *, id> *)echoNullableMap:
                                                (nullable NSDictionary<NSString *, id> *)aNullableMap
                                                      error:(FlutterError *_Nullable *_Nonnull)error;
-- (AnEnumBox *_Nullable)echoNullableEnum:(nullable AnEnumBox *)anEnumBoxed
-                                   error:(FlutterError *_Nullable *_Nonnull)error;
+- (FLTAnEnumBox *_Nullable)echoNullableEnum:(nullable FLTAnEnumBox *)anEnumBoxed
+                                      error:(FlutterError *_Nullable *_Nonnull)error;
 /// Returns passed in int.
 - (nullable NSNumber *)echoOptionalNullableInt:(nullable NSNumber *)aNullableInt
                                          error:(FlutterError *_Nullable *_Nonnull)error;
@@ -289,8 +290,8 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
           completion:(void (^)(NSDictionary<NSString *, id> *_Nullable,
                                FlutterError *_Nullable))completion;
 /// Returns the passed enum, to test asynchronous serialization and deserialization.
-- (void)echoAsyncEnum:(AnEnum)anEnum
-           completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion;
+- (void)echoAsyncEnum:(FLTAnEnum)anEnum
+           completion:(void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion;
 /// Responds with an error from an async function returning a value.
 - (void)throwAsyncErrorWithCompletion:(void (^)(id _Nullable, FlutterError *_Nullable))completion;
 /// Responds with an error from an async void function.
@@ -299,11 +300,11 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 - (void)throwAsyncFlutterErrorWithCompletion:(void (^)(id _Nullable,
                                                        FlutterError *_Nullable))completion;
 /// Returns the passed object, to test async serialization and deserialization.
-- (void)echoAsyncAllTypes:(AllTypes *)everything
-               completion:(void (^)(AllTypes *_Nullable, FlutterError *_Nullable))completion;
+- (void)echoAsyncAllTypes:(FLTAllTypes *)everything
+               completion:(void (^)(FLTAllTypes *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed object, to test serialization and deserialization.
-- (void)echoAsyncNullableAllNullableTypes:(nullable AllNullableTypes *)everything
-                               completion:(void (^)(AllNullableTypes *_Nullable,
+- (void)echoAsyncNullableAllNullableTypes:(nullable FLTAllNullableTypes *)everything
+                               completion:(void (^)(FLTAllNullableTypes *_Nullable,
                                                     FlutterError *_Nullable))completion;
 /// Returns passed in int asynchronously.
 - (void)echoAsyncNullableInt:(nullable NSNumber *)anInt
@@ -332,21 +333,23 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
                   completion:(void (^)(NSDictionary<NSString *, id> *_Nullable,
                                        FlutterError *_Nullable))completion;
 /// Returns the passed enum, to test asynchronous serialization and deserialization.
-- (void)echoAsyncNullableEnum:(nullable AnEnumBox *)anEnumBoxed
-                   completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion;
+- (void)echoAsyncNullableEnum:(nullable FLTAnEnumBox *)anEnumBoxed
+                   completion:
+                       (void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion;
 - (void)callFlutterNoopWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 - (void)callFlutterThrowErrorWithCompletion:(void (^)(id _Nullable,
                                                       FlutterError *_Nullable))completion;
 - (void)callFlutterThrowErrorFromVoidWithCompletion:(void (^)(FlutterError *_Nullable))completion;
-- (void)callFlutterEchoAllTypes:(AllTypes *)everything
-                     completion:(void (^)(AllTypes *_Nullable, FlutterError *_Nullable))completion;
-- (void)callFlutterEchoAllNullableTypes:(nullable AllNullableTypes *)everything
-                             completion:(void (^)(AllNullableTypes *_Nullable,
+- (void)callFlutterEchoAllTypes:(FLTAllTypes *)everything
+                     completion:
+                         (void (^)(FLTAllTypes *_Nullable, FlutterError *_Nullable))completion;
+- (void)callFlutterEchoAllNullableTypes:(nullable FLTAllNullableTypes *)everything
+                             completion:(void (^)(FLTAllNullableTypes *_Nullable,
                                                   FlutterError *_Nullable))completion;
 - (void)callFlutterSendMultipleNullableTypesABool:(nullable NSNumber *)aNullableBool
                                             anInt:(nullable NSNumber *)aNullableInt
                                           aString:(nullable NSString *)aNullableString
-                                       completion:(void (^)(AllNullableTypes *_Nullable,
+                                       completion:(void (^)(FLTAllNullableTypes *_Nullable,
                                                             FlutterError *_Nullable))completion;
 - (void)callFlutterEchoBool:(BOOL)aBool
                  completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
@@ -364,8 +367,8 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 - (void)callFlutterEchoMap:(NSDictionary<NSString *, id> *)aMap
                 completion:(void (^)(NSDictionary<NSString *, id> *_Nullable,
                                      FlutterError *_Nullable))completion;
-- (void)callFlutterEchoEnum:(AnEnum)anEnum
-                 completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion;
+- (void)callFlutterEchoEnum:(FLTAnEnum)anEnum
+                 completion:(void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion;
 - (void)callFlutterEchoNullableBool:(nullable NSNumber *)aBool
                          completion:
                              (void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
@@ -387,20 +390,20 @@ NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void);
 - (void)callFlutterEchoNullableMap:(nullable NSDictionary<NSString *, id> *)aMap
                         completion:(void (^)(NSDictionary<NSString *, id> *_Nullable,
                                              FlutterError *_Nullable))completion;
-- (void)callFlutterEchoNullableEnum:(nullable AnEnumBox *)anEnumBoxed
+- (void)callFlutterEchoNullableEnum:(nullable FLTAnEnumBox *)anEnumBoxed
                          completion:
-                             (void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion;
+                             (void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion;
 @end
 
-extern void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
-                                        NSObject<HostIntegrationCoreApi> *_Nullable api);
+extern void SetUpFLTHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
+                                           NSObject<FLTHostIntegrationCoreApi> *_Nullable api);
 
-/// The codec used by FlutterIntegrationCoreApi.
-NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void);
+/// The codec used by FLTFlutterIntegrationCoreApi.
+NSObject<FlutterMessageCodec> *FLTFlutterIntegrationCoreApiGetCodec(void);
 
 /// The core interface that the Dart platform_test code implements for host
 /// integration tests to call into.
-@interface FlutterIntegrationCoreApi : NSObject
+@interface FLTFlutterIntegrationCoreApi : NSObject
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger;
 /// A no-op function taking no arguments and returning no value, to sanity
 /// test basic calling.
@@ -410,19 +413,19 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void);
 /// Responds with an error from an async void function.
 - (void)throwErrorFromVoidWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 /// Returns the passed object, to test serialization and deserialization.
-- (void)echoAllTypes:(AllTypes *)everything
-          completion:(void (^)(AllTypes *_Nullable, FlutterError *_Nullable))completion;
+- (void)echoAllTypes:(FLTAllTypes *)everything
+          completion:(void (^)(FLTAllTypes *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed object, to test serialization and deserialization.
-- (void)echoAllNullableTypes:(nullable AllNullableTypes *)everything
+- (void)echoAllNullableTypes:(nullable FLTAllNullableTypes *)everything
                   completion:
-                      (void (^)(AllNullableTypes *_Nullable, FlutterError *_Nullable))completion;
+                      (void (^)(FLTAllNullableTypes *_Nullable, FlutterError *_Nullable))completion;
 /// Returns passed in arguments of multiple types.
 ///
 /// Tests multiple-arity FlutterApi handling.
 - (void)sendMultipleNullableTypesABool:(nullable NSNumber *)aNullableBool
                                  anInt:(nullable NSNumber *)aNullableInt
                                aString:(nullable NSString *)aNullableString
-                            completion:(void (^)(AllNullableTypes *_Nullable,
+                            completion:(void (^)(FLTAllNullableTypes *_Nullable,
                                                  FlutterError *_Nullable))completion;
 /// Returns the passed boolean, to test serialization and deserialization.
 - (void)echoBool:(BOOL)aBool
@@ -448,8 +451,8 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void);
      completion:
          (void (^)(NSDictionary<NSString *, id> *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed enum to test serialization and deserialization.
-- (void)echoEnum:(AnEnum)anEnum
-      completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion;
+- (void)echoEnum:(FLTAnEnum)anEnum
+      completion:(void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion;
 /// Returns the passed boolean, to test serialization and deserialization.
 - (void)echoNullableBool:(nullable NSNumber *)aBool
               completion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
@@ -474,8 +477,8 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void);
              completion:(void (^)(NSDictionary<NSString *, id> *_Nullable,
                                   FlutterError *_Nullable))completion;
 /// Returns the passed enum to test serialization and deserialization.
-- (void)echoNullableEnum:(nullable AnEnumBox *)anEnumBoxed
-              completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion;
+- (void)echoNullableEnum:(nullable FLTAnEnumBox *)anEnumBoxed
+              completion:(void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion;
 /// A no-op function taking no arguments and returning no value, to sanity
 /// test basic asynchronous calling.
 - (void)noopAsyncWithCompletion:(void (^)(FlutterError *_Nullable))completion;
@@ -484,38 +487,38 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void);
              completion:(void (^)(NSString *_Nullable, FlutterError *_Nullable))completion;
 @end
 
-/// The codec used by HostTrivialApi.
-NSObject<FlutterMessageCodec> *HostTrivialApiGetCodec(void);
+/// The codec used by FLTHostTrivialApi.
+NSObject<FlutterMessageCodec> *FLTHostTrivialApiGetCodec(void);
 
 /// An API that can be implemented for minimal, compile-only tests.
-@protocol HostTrivialApi
+@protocol FLTHostTrivialApi
 - (void)noopWithError:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
-extern void SetUpHostTrivialApi(id<FlutterBinaryMessenger> binaryMessenger,
-                                NSObject<HostTrivialApi> *_Nullable api);
+extern void SetUpFLTHostTrivialApi(id<FlutterBinaryMessenger> binaryMessenger,
+                                   NSObject<FLTHostTrivialApi> *_Nullable api);
 
-/// The codec used by HostSmallApi.
-NSObject<FlutterMessageCodec> *HostSmallApiGetCodec(void);
+/// The codec used by FLTHostSmallApi.
+NSObject<FlutterMessageCodec> *FLTHostSmallApiGetCodec(void);
 
 /// A simple API implemented in some unit tests.
-@protocol HostSmallApi
+@protocol FLTHostSmallApi
 - (void)echoString:(NSString *)aString
         completion:(void (^)(NSString *_Nullable, FlutterError *_Nullable))completion;
 - (void)voidVoidWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 @end
 
-extern void SetUpHostSmallApi(id<FlutterBinaryMessenger> binaryMessenger,
-                              NSObject<HostSmallApi> *_Nullable api);
+extern void SetUpFLTHostSmallApi(id<FlutterBinaryMessenger> binaryMessenger,
+                                 NSObject<FLTHostSmallApi> *_Nullable api);
 
-/// The codec used by FlutterSmallApi.
-NSObject<FlutterMessageCodec> *FlutterSmallApiGetCodec(void);
+/// The codec used by FLTFlutterSmallApi.
+NSObject<FlutterMessageCodec> *FLTFlutterSmallApiGetCodec(void);
 
 /// A simple API called in some unit tests.
-@interface FlutterSmallApi : NSObject
+@interface FLTFlutterSmallApi : NSObject
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger;
-- (void)echoWrappedList:(TestMessage *)msg
-             completion:(void (^)(TestMessage *_Nullable, FlutterError *_Nullable))completion;
+- (void)echoWrappedList:(FLTTestMessage *)msg
+             completion:(void (^)(FLTTestMessage *_Nullable, FlutterError *_Nullable))completion;
 - (void)echoString:(NSString *)aString
         completion:(void (^)(NSString *_Nullable, FlutterError *_Nullable))completion;
 @end

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.m
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/ios/Classes/CoreTests.gen.m
@@ -40,8 +40,8 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   return (result == [NSNull null]) ? nil : result;
 }
 
-@implementation AnEnumBox
-- (instancetype)initWithValue:(AnEnum)value {
+@implementation FLTAnEnumBox
+- (instancetype)initWithValue:(FLTAnEnum)value {
   self = [super init];
   if (self) {
     _value = value;
@@ -50,31 +50,31 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 @end
 
-@interface AllTypes ()
-+ (AllTypes *)fromList:(NSArray *)list;
-+ (nullable AllTypes *)nullableFromList:(NSArray *)list;
+@interface FLTAllTypes ()
++ (FLTAllTypes *)fromList:(NSArray *)list;
++ (nullable FLTAllTypes *)nullableFromList:(NSArray *)list;
 - (NSArray *)toList;
 @end
 
-@interface AllNullableTypes ()
-+ (AllNullableTypes *)fromList:(NSArray *)list;
-+ (nullable AllNullableTypes *)nullableFromList:(NSArray *)list;
+@interface FLTAllNullableTypes ()
++ (FLTAllNullableTypes *)fromList:(NSArray *)list;
++ (nullable FLTAllNullableTypes *)nullableFromList:(NSArray *)list;
 - (NSArray *)toList;
 @end
 
-@interface AllClassesWrapper ()
-+ (AllClassesWrapper *)fromList:(NSArray *)list;
-+ (nullable AllClassesWrapper *)nullableFromList:(NSArray *)list;
+@interface FLTAllClassesWrapper ()
++ (FLTAllClassesWrapper *)fromList:(NSArray *)list;
++ (nullable FLTAllClassesWrapper *)nullableFromList:(NSArray *)list;
 - (NSArray *)toList;
 @end
 
-@interface TestMessage ()
-+ (TestMessage *)fromList:(NSArray *)list;
-+ (nullable TestMessage *)nullableFromList:(NSArray *)list;
+@interface FLTTestMessage ()
++ (FLTTestMessage *)fromList:(NSArray *)list;
++ (nullable FLTTestMessage *)nullableFromList:(NSArray *)list;
 - (NSArray *)toList;
 @end
 
-@implementation AllTypes
+@implementation FLTAllTypes
 + (instancetype)makeWithABool:(BOOL)aBool
                         anInt:(NSInteger)anInt
                       anInt64:(NSInteger)anInt64
@@ -85,10 +85,10 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
                   aFloatArray:(FlutterStandardTypedData *)aFloatArray
                         aList:(NSArray *)aList
                          aMap:(NSDictionary *)aMap
-                       anEnum:(AnEnum)anEnum
+                       anEnum:(FLTAnEnum)anEnum
                       aString:(NSString *)aString
                      anObject:(id)anObject {
-  AllTypes *pigeonResult = [[AllTypes alloc] init];
+  FLTAllTypes *pigeonResult = [[FLTAllTypes alloc] init];
   pigeonResult.aBool = aBool;
   pigeonResult.anInt = anInt;
   pigeonResult.anInt64 = anInt64;
@@ -104,8 +104,8 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.anObject = anObject;
   return pigeonResult;
 }
-+ (AllTypes *)fromList:(NSArray *)list {
-  AllTypes *pigeonResult = [[AllTypes alloc] init];
++ (FLTAllTypes *)fromList:(NSArray *)list {
+  FLTAllTypes *pigeonResult = [[FLTAllTypes alloc] init];
   pigeonResult.aBool = [GetNullableObjectAtIndex(list, 0) boolValue];
   pigeonResult.anInt = [GetNullableObjectAtIndex(list, 1) integerValue];
   pigeonResult.anInt64 = [GetNullableObjectAtIndex(list, 2) integerValue];
@@ -121,8 +121,8 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.anObject = GetNullableObjectAtIndex(list, 12);
   return pigeonResult;
 }
-+ (nullable AllTypes *)nullableFromList:(NSArray *)list {
-  return (list) ? [AllTypes fromList:list] : nil;
++ (nullable FLTAllTypes *)nullableFromList:(NSArray *)list {
+  return (list) ? [FLTAllTypes fromList:list] : nil;
 }
 - (NSArray *)toList {
   return @[
@@ -143,7 +143,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 @end
 
-@implementation AllNullableTypes
+@implementation FLTAllNullableTypes
 + (instancetype)makeWithANullableBool:(nullable NSNumber *)aNullableBool
                          aNullableInt:(nullable NSNumber *)aNullableInt
                        aNullableInt64:(nullable NSNumber *)aNullableInt64
@@ -158,10 +158,10 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
            nullableMapWithAnnotations:
                (nullable NSDictionary<NSString *, NSString *> *)nullableMapWithAnnotations
                 nullableMapWithObject:(nullable NSDictionary<NSString *, id> *)nullableMapWithObject
-                        aNullableEnum:(nullable AnEnumBox *)aNullableEnum
+                        aNullableEnum:(nullable FLTAnEnumBox *)aNullableEnum
                       aNullableString:(nullable NSString *)aNullableString
                       aNullableObject:(nullable id)aNullableObject {
-  AllNullableTypes *pigeonResult = [[AllNullableTypes alloc] init];
+  FLTAllNullableTypes *pigeonResult = [[FLTAllNullableTypes alloc] init];
   pigeonResult.aNullableBool = aNullableBool;
   pigeonResult.aNullableInt = aNullableInt;
   pigeonResult.aNullableInt64 = aNullableInt64;
@@ -180,8 +180,8 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.aNullableObject = aNullableObject;
   return pigeonResult;
 }
-+ (AllNullableTypes *)fromList:(NSArray *)list {
-  AllNullableTypes *pigeonResult = [[AllNullableTypes alloc] init];
++ (FLTAllNullableTypes *)fromList:(NSArray *)list {
+  FLTAllNullableTypes *pigeonResult = [[FLTAllNullableTypes alloc] init];
   pigeonResult.aNullableBool = GetNullableObjectAtIndex(list, 0);
   pigeonResult.aNullableInt = GetNullableObjectAtIndex(list, 1);
   pigeonResult.aNullableInt64 = GetNullableObjectAtIndex(list, 2);
@@ -196,17 +196,17 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.nullableMapWithAnnotations = GetNullableObjectAtIndex(list, 11);
   pigeonResult.nullableMapWithObject = GetNullableObjectAtIndex(list, 12);
   NSNumber *aNullableEnumAsNumber = GetNullableObjectAtIndex(list, 13);
-  AnEnumBox *aNullableEnum =
+  FLTAnEnumBox *aNullableEnum =
       aNullableEnumAsNumber == nil
           ? nil
-          : [[AnEnumBox alloc] initWithValue:[aNullableEnumAsNumber integerValue]];
+          : [[FLTAnEnumBox alloc] initWithValue:[aNullableEnumAsNumber integerValue]];
   pigeonResult.aNullableEnum = aNullableEnum;
   pigeonResult.aNullableString = GetNullableObjectAtIndex(list, 14);
   pigeonResult.aNullableObject = GetNullableObjectAtIndex(list, 15);
   return pigeonResult;
 }
-+ (nullable AllNullableTypes *)nullableFromList:(NSArray *)list {
-  return (list) ? [AllNullableTypes fromList:list] : nil;
++ (nullable FLTAllNullableTypes *)nullableFromList:(NSArray *)list {
+  return (list) ? [FLTAllNullableTypes fromList:list] : nil;
 }
 - (NSArray *)toList {
   return @[
@@ -231,23 +231,23 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 @end
 
-@implementation AllClassesWrapper
-+ (instancetype)makeWithAllNullableTypes:(AllNullableTypes *)allNullableTypes
-                                allTypes:(nullable AllTypes *)allTypes {
-  AllClassesWrapper *pigeonResult = [[AllClassesWrapper alloc] init];
+@implementation FLTAllClassesWrapper
++ (instancetype)makeWithAllNullableTypes:(FLTAllNullableTypes *)allNullableTypes
+                                allTypes:(nullable FLTAllTypes *)allTypes {
+  FLTAllClassesWrapper *pigeonResult = [[FLTAllClassesWrapper alloc] init];
   pigeonResult.allNullableTypes = allNullableTypes;
   pigeonResult.allTypes = allTypes;
   return pigeonResult;
 }
-+ (AllClassesWrapper *)fromList:(NSArray *)list {
-  AllClassesWrapper *pigeonResult = [[AllClassesWrapper alloc] init];
++ (FLTAllClassesWrapper *)fromList:(NSArray *)list {
+  FLTAllClassesWrapper *pigeonResult = [[FLTAllClassesWrapper alloc] init];
   pigeonResult.allNullableTypes =
-      [AllNullableTypes nullableFromList:(GetNullableObjectAtIndex(list, 0))];
-  pigeonResult.allTypes = [AllTypes nullableFromList:(GetNullableObjectAtIndex(list, 1))];
+      [FLTAllNullableTypes nullableFromList:(GetNullableObjectAtIndex(list, 0))];
+  pigeonResult.allTypes = [FLTAllTypes nullableFromList:(GetNullableObjectAtIndex(list, 1))];
   return pigeonResult;
 }
-+ (nullable AllClassesWrapper *)nullableFromList:(NSArray *)list {
-  return (list) ? [AllClassesWrapper fromList:list] : nil;
++ (nullable FLTAllClassesWrapper *)nullableFromList:(NSArray *)list {
+  return (list) ? [FLTAllClassesWrapper fromList:list] : nil;
 }
 - (NSArray *)toList {
   return @[
@@ -257,19 +257,19 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 @end
 
-@implementation TestMessage
+@implementation FLTTestMessage
 + (instancetype)makeWithTestList:(nullable NSArray *)testList {
-  TestMessage *pigeonResult = [[TestMessage alloc] init];
+  FLTTestMessage *pigeonResult = [[FLTTestMessage alloc] init];
   pigeonResult.testList = testList;
   return pigeonResult;
 }
-+ (TestMessage *)fromList:(NSArray *)list {
-  TestMessage *pigeonResult = [[TestMessage alloc] init];
++ (FLTTestMessage *)fromList:(NSArray *)list {
+  FLTTestMessage *pigeonResult = [[FLTTestMessage alloc] init];
   pigeonResult.testList = GetNullableObjectAtIndex(list, 0);
   return pigeonResult;
 }
-+ (nullable TestMessage *)nullableFromList:(NSArray *)list {
-  return (list) ? [TestMessage fromList:list] : nil;
++ (nullable FLTTestMessage *)nullableFromList:(NSArray *)list {
+  return (list) ? [FLTTestMessage fromList:list] : nil;
 }
 - (NSArray *)toList {
   return @[
@@ -278,39 +278,39 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 @end
 
-@interface HostIntegrationCoreApiCodecReader : FlutterStandardReader
+@interface FLTHostIntegrationCoreApiCodecReader : FlutterStandardReader
 @end
-@implementation HostIntegrationCoreApiCodecReader
+@implementation FLTHostIntegrationCoreApiCodecReader
 - (nullable id)readValueOfType:(UInt8)type {
   switch (type) {
     case 128:
-      return [AllClassesWrapper fromList:[self readValue]];
+      return [FLTAllClassesWrapper fromList:[self readValue]];
     case 129:
-      return [AllNullableTypes fromList:[self readValue]];
+      return [FLTAllNullableTypes fromList:[self readValue]];
     case 130:
-      return [AllTypes fromList:[self readValue]];
+      return [FLTAllTypes fromList:[self readValue]];
     case 131:
-      return [TestMessage fromList:[self readValue]];
+      return [FLTTestMessage fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
   }
 }
 @end
 
-@interface HostIntegrationCoreApiCodecWriter : FlutterStandardWriter
+@interface FLTHostIntegrationCoreApiCodecWriter : FlutterStandardWriter
 @end
-@implementation HostIntegrationCoreApiCodecWriter
+@implementation FLTHostIntegrationCoreApiCodecWriter
 - (void)writeValue:(id)value {
-  if ([value isKindOfClass:[AllClassesWrapper class]]) {
+  if ([value isKindOfClass:[FLTAllClassesWrapper class]]) {
     [self writeByte:128];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[AllNullableTypes class]]) {
+  } else if ([value isKindOfClass:[FLTAllNullableTypes class]]) {
     [self writeByte:129];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[AllTypes class]]) {
+  } else if ([value isKindOfClass:[FLTAllTypes class]]) {
     [self writeByte:130];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[TestMessage class]]) {
+  } else if ([value isKindOfClass:[FLTTestMessage class]]) {
     [self writeByte:131];
     [self writeValue:[value toList]];
   } else {
@@ -319,40 +319,40 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 @end
 
-@interface HostIntegrationCoreApiCodecReaderWriter : FlutterStandardReaderWriter
+@interface FLTHostIntegrationCoreApiCodecReaderWriter : FlutterStandardReaderWriter
 @end
-@implementation HostIntegrationCoreApiCodecReaderWriter
+@implementation FLTHostIntegrationCoreApiCodecReaderWriter
 - (FlutterStandardWriter *)writerWithData:(NSMutableData *)data {
-  return [[HostIntegrationCoreApiCodecWriter alloc] initWithData:data];
+  return [[FLTHostIntegrationCoreApiCodecWriter alloc] initWithData:data];
 }
 - (FlutterStandardReader *)readerWithData:(NSData *)data {
-  return [[HostIntegrationCoreApiCodecReader alloc] initWithData:data];
+  return [[FLTHostIntegrationCoreApiCodecReader alloc] initWithData:data];
 }
 @end
 
-NSObject<FlutterMessageCodec> *HostIntegrationCoreApiGetCodec(void) {
+NSObject<FlutterMessageCodec> *FLTHostIntegrationCoreApiGetCodec(void) {
   static FlutterStandardMessageCodec *sSharedObject = nil;
   static dispatch_once_t sPred = 0;
   dispatch_once(&sPred, ^{
-    HostIntegrationCoreApiCodecReaderWriter *readerWriter =
-        [[HostIntegrationCoreApiCodecReaderWriter alloc] init];
+    FLTHostIntegrationCoreApiCodecReaderWriter *readerWriter =
+        [[FLTHostIntegrationCoreApiCodecReaderWriter alloc] init];
     sSharedObject = [FlutterStandardMessageCodec codecWithReaderWriter:readerWriter];
   });
   return sSharedObject;
 }
 
-void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
-                                 NSObject<HostIntegrationCoreApi> *api) {
+void SetUpFLTHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
+                                    NSObject<FLTHostIntegrationCoreApi> *api) {
   /// A no-op function taking no arguments and returning no value, to sanity
   /// test basic calling.
   {
     FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.noop"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(noopWithError:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(noopWithError:)",
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(noopWithError:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -369,17 +369,17 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAllTypes"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert(
           [api respondsToSelector:@selector(echoAllTypes:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoAllTypes:error:)",
+          @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoAllTypes:error:)",
           api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AllTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
+        FLTAllTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
         FlutterError *error;
-        AllTypes *output = [api echoAllTypes:arg_everything error:&error];
+        FLTAllTypes *output = [api echoAllTypes:arg_everything error:&error];
         callback(wrapResult(output, error));
       }];
     } else {
@@ -392,11 +392,11 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.throwError"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert(
           [api respondsToSelector:@selector(throwErrorWithError:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(throwErrorWithError:)",
+          @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(throwErrorWithError:)",
           api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -413,10 +413,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"throwErrorFromVoid"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(throwErrorFromVoidWithError:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(throwErrorFromVoidWithError:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -434,10 +434,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"throwFlutterError"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(throwFlutterErrorWithError:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(throwFlutterErrorWithError:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -455,10 +455,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoInt"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoInt:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoInt:error:)",
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoInt:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
@@ -477,11 +477,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoDouble"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(echoDouble:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoDouble:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(echoDouble:error:)],
+          @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoDouble:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         double arg_aDouble = [GetNullableObjectAtIndex(args, 0) doubleValue];
@@ -499,10 +500,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoBool"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoBool:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoBool:error:)",
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoBool:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
@@ -521,11 +522,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(echoString:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoString:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(echoString:error:)],
+          @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoString:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSString *arg_aString = GetNullableObjectAtIndex(args, 0);
@@ -543,11 +545,11 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoUint8List"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert(
           [api respondsToSelector:@selector(echoUint8List:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoUint8List:error:)",
+          @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoUint8List:error:)",
           api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
@@ -566,11 +568,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoObject"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(echoObject:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoObject:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(echoObject:error:)],
+          @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoObject:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         id arg_anObject = GetNullableObjectAtIndex(args, 0);
@@ -588,10 +591,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoList"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoList:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoList:error:)",
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoList:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
@@ -610,10 +613,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoMap"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoMap:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoMap:error:)",
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoMap:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
@@ -632,17 +635,17 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoClassWrapper"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoClassWrapper:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoClassWrapper:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoClassWrapper:error:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoClassWrapper:error:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AllClassesWrapper *arg_wrapper = GetNullableObjectAtIndex(args, 0);
+        FLTAllClassesWrapper *arg_wrapper = GetNullableObjectAtIndex(args, 0);
         FlutterError *error;
-        AllClassesWrapper *output = [api echoClassWrapper:arg_wrapper error:&error];
+        FLTAllClassesWrapper *output = [api echoClassWrapper:arg_wrapper error:&error];
         callback(wrapResult(output, error));
       }];
     } else {
@@ -655,16 +658,16 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoEnum"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoEnum:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoEnum:error:)",
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to @selector(echoEnum:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        FLTAnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         FlutterError *error;
-        AnEnumBox *enumBox = [api echoEnum:arg_anEnum error:&error];
+        FLTAnEnumBox *enumBox = [api echoEnum:arg_anEnum error:&error];
         NSNumber *output = enumBox == nil ? nil : [NSNumber numberWithInteger:enumBox.value];
         callback(wrapResult(output, error));
       }];
@@ -678,10 +681,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNamedDefaultString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoNamedDefaultString:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoNamedDefaultString:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -701,10 +704,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoOptionalDefaultDouble"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoOptionalDefaultDouble:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoOptionalDefaultDouble:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -724,12 +727,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoRequiredInt"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoRequiredInt:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoRequiredInt:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoRequiredInt:error:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoRequiredInt:error:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSInteger arg_anInt = [GetNullableObjectAtIndex(args, 0) integerValue];
@@ -747,17 +750,17 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAllNullableTypes"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAllNullableTypes:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAllNullableTypes:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AllNullableTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
+        FLTAllNullableTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
         FlutterError *error;
-        AllNullableTypes *output = [api echoAllNullableTypes:arg_everything error:&error];
+        FLTAllNullableTypes *output = [api echoAllNullableTypes:arg_everything error:&error];
         callback(wrapResult(output, error));
       }];
     } else {
@@ -771,15 +774,15 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"extractNestedNullableString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(extractNestedNullableStringFrom:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(extractNestedNullableStringFrom:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AllClassesWrapper *arg_wrapper = GetNullableObjectAtIndex(args, 0);
+        FLTAllClassesWrapper *arg_wrapper = GetNullableObjectAtIndex(args, 0);
         FlutterError *error;
         NSString *output = [api extractNestedNullableStringFrom:arg_wrapper error:&error];
         callback(wrapResult(output, error));
@@ -795,18 +798,18 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"createNestedNullableString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(createNestedObjectWithNullableString:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(createNestedObjectWithNullableString:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSString *arg_nullableString = GetNullableObjectAtIndex(args, 0);
         FlutterError *error;
-        AllClassesWrapper *output = [api createNestedObjectWithNullableString:arg_nullableString
-                                                                        error:&error];
+        FLTAllClassesWrapper *output = [api createNestedObjectWithNullableString:arg_nullableString
+                                                                           error:&error];
         callback(wrapResult(output, error));
       }];
     } else {
@@ -819,11 +822,11 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"sendMultipleNullableTypes"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(sendMultipleNullableTypesABool:
                                                                            anInt:aString:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(sendMultipleNullableTypesABool:anInt:aString:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -832,10 +835,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
         NSNumber *arg_aNullableInt = GetNullableObjectAtIndex(args, 1);
         NSString *arg_aNullableString = GetNullableObjectAtIndex(args, 2);
         FlutterError *error;
-        AllNullableTypes *output = [api sendMultipleNullableTypesABool:arg_aNullableBool
-                                                                 anInt:arg_aNullableInt
-                                                               aString:arg_aNullableString
-                                                                 error:&error];
+        FLTAllNullableTypes *output = [api sendMultipleNullableTypesABool:arg_aNullableBool
+                                                                    anInt:arg_aNullableInt
+                                                                  aString:arg_aNullableString
+                                                                    error:&error];
         callback(wrapResult(output, error));
       }];
     } else {
@@ -848,12 +851,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoNullableInt"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoNullableInt:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoNullableInt:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoNullableInt:error:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoNullableInt:error:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSNumber *arg_aNullableInt = GetNullableObjectAtIndex(args, 0);
@@ -871,10 +874,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNullableDouble"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoNullableDouble:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoNullableDouble:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -894,12 +897,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNullableBool"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoNullableBool:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoNullableBool:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoNullableBool:error:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoNullableBool:error:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSNumber *arg_aNullableBool = GetNullableObjectAtIndex(args, 0);
@@ -917,10 +920,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNullableString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoNullableString:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoNullableString:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -940,10 +943,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNullableUint8List"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoNullableUint8List:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoNullableUint8List:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -964,10 +967,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNullableObject"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoNullableObject:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoNullableObject:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -987,12 +990,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNullableList"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoNullableList:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoNullableList:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoNullableList:error:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoNullableList:error:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSArray<id> *arg_aNullableList = GetNullableObjectAtIndex(args, 0);
@@ -1010,12 +1013,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoNullableMap"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoNullableMap:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoNullableMap:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoNullableMap:error:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoNullableMap:error:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSDictionary<NSString *, id> *arg_aNullableMap = GetNullableObjectAtIndex(args, 0);
@@ -1032,21 +1035,21 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNullableEnum"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoNullableEnum:error:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoNullableEnum:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoNullableEnum:error:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoNullableEnum:error:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSNumber *arg_anEnumAsNumber = GetNullableObjectAtIndex(args, 0);
-        AnEnumBox *arg_anEnum =
+        FLTAnEnumBox *arg_anEnum =
             arg_anEnumAsNumber == nil
                 ? nil
-                : [[AnEnumBox alloc] initWithValue:[arg_anEnumAsNumber integerValue]];
+                : [[FLTAnEnumBox alloc] initWithValue:[arg_anEnumAsNumber integerValue]];
         FlutterError *error;
-        AnEnumBox *enumBox = [api echoNullableEnum:arg_anEnum error:&error];
+        FLTAnEnumBox *enumBox = [api echoNullableEnum:arg_anEnum error:&error];
         NSNumber *output = enumBox == nil ? nil : [NSNumber numberWithInteger:enumBox.value];
         callback(wrapResult(output, error));
       }];
@@ -1060,10 +1063,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoOptionalNullableInt"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoOptionalNullableInt:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoOptionalNullableInt:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1083,10 +1086,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoNamedNullableString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoNamedNullableString:error:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoNamedNullableString:error:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1107,12 +1110,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.noopAsync"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(noopAsyncWithCompletion:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(noopAsyncWithCompletion:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(noopAsyncWithCompletion:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(noopAsyncWithCompletion:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         [api noopAsyncWithCompletion:^(FlutterError *_Nullable error) {
           callback(wrapResult(nil, error));
@@ -1128,12 +1131,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAsyncInt"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoAsyncInt:completion:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoAsyncInt:completion:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoAsyncInt:completion:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoAsyncInt:completion:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSInteger arg_anInt = [GetNullableObjectAtIndex(args, 0) integerValue];
@@ -1152,10 +1155,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAsyncDouble"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncDouble:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncDouble:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1176,10 +1179,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAsyncBool"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncBool:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncBool:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1200,10 +1203,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAsyncString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncString:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncString:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1224,10 +1227,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncUint8List"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncUint8List:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncUint8List:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1249,10 +1252,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAsyncObject"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncObject:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncObject:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1273,10 +1276,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAsyncList"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncList:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncList:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1297,12 +1300,12 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAsyncMap"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(echoAsyncMap:completion:)],
-          @"HostIntegrationCoreApi api (%@) doesn't respond to @selector(echoAsyncMap:completion:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(echoAsyncMap:completion:)],
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
+                @"@selector(echoAsyncMap:completion:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSDictionary<NSString *, id> *arg_aMap = GetNullableObjectAtIndex(args, 0);
@@ -1322,17 +1325,17 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.echoAsyncEnum"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncEnum:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncEnum:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        FLTAnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api echoAsyncEnum:arg_anEnum
-                completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
+                completion:^(FLTAnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
                   NSNumber *output =
                       enumValue == nil ? nil : [NSNumber numberWithInteger:enumValue.value];
                   callback(wrapResult(output, error));
@@ -1348,10 +1351,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.throwAsyncError"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(throwAsyncErrorWithCompletion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(throwAsyncErrorWithCompletion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1369,10 +1372,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"throwAsyncErrorFromVoid"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(throwAsyncErrorFromVoidWithCompletion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(throwAsyncErrorFromVoidWithCompletion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1390,10 +1393,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"throwAsyncFlutterError"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(throwAsyncFlutterErrorWithCompletion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(throwAsyncFlutterErrorWithCompletion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1412,17 +1415,17 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncAllTypes"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncAllTypes:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncAllTypes:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AllTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
+        FLTAllTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
         [api echoAsyncAllTypes:arg_everything
-                    completion:^(AllTypes *_Nullable output, FlutterError *_Nullable error) {
+                    completion:^(FLTAllTypes *_Nullable output, FlutterError *_Nullable error) {
                       callback(wrapResult(output, error));
                     }];
       }];
@@ -1436,17 +1439,17 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableAllNullableTypes"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableAllNullableTypes:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableAllNullableTypes:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AllNullableTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
+        FLTAllNullableTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
         [api echoAsyncNullableAllNullableTypes:arg_everything
-                                    completion:^(AllNullableTypes *_Nullable output,
+                                    completion:^(FLTAllNullableTypes *_Nullable output,
                                                  FlutterError *_Nullable error) {
                                       callback(wrapResult(output, error));
                                     }];
@@ -1461,10 +1464,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableInt"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableInt:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableInt:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1485,10 +1488,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableDouble"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableDouble:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableDouble:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1509,10 +1512,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableBool"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableBool:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableBool:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1533,10 +1536,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableString:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableString:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1557,10 +1560,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableUint8List"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableUint8List:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableUint8List:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1582,10 +1585,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableObject"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableObject:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableObject:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1606,10 +1609,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableList"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableList:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableList:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1630,10 +1633,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableMap"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableMap:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableMap:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1655,26 +1658,26 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"echoAsyncNullableEnum"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoAsyncNullableEnum:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(echoAsyncNullableEnum:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSNumber *arg_anEnumAsNumber = GetNullableObjectAtIndex(args, 0);
-        AnEnumBox *arg_anEnum =
+        FLTAnEnumBox *arg_anEnum =
             arg_anEnumAsNumber == nil
                 ? nil
-                : [[AnEnumBox alloc] initWithValue:[arg_anEnumAsNumber integerValue]];
-        [api
-            echoAsyncNullableEnum:arg_anEnum
-                       completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
-                         NSNumber *output =
-                             enumValue == nil ? nil : [NSNumber numberWithInteger:enumValue.value];
-                         callback(wrapResult(output, error));
-                       }];
+                : [[FLTAnEnumBox alloc] initWithValue:[arg_anEnumAsNumber integerValue]];
+        [api echoAsyncNullableEnum:arg_anEnum
+                        completion:^(FLTAnEnumBox *_Nullable enumValue,
+                                     FlutterError *_Nullable error) {
+                          NSNumber *output =
+                              enumValue == nil ? nil : [NSNumber numberWithInteger:enumValue.value];
+                          callback(wrapResult(output, error));
+                        }];
       }];
     } else {
       [channel setMessageHandler:nil];
@@ -1685,10 +1688,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:
                @"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi.callFlutterNoop"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterNoopWithCompletion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterNoopWithCompletion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1705,10 +1708,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterThrowError"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterThrowErrorWithCompletion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterThrowErrorWithCompletion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1726,10 +1729,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterThrowErrorFromVoid"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterThrowErrorFromVoidWithCompletion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterThrowErrorFromVoidWithCompletion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1746,17 +1749,18 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoAllTypes"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoAllTypes:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoAllTypes:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AllTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
+        FLTAllTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
         [api callFlutterEchoAllTypes:arg_everything
-                          completion:^(AllTypes *_Nullable output, FlutterError *_Nullable error) {
+                          completion:^(FLTAllTypes *_Nullable output,
+                                       FlutterError *_Nullable error) {
                             callback(wrapResult(output, error));
                           }];
       }];
@@ -1769,17 +1773,17 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoAllNullableTypes"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoAllNullableTypes:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoAllNullableTypes:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AllNullableTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
+        FLTAllNullableTypes *arg_everything = GetNullableObjectAtIndex(args, 0);
         [api callFlutterEchoAllNullableTypes:arg_everything
-                                  completion:^(AllNullableTypes *_Nullable output,
+                                  completion:^(FLTAllNullableTypes *_Nullable output,
                                                FlutterError *_Nullable error) {
                                     callback(wrapResult(output, error));
                                   }];
@@ -1793,11 +1797,11 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterSendMultipleNullableTypes"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector
                      (callFlutterSendMultipleNullableTypesABool:anInt:aString:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterSendMultipleNullableTypesABool:anInt:aString:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1808,7 +1812,7 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
         [api callFlutterSendMultipleNullableTypesABool:arg_aNullableBool
                                                  anInt:arg_aNullableInt
                                                aString:arg_aNullableString
-                                            completion:^(AllNullableTypes *_Nullable output,
+                                            completion:^(FLTAllNullableTypes *_Nullable output,
                                                          FlutterError *_Nullable error) {
                                               callback(wrapResult(output, error));
                                             }];
@@ -1822,10 +1826,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoBool"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoBool:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoBool:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1845,10 +1849,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoInt"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoInt:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoInt:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1868,10 +1872,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoDouble"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoDouble:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoDouble:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1891,10 +1895,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoString:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoString:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1914,10 +1918,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoUint8List"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoUint8List:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoUint8List:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1938,10 +1942,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoList"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoList:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoList:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1961,10 +1965,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoMap"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoMap:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoMap:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -1985,17 +1989,18 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoEnum"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoEnum:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoEnum:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        AnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
+        FLTAnEnum arg_anEnum = [GetNullableObjectAtIndex(args, 0) integerValue];
         [api callFlutterEchoEnum:arg_anEnum
-                      completion:^(AnEnumBox *_Nullable enumValue, FlutterError *_Nullable error) {
+                      completion:^(FLTAnEnumBox *_Nullable enumValue,
+                                   FlutterError *_Nullable error) {
                         NSNumber *output =
                             enumValue == nil ? nil : [NSNumber numberWithInteger:enumValue.value];
                         callback(wrapResult(output, error));
@@ -2010,10 +2015,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoNullableBool"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoNullableBool:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoNullableBool:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -2034,10 +2039,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoNullableInt"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoNullableInt:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoNullableInt:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -2058,10 +2063,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoNullableDouble"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoNullableDouble:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoNullableDouble:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -2082,10 +2087,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoNullableString"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoNullableString:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoNullableString:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -2106,10 +2111,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoNullableUint8List"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoNullableUint8List:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoNullableUint8List:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -2130,10 +2135,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoNullableList"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoNullableList:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoNullableList:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -2154,10 +2159,10 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoNullableMap"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoNullableMap:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoNullableMap:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
@@ -2178,21 +2183,21 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostIntegrationCoreApi."
                         @"callFlutterEchoNullableEnum"
         binaryMessenger:binaryMessenger
-                  codec:HostIntegrationCoreApiGetCodec()];
+                  codec:FLTHostIntegrationCoreApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(callFlutterEchoNullableEnum:completion:)],
-                @"HostIntegrationCoreApi api (%@) doesn't respond to "
+                @"FLTHostIntegrationCoreApi api (%@) doesn't respond to "
                 @"@selector(callFlutterEchoNullableEnum:completion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSNumber *arg_anEnumAsNumber = GetNullableObjectAtIndex(args, 0);
-        AnEnumBox *arg_anEnum =
+        FLTAnEnumBox *arg_anEnum =
             arg_anEnumAsNumber == nil
                 ? nil
-                : [[AnEnumBox alloc] initWithValue:[arg_anEnumAsNumber integerValue]];
+                : [[FLTAnEnumBox alloc] initWithValue:[arg_anEnumAsNumber integerValue]];
         [api callFlutterEchoNullableEnum:arg_anEnum
-                              completion:^(AnEnumBox *_Nullable enumValue,
+                              completion:^(FLTAnEnumBox *_Nullable enumValue,
                                            FlutterError *_Nullable error) {
                                 NSNumber *output =
                                     enumValue == nil ? nil
@@ -2205,39 +2210,39 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
     }
   }
 }
-@interface FlutterIntegrationCoreApiCodecReader : FlutterStandardReader
+@interface FLTFlutterIntegrationCoreApiCodecReader : FlutterStandardReader
 @end
-@implementation FlutterIntegrationCoreApiCodecReader
+@implementation FLTFlutterIntegrationCoreApiCodecReader
 - (nullable id)readValueOfType:(UInt8)type {
   switch (type) {
     case 128:
-      return [AllClassesWrapper fromList:[self readValue]];
+      return [FLTAllClassesWrapper fromList:[self readValue]];
     case 129:
-      return [AllNullableTypes fromList:[self readValue]];
+      return [FLTAllNullableTypes fromList:[self readValue]];
     case 130:
-      return [AllTypes fromList:[self readValue]];
+      return [FLTAllTypes fromList:[self readValue]];
     case 131:
-      return [TestMessage fromList:[self readValue]];
+      return [FLTTestMessage fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
   }
 }
 @end
 
-@interface FlutterIntegrationCoreApiCodecWriter : FlutterStandardWriter
+@interface FLTFlutterIntegrationCoreApiCodecWriter : FlutterStandardWriter
 @end
-@implementation FlutterIntegrationCoreApiCodecWriter
+@implementation FLTFlutterIntegrationCoreApiCodecWriter
 - (void)writeValue:(id)value {
-  if ([value isKindOfClass:[AllClassesWrapper class]]) {
+  if ([value isKindOfClass:[FLTAllClassesWrapper class]]) {
     [self writeByte:128];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[AllNullableTypes class]]) {
+  } else if ([value isKindOfClass:[FLTAllNullableTypes class]]) {
     [self writeByte:129];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[AllTypes class]]) {
+  } else if ([value isKindOfClass:[FLTAllTypes class]]) {
     [self writeByte:130];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[TestMessage class]]) {
+  } else if ([value isKindOfClass:[FLTTestMessage class]]) {
     [self writeByte:131];
     [self writeValue:[value toList]];
   } else {
@@ -2246,33 +2251,33 @@ void SetUpHostIntegrationCoreApi(id<FlutterBinaryMessenger> binaryMessenger,
 }
 @end
 
-@interface FlutterIntegrationCoreApiCodecReaderWriter : FlutterStandardReaderWriter
+@interface FLTFlutterIntegrationCoreApiCodecReaderWriter : FlutterStandardReaderWriter
 @end
-@implementation FlutterIntegrationCoreApiCodecReaderWriter
+@implementation FLTFlutterIntegrationCoreApiCodecReaderWriter
 - (FlutterStandardWriter *)writerWithData:(NSMutableData *)data {
-  return [[FlutterIntegrationCoreApiCodecWriter alloc] initWithData:data];
+  return [[FLTFlutterIntegrationCoreApiCodecWriter alloc] initWithData:data];
 }
 - (FlutterStandardReader *)readerWithData:(NSData *)data {
-  return [[FlutterIntegrationCoreApiCodecReader alloc] initWithData:data];
+  return [[FLTFlutterIntegrationCoreApiCodecReader alloc] initWithData:data];
 }
 @end
 
-NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
+NSObject<FlutterMessageCodec> *FLTFlutterIntegrationCoreApiGetCodec(void) {
   static FlutterStandardMessageCodec *sSharedObject = nil;
   static dispatch_once_t sPred = 0;
   dispatch_once(&sPred, ^{
-    FlutterIntegrationCoreApiCodecReaderWriter *readerWriter =
-        [[FlutterIntegrationCoreApiCodecReaderWriter alloc] init];
+    FLTFlutterIntegrationCoreApiCodecReaderWriter *readerWriter =
+        [[FLTFlutterIntegrationCoreApiCodecReaderWriter alloc] init];
     sSharedObject = [FlutterStandardMessageCodec codecWithReaderWriter:readerWriter];
   });
   return sSharedObject;
 }
 
-@interface FlutterIntegrationCoreApi ()
+@interface FLTFlutterIntegrationCoreApi ()
 @property(nonatomic, strong) NSObject<FlutterBinaryMessenger> *binaryMessenger;
 @end
 
-@implementation FlutterIntegrationCoreApi
+@implementation FLTFlutterIntegrationCoreApi
 
 - (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger {
   self = [super init];
@@ -2287,7 +2292,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:nil
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2309,7 +2314,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:nil
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2332,7 +2337,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:nil
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2348,14 +2353,14 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoAllTypes:(AllTypes *)arg_everything
-          completion:(void (^)(AllTypes *_Nullable, FlutterError *_Nullable))completion {
+- (void)echoAllTypes:(FLTAllTypes *)arg_everything
+          completion:(void (^)(FLTAllTypes *_Nullable, FlutterError *_Nullable))completion {
   NSString *channelName =
       @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoAllTypes";
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_everything ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2364,7 +2369,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                                                            message:reply[1]
                                                            details:reply[2]]);
                      } else {
-                       AllTypes *output = reply[0] == [NSNull null] ? nil : reply[0];
+                       FLTAllTypes *output = reply[0] == [NSNull null] ? nil : reply[0];
                        completion(output, nil);
                      }
                    } else {
@@ -2372,15 +2377,15 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoAllNullableTypes:(nullable AllNullableTypes *)arg_everything
-                  completion:
-                      (void (^)(AllNullableTypes *_Nullable, FlutterError *_Nullable))completion {
+- (void)echoAllNullableTypes:(nullable FLTAllNullableTypes *)arg_everything
+                  completion:(void (^)(FLTAllNullableTypes *_Nullable,
+                                       FlutterError *_Nullable))completion {
   NSString *channelName =
       @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoAllNullableTypes";
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_everything ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2389,7 +2394,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                                                            message:reply[1]
                                                            details:reply[2]]);
                      } else {
-                       AllNullableTypes *output = reply[0] == [NSNull null] ? nil : reply[0];
+                       FLTAllNullableTypes *output = reply[0] == [NSNull null] ? nil : reply[0];
                        completion(output, nil);
                      }
                    } else {
@@ -2400,14 +2405,14 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
 - (void)sendMultipleNullableTypesABool:(nullable NSNumber *)arg_aNullableBool
                                  anInt:(nullable NSNumber *)arg_aNullableInt
                                aString:(nullable NSString *)arg_aNullableString
-                            completion:(void (^)(AllNullableTypes *_Nullable,
+                            completion:(void (^)(FLTAllNullableTypes *_Nullable,
                                                  FlutterError *_Nullable))completion {
   NSString *channelName = @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi."
                           @"sendMultipleNullableTypes";
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[
     arg_aNullableBool ?: [NSNull null], arg_aNullableInt ?: [NSNull null],
     arg_aNullableString ?: [NSNull null]
@@ -2419,7 +2424,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                                                            message:reply[1]
                                                            details:reply[2]]);
                      } else {
-                       AllNullableTypes *output = reply[0] == [NSNull null] ? nil : reply[0];
+                       FLTAllNullableTypes *output = reply[0] == [NSNull null] ? nil : reply[0];
                        completion(output, nil);
                      }
                    } else {
@@ -2434,7 +2439,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ @(arg_aBool) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2458,7 +2463,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ @(arg_anInt) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2482,7 +2487,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ @(arg_aDouble) ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2506,7 +2511,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aString ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2531,7 +2536,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aList ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2556,7 +2561,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aList ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2581,7 +2586,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aMap ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2599,14 +2604,14 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoEnum:(AnEnum)arg_anEnum
-      completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion {
+- (void)echoEnum:(FLTAnEnum)arg_anEnum
+      completion:(void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion {
   NSString *channelName =
       @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoEnum";
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ [NSNumber numberWithInteger:arg_anEnum] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2616,10 +2621,10 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                                                            details:reply[2]]);
                      } else {
                        NSNumber *outputAsNumber = reply[0] == [NSNull null] ? nil : reply[0];
-                       AnEnumBox *output =
+                       FLTAnEnumBox *output =
                            outputAsNumber == nil
                                ? nil
-                               : [[AnEnumBox alloc] initWithValue:[outputAsNumber integerValue]];
+                               : [[FLTAnEnumBox alloc] initWithValue:[outputAsNumber integerValue]];
                        completion(output, nil);
                      }
                    } else {
@@ -2634,7 +2639,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aBool ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2658,7 +2663,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_anInt ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2682,7 +2687,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aDouble ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2706,7 +2711,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aString ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2731,7 +2736,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aList ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2756,7 +2761,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aList ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2781,7 +2786,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aMap ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2799,14 +2804,14 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                    }
                  }];
 }
-- (void)echoNullableEnum:(nullable AnEnumBox *)arg_anEnum
-              completion:(void (^)(AnEnumBox *_Nullable, FlutterError *_Nullable))completion {
+- (void)echoNullableEnum:(nullable FLTAnEnumBox *)arg_anEnum
+              completion:(void (^)(FLTAnEnumBox *_Nullable, FlutterError *_Nullable))completion {
   NSString *channelName =
       @"dev.flutter.pigeon.pigeon_integration_tests.FlutterIntegrationCoreApi.echoNullableEnum";
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_anEnum == nil ? [NSNull null]
                                             : [NSNumber numberWithInteger:arg_anEnum.value] ]
                  reply:^(NSArray<id> *reply) {
@@ -2817,10 +2822,10 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
                                                            details:reply[2]]);
                      } else {
                        NSNumber *outputAsNumber = reply[0] == [NSNull null] ? nil : reply[0];
-                       AnEnumBox *output =
+                       FLTAnEnumBox *output =
                            outputAsNumber == nil
                                ? nil
-                               : [[AnEnumBox alloc] initWithValue:[outputAsNumber integerValue]];
+                               : [[FLTAnEnumBox alloc] initWithValue:[outputAsNumber integerValue]];
                        completion(output, nil);
                      }
                    } else {
@@ -2834,7 +2839,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:nil
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2857,7 +2862,7 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterIntegrationCoreApiGetCodec()];
+                                                   codec:FLTFlutterIntegrationCoreApiGetCodec()];
   [channel sendMessage:@[ arg_aString ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -2876,22 +2881,22 @@ NSObject<FlutterMessageCodec> *FlutterIntegrationCoreApiGetCodec(void) {
 }
 @end
 
-NSObject<FlutterMessageCodec> *HostTrivialApiGetCodec(void) {
+NSObject<FlutterMessageCodec> *FLTHostTrivialApiGetCodec(void) {
   static FlutterStandardMessageCodec *sSharedObject = nil;
   sSharedObject = [FlutterStandardMessageCodec sharedInstance];
   return sSharedObject;
 }
 
-void SetUpHostTrivialApi(id<FlutterBinaryMessenger> binaryMessenger,
-                         NSObject<HostTrivialApi> *api) {
+void SetUpFLTHostTrivialApi(id<FlutterBinaryMessenger> binaryMessenger,
+                            NSObject<FLTHostTrivialApi> *api) {
   {
     FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostTrivialApi.noop"
         binaryMessenger:binaryMessenger
-                  codec:HostTrivialApiGetCodec()];
+                  codec:FLTHostTrivialApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(noopWithError:)],
-                @"HostTrivialApi api (%@) doesn't respond to @selector(noopWithError:)", api);
+                @"FLTHostTrivialApi api (%@) doesn't respond to @selector(noopWithError:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         [api noopWithError:&error];
@@ -2902,21 +2907,23 @@ void SetUpHostTrivialApi(id<FlutterBinaryMessenger> binaryMessenger,
     }
   }
 }
-NSObject<FlutterMessageCodec> *HostSmallApiGetCodec(void) {
+NSObject<FlutterMessageCodec> *FLTHostSmallApiGetCodec(void) {
   static FlutterStandardMessageCodec *sSharedObject = nil;
   sSharedObject = [FlutterStandardMessageCodec sharedInstance];
   return sSharedObject;
 }
 
-void SetUpHostSmallApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<HostSmallApi> *api) {
+void SetUpFLTHostSmallApi(id<FlutterBinaryMessenger> binaryMessenger,
+                          NSObject<FLTHostSmallApi> *api) {
   {
     FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostSmallApi.echo"
         binaryMessenger:binaryMessenger
-                  codec:HostSmallApiGetCodec()];
+                  codec:FLTHostSmallApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(echoString:completion:)],
-                @"HostSmallApi api (%@) doesn't respond to @selector(echoString:completion:)", api);
+                @"FLTHostSmallApi api (%@) doesn't respond to @selector(echoString:completion:)",
+                api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSString *arg_aString = GetNullableObjectAtIndex(args, 0);
@@ -2933,10 +2940,10 @@ void SetUpHostSmallApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<Host
     FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
            initWithName:@"dev.flutter.pigeon.pigeon_integration_tests.HostSmallApi.voidVoid"
         binaryMessenger:binaryMessenger
-                  codec:HostSmallApiGetCodec()];
+                  codec:FLTHostSmallApiGetCodec()];
     if (api) {
       NSCAssert([api respondsToSelector:@selector(voidVoidWithCompletion:)],
-                @"HostSmallApi api (%@) doesn't respond to @selector(voidVoidWithCompletion:)",
+                @"FLTHostSmallApi api (%@) doesn't respond to @selector(voidVoidWithCompletion:)",
                 api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         [api voidVoidWithCompletion:^(FlutterError *_Nullable error) {
@@ -2948,24 +2955,24 @@ void SetUpHostSmallApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<Host
     }
   }
 }
-@interface FlutterSmallApiCodecReader : FlutterStandardReader
+@interface FLTFlutterSmallApiCodecReader : FlutterStandardReader
 @end
-@implementation FlutterSmallApiCodecReader
+@implementation FLTFlutterSmallApiCodecReader
 - (nullable id)readValueOfType:(UInt8)type {
   switch (type) {
     case 128:
-      return [TestMessage fromList:[self readValue]];
+      return [FLTTestMessage fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
   }
 }
 @end
 
-@interface FlutterSmallApiCodecWriter : FlutterStandardWriter
+@interface FLTFlutterSmallApiCodecWriter : FlutterStandardWriter
 @end
-@implementation FlutterSmallApiCodecWriter
+@implementation FLTFlutterSmallApiCodecWriter
 - (void)writeValue:(id)value {
-  if ([value isKindOfClass:[TestMessage class]]) {
+  if ([value isKindOfClass:[FLTTestMessage class]]) {
     [self writeByte:128];
     [self writeValue:[value toList]];
   } else {
@@ -2974,33 +2981,33 @@ void SetUpHostSmallApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<Host
 }
 @end
 
-@interface FlutterSmallApiCodecReaderWriter : FlutterStandardReaderWriter
+@interface FLTFlutterSmallApiCodecReaderWriter : FlutterStandardReaderWriter
 @end
-@implementation FlutterSmallApiCodecReaderWriter
+@implementation FLTFlutterSmallApiCodecReaderWriter
 - (FlutterStandardWriter *)writerWithData:(NSMutableData *)data {
-  return [[FlutterSmallApiCodecWriter alloc] initWithData:data];
+  return [[FLTFlutterSmallApiCodecWriter alloc] initWithData:data];
 }
 - (FlutterStandardReader *)readerWithData:(NSData *)data {
-  return [[FlutterSmallApiCodecReader alloc] initWithData:data];
+  return [[FLTFlutterSmallApiCodecReader alloc] initWithData:data];
 }
 @end
 
-NSObject<FlutterMessageCodec> *FlutterSmallApiGetCodec(void) {
+NSObject<FlutterMessageCodec> *FLTFlutterSmallApiGetCodec(void) {
   static FlutterStandardMessageCodec *sSharedObject = nil;
   static dispatch_once_t sPred = 0;
   dispatch_once(&sPred, ^{
-    FlutterSmallApiCodecReaderWriter *readerWriter =
-        [[FlutterSmallApiCodecReaderWriter alloc] init];
+    FLTFlutterSmallApiCodecReaderWriter *readerWriter =
+        [[FLTFlutterSmallApiCodecReaderWriter alloc] init];
     sSharedObject = [FlutterStandardMessageCodec codecWithReaderWriter:readerWriter];
   });
   return sSharedObject;
 }
 
-@interface FlutterSmallApi ()
+@interface FLTFlutterSmallApi ()
 @property(nonatomic, strong) NSObject<FlutterBinaryMessenger> *binaryMessenger;
 @end
 
-@implementation FlutterSmallApi
+@implementation FLTFlutterSmallApi
 
 - (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger {
   self = [super init];
@@ -3009,14 +3016,14 @@ NSObject<FlutterMessageCodec> *FlutterSmallApiGetCodec(void) {
   }
   return self;
 }
-- (void)echoWrappedList:(TestMessage *)arg_msg
-             completion:(void (^)(TestMessage *_Nullable, FlutterError *_Nullable))completion {
+- (void)echoWrappedList:(FLTTestMessage *)arg_msg
+             completion:(void (^)(FLTTestMessage *_Nullable, FlutterError *_Nullable))completion {
   NSString *channelName =
       @"dev.flutter.pigeon.pigeon_integration_tests.FlutterSmallApi.echoWrappedList";
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterSmallApiGetCodec()];
+                                                   codec:FLTFlutterSmallApiGetCodec()];
   [channel sendMessage:@[ arg_msg ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
@@ -3025,7 +3032,7 @@ NSObject<FlutterMessageCodec> *FlutterSmallApiGetCodec(void) {
                                                            message:reply[1]
                                                            details:reply[2]]);
                      } else {
-                       TestMessage *output = reply[0] == [NSNull null] ? nil : reply[0];
+                       FLTTestMessage *output = reply[0] == [NSNull null] ? nil : reply[0];
                        completion(output, nil);
                      }
                    } else {
@@ -3039,7 +3046,7 @@ NSObject<FlutterMessageCodec> *FlutterSmallApiGetCodec(void) {
   FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel messageChannelWithName:channelName
                                          binaryMessenger:self.binaryMessenger
-                                                   codec:FlutterSmallApiGetCodec()];
+                                                   codec:FLTFlutterSmallApiGetCodec()];
   [channel sendMessage:@[ arg_aString ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 17.1.2 # This must match the version in lib/generator_tools.dart
+version: 17.1.3 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ^3.1.0

--- a/packages/pigeon/test/objc_generator_test.dart
+++ b/packages/pigeon/test/objc_generator_test.dart
@@ -2931,4 +2931,178 @@ void main() {
             'return [FlutterError errorWithCode:@"channel-error" message:[NSString stringWithFormat:@"%@/%@/%@", @"Unable to establish connection on channel: \'", channelName, @"\'."] details:@""]'));
     expect(code, contains('completion(createConnectionError(channelName))'));
   });
+
+  test('header of FlutterApi uses correct enum name with prefix', () {
+    final Enum enum1 = Enum(
+      name: 'Enum1',
+      members: <EnumMember>[
+        EnumMember(name: 'one'),
+        EnumMember(name: 'two'),
+      ],
+    );
+    final Root root = Root(apis: <Api>[
+      AstFlutterApi(name: 'Api', methods: <Method>[
+        Method(
+          name: 'doSomething',
+          location: ApiLocation.flutter,
+          isAsynchronous: true,
+          parameters: <Parameter>[],
+          returnType: TypeDeclaration(
+            baseName: 'Enum1',
+            isNullable: false,
+            associatedEnum: enum1,
+          ),
+        )
+      ]),
+    ], classes: <Class>[], enums: <Enum>[
+      enum1,
+    ]);
+    final StringBuffer sink = StringBuffer();
+    const ObjcGenerator generator = ObjcGenerator();
+    final OutputFileOptions<ObjcOptions> generatorOptions =
+        OutputFileOptions<ObjcOptions>(
+      fileType: FileType.header,
+      languageOptions: const ObjcOptions(prefix: 'FLT'),
+    );
+    generator.generate(
+      generatorOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(code, isNot(contains('FLTFLT')));
+    expect(code, contains('FLTEnum1Box'));
+  });
+
+  test('source of FlutterApi uses correct enum name with prefix', () {
+    final Enum enum1 = Enum(
+      name: 'Enum1',
+      members: <EnumMember>[
+        EnumMember(name: 'one'),
+        EnumMember(name: 'two'),
+      ],
+    );
+    final Root root = Root(apis: <Api>[
+      AstFlutterApi(name: 'Api', methods: <Method>[
+        Method(
+          name: 'doSomething',
+          location: ApiLocation.flutter,
+          isAsynchronous: true,
+          parameters: <Parameter>[],
+          returnType: TypeDeclaration(
+            baseName: 'Enum1',
+            isNullable: false,
+            associatedEnum: enum1,
+          ),
+        )
+      ]),
+    ], classes: <Class>[], enums: <Enum>[
+      enum1,
+    ]);
+    final StringBuffer sink = StringBuffer();
+    const ObjcGenerator generator = ObjcGenerator();
+    final OutputFileOptions<ObjcOptions> generatorOptions =
+        OutputFileOptions<ObjcOptions>(
+      fileType: FileType.source,
+      languageOptions: const ObjcOptions(prefix: 'FLT'),
+    );
+    generator.generate(
+      generatorOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(code, isNot(contains('FLTFLT')));
+    expect(code, contains('FLTEnum1Box'));
+  });
+
+  test('header of HostApi uses correct enum name with prefix', () {
+    final Enum enum1 = Enum(
+      name: 'Enum1',
+      members: <EnumMember>[
+        EnumMember(name: 'one'),
+        EnumMember(name: 'two'),
+      ],
+    );
+    final TypeDeclaration enumType = TypeDeclaration(
+      baseName: 'Enum1',
+      isNullable: false,
+      associatedEnum: enum1,
+    );
+    final Root root = Root(apis: <Api>[
+      AstHostApi(name: 'Api', methods: <Method>[
+        Method(
+          name: 'doSomething',
+          location: ApiLocation.host,
+          isAsynchronous: true,
+          parameters: <Parameter>[Parameter(name: 'value', type: enumType)],
+          returnType: enumType,
+        )
+      ]),
+    ], classes: <Class>[], enums: <Enum>[
+      enum1,
+    ]);
+    final StringBuffer sink = StringBuffer();
+    const ObjcGenerator generator = ObjcGenerator();
+    final OutputFileOptions<ObjcOptions> generatorOptions =
+        OutputFileOptions<ObjcOptions>(
+      fileType: FileType.header,
+      languageOptions: const ObjcOptions(prefix: 'FLT'),
+    );
+    generator.generate(
+      generatorOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(code, isNot(contains('FLTFLT')));
+    expect(code, contains('FLTEnum1Box'));
+  });
+
+  test('source of HostApi uses correct enum name with prefix', () {
+    final Enum enum1 = Enum(
+      name: 'Enum1',
+      members: <EnumMember>[
+        EnumMember(name: 'one'),
+        EnumMember(name: 'two'),
+      ],
+    );
+    final TypeDeclaration enumType = TypeDeclaration(
+      baseName: 'Enum1',
+      isNullable: false,
+      associatedEnum: enum1,
+    );
+    final Root root = Root(apis: <Api>[
+      AstHostApi(name: 'Api', methods: <Method>[
+        Method(
+          name: 'doSomething',
+          location: ApiLocation.host,
+          isAsynchronous: true,
+          parameters: <Parameter>[Parameter(name: 'value', type: enumType)],
+          returnType: enumType,
+        )
+      ]),
+    ], classes: <Class>[], enums: <Enum>[
+      enum1,
+    ]);
+    final StringBuffer sink = StringBuffer();
+    const ObjcGenerator generator = ObjcGenerator();
+    final OutputFileOptions<ObjcOptions> generatorOptions =
+        OutputFileOptions<ObjcOptions>(
+      fileType: FileType.source,
+      languageOptions: const ObjcOptions(prefix: 'FLT'),
+    );
+    generator.generate(
+      generatorOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(code, isNot(contains('FLTFLT')));
+    expect(code, contains('FLTEnum1Box'));
+  });
 }

--- a/packages/pigeon/tool/shared/generation.dart
+++ b/packages/pigeon/tool/shared/generation.dart
@@ -151,6 +151,7 @@ Future<int> generateTestPigeons({required String baseDir}) async {
       objcSourceOut: skipLanguages.contains(GeneratorLanguage.objc)
           ? null
           : '$alternateOutputBase/ios/Classes/$pascalCaseName.gen.m',
+      objcPrefix: input == 'core_tests' ? 'FLT' : '',
       suppressVersion: true,
       dartPackageName: 'pigeon_integration_tests',
     );


### PR DESCRIPTION
In some areas of the Objc generator, the the name created from [_objcTypeForDartType](https://github.com/flutter/packages/blob/main/packages/pigeon/lib/objc_generator.dart#L1353) is being passed to [_enumName](https://github.com/flutter/packages/blob/main/packages/pigeon/lib/objc_generator.dart#L1196) and both of these methods add a prefix to enums. The locations are when they are used in `HostApi` or `FlutterApi` methods, but the name of the generated enum would be correct. e.g. `FLTEnumName` vs `FLTFLTEnumName`.

This fixes the locations where this is happening by passing the AST name to `_enumName` instead. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
