### PR TITLE
[ci] Switch podspec check over to ARM

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -961,30 +961,15 @@ targets:
         }
 
   ### iOS+macOS tasks ###
-  # TODO(stuartmorgan): Move this to ARM once google_maps_flutter has ARM
-  # support. `pod lint` makes a synthetic target that doesn't respect the
-  # pod's arch exclusions, so fails to build.
-  - name: Mac_x64 check_podspecs
-    recipe: packages/packages
-    timeout: 30
-    properties:
-      version_file: flutter_master.version
-      target_file: macos_repo_checks.yaml
-      dependencies: >
-        [
-          {"dependency": "swift_format", "version": "build_id:8797338980206841409"}
-        ]
-
   - name: Mac_arm64 macos_repo_checks
     recipe: packages/packages
-    bringup: true # New target
     timeout: 30
     properties:
       version_file: flutter_master.version
       target_file: macos_repo_checks.yaml
       dependencies: >
         [
-          {"dependency": "swift_format", "version": "build_id:8797338980206841409"}
+          {"dependency": "swift_format", "version": "build_id:8797338979890974865"}
         ]
 
   ### macOS desktop tasks ###


### PR DESCRIPTION
Completes the switch of podspec checks to ARM, following up from https://github.com/flutter/packages/pull/6782
- Brings the new target out of bringup mode.
- Removes the old target.
- Fixes the build ID of the swift-format CIPD package, since the previous one was copied from the other target, but the arm64 version of the package has a different build ID.

Fixes https://github.com/flutter/flutter/issues/141493