### PR TITLE
[camerax] Make fixes required to swap camera_android_camerax for camera_android

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.5
+
+* Modifies `stopVideoRecording` to ensure the method only returns when the recorded video finishes saving to a file.
+* Adds empty implementation for `setDescriptionWhileRecording` and leaves a todo to add this feature.
+
 ## 0.6.4+1
 
 * Adds empty implementation for `prepareForVideoRecording` since this optimization is not used on Android.

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.6.5
 
-* Modifies `stopVideoRecording` to ensure the method only returns when the recorded video finishes saving to a file.
+* Modifies `stopVideoRecording` to ensure that the method only returns when CameraX reports that the
+  recorded video finishes saving to a file.
+* Modifies `startVideoCapturing` to ensure that the method only returns when CameraX reports that
+  video recording has started.
 * Adds empty implementation for `setDescriptionWhileRecording` and leaves a todo to add this feature.
 
 ## 0.6.4+1

--- a/packages/camera/camera_android_camerax/README.md
+++ b/packages/camera/camera_android_camerax/README.md
@@ -37,6 +37,9 @@ use cases, the plugin behaves according to the following:
     video recording and image streaming is supported, but concurrent video recording, image
     streaming, and image capture is not supported.
 
+### `setDescriptionWhileRecording` is unimplemented [Issue #148013][148013]
+`setDescriptionWhileRecording`, used to switch cameras while recording video, is currently unimplemented.
+
 ### 240p resolution configuration for video recording
 
 240p resolution configuration for video recording is unsupported by CameraX,
@@ -64,11 +67,4 @@ For more information on contributing to this plugin, see [`CONTRIBUTING.md`](CON
 [6]: https://developer.android.com/media/camera/camerax/architecture#combine-use-cases
 [7]: https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#INFO_SUPPORTED_HARDWARE_LEVEL_3
 [8]: https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#INFO_SUPPORTED_HARDWARE_LEVEL_LIMITED
-[120462]: https://github.com/flutter/flutter/issues/120462
-[125915]: https://github.com/flutter/flutter/issues/125915
-[120715]: https://github.com/flutter/flutter/issues/120715
-[120468]: https://github.com/flutter/flutter/issues/120468
-[120467]: https://github.com/flutter/flutter/issues/120467
-[125371]: https://github.com/flutter/flutter/issues/125371
-[126477]: https://github.com/flutter/flutter/issues/126477
-[127896]: https://github.com/flutter/flutter/issues/127896
+[148013]: https://github.com/flutter/flutter/issues/148013

--- a/packages/camera/camera_android_camerax/README.md
+++ b/packages/camera/camera_android_camerax/README.md
@@ -38,7 +38,8 @@ use cases, the plugin behaves according to the following:
     streaming, and image capture is not supported.
 
 ### `setDescriptionWhileRecording` is unimplemented [Issue #148013][148013]
-`setDescriptionWhileRecording`, used to switch cameras while recording video, is currently unimplemented.
+`setDescriptionWhileRecording`, used to switch cameras while recording video, is currently unimplemented
+due to this not currently being supported by CameraX.
 
 ### 240p resolution configuration for video recording
 

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/GeneratedCameraXLibrary.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/GeneratedCameraXLibrary.java
@@ -2144,6 +2144,15 @@ public class GeneratedCameraXLibrary {
           new ArrayList<Object>(Collections.singletonList(identifierArg)),
           channelReply -> callback.reply(null));
     }
+
+    public void onVideoRecordingFinalized(@NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger,
+              "dev.flutter.pigeon.PendingRecordingFlutterApi.onVideoRecordingFinalized",
+              getCodec());
+      channel.send(null, channelReply -> callback.reply(null));
+    }
   }
   /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
   public interface RecordingHostApi {

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/GeneratedCameraXLibrary.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/GeneratedCameraXLibrary.java
@@ -147,6 +147,22 @@ public class GeneratedCameraXLibrary {
   }
 
   /**
+   * Video recording status.
+   *
+   * <p>See https://developer.android.com/reference/androidx/camera/video/VideoRecordEvent.
+   */
+  public enum VideoRecordEvent {
+    START(0),
+    FINALIZE(1);
+
+    final int index;
+
+    private VideoRecordEvent(final int index) {
+      this.index = index;
+    }
+  }
+
+  /**
    * The types of capture request options this plugin currently supports.
    *
    * <p>If you need to add another option to support, ensure the following is done on the Dart side:
@@ -554,6 +570,55 @@ public class GeneratedCameraXLibrary {
       VideoQualityData pigeonResult = new VideoQualityData();
       Object quality = list.get(0);
       pigeonResult.setQuality(quality == null ? null : VideoQuality.values()[(int) quality]);
+      return pigeonResult;
+    }
+  }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static final class VideoRecordEventData {
+    private @NonNull VideoRecordEvent value;
+
+    public @NonNull VideoRecordEvent getValue() {
+      return value;
+    }
+
+    public void setValue(@NonNull VideoRecordEvent setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"value\" is null.");
+      }
+      this.value = setterArg;
+    }
+
+    /** Constructor is non-public to enforce null safety; use Builder. */
+    VideoRecordEventData() {}
+
+    public static final class Builder {
+
+      private @Nullable VideoRecordEvent value;
+
+      public @NonNull Builder setValue(@NonNull VideoRecordEvent setterArg) {
+        this.value = setterArg;
+        return this;
+      }
+
+      public @NonNull VideoRecordEventData build() {
+        VideoRecordEventData pigeonReturn = new VideoRecordEventData();
+        pigeonReturn.setValue(value);
+        return pigeonReturn;
+      }
+    }
+
+    @NonNull
+    ArrayList<Object> toList() {
+      ArrayList<Object> toListResult = new ArrayList<Object>(1);
+      toListResult.add(value == null ? null : value.index);
+      return toListResult;
+    }
+
+    static @NonNull VideoRecordEventData fromList(@NonNull ArrayList<Object> list) {
+      VideoRecordEventData pigeonResult = new VideoRecordEventData();
+      Object value = list.get(0);
+      pigeonResult.setValue(value == null ? null : VideoRecordEvent.values()[(int) value]);
       return pigeonResult;
     }
   }
@@ -2118,6 +2183,34 @@ public class GeneratedCameraXLibrary {
       }
     }
   }
