### PR TITLE
[url_launcher][web] Fix Link issues when Semantics are enabled

### DIFF
--- a/packages/url_launcher/url_launcher_web/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/link.dart
@@ -236,7 +236,14 @@ class LinkViewController extends PlatformViewController {
   /// to only trigger the link if a hit test was registered and remains valid at
   /// the time the click handler executes.
   static void _onGlobalClick(html.MouseEvent event) {
-    triggeredMouseEvent = event;
+    final html.Element? targetElement = event.target as html.Element?;
+
+    // We only want to cache the mouse event if its target is a link, so that 
+    // we can later prevent its default behavior and handle how it should 
+    // open the link ourselves.
+    if(isLinkElement(targetElement) || isSemanticLinkElement(targetElement)) {
+      triggeredMouseEvent = event;
+    }
 
     if (followLinkTriggered) {
       final int? viewId = getViewIdFromTarget(event) ?? _hitTestedViewId;
@@ -439,4 +446,25 @@ bool isLinkElement(html.Element? element) {
   return element != null &&
       element.tagName == 'A' &&
       element.hasProperty(linkViewIdProperty.toJS).toDart;
+}
+
+/// Checks if the given [element] is a semantic Link. This is necessary because
+/// we need a way to distinguish click event targets that are links.
+bool isSemanticLinkElement(html.Element? element) {
+  return element != null &&
+      element.tagName == 'FLT-SEMANTICS' &&
+      hasLinkAncestor(element);
+}
+
+/// Checks if the given [element] has a link ancestor.
+bool hasLinkAncestor(html.Element? element) {
+  while (element != null) {
+    if(element.tagName == 'A') {
+      return true;
+    }
+
+    element = element.parentElement;
+  }
+
+  return false;
 }


### PR DESCRIPTION
DRAFT PR - will add tests shortly.

This PR fixes an issue where Links break in Semantics mode (clicking links does nothing) because the Link's child semantics obscure the platform view. 

The fix:
- Clean up the extraneous semantics nodes being generated by `PlatformViewLink` so we can consolidate all of the link information in a single place.  Also exclude it from the focus tree to fix the "double tabbing" issue.
- Pass the link role and URI to the child semantics so that we can wrap the node in an `<a>` tag to enable the context menu and provide link preview info.  This requires a separate engine PR.
- Click events never bubbled back up when clicking the Link's child semantics nodes (due to `stopPropagation` being called in the engine), so we have to handle click events in the `capture` phase.
- Handle link trigger logic during hit test registration (not just during browser events).  

For keydown events, things remain the same:
1. User hits enter
2. Framework receives + handles event, executes `followLink`, registers a hit test view id
3. Browser receives event and triggers link behavior using the registered `viewId`
4. Cleanup 

For click events, things are slightly different depending on if the node that's clicked is a semantic node or a platform view link.

Clicking platform view links will behave similarly to keydown events.

Clicking the generated semantic node of a link (specifically its children) will behave as follows:
1. User clicks button
2. Browser receives + handles event. No hit test id is registered yet, so we just cache the click event for later 
3. Framework executes `followLink`, registers a hit test view id.  Triggers link behavior using the registered `viewId`
4. Cleanup 

Fixes https://github.com/flutter/flutter/issues/143164

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
