### PR TITLE
[Many] Bump to min minSdkVersion of 19 across all plugins

### DIFF
--- a/.ci/legacy_project/all_packages/android/app/build.gradle
+++ b/.ci/legacy_project/all_packages/android/app/build.gradle
@@ -29,7 +29,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.all_packages"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.3.0+8
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 * Updates compileSdk version to 34.
 
 ## 0.3.0+7

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.3.0+8
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
 * Updates compileSdk version to 34.
 
 ## 0.3.0+7

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.3.0+8
 
+* Updates minSdkVersion to 19.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 * Updates compileSdk version to 34.
 

--- a/packages/espresso/android/build.gradle
+++ b/packages/espresso/android/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.3.0+8
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.3.0+8
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -3,7 +3,7 @@ description: Java classes for testing Flutter apps using Espresso.
   Allows driving Flutter widgets from a native Espresso test.
 repository: https://github.com/flutter/packages/tree/main/packages/espresso
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+espresso%22
-version: 0.3.0+7
+version: 0.3.0+8
 
 environment:
   sdk: ^3.1.0

--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.19
 
 * Updates minSdkVersion to 19.
+* Updates minimum supported SDK version to Flutter 3.16.
 
 ## 2.0.18
 

--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.0.19
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.16.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 
 ## 2.0.18
 

--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.19
+
+* Updates minSdkVersion to 19.
+
 ## 2.0.18
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.

--- a/packages/flutter_plugin_android_lifecycle/android/build.gradle
+++ b/packages/flutter_plugin_android_lifecycle/android/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard.txt'
     }

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_android_lifecycle
 description: Flutter plugin for accessing an Android Lifecycle within other plugins.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_plugin_android_lifecycle
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_plugin_android_lifecycle%22
-version: 2.0.18
+version: 2.0.19
 
 environment:
   sdk: ^3.1.0

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.0.19
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.19
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.1.23
 
 * Updates minSdkVersion to 19.
+* Updates minimum supported SDK version to Flutter 3.16.
 
 ## 6.1.22
 

--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.1.23
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.16.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 
 ## 6.1.22
 

--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.23
+
+* Updates minSdkVersion to 19.
+
 ## 6.1.22
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.

--- a/packages/google_sign_in/google_sign_in_android/android/build.gradle
+++ b/packages/google_sign_in/google_sign_in_android/android/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 6.1.23
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_android
 description: Android implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 6.1.22
+version: 6.1.23
 
 environment:
   sdk: ^3.1.0

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 6.1.23
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.8.9+6
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.16.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 
 ## 0.8.9+5
 

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.9+6
+
+* Updates minSdkVersion to 19.
+
 ## 0.8.9+5
 
 * Bumps androidx.exifinterface:exifinterface from 1.3.6 to 1.3.7.

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.8.9+6
 
 * Updates minSdkVersion to 19.
+* Updates minimum supported SDK version to Flutter 3.16.
 
 ## 0.8.9+5
 

