### PR TITLE
[two_dimensional_scrollables] Adds generics to the callbacks and builders of TreeView

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0+1
+## 0.3.1
 
 * Adds generics to the callbacks and builders of TreeView.
 

--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+1
+
+* Adds generics to the callbacks and builders of TreeView.
+
 ## 0.3.0
 
 * Adds new TreeView widget and associated classes.

--- a/packages/two_dimensional_scrollables/example/lib/tree_view/custom_tree.dart
+++ b/packages/two_dimensional_scrollables/example/lib/tree_view/custom_tree.dart
@@ -105,7 +105,7 @@ class CustomTreeExampleState extends State<CustomTreeExample> {
 
   Widget _treeNodeBuilder(
     BuildContext context,
-    TreeViewNode<Object?> node,
+    TreeViewNode<String> node,
     AnimationStyle toggleAnimationStyle,
   ) {
     final bool isParentNode = node.children.isNotEmpty;
@@ -144,7 +144,7 @@ class CustomTreeExampleState extends State<CustomTreeExample> {
         // Spacer
         const SizedBox(width: 8.0),
         // Content
-        Text(node.content.toString()),
+        Text(node.content),
       ],
     );
   }
@@ -188,14 +188,14 @@ class CustomTreeExampleState extends State<CustomTreeExample> {
               controller: _horizontalController,
             ),
             tree: _tree,
