### PR TITLE
[pigeon] Fully-qualify types in Equatable extension test

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+* Fully-qualifies types in Equatable extension test.
+
 ## 20.0.1
 
 * [cpp] Fixes handling of null class arguments.

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
-* Fully-qualifies types in Equatable extension test.
+
+* Fully-qualifies types in Equatable extension Swift test.
 
 ## 20.0.1
 

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Fully-qualifies types in Equatable extension Swift test.
+* [swift] Fully-qualifies types in Equatable extension test.
 
 ## 20.0.1
 

--- a/packages/pigeon/platform_tests/test_plugin/example/ios/Runner/AppDelegate.swift
+++ b/packages/pigeon/platform_tests/test_plugin/example/ios/Runner/AppDelegate.swift
@@ -5,7 +5,7 @@
 import Flutter
 import UIKit
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/EnumTests.swift
+++ b/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/EnumTests.swift
@@ -12,7 +12,7 @@ class MockEnumApi2Host: EnumApi2Host {
   }
 }
 
-extension DataWithEnum: Equatable {
+extension test_plugin.DataWithEnum: Swift.Equatable {
   public static func == (lhs: DataWithEnum, rhs: DataWithEnum) -> Bool {
     lhs.state == rhs.state
   }


### PR DESCRIPTION
Updating to Xcode 16 exposed a new compilation error: "extension declares a conformance of imported type 'DataWithEnum' to imported protocol 'Equatable'".  The [Swift Warning for Retroactive Conformances of External Types](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md) proposal says:

> It does mean projects building with an older Swift will not have access to [the @retroactive] syntax, so as a source compatible fallback, a client can silence this warning by fully-qualifying all types in the extension. As an example, the above conformance can also be written as
> ```
> extension Foundation.Date: Swift.Identifiable {
>     // ...
> }
> ```
> This will allow projects that need to build with multiple versions of Swift, and which have valid reason to declare such conformances, to declare them without tying their project to a newer compiler build.

So change the test to fully-qualify the types.  This prevented the warning when I tried it in https://github.com/flutter/packages/pull/6942.

Fixes https://github.com/flutter/flutter/issues/150391

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
