### PR TITLE
[flutter_adaptive_scaffold] use `MediaQuery.sizeOf` instead of `MediaQuery.of` to prevent unnecessary rebuilds

### DIFF
--- a/packages/flutter_adaptive_scaffold/lib/src/breakpoints.dart
+++ b/packages/flutter_adaptive_scaffold/lib/src/breakpoints.dart
@@ -95,7 +95,7 @@ class WidthPlatformBreakpoint extends Breakpoint {
 
     // Null boundaries are unbounded, assign the max/min of their associated
     // direction on a number line.
-    final double width = MediaQuery.of(context).size.width;
+    final double width = MediaQuery.sizeOf(context).width;
     final double lowerBound = begin ?? double.negativeInfinity;
     final double upperBound = end ?? double.infinity;
 
@@ -126,6 +126,6 @@ abstract class Breakpoint {
   const Breakpoint();
 
   /// A method that returns true based on conditions related to the context of
-  /// the screen such as MediaQuery.of(context).size.width.
+  /// the screen such as MediaQuery.sizeOf(context).width.
   bool isActive(BuildContext context);
 }


### PR DESCRIPTION
the `isActive` method uses `MediaQuery.of(context).size.width`, which triggers widget rebuilds whenever a property of `MediaQuery` changes, even when the size.width doesn't change.

instead, we should be using `MediaQuery.sizeOf(context).width`.  

fixes: https://github.com/flutter/flutter/issues/146801