### PR TITLE
[go_router] New feature improve debug full path

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 14.1.0
+
+- Adds route redirect to ShellRoutes
+
 ## 14.0.2
 
 - Fixes unwanted logs when `hierarchicalLoggingEnabled` was set to `true`.

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 14.1.1
+
+- Improves the logging of routes when `debugLogDiagnostics` is enabled or `debugKnownRoutes() is called. Explains the position of shell routes in the route tree
+
 ## 14.1.0
 
 - Adds route redirect to ShellRoutes

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 14.1.1
 
-- Improves the logging of routes when `debugLogDiagnostics` is enabled or `debugKnownRoutes() is called. Explains the position of shell routes in the route tree
+- Improves the logging of routes when `debugLogDiagnostics` is enabled or `debugKnownRoutes() is called. Explains the position of shell routes in the route tree. Prints the widget name of the routes it is building.
 
 ## 14.1.0
 

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -550,7 +550,7 @@ class RouteConfiguration {
         sb.writeln('$decoration$path ($screenName)'
             '${route.name == null ? '' : ' (${route.name})'}');
       } else if (route is ShellRouteBase) {
-        sb.writeln('$decoration$parentFullpath (ShellRoute)');
+        sb.writeln('$decoration (ShellRoute)');
       }
       _debugFullPathsFor(route.routes, path, decoration, sb);
     }

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -394,14 +394,13 @@ class RouteConfiguration {
           return prevMatchList;
         }
 
-        final List<RouteMatch> routeMatches = <RouteMatch>[];
+        final List<RouteMatchBase> routeMatches = <RouteMatchBase>[];
         prevMatchList.visitRouteMatches((RouteMatchBase match) {
-          if (match is RouteMatch) {
+          if (match.route.redirect != null) {
             routeMatches.add(match);
           }
           return true;
         });
-
         final FutureOr<String?> routeLevelRedirectResult =
             _getRouteLevelRedirect(context, prevMatchList, routeMatches, 0);
 
@@ -434,25 +433,22 @@ class RouteConfiguration {
   FutureOr<String?> _getRouteLevelRedirect(
     BuildContext context,
     RouteMatchList matchList,
-    List<RouteMatch> routeMatches,
+    List<RouteMatchBase> routeMatches,
     int currentCheckIndex,
   ) {
     if (currentCheckIndex >= routeMatches.length) {
       return null;
     }
-    final RouteMatch match = routeMatches[currentCheckIndex];
+    final RouteMatchBase match = routeMatches[currentCheckIndex];
     FutureOr<String?> processRouteRedirect(String? newLocation) =>
         newLocation ??
         _getRouteLevelRedirect(
             context, matchList, routeMatches, currentCheckIndex + 1);
-    final GoRoute route = match.route;
-    FutureOr<String?> routeRedirectResult;
-    if (route.redirect != null) {
-      routeRedirectResult = route.redirect!(
-        context,
-        match.buildState(this, matchList),
-      );
-    }
+    final RouteBase route = match.route;
+    final FutureOr<String?> routeRedirectResult = route.redirect!.call(
+      context,
+      match.buildState(this, matchList),
+    );
     if (routeRedirectResult is String?) {
       return processRouteRedirect(routeRedirectResult);
     }

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -525,7 +525,7 @@ class RouteConfiguration {
   String debugKnownRoutes() {
     final StringBuffer sb = StringBuffer();
     sb.writeln('Full paths for routes:');
-    _debugFullPathsFor(_routingConfig.value.routes, '', 0, sb);
+    _debugFullPathsFor(_routingConfig.value.routes, '', '', sb);
 
     if (_nameToPath.isNotEmpty) {
       sb.writeln('known full paths for route names:');
@@ -538,15 +538,35 @@ class RouteConfiguration {
   }
 
   void _debugFullPathsFor(List<RouteBase> routes, String parentFullpath,
-      int depth, StringBuffer sb) {
-    for (final RouteBase route in routes) {
+      String parentDecoration, StringBuffer sb) {
+    for (final (int index, RouteBase route) in routes.indexed) {
+      final String decoration =
+          _getDecoration(parentDecoration, index, routes.length);
+      String path = parentFullpath;
       if (route is GoRoute) {
-        final String fullPath = concatenatePaths(parentFullpath, route.path);
-        sb.writeln('  => ${''.padLeft(depth * 2)}$fullPath');
-        _debugFullPathsFor(route.routes, fullPath, depth + 1, sb);
+        path = concatenatePaths(parentFullpath, route.path);
+        final String screenName =
+            route.builder?.runtimeType.toString().split('=> ').last ?? '';
+        sb.writeln('$decoration$path ($screenName)'
+            '${route.name == null ? '' : ' (${route.name})'}');
       } else if (route is ShellRouteBase) {
-        _debugFullPathsFor(route.routes, parentFullpath, depth, sb);
+        sb.writeln('$decoration$parentFullpath (ShellRoute)');
       }
+      _debugFullPathsFor(route.routes, path, decoration, sb);
+    }
+  }
+
+  String _getDecoration(
+    String parentDecoration,
+    int index,
+    int length,
+  ) {
+    final String newDecoration =
+        parentDecoration.replaceAll('├─', '│ ').replaceAll('└─', '  ');
+    if (index == length - 1) {
+      return '$newDecoration└─';
+    } else {
+      return '$newDecoration├─';
     }
   }
 

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -152,9 +152,66 @@ typedef ExitCallback = FutureOr<bool> Function(
 @immutable
 abstract class RouteBase with Diagnosticable {
   const RouteBase._({
+    this.redirect,
     required this.routes,
     required this.parentNavigatorKey,
   });
+
+  /// An optional redirect function for this route.
+  ///
+  /// In the case that you like to make a redirection decision for a specific
+  /// route (or sub-route), consider doing so by passing a redirect function to
+  /// the GoRoute constructor.
+  ///
+  /// For example:
+  /// ```
+  /// final GoRouter _router = GoRouter(
+  ///   routes: <GoRoute>[
+  ///     GoRoute(
+  ///       path: '/',
+  ///       redirect: (_) => '/family/${Families.data[0].id}',
+  ///     ),
+  ///     GoRoute(
+  ///       path: '/family/:fid',
+  ///       pageBuilder: (BuildContext context, GoRouterState state) => ...,
+  ///     ),
+  ///   ],
+  /// );
+  /// ```
+  ///
+  /// If there are multiple redirects in the matched routes, the parent route's
+  /// redirect takes priority over sub-route's.
+  ///
+  /// For example:
+  /// ```
+  /// final GoRouter _router = GoRouter(
+  ///   routes: <GoRoute>[
+  ///     GoRoute(
+  ///       path: '/',
+  ///       redirect: (_) => '/page1', // this takes priority over the sub-route.
+  ///       routes: <GoRoute>[
+  ///         GoRoute(
+  ///           path: 'child',
+  ///           redirect: (_) => '/page2',
+  ///         ),
+  ///       ],
+  ///     ),
+  ///   ],
+  /// );
+  /// ```
+  ///
+  /// The `context.go('/child')` will be redirected to `/page1` instead of
+  /// `/page2`.
+  ///
+  /// Redirect can also be used for conditionally preventing users from visiting
+  /// routes, also known as route guards. One canonical example is user
+  /// authentication. See [Redirection](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/redirection.dart)
+  /// for a complete runnable example.
+  ///
+  /// If [BuildContext.dependOnInheritedWidgetOfExactType] is used during the
+  /// redirection (which is how `of` method is usually implemented), a
+  /// re-evaluation will be triggered if the [InheritedWidget] changes.
+  final GoRouterRedirect? redirect;
 
   /// The list of child routes associated with this route.
   final List<RouteBase> routes;
