### PR TITLE
[go_router] guard context access in then clauses

### DIFF
--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -72,7 +72,9 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
       return debugParserFuture = _redirect(context, matchList)
           .then<RouteMatchList>((RouteMatchList value) {
         if (value.isError && onParserException != null) {
-          return onParserException!(context, value); // ignore: use_build_context_synchronously
+          // TODO(chunhtai): Figure out what to return if context is invalid.
+          // ignore: use_build_context_synchronously
+          return onParserException!(context, value);
         }
         return value;
       });
@@ -106,7 +108,9 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
       initialMatches,
     ).then<RouteMatchList>((RouteMatchList matchList) {
       if (matchList.isError && onParserException != null) {
-        return onParserException!(context, matchList); // ignore: use_build_context_synchronously
+        // TODO(chunhtai): Figure out what to return if context is invalid.
+        // ignore: use_build_context_synchronously
+        return onParserException!(context, matchList);
       }
 
       assert(() {

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -72,7 +72,7 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
       return debugParserFuture = _redirect(context, matchList)
           .then<RouteMatchList>((RouteMatchList value) {
         if (value.isError && onParserException != null) {
-          return onParserException!(context, value);
+          return onParserException!(context, value); // ignore: use_build_context_synchronously
         }
         return value;
       });
@@ -106,7 +106,7 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
       initialMatches,
     ).then<RouteMatchList>((RouteMatchList matchList) {
       if (matchList.isError && onParserException != null) {
-        return onParserException!(context, matchList);
+        return onParserException!(context, matchList); // ignore: use_build_context_synchronously
       }
 
       assert(() {

--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.2
+
+* Fixes a bug in the example app when accessing `BuildContext`.
+
 ## 2.6.1
 
 * Fixes typo in `durationDecoderHelperName`.

--- a/packages/go_router_builder/example/lib/main.dart
+++ b/packages/go_router_builder/example/lib/main.dart
@@ -188,6 +188,9 @@ class HomeScreen extends StatelessWidget {
                     unawaited(FamilyCountRoute(familyData.length)
                         .push<int>(context)
                         .then((int? value) {
+                      if (!context.mounted) {
+                        return;
+                      }
                       if (value != null) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 2.6.1
+version: 2.6.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 


### PR DESCRIPTION
Prepares for a fix to the `use_build_context_synchronously` lint (https://dart-review.googlesource.com/c/sdk/+/365541) that will complain about these unsafe usages.