### PR TITLE
Update Flutter wiki links

### DIFF
--- a/.ci/targets/analyze_legacy.yaml
+++ b/.ci/targets/analyze_legacy.yaml
@@ -7,6 +7,6 @@ tasks:
   # This is to minimize accidentally making changes that break old versions
   # (which we don't commit to supporting, but don't want to actively break)
   # without updating the constraints.
-  # See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#supported-flutter-versions
+  # See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#supported-flutter-versions
   - name: analyze - legacy
     script: .ci/scripts/analyze_legacy.sh

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,18 +2,16 @@
 
 *List which issues are fixed by this PR. You must list at least one issue.*
 
-*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
-
 ## Pre-launch Checklist
 
 - [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
-- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
+- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
 - [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
 - [ ] I signed the [CLA].
 - [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
 - [ ] I [linked to at least one issue that this PR fixes] in the description above.
 - [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
-- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
+- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
 - [ ] I updated/added relevant documentation (doc comments with `///`).
 - [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
 - [ ] All existing and new tests are passing.
@@ -22,14 +20,13 @@ If you need help, consider asking for advice on the #hackers-new channel on [Dis
 
 <!-- Links -->
 [Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
-[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
+[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
 [relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
 [CLA]: https://cla.developers.google.com/
-[flutter/tests]: https://github.com/flutter/tests
-[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
-[Discord]: https://github.com/flutter/flutter/wiki/Chat
-[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
+[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
+[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
 [pub versioning philosophy]: https://dart.dev/tools/pub/versioning
-[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
-[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
-[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
+[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
+[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
+[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
+[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,17 +5,17 @@ guide](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md).
 
 Additional resources specific to the packages repository:
 - [Setting up the Packages development
-  environment](https://github.com/flutter/flutter/wiki/Setting-up-the-Packages-development-environment),
+  environment](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/Setting-up-the-Packages-development-environment.md),
   which covers the setup process for this repository.
-- [Packages repository structure](https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure),
+- [Packages repository structure](https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md),
   to get an overview of how this repository is laid out.
-- [Contributing to Plugins and Packages](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages),
+- [Contributing to Plugins and Packages](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md),
   for more information about how to make PRs for this repository, especially when
   changing federated plugins.
-- [Plugin tests](https://github.com/flutter/flutter/wiki/Plugin-Tests), which explains
-  the different kinds of tests used for plugins, where to find them, and how to run them.
+- [Plugin tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md),
+  which explains the different kinds of tests used for plugins, where to find them, and how to run them.
   As explained in the Flutter guide,
-  [**PRs need tests**](https://github.com/flutter/flutter/wiki/Tree-hygiene#tests), so
+  [**PRs need tests**](https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests), so
   this is critical to read before submitting a plugin PR.
 
 ### Code review processes and automation
@@ -24,14 +24,14 @@ PRs will automatically be assigned to
 [code owners](https://github.com/flutter/packages/blob/main/CODEOWNERS)
 for review.
 If a code owner is creating a PR, they should explicitly pick another
-[Flutter team member](https://github.com/flutter/flutter/wiki/Contributor-access)
+[Flutter team member](https://github.com/flutter/flutter/blob/master/docs/contributing/Contributor-access.md)
 as a code reviewer.
 
 ### Style
 
 Flutter packages and plugins follow Google style—or Flutter style for Dart—for the languages they
 use, and use auto-formatters:
-- [Dart](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo) formatted
+- [Dart](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md) formatted
   with `dart format`
 - [C++](https://google.github.io/styleguide/cppguide.html) formatted with `clang-format`
   - **Note**: The Linux plugins generally follow idiomatic GObject-based C
@@ -50,4 +50,4 @@ use, and use auto-formatters:
 
 If you are a team member landing a PR, or just want to know what the release
 process is for package changes, see [the release
-documentation](https://github.com/flutter/flutter/wiki/Releasing-a-Plugin-or-Package).
+documentation](https://github.com/flutter/flutter/blob/master/docs/ecosystem/release/README.md).

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -147,7 +147,7 @@ linter:
     # - prefer_constructors_over_static_methods # far too many false positives
     - prefer_contains
     # - prefer_double_quotes # opposite of prefer_single_quotes
-    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
+    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
@@ -160,7 +160,7 @@ linter:
     - prefer_if_null_operators
     - prefer_initializing_formals
     - prefer_inlined_adds
-    # - prefer_int_literals # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#use-double-literals-for-double-constants
+    # - prefer_int_literals # conflicts with https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#use-double-literals-for-double-constants
     - prefer_interpolation_to_compose_strings
     - prefer_is_empty
     - prefer_is_not_empty

--- a/packages/animations/example/android/build.gradle
+++ b/packages/animations/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/animations/example/android/settings.gradle
+++ b/packages/animations/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/camera/camera/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/camera/camera/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/camera/camera/example/android/build.gradle
+++ b/packages/camera/camera/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/camera/camera/example/android/settings.gradle
+++ b/packages/camera/camera/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/camera/camera_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/camera/camera_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/camera/camera_android/example/android/build.gradle
+++ b/packages/camera/camera_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/camera/camera_android/example/android/settings.gradle
+++ b/packages/camera/camera_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/camera/camera_android_camerax/CONTRIBUTING.md
+++ b/packages/camera/camera_android_camerax/CONTRIBUTING.md
@@ -74,5 +74,5 @@ testing purposes. To generate the mock objects, run
 [2]: https://docs.google.com/document/d/1wXB1zNzYhd2SxCu1_BK3qmNWRhonTB6qdv4erdtBQqo/edit?usp=sharing&resourcekey=0-WOBqqOKiO9SARnziBg28pg
 [3]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
 [4]: https://pub.dev/packages/mockito
-[5]: https://github.com/flutter/flutter/wiki/Plugin-Tests#running-tests
-[6]: https://github.com/flutter/flutter/wiki/Chat
+[5]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#running-tests
+[6]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md

--- a/packages/camera/camera_android_camerax/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/camera/camera_android_camerax/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/camera/camera_android_camerax/example/android/build.gradle
+++ b/packages/camera/camera_android_camerax/example/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/camera/camera_android_camerax/example/android/settings.gradle
+++ b/packages/camera/camera_android_camerax/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/camera/camera_web/example/README.md
+++ b/packages/camera/camera_web/example/README.md
@@ -12,8 +12,8 @@ very unlikely to be relevant.
 
 This package uses `package:integration_test` to run its tests in a web browser.
 
-See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
-in the Flutter wiki for instructions to setup and run the tests in this package.
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests)
+in the Flutter documentation for instructions to set up and run the tests in this package.
 
 Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
 for more info.

--- a/packages/dynamic_layouts/example/android/build.gradle
+++ b/packages/dynamic_layouts/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/dynamic_layouts/example/android/settings.gradle
+++ b/packages/dynamic_layouts/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/espresso/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/espresso/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/espresso/example/android/build.gradle
+++ b/packages/espresso/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/espresso/example/android/settings.gradle
+++ b/packages/espresso/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/build.gradle
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/settings.gradle
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/file_selector/file_selector/example/android/build.gradle
+++ b/packages/file_selector/file_selector/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/file_selector/file_selector/example/android/settings.gradle
+++ b/packages/file_selector/file_selector/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/file_selector/file_selector_android/example/android/app/src/main/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/file_selector/file_selector_android/example/android/app/src/main/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/file_selector/file_selector_android/example/android/build.gradle
+++ b/packages/file_selector/file_selector_android/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/file_selector/file_selector_android/example/android/settings.gradle
+++ b/packages/file_selector/file_selector_android/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/file_selector/file_selector_web/example/README.md
+++ b/packages/file_selector/file_selector_web/example/README.md
@@ -12,8 +12,8 @@ very unlikely to be relevant.
 
 This package uses `package:integration_test` to run its tests in a web browser.
 
-See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
-in the Flutter wiki for instructions to setup and run the tests in this package.
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests)
+in the Flutter documentation for instructions to set up and run the tests in this package.
 
 Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
 for more info.

--- a/packages/flutter_adaptive_scaffold/example/android/build.gradle
+++ b/packages/flutter_adaptive_scaffold/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/flutter_adaptive_scaffold/example/android/settings.gradle
+++ b/packages/flutter_adaptive_scaffold/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/flutter_image/example/android/build.gradle
+++ b/packages/flutter_image/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/flutter_image/example/android/settings.gradle
+++ b/packages/flutter_image/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/flutter_markdown/example/android/build.gradle
+++ b/packages/flutter_markdown/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/flutter_markdown/example/android/settings.gradle
+++ b/packages/flutter_markdown/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/flutter_plugin_android_lifecycle/example/android/build.gradle
+++ b/packages/flutter_plugin_android_lifecycle/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/flutter_plugin_android_lifecycle/example/android/settings.gradle
+++ b/packages/flutter_plugin_android_lifecycle/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/go_router/example/android/build.gradle
+++ b/packages/go_router/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/go_router/example/android/settings.gradle
+++ b/packages/go_router/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/settings.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/android/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/android/settings.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/README.md
@@ -12,8 +12,8 @@ very unlikely to be relevant.
 
 This package uses `package:integration_test` to run its tests in a web browser.
 
-See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
-in the Flutter wiki for instructions to setup and run the tests in this package.
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests)
+in the Flutter documentation for instructions to set up and run the tests in this package.
 
 Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
 for more info.

--- a/packages/google_sign_in/google_sign_in/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/google_sign_in/google_sign_in/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/google_sign_in/google_sign_in/example/android/build.gradle
+++ b/packages/google_sign_in/google_sign_in/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/google_sign_in/google_sign_in/example/android/settings.gradle
+++ b/packages/google_sign_in/google_sign_in/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/google_sign_in/google_sign_in_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/google_sign_in/google_sign_in_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/google_sign_in/google_sign_in_android/example/android/build.gradle
+++ b/packages/google_sign_in/google_sign_in_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/google_sign_in/google_sign_in_android/example/android/settings.gradle
+++ b/packages/google_sign_in/google_sign_in_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/google_sign_in/google_sign_in_web/example/README.md
+++ b/packages/google_sign_in/google_sign_in_web/example/README.md
@@ -12,8 +12,8 @@ very unlikely to be relevant.
 
 This package uses `package:integration_test` to run its tests in a web browser.
 
-See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
-in the Flutter wiki for instructions to setup and run the tests in this package.
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests)
+in the Flutter documentation for instructions to set up and run the tests in this package.
 
 Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
 for more info.

--- a/packages/image_picker/image_picker/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/image_picker/image_picker/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/image_picker/image_picker/example/android/build.gradle
+++ b/packages/image_picker/image_picker/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/image_picker/image_picker/example/android/settings.gradle
+++ b/packages/image_picker/image_picker/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/image_picker/image_picker_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/image_picker/image_picker_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/image_picker/image_picker_android/example/android/build.gradle
+++ b/packages/image_picker/image_picker_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/image_picker/image_picker_android/example/android/settings.gradle
+++ b/packages/image_picker/image_picker_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/image_picker/image_picker_for_web/example/README.md
+++ b/packages/image_picker/image_picker_for_web/example/README.md
@@ -12,8 +12,8 @@ very unlikely to be relevant.
 
 This package uses `package:integration_test` to run its tests in a web browser.
 
-See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
-in the Flutter wiki for instructions to setup and run the tests in this package.
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests)
+in the Flutter documentation for instructions to set up and run the tests in this package.
 
 Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
 for more info.

--- a/packages/in_app_purchase/in_app_purchase/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/in_app_purchase/in_app_purchase/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/in_app_purchase/in_app_purchase/example/android/build.gradle
+++ b/packages/in_app_purchase/in_app_purchase/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/in_app_purchase/in_app_purchase/example/android/settings.gradle
+++ b/packages/in_app_purchase/in_app_purchase/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/in_app_purchase/in_app_purchase_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/in_app_purchase/in_app_purchase_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/in_app_purchase/in_app_purchase_android/example/android/build.gradle
+++ b/packages/in_app_purchase/in_app_purchase_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/in_app_purchase/in_app_purchase_android/example/android/settings.gradle
+++ b/packages/in_app_purchase/in_app_purchase_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/interactive_media_ads/example/android/app/src/main/kotlin/io/flutter/plugins/DartIntegrationTest.kt
+++ b/packages/interactive_media_ads/example/android/app/src/main/kotlin/io/flutter/plugins/DartIntegrationTest.kt
@@ -8,7 +8,7 @@ package io.flutter.plugins
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(AnnotationRetention.RUNTIME)

--- a/packages/interactive_media_ads/example/android/build.gradle
+++ b/packages/interactive_media_ads/example/android/build.gradle
@@ -19,7 +19,7 @@ tasks.register("clean", Delete) {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/interactive_media_ads/example/android/settings.gradle
+++ b/packages/interactive_media_ads/example/android/settings.gradle
@@ -16,7 +16,7 @@ pluginManagement {
     }
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
     repositories {
         maven {

--- a/packages/local_auth/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/local_auth/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/local_auth/local_auth/example/android/build.gradle
+++ b/packages/local_auth/local_auth/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/local_auth/local_auth/example/android/settings.gradle
+++ b/packages/local_auth/local_auth/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/local_auth/local_auth_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/local_auth/local_auth_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/local_auth/local_auth_android/example/android/build.gradle
+++ b/packages/local_auth/local_auth_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/local_auth/local_auth_android/example/android/settings.gradle
+++ b/packages/local_auth/local_auth_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/local_auth/local_auth_android/lib/local_auth_android.dart
+++ b/packages/local_auth/local_auth_android/lib/local_auth_android.dart
@@ -44,7 +44,7 @@ class LocalAuthAndroid extends LocalAuthPlatform {
         _pigeonStringsFromAuthMessages(localizedReason, authMessages));
     // TODO(stuartmorgan): Replace this with structured errors, coordinated
     // across all platform implementations, per
-    // https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#platform-exception-handling
+    // https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#platform-exception-handling
     // The PlatformExceptions thrown here are for compatibiilty with the
     // previous Java implementation.
     switch (result) {

--- a/packages/local_auth/local_auth_darwin/lib/local_auth_darwin.dart
+++ b/packages/local_auth/local_auth_darwin/lib/local_auth_darwin.dart
@@ -43,7 +43,7 @@ class LocalAuthDarwin extends LocalAuthPlatform {
         _pigeonStringsFromAuthMessages(localizedReason, authMessages));
     // TODO(stuartmorgan): Replace this with structured errors, coordinated
     // across all platform implementations, per
-    // https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#platform-exception-handling
+    // https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#platform-exception-handling
     // The PlatformExceptions thrown here are for compatibiilty with the
     // previous Objective-C implementation.
     switch (resultDetails.result) {

--- a/packages/palette_generator/example/android/build.gradle
+++ b/packages/palette_generator/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/palette_generator/example/android/settings.gradle
+++ b/packages/palette_generator/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/path_provider/path_provider/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/path_provider/path_provider/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/path_provider/path_provider/example/android/build.gradle
+++ b/packages/path_provider/path_provider/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/path_provider/path_provider/example/android/settings.gradle
+++ b/packages/path_provider/path_provider/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/path_provider/path_provider_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/path_provider/path_provider_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/path_provider/path_provider_android/example/android/build.gradle
+++ b/packages/path_provider/path_provider_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/path_provider/path_provider_android/example/android/settings.gradle
+++ b/packages/path_provider/path_provider_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/pigeon/example/app/android/build.gradle
+++ b/packages/pigeon/example/app/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/pigeon/example/app/android/settings.gradle
+++ b/packages/pigeon/example/app/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/pigeon/platform_tests/README.md
+++ b/packages/pigeon/platform_tests/README.md
@@ -15,7 +15,7 @@ necessary Pigeon output.
 
 The new unified test harness for all platforms. Tests in this plugin use the
 same structure as tests for the Flutter team-maintained plugins, as described
-[in the repository documentation](https://github.com/flutter/flutter/wiki/Plugin-Tests).
+[in the repository documentation](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests).
 
 ## alternate\_language\_test\_plugin
 

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/build.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/settings.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/pigeon/platform_tests/test_plugin/example/android/build.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/pigeon/platform_tests/test_plugin/example/android/settings.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/platform/example/android/build.gradle
+++ b/packages/platform/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/platform/example/android/settings.gradle
+++ b/packages/platform/example/android/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 
 include ":app"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/quick_actions/quick_actions/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/quick_actions/quick_actions/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/quick_actions/quick_actions/example/android/build.gradle
+++ b/packages/quick_actions/quick_actions/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/quick_actions/quick_actions/example/android/settings.gradle
+++ b/packages/quick_actions/quick_actions/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/quick_actions/quick_actions_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/quick_actions/quick_actions_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/quick_actions/quick_actions_android/example/android/build.gradle
+++ b/packages/quick_actions/quick_actions_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/quick_actions/quick_actions_android/example/android/settings.gradle
+++ b/packages/quick_actions/quick_actions_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/rfw/example/hello/android/build.gradle
+++ b/packages/rfw/example/hello/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/rfw/example/hello/android/settings.gradle
+++ b/packages/rfw/example/hello/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/rfw/example/local/android/build.gradle
+++ b/packages/rfw/example/local/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/rfw/example/local/android/settings.gradle
+++ b/packages/rfw/example/local/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/rfw/example/remote/android/build.gradle
+++ b/packages/rfw/example/remote/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/rfw/example/remote/android/settings.gradle
+++ b/packages/rfw/example/remote/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/shared_preferences/shared_preferences/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/shared_preferences/shared_preferences/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/shared_preferences/shared_preferences/example/android/build.gradle
+++ b/packages/shared_preferences/shared_preferences/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/shared_preferences/shared_preferences/example/android/settings.gradle
+++ b/packages/shared_preferences/shared_preferences/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/shared_preferences/shared_preferences_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/shared_preferences/shared_preferences_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/shared_preferences/shared_preferences_android/example/android/build.gradle
+++ b/packages/shared_preferences/shared_preferences_android/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/shared_preferences/shared_preferences_android/example/android/settings.gradle
+++ b/packages/shared_preferences/shared_preferences_android/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/shared_preferences/shared_preferences_web/example/README.md
+++ b/packages/shared_preferences/shared_preferences_web/example/README.md
@@ -12,8 +12,8 @@ very unlikely to be relevant.
 
 This package uses `package:integration_test` to run its tests in a web browser.
 
-See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
-in the Flutter wiki for instructions to setup and run the tests in this package.
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests)
+in the Flutter documentation for instructions to set up and run the tests in this package.
 
 Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
 for more info.

--- a/packages/two_dimensional_scrollables/example/android/build.gradle
+++ b/packages/two_dimensional_scrollables/example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/two_dimensional_scrollables/example/android/settings.gradle
+++ b/packages/two_dimensional_scrollables/example/android/settings.gradle
@@ -10,7 +10,7 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
     repositories {
         maven {

--- a/packages/url_launcher/url_launcher/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/url_launcher/url_launcher/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/url_launcher/url_launcher/example/android/build.gradle
+++ b/packages/url_launcher/url_launcher/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/url_launcher/url_launcher/example/android/settings.gradle
+++ b/packages/url_launcher/url_launcher/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/url_launcher/url_launcher_android/example/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/url_launcher/url_launcher_android/example/android/settings.gradle
+++ b/packages/url_launcher/url_launcher_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/url_launcher/url_launcher_web/example/README.md
+++ b/packages/url_launcher/url_launcher_web/example/README.md
@@ -12,8 +12,8 @@ very unlikely to be relevant.
 
 This package uses `package:integration_test` to run its tests in a web browser.
 
-See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
-in the Flutter wiki for instructions to setup and run the tests in this package.
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests)
+in the Flutter documentation for instructions to set up and run the tests in this package.
 
 Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
 for more info.

--- a/packages/video_player/video_player/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/video_player/video_player/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/video_player/video_player/example/android/build.gradle
+++ b/packages/video_player/video_player/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/video_player/video_player/example/android/settings.gradle
+++ b/packages/video_player/video_player/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/video_player/video_player_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/video_player/video_player_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/video_player/video_player_android/example/android/build.gradle
+++ b/packages/video_player/video_player_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/video_player/video_player_android/example/android/settings.gradle
+++ b/packages/video_player/video_player_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/video_player/video_player_web/example/README.md
+++ b/packages/video_player/video_player_web/example/README.md
@@ -12,8 +12,8 @@ very unlikely to be relevant.
 
 This package uses `package:integration_test` to run its tests in a web browser.
 
-See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/wiki/Plugin-Tests#web-tests)
-in the Flutter wiki for instructions to setup and run the tests in this package.
+See [Plugin Tests > Web Tests](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#web-tests)
+in the Flutter documentation for instructions to set up and run the tests in this package.
 
 Check [flutter.dev > Integration testing](https://flutter.dev/docs/testing/integration-tests)
 for more info.

--- a/packages/webview_flutter/webview_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/webview_flutter/webview_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/webview_flutter/webview_flutter/example/android/build.gradle
+++ b/packages/webview_flutter/webview_flutter/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/webview_flutter/webview_flutter/example/android/settings.gradle
+++ b/packages/webview_flutter/webview_flutter/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/packages/webview_flutter/webview_flutter_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/webview_flutter/webview_flutter_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/webview_flutter/webview_flutter_android/example/android/build.gradle
+++ b/packages/webview_flutter/webview_flutter_android/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
         def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
         if (System.getenv().containsKey(artifactRepoKey)) {
             println "Using artifact hub"

--- a/packages/webview_flutter/webview_flutter_android/example/android/settings.gradle
+++ b/packages/webview_flutter/webview_flutter_android/example/android/settings.gradle
@@ -14,7 +14,7 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-// See https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure for more info.
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 buildscript {
   repositories {
     maven {

--- a/script/configs/allowed_pinned_deps.yaml
+++ b/script/configs/allowed_pinned_deps.yaml
@@ -1,5 +1,5 @@
 # The list of external dependencies that are allowed as pinned dependencies.
-# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#Dependencies
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#Dependencies
 #
 # All entries here should have an explanation for why they are here.
 

--- a/script/configs/allowed_unpinned_deps.yaml
+++ b/script/configs/allowed_unpinned_deps.yaml
@@ -1,5 +1,5 @@
 # The list of external dependencies that are allowed as unpinned dependencies.
-# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#Dependencies
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#Dependencies
 #
 # All entries here should have an explanation for why they are here, either
 # via being part of one of the default-allowed groups, or a specific reason.

--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -96,7 +96,7 @@ dart run script/tool/bin/flutter_plugin_tools.dart update-excerpts
 dart run script/tool/bin/flutter_plugin_tools.dart update-excerpts --packages package_name
 ```
 
-_See also: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#readme-code_
+_See also: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#readme-code_
 
 ### Update CHANGELOG and Version
 
@@ -153,9 +153,9 @@ generation (e.g., regenerating mocks when updating `mockito`).
 **Releases are automated for `flutter/packages`.**
 
 The manual procedure described here is _deprecated_, and should only be used when
-the automated process fails. Please, read
-[Releasing a Plugin or Package](https://github.com/flutter/flutter/wiki/Releasing-a-Plugin-or-Package)
-on the Flutter Wiki first.
+the automated process fails. Please read
+[Releasing a Plugin or Package](https://github.com/flutter/flutter/blob/master/docs/ecosystem/release/README.md)
+before using `publish`.
 
 ```sh
 cd <path_to_repo>

--- a/script/tool/lib/src/gradle_check_command.dart
+++ b/script/tool/lib/src/gradle_check_command.dart
@@ -133,7 +133,7 @@ class GradleCheckCommand extends PackageLoopingCommand {
   /// Documentation url for Artifact hub implementation in flutter repo's.
   @visibleForTesting
   static const String artifactHubDocumentationString =
-      r'https://github.com/flutter/flutter/wiki/Plugins-and-Packages-repository-structure#gradle-structure';
+      r'https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure';
 
   /// String printed as example of valid example root build.gradle repository
   /// configuration that enables artifact hub env variable.
@@ -158,7 +158,7 @@ class GradleCheckCommand extends PackageLoopingCommand {
     final RegExp keyPresentRegex =
         RegExp('$keyVariable' r"\s+=\s+'ARTIFACT_HUB_REPOSITORY'");
     final RegExp documentationPresentRegex = RegExp(
-        r'github\.com.*wiki.*Plugins-and-Packages-repository-structure.*gradle-structure');
+        r'github\.com.*flutter.*blob.*Plugins-and-Packages-repository-structure.*gradle-structure');
     final RegExp keyReadRegex =
         RegExp(r'if.*System\.getenv.*\.containsKey.*' '$keyVariable');
     final RegExp keyUsedRegex =
@@ -223,7 +223,7 @@ apply plugin: "com.google.cloud.artifactregistry.gradle-plugin"
   bool _validateArtifactHubSettingsUsage(
       RepositoryPackage example, List<String> gradleLines) {
     final RegExp documentationPresentRegex = RegExp(
-        r'github\.com.*wiki.*Plugins-and-Packages-repository-structure.*gradle-structure');
+        r'github\.com.*flutter.*blob.*Plugins-and-Packages-repository-structure.*gradle-structure');
     final RegExp artifactRegistryDefinitionRegex = RegExp(
         r'classpath.*gradle\.plugin\.com\.google\.cloud\.artifactregistry:artifactregistry-gradle-plugin');
     final RegExp artifactRegistryPluginApplyRegex = RegExp(

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -58,7 +58,7 @@ class MakeDepsPathBasedCommand extends PackageCommand {
   // the federated plugin change process don't think it's a mistake.
   static const String _dependencyOverrideWarningComment =
       '# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.\n'
-      '# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins';
+      '# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins';
 
   @override
   final String name = 'make-deps-path-based';

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -30,7 +30,7 @@ const String misconfiguredJavaIntegrationTestErrorExplanation =
     'The following files use @RunWith(FlutterTestRunner.class) '
     'but not @DartIntegrationTest, which will cause hangs when run with '
     'this command. See '
-    'https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests '
+    'https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests '
     'for instructions.';
 
 /// The command to run native tests for plugins:

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -583,7 +583,7 @@ class PubspecCheckCommand extends PackageLoopingCommand {
         '''
 The following unexpected non-local dependencies were found:
 ${badDependencies.map((String name) => '  $name').join('\n')}
-Please see https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#Dependencies
+Please see https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#Dependencies
 for more information and next steps.
 ''',
       if (misplacedDevDependencies.isNotEmpty)

--- a/script/tool/lib/src/readme_check_command.dart
+++ b/script/tool/lib/src/readme_check_command.dart
@@ -10,8 +10,8 @@ import 'common/output_utils.dart';
 import 'common/package_looping_command.dart';
 import 'common/repository_package.dart';
 
-const String _instructionWikiUrl =
-    'https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages';
+const String _instructionUrl =
+    'https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md';
 
 /// A command to enforce README conventions across the repository.
 class ReadmeCheckCommand extends PackageLoopingCommand {
@@ -180,7 +180,7 @@ class ReadmeCheckCommand extends PackageLoopingCommand {
       printError(
           '\n${indentation}For each block listed above, add <?code-excerpt ...> '
           'tag on the previous line, as explained at\n'
-          '$_instructionWikiUrl');
+          '$_instructionUrl');
       errorSummary ??= 'Missing code-excerpt management for code block';
     }
 

--- a/script/tool/lib/src/update_excerpts_command.dart
+++ b/script/tool/lib/src/update_excerpts_command.dart
@@ -92,7 +92,7 @@ class UpdateExcerptsCommand extends PackageLoopingCommand {
         'the resulting changes.\n'
         '\n'
         '${indentation}For more information, see '
-        'https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#readme-code',
+        'https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#readme-code',
       );
       return PackageResult.fail();
     }

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -358,7 +358,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
           '${indentation}Breaking changes to platform interfaces are not '
           'allowed without explicit justification.\n'
           '${indentation}See '
-          'https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages '
+          'https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md '
           'for more information.');
       return _CurrentVersionState.invalidChange;
     }

--- a/script/tool/test/make_deps_path_based_command_test.dart
+++ b/script/tool/test/make_deps_path_based_command_test.dart
@@ -122,7 +122,7 @@ ${devDependencies.map((String dep) => '  $dep: $constraint').join('\n')}
         packageA.pubspecFile.readAsLinesSync(),
         containsAllInOrder(<String>[
           '# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.',
-          '# See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins',
+          '# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins',
           'dependency_overrides:',
         ]));
   });

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -1613,7 +1613,7 @@ ${_topicsSection()}
             contains(
                 '  The following unexpected non-local dependencies were found:\n'
                 '    bad_dependency\n'
-                '  Please see https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#Dependencies\n'
+                '  Please see https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#Dependencies\n'
                 '  for more information and next steps.'),
           ]),
         );
@@ -1645,7 +1645,7 @@ ${_topicsSection()}
             contains(
                 '  The following unexpected non-local dependencies were found:\n'
                 '    bad_dependency\n'
-                '  Please see https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#Dependencies\n'
+                '  Please see https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#Dependencies\n'
                 '  for more information and next steps.'),
           ]),
         );
@@ -1729,7 +1729,7 @@ ${_topicsSection()}
             contains(
                 '  The following unexpected non-local dependencies were found:\n'
                 '    allow_pinned\n'
-                '  Please see https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#Dependencies\n'
+                '  Please see https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#Dependencies\n'
                 '  for more information and next steps.'),
           ]),
         );

--- a/script/tool/test/readme_check_command_test.dart
+++ b/script/tool/test/readme_check_command_test.dart
@@ -697,7 +697,7 @@ A B C
           contains('Dart code block at line 3 is not managed by code-excerpt.'),
           // Ensure that the failure message links to instructions.
           contains(
-              'https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages'),
+              'https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md'),
           contains('Missing code-excerpt management for code block'),
         ]),
       );

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -281,7 +281,7 @@ void main() {
             contains(
                 '  Breaking changes to platform interfaces are not allowed '
                 'without explicit justification.\n'
-                '  See https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages '
+                '  See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md '
                 'for more information.'),
           ]));
       expect(


### PR DESCRIPTION
Updates all links to the Flutter wiki to point to their new location in the flutter/flutter repository. (The sole exception is a link to a doc that doesn't have a final home yet, and is linked from legacy code anyway so doesn't really need to be updated.)

While touching the PR template, makes a few minor improvements:
- Removes the breaking change discussion that doesn't apply to this repository, as breaking changes are handled totally differently for packages (and is covered by the link to docs about Dart versioning).
- Adds text and a link to reflect the fact that some PRs can be changelog-exempt.