### PR TITLE
[flutter_lints] Rev to 4.0.0; prepare for publishing

### DIFF
--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 4.0.0
 
-* Updated `package:lints` dependency to version 4.0.0, with the following changes:
-    * added `library_annotations`
-    * added `no_wildcard_variable_uses`
-    * removed `package_prefixed_library_names`
-    * removed `library_names`
+* Updates `package:lints` dependency to version 4.0.0, with the following changes:
+    * adds `library_annotations`
+    * adds `no_wildcard_variable_uses`
+    * removes `package_prefixed_library_names`
+    * removes `library_names`
 
 ## 3.0.2
 

--- a/packages/flutter_lints/CHANGELOG.md
+++ b/packages/flutter_lints/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.0.0
+
+* Updated `package:lints` dependency to version 4.0.0, with the following changes:
+    * added `library_annotations`
+    * added `no_wildcard_variable_uses`
+    * removed `package_prefixed_library_names`
+    * removed `library_names`
+
 ## 3.0.2
 
 * Updates minimum supported SDK version to Flutter 3.13/Dart 3.1.

--- a/packages/flutter_lints/pubspec.yaml
+++ b/packages/flutter_lints/pubspec.yaml
@@ -2,13 +2,13 @@ name: flutter_lints
 description: Recommended lints for Flutter apps, packages, and plugins to encourage good coding practices.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_lints
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_lints%22
-version: 3.0.2
+version: 4.0.0
 
 environment:
   sdk: ^3.1.0
 
 dependencies:
-  lints: ^3.0.0
+  lints: ^4.0.0
   # Code is not allowed in this package. Do not add any dependencies or dev_dependencies.
 
 topics:


### PR DESCRIPTION
To be submitted after https://github.com/dart-lang/lints/pull/184 is published.