-            onNodeToggle: (TreeViewNode<Object?> node) {
+            onNodeToggle: (TreeViewNode<String> node) {
               setState(() {
-                _selectedNode = node as TreeViewNode<String>;
+                _selectedNode = node;
               });
             },
             treeNodeBuilder: _treeNodeBuilder,
-            treeRowBuilder: (TreeViewNode<Object?> node) {
-              if (_selectedNode == (node as TreeViewNode<String>)) {
+            treeRowBuilder: (TreeViewNode<String> node) {
+              if (_selectedNode == node) {
                 return TreeRow(
                   extent: FixedTreeRowExtent(
                     node.children.isNotEmpty ? 60.0 : 50.0,

--- a/packages/two_dimensional_scrollables/example/lib/tree_view/simple_tree.dart
+++ b/packages/two_dimensional_scrollables/example/lib/tree_view/simple_tree.dart
@@ -100,13 +100,13 @@ class TreeExampleState extends State<TreeExample> {
               controller: horizontalController,
             ),
             tree: _tree,
-            onNodeToggle: (TreeViewNode<Object?> node) {
+            onNodeToggle: (TreeViewNode<String> node) {
               setState(() {
-                _selectedNode = node as TreeViewNode<String>;
+                _selectedNode = node;
               });
             },
-            treeRowBuilder: (TreeViewNode<Object?> node) {
-              if (_selectedNode == (node as TreeViewNode<String>)) {
+            treeRowBuilder: (TreeViewNode<String> node) {
+              if (_selectedNode == node) {
                 return TreeView.defaultTreeRowBuilder(node).copyWith(
                   recognizerFactories: _getTapRecognizer(node),
                   backgroundDecoration: TreeRowDecoration(

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
@@ -338,14 +338,14 @@ class TreeView<T> extends StatefulWidget {
   ///
   /// By default, if this is unset, the [TreeView.defaultTreeNodeBuilder] is
   /// used.
-  final TreeViewNodeBuilder treeNodeBuilder;
+  final TreeViewNodeBuilder<T> treeNodeBuilder;
 
   /// Builds the [TreeRow] that describes the row for the provided
   /// [TreeViewNode].
   ///
   /// By default, if this is unset, the [TreeView.defaultTreeRowBuilder]
   /// is used.
-  final TreeViewRowBuilder treeRowBuilder;
+  final TreeViewRowBuilder<T> treeRowBuilder;
 
   /// If provided, the controller can be used to expand and collapse
   /// [TreeViewNode]s, or lookup information about the current state of the
@@ -360,7 +360,7 @@ class TreeView<T> extends StatefulWidget {
   /// a result of being toggled.
   ///
   /// This will not be called if a [TreeViewNode] does not have any children.
-  final TreeViewNodeCallback? onNodeToggle;
+  final TreeViewNodeCallback<T>? onNodeToggle;
 
   /// The default [AnimationStyle] for expanding and collapsing nodes in the
   /// [TreeView].

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/tree_core.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/tree_core.dart
@@ -21,7 +21,7 @@ import 'tree.dart';
 ///
 ///   * [TreeViewNode.toggleNode], for controlling node expansion
 ///     programmatically.
-typedef TreeViewNodeCallback = void Function(TreeViewNode<Object?> node);
+typedef TreeViewNodeCallback<T> = void Function(TreeViewNode<T> node);
 
 /// A mixin for classes implementing a tree structure as expected by a
 /// [TreeViewController].

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/tree_delegate.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/tree_delegate.dart
@@ -12,16 +12,16 @@ import 'tree_span.dart';
 ///
 /// Used by the [TreeViewDelegateMixin.buildRow] to configure rows in the
 /// [TreeView].
-typedef TreeViewRowBuilder = TreeRow Function(TreeViewNode<Object?> node);
+typedef TreeViewRowBuilder<T> = TreeRow Function(TreeViewNode<T> node);
 
 /// Signature for a function that creates a [Widget] to represent the given
 /// [TreeViewNode] in the [TreeView].
 ///
 /// Used by [TreeView.treeRowBuilder] to build rows on demand for the
 /// tree.
-typedef TreeViewNodeBuilder = Widget Function(
+typedef TreeViewNodeBuilder<T> = Widget Function(
   BuildContext context,
-  TreeViewNode<Object?> node,
+  TreeViewNode<T> node,
   AnimationStyle toggleAnimationStyle,
 );
 

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.3.0+1
+version: 0.3.1
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.3.0
+version: 0.3.0+1
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/tree_view/render_tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/render_tree_test.dart
@@ -141,10 +141,10 @@ void main() {
       final List<String> log = <String>[];
       final TreeView<String> treeView = TreeView<String>(
         tree: treeNodes,
-        treeRowBuilder: (TreeViewNode<Object?> node) {
+        treeRowBuilder: (TreeViewNode<String> node) {
           if (node.depth! == 0) {
             return getTappableRow(
-              node as TreeViewNode<String>,
+              node,
               () {
                 log.add(node.content);
                 tapCounter++;
@@ -174,7 +174,7 @@ void main() {
       int exitCounter = 0;
       final TreeView<String> treeView = TreeView<String>(
         tree: treeNodes,
-        treeRowBuilder: (TreeViewNode<Object?> node) {
+        treeRowBuilder: (TreeViewNode<String> node) {
           if (node.depth! == 0) {
             return getMouseTrackingRow(
               onEnter: (_) => enterCounter++,
@@ -397,7 +397,7 @@ void main() {
 
         treeView = TreeView<String>(
           tree: treeNodes,
-          treeRowBuilder: (TreeViewNode<Object?> node) {
+          treeRowBuilder: (TreeViewNode<String> node) {
             if (node.depth! == 1) {
               // extent == 100
               return row;
@@ -766,7 +766,7 @@ void main() {
             controller: horizontalController,
           ),
           tree: treeNodes,
-          treeRowBuilder: (TreeViewNode<Object?> node) {
+          treeRowBuilder: (TreeViewNode<String> node) {
             return row.copyWith(
               backgroundDecoration: node.depth! == 0
                   ? rootBackgroundDecoration

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -510,7 +510,7 @@ void main() {
                   // Spacer
                   const SizedBox(width: 8.0),
                   // Content
-                  Text(node.content.toString()),
+                  Text(node.content),
                 ]),
               ),
             );

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -130,7 +130,7 @@ void main() {
           controller: controller,
           treeNodeBuilder: (
             BuildContext context,
-            TreeViewNode<Object?> node,
+            TreeViewNode<String> node,
             AnimationStyle toggleAnimationStyle,
           ) {
             returnedController ??= TreeViewController.of(context);
@@ -153,7 +153,7 @@ void main() {
           tree: simpleNodeSet,
           treeNodeBuilder: (
             BuildContext context,
-            TreeViewNode<Object?> node,
+            TreeViewNode<String> node,
             AnimationStyle toggleAnimationStyle,
           ) {
             returnedController ??= TreeViewController.maybeOf(context);
@@ -454,9 +454,9 @@ void main() {
         home: TreeView<String>(
           tree: simpleNodeSet,
           controller: controller,
-          onNodeToggle: (TreeViewNode<Object?> node) {
+          onNodeToggle: (TreeViewNode<String> node) {
             toggled = true;
-            toggledNode = node as TreeViewNode<String>;
+            toggledNode = node;
           },
         ),
       ));
@@ -476,13 +476,13 @@ void main() {
         home: TreeView<String>(
           tree: simpleNodeSet,
           controller: controller,
-          onNodeToggle: (TreeViewNode<Object?> node) {
+          onNodeToggle: (TreeViewNode<String> node) {
             toggled = true;
-            toggledNode = node as TreeViewNode<String>;
+            toggledNode = node;
           },
           treeNodeBuilder: (
             BuildContext context,
-            TreeViewNode<Object?> node,
+            TreeViewNode<String> node,
             AnimationStyle toggleAnimationStyle,
           ) {
             final Duration animationDuration = toggleAnimationStyle.duration ??
@@ -535,11 +535,11 @@ void main() {
           tree: simpleNodeSet,
           treeNodeBuilder: (
             BuildContext context,
-            TreeViewNode<Object?> node,
+            TreeViewNode<String> node,
             AnimationStyle toggleAnimationStyle,
           ) {
             style ??= toggleAnimationStyle;
-            return Text(node.content.toString());
+            return Text(node.content);
           },
         ),
       ));
@@ -558,11 +558,11 @@ void main() {
           toggleAnimationStyle: AnimationStyle.noAnimation,
           treeNodeBuilder: (
             BuildContext context,
-            TreeViewNode<Object?> node,
+            TreeViewNode<String> node,
             AnimationStyle toggleAnimationStyle,
           ) {
             style = toggleAnimationStyle;
-            return Text(node.content.toString());
+            return Text(node.content);
           },
         ),
       ));
@@ -580,11 +580,11 @@ void main() {
           ),
           treeNodeBuilder: (
             BuildContext context,
-            TreeViewNode<Object?> node,
+            TreeViewNode<String> node,
             AnimationStyle toggleAnimationStyle,
           ) {
             style ??= toggleAnimationStyle;
-            return Text(node.content.toString());
+            return Text(node.content);
           },
         ),
       ));

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -695,28 +695,28 @@ void main() {
     });
 
     test('should use the generic type for callbacks and builders', () {
-      Widget createTreeView() {
-        return TreeView<String>(
-          tree: simpleNodeSet,
-          treeNodeBuilder: (
-            BuildContext context,
-            TreeViewNode<String> node,
-            AnimationStyle animationStyle,
-          ) {
-            return TreeView.defaultTreeNodeBuilder(
-              context,
-              node,
-              animationStyle,
-            );
-          },
-          treeRowBuilder: (TreeViewNode<String> node) {
-            return TreeView.defaultTreeRowBuilder(node);
-          },
-          onNodeToggle: (TreeViewNode<String> node) {},
-        );
-      }
+      final TreeView<String> treeView = TreeView<String>(
+        tree: simpleNodeSet,
+        treeNodeBuilder: (
+          BuildContext context,
+          TreeViewNode<String> node,
+          AnimationStyle animationStyle,
+        ) {
+          return TreeView.defaultTreeNodeBuilder(
+            context,
+            node,
+            animationStyle,
+          );
+        },
+        treeRowBuilder: (TreeViewNode<String> node) {
+          return TreeView.defaultTreeRowBuilder(node);
+        },
+        onNodeToggle: (TreeViewNode<String> node) {},
+      );
 
-      expect(createTreeView, returnsNormally);
+      expect(treeView.onNodeToggle, isA<TreeViewNodeCallback<String>>());
+      expect(treeView.treeNodeBuilder, isA<TreeViewNodeBuilder<String>>());
+      expect(treeView.treeRowBuilder, isA<TreeViewRowBuilder<String>>());
     });
   });
 

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -693,6 +693,31 @@ void main() {
       expect(find.text('Child 2:1'), findsNothing);
       expect(find.text('Root 3'), findsOneWidget);
     });
+
+    test('should use the generic type for callbacks and builders', () {
+      Widget createTreeView() {
+        return TreeView<String>(
+          tree: simpleNodeSet,
+          treeNodeBuilder: (
+            BuildContext context,
+            TreeViewNode<String> node,
+            AnimationStyle animationStyle,
+          ) {
+            return TreeView.defaultTreeNodeBuilder(
+              context,
+              node,
+              animationStyle,
+            );
+          },
+          treeRowBuilder: (TreeViewNode<String> node) {
+            return TreeView.defaultTreeRowBuilder(node);
+          },
+          onNodeToggle: (TreeViewNode<String> node) {},
+        );
+      }
+
+      expect(createTreeView, returnsNormally);
+    });
   });
 
   group('TreeViewport', () {


### PR DESCRIPTION
This PR adds generics to the callbacks and builders of the TreeView widget. This removes the need to type cast the content of a TreeViewNode.

Fixes https://github.com/flutter/flutter/issues/149656

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