--- a/packages/image_picker/image_picker_android/android/build.gradle
+++ b/packages/image_picker/image_picker_android/android/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -295,7 +295,7 @@ public class ImagePickerDelegate
 
   private void launchPickMediaFromGalleryIntent(Messages.GeneralOptions generalOptions) {
     Intent pickMediaIntent;
-    if (generalOptions.getUsePhotoPicker() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (generalOptions.getUsePhotoPicker()) {
       if (generalOptions.getAllowMultiple()) {
         pickMediaIntent =
             new ActivityResultContracts.PickMultipleVisualMedia()

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -341,7 +341,7 @@ public class ImagePickerDelegate
 
   private void launchPickVideoFromGalleryIntent(Boolean usePhotoPicker) {
     Intent pickVideoIntent;
-    if (usePhotoPicker && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (usePhotoPicker) {
       pickVideoIntent =
           new ActivityResultContracts.PickVisualMedia()
               .createIntent(
@@ -439,7 +439,7 @@ public class ImagePickerDelegate
 
   private void launchPickImageFromGalleryIntent(Boolean usePhotoPicker) {
     Intent pickImageIntent;
-    if (usePhotoPicker && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (usePhotoPicker) {
       pickImageIntent =
           new ActivityResultContracts.PickVisualMedia()
               .createIntent(
@@ -456,7 +456,7 @@ public class ImagePickerDelegate
 
   private void launchMultiPickImageFromGalleryIntent(Boolean usePhotoPicker) {
     Intent pickMultiImageIntent;
-    if (usePhotoPicker && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (usePhotoPicker) {
       pickMultiImageIntent =
           new ActivityResultContracts.PickMultipleVisualMedia()
               .createIntent(

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -320,9 +320,7 @@ public class ImagePickerDelegate
       pickMediaIntent.setType("*/*");
       String[] mimeTypes = {"video/*", "image/*"};
       pickMediaIntent.putExtra("CONTENT_TYPE", mimeTypes);
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-        pickMediaIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, generalOptions.getAllowMultiple());
-      }
+      pickMediaIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, generalOptions.getAllowMultiple());
     }
     activity.startActivityForResult(pickMediaIntent, REQUEST_CODE_CHOOSE_MEDIA_FROM_GALLERY);
   }
@@ -467,9 +465,7 @@ public class ImagePickerDelegate
     } else {
       pickMultiImageIntent = new Intent(Intent.ACTION_GET_CONTENT);
       pickMultiImageIntent.setType("image/*");
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-        pickMultiImageIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
-      }
+      pickMultiImageIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
     }
     activity.startActivityForResult(
         pickMultiImageIntent, REQUEST_CODE_CHOOSE_MULTI_IMAGE_FROM_GALLERY);

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.8.9+6
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.8.9+6
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.9+5
+version: 0.8.9+6
 
 environment:
   sdk: ^3.1.0

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.4
 
-* Updates minSdkVersion version to 34.
+* Updates minSdkVersion version to 19.
 
 ## 2.2.3
 

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.4
+
+* Updates minSdkVersion version to 34.
+
 ## 2.2.3
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.4
 
 * Updates minSdkVersion version to 19.
+* Updates minimum supported SDK version to Flutter 3.16.
 
 ## 2.2.3
 

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.2.4
 
 * Updates minSdkVersion version to 19.
-* Updates minimum supported SDK version to Flutter 3.16.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 
 ## 2.2.3
 

--- a/packages/path_provider/path_provider_android/android/build.gradle
+++ b/packages/path_provider/path_provider_android/android/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -110,14 +110,7 @@ public class PathProviderPlugin implements FlutterPlugin, PathProviderApi {
   private List<String> getPathProviderExternalCacheDirectories() {
     final List<String> paths = new ArrayList<>();
 
-    if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-      for (File dir : context.getExternalCacheDirs()) {
-        if (dir != null) {
-          paths.add(dir.getAbsolutePath());
-        }
-      }
-    } else {
-      File dir = context.getExternalCacheDir();
+    for (File dir : context.getExternalCacheDirs()) {
       if (dir != null) {
         paths.add(dir.getAbsolutePath());
       }
@@ -159,14 +152,7 @@ public class PathProviderPlugin implements FlutterPlugin, PathProviderApi {
       @NonNull Messages.StorageDirectory directory) {
     final List<String> paths = new ArrayList<>();
 
-    if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-      for (File dir : context.getExternalFilesDirs(getStorageDirectoryString(directory))) {
-        if (dir != null) {
-          paths.add(dir.getAbsolutePath());
-        }
-      }
-    } else {
-      File dir = context.getExternalFilesDir(getStorageDirectoryString(directory));
+    for (File dir : context.getExternalFilesDirs(getStorageDirectoryString(directory))) {
       if (dir != null) {
         paths.add(dir.getAbsolutePath());
       }

--- a/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -5,8 +5,6 @@
 package io.flutter.plugins.pathprovider;
 
 import android.content.Context;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/StorageDirectoryMapper.java
+++ b/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/StorageDirectoryMapper.java
@@ -42,11 +42,7 @@ class StorageDirectoryMapper {
       case 8:
         return Environment.DIRECTORY_DCIM;
       case 9:
-        if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-          return Environment.DIRECTORY_DOCUMENTS;
-        } else {
-          throw new IllegalArgumentException("Documents directory is unsupported.");
-        }
+        return Environment.DIRECTORY_DOCUMENTS;
       default:
         throw new IllegalArgumentException("Unknown index: " + dartIndex);
     }

--- a/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/StorageDirectoryMapper.java
+++ b/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/StorageDirectoryMapper.java
@@ -4,8 +4,6 @@
 
 package io.flutter.plugins.pathprovider;
 
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.os.Environment;
 
 /** Helps to map the Dart `StorageDirectory` enum to a Android system constant. */

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_android
 description: Android implementation of the path_provider plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.2.3
+version: 2.2.4
 
 environment:
   sdk: ^3.1.0

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.2.4
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.2.4
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
@@ -34,7 +34,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
     }
 
     testOptions {

--- a/packages/pigeon/platform_tests/test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/android/build.gradle
@@ -46,7 +46,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
     }
 
     testOptions {

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.11
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 * Updates compileSdk version to 34.
 
 ## 1.0.10

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.0.11
 
+* Updates minSdkVersion to 19.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 * Updates compileSdk version to 34.
 

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.11
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
 * Updates compileSdk version to 34.
 
 ## 1.0.10

--- a/packages/quick_actions/quick_actions_android/android/build.gradle
+++ b/packages/quick_actions/quick_actions_android/android/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.11
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_android
 description: An implementation for the Android platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/quick_actions/quick_actions_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 1.0.10
+version: 1.0.11
 
 environment:
   sdk: ^3.1.0

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 1.0.11
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.2.2
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 * Updates compileSdk version to 34.
 * Updates mockito to 5.2.0.
 

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.2.2
 
+* Updates minSdkVersion to 19.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 * Updates compileSdk version to 34.
 * Updates mockito to 5.2.0.

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.2.2
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
 * Updates compileSdk version to 34.
 * Updates mockito to 5.2.0.
 

--- a/packages/shared_preferences/shared_preferences_android/android/build.gradle
+++ b/packages/shared_preferences/shared_preferences_android/android/build.gradle
@@ -42,7 +42,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.2.2
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.2.2
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.2.1
+version: 2.2.2
 
 environment:
   sdk: ^3.1.0

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 6.3.1
 
+* Updates minSdkVersion to 19.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 
 ## 6.3.0

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.3.1
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 
 ## 6.3.0
 

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.3.1
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
 
 ## 6.3.0
 

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -32,7 +32,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.3.0
+version: 6.3.1
 environment:
   sdk: ^3.1.0
   flutter: ">=3.13.0"

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
 version: 6.3.1
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 6.3.1
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.4.13
 
+* Updates minSdkVersion to 19.
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
 
 ## 2.4.12

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.4.13
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
 
 ## 2.4.12
 

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.4.13
 
 * Updates minSdkVersion to 19.
-* Updates minimum supported SDK version to Flutter 3.16/Dart 3.1.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 
 ## 2.4.12
 

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -34,7 +34,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 
 import android.graphics.SurfaceTexture;
-
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.PlaybackException;

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -8,11 +8,12 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
+
+import android.graphics.SurfaceTexture;
 
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.Format;
@@ -39,6 +40,7 @@ public class VideoPlayerTest {
   private ExoPlayer fakeExoPlayer;
   private EventChannel fakeEventChannel;
   private TextureRegistry.SurfaceTextureEntry fakeSurfaceTextureEntry;
+  private SurfaceTexture fakeSurfaceTexture;
   private VideoPlayerOptions fakeVideoPlayerOptions;
   private QueuingEventSink fakeEventSink;
   private DefaultHttpDataSource.Factory httpDataSourceFactorySpy;
@@ -52,6 +54,8 @@ public class VideoPlayerTest {
     fakeExoPlayer = mock(ExoPlayer.class);
     fakeEventChannel = mock(EventChannel.class);
     fakeSurfaceTextureEntry = mock(TextureRegistry.SurfaceTextureEntry.class);
+    fakeSurfaceTexture = mock(SurfaceTexture.class);
+    when(fakeSurfaceTextureEntry.surfaceTexture()).thenReturn(fakeSurfaceTexture);
     fakeVideoPlayerOptions = mock(VideoPlayerOptions.class);
     fakeEventSink = mock(QueuingEventSink.class);
     httpDataSourceFactorySpy = spy(new DefaultHttpDataSource.Factory());

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.4.13
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=3.16.0"
 
 flutter:

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.4.13
 
 environment:
   sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.12
+version: 2.4.13
 
 environment:
   sdk: ^3.1.0


### PR DESCRIPTION
* Bumps any `minSdkVersion`'s below 19 to 19, as the change to only support 19+ has been in stable for a bit now.
* Bumps the minimum required flutter version to 3.16 for the changed packages, as that is the first version in which we started automigrating `minSdkVersion`'s less than 19.
* Also bumps the `minSdkVersion` in the legacy project to `flutter.minSdkVersion`, as this would happen when running an app with `minSdkVersion` < 19.
* Removes some code branches for cases of sdk < 19.
* Fixes some failing tests in `video_player` - for full transparency, I have now idea how these could have been passing before?

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
