### PR TITLE
Update multiple packages to depend on versions with iOS privacy manifest included

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,9 +1,10 @@
-## NEXT
+## 1.0.8
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 * Updates support matrix in README to indicate that iOS 11 is no longer supported.
 * Clients on versions of Flutter that still support iOS 11 can continue to use this
   package with iOS 11, but will not receive any further updates to the iOS implementation.
+* Updates minimum iOS implementation version to include a privacy manifest.
 
 ## 1.0.7
 

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 1.0.7
+version: 1.0.8
 
 environment:
   sdk: ^3.1.0
@@ -30,7 +30,7 @@ dependencies:
     sdk: flutter
   image_picker_android: ^0.8.7
   image_picker_for_web: ">=2.2.0 <4.0.0"
-  image_picker_ios: ^0.8.8
+  image_picker_ios: ^0.8.9+1
   image_picker_linux: ^0.2.1
   image_picker_macos: ^0.2.1
   image_picker_platform_interface: ^2.8.0

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,9 +1,10 @@
-## NEXT
+## 2.1.3
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 * Updates support matrix in README to indicate that iOS 11 is no longer supported.
 * Clients on versions of Flutter that still support iOS 11 can continue to use this
   package with iOS 11, but will not receive any further updates to the iOS implementation.
+* Updates minimum iOS implementation version to include a privacy manifest.
 
 ## 2.1.2
 

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: ^3.1.0
@@ -26,7 +26,7 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider_android: ^2.1.0
-  path_provider_foundation: ^2.3.0
+  path_provider_foundation: ^2.3.2
   path_provider_linux: ^2.2.0
   path_provider_platform_interface: ^2.1.0
   path_provider_windows: ^2.2.0

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,10 +1,11 @@
-## NEXT
+## 2.2.3
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 * Updates support matrix in README to indicate that iOS 11 is no longer supported.
 * Clients on versions of Flutter that still support iOS 11 can continue to use this
   package with iOS 11, but will not receive any further updates to the iOS implementation.
 * Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Updates minimum iOS implementation version to include a privacy manifest.
 
 ## 2.2.2
 

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.2.2
+version: 2.2.3
 
 environment:
   sdk: ^3.1.0
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences_android: ^2.1.0
-  shared_preferences_foundation: ^2.2.0
+  shared_preferences_foundation: ^2.3.5
   shared_preferences_linux: ^2.2.0
   shared_preferences_platform_interface: ^2.3.0
   shared_preferences_web: ^2.1.0

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.6
+
+* Updates minimum iOS implementation version to include a privacy manifest.
+
 ## 6.2.5
 
 * Removes use of deprecated `renderView` API.

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.2.5
+version: 6.2.6
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
   url_launcher_android: ^6.2.0
-  url_launcher_ios: ^6.2.0
+  url_launcher_ios: ^6.2.4
   # Allow either the pure-native or Dart/native hybrid versions of the desktop
   # implementations, as both are compatible.
   url_launcher_linux: ^3.1.0

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.8.6
+
+* Updates minimum iOS implementation version to include a privacy manifest.
+* Updates minimum supported SDK version to Flutter 3.16.6/Dart 3.2.3.
+
 ## 2.8.5
 
 * Updates example to call `super.dispose()` last.

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,11 +3,11 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.8.5
+version: 2.8.6
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ">=3.2.3 <4.0.0"
+  flutter: ">=3.16.6"
 
 flutter:
   plugin:
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   html: ^0.15.0
   video_player_android: ^2.3.5
-  video_player_avfoundation: ^2.5.0
+  video_player_avfoundation: ^2.5.6
   video_player_platform_interface: ">=6.1.0 <7.0.0"
   video_player_web: ^2.0.0
 


### PR DESCRIPTION
Updated multiple packages `pubspec.yaml` to depend on iOS implementation versions that include privacy manifest required by Apple. I touched packages that were referenced in https://github.com/flutter/flutter/issues/131940 issue. 
The reason to do this change is that in a few projects I noticed that updating `url_launcher` dependency to the currently latest 6.2.5 doesn't also update `url_launcher_ios` to version with privacy manifest (appeared in 6.2.4) included in the plugin's `pubspec.yaml` it is declared as `^6.2.0`, thus, version resolution picks 6.2.0 and that is it.

Considering that there is already a deadline of May 1, 2024 from Apple on when apps would have to include privacy manifests, it would be good to let devs already prepare their projects. This change should be especially useful for `shared_preferences`, which has `NSPrivacyAccessedAPITypes` array declared in its privacy manifest and which is already asked by Apple in emails after uploading new builds:

<img width="681" alt="Screenshot 2024-03-19 at 12 36 47" src="https://github.com/flutter/packages/assets/13467769/c81e5a15-86d8-4270-aafe-845679fc901b">

Didn't update changelogs due to the fact that plugins stayed in almost the same versions range, where those minor changes to iOS part had no serious changed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
