### PR TITLE
[pointer_interceptor_web] Remove semantic tests.

### DIFF
--- a/packages/pointer_interceptor/pointer_interceptor_web/example/integration_test/widget_test.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_web/example/integration_test/widget_test.dart
@@ -64,68 +64,6 @@ void main() {
       expect(element.id, 'background-html-view');
     }, semanticsEnabled: false);
   });
-
-  group('With semantics', () {
-    testWidgets('finds semantics of wrapped widgets',
-        (WidgetTester tester) async {
-      await _fullyRenderApp(tester);
-
-      final web.Element element =
-          _getHtmlElementAtCenter(clickableButtonFinder, tester);
-
-      expect(element.tagName.toLowerCase(), 'flt-semantics');
-      expect(element.getAttribute('aria-label'), 'Works As Expected');
-    },
-        // TODO(bparrishMines): The semantics label is returning null.
-        // See https://github.com/flutter/flutter/issues/145238
-        skip: true);
-
-    testWidgets(
-        'finds semantics of wrapped widgets with intercepting set to false',
-        (WidgetTester tester) async {
-      await _fullyRenderApp(tester);
-
-      final web.Element element =
-          _getHtmlElementAtCenter(clickableWrappedButtonFinder, tester);
-
-      expect(element.tagName.toLowerCase(), 'flt-semantics');
-      expect(element.getAttribute('aria-label'),
-          'Never calls onPressed transparent');
-    },
-        // TODO(bparrishMines): The semantics label is returning null.
-        // See https://github.com/flutter/flutter/issues/145238
-        skip: true);
-
-    testWidgets('finds semantics of unwrapped elements',
-        (WidgetTester tester) async {
-      await _fullyRenderApp(tester);
-
-      final web.Element element =
-          _getHtmlElementAtCenter(nonClickableButtonFinder, tester);
-
-      expect(element.tagName.toLowerCase(), 'flt-semantics');
-      expect(element.getAttribute('aria-label'), 'Never calls onPressed');
-    },
-        // TODO(bparrishMines): The semantics label is returning null.
-        // See https://github.com/flutter/flutter/issues/145238
-        skip: true);
-
-    // Notice that, when hit-testing the background platform view, instead of
-    // finding a semantics node, the platform view itself is found. This is
-    // because the platform view does not add interactive semantics nodes into
-    // the framework's semantics tree. Instead, its semantics is determined by
-    // the HTML content of the platform view itself. Flutter's semantics tree
-    // simply allows the hit test to land on the platform view by making itself
-    // hit test transparent.
-    testWidgets('on background directly', (WidgetTester tester) async {
-      await _fullyRenderApp(tester);
-
-      final web.Element element =
-          _getHtmlElementAt(tester.getTopLeft(backgroundFinder));
-
-      expect(element.id, 'background-html-view');
-    });
-  });
 }
 
 Future<void> _fullyRenderApp(WidgetTester tester) async {


### PR DESCRIPTION
After discussing with @yjbanov, we've decided to remove the semantics-related tests from the `pointer_interceptor_web` package.

The tests are no better than general platform view semantics tests in general, and should belong only to the framework/engine.

### Issues

* Closes https://github.com/flutter/flutter/issues/145238

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
