### PR TITLE
[web] Use TrustedTypes from pkg web.

### DIFF
--- a/packages/google_identity_services_web/CHANGELOG.md
+++ b/packages/google_identity_services_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+1
+
+* Uses `TrustedTypes` from `web: ^0.5.1`.
+
 ## 0.3.1
 
 * Updates web code to package `web: ^0.5.0`.

--- a/packages/google_identity_services_web/example/pubspec.yaml
+++ b/packages/google_identity_services_web/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: An example for the google_identity_services_web package, OneTap.
 publish_to: 'none'
 
 environment:
-  flutter: ">=3.16.0"
-  sdk: ">=3.2.0 <4.0.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:
@@ -12,7 +12,7 @@ dependencies:
   google_identity_services_web:
     path: ../
   http: ">=0.13.0 <2.0.0"
-  web: ^0.5.0
+  web: ^0.5.1
 
 dev_dependencies:
   build_runner: ^2.1.10 # To extract README excerpts only.

--- a/packages/google_identity_services_web/lib/src/js_interop/package_web_tweaks.dart
+++ b/packages/google_identity_services_web/lib/src/js_interop/package_web_tweaks.dart
@@ -17,60 +17,20 @@ extension NullableTrustedTypesGetter on web.Window {
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API
   @JS('trustedTypes')
-  external TrustedTypePolicyFactory? get nullableTrustedTypes;
-
-  /// Bindings to window.trustedTypes.
-  ///
-  /// This will crash if accessed in a browser that doesn't support the
-  /// Trusted Types API.
-  ///
-  /// See: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API
-  @JS('trustedTypes')
-  external TrustedTypePolicyFactory get trustedTypes;
+  external web.TrustedTypePolicyFactory? get nullableTrustedTypes;
 }
 
-/// This extension allows setting a TrustedScriptURL as the src of a script element,
-/// which currently only accepts a string.
+/// Allows setting a TrustedScriptURL as the src of a script element.
 extension TrustedTypeSrcAttribute on web.HTMLScriptElement {
   @JS('src')
-  external set trustedSrc(TrustedScriptURL value);
+  external set trustedSrc(web.TrustedScriptURL value);
 }
 
