### PR TITLE
[ci] Allow `platform` references

### DIFF
--- a/script/configs/allowed_unpinned_deps.yaml
+++ b/script/configs/allowed_unpinned_deps.yaml
@@ -45,6 +45,7 @@
 - meta
 - mime
 - path
+- platform
 - shelf
 - shelf_static
 - source_gen


### PR DESCRIPTION
Now that `platform` is no longer in-repo, it needs a dependency allowance.

Fixes tree breakage.