### PR TITLE
[camera_avfoundation] Revert camera example PRODUCT_BUNDLE_IDENTIFIER

### DIFF
--- a/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
@@ -673,7 +673,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bradenbagby.test;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.cameraExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -697,7 +697,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bradenbagby.test;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.cameraExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;


### PR DESCRIPTION
Introduced in https://github.com/flutter/packages/pull/3272/files#diff-92a81cce4f20ea0f44193e7f760655d78f05a720378e1e085a244472fb85fc04R656

Put the bundle ID back to what it was.