-// TODO(kevmoo): drop all of this once `pkg:web` publishes `0.5.1`.
-
-/// Bindings to a JS TrustedScriptURL.
-///
-/// See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedScriptURL
-extension type TrustedScriptURL._(JSObject _) implements JSObject {}
-
-/// Bindings to a JS TrustedTypePolicyFactory.
-///
-/// See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicyFactory
-extension type TrustedTypePolicyFactory._(JSObject _) implements JSObject {
-  ///
-  external TrustedTypePolicy createPolicy(
-    String policyName, [
-    TrustedTypePolicyOptions policyOptions,
-  ]);
-}
-
-/// Bindings to a JS TrustedTypePolicy.
-///
-/// See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicy
-extension type TrustedTypePolicy._(JSObject _) implements JSObject {
-  ///
+/// Allows creating a script URL only from a string, with no arguments.
+extension CreateScriptUrlNoArgs on web.TrustedTypePolicy {
+  /// Allows calling `createScriptURL` with only the `input` argument.
   @JS('createScriptURL')
-  external TrustedScriptURL createScriptURLNoArgs(
+  external web.TrustedScriptURL createScriptURLNoArgs(
     String input,
   );
-}
-
-/// Bindings to a JS TrustedTypePolicyOptions (anonymous).
-///
-/// See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#policyoptions
-extension type TrustedTypePolicyOptions._(JSObject _) implements JSObject {
-  ///
-  external factory TrustedTypePolicyOptions({
-    JSFunction createScriptURL,
-  });
 }

--- a/packages/google_identity_services_web/lib/src/js_loader.dart
+++ b/packages/google_identity_services_web/lib/src/js_loader.dart
@@ -25,15 +25,15 @@ Future<void> loadWebSdk({
   onGoogleLibraryLoad = () => completer.complete();
 
   // If TrustedTypes are available, prepare a trusted URL.
-  TrustedScriptURL? trustedUrl;
+  web.TrustedScriptURL? trustedUrl;
   if (web.window.nullableTrustedTypes != null) {
     web.console.debug(
       'TrustedTypes available. Creating policy: $trustedTypePolicyName'.toJS,
     );
     try {
-      final TrustedTypePolicy policy = web.window.trustedTypes.createPolicy(
+      final web.TrustedTypePolicy policy = web.window.trustedTypes.createPolicy(
           trustedTypePolicyName,
-          TrustedTypePolicyOptions(
+          web.TrustedTypePolicyOptions(
             createScriptURL: ((JSString url) => _url).toJS,
           ));
       trustedUrl = policy.createScriptURLNoArgs(_url);

--- a/packages/google_identity_services_web/pubspec.yaml
+++ b/packages/google_identity_services_web/pubspec.yaml
@@ -2,14 +2,14 @@ name: google_identity_services_web
 description: A Dart JS-interop layer for Google Identity Services. Google's new sign-in SDK for Web that supports multiple types of credentials.
 repository: https://github.com/flutter/packages/tree/main/packages/google_identity_services_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_identiy_services_web%22
-version: 0.3.1
+version: 0.3.1+1
 
 environment:
   sdk: ^3.3.0
 
 dependencies:
   meta: ^1.3.0
-  web: ^0.5.0
+  web: ^0.5.1
 
 dev_dependencies:
   path: ^1.8.1

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.6+2
+
+* Uses `TrustedTypes` from `web: ^0.5.1`.
+
 ## 0.5.6+1
 
 * Fixes an issue where `dart:js_interop` object literal factories did not

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/dom_window_extension.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/dom_window_extension.dart
@@ -31,9 +31,9 @@ extension TrustedInnerHTML on web.HTMLElement {
   external set trustedInnerHTML(web.TrustedHTML trustedHTML);
 }
 
-/// Allows creating a script URL only from a string, with no arguments.
+/// Allows creating a TrustedHTML object from a string, with no arguments.
 extension CreateHTMLNoArgs on web.TrustedTypePolicy {
-  /// Allows calling `createScriptURL` with only the `input` argument.
+  /// Allows calling `createHTML` with only the `input` argument.
   @JS('createHTML')
   external web.TrustedHTML createHTMLNoArgs(
     String input,

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/dom_window_extension.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/dom_window_extension.dart
@@ -9,7 +9,6 @@
 library;
 
 import 'dart:js_interop';
-
 import 'package:web/web.dart' as web;
 
 /// This extension gives [web.Window] a nullable getter to the `trustedTypes`
@@ -21,75 +20,22 @@ extension NullableTrustedTypesGetter on web.Window {
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API
   @JS('trustedTypes')
-  external GoogleMapsTrustedTypePolicyFactory? get nullableTrustedTypes;
+  external web.TrustedTypePolicyFactory? get nullableTrustedTypes;
 }
-
-// TODO(ditman): remove this extension type when we depend on package:web 0.5.1
-/// This extension exists as a stop gap until `package:web 0.5.1` is released.
-/// That version provides the `TrustedTypes` API.
-@JS('TrustedTypePolicyFactory')
-extension type GoogleMapsTrustedTypePolicyFactory._(JSObject _)
-    implements JSObject {
-  /// The `TrustedTypePolicy` for Google Maps Flutter.
-  static GoogleMapsTrustedTypePolicy? _policy;
-
-  @JS('createPolicy')
-  external GoogleMapsTrustedTypePolicy _createPolicy(
-    String policyName, [
-    GoogleMapsTrustedTypePolicyOptions policyOptions,
-  ]);
-
-  /// Get a new [GoogleMapsTrustedTypePolicy].
-  ///
-  /// If a policy already exists, it will be returned.
-  /// Otherwise, a new policy is created.
-  ///
-  /// Because of we only cache one _policy, this method
-  /// specifically hardcoded to the GoogleMaps use case.
-  GoogleMapsTrustedTypePolicy getGoogleMapsTrustedTypesPolicy(
-    GoogleMapsTrustedTypePolicyOptions policyOptions,
-  ) {
-    const String policyName = 'google_maps_flutter_sanitize';
-    _policy ??= _createPolicy(policyName, policyOptions);
-
-    return _policy!;
-  }
-}
-
-// TODO(ditman): remove this extension type when we depend on package:web 0.5.1
-/// This extension exists as a stop gap until `package:web 0.5.1` is released.
-/// That version provides the `TrustedTypes` API.
-@JS('TrustedTypePolicy')
-extension type GoogleMapsTrustedTypePolicy._(JSObject _) implements JSObject {
-  /// Create a new `TrustedHTML` instance with the given [input] and [arguments].
-  external GoogleMapsTrustedHTML createHTML(
-    String input,
-    JSAny? arguments,
-  );
-}
-
-// TODO(ditman): remove this extension type when we depend on package:web 0.5.1
-/// This extension exists as a stop gap until `package:web 0.5.1` is released.
-/// That version provides the `TrustedTypes` API.
-@JS('TrustedTypePolicyOptions')
-extension type GoogleMapsTrustedTypePolicyOptions._(JSObject _)
-    implements JSObject {
-  /// Create a new `TrustedTypePolicyOptions` instance.
-  external factory GoogleMapsTrustedTypePolicyOptions({
-    JSFunction createHTML,
-  });
-}
-
-// TODO(ditman): remove this extension type when we depend on package:web 0.5.1
-/// This extension exists as a stop gap until `package:web 0.5.1` is released.
-/// That version provides the `TrustedTypes` API.
-@JS('TrustedHTML')
-extension type GoogleMapsTrustedHTML._(JSObject _) implements JSObject {}
 
 /// This extension provides a setter for the [web.HTMLElement] `innerHTML` property,
 /// that accepts trusted HTML only.
 extension TrustedInnerHTML on web.HTMLElement {
   /// Set the inner HTML of this element to the given [trustedHTML].
   @JS('innerHTML')
-  external set trustedInnerHTML(GoogleMapsTrustedHTML trustedHTML);
+  external set trustedInnerHTML(web.TrustedHTML trustedHTML);
+}
+
+/// Allows creating a script URL only from a string, with no arguments.
+extension CreateHTMLNoArgs on web.TrustedTypePolicy {
+  /// Allows calling `createScriptURL` with only the `input` argument.
+  @JS('createHTML')
+  external web.TrustedHTML createHTMLNoArgs(
+    String input,
+  );
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.5.6+1
+version: 0.5.6+2
 
 environment:
   sdk: ^3.3.0
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: ^2.5.0
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0
-  web: ^0.5.0
+  web: ^0.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
During the `package:web` migration, some packages that needed the TrustedTypes API defined those as custom JS-interop.

In `google_identity_services_web`, the names of the JS-interop types clashed with those from the incoming package:web, breaking the build.

In `google_maps_flutter_web`, the whole definition code is redundant now that the standard API is exposed through package:web.

Part of: https://github.com/flutter/flutter/issues/117022

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
