### PR TITLE
[file_selector] Remove OCMock from iOS implementation

### DIFF
--- a/packages/file_selector/file_selector_ios/CHANGELOG.md
+++ b/packages/file_selector/file_selector_ios/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.5.1+9
 
+* Adjusts implementation for testabiity.
 * Updates minimum iOS version to 12.0 and minimum Flutter version to 3.16.6.
 
 ## 0.5.1+8

--- a/packages/file_selector/file_selector_ios/example/ios/Podfile
+++ b/packages/file_selector/file_selector_ios/example/ios/Podfile
@@ -34,8 +34,6 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do
     inherit! :search_paths
-    # Pods for testing
-    pod 'OCMock', '~> 3.8.1'
   end
 end
 

--- a/packages/file_selector/file_selector_ios/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/file_selector/file_selector_ios/example/ios/Runner.xcodeproj/project.pbxproj
@@ -197,7 +197,6 @@
 				C71AE4B2281C6A090086307A /* Sources */,
 				C71AE4B3281C6A090086307A /* Frameworks */,
 				C71AE4B4281C6A090086307A /* Resources */,
-				5BE5886DAAA885227DE0796D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -215,7 +214,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -284,23 +283,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
-		5BE5886DAAA885227DE0796D /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RunnerTests/Pods-RunnerTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RunnerTests/Pods-RunnerTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RunnerTests/Pods-RunnerTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/file_selector/file_selector_ios/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/file_selector/file_selector_ios/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/file_selector/file_selector_ios/example/ios/RunnerTests/FileSelectorTests.m
+++ b/packages/file_selector/file_selector_ios/example/ios/RunnerTests/FileSelectorTests.m
@@ -6,7 +6,19 @@
 @import file_selector_ios.Test;
 @import XCTest;
 
-#import <OCMock/OCMock.h>
+@interface TestPresenter : NSObject <FFSViewPresenter>
+@property(nonatomic) UIViewController *presentedController;
+@end
+
+@implementation TestPresenter
+- (void)presentViewController:(UIViewController *)viewControllerToPresent
+                     animated:(BOOL)animated
+                   completion:(void (^__nullable)(void))completion {
+  self.presentedController = viewControllerToPresent;
+}
+@end
+
+#pragma mark -
 
 @interface FileSelectorTests : XCTestCase
 
@@ -19,18 +31,16 @@
   UIDocumentPickerViewController *picker =
       [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[]
                                                              inMode:UIDocumentPickerModeImport];
-  id mockPresentingVC = OCMClassMock([UIViewController class]);
+  TestPresenter *presenter = [[TestPresenter alloc] init];
   plugin.documentPickerViewControllerOverride = picker;
-  plugin.presentingViewControllerOverride = mockPresentingVC;
+  plugin.viewPresenterOverride = presenter;
 
   [plugin openFileSelectorWithConfig:[FFSFileSelectorConfig makeWithUtis:@[] allowMultiSelection:NO]
                           completion:^(NSArray<NSString *> *paths, FlutterError *error){
                           }];
 
   XCTAssertEqualObjects(picker.delegate, plugin);
-  OCMVerify(times(1), [mockPresentingVC presentViewController:picker
-                                                     animated:[OCMArg any]
-                                                   completion:[OCMArg any]]);
+  XCTAssertEqual(presenter.presentedController, picker);
 }
 
 - (void)testReturnsPickedFiles {

--- a/packages/file_selector/file_selector_ios/example/ios/RunnerTests/FileSelectorTests.m
+++ b/packages/file_selector/file_selector_ios/example/ios/RunnerTests/FileSelectorTests.m
@@ -40,7 +40,7 @@
                           }];
 
   XCTAssertEqualObjects(picker.delegate, plugin);
