### PR TITLE
[ci] Temporarily allow-warnings in podspec_check_command.dart

### DIFF
--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -151,6 +151,7 @@ class PodspecCheckCommand extends PackageLoopingCommand {
       podspecPath,
       '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
       '--skip-tests',
+      '--allow-warnings',
       '--use-modular-headers', // Flutter sets use_modular_headers! in its templates.
       if (libraryLint) '--use-libraries'
     ];

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -156,6 +156,7 @@ void main() {
                     .path,
                 '--configuration=Debug',
                 '--skip-tests',
+                '--allow-warnings',
                 '--use-modular-headers',
                 '--use-libraries'
               ],
@@ -171,6 +172,7 @@ void main() {
                     .path,
                 '--configuration=Debug',
                 '--skip-tests',
+                '--allow-warnings',
                 '--use-modular-headers',
               ],
               packagesDir.path),
@@ -212,6 +214,7 @@ void main() {
                     .path,
                 '--configuration=Debug',
                 '--skip-tests',
+                '--allow-warnings',
                 '--use-modular-headers',
                 '--use-libraries'
               ],
@@ -227,6 +230,7 @@ void main() {
                     .path,
                 '--configuration=Debug',
                 '--skip-tests',
+                '--allow-warnings',
                 '--use-modular-headers',
               ],
               packagesDir.path),


### PR DESCRIPTION
Adds `--allow-warnings` to podspec_check_command.dart so stuff can keep rolling.

**To be removed soon!**

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
