### PR TITLE
Ensure each code block specified in the markdown uses its own ScrollController.

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2
+
+* Multiple code blocks within a single markdown will now use separate ScrollControllers.
+
 ## 0.7.1
 
 * Allows for choosing a custom font feature to create superscript in footnotes when the font does not support the `supr` font feature.

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -174,7 +174,6 @@ class MarkdownBuilder implements md.NodeVisitor {
   final List<_TableElement> _tables = <_TableElement>[];
   final List<_InlineElement> _inlines = <_InlineElement>[];
   final List<GestureRecognizer> _linkHandlers = <GestureRecognizer>[];
-  final ScrollController _preScrollController = ScrollController();
   String? _currentBlockTag;
   String? _lastVisitedTag;
   bool _isInBlockquote = false;
@@ -347,10 +346,11 @@ class MarkdownBuilder implements md.NodeVisitor {
       child = builders[_blocks.last.tag!]!
           .visitText(text, styleSheet.styles[_blocks.last.tag!]);
     } else if (_blocks.last.tag == 'pre') {
+      final ScrollController preScrollController = ScrollController();
       child = Scrollbar(
-        controller: _preScrollController,
+        controller: preScrollController,
         child: SingleChildScrollView(
-          controller: _preScrollController,
+          controller: preScrollController,
           scrollDirection: Axis.horizontal,
           padding: styleSheet.codeblockPadding,
           child: _buildRichText(delegate.formatText(styleSheet, text.text)),

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.7.1
+version: 0.7.2
 
 environment:
   sdk: ^3.3.0

--- a/packages/flutter_markdown/test/scrollable_test.dart
+++ b/packages/flutter_markdown/test/scrollable_test.dart
@@ -35,6 +35,34 @@ void defineTests() {
     );
 
     testWidgets(
+      'two code blocks use different scroll controllers',
+      (WidgetTester tester) async {
+        const String data =
+            "```\nvoid main() {\n  print('Hello World!');\n}\n```"
+            '\n'
+            "```\nvoid main() {\n  print('Hello World!');\n}\n```";
+
+        await tester.pumpWidget(
+          boilerplate(
+            const MediaQuery(
+              data: MediaQueryData(),
+              child: MarkdownBody(data: data),
+            ),
+          ),
+        );
+
+        final Iterable<Widget> widgets = tester.allWidgets;
+        final Iterable<SingleChildScrollView> scrollViews =
+            widgets.whereType<SingleChildScrollView>();
+        expect(scrollViews, hasLength(2));
+        expect(scrollViews.first.controller, isNotNull);
+        expect(scrollViews.last.controller, isNotNull);
+        expect(scrollViews.first.controller,
+            isNot(equals(scrollViews.last.controller)));
+      },
+    );
+
+    testWidgets(
       'controller',
       (WidgetTester tester) async {
         final ScrollController controller = ScrollController(


### PR DESCRIPTION
Currently all code blocks share the same ScrollController causing an exception when they appear on screen together.  This fixes that situation.