+
+  private static class PendingRecordingFlutterApiCodec extends StandardMessageCodec {
+    public static final PendingRecordingFlutterApiCodec INSTANCE =
+        new PendingRecordingFlutterApiCodec();
+
+    private PendingRecordingFlutterApiCodec() {}
+
+    @Override
+    protected Object readValueOfType(byte type, @NonNull ByteBuffer buffer) {
+      switch (type) {
+        case (byte) 128:
+          return VideoRecordEventData.fromList((ArrayList<Object>) readValue(buffer));
+        default:
+          return super.readValueOfType(type, buffer);
+      }
+    }
+
+    @Override
+    protected void writeValue(@NonNull ByteArrayOutputStream stream, Object value) {
+      if (value instanceof VideoRecordEventData) {
+        stream.write(128);
+        writeValue(stream, ((VideoRecordEventData) value).toList());
+      } else {
+        super.writeValue(stream, value);
+      }
+    }
+  }
+
   /** Generated class from Pigeon that represents Flutter messages that can be called from Java. */
   public static class PendingRecordingFlutterApi {
     private final @NonNull BinaryMessenger binaryMessenger;
@@ -2133,7 +2226,7 @@ public class GeneratedCameraXLibrary {
     }
     /** The codec used by PendingRecordingFlutterApi. */
     static @NonNull MessageCodec<Object> getCodec() {
-      return new StandardMessageCodec();
+      return PendingRecordingFlutterApiCodec.INSTANCE;
     }
 
     public void create(@NonNull Long identifierArg, @NonNull Reply<Void> callback) {
@@ -2145,13 +2238,16 @@ public class GeneratedCameraXLibrary {
           channelReply -> callback.reply(null));
     }
 
-    public void onVideoRecordingFinalized(@NonNull Reply<Void> callback) {
+    public void onVideoRecordingEvent(
+        @NonNull VideoRecordEventData eventArg, @NonNull Reply<Void> callback) {
       BasicMessageChannel<Object> channel =
           new BasicMessageChannel<>(
               binaryMessenger,
-              "dev.flutter.pigeon.PendingRecordingFlutterApi.onVideoRecordingFinalized",
+              "dev.flutter.pigeon.PendingRecordingFlutterApi.onVideoRecordingEvent",
               getCodec());
-      channel.send(null, channelReply -> callback.reply(null));
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(eventArg)),
+          channelReply -> callback.reply(null));
     }
   }
   /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
@@ -4036,6 +4132,8 @@ public class GeneratedCameraXLibrary {
           return ResolutionInfo.fromList((ArrayList<Object>) readValue(buffer));
         case (byte) 134:
           return VideoQualityData.fromList((ArrayList<Object>) readValue(buffer));
+        case (byte) 135:
+          return VideoRecordEventData.fromList((ArrayList<Object>) readValue(buffer));
         default:
           return super.readValueOfType(type, buffer);
       }
@@ -4064,6 +4162,9 @@ public class GeneratedCameraXLibrary {
       } else if (value instanceof VideoQualityData) {
         stream.write(134);
         writeValue(stream, ((VideoQualityData) value).toList());
+      } else if (value instanceof VideoRecordEventData) {
+        stream.write(135);
+        writeValue(stream, ((VideoRecordEventData) value).toList());
       } else {
         super.writeValue(stream, value);
       }

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingFlutterApiImpl.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingFlutterApiImpl.java
@@ -22,4 +22,8 @@ public class PendingRecordingFlutterApiImpl extends PendingRecordingFlutterApi {
   void create(@NonNull PendingRecording pendingRecording, @Nullable Reply<Void> reply) {
     create(instanceManager.addHostCreatedInstance(pendingRecording), reply);
   }
+
+  void sendVideoRecordingFinalizedEvent(@NonNull Reply<Void> reply) {
+    super.onVideoRecordingFinalized(reply);
+  }
 }

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingFlutterApiImpl.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingFlutterApiImpl.java
@@ -9,6 +9,8 @@ import androidx.annotation.Nullable;
 import androidx.camera.video.PendingRecording;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugins.camerax.GeneratedCameraXLibrary.PendingRecordingFlutterApi;
