### PR TITLE
[camera_web] Don't require enumerating cameras on web

### DIFF
--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -376,7 +376,13 @@ class CameraController extends ValueNotifier<CameraValue> {
             .then((CameraInitializedEvent event) => event.focusPointSupported),
       );
     } on PlatformException catch (e) {
+      _unawaited(_deviceOrientationSubscription?.cancel());
+      _cameraId = kUninitializedCameraId;
       throw CameraException(e.code, e.message);
+    } catch (e) {
+      _unawaited(_deviceOrientationSubscription?.cancel());
+      _cameraId = kUninitializedCameraId;
+      rethrow;
     } finally {
       initializeCompleter.complete();
     }
@@ -880,8 +886,10 @@ class CameraController extends ValueNotifier<CameraValue> {
     _unawaited(_deviceOrientationSubscription?.cancel());
     _isDisposed = true;
     super.dispose();
-    if (_initializeFuture != null) {
-      await _initializeFuture;
+    if (_initializeFuture == null) {
+      return;
+    }
+    if (_cameraId != kUninitializedCameraId) {
       await CameraPlatform.instance.dispose(_cameraId);
     }
   }

--- a/packages/camera/camera_web/example/integration_test/camera_error_code_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_error_code_test.dart
@@ -72,13 +72,6 @@ void main() {
         );
       });
 
-      testWidgets('missingMetadata', (WidgetTester tester) async {
-        expect(
-          CameraErrorCode.missingMetadata.toString(),
-          equals('cameraMissingMetadata'),
-        );
-      });
-
       testWidgets('orientationNotSupported', (WidgetTester tester) async {
         expect(
           CameraErrorCode.orientationNotSupported.toString(),

--- a/packages/camera/camera_web/example/integration_test/camera_service_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_service_test.dart
@@ -661,7 +661,7 @@ void main() {
           'returns front '
           'when the facing mode is user', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToLensDirection('user'),
+          mapFacingModeToLensDirection('user'),
           equals(CameraLensDirection.front),
         );
       });
@@ -670,7 +670,7 @@ void main() {
           'returns back '
           'when the facing mode is environment', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToLensDirection('environment'),
+          mapFacingModeToLensDirection('environment'),
           equals(CameraLensDirection.back),
         );
       });
@@ -679,7 +679,7 @@ void main() {
           'returns external '
           'when the facing mode is left', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToLensDirection('left'),
+          mapFacingModeToLensDirection('left'),
           equals(CameraLensDirection.external),
         );
       });
@@ -688,7 +688,7 @@ void main() {
           'returns external '
           'when the facing mode is right', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToLensDirection('right'),
+          mapFacingModeToLensDirection('right'),
           equals(CameraLensDirection.external),
         );
       });
@@ -699,7 +699,7 @@ void main() {
           'returns user '
           'when the facing mode is user', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToCameraType('user'),
+          mapFacingModeToCameraType('user'),
           equals(CameraType.user),
         );
       });
@@ -708,7 +708,7 @@ void main() {
           'returns environment '
           'when the facing mode is environment', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToCameraType('environment'),
+          mapFacingModeToCameraType('environment'),
           equals(CameraType.environment),
         );
       });
@@ -717,7 +717,7 @@ void main() {
           'returns user '
           'when the facing mode is left', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToCameraType('left'),
+          mapFacingModeToCameraType('left'),
           equals(CameraType.user),
         );
       });
@@ -726,7 +726,7 @@ void main() {
           'returns user '
           'when the facing mode is right', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToCameraType('right'),
+          mapFacingModeToCameraType('right'),
           equals(CameraType.user),
         );
       });
@@ -737,7 +737,7 @@ void main() {
           'returns 4096x2160 '
           'when the resolution preset is max', (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.max),
+          mapResolutionPresetToSize(ResolutionPreset.max),
           equals(const Size(4096, 2160)),
         );
       });
@@ -747,7 +747,7 @@ void main() {
           'when the resolution preset is ultraHigh',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
+          mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
           equals(const Size(4096, 2160)),
         );
       });
@@ -757,7 +757,7 @@ void main() {
           'when the resolution preset is veryHigh',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.veryHigh),
+          mapResolutionPresetToSize(ResolutionPreset.veryHigh),
           equals(const Size(1920, 1080)),
         );
       });
