### PR TITLE
[rfw] Adds support for `DecorationImage.filterQuality`.

### DIFF
--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.27
+* Adds support for `DecorationImage.filterQuality`.
+
 ## 1.0.26
 * Supports overriding the error widget builder.
 

--- a/packages/rfw/lib/src/flutter/argument_decoders.dart
+++ b/packages/rfw/lib/src/flutter/argument_decoders.dart
@@ -550,6 +550,7 @@ class ArgumentDecoders {
       centerSlice: rect(source, [...key, 'centerSlice']),
       repeat: enumValue<ImageRepeat>(ImageRepeat.values, source, [...key, 'repeat']) ?? ImageRepeat.noRepeat,
       matchTextDirection: source.v<bool>([...key, 'matchTextDirection']) ?? false,
+      filterQuality: enumValue<FilterQuality>(FilterQuality.values, source, [...key, 'filterQuality']) ?? FilterQuality.medium,
     );
   }
 

--- a/packages/rfw/pubspec.yaml
+++ b/packages/rfw/pubspec.yaml
@@ -2,7 +2,7 @@ name: rfw
 description: "Remote Flutter widgets: a library for rendering declarative widget description files at runtime."
 repository: https://github.com/flutter/packages/tree/main/packages/rfw
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+rfw%22
-version: 1.0.26
+version: 1.0.27
 
 environment:
   sdk: ^3.2.0

--- a/packages/rfw/test/argument_decoders_test.dart
+++ b/packages/rfw/test/argument_decoders_test.dart
@@ -295,7 +295,7 @@ void main() {
                 1.0, 1.0, 1.0, 1.0, 1.0,
               ],
             },
-            filterQuality: "medium",
+            filterQuality: "none",
           },
           gradient: {
             type: 'sweep',
@@ -315,7 +315,7 @@ void main() {
               blendMode: "xor",
             },
             onError: event 'image-error-event' { },
-            filterQuality: "medium",
+            filterQuality: "high",
           },
           gradient: {
             type: 'linear',
@@ -385,13 +385,13 @@ void main() {
       (tester.widgetList<DecoratedBox>(find.byType(DecoratedBox)).toList()[1].decoration as BoxDecoration).image.toString(),
       'DecorationImage(AssetImage(bundle: null, name: "asset"), ' // this just seemed like the easiest way to check all this...
       'ColorFilter.matrix([$matrix]), '
-      'Alignment.center, centerSlice: Rect.fromLTRB(5.0, 8.0, 105.0, 78.0), scale 1.0, opacity 1.0, FilterQuality.medium)',
+      'Alignment.center, centerSlice: Rect.fromLTRB(5.0, 8.0, 105.0, 78.0), scale 1.0, opacity 1.0, FilterQuality.none)',
     );
     expect(
       (tester.widgetList<DecoratedBox>(find.byType(DecoratedBox)).toList()[0].decoration as BoxDecoration).image.toString(),
       'DecorationImage(NetworkImage("x-invalid://", scale: 1.0), '
       'ColorFilter.mode(Color(0xff8811ff), BlendMode.xor), Alignment.center, scale 1.0, '
-      'opacity 1.0, FilterQuality.medium)',
+      'opacity 1.0, FilterQuality.high)',
     );
 
     ArgumentDecoders.colorFilterDecoders['custom'] = (DataSource source, List<Object> key) {

--- a/packages/rfw/test/argument_decoders_test.dart
+++ b/packages/rfw/test/argument_decoders_test.dart
@@ -295,6 +295,7 @@ void main() {
                 1.0, 1.0, 1.0, 1.0, 1.0,
               ],
             },
+            filterQuality: "medium",
           },
           gradient: {
             type: 'sweep',
@@ -314,6 +315,7 @@ void main() {
               blendMode: "xor",
             },
             onError: event 'image-error-event' { },
+            filterQuality: "medium",
           },
           gradient: {
             type: 'linear',
@@ -383,13 +385,13 @@ void main() {
       (tester.widgetList<DecoratedBox>(find.byType(DecoratedBox)).toList()[1].decoration as BoxDecoration).image.toString(),
       'DecorationImage(AssetImage(bundle: null, name: "asset"), ' // this just seemed like the easiest way to check all this...
       'ColorFilter.matrix([$matrix]), '
-      'Alignment.center, centerSlice: Rect.fromLTRB(5.0, 8.0, 105.0, 78.0), scale 1.0, opacity 1.0, FilterQuality.low)',
+      'Alignment.center, centerSlice: Rect.fromLTRB(5.0, 8.0, 105.0, 78.0), scale 1.0, opacity 1.0, FilterQuality.medium)',
     );
     expect(
       (tester.widgetList<DecoratedBox>(find.byType(DecoratedBox)).toList()[0].decoration as BoxDecoration).image.toString(),
       'DecorationImage(NetworkImage("x-invalid://", scale: 1.0), '
       'ColorFilter.mode(Color(0xff8811ff), BlendMode.xor), Alignment.center, scale 1.0, '
-      'opacity 1.0, FilterQuality.low)',
+      'opacity 1.0, FilterQuality.medium)',
     );
 
     ArgumentDecoders.colorFilterDecoders['custom'] = (DataSource source, List<Object> key) {


### PR DESCRIPTION
And hard-codes filter qualities in tests to prepare for https://github.com/flutter/flutter/pull/148799, which switches the default to `medium`. This hard-codes a filter quality in the test so the test passes no matter what the default is.