### PR TITLE
[video_player] Added `onScrubbingCallback` to `VideoProgressIndicator`

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.8.4
 
-* Added `onScrubbingCallback` to `VideoProgressIndicator`
+* Adds `onScrubbingCallback` to `VideoProgressIndicator`.
 
 ## 2.8.3
 

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.4
+
+* Added `onScrubbingCallback` to `VideoProgressIndicator`
+
 ## 2.8.3
 
 * Fixes typo in `README.md`.

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -32,7 +32,7 @@ VideoPlayerPlatform get _videoPlayerPlatform {
 }
 
 /// Signature of a callback that returns the current duration after scrubbing through the [VideoProgressIndicator].
-typedef OnScrubbingCallback = void Function(Duration)?;
+typedef OnScrubbingCallback = void Function(Duration);
 
 /// The duration, current position, buffering state, error state and settings
 /// of a [VideoPlayerController].

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -31,6 +31,9 @@ VideoPlayerPlatform get _videoPlayerPlatform {
   return currentInstance;
 }
 
+/// Signature of a callback that returns the current duration after scrubbing through the [VideoProgressIndicator].
+typedef OnScrubbingCallback = void Function(Duration)?;
+
 /// The duration, current position, buffering state, error state and settings
 /// of a [VideoPlayerController].
 @immutable
@@ -916,6 +919,7 @@ class VideoScrubber extends StatefulWidget {
     super.key,
     required this.child,
     required this.controller,
+    this.onScrubbing,
   });
 
   /// The widget that will be displayed inside the gesture detector.
@@ -923,6 +927,9 @@ class VideoScrubber extends StatefulWidget {
 
   /// The [VideoPlayerController] that will be controlled by this scrubber.
   final VideoPlayerController controller;
+
+  /// The callback to return the current duration after scrubbing.
+  final OnScrubbingCallback? onScrubbing;
 
   @override
   State<VideoScrubber> createState() => _VideoScrubberState();
@@ -941,6 +948,9 @@ class _VideoScrubberState extends State<VideoScrubber> {
       final double relative = tapPos.dx / box.size.width;
       final Duration position = controller.value.duration * relative;
       controller.seekTo(position);
+      if (widget.onScrubbing != null) {
+        widget.onScrubbing!(position);
+      }
     }
 
     return GestureDetector(
@@ -996,6 +1006,7 @@ class VideoProgressIndicator extends StatefulWidget {
     super.key,
     this.colors = const VideoProgressColors(),
     required this.allowScrubbing,
+    this.onScrubbing,
     this.padding = const EdgeInsets.only(top: 5.0),
   });
 
@@ -1013,6 +1024,9 @@ class VideoProgressIndicator extends StatefulWidget {
   ///
   /// Defaults to false.
   final bool allowScrubbing;
+
+  /// The callback to return the current duration after scrubbing.
+  final OnScrubbingCallback? onScrubbing;
 
   /// This allows for visual padding around the progress indicator that can
   /// still detect gestures via [allowScrubbing].
@@ -1095,6 +1109,7 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
     if (widget.allowScrubbing) {
       return VideoScrubber(
         controller: controller,
+        onScrubbing: widget.onScrubbing,
         child: paddedProgressIndicator,
       );
     } else {

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.8.3
+version: 2.8.4
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -700,6 +700,38 @@ void main() {
         await controller.pause();
       });
 
+      testWidgets('onScrubbing is called when the controller seeks',
+          (WidgetTester tester) async {
+        final VideoPlayerController controller =
+            VideoPlayerController.networkUrl(_localhostUri);
+
+        Duration? scrubbingDuration;
+        await controller.initialize();
+        final VideoProgressIndicator progressWidget = VideoProgressIndicator(
+          controller,
+          allowScrubbing: true,
+          onScrubbing: (Duration duration) => scrubbingDuration = duration,
+        );
+
+        await tester.pumpWidget(Directionality(
+          textDirection: TextDirection.ltr,
+          child: progressWidget,
+        ));
+
+        await controller.play();
+        expect(controller.value.isPlaying, isTrue);
+
+        final Rect progressRect = tester.getRect(find.byWidget(progressWidget));
+        await tester.dragFrom(progressRect.center, const Offset(1.0, 0.0));
+        await tester.pumpAndSettle();
+
+        expect(controller.value.isPlaying, isTrue);
+        expect(scrubbingDuration, isNotNull);
+        expect(scrubbingDuration, controller.value.position);
+
+        await controller.pause();
+      });
+
       testWidgets('does not restart when dragging to end',
           (WidgetTester tester) async {
         final VideoPlayerController controller =


### PR DESCRIPTION
This pull requests adds `onScrubbingCallback` to `VideoProgressIndicator` widget, as a nullable callback function.

Related issue: https://github.com/flutter/flutter/issues/144777

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.