### PR TITLE
[in_app_purchase_storekit] Handle translation of errors nested in dictionaries

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.13+1
+
+* Handle translation of errors nested in dictionaries.
+
 ## 0.3.13
 
 * Added new native tests for more complete test coverage.

--- a/packages/in_app_purchase/in_app_purchase_storekit/darwin/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/darwin/Classes/FIAObjectTranslator.m
@@ -166,12 +166,11 @@
     return nil;
   }
 
-  NSMutableDictionary *userInfo = [NSMutableDictionary new];
-  for (NSErrorUserInfoKey key in error.userInfo) {
-    id value = error.userInfo[key];
-    userInfo[key] = [FIAObjectTranslator encodeNSErrorUserInfo:value];
-  }
-  return @{@"code" : @(error.code), @"domain" : error.domain ?: @"", @"userInfo" : userInfo};
+  return @{
+    @"code" : @(error.code),
+    @"domain" : error.domain ?: @"",
+    @"userInfo" : [FIAObjectTranslator encodeNSErrorUserInfo:error.userInfo]
+  };
 }
 
 + (id)encodeNSErrorUserInfo:(id)value {
@@ -187,6 +186,12 @@
     NSMutableArray *errors = [[NSMutableArray alloc] init];
     for (id error in value) {
       [errors addObject:[FIAObjectTranslator encodeNSErrorUserInfo:error]];
+    }
+    return errors;
+  } else if ([value isKindOfClass:[NSDictionary class]]) {
+    NSMutableDictionary *errors = [[NSMutableDictionary alloc] init];
+    for (id key in value) {
+      errors[key] = [FIAObjectTranslator encodeNSErrorUserInfo:value[key]];
     }
     return errors;
   } else {

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/TranslatorTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/TranslatorTests.m
@@ -191,7 +191,7 @@
   XCTAssertEqualObjects(expectedMap, map);
 }
 
-- (void)testErrorNestedWithUnderlyingError {
+- (void)testErrorWithNestedUnderlyingError {
   NSError *underlyingError = [NSError errorWithDomain:SKErrorDomain code:2 userInfo:nil];
   NSError *mainError =
       [NSError errorWithDomain:SKErrorDomain

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/TranslatorTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/TranslatorTests.m
@@ -191,6 +191,26 @@
   XCTAssertEqualObjects(expectedMap, map);
 }
 
+- (void)testErrorNestedWithUnderlyingError {
+  NSError *underlyingError = [NSError errorWithDomain:SKErrorDomain code:2 userInfo:nil];
+  NSError *mainError =
+      [NSError errorWithDomain:SKErrorDomain
+                          code:3
+                      userInfo:@{@"nesting" : @{@"underlyingError" : underlyingError}}];
+  NSDictionary *expectedMap = @{
+    @"domain" : SKErrorDomain,
+    @"code" : @3,
+    @"userInfo" : @{
+      @"nesting" : @{
+        @"underlyingError" : @{@"domain" : SKErrorDomain, @"code" : @2, @"userInfo" : @{}},
+
+      }
+    }
+  };
+  NSDictionary *map = [FIAObjectTranslator getMapFromNSError:mainError];
+  XCTAssertEqualObjects(expectedMap, map);
+}
+
 - (void)testErrorWithUnsupportedUserInfo {
   NSError *error = [NSError errorWithDomain:SKErrorDomain
                                        code:3

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS and macOS platforms of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.13
+version: 0.3.13+1
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
The native userInfo object can contain nested dictionaries. Previously this information was lost because `FIAObjectTranslator encodeNSErrorUserInfo` did not handle `NSDictionary`s.

Fixes https://github.com/flutter/flutter/issues/138407

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