+import io.flutter.plugins.camerax.GeneratedCameraXLibrary.VideoRecordEvent;
+import io.flutter.plugins.camerax.GeneratedCameraXLibrary.VideoRecordEventData;
 
 public class PendingRecordingFlutterApiImpl extends PendingRecordingFlutterApi {
   private final InstanceManager instanceManager;
@@ -24,6 +26,12 @@ public class PendingRecordingFlutterApiImpl extends PendingRecordingFlutterApi {
   }
 
   void sendVideoRecordingFinalizedEvent(@NonNull Reply<Void> reply) {
-    super.onVideoRecordingFinalized(reply);
+    super.onVideoRecordingEvent(
+        new VideoRecordEventData.Builder().setValue(VideoRecordEvent.FINALIZE).build(), reply);
+  }
+
+  void sendVideoRecordingStartedEvent(@NonNull Reply<Void> reply) {
+    super.onVideoRecordingEvent(
+        new VideoRecordEventData.Builder().setValue(VideoRecordEvent.START).build(), reply);
   }
 }

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingHostApiImpl.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingHostApiImpl.java
@@ -24,6 +24,8 @@ public class PendingRecordingHostApiImpl implements PendingRecordingHostApi {
 
   @VisibleForTesting @NonNull public CameraXProxy cameraXProxy = new CameraXProxy();
 
+  PendingRecordingFlutterApiImpl pendingRecordingFlutterApi;
+
   @VisibleForTesting SystemServicesFlutterApiImpl systemServicesFlutterApi;
 
   @VisibleForTesting RecordingFlutterApiImpl recordingFlutterApi;
@@ -37,6 +39,8 @@ public class PendingRecordingHostApiImpl implements PendingRecordingHostApi {
     this.context = context;
     systemServicesFlutterApi = cameraXProxy.createSystemServicesFlutterApiImpl(binaryMessenger);
     recordingFlutterApi = new RecordingFlutterApiImpl(binaryMessenger, instanceManager);
+    pendingRecordingFlutterApi =
+        new PendingRecordingFlutterApiImpl(binaryMessenger, instanceManager);
   }
 
   /** Sets the context, which is used to get the {@link Executor} needed to start the recording. */
@@ -77,6 +81,7 @@ public class PendingRecordingHostApiImpl implements PendingRecordingHostApi {
   @VisibleForTesting
   public void handleVideoRecordEvent(@NonNull VideoRecordEvent event) {
     if (event instanceof VideoRecordEvent.Finalize) {
+      pendingRecordingFlutterApi.sendVideoRecordingFinalizedEvent(reply -> {});
       VideoRecordEvent.Finalize castedEvent = (VideoRecordEvent.Finalize) event;
       if (castedEvent.hasError()) {
         String cameraErrorMessage;

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingHostApiImpl.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingHostApiImpl.java
@@ -77,10 +77,15 @@ public class PendingRecordingHostApiImpl implements PendingRecordingHostApi {
   /**
    * Handles {@link VideoRecordEvent}s that come in during video recording. Sends any errors
    * encountered using {@link SystemServicesFlutterApiImpl}.
+   *
+   * <p>Currently only sends {@link VideoRecordEvent.Start} and {@link VideoRecordEvent.Finalize}
+   * events to the Dart side.
    */
   @VisibleForTesting
   public void handleVideoRecordEvent(@NonNull VideoRecordEvent event) {
-    if (event instanceof VideoRecordEvent.Finalize) {
+    if (event instanceof VideoRecordEvent.Start) {
+      pendingRecordingFlutterApi.sendVideoRecordingStartedEvent(reply -> {});
+    } else if (event instanceof VideoRecordEvent.Finalize) {
       pendingRecordingFlutterApi.sendVideoRecordingFinalizedEvent(reply -> {});
       VideoRecordEvent.Finalize castedEvent = (VideoRecordEvent.Finalize) event;
       if (castedEvent.hasError()) {

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingHostApiImpl.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PendingRecordingHostApiImpl.java
@@ -24,7 +24,7 @@ public class PendingRecordingHostApiImpl implements PendingRecordingHostApi {
 
   @VisibleForTesting @NonNull public CameraXProxy cameraXProxy = new CameraXProxy();
 
-  PendingRecordingFlutterApiImpl pendingRecordingFlutterApi;
+  @VisibleForTesting PendingRecordingFlutterApiImpl pendingRecordingFlutterApi;
 
   @VisibleForTesting SystemServicesFlutterApiImpl systemServicesFlutterApi;
 

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PendingRecordingTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PendingRecordingTest.java
@@ -100,14 +100,24 @@ public class PendingRecordingTest {
     PendingRecordingHostApiImpl pendingRecordingHostApi =
         new PendingRecordingHostApiImpl(mockBinaryMessenger, testInstanceManager, mockContext);
     pendingRecordingHostApi.pendingRecordingFlutterApi = mockPendingRecordingFlutterApi;
-    final String eventMessage = "example failure message";
 
     when(event.hasError()).thenReturn(false);
-    doNothing().when(mockSystemServicesFlutterApi).sendCameraError(any(), any());
 
     pendingRecordingHostApi.handleVideoRecordEvent(event);
 
     verify(mockPendingRecordingFlutterApi).sendVideoRecordingFinalizedEvent(any());
+  }
+
+  @Test
+  public void handleVideoRecordEvent_SendsVideoRecordingStartedEvent() {
+    PendingRecordingHostApiImpl pendingRecordingHostApi =
+        new PendingRecordingHostApiImpl(mockBinaryMessenger, testInstanceManager, mockContext);
+    pendingRecordingHostApi.pendingRecordingFlutterApi = mockPendingRecordingFlutterApi;
+    VideoRecordEvent.Start mockStartEvent = mock(VideoRecordEvent.Start.class);
+
+    pendingRecordingHostApi.handleVideoRecordEvent(mockStartEvent);
+
+    verify(mockPendingRecordingFlutterApi).sendVideoRecordingStartedEvent(any());
   }
 
   @Test

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PendingRecordingTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PendingRecordingTest.java
@@ -91,7 +91,7 @@ public class PendingRecordingTest {
 
     pendingRecordingHostApi.handleVideoRecordEvent(event);
 
-    verify(mockPendingRecordingFlutterApi).sendVideoRecordingFinalizedEventaError(any());
+    verify(mockPendingRecordingFlutterApi).sendVideoRecordingFinalizedEvent(any());
     verify(mockSystemServicesFlutterApi).sendCameraError(eq(eventMessage), any());
   }
 
@@ -107,7 +107,7 @@ public class PendingRecordingTest {
 
     pendingRecordingHostApi.handleVideoRecordEvent(event);
 
-    verify(mockPendingRecordingFlutterApi).sendVideoRecordingFinalizedEventaError(any());
+    verify(mockPendingRecordingFlutterApi).sendVideoRecordingFinalizedEvent(any());
   }
 
   @Test

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PendingRecordingTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PendingRecordingTest.java
@@ -41,6 +41,7 @@ public class PendingRecordingTest {
   @Mock public RecordingFlutterApiImpl mockRecordingFlutterApi;
   @Mock public Context mockContext;
   @Mock public SystemServicesFlutterApiImpl mockSystemServicesFlutterApi;
+  @Mock public PendingRecordingFlutterApiImpl mockPendingRecordingFlutterApi;
   @Mock public VideoRecordEvent.Finalize event;
   @Mock public Throwable throwable;
 
@@ -80,6 +81,7 @@ public class PendingRecordingTest {
     PendingRecordingHostApiImpl pendingRecordingHostApi =
         new PendingRecordingHostApiImpl(mockBinaryMessenger, testInstanceManager, mockContext);
     pendingRecordingHostApi.systemServicesFlutterApi = mockSystemServicesFlutterApi;
+    pendingRecordingHostApi.pendingRecordingFlutterApi = mockPendingRecordingFlutterApi;
     final String eventMessage = "example failure message";
 
     when(event.hasError()).thenReturn(true);
@@ -89,7 +91,23 @@ public class PendingRecordingTest {
 
     pendingRecordingHostApi.handleVideoRecordEvent(event);
 
+    verify(mockPendingRecordingFlutterApi).sendVideoRecordingFinalizedEventaError(any());
     verify(mockSystemServicesFlutterApi).sendCameraError(eq(eventMessage), any());
+  }
+
+  @Test
+  public void handleVideoRecordEvent_SendsVideoRecordingFinalizedEvent() {
+    PendingRecordingHostApiImpl pendingRecordingHostApi =
+        new PendingRecordingHostApiImpl(mockBinaryMessenger, testInstanceManager, mockContext);
+    pendingRecordingHostApi.pendingRecordingFlutterApi = mockPendingRecordingFlutterApi;
+    final String eventMessage = "example failure message";
+
+    when(event.hasError()).thenReturn(false);
+    doNothing().when(mockSystemServicesFlutterApi).sendCameraError(any(), any());
+
+    pendingRecordingHostApi.handleVideoRecordEvent(event);
+
+    verify(mockPendingRecordingFlutterApi).sendVideoRecordingFinalizedEventaError(any());
   }
 
   @Test

--- a/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
+++ b/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
@@ -195,11 +195,8 @@ void main() {
     await controller.startVideoRecording();
     final int recordingStart = DateTime.now().millisecondsSinceEpoch;
 
-    const int recordDuration = 2000;
-    sleep(const Duration(milliseconds: recordDuration));
+    sleep(const Duration(seconds: 2));
 
-    final int preStopTime =
-        DateTime.now().millisecondsSinceEpoch - recordingStart;
     final XFile file = await controller.stopVideoRecording();
     final int postStopTime =
         DateTime.now().millisecondsSinceEpoch - recordingStart;
@@ -212,7 +209,6 @@ void main() {
     final int duration = videoController.value.duration.inMilliseconds;
     await videoController.dispose();
 
-    expect(duration, greaterThan(preStopTime));
     expect(duration, lessThan(postStopTime));
   });
 

--- a/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
+++ b/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
@@ -219,8 +219,8 @@ void main() {
     }
 
     final CameraController controller = CameraController(cameras[0],
-        mediaSettings: const MediaSettings(
-            resolutionPreset: ResolutionPreset.low, enableAudio: false));
+        mediaSettings:
+            const MediaSettings(resolutionPreset: ResolutionPreset.low));
     await controller.initialize();
     await controller.prepareForVideoRecording();
 

--- a/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
+++ b/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
@@ -195,8 +195,11 @@ void main() {
     await controller.startVideoRecording();
     final int recordingStart = DateTime.now().millisecondsSinceEpoch;
 
-    sleep(const Duration(seconds: 2));
+    const int recordDuration = 2000;
+    sleep(const Duration(milliseconds: recordDuration));
 
+    final int preStopTime =
+        DateTime.now().millisecondsSinceEpoch - recordingStart;
     final XFile file = await controller.stopVideoRecording();
     final int postStopTime =
         DateTime.now().millisecondsSinceEpoch - recordingStart;
@@ -209,6 +212,7 @@ void main() {
     final int duration = videoController.value.duration.inMilliseconds;
     await videoController.dispose();
 
+    expect(duration, greaterThan(preStopTime));
     expect(duration, lessThan(postStopTime));
   });
 

--- a/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
+++ b/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
@@ -13,6 +13,7 @@ import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:video_player/video_player.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -177,5 +178,87 @@ void main() {
         await controller.dispose();
       }
     }
+  });
+
+  testWidgets('Video capture records valid video', (WidgetTester tester) async {
+    final List<CameraDescription> cameras = await availableCameras();
+    if (cameras.isEmpty) {
+      return;
+    }
+
+    final CameraController controller = CameraController(cameras[0],
+        mediaSettings:
+            const MediaSettings(resolutionPreset: ResolutionPreset.low));
+    await controller.initialize();
+    await controller.prepareForVideoRecording();
+
+    await controller.startVideoRecording();
+    final int recordingStart = DateTime.now().millisecondsSinceEpoch;
+
+    sleep(const Duration(seconds: 2));
+
+    final XFile file = await controller.stopVideoRecording();
+    final int recordingTime =
+        DateTime.now().millisecondsSinceEpoch - recordingStart;
+
+    final File videoFile = File(file.path);
+    final VideoPlayerController videoController = VideoPlayerController.file(
+      videoFile,
+    );
+    await videoController.initialize();
+    final int duration = videoController.value.duration.inMilliseconds;
+    await videoController.dispose();
+
+    expect(duration, lessThan(recordingTime));
+  });
+
+  testWidgets('Pause and resume video recording', (WidgetTester tester) async {
+    final List<CameraDescription> cameras = await availableCameras();
+    if (cameras.isEmpty) {
+      return;
+    }
+
+    final CameraController controller = CameraController(cameras[0],
+        mediaSettings: const MediaSettings(
+            resolutionPreset: ResolutionPreset.low, enableAudio: false));
+    await controller.initialize();
+    await controller.prepareForVideoRecording();
+
+    int startPause;
+    int timePaused = 0;
+
+    await controller.startVideoRecording();
+    final int recordingStart = DateTime.now().millisecondsSinceEpoch;
+    sleep(const Duration(milliseconds: 500));
+
+    await controller.pauseVideoRecording();
+    startPause = DateTime.now().millisecondsSinceEpoch;
+    sleep(const Duration(milliseconds: 500));
+    await controller.resumeVideoRecording();
+    timePaused += DateTime.now().millisecondsSinceEpoch - startPause;
+
+    sleep(const Duration(milliseconds: 500));
+
+    await controller.pauseVideoRecording();
+    startPause = DateTime.now().millisecondsSinceEpoch;
+    sleep(const Duration(milliseconds: 500));
+    await controller.resumeVideoRecording();
+    timePaused += DateTime.now().millisecondsSinceEpoch - startPause;
+
+    sleep(const Duration(milliseconds: 500));
+
+    final XFile file = await controller.stopVideoRecording();
+    final int recordingTime =
+        DateTime.now().millisecondsSinceEpoch - recordingStart;
+
+    final File videoFile = File(file.path);
+    final VideoPlayerController videoController = VideoPlayerController.file(
+      videoFile,
+    );
+    await videoController.initialize();
+    final int duration = videoController.value.duration.inMilliseconds;
+    await videoController.dispose();
+
+    expect(duration, lessThan(recordingTime - timePaused));
   });
 }

--- a/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
+++ b/packages/camera/camera_android_camerax/example/integration_test/integration_test.dart
@@ -198,7 +198,7 @@ void main() {
     sleep(const Duration(seconds: 2));
 
     final XFile file = await controller.stopVideoRecording();
-    final int recordingTime =
+    final int postStopTime =
         DateTime.now().millisecondsSinceEpoch - recordingStart;
 
     final File videoFile = File(file.path);
@@ -209,7 +209,7 @@ void main() {
     final int duration = videoController.value.duration.inMilliseconds;
     await videoController.dispose();
 
-    expect(duration, lessThan(recordingTime));
+    expect(duration, lessThan(postStopTime));
   });
 
   testWidgets('Pause and resume video recording', (WidgetTester tester) async {
@@ -226,26 +226,21 @@ void main() {
 
     int startPause;
     int timePaused = 0;
+    const int pauseIterations = 2;
 
     await controller.startVideoRecording();
     final int recordingStart = DateTime.now().millisecondsSinceEpoch;
     sleep(const Duration(milliseconds: 500));
 
-    await controller.pauseVideoRecording();
-    startPause = DateTime.now().millisecondsSinceEpoch;
-    sleep(const Duration(milliseconds: 500));
-    await controller.resumeVideoRecording();
-    timePaused += DateTime.now().millisecondsSinceEpoch - startPause;
+    for (int i = 0; i < pauseIterations; i++) {
+      await controller.pauseVideoRecording();
+      startPause = DateTime.now().millisecondsSinceEpoch;
+      sleep(const Duration(milliseconds: 500));
+      await controller.resumeVideoRecording();
+      timePaused += DateTime.now().millisecondsSinceEpoch - startPause;
 
-    sleep(const Duration(milliseconds: 500));
-
-    await controller.pauseVideoRecording();
-    startPause = DateTime.now().millisecondsSinceEpoch;
-    sleep(const Duration(milliseconds: 500));
-    await controller.resumeVideoRecording();
-    timePaused += DateTime.now().millisecondsSinceEpoch - startPause;
-
-    sleep(const Duration(milliseconds: 500));
+      sleep(const Duration(milliseconds: 500));
+    }
 
     final XFile file = await controller.stopVideoRecording();
     final int recordingTime =

--- a/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
+++ b/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
@@ -788,6 +788,7 @@ class AndroidCameraCameraX extends CameraPlatform {
   /// Currently unsupported, so is a no-op.
   @override
   Future<void> setDescriptionWhileRecording(CameraDescription description) {
+    // TODO(camsim99): Implement this feature, see https://github.com/flutter/flutter/issues/148013.
     return Future<void>.value();
   }
 

--- a/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
+++ b/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
@@ -970,7 +970,8 @@ class AndroidCameraCameraX extends CameraPlatform {
           .setTargetRotation(await proxy.getDefaultDisplayRotation());
     }
 
-    videoOutputPath = await SystemServices.getTempFilePath(videoPrefix, '.mp4');
+    videoOutputPath =
+        await SystemServices.getTempFilePath(videoPrefix, '.temp');
     pendingRecording = await recorder!.prepareRecording(videoOutputPath!);
     recording = await pendingRecording!.start();
 

--- a/packages/camera/camera_android_camerax/lib/src/camerax_library.g.dart
+++ b/packages/camera/camera_android_camerax/lib/src/camerax_library.g.dart
@@ -68,6 +68,14 @@ enum VideoResolutionFallbackRule {
   lowerQualityThan,
 }
 
+/// Video recording status.
+///
+/// See https://developer.android.com/reference/androidx/camera/video/VideoRecordEvent.
+enum VideoRecordEvent {
+  start,
+  finalize,
+}
+
 /// The types of capture request options this plugin currently supports.
 ///
 /// If you need to add another option to support, ensure the following is done
@@ -228,6 +236,27 @@ class VideoQualityData {
     result as List<Object?>;
     return VideoQualityData(
       quality: VideoQuality.values[result[0]! as int],
+    );
+  }
+}
+
+class VideoRecordEventData {
+  VideoRecordEventData({
+    required this.value,
+  });
+
+  VideoRecordEvent value;
+
+  Object encode() {
+    return <Object?>[
+      value.index,
+    ];
+  }
+
+  static VideoRecordEventData decode(Object result) {
+    result as List<Object?>;
+    return VideoRecordEventData(
+      value: VideoRecordEvent.values[result[0]! as int],
     );
   }
 }
@@ -1580,12 +1609,35 @@ class PendingRecordingHostApi {
   }
 }
 
+class _PendingRecordingFlutterApiCodec extends StandardMessageCodec {
+  const _PendingRecordingFlutterApiCodec();
+  @override
+  void writeValue(WriteBuffer buffer, Object? value) {
+    if (value is VideoRecordEventData) {
+      buffer.putUint8(128);
+      writeValue(buffer, value.encode());
+    } else {
+      super.writeValue(buffer, value);
+    }
+  }
+
+  @override
+  Object? readValueOfType(int type, ReadBuffer buffer) {
+    switch (type) {
+      case 128:
+        return VideoRecordEventData.decode(readValue(buffer)!);
+      default:
+        return super.readValueOfType(type, buffer);
+    }
+  }
+}
+
 abstract class PendingRecordingFlutterApi {
-  static const MessageCodec<Object?> codec = StandardMessageCodec();
+  static const MessageCodec<Object?> codec = _PendingRecordingFlutterApiCodec();
 
   void create(int identifier);
 
-  void onVideoRecordingFinalized();
+  void onVideoRecordingEvent(VideoRecordEventData event);
 
   static void setup(PendingRecordingFlutterApi? api,
       {BinaryMessenger? binaryMessenger}) {
@@ -1610,15 +1662,21 @@ abstract class PendingRecordingFlutterApi {
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.PendingRecordingFlutterApi.onVideoRecordingFinalized',
+          'dev.flutter.pigeon.PendingRecordingFlutterApi.onVideoRecordingEvent',
           codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
-          // ignore message
-          api.onVideoRecordingFinalized();
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.PendingRecordingFlutterApi.onVideoRecordingEvent was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final VideoRecordEventData? arg_event =
+              (args[0] as VideoRecordEventData?);
+          assert(arg_event != null,
+              'Argument for dev.flutter.pigeon.PendingRecordingFlutterApi.onVideoRecordingEvent was null, expected non-null VideoRecordEventData.');
+          api.onVideoRecordingEvent(arg_event!);
           return;
         });
       }
@@ -3239,6 +3297,9 @@ class _CaptureRequestOptionsHostApiCodec extends StandardMessageCodec {
     } else if (value is VideoQualityData) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
+    } else if (value is VideoRecordEventData) {
+      buffer.putUint8(135);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -3261,6 +3322,8 @@ class _CaptureRequestOptionsHostApiCodec extends StandardMessageCodec {
         return ResolutionInfo.decode(readValue(buffer)!);
       case 134:
         return VideoQualityData.decode(readValue(buffer)!);
+      case 135:
+        return VideoRecordEventData.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/camera/camera_android_camerax/lib/src/camerax_library.g.dart
+++ b/packages/camera/camera_android_camerax/lib/src/camerax_library.g.dart
@@ -1585,6 +1585,8 @@ abstract class PendingRecordingFlutterApi {
 
   void create(int identifier);
 
+  void onVideoRecordingFinalized();
+
   static void setup(PendingRecordingFlutterApi? api,
       {BinaryMessenger? binaryMessenger}) {
     {
@@ -1602,6 +1604,21 @@ abstract class PendingRecordingFlutterApi {
           assert(arg_identifier != null,
               'Argument for dev.flutter.pigeon.PendingRecordingFlutterApi.create was null, expected non-null int.');
           api.create(arg_identifier!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.PendingRecordingFlutterApi.onVideoRecordingFinalized',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          // ignore message
+          api.onVideoRecordingFinalized();
           return;
         });
       }

--- a/packages/camera/camera_android_camerax/lib/src/pending_recording.dart
+++ b/packages/camera/camera_android_camerax/lib/src/pending_recording.dart
@@ -33,8 +33,9 @@ class PendingRecording extends JavaObject {
   late final PendingRecordingHostApiImpl _api;
 
   /// Stream that emits an event when the corresponding video recording is finalized.
-  static final StreamController<void> videoRecordingFinalizedStreamController =
-      StreamController<void>.broadcast();
+  static final StreamController<VideoRecordEvent>
+      videoRecordingEventStreamController =
+      StreamController<VideoRecordEvent>.broadcast();
 
   /// Starts the recording, making it an active recording.
   Future<Recording> start() {
@@ -108,7 +109,7 @@ class PendingRecordingFlutterApiImpl extends PendingRecordingFlutterApi {
   }
 
   @override
-  void onVideoRecordingFinalized() {
-    PendingRecording.videoRecordingFinalizedStreamController.add(null);
+  void onVideoRecordingEvent(VideoRecordEventData event) {
+    PendingRecording.videoRecordingEventStreamController.add(event.value);
   }
 }

--- a/packages/camera/camera_android_camerax/lib/src/pending_recording.dart
+++ b/packages/camera/camera_android_camerax/lib/src/pending_recording.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/services.dart' show BinaryMessenger;
 import 'package:meta/meta.dart' show immutable;
 
@@ -29,6 +31,10 @@ class PendingRecording extends JavaObject {
   }
 
   late final PendingRecordingHostApiImpl _api;
+
+  /// Stream that emits an event when the corresponding video recording is finalized.
+  static final StreamController<void> videoRecordingFinalizedStreamController =
+      StreamController<void>.broadcast();
 
   /// Starts the recording, making it an active recording.
   Future<Recording> start() {
@@ -99,5 +105,10 @@ class PendingRecordingFlutterApiImpl extends PendingRecordingFlutterApi {
         instanceManager: instanceManager,
       );
     });
+  }
+
+  @override
+  void onVideoRecordingFinalized() {
+    PendingRecording.videoRecordingFinalizedStreamController.add(null);
   }
 }

--- a/packages/camera/camera_android_camerax/pigeons/camerax_library.dart
+++ b/packages/camera/camera_android_camerax/pigeons/camerax_library.dart
@@ -126,6 +126,15 @@ enum VideoResolutionFallbackRule {
   lowerQualityThan,
 }
 
+/// Video recording status.
+///
+/// See https://developer.android.com/reference/androidx/camera/video/VideoRecordEvent.
+enum VideoRecordEvent { start, finalize }
+
+class VideoRecordEventData {
+  late VideoRecordEvent value;
+}
+
 /// Convenience class for building [FocusMeteringAction]s with multiple metering
 /// points.
 class MeteringPointInfo {
@@ -326,7 +335,7 @@ abstract class PendingRecordingHostApi {
 abstract class PendingRecordingFlutterApi {
   void create(int identifier);
 
-  void onVideoRecordingFinalized();
+  void onVideoRecordingEvent(VideoRecordEventData event);
 }
 
 @HostApi(dartHostTestHandler: 'TestRecordingHostApi')

--- a/packages/camera/camera_android_camerax/pigeons/camerax_library.dart
+++ b/packages/camera/camera_android_camerax/pigeons/camerax_library.dart
@@ -325,6 +325,8 @@ abstract class PendingRecordingHostApi {
 @FlutterApi()
 abstract class PendingRecordingFlutterApi {
   void create(int identifier);
+
+  void onVideoRecordingFinalized();
 }
 
 @HostApi(dartHostTestHandler: 'TestRecordingHostApi')

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.4+1
+version: 0.6.5
 
 environment:
   sdk: ^3.1.0

--- a/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
+++ b/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
@@ -1290,10 +1290,10 @@ void main() {
               Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
       const int cameraId = 17;
-      const String outputPath = '/temp/REC123.mp4';
+      const String outputPath = '/temp/REC123.temp';
 
       // Mock method calls.
-      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
           .thenReturn(outputPath);
       when(camera.recorder!.prepareRecording(outputPath))
           .thenAnswer((_) async => mockPendingRecording);
@@ -1369,10 +1369,10 @@ void main() {
               Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
       const int cameraId = 17;
-      const String outputPath = '/temp/REC123.mp4';
+      const String outputPath = '/temp/REC123.temp';
 
       // Mock method calls.
-      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
           .thenReturn(outputPath);
       when(camera.recorder!.prepareRecording(outputPath))
           .thenAnswer((_) async => mockPendingRecording);
@@ -1398,7 +1398,7 @@ void main() {
 
       await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
       // Verify that each of these calls happened only once.
-      verify(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+      verify(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
           .called(1);
       verifyNoMoreInteractions(mockSystemServicesApi);
       verify(camera.recorder!.prepareRecording(outputPath)).called(1);
@@ -1448,7 +1448,7 @@ void main() {
                   : MockCamera2CameraInfo());
 
       const int cameraId = 17;
-      const String outputPath = '/temp/REC123.mp4';
+      const String outputPath = '/temp/REC123.temp';
       final Completer<CameraImageData> imageDataCompleter =
           Completer<CameraImageData>();
       final VideoCaptureOptions videoCaptureOptions = VideoCaptureOptions(
@@ -1461,7 +1461,7 @@ void main() {
           .thenAnswer((_) async => true);
       when(camera.processCameraProvider!.isBound(camera.imageAnalysis!))
           .thenAnswer((_) async => true);
-      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
           .thenReturn(outputPath);
       when(camera.recorder!.prepareRecording(outputPath))
           .thenAnswer((_) async => mockPendingRecording);
@@ -1516,10 +1516,10 @@ void main() {
                   : MockCamera2CameraInfo());
 
       const int cameraId = 87;
-      const String outputPath = '/temp/REC123.mp4';
+      const String outputPath = '/temp/REC123.temp';
 
       // Mock method calls.
-      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
           .thenReturn(outputPath);
       when(camera.recorder!.prepareRecording(outputPath))
           .thenAnswer((_) async => mockPendingRecording);
@@ -3728,10 +3728,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 7;
-    const String outputPath = '/temp/REC123.mp4';
+    const String outputPath = '/temp/REC123.temp';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -3789,10 +3789,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 77;
-    const String outputPath = '/temp/REC123.mp4';
+    const String outputPath = '/temp/REC123.temp';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -3850,10 +3850,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 87;
-    const String outputPath = '/temp/REC123.mp4';
+    const String outputPath = '/temp/REC123.temp';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -3915,10 +3915,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 107;
-    const String outputPath = '/temp/REC123.mp4';
+    const String outputPath = '/temp/REC123.temp';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -3980,10 +3980,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 97;
-    const String outputPath = '/temp/REC123.mp4';
+    const String outputPath = '/temp/REC123.temp';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -4042,10 +4042,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 44;
-    const String outputPath = '/temp/REC123.mp4';
+    const String outputPath = '/temp/REC123.temp';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);

--- a/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
+++ b/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
@@ -1312,6 +1312,10 @@ void main() {
       when(mockCamera2CameraInfo.getSupportedHardwareLevel()).thenAnswer(
           (_) async => CameraMetadata.infoSupportedHardwareLevelLimited);
 
+      // Simulate video recording being started so startVideoRecording completes.
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.start);
+
       await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
 
       // Verify VideoCapture UseCase is bound and camera & its properties
@@ -1388,6 +1392,10 @@ void main() {
           .thenAnswer((_) async => MockLiveCameraState());
       when(mockCamera2CameraInfo.getSupportedHardwareLevel()).thenAnswer(
           (_) async => CameraMetadata.infoSupportedHardwareLevelLimited);
+
+      // Simulate video recording being started so startVideoRecording completes.
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.start);
 
       await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
 
@@ -1472,6 +1480,10 @@ void main() {
       when(mockCamera2CameraInfo.getSupportedHardwareLevel())
           .thenAnswer((_) async => CameraMetadata.infoSupportedHardwareLevel3);
 
+      // Simulate video recording being started so startVideoRecording completes.
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.start);
+
       await camera.startVideoCapturing(videoCaptureOptions);
 
       final CameraImageData mockCameraImageData = MockCameraImageData();
@@ -1529,11 +1541,19 @@ void main() {
       when(camera.processCameraProvider!.isBound(camera.imageAnalysis!))
           .thenAnswer((_) async => false);
 
+      // Simulate video recording being started so startVideoRecording completes.
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.start);
+
       // Orientation is unlocked and plugin does not need to set default target
       // rotation manually.
       camera.recording = null;
       await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
       verifyNever(mockVideoCapture.setTargetRotation(any));
+
+      // Simulate video recording being started so startVideoRecording completes.
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.start);
 
       // Orientation is locked and plugin does not need to set default target
       // rotation manually.
@@ -1542,6 +1562,10 @@ void main() {
       await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
       verifyNever(mockVideoCapture.setTargetRotation(any));
 
+      // Simulate video recording being started so startVideoRecording completes.
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.start);
+
       // Orientation is locked and plugin does need to set default target
       // rotation manually.
       camera.recording = null;
@@ -1549,6 +1573,10 @@ void main() {
       camera.shouldSetDefaultRotation = true;
       await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
       verifyNever(mockVideoCapture.setTargetRotation(any));
+
+      // Simulate video recording being started so startVideoRecording completes.
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.start);
 
       // Orientation is unlocked and plugin does need to set default target
       // rotation manually.
@@ -1602,7 +1630,8 @@ void main() {
           .thenAnswer((_) async => true);
 
       // Simulate video recording being finalized so stopVideoRecording completes.
-      PendingRecording.videoRecordingFinalizedStreamController.add(null);
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.finalize);
 
       final XFile file = await camera.stopVideoRecording(0);
       expect(file.path, videoOutputPath);
@@ -1646,7 +1675,8 @@ void main() {
 
       await expectLater(() async {
         // Simulate video recording being finalized so stopVideoRecording completes.
-        PendingRecording.videoRecordingFinalizedStreamController.add(null);
+        PendingRecording.videoRecordingEventStreamController
+            .add(VideoRecordEvent.finalize);
         await camera.stopVideoRecording(0);
       }, throwsA(isA<CameraException>()));
       expect(camera.recording, null);
@@ -1669,7 +1699,8 @@ void main() {
       camera.videoOutputPath = videoOutputPath;
 
       // Simulate video recording being finalized so stopVideoRecording completes.
-      PendingRecording.videoRecordingFinalizedStreamController.add(null);
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.finalize);
 
       final XFile file = await camera.stopVideoRecording(0);
       expect(file.path, videoOutputPath);
@@ -1700,7 +1731,8 @@ void main() {
           .thenAnswer((_) async => true);
 
       // Simulate video recording being finalized so stopVideoRecording completes.
-      PendingRecording.videoRecordingFinalizedStreamController.add(null);
+      PendingRecording.videoRecordingEventStreamController
+          .add(VideoRecordEvent.finalize);
 
       await camera.stopVideoRecording(90);
       verify(processCameraProvider.unbind(<UseCase>[videoCapture]));
@@ -3750,6 +3782,10 @@ void main() {
     when(mockCamera2CameraInfo.getSupportedHardwareLevel())
         .thenAnswer((_) async => CameraMetadata.infoSupportedHardwareLevelFull);
 
+    // Simulate video recording being started so startVideoRecording completes.
+    PendingRecording.videoRecordingEventStreamController
+        .add(VideoRecordEvent.start);
+
     await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
 
     verify(
@@ -3811,6 +3847,10 @@ void main() {
     when(mockCamera2CameraInfo.getSupportedHardwareLevel())
         .thenAnswer((_) async => CameraMetadata.infoSupportedHardwareLevel3);
 
+    // Simulate video recording being started so startVideoRecording completes.
+    PendingRecording.videoRecordingEventStreamController
+        .add(VideoRecordEvent.start);
+
     await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
 
     verify(
@@ -3871,6 +3911,10 @@ void main() {
         .thenAnswer((_) async => MockLiveCameraState());
     when(mockCamera2CameraInfo.getSupportedHardwareLevel()).thenAnswer(
         (_) async => CameraMetadata.infoSupportedHardwareLevelExternal);
+
+    // Simulate video recording being started so startVideoRecording completes.
+    PendingRecording.videoRecordingEventStreamController
+        .add(VideoRecordEvent.start);
 
     await camera.startVideoCapturing(VideoCaptureOptions(cameraId,
         streamCallback: (CameraImageData image) {}));
@@ -3939,6 +3983,10 @@ void main() {
     when(mockCamera2CameraInfo.getSupportedHardwareLevel())
         .thenAnswer((_) async => CameraMetadata.infoSupportedHardwareLevel3);
 
+    // Simulate video recording being started so startVideoRecording completes.
+    PendingRecording.videoRecordingEventStreamController
+        .add(VideoRecordEvent.start);
+
     await camera.startVideoCapturing(VideoCaptureOptions(cameraId,
         streamCallback: (CameraImageData image) {}));
     verify(
@@ -3999,6 +4047,11 @@ void main() {
         .thenAnswer((_) async => MockLiveCameraState());
 
     await camera.pausePreview(cameraId);
+
+    // Simulate video recording being started so startVideoRecording completes.
+    PendingRecording.videoRecordingEventStreamController
+        .add(VideoRecordEvent.start);
+
     await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
 
     verifyNever(
@@ -4065,6 +4118,10 @@ void main() {
         .thenAnswer((_) async => MockLiveCameraState());
     when(mockCamera2CameraInfo.getSupportedHardwareLevel()).thenAnswer(
         (_) async => CameraMetadata.infoSupportedHardwareLevelLegacy);
+
+    // Simulate video recording being started so startVideoRecording completes.
+    PendingRecording.videoRecordingEventStreamController
+        .add(VideoRecordEvent.start);
 
     await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
 

--- a/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
+++ b/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
@@ -1290,10 +1290,10 @@ void main() {
               Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
       const int cameraId = 17;
-      const String outputPath = '/temp/MOV123.temp';
+      const String outputPath = '/temp/REC123.mp4';
 
       // Mock method calls.
-      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
           .thenReturn(outputPath);
       when(camera.recorder!.prepareRecording(outputPath))
           .thenAnswer((_) async => mockPendingRecording);
@@ -1369,10 +1369,10 @@ void main() {
               Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
       const int cameraId = 17;
-      const String outputPath = '/temp/MOV123.temp';
+      const String outputPath = '/temp/REC123.mp4';
 
       // Mock method calls.
-      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
           .thenReturn(outputPath);
       when(camera.recorder!.prepareRecording(outputPath))
           .thenAnswer((_) async => mockPendingRecording);
@@ -1398,7 +1398,7 @@ void main() {
 
       await camera.startVideoCapturing(const VideoCaptureOptions(cameraId));
       // Verify that each of these calls happened only once.
-      verify(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+      verify(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
           .called(1);
       verifyNoMoreInteractions(mockSystemServicesApi);
       verify(camera.recorder!.prepareRecording(outputPath)).called(1);
@@ -1448,7 +1448,7 @@ void main() {
                   : MockCamera2CameraInfo());
 
       const int cameraId = 17;
-      const String outputPath = '/temp/MOV123.temp';
+      const String outputPath = '/temp/REC123.mp4';
       final Completer<CameraImageData> imageDataCompleter =
           Completer<CameraImageData>();
       final VideoCaptureOptions videoCaptureOptions = VideoCaptureOptions(
@@ -1461,7 +1461,7 @@ void main() {
           .thenAnswer((_) async => true);
       when(camera.processCameraProvider!.isBound(camera.imageAnalysis!))
           .thenAnswer((_) async => true);
-      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
           .thenReturn(outputPath);
       when(camera.recorder!.prepareRecording(outputPath))
           .thenAnswer((_) async => mockPendingRecording);
@@ -1516,10 +1516,10 @@ void main() {
                   : MockCamera2CameraInfo());
 
       const int cameraId = 87;
-      const String outputPath = '/temp/MOV123.temp';
+      const String outputPath = '/temp/REC123.mp4';
 
       // Mock method calls.
-      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+      when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
           .thenReturn(outputPath);
       when(camera.recorder!.prepareRecording(outputPath))
           .thenAnswer((_) async => mockPendingRecording);
@@ -1601,6 +1601,9 @@ void main() {
       when(camera.processCameraProvider!.isBound(videoCapture))
           .thenAnswer((_) async => true);
 
+      // Simulate video recording being finalized so stopVideoRecording completes.
+      PendingRecording.videoRecordingFinalizedStreamController.add(null);
+
       final XFile file = await camera.stopVideoRecording(0);
       expect(file.path, videoOutputPath);
 
@@ -1642,6 +1645,8 @@ void main() {
           .thenAnswer((_) async => true);
 
       await expectLater(() async {
+        // Simulate video recording being finalized so stopVideoRecording completes.
+        PendingRecording.videoRecordingFinalizedStreamController.add(null);
         await camera.stopVideoRecording(0);
       }, throwsA(isA<CameraException>()));
       expect(camera.recording, null);
@@ -1662,6 +1667,9 @@ void main() {
       camera.recording = recording;
       camera.videoCapture = videoCapture;
       camera.videoOutputPath = videoOutputPath;
+
+      // Simulate video recording being finalized so stopVideoRecording completes.
+      PendingRecording.videoRecordingFinalizedStreamController.add(null);
 
       final XFile file = await camera.stopVideoRecording(0);
       expect(file.path, videoOutputPath);
@@ -1691,12 +1699,37 @@ void main() {
       when(camera.processCameraProvider!.isBound(videoCapture))
           .thenAnswer((_) async => true);
 
+      // Simulate video recording being finalized so stopVideoRecording completes.
+      PendingRecording.videoRecordingFinalizedStreamController.add(null);
+
       await camera.stopVideoRecording(90);
       verify(processCameraProvider.unbind(<UseCase>[videoCapture]));
 
       // Verify that recording stops.
       verify(recording.close());
       verifyNoMoreInteractions(recording);
+    });
+
+    test(
+        'setDescriptionWhileRecording does not make any calls involving starting video recording',
+        () async {
+      // TODO(camsim99): Modify test when implemented, see https://github.com/flutter/flutter/issues/148013.
+      final AndroidCameraCameraX camera = AndroidCameraCameraX();
+
+      // Set directly for test versus calling createCamera.
+      camera.processCameraProvider = MockProcessCameraProvider();
+      camera.recorder = MockRecorder();
+      camera.videoCapture = MockVideoCapture();
+      camera.camera = MockCamera();
+
+      await camera.setDescriptionWhileRecording(const CameraDescription(
+          name: 'fakeCameraName',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90));
+      verifyNoMoreInteractions(camera.processCameraProvider);
+      verifyNoMoreInteractions(camera.recorder);
+      verifyNoMoreInteractions(camera.videoCapture);
+      verifyNoMoreInteractions(camera.camera);
     });
   });
 
@@ -3695,10 +3728,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 7;
-    const String outputPath = '/temp/MOV123.temp';
+    const String outputPath = '/temp/REC123.mp4';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -3756,10 +3789,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 77;
-    const String outputPath = '/temp/MOV123.temp';
+    const String outputPath = '/temp/REC123.mp4';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -3817,10 +3850,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 87;
-    const String outputPath = '/temp/MOV123.temp';
+    const String outputPath = '/temp/REC123.mp4';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -3882,10 +3915,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 107;
-    const String outputPath = '/temp/MOV123.temp';
+    const String outputPath = '/temp/REC123.mp4';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -3947,10 +3980,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 97;
-    const String outputPath = '/temp/MOV123.temp';
+    const String outputPath = '/temp/REC123.mp4';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);
@@ -4009,10 +4042,10 @@ void main() {
             Future<Camera2CameraInfo>.value(mockCamera2CameraInfo));
 
     const int cameraId = 44;
-    const String outputPath = '/temp/MOV123.temp';
+    const String outputPath = '/temp/REC123.mp4';
 
     // Mock method calls.
-    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.temp'))
+    when(mockSystemServicesApi.getTempFilePath(camera.videoPrefix, '.mp4'))
         .thenReturn(outputPath);
     when(camera.recorder!.prepareRecording(outputPath))
         .thenAnswer((_) async => mockPendingRecording);

--- a/packages/camera/camera_android_camerax/test/test_camerax_library.g.dart
+++ b/packages/camera/camera_android_camerax/test/test_camerax_library.g.dart
@@ -2230,6 +2230,9 @@ class _TestCaptureRequestOptionsHostApiCodec extends StandardMessageCodec {
     } else if (value is VideoQualityData) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
+    } else if (value is VideoRecordEventData) {
+      buffer.putUint8(135);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -2252,6 +2255,8 @@ class _TestCaptureRequestOptionsHostApiCodec extends StandardMessageCodec {
         return ResolutionInfo.decode(readValue(buffer)!);
       case 134:
         return VideoQualityData.decode(readValue(buffer)!);
+      case 135:
+        return VideoRecordEventData.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }


### PR DESCRIPTION
Makes changes needed to land https://github.com/flutter/packages/pull/6629. Specifically:

- Fixes timing issue with `stopVideoRecording` such that the `Future` it returns will only complete when CameraX reports that the recording is finalized (via listening for the [finalized video recording event](https://developer.android.com/reference/androidx/camera/video/VideoRecordEvent.Finalize))
- Modifies `startVideoCapturing` such that the `Future` it returns will only complete when CameraX reports that video capturing has started (via listening for the [started video recording event](https://developer.android.com/reference/androidx/camera/video/VideoRecordEvent.Start))
- Adds empty implementation and TODO for implementing `setDescriptionWhileRecording`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
