### PR TITLE
Skip podspec Swift Search Path validation if only swift file is Package.swift for darwin plugins

### DIFF
--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -169,6 +169,11 @@ class PodspecCheckCommand extends PackageLoopingCommand {
         .childDirectory(package.directory.basename)
         .childFile('Package.swift')
         .path;
+    final String darwinSwiftPackageManifestPath = package.directory
+        .childDirectory('darwin')
+        .childDirectory(package.directory.basename)
+        .childFile('Package.swift')
+        .path;
     return getFilesForPackage(package).any((File entity) {
       final String relativePath =
           getRelativePosixPath(entity, from: package.directory);
@@ -178,6 +183,7 @@ class PodspecCheckCommand extends PackageLoopingCommand {
       }
       final String filePath = entity.path;
       return filePath != iosSwiftPackageManifestPath &&
+          filePath != darwinSwiftPackageManifestPath &&
           path.extension(filePath) == '.swift';
     });
   }

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -405,7 +405,8 @@ void main() {
           ));
     });
 
-    test('does not require the search paths workaround for darwin Package.swift',
+    test(
+        'does not require the search paths workaround for darwin Package.swift',
         () async {
       final RepositoryPackage plugin = createFakePlugin(
         'plugin1',

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -405,6 +405,27 @@ void main() {
           ));
     });
 
+    test('does not require the search paths workaround for darwin Package.swift',
+        () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin1',
+        packagesDir,
+        extraFiles: <String>['darwin/plugin1/Package.swift'],
+      );
+      _writeFakePodspec(plugin, 'darwin');
+
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['podspec-check']);
+
+      expect(
+          output,
+          containsAllInOrder(
+            <Matcher>[
+              contains('Ran for 1 package(s)'),
+            ],
+          ));
+    });
+
     test('does not require the search paths workaround for macOS plugins',
         () async {
       final RepositoryPackage plugin = createFakePlugin('plugin1', packagesDir,


### PR DESCRIPTION
Fix for iOS was added in https://github.com/flutter/packages/pull/6627, but neglected to handle when plugin uses darwin directory.

Supplemental fix for https://github.com/flutter/flutter/issues/147548.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
