### PR TITLE
[tool] Provide better CI feedback for combo PRs

### DIFF
--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -33,6 +33,10 @@ const String platformWindows = 'windows';
 /// Key for enable experiment.
 const String kEnableExperiment = 'enable-experiment';
 
+/// A String to add to comments on temporarily-added changes that should not
+/// land (e.g., dependency overrides in federated plugin combination PRs).
+const String kDoNotLandWarning = 'DO NOT MERGE';
+
 /// Target platforms supported by Flutter.
 // ignore: public_member_api_docs
 enum FlutterPlatform { android, ios, linux, macos, web, windows }

--- a/script/tool/lib/src/federation_safety_check_command.dart
+++ b/script/tool/lib/src/federation_safety_check_command.dart
@@ -6,6 +6,7 @@ import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
+import 'common/core.dart';
 import 'common/file_utils.dart';
 import 'common/git_version_finder.dart';
 import 'common/output_utils.dart';
@@ -112,6 +113,21 @@ class FederationSafetyCheckCommand extends PackageLoopingCommand {
           'Platform interface changes are not validated.');
     }
 
+    // Special-case combination PRs that are following repo process, so that
+    // they don't get an error that makes it sound like something is wrong with
+    // the PR (but is still an error so that the PR can't land without following
+    // the resolution process).
+    if (package.getExamples().any(_hasTemporaryDependencyOverrides)) {
+      printError('"$kDoNotLandWarning" found in pubspec.yaml, so this is '
+          'assumed to be the initial combination PR for a federated change, '
+          'following the standard repository procedure. This failure is '
+          'expected, in order to prevent accidentally landing the temporary '
+          'overrides, and will automatically be resolved when the temporary '
+          'overrides are replaced by dependency version bumps later in the '
+          'process.');
+      return PackageResult.fail(<String>['Unresolved combo PR.']);
+    }
+
     // Uses basename to match _changedPackageFiles.
     final String basePackageName = package.directory.parent.basename;
     final String platformInterfacePackageName =
@@ -215,5 +231,10 @@ class FederationSafetyCheckCommand extends PackageLoopingCommand {
     // Only return true if a comment change was found, as a fail-safe against
     // against having the wrong (e.g., incorrectly empty) diff output.
     return foundComment;
+  }
+
+  bool _hasTemporaryDependencyOverrides(RepositoryPackage package) {
+    final String pubspecContents = package.pubspecFile.readAsStringSync();
+    return pubspecContents.contains(kDoNotLandWarning);
   }
 }

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -57,7 +57,7 @@ class MakeDepsPathBasedCommand extends PackageCommand {
   // Includes a reference to the docs so that reviewers who aren't familiar with
   // the federated plugin change process don't think it's a mistake.
   static const String _dependencyOverrideWarningComment =
-      '# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.\n'
+      '# FOR TESTING AND INITIAL REVIEW ONLY. $kDoNotLandWarning.\n'
       '# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins';
 
   @override


### PR DESCRIPTION
Currently if a PR follows the recommended combo PR process for a federated plugin, the main PR will have CI errors that say the PR isn't allowed to do what it is doing, which is confusing, especially to new contributors or reviewers.

This updates the tooling to detect the temporary overrides created by the tooling, and uses that to trigger a different error message that explains that the error is expected, and exists only to prevent accidental landing.

Fixes https://github.com/flutter/flutter/issues/129303

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
