### PR TITLE
Access current location using uri.path to support deep links

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.2.4
+
+- Updates examples to use uri.path instead of uri.toString() for accessing the current location.
+
 ## 13.2.3
 
 - Fixes an issue where deep links without path caused an exception

--- a/packages/go_router/example/lib/shell_route.dart
+++ b/packages/go_router/example/lib/shell_route.dart
@@ -152,7 +152,7 @@ class ScaffoldWithNavBar extends StatelessWidget {
   }
 
   static int _calculateSelectedIndex(BuildContext context) {
-    final String location = GoRouterState.of(context).uri.toString();
+    final String location = GoRouterState.of(context).uri.path;
     if (location.startsWith('/a')) {
       return 0;
     }

--- a/packages/go_router/example/lib/shell_route_top_route.dart
+++ b/packages/go_router/example/lib/shell_route_top_route.dart
@@ -195,7 +195,7 @@ class ScaffoldWithNavBar extends StatelessWidget {
   }
 
   static int _calculateSelectedIndex(BuildContext context) {
-    final String location = GoRouterState.of(context).uri.toString();
+    final String location = GoRouterState.of(context).uri.path;
     if (location.startsWith('/a')) {
       return 0;
     }

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 13.2.3
+version: 13.2.4
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/go_router_state_test.dart
+++ b/packages/go_router/test/go_router_state_test.dart
@@ -42,7 +42,7 @@ void main() {
             path: '/',
             builder: (_, __) {
               return Builder(builder: (BuildContext context) {
-                return Text('1 ${GoRouterState.of(context).uri}');
+                return Text('1 ${GoRouterState.of(context).uri.path}');
               });
             },
             routes: <GoRoute>[
@@ -50,7 +50,7 @@ void main() {
                   path: 'a',
                   builder: (_, __) {
                     return Builder(builder: (BuildContext context) {
-                      return Text('2 ${GoRouterState.of(context).uri}');
+                      return Text('2 ${GoRouterState.of(context).uri.path}');
                     });
                   }),
             ]),
@@ -74,7 +74,7 @@ void main() {
             path: '/',
             builder: (_, __) {
               return Builder(builder: (BuildContext context) {
-                return Text('1 ${GoRouterState.of(context).uri}');
+                return Text('1 ${GoRouterState.of(context).uri.path}');
               });
             },
             routes: <GoRoute>[
@@ -110,7 +110,7 @@ void main() {
             path: '/',
             builder: (_, __) {
               return Builder(builder: (BuildContext context) {
-                return Text(GoRouterState.of(context).uri.toString());
+                return Text(GoRouterState.of(context).uri.path);
               });
             },
             routes: <GoRoute>[
@@ -118,8 +118,7 @@ void main() {
                   path: 'a',
                   builder: (_, __) {
                     return Builder(builder: (BuildContext context) {
-                      return Text(
-                          key: key, GoRouterState.of(context).uri.toString());
+                      return Text(key: key, GoRouterState.of(context).uri.path);
                     });
                   }),
             ]),
@@ -153,7 +152,7 @@ void main() {
             path: '/',
             builder: (_, __) {
               return Builder(builder: (BuildContext context) {
-                return Text(GoRouterState.of(context).uri.toString());
+                return Text(GoRouterState.of(context).uri.path);
               });
             },
             routes: <GoRoute>[
@@ -161,8 +160,7 @@ void main() {
                   path: 'a',
                   builder: (_, __) {
                     return Builder(builder: (BuildContext context) {
-                      return Text(
-                          key: key, GoRouterState.of(context).uri.toString());
+                      return Text(key: key, GoRouterState.of(context).uri.path);
                     });
                   }),
             ]),

--- a/packages/go_router/test/go_router_state_test.dart
+++ b/packages/go_router/test/go_router_state_test.dart
@@ -56,9 +56,9 @@ void main() {
             ]),
       ];
       final GoRouter router = await createRouter(routes, tester);
-      router.go('/?p=123');
+      router.go('/');
       await tester.pumpAndSettle();
-      expect(find.text('1 /?p=123'), findsOneWidget);
+      expect(find.text('1 /'), findsOneWidget);
 
       router.go('/a');
       await tester.pumpAndSettle();
@@ -124,8 +124,8 @@ void main() {
             ]),
       ];
       final GoRouter router =
-          await createRouter(routes, tester, initialLocation: '/a?p=123');
-      expect(tester.widget<Text>(find.byKey(key)).data, '/a?p=123');
+          await createRouter(routes, tester, initialLocation: '/a');
+      expect(tester.widget<Text>(find.byKey(key)).data, '/a');
       final GoRouterStateRegistry registry = tester
           .widget<GoRouterStateRegistryScope>(
               find.byType(GoRouterStateRegistryScope))
@@ -135,7 +135,7 @@ void main() {
       await tester.pump();
       expect(registry.registry.length, 2);
       // should retain the same location even if the location has changed.
-      expect(tester.widget<Text>(find.byKey(key)).data, '/a?p=123');
+      expect(tester.widget<Text>(find.byKey(key)).data, '/a');
 
       // Finish the pop animation.
       await tester.pumpAndSettle();
@@ -166,8 +166,8 @@ void main() {
             ]),
       ];
       await createRouter(routes, tester,
-          initialLocation: '/a?p=123', navigatorKey: nav);
-      expect(tester.widget<Text>(find.byKey(key)).data, '/a?p=123');
+          initialLocation: '/a', navigatorKey: nav);
+      expect(tester.widget<Text>(find.byKey(key)).data, '/a');
       final GoRouterStateRegistry registry = tester
           .widget<GoRouterStateRegistryScope>(
               find.byType(GoRouterStateRegistryScope))
