### PR TITLE
[path_provider] Skip verifying sample file on macOS

### DIFF
--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -22,7 +22,7 @@ void main() {
       // because the path changes from an app specific directory to
       // ~/Documents, which requires additional permissions to access on macOS.
       // Instead, validate that a non-empty path was returned.
-      expect(result, isNotEmpty);
+      expect(result.path, isNotEmpty);
     } else {
       _verifySampleFile(result, 'applicationDocuments');
     }

--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -17,7 +17,15 @@ void main() {
 
   testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
     final Directory result = await getApplicationDocumentsDirectory();
-    _verifySampleFile(result, 'applicationDocuments');
+    if (Platform.isMacOS) {
+      // _verifySampleFile causes hangs in driver when sandboxing is disabled
+      // because the path changes from an app specific directory to
+      // ~/Documents, which requires additional permissions to access on macOS.
+      // Instead, validate that a non-empty path was returned.
+      expect(result, isNotEmpty);
+    } else {
+      _verifySampleFile(result, 'applicationDocuments');
+    }
   });
 
   testWidgets('getApplicationSupportDirectory', (WidgetTester tester) async {

--- a/packages/path_provider/path_provider_foundation/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_foundation/example/integration_test/path_provider_test.dart
@@ -20,7 +20,15 @@ void main() {
   testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
     final PathProviderPlatform provider = PathProviderPlatform.instance;
     final String? result = await provider.getApplicationDocumentsPath();
-    _verifySampleFile(result, 'applicationDocuments');
+    if (Platform.isMacOS) {
+      // _verifySampleFile causes hangs in driver when sandboxing is disabled
+      // because the path changes from an app specific directory to
+      // ~/Documents, which requires additional permissions to access on macOS.
+      // Instead, validate that a non-empty path was returned.
+      expect(result, isNotEmpty);
+    } else {
+      _verifySampleFile(result, 'applicationDocuments');
+    }
   });
 
   testWidgets('getApplicationSupportDirectory', (WidgetTester tester) async {


### PR DESCRIPTION
[Sandboxing was recently disabled for macOS CI tests](https://github.com/flutter/flutter/pull/149618). This caused `getApplicationDocumentsDirectory` tests in path_provider to fail because it changes the path.

With sandboxing enabled, the path is `~/Library/Containers/dev.flutter.plugins.pathProviderExample/Data/Documents`. With sandboxing disabled, the path is `~/Documents`, which requires additional permissions to access. 

To workaround, skip verifying a file can be created/deleted and simply validate a path is returned.

Fixes https://github.com/flutter/flutter/issues/149713.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
