### PR TITLE
[in_app_purchase] implement countryCode correctly

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5
+
+* Replaces `getCountryCode` with `countryCode`.
+
 ## 0.3.4+1
 
 * Adds documentation for UserChoice and Alternative Billing.

--- a/packages/in_app_purchase/in_app_purchase_android/lib/src/in_app_purchase_android_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/lib/src/in_app_purchase_android_platform.dart
@@ -317,9 +317,14 @@ class InAppPurchaseAndroidPlatform extends InAppPurchasePlatform {
   ///
   /// See: https://developer.android.com/reference/com/android/billingclient/api/BillingConfig
   /// See: https://unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html
-  Future<String> getCountryCode() async {
+  @override
+  Future<String> countryCode() async {
     final BillingConfigWrapper billingConfig = await billingClientManager
         .runWithClient((BillingClient client) => client.getBillingConfig());
     return billingConfig.countryCode;
   }
+
+  /// Use countryCode instead.
+  @Deprecated('Use countryCode')
+  Future<String> getCountryCode() => countryCode();
 }

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.4+1
+version: 0.3.5
 
 environment:
   sdk: ^3.1.0

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
@@ -760,9 +760,11 @@ void main() {
 
       when(mockApi.getBillingConfigAsync())
           .thenAnswer((_) async => platformBillingConfigFromWrapper(expected));
-      final String countryCode = await iapAndroidPlatform.getCountryCode();
+      final String countryCode = await iapAndroidPlatform.countryCode();
 
       expect(countryCode, equals(expectedCountryCode));
+      // Ensure deprecated code keeps working until removed.
+      expect(await iapAndroidPlatform.getCountryCode(), equals(expectedCountryCode));
     });
   });
 }

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
@@ -764,7 +764,8 @@ void main() {
 
       expect(countryCode, equals(expectedCountryCode));
       // Ensure deprecated code keeps working until removed.
-      expect(await iapAndroidPlatform.getCountryCode(), equals(expectedCountryCode));
+      expect(await iapAndroidPlatform.getCountryCode(),
+          equals(expectedCountryCode));
     });
   });
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.15
+
+* Replaces `getCountryCode` with `countryCode`.
+
 ## 0.3.14
 
 * Adds `countryCode` API.

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
@@ -158,9 +158,14 @@ class InAppPurchaseStoreKitPlatform extends InAppPurchasePlatform {
   ///
   /// Uses the ISO 3166-1 Alpha-3 country code representation.
   /// See: https://developer.apple.com/documentation/storekit/skstorefront?language=objc
-  Future<String?> getCountryCode() async {
-    return (await _skPaymentQueueWrapper.storefront())?.countryCode;
+  @override
+  Future<String> countryCode() async {
+    return (await _skPaymentQueueWrapper.storefront())?.countryCode ?? '';
   }
+
+  /// Use countryCode instead.
+  @Deprecated('Use countryCode')
+  Future<String?> getCountryCode() => countryCode();
 }
 
 enum _TransactionRestoreState {

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS and macOS platforms of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.14
+version: 0.3.15
 
 environment:
   sdk: ^3.2.3

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_test.dart
@@ -576,8 +576,10 @@ void main() {
       const String expectedCountryCode = 'CA';
       fakeStoreKitPlatform.setStoreFrontInfo(
           countryCode: expectedCountryCode, identifier: 'ABC');
-      final String? countryCode = await iapStoreKitPlatform.getCountryCode();
+      final String countryCode = await iapStoreKitPlatform.countryCode();
       expect(countryCode, expectedCountryCode);
+      // Ensure deprecated code keeps working until removed.
+      expect(await iapStoreKitPlatform.countryCode(), expectedCountryCode);
     });
   });
 }


### PR DESCRIPTION
- **Rename getCountryCode to country code for ios and android IAP**
- **Add changelog**
fixes https://github.com/flutter/flutter/issues/147230

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
