### PR TITLE
[flutter_adaptive_scaffold] Add additional slot animation parameters

### DIFF
--- a/packages/flutter_adaptive_scaffold/CHANGELOG.md
+++ b/packages/flutter_adaptive_scaffold/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.12
+
+* Adds `inDuration`, `outDuration`, `inCurve`, and `outCurve` parameters for 
+configuring additional SlotLayoutConfig animation behavior.
+
 ## 0.1.11
 
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.

--- a/packages/flutter_adaptive_scaffold/lib/src/slot_layout.dart
+++ b/packages/flutter_adaptive_scaffold/lib/src/slot_layout.dart
@@ -74,12 +74,20 @@ class SlotLayout extends StatefulWidget {
     WidgetBuilder? builder,
     Widget Function(Widget, Animation<double>)? inAnimation,
     Widget Function(Widget, Animation<double>)? outAnimation,
+    Duration? inDuration,
+    Duration? outDuration,
+    Curve? inCurve,
+    Curve? outCurve,
     required Key key,
   }) =>
       SlotLayoutConfig._(
         builder: builder,
         inAnimation: inAnimation,
         outAnimation: outAnimation,
+        inDuration: inDuration,
+        outDuration: outDuration,
+        inCurve: inCurve,
+        outCurve: outCurve,
         key: key,
       );
 
@@ -96,7 +104,11 @@ class _SlotLayoutState extends State<SlotLayout>
     chosenWidget = SlotLayout.pickWidget(context, widget.config);
     bool hasAnimation = false;
     return AnimatedSwitcher(
-        duration: const Duration(milliseconds: 1000),
+        duration:
+            chosenWidget?.inDuration ?? const Duration(milliseconds: 1000),
+        reverseDuration: chosenWidget?.outDuration,
+        switchInCurve: chosenWidget?.inCurve ?? Curves.linear,
+        switchOutCurve: chosenWidget?.outCurve ?? Curves.linear,
         layoutBuilder: (Widget? currentChild, List<Widget> previousChildren) {
           final Stack elements = Stack(
             children: <Widget>[
@@ -137,6 +149,10 @@ class SlotLayoutConfig extends StatelessWidget {
     required this.builder,
     this.inAnimation,
     this.outAnimation,
+    this.inDuration,
+    this.outDuration,
+    this.inCurve,
+    this.outCurve,
   });
 
   /// The child Widget that [SlotLayout] eventually returns with an animation.
@@ -159,6 +175,22 @@ class SlotLayoutConfig extends StatelessWidget {
   ///  * [AnimatedWidget] and [ImplicitlyAnimatedWidget], which are commonly used
   ///   as the returned widget.
   final Widget Function(Widget, Animation<double>)? outAnimation;
+
+  /// The duration of the transition from the old child to the new one during
+  /// a switch in [SlotLayout].
+  final Duration? inDuration;
+
+  /// The duration of the transition from the new child to the old one during
+  /// a switch in [SlotLayout].
+  final Duration? outDuration;
+
+  /// The animation curve to use when transitioning in a new child during a
+  /// switch in [SlotLayout].
+  final Curve? inCurve;
+
+  /// The animation curve to use when transitioning a previous slot out during
+  /// a switch in [SlotLayout].
+  final Curve? outCurve;
 
   /// An empty [SlotLayoutConfig] to be placed in a slot to indicate that the slot
   /// should show nothing.

--- a/packages/flutter_adaptive_scaffold/pubspec.yaml
+++ b/packages/flutter_adaptive_scaffold/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_adaptive_scaffold
 description: Widgets to easily build adaptive layouts, including navigation elements.
-version: 0.1.11
+version: 0.1.12
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_adaptive_scaffold%22
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold
 


### PR DESCRIPTION
Slots can currently be animated in and out of view, but there is not an ability to change the duration or curves of these animations. This PR adds additional parameters that are passed to the underlying AnimatedSwitcher when switching slots in and out of view.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
