### PR TITLE
Fix error in markdown parsing image dimensions

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.23
+
+* Gracefully handle image dimension parsing failures.
+
 ## 0.6.22+1
 
 * Removes `_ambiguate` methods from code.

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -568,8 +568,8 @@ class MarkdownBuilder implements md.NodeVisitor {
     if (parts.length == 2) {
       final List<String> dimensions = parts.last.split('x');
       if (dimensions.length == 2) {
-        width = double.parse(dimensions[0]);
-        height = double.parse(dimensions[1]);
+        width = double.tryParse(dimensions[0]);
+        height = double.tryParse(dimensions[1]);
       }
     }
 

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.6.22+1
+version: 0.6.23
 
 environment:
   sdk: ^3.3.0

--- a/packages/flutter_markdown/test/image_test.dart
+++ b/packages/flutter_markdown/test/image_test.dart
@@ -334,6 +334,42 @@ void defineTests() {
     );
 
     testWidgets(
+      'should gracefully handle width parsing failures',
+      (WidgetTester tester) async {
+        const String data = '![alt](https://img#x50)';
+        await tester.pumpWidget(
+          boilerplate(
+            const Markdown(data: data),
+          ),
+        );
+
+        final Image image = tester.widget(find.byType(Image));
+        final NetworkImage networkImage = image.image as NetworkImage;
+        expect(networkImage.url, 'https://img');
+        expect(image.width, null);
+        expect(image.height, 50);
+      },
+    );
+
+    testWidgets(
+      'should gracefully handle height parsing failures',
+      (WidgetTester tester) async {
+        const String data = '![alt](https://img#50x)';
+        await tester.pumpWidget(
+          boilerplate(
+            const Markdown(data: data),
+          ),
+        );
+
+        final Image image = tester.widget(find.byType(Image));
+        final NetworkImage networkImage = image.image as NetworkImage;
+        expect(networkImage.url, 'https://img');
+        expect(image.width, 50);
+        expect(image.height, null);
+      },
+    );
+
+    testWidgets(
       'custom image builder',
       (WidgetTester tester) async {
         const String data = '![alt](https://img.png)';

--- a/packages/flutter_markdown/test/image_test.dart
+++ b/packages/flutter_markdown/test/image_test.dart
@@ -354,7 +354,7 @@ void defineTests() {
     testWidgets(
       'should gracefully handle height parsing failures',
       (WidgetTester tester) async {
-        const String data = '![alt](https://img#50x)';
+        const String data = ' ![alt](https://img#50x)';
         await tester.pumpWidget(
           boilerplate(
             const Markdown(data: data),


### PR DESCRIPTION
Gracefully handle parsing failures for image width and height in Markdown. Unit tests are provided.

Fixes https://github.com/flutter/flutter/issues/146739

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] ~I updated/added relevant documentation (doc comments with `///`).~ Not needed as there was no API change.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