-  XCTAssertEqual(presenter.presentedController, picker);
+  XCTAssertEqualObjects(presenter.presentedController, picker);
 }
 
 - (void)testReturnsPickedFiles {

--- a/packages/file_selector/file_selector_ios/ios/Classes/FFSFileSelectorPlugin.m
+++ b/packages/file_selector/file_selector_ios/ios/Classes/FFSFileSelectorPlugin.m
@@ -8,6 +8,34 @@
 
 #import <objc/runtime.h>
 
+// TODO(stuartmorgan): When migrating to Swift, eliminate this in favor of
+// adding FFSViewPresenter conformance to UIViewController.
+@interface FFSPresentingViewController : NSObject <FFSViewPresenter>
+- (instancetype)initWithViewController:(nullable UIViewController *)controller;
+// The wrapped controller.
+@property(nonatomic) UIViewController *controller;
+@end
+
+@implementation FFSPresentingViewController
+- (instancetype)initWithViewController:(nullable UIViewController *)controller {
+  self = [super init];
+  if (self) {
+    _controller = controller;
+  }
+  return self;
+}
+
+- (void)presentViewController:(UIViewController *)viewControllerToPresent
+                     animated:(BOOL)animated
+                   completion:(void (^__nullable)(void))completion {
+  [self.controller presentViewController:viewControllerToPresent
+                                animated:animated
+                              completion:completion];
+}
+@end
+
+#pragma mark -
+
 @implementation FFSFileSelectorPlugin
 
 #pragma mark - FFSFileSelectorApi
@@ -23,13 +51,15 @@
   documentPicker.delegate = self;
   documentPicker.allowsMultipleSelection = config.allowMultiSelection;
 
-  UIViewController *presentingVC =
-      self.presentingViewControllerOverride
-          ?: UIApplication.sharedApplication.delegate.window.rootViewController;
-  if (presentingVC) {
+  id<FFSViewPresenter> presenter =
+      self.viewPresenterOverride
+          ?: [[FFSPresentingViewController alloc]
+                 initWithViewController:UIApplication.sharedApplication.delegate.window
+                                            .rootViewController];
+  if (presenter) {
     objc_setAssociatedObject(documentPicker, @selector(openFileSelectorWithConfig:completion:),
                              completion, OBJC_ASSOCIATION_COPY_NONATOMIC);
-    [presentingVC presentViewController:documentPicker animated:YES completion:nil];
+    [presenter presentViewController:documentPicker animated:YES completion:nil];
   } else {
     completion(nil, [FlutterError errorWithCode:@"error"
                                         message:@"Missing root view controller."

--- a/packages/file_selector/file_selector_ios/ios/Classes/FFSFileSelectorPlugin_Test.h
+++ b/packages/file_selector/file_selector_ios/ios/Classes/FFSFileSelectorPlugin_Test.h
@@ -4,13 +4,24 @@
 
 #import "FFSFileSelectorPlugin.h"
 
+@import UIKit;
+
 #import "messages.g.h"
+
+/// Interface for presenting a view controller, to allow injecting an alternate
+/// test implementation.
+@protocol FFSViewPresenter <NSObject>
+/// Wrapper for -[UIViewController presentViewController:animated:completion:].
+- (void)presentViewController:(UIViewController *_Nonnull)viewControllerToPresent
+                     animated:(BOOL)animated
+                   completion:(void (^__nullable)(void))completion;
+@end
 
 // This header is available in the Test module. Import via "@import file_selector_ios.Test;".
 @interface FFSFileSelectorPlugin () <FFSFileSelectorApi, UIDocumentPickerDelegate>
 
 /// Overrides the view controller used for presenting the document picker.
-@property(nonatomic) UIViewController *_Nullable presentingViewControllerOverride;
+@property(nonatomic) id<FFSViewPresenter> _Nullable viewPresenterOverride;
 
 /// Overrides the UIDocumentPickerViewController used for file picking.
 @property(nonatomic) UIDocumentPickerViewController *_Nullable documentPickerViewControllerOverride;

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_ios
 description: iOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.5.1+8
+version: 0.5.1+9
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
To aid in future conversion to Swift, remove the use of OCMock in favor of a protocol and an explicit stub.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
