### PR TITLE
Refactor `VideoPlayer` to be less exposed to `EventChannel` & related

### DIFF
--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -28,12 +28,7 @@ import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
-import io.flutter.plugin.common.EventChannel;
 import io.flutter.view.TextureRegistry;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 final class VideoPlayer {
@@ -48,9 +43,7 @@ final class VideoPlayer {
 
   private final TextureRegistry.SurfaceTextureEntry textureEntry;
 
-  private QueuingEventSink eventSink;
-
-  private final EventChannel eventChannel;
+  private final VideoPlayerCallbacks events;
 
   private static final String USER_AGENT = "User-Agent";
 
@@ -62,13 +55,13 @@ final class VideoPlayer {
 
   VideoPlayer(
       Context context,
-      EventChannel eventChannel,
+      VideoPlayerCallbacks events,
       TextureRegistry.SurfaceTextureEntry textureEntry,
       String dataSource,
       String formatHint,
       @NonNull Map<String, String> httpHeaders,
       VideoPlayerOptions options) {
-    this.eventChannel = eventChannel;
+    this.events = events;
     this.textureEntry = textureEntry;
     this.options = options;
 
@@ -86,24 +79,23 @@ final class VideoPlayer {
     exoPlayer.setMediaItem(mediaItem);
     exoPlayer.prepare();
 
-    setUpVideoPlayer(exoPlayer, new QueuingEventSink());
+    setUpVideoPlayer(exoPlayer);
   }
 
   // Constructor used to directly test members of this class.
   @VisibleForTesting
   VideoPlayer(
       ExoPlayer exoPlayer,
-      EventChannel eventChannel,
+      VideoPlayerCallbacks events,
       TextureRegistry.SurfaceTextureEntry textureEntry,
       VideoPlayerOptions options,
-      QueuingEventSink eventSink,
       DefaultHttpDataSource.Factory httpDataSourceFactory) {
-    this.eventChannel = eventChannel;
+    this.events = events;
     this.textureEntry = textureEntry;
     this.options = options;
     this.httpDataSourceFactory = httpDataSourceFactory;
 
-    setUpVideoPlayer(exoPlayer, eventSink);
+    setUpVideoPlayer(exoPlayer);
   }
 
   @VisibleForTesting
@@ -118,22 +110,8 @@ final class VideoPlayer {
         httpDataSourceFactory, httpHeaders, userAgent, httpHeadersNotEmpty);
   }
 
-  private void setUpVideoPlayer(ExoPlayer exoPlayer, QueuingEventSink eventSink) {
+  private void setUpVideoPlayer(ExoPlayer exoPlayer) {
     this.exoPlayer = exoPlayer;
-    this.eventSink = eventSink;
-
-    eventChannel.setStreamHandler(
-        new EventChannel.StreamHandler() {
-          @Override
-          public void onListen(Object o, EventChannel.EventSink sink) {
-            eventSink.setDelegate(sink);
-          }
-
-          @Override
-          public void onCancel(Object o) {
-            eventSink.setDelegate(null);
-          }
-        });
 
     surface = new Surface(textureEntry.surfaceTexture());
     exoPlayer.setVideoSurface(surface);
@@ -144,11 +122,14 @@ final class VideoPlayer {
           private boolean isBuffering = false;
 
           public void setBuffering(boolean buffering) {
-            if (isBuffering != buffering) {
-              isBuffering = buffering;
-              Map<String, Object> event = new HashMap<>();
-              event.put("event", isBuffering ? "bufferingStart" : "bufferingEnd");
-              eventSink.success(event);
+            if (isBuffering == buffering) {
+              return;
+            }
+            isBuffering = buffering;
+            if (buffering) {
+              events.onBufferingStart();
+            } else {
+              events.onBufferingEnd();
             }
           }
 
@@ -163,11 +144,8 @@ final class VideoPlayer {
                 sendInitialized();
               }
             } else if (playbackState == Player.STATE_ENDED) {
-              Map<String, Object> event = new HashMap<>();
-              event.put("event", "completed");
-              eventSink.success(event);
+              events.onCompleted();
             }
-
             if (playbackState != Player.STATE_BUFFERING) {
               setBuffering(false);
             }
@@ -180,30 +158,20 @@ final class VideoPlayer {
               // See https://exoplayer.dev/live-streaming.html#behindlivewindowexception-and-error_code_behind_live_window
               exoPlayer.seekToDefaultPosition();
               exoPlayer.prepare();
-            } else if (eventSink != null) {
-              eventSink.error("VideoError", "Video player had error " + error, null);
+            } else {
+              events.onError("VideoPlayer", "Video player had error " + error, null);
             }
           }
 
           @Override
           public void onIsPlayingChanged(boolean isPlaying) {
-            if (eventSink != null) {
-              Map<String, Object> event = new HashMap<>();
-              event.put("event", "isPlayingStateUpdate");
-              event.put("isPlaying", isPlaying);
-              eventSink.success(event);
-            }
+            events.onIsPlayingStateUpdate(isPlaying);
           }
         });
   }
 
   void sendBufferingUpdate() {
-    Map<String, Object> event = new HashMap<>();
-    event.put("event", "bufferingUpdate");
-    List<? extends Number> range = Arrays.asList(0, exoPlayer.getBufferedPosition());
-    // iOS supports a list of buffered ranges, so here is a list with a single range.
-    event.put("values", Collections.singletonList(range));
-    eventSink.success(event);
+    events.onBufferingUpdate(exoPlayer.getBufferedPosition());
   }
 
   private static void setAudioAttributes(ExoPlayer exoPlayer, boolean isMixMode) {
@@ -248,35 +216,29 @@ final class VideoPlayer {
   @SuppressWarnings("SuspiciousNameCombination")
   @VisibleForTesting
   void sendInitialized() {
-    if (isInitialized) {
-      Map<String, Object> event = new HashMap<>();
-      event.put("event", "initialized");
-      event.put("duration", exoPlayer.getDuration());
-
-      VideoSize videoSize = exoPlayer.getVideoSize();
-      int width = videoSize.width;
-      int height = videoSize.height;
-      if (width != 0 && height != 0) {
-        int rotationDegrees = videoSize.unappliedRotationDegrees;
-        // Switch the width/height if video was taken in portrait mode
-        if (rotationDegrees == 90 || rotationDegrees == 270) {
-          width = videoSize.height;
-          height = videoSize.width;
-        }
-        event.put("width", width);
-        event.put("height", height);
-
-        // Rotating the video with ExoPlayer does not seem to be possible with a Surface,
-        // so inform the Flutter code that the widget needs to be rotated to prevent
-        // upside-down playback for videos with rotationDegrees of 180 (other orientations work
-        // correctly without correction).
-        if (rotationDegrees == 180) {
-          event.put("rotationCorrection", rotationDegrees);
-        }
-      }
-
-      eventSink.success(event);
+    if (!isInitialized) {
+      return;
     }
+    VideoSize videoSize = exoPlayer.getVideoSize();
+    @Nullable Integer rotationCorrection = null;
+    int width = videoSize.width;
+    int height = videoSize.height;
+    if (width != 0 && height != 0) {
+      int rotationDegrees = videoSize.unappliedRotationDegrees;
+      // Switch the width/height if video was taken in portrait mode
+      if (rotationDegrees == 90 || rotationDegrees == 270) {
+        width = videoSize.height;
+        height = videoSize.width;
+      }
+      // Rotating the video with ExoPlayer does not seem to be possible with a Surface,
+      // so inform the Flutter code that the widget needs to be rotated to prevent
+      // upside-down playback for videos with rotationDegrees of 180 (other orientations work
+      // correctly without correction).
+      if (rotationDegrees == 180) {
+        rotationCorrection = rotationDegrees;
+      }
+    }
+    events.onInitialized(width, height, exoPlayer.getDuration(), rotationCorrection);
   }
 
   void dispose() {
@@ -284,7 +246,6 @@ final class VideoPlayer {
       exoPlayer.stop();
     }
     textureEntry.release();
-    eventChannel.setStreamHandler(null);
     if (surface != null) {
       surface.release();
     }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -110,12 +110,17 @@ final class VideoPlayer {
         httpDataSourceFactory, httpHeaders, userAgent, httpHeadersNotEmpty);
   }
 
+
+
   private void setUpVideoPlayer(ExoPlayer exoPlayer) {
     this.exoPlayer = exoPlayer;
 
     surface = new Surface(textureEntry.surfaceTexture());
     exoPlayer.setVideoSurface(surface);
     setAudioAttributes(exoPlayer, options.mixWithOthers);
+
+    // Avoids synthetic accessor.
+    VideoPlayerCallbacks events = this.events;
 
     exoPlayer.addListener(
         new Listener() {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -110,8 +110,6 @@ final class VideoPlayer {
         httpDataSourceFactory, httpHeaders, userAgent, httpHeadersNotEmpty);
   }
 
-
-
   private void setUpVideoPlayer(ExoPlayer exoPlayer) {
     this.exoPlayer = exoPlayer;
 
@@ -225,7 +223,7 @@ final class VideoPlayer {
       return;
     }
     VideoSize videoSize = exoPlayer.getVideoSize();
-    @Nullable Integer rotationCorrection = null;
+    int rotationCorrection = 0;
     int width = videoSize.width;
     int height = videoSize.height;
     if (width != 0 && height != 0) {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -43,7 +43,7 @@ final class VideoPlayer {
 
   private final TextureRegistry.SurfaceTextureEntry textureEntry;
 
-  private final VideoPlayerCallbacks events;
+  private final VideoPlayerCallbacks videoPlayerEvents;
 
   private static final String USER_AGENT = "User-Agent";
 
@@ -61,7 +61,7 @@ final class VideoPlayer {
       String formatHint,
       @NonNull Map<String, String> httpHeaders,
       VideoPlayerOptions options) {
-    this.events = events;
+    this.videoPlayerEvents = events;
     this.textureEntry = textureEntry;
     this.options = options;
 
@@ -90,7 +90,7 @@ final class VideoPlayer {
       TextureRegistry.SurfaceTextureEntry textureEntry,
       VideoPlayerOptions options,
       DefaultHttpDataSource.Factory httpDataSourceFactory) {
-    this.events = events;
+    this.videoPlayerEvents = events;
     this.textureEntry = textureEntry;
     this.options = options;
     this.httpDataSourceFactory = httpDataSourceFactory;
@@ -118,7 +118,7 @@ final class VideoPlayer {
     setAudioAttributes(exoPlayer, options.mixWithOthers);
 
     // Avoids synthetic accessor.
-    VideoPlayerCallbacks events = this.events;
+    VideoPlayerCallbacks events = this.videoPlayerEvents;
 
     exoPlayer.addListener(
         new Listener() {
@@ -162,7 +162,7 @@ final class VideoPlayer {
               exoPlayer.seekToDefaultPosition();
               exoPlayer.prepare();
             } else {
-              events.onError("VideoPlayer", "Video player had error " + error, null);
+              events.onError("VideoError", "Video player had error " + error, null);
             }
           }
 
@@ -174,7 +174,7 @@ final class VideoPlayer {
   }
 
   void sendBufferingUpdate() {
-    events.onBufferingUpdate(exoPlayer.getBufferedPosition());
+    videoPlayerEvents.onBufferingUpdate(exoPlayer.getBufferedPosition());
   }
 
   private static void setAudioAttributes(ExoPlayer exoPlayer, boolean isMixMode) {
@@ -241,7 +241,7 @@ final class VideoPlayer {
         rotationCorrection = rotationDegrees;
       }
     }
-    events.onInitialized(width, height, exoPlayer.getDuration(), rotationCorrection);
+    videoPlayerEvents.onInitialized(width, height, exoPlayer.getDuration(), rotationCorrection);
   }
 
   void dispose() {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
@@ -1,0 +1,21 @@
+package io.flutter.plugins.videoplayer;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Callbacks representing events invoked by {@link VideoPlayer}.
+ *
+ * <p>In the actual plugin, this will always be {@link VideoPlayerEventCallbacks}, which creates the
+ * expected events to send back through the plugin channel. In tests methods can be overridden in
+ * order to assert results.
+ */
+interface VideoPlayerCallbacks {
+    void onInitialized(int width, int height, long durationInMs, @Nullable Integer rotationCorrectionInDegrees);
+    void onBufferingStart();
+    void onBufferingUpdate(long bufferedPosition);
+    void onBufferingEnd();
+    void onCompleted();
+    void onError(@NonNull String code, @Nullable String message, @Nullable Object details);
+    void onIsPlayingStateUpdate(boolean isPlaying);
+}

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.videoplayer;
 
 import androidx.annotation.NonNull;

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
@@ -13,6 +13,8 @@ import androidx.annotation.Nullable;
  * <p>In the actual plugin, this will always be {@link VideoPlayerEventCallbacks}, which creates the
  * expected events to send back through the plugin channel. In tests methods can be overridden in
  * order to assert results.
+ *
+ * <p>See {@link androidx.media3.common.Player.Listener} for details.
  */
 interface VideoPlayerCallbacks {
   void onInitialized(int width, int height, long durationInMs, int rotationCorrectionInDegrees);

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
@@ -11,11 +11,18 @@ import androidx.annotation.Nullable;
  * order to assert results.
  */
 interface VideoPlayerCallbacks {
-    void onInitialized(int width, int height, long durationInMs, @Nullable Integer rotationCorrectionInDegrees);
-    void onBufferingStart();
-    void onBufferingUpdate(long bufferedPosition);
-    void onBufferingEnd();
-    void onCompleted();
-    void onError(@NonNull String code, @Nullable String message, @Nullable Object details);
-    void onIsPlayingStateUpdate(boolean isPlaying);
+  void onInitialized(
+      int width, int height, long durationInMs, @Nullable Integer rotationCorrectionInDegrees);
+
+  void onBufferingStart();
+
+  void onBufferingUpdate(long bufferedPosition);
+
+  void onBufferingEnd();
+
+  void onCompleted();
+
+  void onError(@NonNull String code, @Nullable String message, @Nullable Object details);
+
+  void onIsPlayingStateUpdate(boolean isPlaying);
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerCallbacks.java
@@ -15,8 +15,7 @@ import androidx.annotation.Nullable;
  * order to assert results.
  */
 interface VideoPlayerCallbacks {
-  void onInitialized(
-      int width, int height, long durationInMs, @Nullable Integer rotationCorrectionInDegrees);
+  void onInitialized(int width, int height, long durationInMs, int rotationCorrectionInDegrees);
 
   void onBufferingStart();
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
@@ -2,92 +2,91 @@ package io.flutter.plugins.videoplayer;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
+import io.flutter.plugin.common.EventChannel;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.flutter.plugin.common.EventChannel;
-
 final class VideoPlayerEventCallbacks implements VideoPlayerCallbacks {
-    private final EventChannel.EventSink eventSink;
+  private final EventChannel.EventSink eventSink;
 
-    static VideoPlayerEventCallbacks bindTo(EventChannel eventChannel) {
-        QueuingEventSink eventSink = new QueuingEventSink();
-        eventChannel.setStreamHandler(
-                new EventChannel.StreamHandler() {
-                    @Override
-                    public void onListen(Object arguments, EventChannel.EventSink events) {
-                        eventSink.setDelegate(events);
-                    }
+  static VideoPlayerEventCallbacks bindTo(EventChannel eventChannel) {
+    QueuingEventSink eventSink = new QueuingEventSink();
+    eventChannel.setStreamHandler(
+        new EventChannel.StreamHandler() {
+          @Override
+          public void onListen(Object arguments, EventChannel.EventSink events) {
+            eventSink.setDelegate(events);
+          }
 
-                    @Override
-                    public void onCancel(Object arguments) {
-                        eventSink.setDelegate(null);
-                    }
-                });
-        return VideoPlayerEventCallbacks.withSink(eventSink);
+          @Override
+          public void onCancel(Object arguments) {
+            eventSink.setDelegate(null);
+          }
+        });
+    return VideoPlayerEventCallbacks.withSink(eventSink);
+  }
+
+  static VideoPlayerEventCallbacks withSink(EventChannel.EventSink eventSink) {
+    return new VideoPlayerEventCallbacks(eventSink);
+  }
+
+  private VideoPlayerEventCallbacks(EventChannel.EventSink eventSink) {
+    this.eventSink = eventSink;
+  }
+
+  @Override
+  public void onInitialized(
+      int width, int height, long durationInMs, @Nullable Integer rotationCorrectionInDegrees) {
+    Map<String, Object> event = new HashMap<>();
+    event.put("event", "initialized");
+    event.put("width", width);
+    event.put("height", height);
+    event.put("duration", durationInMs);
+    if (rotationCorrectionInDegrees != null) {
+      event.put("rotationCorrection", rotationCorrectionInDegrees);
     }
+    eventSink.success(event);
+  }
 
-    static VideoPlayerEventCallbacks withSink(EventChannel.EventSink eventSink) {
-        return new VideoPlayerEventCallbacks(eventSink);
-    }
+  @Override
+  public void onBufferingStart() {
+    Map<String, Object> event = new HashMap<>();
+    event.put("event", "bufferingStart");
+    eventSink.success(event);
+  }
 
-    private VideoPlayerEventCallbacks(EventChannel.EventSink eventSink) {
-        this.eventSink = eventSink;
-    }
+  @Override
+  public void onBufferingUpdate(long bufferedPosition) {
+    // iOS supports a list of buffered ranges, so we send as a list with a single range.
+    Map<String, Object> event = new HashMap<>();
+    event.put("values", Collections.singletonList(bufferedPosition));
+    eventSink.success(event);
+  }
 
-    @Override
-    public void onInitialized(int width, int height, long durationInMs, @Nullable Integer rotationCorrectionInDegrees) {
-        Map<String, Object> event = new HashMap<>();
-        event.put("event", "initialized");
-        event.put("width", width);
-        event.put("height", height);
-        event.put("duration", durationInMs);
-        if (rotationCorrectionInDegrees != null) {
-            event.put("rotationCorrection", rotationCorrectionInDegrees);
-        }
-        eventSink.success(event);
-    }
+  @Override
+  public void onBufferingEnd() {
+    Map<String, Object> event = new HashMap<>();
+    event.put("event", "bufferingEnd");
+    eventSink.success(event);
+  }
 
-    @Override
-    public void onBufferingStart() {
-        Map<String, Object> event = new HashMap<>();
-        event.put("event", "bufferingStart");
-        eventSink.success(event);
-    }
+  @Override
+  public void onCompleted() {
+    Map<String, Object> event = new HashMap<>();
+    event.put("event", "completed");
+    eventSink.success(event);
+  }
 
-    @Override
-    public void onBufferingUpdate(long bufferedPosition) {
-        // iOS supports a list of buffered ranges, so we send as a list with a single range.
-        Map<String, Object> event = new HashMap<>();
-        event.put("values", Collections.singletonList(bufferedPosition));
-        eventSink.success(event);
-    }
+  @Override
+  public void onError(@NonNull String code, @Nullable String message, @Nullable Object details) {
+    eventSink.error(code, message, details);
+  }
 
-    @Override
-    public void onBufferingEnd() {
-        Map<String, Object> event = new HashMap<>();
-        event.put("event", "bufferingEnd");
-        eventSink.success(event);
-    }
-
-    @Override
-    public void onCompleted() {
-        Map<String, Object> event = new HashMap<>();
-        event.put("event", "completed");
-        eventSink.success(event);
-    }
-
-    @Override
-    public void onError(@NonNull String code, @Nullable String message, @Nullable Object details) {
-        eventSink.error(code, message, details);
-    }
-
-    @Override
-    public void onIsPlayingStateUpdate(boolean isPlaying) {
-        Map<String, Object> event = new HashMap<>();
-        event.put("isPlaying", isPlaying);
-        eventSink.success(event);
-    }
+  @Override
+  public void onIsPlayingStateUpdate(boolean isPlaying) {
+    Map<String, Object> event = new HashMap<>();
+    event.put("isPlaying", isPlaying);
+    eventSink.success(event);
+  }
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.videoplayer;
 
 import androidx.annotation.NonNull;

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
@@ -1,0 +1,93 @@
+package io.flutter.plugins.videoplayer;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.flutter.plugin.common.EventChannel;
+
+final class VideoPlayerEventCallbacks implements VideoPlayerCallbacks {
+    private final EventChannel.EventSink eventSink;
+
+    static VideoPlayerEventCallbacks bindTo(EventChannel eventChannel) {
+        QueuingEventSink eventSink = new QueuingEventSink();
+        eventChannel.setStreamHandler(
+                new EventChannel.StreamHandler() {
+                    @Override
+                    public void onListen(Object arguments, EventChannel.EventSink events) {
+                        eventSink.setDelegate(events);
+                    }
+
+                    @Override
+                    public void onCancel(Object arguments) {
+                        eventSink.setDelegate(null);
+                    }
+                });
+        return VideoPlayerEventCallbacks.withSink(eventSink);
+    }
+
+    static VideoPlayerEventCallbacks withSink(EventChannel.EventSink eventSink) {
+        return new VideoPlayerEventCallbacks(eventSink);
+    }
+
+    private VideoPlayerEventCallbacks(EventChannel.EventSink eventSink) {
+        this.eventSink = eventSink;
+    }
+
+    @Override
+    public void onInitialized(int width, int height, long durationInMs, @Nullable Integer rotationCorrectionInDegrees) {
+        Map<String, Object> event = new HashMap<>();
+        event.put("event", "initialized");
+        event.put("width", width);
+        event.put("height", height);
+        event.put("duration", durationInMs);
+        if (rotationCorrectionInDegrees != null) {
+            event.put("rotationCorrection", rotationCorrectionInDegrees);
+        }
+        eventSink.success(event);
+    }
+
+    @Override
+    public void onBufferingStart() {
+        Map<String, Object> event = new HashMap<>();
+        event.put("event", "bufferingStart");
+        eventSink.success(event);
+    }
+
+    @Override
+    public void onBufferingUpdate(long bufferedPosition) {
+        // iOS supports a list of buffered ranges, so we send as a list with a single range.
+        Map<String, Object> event = new HashMap<>();
+        event.put("values", Collections.singletonList(bufferedPosition));
+        eventSink.success(event);
+    }
+
+    @Override
+    public void onBufferingEnd() {
+        Map<String, Object> event = new HashMap<>();
+        event.put("event", "bufferingEnd");
+        eventSink.success(event);
+    }
+
+    @Override
+    public void onCompleted() {
+        Map<String, Object> event = new HashMap<>();
+        event.put("event", "completed");
+        eventSink.success(event);
+    }
+
+    @Override
+    public void onError(@NonNull String code, @Nullable String message, @Nullable Object details) {
+        eventSink.error(code, message, details);
+    }
+
+    @Override
+    public void onIsPlayingStateUpdate(boolean isPlaying) {
+        Map<String, Object> event = new HashMap<>();
+        event.put("isPlaying", isPlaying);
+        eventSink.success(event);
+    }
+}

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.videoplayer;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.plugin.common.EventChannel;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,6 +32,7 @@ final class VideoPlayerEventCallbacks implements VideoPlayerCallbacks {
     return VideoPlayerEventCallbacks.withSink(eventSink);
   }
 
+  @VisibleForTesting
   static VideoPlayerEventCallbacks withSink(EventChannel.EventSink eventSink) {
     return new VideoPlayerEventCallbacks(eventSink);
   }
@@ -41,13 +43,13 @@ final class VideoPlayerEventCallbacks implements VideoPlayerCallbacks {
 
   @Override
   public void onInitialized(
-      int width, int height, long durationInMs, @Nullable Integer rotationCorrectionInDegrees) {
+      int width, int height, long durationInMs, int rotationCorrectionInDegrees) {
     Map<String, Object> event = new HashMap<>();
     event.put("event", "initialized");
     event.put("width", width);
     event.put("height", height);
     event.put("duration", durationInMs);
-    if (rotationCorrectionInDegrees != null) {
+    if (rotationCorrectionInDegrees != 0) {
       event.put("rotationCorrection", rotationCorrectionInDegrees);
     }
     eventSink.success(event);

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -125,7 +125,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
       player =
           new VideoPlayer(
               flutterState.applicationContext,
-              eventChannel,
+              VideoPlayerEventCallbacks.bindTo(eventChannel),
               handle,
               "asset:///" + assetLookupKey,
               null,
@@ -136,7 +136,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
       player =
           new VideoPlayer(
               flutterState.applicationContext,
-              eventChannel,
+              VideoPlayerEventCallbacks.bindTo(eventChannel),
               handle,
               arg.getUri(),
               arg.getFormatHint(),

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -314,19 +314,21 @@ public class VideoPlayerTest {
   public void otherErrorsReportVideoErrorWithErrorString() {
     List<Player.Listener> listeners = new LinkedList<>();
     doAnswer(invocation -> listeners.add(invocation.getArgument(0)))
-            .when(fakeExoPlayer)
-            .addListener(any());
+        .when(fakeExoPlayer)
+        .addListener(any());
 
     @SuppressWarnings("unused")
     VideoPlayer unused =
-            new VideoPlayer(
-                    fakeExoPlayer,
-                    VideoPlayerEventCallbacks.withSink(fakeEventSink),
-                    fakeSurfaceTextureEntry,
-                    fakeVideoPlayerOptions,
-                    httpDataSourceFactorySpy);
+        new VideoPlayer(
+            fakeExoPlayer,
+            VideoPlayerEventCallbacks.withSink(fakeEventSink),
+            fakeSurfaceTextureEntry,
+            fakeVideoPlayerOptions,
+            httpDataSourceFactorySpy);
 
-    PlaybackException exception = new PlaybackException("You did bad kid", null, PlaybackException.ERROR_CODE_DECODING_FAILED);
+    PlaybackException exception =
+        new PlaybackException(
+            "You did bad kid", null, PlaybackException.ERROR_CODE_DECODING_FAILED);
     listeners.forEach(listener -> listener.onPlayerError(exception));
 
     verify(fakeEventSink).error(eq("VideoError"), contains("You did bad kid"), any());

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -309,4 +309,26 @@ public class VideoPlayerTest {
     verify(fakeExoPlayer).seekToDefaultPosition();
     verify(fakeExoPlayer).prepare();
   }
+
+  @Test
+  public void otherErrorsReportVideoErrorWithErrorString() {
+    List<Player.Listener> listeners = new LinkedList<>();
+    doAnswer(invocation -> listeners.add(invocation.getArgument(0)))
+            .when(fakeExoPlayer)
+            .addListener(any());
+
+    @SuppressWarnings("unused")
+    VideoPlayer unused =
+            new VideoPlayer(
+                    fakeExoPlayer,
+                    VideoPlayerEventCallbacks.withSink(fakeEventSink),
+                    fakeSurfaceTextureEntry,
+                    fakeVideoPlayerOptions,
+                    httpDataSourceFactorySpy);
+
+    PlaybackException exception = new PlaybackException("You did bad kid", null, PlaybackException.ERROR_CODE_DECODING_FAILED);
+    listeners.forEach(listener -> listener.onPlayerError(exception));
+
+    verify(fakeEventSink).error(eq("VideoError"), contains("You did bad kid"), any());
+  }
 }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -211,8 +211,8 @@ public class VideoPlayerTest {
     Map<String, Object> expected = new HashMap<>();
     expected.put("event", "initialized");
     expected.put("duration", 10L);
-    expected.put("width", 200);
-    expected.put("height", 100);
+    expected.put("width", 100);
+    expected.put("height", 200);
 
     assertEquals(expected, actual);
   }
@@ -240,8 +240,8 @@ public class VideoPlayerTest {
     Map<String, Object> expected = new HashMap<>();
     expected.put("event", "initialized");
     expected.put("duration", 10L);
-    expected.put("width", 200);
-    expected.put("height", 100);
+    expected.put("width", 100);
+    expected.put("height", 200);
     expected.put("rotationCorrection", 180);
 
     assertEquals(expected, actual);

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/148417.

I'm working on re-landing https://github.com/flutter/packages/pull/6456, this time without using the `ActivityAware` interface (see https://github.com/flutter/flutter/issues/148417). As part of that work, I'll need to better control the `ExoPlayer` lifecycle and save/restore internal state.

These are some proposed refactors to limit how much work `VideoPlayer` is doing, so I can better understand what needs to be reset (or not) internally. Specifically, `VideoPlayer` no longer knows what an `EventChannel` or `EventSink` is, and does not need to manage the lifecycle (it stores a `private final VideoPlayerCallbacks` instead), and instead there is a `VideoPlayerCallbacks` interface that does all that.

I'm totally open to:
- Landing this as-is (+/- nits) and making minor improvements in follow-up PRs
- Making more significant changes to this PR and then landing it
- Not landing this PR at all because it doesn't follow the approach the folks who maintain the plugin prefer

Also happy to chat in VC/person about any of the changes.