### PR TITLE
[camerax] Add empty implementation for `prepareForVideoRecording` not used on Android

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.4+1
 
-* Adds empty implementation for `prepareVideoRecording` since this optimization is not used on Android.
+* Adds empty implementation for `prepareForVideoRecording` since this optimization is not used on Android.
 
 ## 0.6.4
 

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4+1
+
+* Adds empty implementation for `prepareVideoRecording` since this optimization is not used on Android.
+
 ## 0.6.4
 
 * Prevents usage of unsupported concurrent `UseCase`s based on the capabiliites of the camera device.

--- a/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
+++ b/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
@@ -867,6 +867,15 @@ class AndroidCameraCameraX extends CameraPlatform {
     }
   }
 
+  /// Prepare the capture session for video recording.
+  ///
+  /// This optimization is not used on Android, so this implementation is a
+  /// no-op.
+  @override
+  Future<void> prepareForVideoRecording() {
+    return Future<void>.value();
+  }
+
   /// Configures and starts a video recording. Returns silently without doing
   /// anything if there is currently an active recording.
   ///

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.4
+version: 0.6.4+1
 
 environment:
   sdk: ^3.1.0

--- a/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
+++ b/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
@@ -4040,4 +4040,22 @@ void main() {
     verify(
         camera.processCameraProvider!.unbind(<UseCase>[camera.imageAnalysis!]));
   });
+
+  test(
+      'prepareForVideoRecording does not make any calls involving starting video recording',
+      () async {
+    final AndroidCameraCameraX camera = AndroidCameraCameraX();
+
+    // Set directly for test versus calling createCamera.
+    camera.processCameraProvider = MockProcessCameraProvider();
+    camera.recorder = MockRecorder();
+    camera.videoCapture = MockVideoCapture();
+    camera.camera = MockCamera();
+
+    await camera.prepareForVideoRecording();
+    verifyNoMoreInteractions(camera.processCameraProvider);
+    verifyNoMoreInteractions(camera.recorder);
+    verifyNoMoreInteractions(camera.videoCapture);
+    verifyNoMoreInteractions(camera.camera);
+  });
 }


### PR DESCRIPTION
Adds empty implementation for the camera plugin method `prepareForVideoRecording` that is not used on Android.

Prequel to https://github.com/flutter/packages/pull/6629

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
