### PR TITLE
[in_app_purchase_storekit] Fix type of error code returned from native code in `SKReceiptManager.retrieveReceiptData`

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.12+1
+
+* Fixes type of error code returned from native code in SKReceiptManager.retrieveReceiptData.
+
 ## 0.3.12
 
 * Converts `refreshReceipt()`, `startObservingPaymentQueue()`, `stopObservingPaymentQueue()`, 

--- a/packages/in_app_purchase/in_app_purchase_storekit/darwin/Classes/FIAPReceiptManager.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/darwin/Classes/FIAPReceiptManager.m
@@ -29,9 +29,10 @@
   if (!receipt || receiptError) {
     if (flutterError) {
       NSDictionary *errorMap = [FIAObjectTranslator getMapFromNSError:receiptError];
-      *flutterError = [FlutterError errorWithCode:errorMap[@"code"]
-                                          message:errorMap[@"domain"]
-                                          details:errorMap[@"userInfo"]];
+      *flutterError =
+          [FlutterError errorWithCode:[NSString stringWithFormat:@"%@", errorMap[@"code"]]
+                              message:errorMap[@"domain"]
+                              details:errorMap[@"userInfo"]];
     }
     return nil;
   }

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/InAppPurchasePluginTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/InAppPurchasePluginTests.m
@@ -307,6 +307,7 @@
 
   XCTAssertNil(result);
   XCTAssertNotNil(error);
+  XCTAssert([error.code isKindOfClass:[NSString class]]);
   NSDictionary *details = error.details;
   XCTAssertNotNil(details[@"error"]);
   NSNumber *errorCode = (NSNumber *)details[@"error"][@"code"];

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS and macOS platforms of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.12
+version: 0.3.12+1
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
The native code did not convert the integer `code` returned from `FIAObjectTranslator getMapFromNSError` to a string before passing it to `FlutterError errorWithCode`. This allowed an `int` to flow into a position where the corresponding Dart code expects a `String`.

Fixes https://github.com/flutter/flutter/issues/144595

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
