### PR TITLE
[image_picker] Adds comment for the limit parameter

### DIFF
--- a/packages/image_picker/image_picker/AUTHORS
+++ b/packages/image_picker/image_picker/AUTHORS
@@ -64,3 +64,4 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
+LinXunFeng <linxunfeng@yeah.net>

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+* Adds comment for the limit parameter.
+
 ## 1.1.1
 
 * Updates documentation to note that Android Photo Picker use is not optional on Android 13+.

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -113,10 +113,8 @@ class ImagePicker {
   /// supported for the image that is picked, a warning message will be logged.
   ///
   /// The `limit` parameter modifies the maximum number of images that can be selected.
-  /// On Android, you need to set ImagePickerAndroid's useAndroidPhotoPicker to
-  /// true for this parameter to be valid.
-  /// See: https://github.com/flutter/packages/blob/main/packages/image_picker/image_picker_android/README.md#photo-picker
-  /// for code.
+  /// On Android, [ImagePickerAndroid.useAndroidPhotoPicker] must be set to `true`
+  /// to use the `limit` functionality.
   ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
   /// information the plugin tries to get.
@@ -232,10 +230,8 @@ class ImagePicker {
   /// supported for the image that is picked, a warning message will be logged.
   ///
   /// The `limit` parameter modifies the maximum number of media that can be selected.
-  /// On Android, you need to set ImagePickerAndroid's useAndroidPhotoPicker to
-  /// true for this parameter to be valid.
-  /// See: https://github.com/flutter/packages/blob/main/packages/image_picker/image_picker_android/README.md#photo-picker
-  /// for code.
+  /// On Android, [ImagePickerAndroid.useAndroidPhotoPicker] must be set to `true`
+  /// to use the `limit` functionality.
   ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
   /// information the plugin tries to get.

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -114,7 +114,9 @@ class ImagePicker {
   ///
   /// The `limit` parameter modifies the maximum number of images that can be selected.
   /// On Android, [ImagePickerAndroid.useAndroidPhotoPicker] must be set to `true`
-  /// to use the `limit` functionality.
+  /// to use the `limit` functionality. And it can only be ensured to take effect
+  /// on Android 13 or above. Otherwise, it depends on whether the corresponding
+  /// system app supports it.
   ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
   /// information the plugin tries to get.
@@ -231,7 +233,9 @@ class ImagePicker {
   ///
   /// The `limit` parameter modifies the maximum number of media that can be selected.
   /// On Android, [ImagePickerAndroid.useAndroidPhotoPicker] must be set to `true`
-  /// to use the `limit` functionality.
+  /// to use the `limit` functionality. And it can only be ensured to take effect
+  /// on Android 13 or above. Otherwise, it depends on whether the corresponding
+  /// system app supports it.
   ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
   /// information the plugin tries to get.

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -112,6 +112,12 @@ class ImagePicker {
   /// image types such as JPEG and on Android PNG and WebP, too. If compression is not
   /// supported for the image that is picked, a warning message will be logged.
   ///
+  /// The `limit` parameter modifies the maximum number of images that can be selected.
+  /// On Android, you need to set ImagePickerAndroid's useAndroidPhotoPicker to
+  /// true for this parameter to be valid.
+  /// See: https://github.com/flutter/packages/blob/main/packages/image_picker/image_picker_android/README.md#photo-picker
+  /// for code.
+  ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
   /// information the plugin tries to get.
   /// If `requestFullMetadata` is set to `true`, the plugin tries to get the full
@@ -224,6 +230,12 @@ class ImagePicker {
   /// the original quality will be returned. Compression is only supported for certain
   /// image types such as JPEG and on Android PNG and WebP, too. If compression is not
   /// supported for the image that is picked, a warning message will be logged.
+  ///
+  /// The `limit` parameter modifies the maximum number of media that can be selected.
+  /// On Android, you need to set ImagePickerAndroid's useAndroidPhotoPicker to
+  /// true for this parameter to be valid.
+  /// See: https://github.com/flutter/packages/blob/main/packages/image_picker/image_picker_android/README.md#photo-picker
+  /// for code.
   ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
   /// information the plugin tries to get.

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -113,10 +113,7 @@ class ImagePicker {
   /// supported for the image that is picked, a warning message will be logged.
   ///
   /// The `limit` parameter modifies the maximum number of images that can be selected.
-  /// On Android, [ImagePickerAndroid.useAndroidPhotoPicker] must be set to `true`
-  /// to use the `limit` functionality. And it can only be ensured to take effect
-  /// on Android 13 or above. Otherwise, it depends on whether the corresponding
-  /// system app supports it.
+  /// This value may be ignored by platforms that cannot support it.
   ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
   /// information the plugin tries to get.
@@ -232,10 +229,7 @@ class ImagePicker {
   /// supported for the image that is picked, a warning message will be logged.
   ///
   /// The `limit` parameter modifies the maximum number of media that can be selected.
-  /// On Android, [ImagePickerAndroid.useAndroidPhotoPicker] must be set to `true`
-  /// to use the `limit` functionality. And it can only be ensured to take effect
-  /// on Android 13 or above. Otherwise, it depends on whether the corresponding
-  /// system app supports it.
+  /// This value may be ignored by platforms that cannot support it.
   ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
   /// information the plugin tries to get.

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 1.1.1
+version: 1.1.2
 
 environment:
   sdk: ^3.3.0

--- a/packages/image_picker/image_picker_android/AUTHORS
+++ b/packages/image_picker/image_picker_android/AUTHORS
@@ -65,3 +65,4 @@ Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
 André Sousa <andrelvsousa@gmail.com>
+LinXunFeng <linxunfeng@yeah.net>

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.13
+
+* Update documentation to note that limit is not always supported.
+
 ## 0.8.12+2
 
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.13
+## 0.8.12+3
 
 * Update documentation to note that limit is not always supported.
 

--- a/packages/image_picker/image_picker_android/README.md
+++ b/packages/image_picker/image_picker_android/README.md
@@ -33,5 +33,8 @@ import 'package:image_picker_platform_interface/image_picker_platform_interface.
   }
 ```
 
+In addition, `[ImagePickerAndroid.useAndroidPhotoPicker]` must be set to `true` to use the `limit` functionality. It is implemented based on [`ActivityResultContract`][3], so it can only be ensured to take effect on Android 13 or above. Otherwise, it depends on whether the corresponding system app supports it.
+
 [1]: https://pub.dev/packages/image_picker
 [2]: https://flutter.dev/docs/development/packages-and-plugins/developing-packages#endorsed-federated-plugin
+[3]: https://developer.android.google.cn/reference/kotlin/androidx/activity/result/contract/ActivityResultContracts.PickMultipleVisualMedia

--- a/packages/image_picker/image_picker_android/README.md
+++ b/packages/image_picker/image_picker_android/README.md
@@ -33,7 +33,7 @@ import 'package:image_picker_platform_interface/image_picker_platform_interface.
   }
 ```
 
-In addition, `[ImagePickerAndroid.useAndroidPhotoPicker]` must be set to `true` to use the `limit` functionality. It is implemented based on [`ActivityResultContract`][3], so it can only be ensured to take effect on Android 13 or above. Otherwise, it depends on whether the corresponding system app supports it.
+In addition, `ImagePickerAndroid.useAndroidPhotoPicker` must be set to `true` to use the `limit` functionality. It is implemented based on [`ActivityResultContract`][3], so it can only be ensured to take effect on Android 13 or above. Otherwise, it depends on whether the corresponding system app supports it.
 
 [1]: https://pub.dev/packages/image_picker
 [2]: https://flutter.dev/docs/development/packages-and-plugins/developing-packages#endorsed-federated-plugin

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.13
+version: 0.8.12+3
 
 environment:
   sdk: ^3.4.0

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.12+2
+version: 0.8.13
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/147773

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