@@ -766,7 +766,7 @@ void main() {
           'returns 1280x720 '
           'when the resolution preset is high', (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.high),
+          mapResolutionPresetToSize(ResolutionPreset.high),
           equals(const Size(1280, 720)),
         );
       });
@@ -775,7 +775,7 @@ void main() {
           'returns 720x480 '
           'when the resolution preset is medium', (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.medium),
+          mapResolutionPresetToSize(ResolutionPreset.medium),
           equals(const Size(720, 480)),
         );
       });
@@ -784,7 +784,7 @@ void main() {
           'returns 320x240 '
           'when the resolution preset is low', (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.low),
+          mapResolutionPresetToSize(ResolutionPreset.low),
           equals(const Size(320, 240)),
         );
       });
@@ -796,7 +796,7 @@ void main() {
           'when the device orientation is portraitUp',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapDeviceOrientationToOrientationType(
+          mapDeviceOrientationToOrientationType(
             DeviceOrientation.portraitUp,
           ),
           equals(OrientationType.portraitPrimary),
@@ -808,7 +808,7 @@ void main() {
           'when the device orientation is landscapeLeft',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapDeviceOrientationToOrientationType(
+          mapDeviceOrientationToOrientationType(
             DeviceOrientation.landscapeLeft,
           ),
           equals(OrientationType.landscapePrimary),
@@ -820,7 +820,7 @@ void main() {
           'when the device orientation is portraitDown',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapDeviceOrientationToOrientationType(
+          mapDeviceOrientationToOrientationType(
             DeviceOrientation.portraitDown,
           ),
           equals(OrientationType.portraitSecondary),
@@ -832,7 +832,7 @@ void main() {
           'when the device orientation is landscapeRight',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapDeviceOrientationToOrientationType(
+          mapDeviceOrientationToOrientationType(
             DeviceOrientation.landscapeRight,
           ),
           equals(OrientationType.landscapeSecondary),
@@ -846,7 +846,7 @@ void main() {
           'when the orientation type is portraitPrimary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitPrimary,
           ),
           equals(DeviceOrientation.portraitUp),
@@ -858,7 +858,7 @@ void main() {
           'when the orientation type is landscapePrimary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.landscapePrimary,
           ),
           equals(DeviceOrientation.landscapeLeft),
@@ -870,7 +870,7 @@ void main() {
           'when the orientation type is portraitSecondary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitSecondary,
           ),
           equals(DeviceOrientation.portraitDown),
@@ -882,7 +882,7 @@ void main() {
           'when the orientation type is portraitSecondary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitSecondary,
           ),
           equals(DeviceOrientation.portraitDown),
@@ -894,7 +894,7 @@ void main() {
           'when the orientation type is landscapeSecondary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.landscapeSecondary,
           ),
           equals(DeviceOrientation.landscapeRight),
@@ -905,7 +905,7 @@ void main() {
           'returns portraitUp '
           'for an unknown orientation type', (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             'unknown',
           ),
           equals(DeviceOrientation.portraitUp),

--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -897,12 +897,9 @@ void main() {
         when(firstVideoTrack.getSettings)
             .thenReturn(<dynamic, dynamic>{'facingMode': 'environment'});
 
-        when(() => cameraService.mapFacingModeToLensDirection('environment'))
-            .thenReturn(CameraLensDirection.external);
-
         expect(
           camera.getLensDirection(),
-          equals(CameraLensDirection.external),
+          equals(mapFacingModeToLensDirection('environment')),
         );
       });
 

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -64,7 +64,7 @@ void main() {
       when(
         () => cameraService.getMediaStreamForOptions(
           any(),
-          cameraId: any(named: 'cameraId'),
+          cameraId: any(),
         ),
       ).thenAnswer(
         (_) async => videoElement.captureStream(),

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -638,40 +638,53 @@ void main() {
               maxResolutionSize.height.toInt());
           expect(camera.options.video.deviceId, cameraMetadata.deviceId);
         });
-      });
 
-      testWidgets(
-          'throws CameraException '
-          'with missingMetadata error '
-          'if there is no metadata '
-          'for the given camera description', (WidgetTester tester) async {
-        expect(
-          () => CameraPlatform.instance.createCamera(
+        testWidgets(
+            'if there is no metadata '
+            'for the given camera description', (WidgetTester tester) async {
+          when(
+            () => mapResolutionPresetToSize(ResolutionPreset.max),
+          ).thenReturn(maxResolutionSize);
+
+          final int cameraId = await CameraPlatform.instance.createCamera(
             const CameraDescription(
               name: 'name',
               lensDirection: CameraLensDirection.back,
               sensorOrientation: 0,
             ),
             ResolutionPreset.ultraHigh,
-          ),
-          throwsA(
-            isA<CameraException>().having(
-              (CameraException e) => e.code,
-              'code',
-              CameraErrorCode.missingMetadata.toString(),
+          );
+          expect(
+            (CameraPlatform.instance as CameraPlugin).cameras[cameraId],
+            isA<Camera>().having(
+              (Camera camera) => camera.options,
+              'options',
+              CameraOptions(
+                audio: const AudioConstraints(),
+                video: VideoConstraints(
+                  facingMode: FacingModeConstraint(CameraType.user),
+                  width: VideoSizeConstraint(
+                    ideal: maxResolutionSize.width.toInt(),
+                  ),
+                  height: VideoSizeConstraint(
+                    ideal: maxResolutionSize.height.toInt(),
+                  ),
+                ),
+              ),
             ),
-          ),
-        );
-      });
+          );
+        });
 
-      testWidgets(
-          'throws CameraException '
-          'with missingMetadata error '
-          'if there is no metadata '
-          'for the given camera description '
-          'using createCameraWithSettings', (WidgetTester tester) async {
-        expect(
-          () => CameraPlatform.instance.createCameraWithSettings(
+        testWidgets(
+            'if there is no metadata '
+            'for the given camera description '
+            'using createCameraWithSettings', (WidgetTester tester) async {
+          when(
+            () => mapResolutionPresetToSize(ResolutionPreset.max),
+          ).thenReturn(maxResolutionSize);
+
+          final int cameraId =
+              await CameraPlatform.instance.createCameraWithSettings(
             const CameraDescription(
               name: 'name',
               lensDirection: CameraLensDirection.back,
@@ -684,15 +697,27 @@ void main() {
               audioBitrate: 32000,
               enableAudio: true,
             ),
-          ),
-          throwsA(
-            isA<CameraException>().having(
-              (CameraException e) => e.code,
-              'code',
-              CameraErrorCode.missingMetadata.toString(),
+          );
+          expect(
+            (CameraPlatform.instance as CameraPlugin).cameras[cameraId],
+            isA<Camera>().having(
+              (Camera camera) => camera.options,
+              'options',
+              CameraOptions(
+                audio: const AudioConstraints(),
+                video: VideoConstraints(
+                  facingMode: FacingModeConstraint(CameraType.user),
+                  width: VideoSizeConstraint(
+                    ideal: maxResolutionSize.width.toInt(),
+                  ),
+                  height: VideoSizeConstraint(
+                    ideal: maxResolutionSize.height.toInt(),
+                  ),
+                ),
+              ),
             ),
-          ),
-        );
+          );
+        });
       });
     });
 

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -295,7 +295,7 @@ void main() {
           ),
         ).thenReturn('user');
 
-        when(() => cameraService.mapFacingModeToLensDirection('user'))
+        when(() => mapFacingModeToLensDirection('user'))
             .thenReturn(CameraLensDirection.front);
 
         // Mock camera service to return an environment facing mode
@@ -306,7 +306,7 @@ void main() {
           ),
         ).thenReturn('environment');
 
-        when(() => cameraService.mapFacingModeToLensDirection('environment'))
+        when(() => mapFacingModeToLensDirection('environment'))
             .thenReturn(CameraLensDirection.back);
 
         final List<CameraDescription> cameras =
@@ -360,7 +360,7 @@ void main() {
           ),
         ).thenReturn('left');
 
-        when(() => cameraService.mapFacingModeToLensDirection('left'))
+        when(() => mapFacingModeToLensDirection('left'))
             .thenReturn(CameraLensDirection.external);
 
         final CameraDescription camera =
@@ -518,14 +518,13 @@ void main() {
               .camerasMetadata[cameraDescription] = cameraMetadata;
 
           when(
-            () => cameraService.mapFacingModeToCameraType('user'),
+            () => mapFacingModeToCameraType('user'),
           ).thenReturn(CameraType.user);
         });
 
         testWidgets('with appropriate options', (WidgetTester tester) async {
           when(
-            () => cameraService
-                .mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
+            () => mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
           ).thenReturn(ultraHighResolutionSize);
 
           final int cameraId = await CameraPlatform.instance.createCamera(
@@ -552,8 +551,7 @@ void main() {
         testWidgets('with appropriate createCameraWithSettings options',
             (WidgetTester tester) async {
           when(
-            () => cameraService
-                .mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
+            () => mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
           ).thenReturn(ultraHighResolutionSize);
 
           final int cameraId =
@@ -587,7 +585,7 @@ void main() {
             'and enabled audio set to false '
             'when no options are specified', (WidgetTester tester) async {
           when(
-            () => cameraService.mapResolutionPresetToSize(ResolutionPreset.max),
+            () => mapResolutionPresetToSize(ResolutionPreset.max),
           ).thenReturn(maxResolutionSize);
 
           final int cameraId = await CameraPlatform.instance.createCamera(
@@ -616,7 +614,7 @@ void main() {
             'when no options are specified '
             'using createCameraWithSettings', (WidgetTester tester) async {
           when(
-            () => cameraService.mapResolutionPresetToSize(ResolutionPreset.max),
+            () => mapResolutionPresetToSize(ResolutionPreset.max),
           ).thenReturn(maxResolutionSize);
 
           final int cameraId =
@@ -835,7 +833,7 @@ void main() {
     group('lockCaptureOrientation', () {
       setUp(() {
         when(
-          () => cameraService.mapDeviceOrientationToOrientationType(any()),
+          () => mapDeviceOrientationToOrientationType(any()),
         ).thenReturn(OrientationType.portraitPrimary);
       });
 
@@ -854,7 +852,7 @@ void main() {
           'locks the capture orientation '
           'based on the given device orientation', (WidgetTester tester) async {
         when(
-          () => cameraService.mapDeviceOrientationToOrientationType(
+          () => mapDeviceOrientationToOrientationType(
             DeviceOrientation.landscapeRight,
           ),
         ).thenReturn(OrientationType.landscapeSecondary);
@@ -865,7 +863,7 @@ void main() {
         );
 
         verify(
-          () => cameraService.mapDeviceOrientationToOrientationType(
+          () => mapDeviceOrientationToOrientationType(
             DeviceOrientation.landscapeRight,
           ),
         ).called(1);
@@ -967,7 +965,7 @@ void main() {
     group('unlockCaptureOrientation', () {
       setUp(() {
         when(
-          () => cameraService.mapDeviceOrientationToOrientationType(any()),
+          () => mapDeviceOrientationToOrientationType(any()),
         ).thenReturn(OrientationType.portraitPrimary);
       });
 
@@ -3059,7 +3057,7 @@ void main() {
         testWidgets('emits the initial DeviceOrientationChangedEvent',
             (WidgetTester tester) async {
           when(
-            () => cameraService.mapOrientationTypeToDeviceOrientation(
+            () => mapOrientationTypeToDeviceOrientation(
               OrientationType.portraitPrimary,
             ),
           ).thenReturn(DeviceOrientation.portraitUp);
@@ -3097,13 +3095,13 @@ void main() {
             'when the screen orientation is changed',
             (WidgetTester tester) async {
           when(
-            () => cameraService.mapOrientationTypeToDeviceOrientation(
+            () => mapOrientationTypeToDeviceOrientation(
               OrientationType.landscapePrimary,
             ),
           ).thenReturn(DeviceOrientation.landscapeLeft);
 
           when(
-            () => cameraService.mapOrientationTypeToDeviceOrientation(
+            () => mapOrientationTypeToDeviceOrientation(
               OrientationType.portraitSecondary,
             ),
           ).thenReturn(DeviceOrientation.portraitDown);

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -426,7 +426,7 @@ class Camera {
         defaultVideoTrackSettings['facingMode'] as String?;
 
     if (facingMode != null) {
-      return _cameraService.mapFacingModeToLensDirection(facingMode);
+      return mapFacingModeToLensDirection(facingMode);
     } else {
       return null;
     }

--- a/packages/camera/camera_web/lib/src/camera_service.dart
+++ b/packages/camera/camera_web/lib/src/camera_service.dart
@@ -288,6 +288,20 @@ CameraType mapFacingModeToCameraType(String facingMode) {
   }
 }
 
+/// Maps the given [lensDirection] to [CameraType].
+///
+/// See [CameraMetadata.facingMode] for more details.
+CameraType mapLensDirectionToCameraType(CameraLensDirection lensDirection) {
+  switch (lensDirection) {
+    case CameraLensDirection.front:
+      return CameraType.user;
+    case CameraLensDirection.back:
+      return CameraType.environment;
+    case CameraLensDirection.external:
+      return CameraType.user;
+  }
+}
+
 /// Maps the given [resolutionPreset] to [Size].
 Size mapResolutionPresetToSize(ResolutionPreset resolutionPreset) {
   switch (resolutionPreset) {

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -43,6 +43,7 @@ class CameraPlugin extends CameraPlatform {
   @visibleForTesting
   final Map<int, Camera> cameras = <int, Camera>{};
   int _textureCounter = 1;
+  List<CameraDescription>? _availableCameras;
 
   /// Metadata associated with each camera description.
   /// Populated in [availableCameras].
@@ -81,48 +82,60 @@ class CameraPlugin extends CameraPlatform {
   @visibleForTesting
   html.Window? window = html.window;
 
+  Future<List<html.MediaDeviceInfo>> _videoInputDevices() async {
+    final html.MediaDevices? mediaDevices = window?.navigator.mediaDevices;
+
+    // Throw a not supported exception if the current browser window
+    // does not support any media devices.
+    if (mediaDevices == null) {
+      throw PlatformException(
+        code: CameraErrorCode.notSupported.toString(),
+        message: 'The camera is not supported on this device.',
+      );
+    }
+
+    // Request available media devices.
+    final List<dynamic> devices = await mediaDevices.enumerateDevices();
+
+    // Filter video input devices.
+    final Iterable<html.MediaDeviceInfo> videoInputDevices = devices
+        .whereType<html.MediaDeviceInfo>()
+        .where((html.MediaDeviceInfo device) =>
+            device.kind == MediaDeviceKind.videoInput)
+
+        /// The device id property is currently not supported on Internet Explorer:
+        /// https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo/deviceId#browser_compatibility
+        .where(
+          (html.MediaDeviceInfo device) =>
+              device.deviceId != null && device.deviceId!.isNotEmpty,
+        );
+
+    return videoInputDevices.toList();
+  }
+
   @override
   Future<List<CameraDescription>> availableCameras() async {
+    if (_availableCameras != null) {
+      return _availableCameras!;
+    }
     try {
-      final html.MediaDevices? mediaDevices = window?.navigator.mediaDevices;
-      final List<CameraDescription> cameras = <CameraDescription>[];
+      final List<CameraDescription> cameraDescriptions = <CameraDescription>[];
 
-      // Throw a not supported exception if the current browser window
-      // does not support any media devices.
-      if (mediaDevices == null) {
-        throw PlatformException(
-          code: CameraErrorCode.notSupported.toString(),
-          message: 'The camera is not supported on this device.',
-        );
+      final bool hasPermission = cameras.isNotEmpty;
+      if (!hasPermission) {
+        // Request video permissions only.
+        final html.MediaStream cameraStream = await _cameraService
+            .getMediaStreamForOptions(const CameraOptions());
+
+        // Release the camera stream used to request video permissions.
+        cameraStream
+            .getVideoTracks()
+            .forEach((html.MediaStreamTrack videoTrack) => videoTrack.stop());
       }
 
-      // Request video permissions only.
-      final html.MediaStream cameraStream =
-          await _cameraService.getMediaStreamForOptions(const CameraOptions());
-
-      // Release the camera stream used to request video permissions.
-      cameraStream
-          .getVideoTracks()
-          .forEach((html.MediaStreamTrack videoTrack) => videoTrack.stop());
-
-      // Request available media devices.
-      final List<dynamic> devices = await mediaDevices.enumerateDevices();
-
-      // Filter video input devices.
-      final Iterable<html.MediaDeviceInfo> videoInputDevices = devices
-          .whereType<html.MediaDeviceInfo>()
-          .where((html.MediaDeviceInfo device) =>
-              device.kind == MediaDeviceKind.videoInput)
-
-          /// The device id property is currently not supported on Internet Explorer:
-          /// https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo/deviceId#browser_compatibility
-          .where(
-            (html.MediaDeviceInfo device) =>
-                device.deviceId != null && device.deviceId!.isNotEmpty,
-          );
-
       // Map video input devices to camera descriptions.
-      for (final html.MediaDeviceInfo videoInputDevice in videoInputDevices) {
+      for (final html.MediaDeviceInfo videoInputDevice
+          in await _videoInputDevices()) {
         // Get the video stream for the current video input device
         // to later use for the available video tracks.
         final html.MediaStream videoStream = await _getVideoStreamForDevice(
@@ -134,54 +147,57 @@ class CameraPlugin extends CameraPlatform {
         final List<html.MediaStreamTrack> videoTracks =
             videoStream.getVideoTracks();
 
-        if (videoTracks.isNotEmpty) {
-          // Get the facing mode from the first available video track.
-          final String? facingMode =
-              _cameraService.getFacingModeForVideoTrack(videoTracks.first);
+        if (videoTracks.isEmpty) {
+          // Ignore as no video tracks exist in the current video input device.
+          continue;
+        }
 
-          // Get the lens direction based on the facing mode.
-          // Fallback to the external lens direction
-          // if the facing mode is not available.
-          final CameraLensDirection lensDirection = facingMode != null
-              ? mapFacingModeToLensDirection(facingMode)
-              : CameraLensDirection.external;
+        // Get the facing mode from the first available video track.
+        final String? facingMode =
+            _cameraService.getFacingModeForVideoTrack(videoTracks.first);
 
-          // Create a camera description.
-          //
-          // The name is a camera label which might be empty
-          // if no permissions to media devices have been granted.
-          //
-          // MediaDeviceInfo.label:
-          // https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo/label
-          //
-          // Sensor orientation is currently not supported.
-          final String cameraLabel = videoInputDevice.label ?? '';
-          final CameraDescription camera = CameraDescription(
-            name: cameraLabel,
-            lensDirection: lensDirection,
-            sensorOrientation: 0,
-          );
+        // Get the lens direction based on the facing mode.
+        // Fallback to the external lens direction
+        // if the facing mode is not available.
+        final CameraLensDirection lensDirection = facingMode != null
+            ? mapFacingModeToLensDirection(facingMode)
+            : CameraLensDirection.external;
 
-          final CameraMetadata cameraMetadata = CameraMetadata(
-            deviceId: videoInputDevice.deviceId!,
-            facingMode: facingMode,
-          );
+        // Create a camera description.
+        //
+        // The name is a camera label which might be empty
+        // if no permissions to media devices have been granted.
+        //
+        // MediaDeviceInfo.label:
+        // https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo/label
+        //
+        // Sensor orientation is currently not supported.
+        final String cameraLabel = videoInputDevice.label ?? '';
+        final CameraDescription camera = CameraDescription(
+          name: cameraLabel,
+          lensDirection: lensDirection,
+          sensorOrientation: 0,
+        );
 
-          cameras.add(camera);
+        final CameraMetadata cameraMetadata = CameraMetadata(
+          deviceId: videoInputDevice.deviceId!,
+          facingMode: facingMode,
+        );
 
-          camerasMetadata[camera] = cameraMetadata;
+        cameraDescriptions.add(camera);
 
+        camerasMetadata[camera] = cameraMetadata;
+
+        if (!hasPermission) {
           // Release the camera stream of the current video input device.
           for (final html.MediaStreamTrack videoTrack in videoTracks) {
             videoTrack.stop();
           }
-        } else {
-          // Ignore as no video tracks exist in the current video input device.
-          continue;
         }
       }
 
-      return cameras;
+      _availableCameras = cameraDescriptions;
+      return cameraDescriptions;
     } on html.DomException catch (e) {
       throw CameraException(e.name, e.message);
     } on PlatformException catch (e) {

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -211,21 +211,14 @@ class CameraPlugin extends CameraPlatform {
     MediaSettings? mediaSettings,
   ) async {
     try {
-      if (!camerasMetadata.containsKey(cameraDescription)) {
-        throw PlatformException(
-          code: CameraErrorCode.missingMetadata.toString(),
-          message:
-              'Missing camera metadata. Make sure to call `availableCameras` before creating a camera.',
-        );
-      }
-
       final int textureId = _textureCounter++;
 
-      final CameraMetadata cameraMetadata = camerasMetadata[cameraDescription]!;
+      final CameraMetadata? cameraMetadata = camerasMetadata[cameraDescription];
 
-      final CameraType? cameraType = cameraMetadata.facingMode != null
-          ? mapFacingModeToCameraType(cameraMetadata.facingMode!)
-          : null;
+      final String? facingMode = cameraMetadata?.facingMode;
+      final CameraType cameraType = facingMode != null
+          ? mapFacingModeToCameraType(facingMode)
+          : mapLensDirectionToCameraType(cameraDescription.lensDirection);
 
       // Use the highest resolution possible
       // if the resolution preset is not specified.
@@ -240,15 +233,14 @@ class CameraPlugin extends CameraPlatform {
         options: CameraOptions(
           audio: AudioConstraints(enabled: mediaSettings?.enableAudio ?? true),
           video: VideoConstraints(
-            facingMode:
-                cameraType != null ? FacingModeConstraint(cameraType) : null,
+            facingMode: FacingModeConstraint(cameraType),
             width: VideoSizeConstraint(
               ideal: videoSize.width.toInt(),
             ),
             height: VideoSizeConstraint(
               ideal: videoSize.height.toInt(),
             ),
-            deviceId: cameraMetadata.deviceId,
+            deviceId: cameraMetadata?.deviceId,
           ),
         ),
         recorderOptions: (

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -143,7 +143,7 @@ class CameraPlugin extends CameraPlatform {
           // Fallback to the external lens direction
           // if the facing mode is not available.
           final CameraLensDirection lensDirection = facingMode != null
-              ? _cameraService.mapFacingModeToLensDirection(facingMode)
+              ? mapFacingModeToLensDirection(facingMode)
               : CameraLensDirection.external;
 
           // Create a camera description.
@@ -224,12 +224,12 @@ class CameraPlugin extends CameraPlatform {
       final CameraMetadata cameraMetadata = camerasMetadata[cameraDescription]!;
 
       final CameraType? cameraType = cameraMetadata.facingMode != null
-          ? _cameraService.mapFacingModeToCameraType(cameraMetadata.facingMode!)
+          ? mapFacingModeToCameraType(cameraMetadata.facingMode!)
           : null;
 
       // Use the highest resolution possible
       // if the resolution preset is not specified.
-      final Size videoSize = _cameraService.mapResolutionPresetToSize(
+      final Size videoSize = mapResolutionPresetToSize(
           mediaSettings?.resolutionPreset ?? ResolutionPreset.max);
 
       // Create a camera with the given audio and video constraints.
@@ -383,8 +383,8 @@ class CameraPlugin extends CameraPlatform {
 
       return orientation.onChange.startWith(initialOrientationEvent).map(
         (html.Event _) {
-          final DeviceOrientation deviceOrientation = _cameraService
-              .mapOrientationTypeToDeviceOrientation(orientation.type!);
+          final DeviceOrientation deviceOrientation =
+              mapOrientationTypeToDeviceOrientation(orientation.type!);
           return DeviceOrientationChangedEvent(deviceOrientation);
         },
       );
@@ -405,7 +405,7 @@ class CameraPlugin extends CameraPlatform {
 
       if (screenOrientation != null && documentElement != null) {
         final String orientationType =
-            _cameraService.mapDeviceOrientationToOrientationType(orientation);
+            mapDeviceOrientationToOrientationType(orientation);
 
         // Full-screen mode may be required to modify the device orientation.
         // See: https://w3c.github.io/screen-orientation/#interaction-with-fullscreen-api

--- a/packages/camera/camera_web/lib/src/types/camera_error_code.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_error_code.dart
@@ -44,10 +44,6 @@ class CameraErrorCode {
   /// The user media support is disabled in the current browser.
   static const CameraErrorCode security = CameraErrorCode._('cameraSecurity');
 
-  /// The camera metadata is missing.
-  static const CameraErrorCode missingMetadata =
-      CameraErrorCode._('cameraMissingMetadata');
-
   /// The camera orientation is not supported.
   static const CameraErrorCode orientationNotSupported =
       CameraErrorCode._('orientationNotSupported');


### PR DESCRIPTION
Enumerating available cameras on web requires permission and activates hardware. This PR allows initializing the camera controller without having to enumerate available cameras first.

https://github.com/flutter/flutter/issues/145541

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].