### PR TITLE
[video_player_web] Add an alternate mode that renders images directly into the canvas

### DIFF
--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+* Adds VideoPlugin.renderVideoAsTexture
+
 ## 2.3.0
 
 * Migrates package and tests to `package:web``.

--- a/packages/video_player/video_player_web/example/integration_test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/example/integration_test/video_player_web_test.dart
@@ -23,7 +23,8 @@ void main() {
     late Future<int> textureId;
 
     setUp(() {
-      VideoPlayerPlatform.instance = VideoPlayerPlugin();
+      VideoPlayerPlatform.instance = VideoPlayerPlugin()
+        ..mode = VideoRenderMode.html;
       textureId = VideoPlayerPlatform.instance
           .create(
             DataSource(

--- a/packages/video_player/video_player_web/lib/src/browser_detection.dart
+++ b/packages/video_player/video_player_web/lib/src/browser_detection.dart
@@ -1,0 +1,83 @@
+import 'package:web/web.dart' as web;
+
+/// Browser detection copied from engine/browser_detection.dart
+
+/// The HTML engine used by the current browser.
+enum BrowserEngine {
+  /// The engine that powers Chrome, Samsung Internet Browser, UC Browser,
+  /// Microsoft Edge, Opera, and others.
+  ///
+  /// Blink is assumed in case when a more precise browser engine wasn't
+  /// detected.
+  blink,
+
+  /// The engine that powers Safari.
+  webkit,
+
+  /// The engine that powers Firefox.
+  firefox,
+}
+
+/// html webgl version qualifier constants.
+abstract class WebGLVersion {
+  /// WebGL 1.0 is based on OpenGL ES 2.0 / GLSL 1.00
+  static const int webgl1 = 1;
+
+  /// WebGL 2.0 is based on OpenGL ES 3.0 / GLSL 3.00
+  static const int webgl2 = 2;
+}
+
+/// Lazily initialized current browser engine.
+final BrowserEngine _browserEngine = _detectBrowserEngine();
+
+/// Override the value of [browserEngine].
+///
+/// Setting this to `null` lets [browserEngine] detect the browser that the
+/// app is running on.
+///
+/// This is intended to be used for testing and debugging only.
+BrowserEngine? debugBrowserEngineOverride;
+
+/// Returns the [BrowserEngine] used by the current browser.
+///
+/// This is used to implement browser-specific behavior.
+BrowserEngine get browserEngine {
+  return debugBrowserEngineOverride ?? _browserEngine;
+}
+
+BrowserEngine _detectBrowserEngine() {
+  final String vendor = web.window.navigator.vendor;
+  final String agent = web.window.navigator.userAgent.toLowerCase();
+  return detectBrowserEngineByVendorAgent(vendor, agent);
+}
+
+/// Detects browser engine for a given vendor and agent string.
+///
+/// Used for testing this library.
+BrowserEngine detectBrowserEngineByVendorAgent(String vendor, String agent) {
+  if (vendor == 'Google Inc.') {
+    return BrowserEngine.blink;
+  } else if (vendor == 'Apple Computer, Inc.') {
+    return BrowserEngine.webkit;
+  } else if (agent.contains('Edg/')) {
+    // Chromium based Microsoft Edge has `Edg` in the user-agent.
+    // https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string
+    return BrowserEngine.blink;
+  } else if (vendor == '' && agent.contains('firefox')) {
+    // An empty string means firefox:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor
+    return BrowserEngine.firefox;
+  }
+
+  // Assume Blink otherwise, but issue a warning.
+  // ignore: avoid_print
+  print(
+      'WARNING: failed to detect current browser engine. Assuming this is a Chromium-compatible browser.');
+  return BrowserEngine.blink;
+}
+
+/// Whether the current browser is Safari.
+bool get isSafari => browserEngine == BrowserEngine.webkit;
+
+/// Whether the current browser is Firefox.
+bool get isFirefox => browserEngine == BrowserEngine.firefox;

--- a/packages/video_player/video_player_web/lib/src/video_player.dart
+++ b/packages/video_player/video_player_web/lib/src/video_player.dart
@@ -349,4 +349,9 @@ class VideoPlayer {
     }
     return durationRange;
   }
+
+  /// Returns the [web.HTMLVideoElement] associated with this player
+  web.HTMLVideoElement get videoElement {
+    return _videoElement;
+  }
 }

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -14,8 +14,8 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
 import 'package:web/web.dart' as web;
 
-import 'src/video_player.dart';
 import 'src/browser_detection.dart';
+import 'src/video_player.dart';
 
 /// The web implementation of [VideoPlayerPlatform].
 ///

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
 import 'dart:js_util';
 import 'dart:math';
 import 'dart:ui' as ui;
@@ -212,8 +211,7 @@ class _AdapterVideoPlayerRendererState
   }
 
   bool get rendererCanvasKit {
-    final JSAny? r = web.window.getProperty('flutterCanvasKit'.toJS);
-    return r != null;
+    return hasProperty(web.window, 'flutterCanvasKit');
   }
 
   @override

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -15,6 +15,7 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 import 'package:web/web.dart' as web;
 
 import 'src/video_player.dart';
+import 'src/browser_detection.dart';
 
 /// The web implementation of [VideoPlayerPlatform].
 ///
@@ -239,7 +240,7 @@ class _AdapterVideoPlayerRendererState
     final web.HTMLVideoElement element = widget.player.videoElement;
     isPlaying = !!(!element.paused && !element.ended && element.readyState > 2);
 
-    if (isPlaying) {
+    if (isPlaying && (isSafari || isFirefox)) {
       desiredMode = VideoRenderMode.canvas;
     } else {
       desiredMode = VideoRenderMode.texture;

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -95,8 +95,11 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
       ..style.border = 'none'
       ..style.height = '100%'
       ..style.width = '100%'
-      ..style.pointerEvents = 'none'
-      ..crossOrigin = 'anonymous';
+      ..style.pointerEvents = 'none';
+
+    if (mode != VideoRenderMode.html) {
+      videoElement.crossOrigin = 'anonymous';
+    }
 
     return videoElement;
   }

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -220,12 +220,13 @@ class _WebVideoPlayerRendererState extends State<_WebVideoPlayerRenderer> {
   int? callbackID;
 
   void getFrame(web.HTMLVideoElement element) {
-    callbackID = element.requestVideoFrameCallback(frameCallback.toJS);
+    callbackID =
+        element.requestVideoFrameCallbackWithFallback(frameCallback.toJS);
   }
 
   void cancelFrame(web.HTMLVideoElement element) {
     if (callbackID != null) {
-      element.cancelVideoFrameCallback(callbackID!);
+      element.cancelVideoFrameCallbackWithFallback(callbackID!);
     }
   }
 
@@ -289,6 +290,25 @@ extension _createImageBitmap on web.Window {
 }
 
 extension _HTMLVideoElementRequestAnimationFrame on web.HTMLVideoElement {
+  int requestVideoFrameCallbackWithFallback(
+      _VideoFrameRequestCallback callback) {
+    if (hasProperty(this, "requestVideoFrameCallback")) {
+      return requestVideoFrameCallback(callback);
+    } else {
+      return web.window.requestAnimationFrame((double num) {
+        callback.callAsFunction(this, 0.toJS, 0.toJS);
+      }.toJS);
+    }
+  }
+
+  void cancelVideoFrameCallbackWithFallback(int callbackID) {
+    if (hasProperty(this, "requestVideoFrameCallback")) {
+      cancelVideoFrameCallback(callbackID);
+    } else {
+      web.window.cancelAnimationFrame(callbackID);
+    }
+  }
+
   external int requestVideoFrameCallback(_VideoFrameRequestCallback callback);
   external void cancelVideoFrameCallback(int callbackID);
 }

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -234,15 +234,20 @@ class _WebVideoPlayerRendererState extends State<_WebVideoPlayerRenderer> {
     capture();
   }
 
+  web.ImageBitmap? source;
+
   Future<void> capture() async {
-    final tmp =
-        await promiseToFuture(web.window.createImageBitmap(widget.element));
-    final ui.Image img = await ui_web.createImageFromImageBitmap(tmp);
+    final newSource =
+        await promiseToFuture(web.window.createImageBitmap(widget.element))
+            as web.ImageBitmap;
+    final ui.Image img = await ui_web.createImageFromImageBitmap(newSource!);
 
     if (mounted) {
       setState(() {
         image?.dispose();
+        source?.close();
         image = img;
+        source = newSource;
       });
       getFrame(widget.element);
     }
@@ -253,6 +258,7 @@ class _WebVideoPlayerRendererState extends State<_WebVideoPlayerRenderer> {
     cancelFrame(widget.element);
     super.dispose();
     image?.dispose();
+    source?.close();
     if (web.document.body!.contains(widget.element)) {
       web.document.body!.removeChild(widget.element);
     }

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -214,6 +214,7 @@ class _WebVideoPlayerRendererState extends State<_WebVideoPlayerRenderer> {
 
     if (mounted) {
       setState(() {
+        image?.dispose();
         image = img;
       });
       getFrame(widget.element);
@@ -224,6 +225,7 @@ class _WebVideoPlayerRendererState extends State<_WebVideoPlayerRenderer> {
   void dispose() {
     cancelFrame(widget.element);
     super.dispose();
+    image?.dispose();
     if (web.document.body!.contains(widget.element)) {
       web.document.body!.removeChild(widget.element);
     }

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.0
+version: 2.4.0
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
This allows the web video player to avoid issues relating to having too many active overlaygroups. When this mode is enabled as follows:

```dart
VideoPlayerPlugin.renderVideoAsTexture = true;`
```

The video player will use createImageFromImageBitmap to grab frames as they are available and render them using RawImage instead.

Fixes:

https://github.com/flutter/flutter/issues/144591

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ X ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ X ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ X] I signed the [CLA].
- [ X ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ X ] I [linked to at least one issue that this PR fixes] in the description above.
- [ X ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ X ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ X ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ X ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