@@ -209,7 +266,7 @@ class GoRoute extends RouteBase {
     this.builder,
     this.pageBuilder,
     super.parentNavigatorKey,
-    this.redirect,
+    super.redirect,
     this.onExit,
     super.routes = const <RouteBase>[],
   })  : assert(path.isNotEmpty, 'GoRoute path cannot be empty'),
@@ -325,62 +382,6 @@ class GoRoute extends RouteBase {
   ///
   final GoRouterWidgetBuilder? builder;
 
-  /// An optional redirect function for this route.
-  ///
-  /// In the case that you like to make a redirection decision for a specific
-  /// route (or sub-route), consider doing so by passing a redirect function to
-  /// the GoRoute constructor.
-  ///
-  /// For example:
-  /// ```
-  /// final GoRouter _router = GoRouter(
-  ///   routes: <GoRoute>[
-  ///     GoRoute(
-  ///       path: '/',
-  ///       redirect: (_) => '/family/${Families.data[0].id}',
-  ///     ),
-  ///     GoRoute(
-  ///       path: '/family/:fid',
-  ///       pageBuilder: (BuildContext context, GoRouterState state) => ...,
-  ///     ),
-  ///   ],
-  /// );
-  /// ```
-  ///
-  /// If there are multiple redirects in the matched routes, the parent route's
-  /// redirect takes priority over sub-route's.
-  ///
-  /// For example:
-  /// ```
-  /// final GoRouter _router = GoRouter(
-  ///   routes: <GoRoute>[
-  ///     GoRoute(
-  ///       path: '/',
-  ///       redirect: (_) => '/page1', // this takes priority over the sub-route.
-  ///       routes: <GoRoute>[
-  ///         GoRoute(
-  ///           path: 'child',
-  ///           redirect: (_) => '/page2',
-  ///         ),
-  ///       ],
-  ///     ),
-  ///   ],
-  /// );
-  /// ```
-  ///
-  /// The `context.go('/child')` will be redirected to `/page1` instead of
-  /// `/page2`.
-  ///
-  /// Redirect can also be used for conditionally preventing users from visiting
-  /// routes, also known as route guards. One canonical example is user
-  /// authentication. See [Redirection](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/redirection.dart)
-  /// for a complete runnable example.
-  ///
-  /// If [BuildContext.dependOnInheritedWidgetOfExactType] is used during the
-  /// redirection (which is how `of` method is usually implemented), a
-  /// re-evaluation will be triggered if the [InheritedWidget] changes.
-  final GoRouterRedirect? redirect;
-
   /// Called when this route is removed from GoRouter's route history.
   ///
   /// Some example this callback may be called:
@@ -458,9 +459,11 @@ class GoRoute extends RouteBase {
 /// as [ShellRoute] and [StatefulShellRoute].
 abstract class ShellRouteBase extends RouteBase {
   /// Constructs a [ShellRouteBase].
-  const ShellRouteBase._(
-      {required super.routes, required super.parentNavigatorKey})
-      : super._();
+  const ShellRouteBase._({
+    super.redirect,
+    required super.routes,
+    required super.parentNavigatorKey,
+  }) : super._();
 
   static void _debugCheckSubRouteParentNavigatorKeys(
       List<RouteBase> subRoutes, GlobalKey<NavigatorState> navigatorKey) {
@@ -623,6 +626,7 @@ class ShellRouteContext {
 class ShellRoute extends ShellRouteBase {
   /// Constructs a [ShellRoute].
   ShellRoute({
+    super.redirect,
     this.builder,
     this.pageBuilder,
     this.observers,
@@ -783,6 +787,7 @@ class StatefulShellRoute extends ShellRouteBase {
   /// [navigatorContainerBuilder].
   StatefulShellRoute({
     required this.branches,
+    super.redirect,
     this.builder,
     this.pageBuilder,
     required this.navigatorContainerBuilder,
@@ -809,12 +814,14 @@ class StatefulShellRoute extends ShellRouteBase {
   /// for a complete runnable example using StatefulShellRoute.indexedStack.
   StatefulShellRoute.indexedStack({
     required List<StatefulShellBranch> branches,
+    GoRouterRedirect? redirect,
     StatefulShellRouteBuilder? builder,
     GlobalKey<NavigatorState>? parentNavigatorKey,
     StatefulShellRoutePageBuilder? pageBuilder,
     String? restorationScopeId,
   }) : this(
           branches: branches,
+          redirect: redirect,
           builder: builder,
           pageBuilder: pageBuilder,
           parentNavigatorKey: parentNavigatorKey,

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 14.0.2
+version: 14.1.0
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 14.1.0
+version: 14.1.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/configuration_test.dart
+++ b/packages/go_router/test/configuration_test.dart
@@ -11,9 +11,12 @@ import 'test_helpers.dart';
 void main() {
   group('RouteConfiguration', () {
     test('throws when parentNavigatorKey is not an ancestor', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> a = GlobalKey<NavigatorState>(debugLabel: 'a');
-      final GlobalKey<NavigatorState> b = GlobalKey<NavigatorState>(debugLabel: 'b');
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> a =
+          GlobalKey<NavigatorState>(debugLabel: 'a');
+      final GlobalKey<NavigatorState> b =
+          GlobalKey<NavigatorState>(debugLabel: 'b');
 
       expect(
         () {
@@ -59,7 +62,8 @@ void main() {
     });
 
     test('throws when ShellRoute has no children', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
       final List<RouteBase> shellRouteChildren = <RouteBase>[];
       expect(
         () {
@@ -78,10 +82,15 @@ void main() {
       );
     });
 
-    test('throws when StatefulShellRoute sub-route uses incorrect parentNavigatorKey', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> keyA = GlobalKey<NavigatorState>(debugLabel: 'A');
-      final GlobalKey<NavigatorState> keyB = GlobalKey<NavigatorState>(debugLabel: 'B');
+    test(
+        'throws when StatefulShellRoute sub-route uses incorrect parentNavigatorKey',
+        () {
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> keyA =
+          GlobalKey<NavigatorState>(debugLabel: 'A');
+      final GlobalKey<NavigatorState> keyB =
+          GlobalKey<NavigatorState>(debugLabel: 'B');
 
       expect(
         () {
@@ -92,10 +101,15 @@ void main() {
                 StatefulShellBranch(
                   navigatorKey: keyA,
                   routes: <RouteBase>[
-                    GoRoute(path: '/a', builder: _mockScreenBuilder, routes: <RouteBase>[
-                      GoRoute(
-                          path: 'details', builder: _mockScreenBuilder, parentNavigatorKey: keyB),
-                    ]),
+                    GoRoute(
+                        path: '/a',
+                        builder: _mockScreenBuilder,
+                        routes: <RouteBase>[
+                          GoRoute(
+                              path: 'details',
+                              builder: _mockScreenBuilder,
+                              parentNavigatorKey: keyB),
+                        ]),
                   ],
                 ),
               ], builder: mockStackedShellBuilder),
@@ -110,9 +124,13 @@ void main() {
       );
     });
 
-    test('does not throw when StatefulShellRoute sub-route uses correct parentNavigatorKeys', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> keyA = GlobalKey<NavigatorState>(debugLabel: 'A');
+    test(
+        'does not throw when StatefulShellRoute sub-route uses correct parentNavigatorKeys',
+        () {
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> keyA =
+          GlobalKey<NavigatorState>(debugLabel: 'A');
 
       createRouteConfiguration(
         navigatorKey: root,
@@ -121,9 +139,15 @@ void main() {
             StatefulShellBranch(
               navigatorKey: keyA,
               routes: <RouteBase>[
-                GoRoute(path: '/a', builder: _mockScreenBuilder, routes: <RouteBase>[
-                  GoRoute(path: 'details', builder: _mockScreenBuilder, parentNavigatorKey: keyA),
-                ]),
+                GoRoute(
+                    path: '/a',
+                    builder: _mockScreenBuilder,
+                    routes: <RouteBase>[
+                      GoRoute(
+                          path: 'details',
+                          builder: _mockScreenBuilder,
+                          parentNavigatorKey: keyA),
+                    ]),
               ],
             ),
           ], builder: mockStackedShellBuilder),
@@ -135,9 +159,13 @@ void main() {
       );
     });
 
-    test('throws when a sub-route of StatefulShellRoute has a parentNavigatorKey', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> someNavigatorKey = GlobalKey<NavigatorState>();
+    test(
+        'throws when a sub-route of StatefulShellRoute has a parentNavigatorKey',
+        () {
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> someNavigatorKey =
+          GlobalKey<NavigatorState>();
       expect(
         () {
           createRouteConfiguration(
@@ -146,12 +174,15 @@ void main() {
               StatefulShellRoute.indexedStack(branches: <StatefulShellBranch>[
                 StatefulShellBranch(
                   routes: <RouteBase>[
-                    GoRoute(path: '/a', builder: _mockScreenBuilder, routes: <RouteBase>[
-                      GoRoute(
-                          path: 'details',
-                          builder: _mockScreenBuilder,
-                          parentNavigatorKey: someNavigatorKey),
-                    ]),
+                    GoRoute(
+                        path: '/a',
+                        builder: _mockScreenBuilder,
+                        routes: <RouteBase>[
+                          GoRoute(
+                              path: 'details',
+                              builder: _mockScreenBuilder,
+                              parentNavigatorKey: someNavigatorKey),
+                        ]),
                   ],
                 ),
                 StatefulShellBranch(
@@ -175,20 +206,24 @@ void main() {
     });
 
     test('throws when StatefulShellRoute has duplicate navigator keys', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> keyA = GlobalKey<NavigatorState>(debugLabel: 'A');
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> keyA =
+          GlobalKey<NavigatorState>(debugLabel: 'A');
       final List<GoRoute> shellRouteChildren = <GoRoute>[
-        GoRoute(path: '/a', builder: _mockScreenBuilder, parentNavigatorKey: keyA),
-        GoRoute(path: '/b', builder: _mockScreenBuilder, parentNavigatorKey: keyA),
+        GoRoute(
+            path: '/a', builder: _mockScreenBuilder, parentNavigatorKey: keyA),
+        GoRoute(
+            path: '/b', builder: _mockScreenBuilder, parentNavigatorKey: keyA),
       ];
       expect(
         () {
           createRouteConfiguration(
             navigatorKey: root,
             routes: <RouteBase>[
-              StatefulShellRoute.indexedStack(
-                  branches: <StatefulShellBranch>[StatefulShellBranch(routes: shellRouteChildren)],
-                  builder: mockStackedShellBuilder),
+              StatefulShellRoute.indexedStack(branches: <StatefulShellBranch>[
+                StatefulShellBranch(routes: shellRouteChildren)
+              ], builder: mockStackedShellBuilder),
             ],
             redirectLimit: 10,
             topRedirect: (BuildContext context, GoRouterState state) {
@@ -203,13 +238,20 @@ void main() {
     test(
         'throws when a child of StatefulShellRoute has an incorrect '
         'parentNavigatorKey', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> sectionANavigatorKey = GlobalKey<NavigatorState>();
-      final GlobalKey<NavigatorState> sectionBNavigatorKey = GlobalKey<NavigatorState>();
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> sectionANavigatorKey =
+          GlobalKey<NavigatorState>();
+      final GlobalKey<NavigatorState> sectionBNavigatorKey =
+          GlobalKey<NavigatorState>();
       final GoRoute routeA = GoRoute(
-          path: '/a', builder: _mockScreenBuilder, parentNavigatorKey: sectionBNavigatorKey);
+          path: '/a',
+          builder: _mockScreenBuilder,
+          parentNavigatorKey: sectionBNavigatorKey);
       final GoRoute routeB = GoRoute(
-          path: '/b', builder: _mockScreenBuilder, parentNavigatorKey: sectionANavigatorKey);
+          path: '/b',
+          builder: _mockScreenBuilder,
+          parentNavigatorKey: sectionANavigatorKey);
       expect(
         () {
           createRouteConfiguration(
@@ -217,9 +259,11 @@ void main() {
             routes: <RouteBase>[
               StatefulShellRoute.indexedStack(branches: <StatefulShellBranch>[
                 StatefulShellBranch(
-                    routes: <RouteBase>[routeA], navigatorKey: sectionANavigatorKey),
+                    routes: <RouteBase>[routeA],
+                    navigatorKey: sectionANavigatorKey),
                 StatefulShellBranch(
-                    routes: <RouteBase>[routeB], navigatorKey: sectionBNavigatorKey),
+                    routes: <RouteBase>[routeB],
+                    navigatorKey: sectionBNavigatorKey),
               ], builder: mockStackedShellBuilder),
             ],
             redirectLimit: 10,
@@ -235,9 +279,12 @@ void main() {
     test(
         'throws when a branch of a StatefulShellRoute has an incorrect '
         'initialLocation', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> sectionANavigatorKey = GlobalKey<NavigatorState>();
-      final GlobalKey<NavigatorState> sectionBNavigatorKey = GlobalKey<NavigatorState>();
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> sectionANavigatorKey =
+          GlobalKey<NavigatorState>();
+      final GlobalKey<NavigatorState> sectionBNavigatorKey =
+          GlobalKey<NavigatorState>();
       expect(
         () {
           createRouteConfiguration(
@@ -278,9 +325,12 @@ void main() {
     test(
         'throws when a branch of a StatefulShellRoute has a initialLocation '
         'that is not a descendant of the same branch', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> sectionANavigatorKey = GlobalKey<NavigatorState>();
-      final GlobalKey<NavigatorState> sectionBNavigatorKey = GlobalKey<NavigatorState>();
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> sectionANavigatorKey =
+          GlobalKey<NavigatorState>();
+      final GlobalKey<NavigatorState> sectionBNavigatorKey =
+          GlobalKey<NavigatorState>();
       expect(
         () {
           createRouteConfiguration(
@@ -301,16 +351,18 @@ void main() {
                   initialLocation: '/b',
                   navigatorKey: sectionBNavigatorKey,
                   routes: <RouteBase>[
-                    StatefulShellRoute.indexedStack(branches: <StatefulShellBranch>[
-                      StatefulShellBranch(
-                        routes: <RouteBase>[
-                          GoRoute(
-                            path: '/b',
-                            builder: _mockScreenBuilder,
+                    StatefulShellRoute.indexedStack(
+                        branches: <StatefulShellBranch>[
+                          StatefulShellBranch(
+                            routes: <RouteBase>[
+                              GoRoute(
+                                path: '/b',
+                                builder: _mockScreenBuilder,
+                              ),
+                            ],
                           ),
                         ],
-                      ),
-                    ], builder: mockStackedShellBuilder),
+                        builder: mockStackedShellBuilder),
                   ],
                 ),
               ], builder: mockStackedShellBuilder),
@@ -328,7 +380,8 @@ void main() {
     test(
         'does not throw when a branch of a StatefulShellRoute has correctly '
         'configured initialLocations', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
 
       createRouteConfiguration(
         navigatorKey: root,
@@ -336,23 +389,29 @@ void main() {
           StatefulShellRoute.indexedStack(branches: <StatefulShellBranch>[
             StatefulShellBranch(
               routes: <RouteBase>[
-                GoRoute(path: '/a', builder: _mockScreenBuilder, routes: <RouteBase>[
-                  GoRoute(
-                    path: 'detail',
+                GoRoute(
+                    path: '/a',
                     builder: _mockScreenBuilder,
-                  ),
-                ]),
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: 'detail',
+                        builder: _mockScreenBuilder,
+                      ),
+                    ]),
               ],
             ),
             StatefulShellBranch(
               initialLocation: '/b/detail',
               routes: <RouteBase>[
-                GoRoute(path: '/b', builder: _mockScreenBuilder, routes: <RouteBase>[
-                  GoRoute(
-                    path: 'detail',
+                GoRoute(
+                    path: '/b',
                     builder: _mockScreenBuilder,
-                  ),
-                ]),
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: 'detail',
+                        builder: _mockScreenBuilder,
+                      ),
+                    ]),
               ],
             ),
             StatefulShellBranch(
@@ -361,23 +420,29 @@ void main() {
                 StatefulShellRoute.indexedStack(branches: <StatefulShellBranch>[
                   StatefulShellBranch(
                     routes: <RouteBase>[
-                      GoRoute(path: '/c', builder: _mockScreenBuilder, routes: <RouteBase>[
-                        GoRoute(
-                          path: 'detail',
+                      GoRoute(
+                          path: '/c',
                           builder: _mockScreenBuilder,
-                        ),
-                      ]),
+                          routes: <RouteBase>[
+                            GoRoute(
+                              path: 'detail',
+                              builder: _mockScreenBuilder,
+                            ),
+                          ]),
                     ],
                   ),
                   StatefulShellBranch(
                     initialLocation: '/d/detail',
                     routes: <RouteBase>[
-                      GoRoute(path: '/d', builder: _mockScreenBuilder, routes: <RouteBase>[
-                        GoRoute(
-                          path: 'detail',
+                      GoRoute(
+                          path: '/d',
                           builder: _mockScreenBuilder,
-                        ),
-                      ]),
+                          routes: <RouteBase>[
+                            GoRoute(
+                              path: 'detail',
+                              builder: _mockScreenBuilder,
+                            ),
+                          ]),
                     ],
                   ),
                 ], builder: mockStackedShellBuilder),
@@ -433,17 +498,20 @@ void main() {
                           StatefulShellRoute.indexedStack(
                               builder: mockStackedShellBuilder,
                               branches: <StatefulShellBranch>[
-                                branchY = StatefulShellBranch(routes: <RouteBase>[
-                                  ShellRoute(builder: _mockShellBuilder, routes: <RouteBase>[
-                                    GoRoute(
-                                      path: 'y1',
-                                      builder: _mockScreenBuilder,
-                                    ),
-                                    GoRoute(
-                                      path: 'y2',
-                                      builder: _mockScreenBuilder,
-                                    ),
-                                  ])
+                                branchY =
+                                    StatefulShellBranch(routes: <RouteBase>[
+                                  ShellRoute(
+                                      builder: _mockShellBuilder,
+                                      routes: <RouteBase>[
+                                        GoRoute(
+                                          path: 'y1',
+                                          builder: _mockScreenBuilder,
+                                        ),
+                                        GoRoute(
+                                          path: 'y2',
+                                          builder: _mockScreenBuilder,
+                                        ),
+                                      ])
                                 ])
                               ]),
                         ],
@@ -491,9 +559,13 @@ void main() {
       },
     );
 
-    test('throws when there is a GoRoute ancestor with a different parentNavigatorKey', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final GlobalKey<NavigatorState> shell = GlobalKey<NavigatorState>(debugLabel: 'shell');
+    test(
+        'throws when there is a GoRoute ancestor with a different parentNavigatorKey',
+        () {
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
+      final GlobalKey<NavigatorState> shell =
+          GlobalKey<NavigatorState>(debugLabel: 'shell');
       expect(
         () {
           createRouteConfiguration(
@@ -530,9 +602,12 @@ void main() {
     test(
       'Does not throw with valid parentNavigatorKey configuration',
       () {
-        final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-        final GlobalKey<NavigatorState> shell = GlobalKey<NavigatorState>(debugLabel: 'shell');
-        final GlobalKey<NavigatorState> shell2 = GlobalKey<NavigatorState>(debugLabel: 'shell2');
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
+        final GlobalKey<NavigatorState> shell2 =
+            GlobalKey<NavigatorState>(debugLabel: 'shell2');
         createRouteConfiguration(
           navigatorKey: root,
           routes: <RouteBase>[
@@ -582,8 +657,10 @@ void main() {
     test(
       'Does not throw with multiple nested GoRoutes using parentNavigatorKey in ShellRoute',
       () {
-        final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-        final GlobalKey<NavigatorState> shell = GlobalKey<NavigatorState>(debugLabel: 'shell');
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
         createRouteConfiguration(
           navigatorKey: root,
           routes: <RouteBase>[
@@ -629,8 +706,10 @@ void main() {
     test(
       'Throws when parentNavigatorKeys are overlapping',
       () {
-        final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-        final GlobalKey<NavigatorState> shell = GlobalKey<NavigatorState>(debugLabel: 'shell');
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
         expect(
           () => createRouteConfiguration(
             navigatorKey: root,
@@ -678,8 +757,10 @@ void main() {
     test(
       'Does not throw when parentNavigatorKeys are overlapping correctly',
       () {
-        final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-        final GlobalKey<NavigatorState> shell = GlobalKey<NavigatorState>(debugLabel: 'shell');
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
         createRouteConfiguration(
           navigatorKey: root,
           routes: <RouteBase>[
@@ -726,9 +807,12 @@ void main() {
       'exists between a GoRoute with a parentNavigatorKey and '
       'its ShellRoute ancestor',
       () {
-        final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-        final GlobalKey<NavigatorState> shell = GlobalKey<NavigatorState>(debugLabel: 'shell');
-        final GlobalKey<NavigatorState> shell2 = GlobalKey<NavigatorState>(debugLabel: 'shell2');
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
+        final GlobalKey<NavigatorState> shell2 =
+            GlobalKey<NavigatorState>(debugLabel: 'shell2');
         expect(
           () => createRouteConfiguration(
             navigatorKey: root,
@@ -777,8 +861,10 @@ void main() {
         );
       },
     );
-    test('does not throw when ShellRoute is the child of another ShellRoute', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
+    test('does not throw when ShellRoute is the child of another ShellRoute',
+        () {
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
       createRouteConfiguration(
         routes: <RouteBase>[
           ShellRoute(
@@ -815,9 +901,12 @@ void main() {
     test(
       'Does not throw with valid parentNavigatorKey configuration',
       () {
-        final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-        final GlobalKey<NavigatorState> shell = GlobalKey<NavigatorState>(debugLabel: 'shell');
-        final GlobalKey<NavigatorState> shell2 = GlobalKey<NavigatorState>(debugLabel: 'shell2');
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
+        final GlobalKey<NavigatorState> shell2 =
+            GlobalKey<NavigatorState>(debugLabel: 'shell2');
         createRouteConfiguration(
           navigatorKey: root,
           routes: <RouteBase>[
@@ -864,8 +953,10 @@ void main() {
       },
     );
 
-    test('throws when ShellRoute contains a GoRoute with a parentNavigatorKey', () {
-      final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
+    test('throws when ShellRoute contains a GoRoute with a parentNavigatorKey',
+        () {
+      final GlobalKey<NavigatorState> root =
+          GlobalKey<NavigatorState>(debugLabel: 'root');
       expect(
         () {
           createRouteConfiguration(
@@ -894,8 +985,10 @@ void main() {
     test(
       'All known route strings returned by debugKnownRoutes are correct',
       () {
-        final GlobalKey<NavigatorState> root = GlobalKey<NavigatorState>(debugLabel: 'root');
-        final GlobalKey<NavigatorState> shell = GlobalKey<NavigatorState>(debugLabel: 'shell');
+        final GlobalKey<NavigatorState> root =
+            GlobalKey<NavigatorState>(debugLabel: 'root');
+        final GlobalKey<NavigatorState> shell =
+            GlobalKey<NavigatorState>(debugLabel: 'shell');
 
         expect(
             createRouteConfiguration(
@@ -1003,8 +1096,10 @@ class _MockScreen extends StatelessWidget {
 Widget _mockScreenBuilder(BuildContext context, GoRouterState state) =>
     _MockScreen(key: state.pageKey);
 
-Widget _mockShellBuilder(BuildContext context, GoRouterState state, Widget child) => child;
+Widget _mockShellBuilder(
+        BuildContext context, GoRouterState state, Widget child) =>
+    child;
 
-Widget _mockIndexedStackShellBuilder(
-        BuildContext context, GoRouterState state, StatefulNavigationShell shell) =>
+Widget _mockIndexedStackShellBuilder(BuildContext context, GoRouterState state,
+        StatefulNavigationShell shell) =>
     shell;

--- a/packages/go_router/test/configuration_test.dart
+++ b/packages/go_router/test/configuration_test.dart
@@ -991,96 +991,97 @@ void main() {
             GlobalKey<NavigatorState>(debugLabel: 'shell');
 
         expect(
-            createRouteConfiguration(
-              navigatorKey: root,
-              routes: <RouteBase>[
-                GoRoute(
-                  path: '/a',
-                  parentNavigatorKey: root,
-                  builder: _mockScreenBuilder,
-                  routes: <RouteBase>[
-                    ShellRoute(
-                      navigatorKey: shell,
-                      builder: _mockShellBuilder,
-                      routes: <RouteBase>[
-                        GoRoute(
-                          path: 'b',
-                          parentNavigatorKey: shell,
-                          builder: _mockScreenBuilder,
-                        ),
-                        GoRoute(
-                          path: 'c',
-                          parentNavigatorKey: shell,
-                          builder: _mockScreenBuilder,
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-                GoRoute(
-                  path: '/d',
-                  parentNavigatorKey: root,
-                  builder: _mockScreenBuilder,
-                  routes: <RouteBase>[
-                    GoRoute(
-                      path: 'e',
-                      parentNavigatorKey: root,
-                      builder: _mockScreenBuilder,
-                      routes: <RouteBase>[
-                        GoRoute(
-                          path: 'f',
-                          parentNavigatorKey: root,
-                          builder: _mockScreenBuilder,
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-                GoRoute(
-                  path: '/g',
-                  builder: _mockScreenBuilder,
-                  routes: <RouteBase>[
-                    StatefulShellRoute.indexedStack(
-                      builder: _mockIndexedStackShellBuilder,
-                      branches: <StatefulShellBranch>[
-                        StatefulShellBranch(
-                          routes: <RouteBase>[
-                            GoRoute(
-                              path: 'h',
-                              builder: _mockScreenBuilder,
-                            ),
-                          ],
-                        ),
-                        StatefulShellBranch(
-                          routes: <RouteBase>[
-                            GoRoute(
-                              path: 'i',
-                              builder: _mockScreenBuilder,
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ],
-              redirectLimit: 10,
-              topRedirect: (BuildContext context, GoRouterState state) {
-                return null;
-              },
-            ).debugKnownRoutes(),
-            'Full paths for routes:\n'
-            '├─/a (Widget)\n'
-            '│ └─/a (ShellRoute)\n'
-            '│   ├─/a/b (Widget)\n'
-            '│   └─/a/c (Widget)\n'
-            '├─/d (Widget)\n'
-            '│ └─/d/e (Widget)\n'
-            '│   └─/d/e/f (Widget)\n'
-            '└─/g (Widget)\n'
-            '  └─/g (ShellRoute)\n'
-            '    ├─/g/h (Widget)\n'
-            '    └─/g/i (Widget)\n');
+          createRouteConfiguration(
+            navigatorKey: root,
+            routes: <RouteBase>[
+              GoRoute(
+                path: '/a',
+                parentNavigatorKey: root,
+                builder: _mockScreenBuilder,
+                routes: <RouteBase>[
+                  ShellRoute(
+                    navigatorKey: shell,
+                    builder: _mockShellBuilder,
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: 'b',
+                        parentNavigatorKey: shell,
+                        builder: _mockScreenBuilder,
+                      ),
+                      GoRoute(
+                        path: 'c',
+                        parentNavigatorKey: shell,
+                        builder: _mockScreenBuilder,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              GoRoute(
+                path: '/d',
+                parentNavigatorKey: root,
+                builder: _mockScreenBuilder,
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: 'e',
+                    parentNavigatorKey: root,
+                    builder: _mockScreenBuilder,
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: 'f',
+                        parentNavigatorKey: root,
+                        builder: _mockScreenBuilder,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              GoRoute(
+                path: '/g',
+                builder: _mockScreenBuilder,
+                routes: <RouteBase>[
+                  StatefulShellRoute.indexedStack(
+                    builder: _mockIndexedStackShellBuilder,
+                    branches: <StatefulShellBranch>[
+                      StatefulShellBranch(
+                        routes: <RouteBase>[
+                          GoRoute(
+                            path: 'h',
+                            builder: _mockScreenBuilder,
+                          ),
+                        ],
+                      ),
+                      StatefulShellBranch(
+                        routes: <RouteBase>[
+                          GoRoute(
+                            path: 'i',
+                            builder: _mockScreenBuilder,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+            redirectLimit: 10,
+            topRedirect: (BuildContext context, GoRouterState state) {
+              return null;
+            },
+          ).debugKnownRoutes(),
+          'Full paths for routes:\n'
+          '├─/a (Widget)\n'
+          '│ └─ (ShellRoute)\n'
+          '│   ├─/a/b (Widget)\n'
+          '│   └─/a/c (Widget)\n'
+          '├─/d (Widget)\n'
+          '│ └─/d/e (Widget)\n'
+          '│   └─/d/e/f (Widget)\n'
+          '└─/g (Widget)\n'
+          '  └─ (ShellRoute)\n'
+          '    ├─/g/h (Widget)\n'
+          '    └─/g/i (Widget)\n',
+        );
       },
     );
   });

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -2462,6 +2462,94 @@ void main() {
       expect(
           router.routerDelegate.currentConfiguration.uri.toString(), '/other');
     });
+
+    testWidgets('redirect when go to a shell route',
+        (WidgetTester tester) async {
+      final List<RouteBase> routes = <RouteBase>[
+        ShellRoute(
+          redirect: (BuildContext context, GoRouterState state) => '/dummy',
+          builder: (BuildContext context, GoRouterState state, Widget child) =>
+              Scaffold(appBar: AppBar(), body: child),
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/other',
+              builder: (BuildContext context, GoRouterState state) =>
+                  const DummyScreen(),
+            ),
+            GoRoute(
+              path: '/other2',
+              builder: (BuildContext context, GoRouterState state) =>
+                  const DummyScreen(),
+            ),
+          ],
+        ),
+        GoRoute(
+          path: '/dummy',
+          builder: (BuildContext context, GoRouterState state) =>
+              const DummyScreen(),
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+
+      for (final String shellRoute in <String>['/other', '/other2']) {
+        router.go(shellRoute);
+        await tester.pump();
+        expect(
+          router.routerDelegate.currentConfiguration.uri.toString(),
+          '/dummy',
+        );
+      }
+    });
+
+    testWidgets('redirect when go to a stateful shell route',
+        (WidgetTester tester) async {
+      final List<RouteBase> routes = <RouteBase>[
+        StatefulShellRoute.indexedStack(
+          redirect: (BuildContext context, GoRouterState state) => '/dummy',
+          builder: (BuildContext context, GoRouterState state,
+              StatefulNavigationShell navigationShell) {
+            return navigationShell;
+          },
+          branches: <StatefulShellBranch>[
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/other',
+                  builder: (BuildContext context, GoRouterState state) =>
+                      const DummyScreen(),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/other2',
+                  builder: (BuildContext context, GoRouterState state) =>
+                      const DummyScreen(),
+                ),
+              ],
+            ),
+          ],
+        ),
+        GoRoute(
+          path: '/dummy',
+          builder: (BuildContext context, GoRouterState state) =>
+              const DummyScreen(),
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+
+      for (final String shellRoute in <String>['/other', '/other2']) {
+        router.go(shellRoute);
+        await tester.pump();
+        expect(
+          router.routerDelegate.currentConfiguration.uri.toString(),
+          '/dummy',
+        );
+      }
+    });
   });
 
   group('initial location', () {


### PR DESCRIPTION

This PR fixes https://github.com/flutter/flutter/issues/148121

- Replaced `=>` with `| `, `├─` and `└─ ` to improve readability
- It prints the Widget name for easy referencing
- Shell routes does not have their own paths for it is presented as ` (Shell route)` in the tree
- Prints the widget name of the routes it is building.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
