### PR TITLE
[rfw] Change test coverage logic to enforce 100% coverage

### DIFF
--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.0.24
+
 * Adds `InkResponse` material widget.
 * Adds `Material` material widget.
 * Adds the `child` to `Opacity` core widget.

--- a/packages/rfw/lib/src/flutter/core_widgets.dart
+++ b/packages/rfw/lib/src/flutter/core_widgets.dart
@@ -277,7 +277,7 @@ Map<String, LocalWidgetBuilder> get _coreWidgetsDefinitions => <String, LocalWid
       clipBehavior: ArgumentDecoders.enumValue<Clip>(Clip.values, source, ['clipBehavior']) ?? Clip.antiAlias,
       child: source.optionalChild(['child']),
     );
-  }, 
+  },
 
   'ColoredBox': (BuildContext context, DataSource source) {
     return ColoredBox(

--- a/packages/rfw/lib/src/flutter/runtime.dart
+++ b/packages/rfw/lib/src/flutter/runtime.dart
@@ -249,12 +249,12 @@ class Runtime extends ChangeNotifier {
   ///
   /// The returned map is an immutable view of the map updated by calls to
   /// [update] and [clearLibraries].
-  /// 
+  ///
   /// The keys are instances [LibraryName] which encode fully qualified library
   /// names, and the values are the corresponding [WidgetLibrary]s.
-  /// 
+  ///
   /// The returned map is an immutable copy of the registered libraries
-  /// at the time of this call. 
+  /// at the time of this call.
   ///
   /// See also:
   ///

--- a/packages/rfw/test/core_widgets_test.dart
+++ b/packages/rfw/test/core_widgets_test.dart
@@ -293,7 +293,7 @@ void main() {
     '''));
     await tester.pump();
     expect(find.byType(ClipRRect), findsOneWidget);
-    final RenderClipRRect renderClip = tester.allRenderObjects.whereType<RenderClipRRect>().first; 
+    final RenderClipRRect renderClip = tester.allRenderObjects.whereType<RenderClipRRect>().first;
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
     expect(renderClip.borderRadius, equals(BorderRadius.zero));
   });


### PR DESCRIPTION
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