@@ -177,7 +177,7 @@ void main() {
       await tester.pump();
       expect(registry.registry.length, 2);
       // should retain the same location even if the location has changed.
-      expect(tester.widget<Text>(find.byKey(key)).data, '/a?p=123');
+      expect(tester.widget<Text>(find.byKey(key)).data, '/a');
 
       // Finish the pop animation.
       await tester.pumpAndSettle();

--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.1
+
+- Updates examples to use uri.path instead of uri.toString() for accessing the current location.
+
 ## 2.5.0
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.

--- a/packages/go_router_builder/example/lib/all_types.dart
+++ b/packages/go_router_builder/example/lib/all_types.dart
@@ -537,7 +537,8 @@ class BasePage<T> extends StatelessWidget {
                 'Query param with default value: $queryParamWithDefaultValue',
               ),
               SelectableText(GoRouterState.of(context).uri.path),
-              SelectableText(GoRouterState.of(context).uri.queryParameters.toString()),
+              SelectableText(
+                  GoRouterState.of(context).uri.queryParameters.toString()),
             ],
           ),
         ),

--- a/packages/go_router_builder/example/lib/all_types.dart
+++ b/packages/go_router_builder/example/lib/all_types.dart
@@ -537,6 +537,7 @@ class BasePage<T> extends StatelessWidget {
                 'Query param with default value: $queryParamWithDefaultValue',
               ),
               SelectableText(GoRouterState.of(context).uri.path),
+              SelectableText(GoRouterState.of(context).uri.queryParameters.toString()),
             ],
           ),
         ),

--- a/packages/go_router_builder/example/lib/all_types.dart
+++ b/packages/go_router_builder/example/lib/all_types.dart
@@ -58,7 +58,7 @@ class BigIntRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('BigIntRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -84,7 +84,7 @@ class BoolRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('BoolRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -107,7 +107,7 @@ class DateTimeRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('DateTimeRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -133,7 +133,7 @@ class DoubleRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('DoubleRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -159,7 +159,7 @@ class IntRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('IntRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -185,7 +185,7 @@ class NumRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('NumRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -212,7 +212,7 @@ class EnumRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('EnumRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -239,7 +239,7 @@ class EnhancedEnumRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('EnhancedEnumRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -265,7 +265,7 @@ class StringRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('StringRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -288,7 +288,7 @@ class UriRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('UriRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -361,7 +361,7 @@ class IterableRoute extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('IterableRoute'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -430,7 +430,7 @@ class IterableRouteWithDefaultValues extends GoRouteData {
   Widget drawerTile(BuildContext context) => ListTile(
         title: const Text('IterableRouteWithDefaultValues'),
         onTap: () => go(context),
-        selected: GoRouterState.of(context).uri.toString() == location,
+        selected: GoRouterState.of(context).uri.path == location,
       );
 }
 
@@ -536,7 +536,7 @@ class BasePage<T> extends StatelessWidget {
               Text(
                 'Query param with default value: $queryParamWithDefaultValue',
               ),
-              SelectableText(GoRouterState.of(context).uri.toString()),
+              SelectableText(GoRouterState.of(context).uri.path),
             ],
           ),
         ),

--- a/packages/go_router_builder/example/lib/shell_route_example.dart
+++ b/packages/go_router_builder/example/lib/shell_route_example.dart
@@ -77,7 +77,7 @@ class MyShellRouteScreen extends StatelessWidget {
   final Widget child;
 
   int getCurrentIndex(BuildContext context) {
-    final String location = GoRouterState.of(context).uri.toString();
+    final String location = GoRouterState.of(context).uri.path;
     if (location == '/bar') {
       return 1;
     }

--- a/packages/go_router_builder/example/lib/shell_route_with_keys_example.dart
+++ b/packages/go_router_builder/example/lib/shell_route_with_keys_example.dart
@@ -57,7 +57,7 @@ class MyShellRouteScreen extends StatelessWidget {
   final Widget child;
 
   int getCurrentIndex(BuildContext context) {
-    final String location = GoRouterState.of(context).uri.toString();
+    final String location = GoRouterState.of(context).uri.path;
     if (location.startsWith('/users')) {
       return 1;
     }

--- a/packages/go_router_builder/example/lib/shell_route_with_observers_example.dart
+++ b/packages/go_router_builder/example/lib/shell_route_with_observers_example.dart
@@ -60,7 +60,7 @@ class MyShellRouteScreen extends StatelessWidget {
   final Widget child;
 
   int getCurrentIndex(BuildContext context) {
-    final String location = GoRouterState.of(context).uri.toString();
+    final String location = GoRouterState.of(context).uri.path;
     if (location.startsWith('/users')) {
       return 1;
     }

--- a/packages/go_router_builder/example/test/all_types_test.dart
+++ b/packages/go_router_builder/example/test/all_types_test.dart
@@ -135,9 +135,10 @@ void main() {
     ).go(scaffoldState.context);
     await tester.pumpAndSettle();
     expect(find.text('IterableRoute'), findsOneWidget);
+    expect(find.text('/iterable-route'), findsOneWidget);
     expect(
         find.text(
-            '/iterable-route?enum-iterable-field=football&int-list-field=1&int-list-field=2&int-list-field=3&enum-only-in-set-field=burger&enum-only-in-set-field=pizza'),
+            '{enum-iterable-field: football, int-list-field: 3, enum-only-in-set-field: pizza}'),
         findsOneWidget);
   });
 

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 2.5.0
+version: 2.5.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 


### PR DESCRIPTION
This PR updates examples to use `uri.path` instead of `uri.toString()` for accessing the current location.

While the examples don't use deep linking, promoting the usage of `uri.toString()` in the examples doesn't seem to be a good idea as it can lead to issues when it's used with deep links (It'll include host and scheme).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
