### PR TITLE
Update local_auth_android minSdkVersion to 19

### DIFF
--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.0.38
 
-* Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.
+* Updates minSdkVersion to 19.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
 
 ## 1.0.37
 

--- a/packages/local_auth/local_auth_android/android/build.gradle
+++ b/packages/local_auth/local_auth_android/android/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/local_auth/local_auth_android/android/build.gradle
+++ b/packages/local_auth/local_auth_android/android/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,11 +2,11 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.37
+version: 1.0.38
 
 environment:
-  sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  sdk: ^3.2.0
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
https://github.com/flutter/packages/pull/6506 was supposed to update everything to 19+, but missed local_auth_android. This updates it to require 19 as well.