### PR TITLE
Run tests on macOS 13 or 14

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1021,8 +1021,6 @@ targets:
     presubmit: false
     timeout: 60
     properties:
-      # TODO(vashworth): Remove os property once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated.
-      os: Mac-13
       channel: stable
       version_file: flutter_stable.version
       target_file: macos_platform_tests.yaml
@@ -1051,8 +1049,6 @@ targets:
     recipe: packages/packages
     timeout: 60
     properties:
-      # TODO(vashworth): Remove os property once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated.
-      os: Mac-13
       version_file: flutter_stable.version
       target_file: macos_custom_package_tests.yaml
       channel: stable

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -90,7 +90,7 @@ platform_properties:
         [
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       device_type: none
       cpu: arm64
       $flutter/osx_sdk : >-
@@ -103,7 +103,7 @@ platform_properties:
         [
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
@@ -1021,6 +1021,8 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      # TODO(vashworth): Remove os property once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated.
+      os: Mac-13
       channel: stable
       version_file: flutter_stable.version
       target_file: macos_platform_tests.yaml
@@ -1049,6 +1051,8 @@ targets:
     recipe: packages/packages
     timeout: 60
     properties:
+      # TODO(vashworth): Remove os property once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated.
+      os: Mac-13
       version_file: flutter_stable.version
       target_file: macos_custom_package_tests.yaml
       channel: stable


### PR DESCRIPTION
In preparation of upgrading our fleet to macOS 14, allow tests to run on either macOS 13 or 14.

Fixes https://github.com/flutter/flutter/issues/148873.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
