### PR TITLE
Final refactor of `video_player_android` before `SurfaceProducer#setCallback`.

### DIFF
--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -57,6 +57,7 @@ android {
         testImplementation 'androidx.test:core:1.3.0'
         testImplementation 'org.mockito:mockito-inline:5.0.0'
         testImplementation 'org.robolectric:robolectric:4.10.3'
+        testImplementation "androidx.media3:media3-test-utils:1.3.1"
     }
 
     testOptions {

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -71,7 +71,3 @@ android {
         }
     }
 }
-
-dependencies {
-    implementation 'androidx.media3:media3-test-utils:1.3.1'
-}

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -71,3 +71,7 @@ android {
         }
     }
 }
+
+dependencies {
+    implementation 'androidx.media3:media3-test-utils:1.3.1'
+}

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/LocalVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/LocalVideoAsset.java
@@ -7,21 +7,12 @@ package io.flutter.plugins.videoplayer;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.media3.common.MediaItem;
-import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.exoplayer.source.MediaSource;
-import androidx.media3.test.utils.FakeMediaSourceFactory;
 
-/** A fake implementation of the {@link VideoAsset} class. */
-final class FakeVideoAsset extends VideoAsset {
-  @NonNull private final MediaSource.Factory mediaSourceFactory;
-
-  FakeVideoAsset(String assetUrl) {
-    this(assetUrl, new FakeMediaSourceFactory());
-  }
-
-  FakeVideoAsset(String assetUrl, @NonNull MediaSource.Factory mediaSourceFactory) {
+final class LocalVideoAsset extends VideoAsset {
+  LocalVideoAsset(@NonNull String assetUrl) {
     super(assetUrl);
-    this.mediaSourceFactory = mediaSourceFactory;
   }
 
   @NonNull
@@ -32,6 +23,6 @@ final class FakeVideoAsset extends VideoAsset {
 
   @Override
   MediaSource.Factory getMediaSourceFactory(Context context) {
-    return mediaSourceFactory;
+    return new DefaultMediaSourceFactory(context);
   }
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/RemoteVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/RemoteVideoAsset.java
@@ -1,0 +1,97 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.videoplayer;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.OptIn;
+import androidx.annotation.VisibleForTesting;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+import androidx.media3.exoplayer.source.MediaSource;
+import java.util.Map;
+
+final class RemoteVideoAsset extends VideoAsset {
+  private static final String DEFAULT_USER_AGENT = "ExoPlayer";
+  private static final String HEADER_USER_AGENT = "User-Agent";
+
+  @NonNull private final StreamingFormat streamingFormat;
+  @NonNull private final Map<String, String> httpHeaders;
+
+  RemoteVideoAsset(
+      @Nullable String assetUrl,
+      @NonNull StreamingFormat streamingFormat,
+      @NonNull Map<String, String> httpHeaders) {
+    super(assetUrl);
+    this.streamingFormat = streamingFormat;
+    this.httpHeaders = httpHeaders;
+  }
+
+  @NonNull
+  @Override
+  MediaItem getMediaItem() {
+    MediaItem.Builder builder = new MediaItem.Builder().setUri(assetUrl);
+    String mimeType = null;
+    switch (streamingFormat) {
+      case Smooth:
+        mimeType = MimeTypes.APPLICATION_SS;
+        break;
+      case DynamicAdaptive:
+        mimeType = MimeTypes.APPLICATION_MPD;
+        break;
+      case HttpLive:
+        mimeType = MimeTypes.APPLICATION_M3U8;
+        break;
+    }
+    if (mimeType != null) {
+      builder.setMimeType(mimeType);
+    }
+    return builder.build();
+  }
+
+  @Override
+  MediaSource.Factory getMediaSourceFactory(Context context) {
+    return getMediaSourceFactory(context, new DefaultHttpDataSource.Factory());
+  }
+
+  /**
+   * Returns a configured media source factory, starting at the provided factory.
+   *
+   * <p>This method is provided for ease of testing without making real HTTP calls.
+   *
+   * @param context application context.
+   * @param initialFactory initial factory, to be configured.
+   * @return configured factory, or {@code null} if not needed for this asset type.
+   */
+  @VisibleForTesting
+  MediaSource.Factory getMediaSourceFactory(
+      Context context, DefaultHttpDataSource.Factory initialFactory) {
+    String userAgent = DEFAULT_USER_AGENT;
+    if (!httpHeaders.isEmpty() && httpHeaders.containsKey(HEADER_USER_AGENT)) {
+      userAgent = httpHeaders.get(HEADER_USER_AGENT);
+    }
+    unstableUpdateDataSourceFactory(initialFactory, httpHeaders, userAgent);
+    DataSource.Factory dataSoruceFactory = new DefaultDataSource.Factory(context, initialFactory);
+    return new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSoruceFactory);
+  }
+
+  // TODO: Migrate to stable API, see https://github.com/flutter/flutter/issues/147039.
+  @OptIn(markerClass = UnstableApi.class)
+  private static void unstableUpdateDataSourceFactory(
+      @NonNull DefaultHttpDataSource.Factory factory,
+      @NonNull Map<String, String> httpHeaders,
+      @Nullable String userAgent) {
+    factory.setUserAgent(userAgent).setAllowCrossProtocolRedirects(true);
+    if (!httpHeaders.isEmpty()) {
+      factory.setDefaultRequestProperties(httpHeaders);
+    }
+  }
+}

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/RemoteVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/RemoteVideoAsset.java
@@ -41,13 +41,13 @@ final class RemoteVideoAsset extends VideoAsset {
     MediaItem.Builder builder = new MediaItem.Builder().setUri(assetUrl);
     String mimeType = null;
     switch (streamingFormat) {
-      case Smooth:
+      case SMOOTH:
         mimeType = MimeTypes.APPLICATION_SS;
         break;
-      case DynamicAdaptive:
+      case DYNAMIC_ADAPTIVE:
         mimeType = MimeTypes.APPLICATION_MPD;
         break;
-      case HttpLive:
+      case HTTP_LIVE:
         mimeType = MimeTypes.APPLICATION_M3U8;
         break;
     }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
@@ -69,15 +69,15 @@ abstract class VideoAsset {
   /** Streaming formats that can be provided to the video player as a hint. */
   enum StreamingFormat {
     /** Default, if the format is either not known or not another valid format. */
-    Unknown,
+    UNKNOWN,
 
     /** Smooth Streaming. */
-    Smooth,
+    SMOOTH,
 
     /** MPEG-DASH (Dynamic Adaptive over HTTP). */
-    DynamicAdaptive,
+    DYNAMIC_ADAPTIVE,
 
     /** HTTP Live Streaming (HLS). */
-    HttpLive
+    HTTP_LIVE
   }
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
@@ -1,7 +1,6 @@
 package io.flutter.plugins.videoplayer;
 
 import android.content.Context;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
@@ -14,197 +13,180 @@ import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.exoplayer.source.MediaSource;
-
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * A video to be played by {@link VideoPlayer}.
- */
+/** A video to be played by {@link VideoPlayer}. */
 abstract class VideoAsset {
-    /**
-     * Returns an asset from a local {@code asset:///} URL, i.e. an on-device asset.
-     *
-     * @param assetUrl local asset, beginning in {@code asset:///}.
-     *
-     * @return the asset.
-     */
+  /**
+   * Returns an asset from a local {@code asset:///} URL, i.e. an on-device asset.
+   *
+   * @param assetUrl local asset, beginning in {@code asset:///}.
+   * @return the asset.
+   */
+  @NonNull
+  static VideoAsset fromAssetUrl(@NonNull String assetUrl) {
+    if (!assetUrl.startsWith("asset:///")) {
+      throw new IllegalArgumentException("assetUrl must start with 'asset:///'");
+    }
+    return new LocalVideoAsset(assetUrl);
+  }
+
+  /**
+   * Returns an asset from a remote URL.
+   *
+   * @param remoteUrl remote asset, i.e. typically beginning with {@code https://} or similar.
+   * @param streamingFormat which streaming format, provided as a hint if able.
+   * @param httpHeaders HTTP headers to set for a request.
+   * @return the asset.
+   */
+  @NonNull
+  static VideoAsset fromRemoteUrl(
+      @Nullable String remoteUrl,
+      @NonNull StreamingFormat streamingFormat,
+      @NonNull Map<String, String> httpHeaders) {
+    return new RemoteVideoAsset(remoteUrl, streamingFormat, new HashMap<>(httpHeaders));
+  }
+
+  @Nullable protected final String assetUrl;
+
+  protected VideoAsset(@Nullable String assetUrl) {
+    this.assetUrl = assetUrl;
+  }
+
+  /**
+   * Returns the configured media item to be played.
+   *
+   * @return media item.
+   */
+  @NonNull
+  abstract MediaItem getMediaItem();
+
+  /**
+   * Returns a configured media source factory, starting at the provided factory.
+   *
+   * <p>This method is provided for ease of testing without making real HTTP calls.
+   *
+   * @param context application context.
+   * @param initialFactory initial factory, to be configured.
+   * @return configured factory, or {@code null} if not needed for this asset type.
+   */
+  @VisibleForTesting
+  abstract MediaSource.Factory getMediaSourceFactory(
+      Context context, DefaultHttpDataSource.Factory initialFactory);
+
+  /**
+   * Returns the configured media source factory, if needed for this asset type.
+   *
+   * @param context application context.
+   * @return configured factory, or {@code null} if not needed for this asset type.
+   */
+  abstract MediaSource.Factory getMediaSourceFactory(Context context);
+
+  private static final class LocalVideoAsset extends VideoAsset {
+    private LocalVideoAsset(@NonNull String assetUrl) {
+      super(assetUrl);
+    }
+
     @NonNull
-    static VideoAsset fromAssetUrl(@NonNull String assetUrl) {
-        if (!assetUrl.startsWith("asset:///")) {
-            throw new IllegalArgumentException("assetUrl must start with 'asset:///'");
-        }
-        return new LocalVideoAsset(assetUrl);
+    @Override
+    MediaItem getMediaItem() {
+      return new MediaItem.Builder().setUri(assetUrl).build();
     }
 
-    /**
-     * Returns an asset from a remote URL.
-     *
-     * @param remoteUrl remote asset, i.e. typically beginning with {@code https://} or similar.
-     * @param streamingFormat which streaming format, provided as a hint if able.
-     * @param httpHeaders HTTP headers to set for a request.
-     *
-     * @return the asset.
-     */
+    @Override
+    MediaSource.Factory getMediaSourceFactory(Context context) {
+      return new DefaultMediaSourceFactory(context);
+    }
+
+    @Override
+    MediaSource.Factory getMediaSourceFactory(
+        Context context, DefaultHttpDataSource.Factory initialFactory) {
+      return new DefaultMediaSourceFactory(context);
+    }
+  }
+
+  private static final class RemoteVideoAsset extends VideoAsset {
+    private static final String DEFAULT_USER_AGENT = "ExoPlayer";
+    private static final String HEADER_USER_AGENT = "User-Agent";
+
+    @NonNull private final StreamingFormat streamingFormat;
+    @NonNull private final Map<String, String> httpHeaders;
+
+    private RemoteVideoAsset(
+        @Nullable String assetUrl,
+        @NonNull StreamingFormat streamingFormat,
+        @NonNull Map<String, String> httpHeaders) {
+      super(assetUrl);
+      this.streamingFormat = streamingFormat;
+      this.httpHeaders = httpHeaders;
+    }
+
     @NonNull
-    static VideoAsset fromRemoteUrl(
-            @Nullable String remoteUrl,
-            @NonNull StreamingFormat streamingFormat,
-            @NonNull Map<String, String> httpHeaders) {
-        return new RemoteVideoAsset(remoteUrl, streamingFormat, new HashMap<>(httpHeaders));
+    @Override
+    MediaItem getMediaItem() {
+      MediaItem.Builder builder = new MediaItem.Builder().setUri(assetUrl);
+      String mimeType = null;
+      switch (streamingFormat) {
+        case Smooth:
+          mimeType = MimeTypes.APPLICATION_SS;
+          break;
+        case DynamicAdaptive:
+          mimeType = MimeTypes.APPLICATION_MPD;
+          break;
+        case HttpLive:
+          mimeType = MimeTypes.APPLICATION_M3U8;
+          break;
+      }
+      if (mimeType != null) {
+        builder.setMimeType(mimeType);
+      }
+      return builder.build();
     }
 
-    @Nullable
-    protected final String assetUrl;
-
-    protected VideoAsset(@Nullable String assetUrl) {
-        this.assetUrl = assetUrl;
+    @Override
+    MediaSource.Factory getMediaSourceFactory(Context context) {
+      return getMediaSourceFactory(context, new DefaultHttpDataSource.Factory());
     }
 
-    /**
-     * Returns the configured media item to be played.
-     *
-     * @return media item.
-     */
-    @NonNull
-    abstract MediaItem getMediaItem();
+    @Override
+    MediaSource.Factory getMediaSourceFactory(
+        Context context, DefaultHttpDataSource.Factory factory) {
+      String userAgent = DEFAULT_USER_AGENT;
+      if (!httpHeaders.isEmpty() && httpHeaders.containsKey(HEADER_USER_AGENT)) {
+        userAgent = httpHeaders.get(HEADER_USER_AGENT);
+      }
+      unstableUpdateDataSourceFactory(factory, httpHeaders, userAgent);
 
-    /**
-     * Returns a configured media source factory, starting at the provided factory.
-     *
-     * <p>This method is provided for ease of testing without making real HTTP calls.
-     *
-     * @param context application context.
-     * @param initialFactory initial factory, to be configured.
-     *
-     * @return configured factory, or {@code null} if not needed for this asset type.
-     */
-    @VisibleForTesting
-    abstract MediaSource.Factory getMediaSourceFactory(Context context, DefaultHttpDataSource.Factory initialFactory);
-
-    /**
-     * Returns the configured media source factory, if needed for this asset type.
-     *
-     * @param context application context.
-     *
-     * @return configured factory, or {@code null} if not needed for this asset type.
-     */
-    abstract MediaSource.Factory getMediaSourceFactory(Context context);
-
-    private static final class LocalVideoAsset extends VideoAsset {
-        private LocalVideoAsset(@NonNull String assetUrl) {
-            super(assetUrl);
-        }
-
-        @NonNull
-        @Override
-        MediaItem getMediaItem() {
-            return new MediaItem.Builder().setUri(assetUrl).build();
-        }
-
-        @Override
-        MediaSource.Factory getMediaSourceFactory(Context context) {
-            return new DefaultMediaSourceFactory(context);
-        }
-
-        @Override
-        MediaSource.Factory getMediaSourceFactory(Context context, DefaultHttpDataSource.Factory initialFactory) {
-            return new DefaultMediaSourceFactory(context);
-        }
+      DataSource.Factory dataSoruceFactory = new DefaultDataSource.Factory(context, factory);
+      return new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSoruceFactory);
     }
 
-    private static final class RemoteVideoAsset extends VideoAsset {
-        private static final String DEFAULT_USER_AGENT = "ExoPlayer";
-        private static final String HEADER_USER_AGENT = "User-Agent";
-
-        @NonNull
-        private final StreamingFormat streamingFormat;
-        @NonNull
-        private final Map<String, String> httpHeaders;
-
-        private RemoteVideoAsset(
-                @Nullable String assetUrl,
-                @NonNull StreamingFormat streamingFormat,
-                @NonNull Map<String, String> httpHeaders) {
-            super(assetUrl);
-            this.streamingFormat = streamingFormat;
-            this.httpHeaders = httpHeaders;
-        }
-
-        @NonNull
-        @Override
-        MediaItem getMediaItem() {
-            MediaItem.Builder builder = new MediaItem.Builder().setUri(assetUrl);
-            String mimeType = null;
-            switch (streamingFormat) {
-                case Smooth:
-                    mimeType = MimeTypes.APPLICATION_SS;
-                    break;
-                case DynamicAdaptive:
-                    mimeType = MimeTypes.APPLICATION_MPD;
-                    break;
-                case HttpLive:
-                    mimeType = MimeTypes.APPLICATION_M3U8;
-                    break;
-            }
-            if (mimeType != null) {
-                builder.setMimeType(mimeType);
-            }
-            return builder.build();
-        }
-
-        @Override
-        MediaSource.Factory getMediaSourceFactory(Context context) {
-            return getMediaSourceFactory(context, new DefaultHttpDataSource.Factory());
-        }
-
-        @Override
-        MediaSource.Factory getMediaSourceFactory(Context context, DefaultHttpDataSource.Factory factory) {
-            String userAgent = DEFAULT_USER_AGENT;
-            if (!httpHeaders.isEmpty() && httpHeaders.containsKey(HEADER_USER_AGENT)) {
-                userAgent = httpHeaders.get(HEADER_USER_AGENT);
-            }
-            unstableUpdateDataSourceFactory(factory, httpHeaders, userAgent);
-
-            DataSource.Factory dataSoruceFactory = new DefaultDataSource.Factory(context, factory);
-            return new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSoruceFactory);
-        }
-
-        // TODO: Migrate to stable API, see https://github.com/flutter/flutter/issues/147039.
-        @OptIn(markerClass = UnstableApi.class)
-        private static void unstableUpdateDataSourceFactory(
-                @NonNull DefaultHttpDataSource.Factory factory,
-                @NonNull Map<String, String> httpHeaders,
-                @Nullable String userAgent) {
-            factory.setUserAgent(userAgent).setAllowCrossProtocolRedirects(true);
-            if (!httpHeaders.isEmpty()) {
-                factory.setDefaultRequestProperties(httpHeaders);
-            }
-        }
+    // TODO: Migrate to stable API, see https://github.com/flutter/flutter/issues/147039.
+    @OptIn(markerClass = UnstableApi.class)
+    private static void unstableUpdateDataSourceFactory(
+        @NonNull DefaultHttpDataSource.Factory factory,
+        @NonNull Map<String, String> httpHeaders,
+        @Nullable String userAgent) {
+      factory.setUserAgent(userAgent).setAllowCrossProtocolRedirects(true);
+      if (!httpHeaders.isEmpty()) {
+        factory.setDefaultRequestProperties(httpHeaders);
+      }
     }
+  }
 
-    /**
-     * Streaming formats that can be provided to the video player as a hint.
-     */
-    enum StreamingFormat {
-        /**
-         * Default, if the format is either not known or not another valid format.
-         */
-        Unknown,
+  /** Streaming formats that can be provided to the video player as a hint. */
+  enum StreamingFormat {
+    /** Default, if the format is either not known or not another valid format. */
+    Unknown,
 
-        /**
-         * Smooth Streaming.
-         */
-        Smooth,
+    /** Smooth Streaming. */
+    Smooth,
 
-        /**
-         * MPEG-DASH (Dynamic Adaptive over HTTP).
-         */
-        DynamicAdaptive,
+    /** MPEG-DASH (Dynamic Adaptive over HTTP). */
+    DynamicAdaptive,
 
-        /**
-         * HTTP Live Streaming (HLS).
-         */
-        HttpLive
-    }
+    /** HTTP Live Streaming (HLS). */
+    HttpLive
+  }
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
@@ -1,17 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.videoplayer;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.OptIn;
-import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.MediaItem;
-import androidx.media3.common.MimeTypes;
-import androidx.media3.common.util.UnstableApi;
-import androidx.media3.datasource.DataSource;
-import androidx.media3.datasource.DefaultDataSource;
-import androidx.media3.datasource.DefaultHttpDataSource;
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.exoplayer.source.MediaSource;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,117 +59,12 @@ abstract class VideoAsset {
   abstract MediaItem getMediaItem();
 
   /**
-   * Returns a configured media source factory, starting at the provided factory.
-   *
-   * <p>This method is provided for ease of testing without making real HTTP calls.
-   *
-   * @param context application context.
-   * @param initialFactory initial factory, to be configured.
-   * @return configured factory, or {@code null} if not needed for this asset type.
-   */
-  @VisibleForTesting
-  abstract MediaSource.Factory getMediaSourceFactory(
-      Context context, DefaultHttpDataSource.Factory initialFactory);
-
-  /**
    * Returns the configured media source factory, if needed for this asset type.
    *
    * @param context application context.
    * @return configured factory, or {@code null} if not needed for this asset type.
    */
   abstract MediaSource.Factory getMediaSourceFactory(Context context);
-
-  private static final class LocalVideoAsset extends VideoAsset {
-    private LocalVideoAsset(@NonNull String assetUrl) {
-      super(assetUrl);
-    }
-
-    @NonNull
-    @Override
-    MediaItem getMediaItem() {
-      return new MediaItem.Builder().setUri(assetUrl).build();
-    }
-
-    @Override
-    MediaSource.Factory getMediaSourceFactory(Context context) {
-      return new DefaultMediaSourceFactory(context);
-    }
-
-    @Override
-    MediaSource.Factory getMediaSourceFactory(
-        Context context, DefaultHttpDataSource.Factory initialFactory) {
-      return new DefaultMediaSourceFactory(context);
-    }
-  }
-
-  private static final class RemoteVideoAsset extends VideoAsset {
-    private static final String DEFAULT_USER_AGENT = "ExoPlayer";
-    private static final String HEADER_USER_AGENT = "User-Agent";
-
-    @NonNull private final StreamingFormat streamingFormat;
-    @NonNull private final Map<String, String> httpHeaders;
-
-    private RemoteVideoAsset(
-        @Nullable String assetUrl,
-        @NonNull StreamingFormat streamingFormat,
-        @NonNull Map<String, String> httpHeaders) {
-      super(assetUrl);
-      this.streamingFormat = streamingFormat;
-      this.httpHeaders = httpHeaders;
-    }
-
-    @NonNull
-    @Override
-    MediaItem getMediaItem() {
-      MediaItem.Builder builder = new MediaItem.Builder().setUri(assetUrl);
-      String mimeType = null;
-      switch (streamingFormat) {
-        case Smooth:
-          mimeType = MimeTypes.APPLICATION_SS;
-          break;
-        case DynamicAdaptive:
-          mimeType = MimeTypes.APPLICATION_MPD;
-          break;
-        case HttpLive:
-          mimeType = MimeTypes.APPLICATION_M3U8;
-          break;
-      }
-      if (mimeType != null) {
-        builder.setMimeType(mimeType);
-      }
-      return builder.build();
-    }
-
-    @Override
-    MediaSource.Factory getMediaSourceFactory(Context context) {
-      return getMediaSourceFactory(context, new DefaultHttpDataSource.Factory());
-    }
-
-    @Override
-    MediaSource.Factory getMediaSourceFactory(
-        Context context, DefaultHttpDataSource.Factory factory) {
-      String userAgent = DEFAULT_USER_AGENT;
-      if (!httpHeaders.isEmpty() && httpHeaders.containsKey(HEADER_USER_AGENT)) {
-        userAgent = httpHeaders.get(HEADER_USER_AGENT);
-      }
-      unstableUpdateDataSourceFactory(factory, httpHeaders, userAgent);
-
-      DataSource.Factory dataSoruceFactory = new DefaultDataSource.Factory(context, factory);
-      return new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSoruceFactory);
-    }
-
-    // TODO: Migrate to stable API, see https://github.com/flutter/flutter/issues/147039.
-    @OptIn(markerClass = UnstableApi.class)
-    private static void unstableUpdateDataSourceFactory(
-        @NonNull DefaultHttpDataSource.Factory factory,
-        @NonNull Map<String, String> httpHeaders,
-        @Nullable String userAgent) {
-      factory.setUserAgent(userAgent).setAllowCrossProtocolRedirects(true);
-      if (!httpHeaders.isEmpty()) {
-        factory.setDefaultRequestProperties(httpHeaders);
-      }
-    }
-  }
 
   /** Streaming formats that can be provided to the video player as a hint. */
   enum StreamingFormat {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
@@ -1,0 +1,210 @@
+package io.flutter.plugins.videoplayer;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.OptIn;
+import androidx.annotation.VisibleForTesting;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+import androidx.media3.exoplayer.source.MediaSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A video to be played by {@link VideoPlayer}.
+ */
+abstract class VideoAsset {
+    /**
+     * Returns an asset from a local {@code asset:///} URL, i.e. an on-device asset.
+     *
+     * @param assetUrl local asset, beginning in {@code asset:///}.
+     *
+     * @return the asset.
+     */
+    @NonNull
+    static VideoAsset fromAssetUrl(@NonNull String assetUrl) {
+        if (!assetUrl.startsWith("asset:///")) {
+            throw new IllegalArgumentException("assetUrl must start with 'asset:///'");
+        }
+        return new LocalVideoAsset(assetUrl);
+    }
+
+    /**
+     * Returns an asset from a remote URL.
+     *
+     * @param remoteUrl remote asset, i.e. typically beginning with {@code https://} or similar.
+     * @param streamingFormat which streaming format, provided as a hint if able.
+     * @param httpHeaders HTTP headers to set for a request.
+     *
+     * @return the asset.
+     */
+    @NonNull
+    static VideoAsset fromRemoteUrl(
+            @Nullable String remoteUrl,
+            @NonNull StreamingFormat streamingFormat,
+            @NonNull Map<String, String> httpHeaders) {
+        return new RemoteVideoAsset(remoteUrl, streamingFormat, new HashMap<>(httpHeaders));
+    }
+
+    @Nullable
+    protected final String assetUrl;
+
+    protected VideoAsset(@Nullable String assetUrl) {
+        this.assetUrl = assetUrl;
+    }
+
+    /**
+     * Returns the configured media item to be played.
+     *
+     * @return media item.
+     */
+    @NonNull
+    abstract MediaItem getMediaItem();
+
+    /**
+     * Returns a configured media source factory, starting at the provided factory.
+     *
+     * <p>This method is provided for ease of testing without making real HTTP calls.
+     *
+     * @param context application context.
+     * @param initialFactory initial factory, to be configured.
+     *
+     * @return configured factory, or {@code null} if not needed for this asset type.
+     */
+    @VisibleForTesting
+    abstract MediaSource.Factory getMediaSourceFactory(Context context, DefaultHttpDataSource.Factory initialFactory);
+
+    /**
+     * Returns the configured media source factory, if needed for this asset type.
+     *
+     * @param context application context.
+     *
+     * @return configured factory, or {@code null} if not needed for this asset type.
+     */
+    abstract MediaSource.Factory getMediaSourceFactory(Context context);
+
+    private static final class LocalVideoAsset extends VideoAsset {
+        private LocalVideoAsset(@NonNull String assetUrl) {
+            super(assetUrl);
+        }
+
+        @NonNull
+        @Override
+        MediaItem getMediaItem() {
+            return new MediaItem.Builder().setUri(assetUrl).build();
+        }
+
+        @Override
+        MediaSource.Factory getMediaSourceFactory(Context context) {
+            return new DefaultMediaSourceFactory(context);
+        }
+
+        @Override
+        MediaSource.Factory getMediaSourceFactory(Context context, DefaultHttpDataSource.Factory initialFactory) {
+            return new DefaultMediaSourceFactory(context);
+        }
+    }
+
+    private static final class RemoteVideoAsset extends VideoAsset {
+        private static final String DEFAULT_USER_AGENT = "ExoPlayer";
+        private static final String HEADER_USER_AGENT = "User-Agent";
+
+        @NonNull
+        private final StreamingFormat streamingFormat;
+        @NonNull
+        private final Map<String, String> httpHeaders;
+
+        private RemoteVideoAsset(
+                @Nullable String assetUrl,
+                @NonNull StreamingFormat streamingFormat,
+                @NonNull Map<String, String> httpHeaders) {
+            super(assetUrl);
+            this.streamingFormat = streamingFormat;
+            this.httpHeaders = httpHeaders;
+        }
+
+        @NonNull
+        @Override
+        MediaItem getMediaItem() {
+            MediaItem.Builder builder = new MediaItem.Builder().setUri(assetUrl);
+            String mimeType = null;
+            switch (streamingFormat) {
+                case Smooth:
+                    mimeType = MimeTypes.APPLICATION_SS;
+                    break;
+                case DynamicAdaptive:
+                    mimeType = MimeTypes.APPLICATION_MPD;
+                    break;
+                case HttpLive:
+                    mimeType = MimeTypes.APPLICATION_M3U8;
+                    break;
+            }
+            if (mimeType != null) {
+                builder.setMimeType(mimeType);
+            }
+            return builder.build();
+        }
+
+        @Override
+        MediaSource.Factory getMediaSourceFactory(Context context) {
+            return getMediaSourceFactory(context, new DefaultHttpDataSource.Factory());
+        }
+
+        @Override
+        MediaSource.Factory getMediaSourceFactory(Context context, DefaultHttpDataSource.Factory factory) {
+            String userAgent = DEFAULT_USER_AGENT;
+            if (!httpHeaders.isEmpty() && httpHeaders.containsKey(HEADER_USER_AGENT)) {
+                userAgent = httpHeaders.get(HEADER_USER_AGENT);
+            }
+            unstableUpdateDataSourceFactory(factory, httpHeaders, userAgent);
+
+            DataSource.Factory dataSoruceFactory = new DefaultDataSource.Factory(context, factory);
+            return new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSoruceFactory);
+        }
+
+        // TODO: Migrate to stable API, see https://github.com/flutter/flutter/issues/147039.
+        @OptIn(markerClass = UnstableApi.class)
+        private static void unstableUpdateDataSourceFactory(
+                @NonNull DefaultHttpDataSource.Factory factory,
+                @NonNull Map<String, String> httpHeaders,
+                @Nullable String userAgent) {
+            factory.setUserAgent(userAgent).setAllowCrossProtocolRedirects(true);
+            if (!httpHeaders.isEmpty()) {
+                factory.setDefaultRequestProperties(httpHeaders);
+            }
+        }
+    }
+
+    /**
+     * Streaming formats that can be provided to the video player as a hint.
+     */
+    enum StreamingFormat {
+        /**
+         * Default, if the format is either not known or not another valid format.
+         */
+        Unknown,
+
+        /**
+         * Smooth Streaming.
+         */
+        Smooth,
+
+        /**
+         * MPEG-DASH (Dynamic Adaptive over HTTP).
+         */
+        DynamicAdaptive,
+
+        /**
+         * HTTP Live Streaming (HLS).
+         */
+        HttpLive
+    }
+}

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -10,98 +10,63 @@ import static androidx.media3.common.Player.REPEAT_MODE_OFF;
 import android.content.Context;
 import android.view.Surface;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.OptIn;
 import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
-import androidx.media3.common.MimeTypes;
 import androidx.media3.common.PlaybackParameters;
-import androidx.media3.common.util.UnstableApi;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DefaultDataSource;
-import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import io.flutter.view.TextureRegistry;
-import java.util.Map;
 
 final class VideoPlayer {
-  private static final String FORMAT_SS = "ss";
-  private static final String FORMAT_DASH = "dash";
-  private static final String FORMAT_HLS = "hls";
-  private static final String FORMAT_OTHER = "other";
-
   private ExoPlayer exoPlayer;
-
   private Surface surface;
-
   private final TextureRegistry.SurfaceTextureEntry textureEntry;
-
   private final VideoPlayerCallbacks videoPlayerEvents;
-
-  private static final String USER_AGENT = "User-Agent";
-
   private final VideoPlayerOptions options;
 
-  private final DefaultHttpDataSource.Factory httpDataSourceFactory;
 
-  VideoPlayer(
+  /**
+   * Creates a video player.
+   *
+   * @param context application context.
+   * @param events event callbacks.
+   * @param textureEntry texture to render to.
+   * @param asset asset to play.
+   * @param options options for playback.
+   *
+   * @return a video player instance.
+   */
+  @NonNull
+  static VideoPlayer create (
       Context context,
       VideoPlayerCallbacks events,
       TextureRegistry.SurfaceTextureEntry textureEntry,
-      String dataSource,
-      String formatHint,
-      @NonNull Map<String, String> httpHeaders,
+      VideoAsset asset,
       VideoPlayerOptions options) {
-    this.videoPlayerEvents = events;
+    ExoPlayer.Builder builder = new ExoPlayer.Builder(context).setMediaSourceFactory(asset.getMediaSourceFactory(context));
+    return new VideoPlayer(builder, events, textureEntry, asset.getMediaItem(), options);
+  }
+
+  @VisibleForTesting
+  VideoPlayer(
+      ExoPlayer.Builder builder,
+      VideoPlayerCallbacks events,
+      TextureRegistry.SurfaceTextureEntry textureEntry,
+      MediaItem mediaItem,
+      VideoPlayerOptions options) {
+      this.videoPlayerEvents = events;
     this.textureEntry = textureEntry;
     this.options = options;
 
-    MediaItem mediaItem =
-        new MediaItem.Builder()
-            .setUri(dataSource)
-            .setMimeType(mimeFromFormatHint(formatHint))
-            .build();
-
-    httpDataSourceFactory = new DefaultHttpDataSource.Factory();
-    configureHttpDataSourceFactory(httpHeaders);
-
-    ExoPlayer exoPlayer = buildExoPlayer(context, httpDataSourceFactory);
-
+    ExoPlayer exoPlayer = builder.build();
     exoPlayer.setMediaItem(mediaItem);
     exoPlayer.prepare();
 
     setUpVideoPlayer(exoPlayer);
-  }
-
-  // Constructor used to directly test members of this class.
-  @VisibleForTesting
-  VideoPlayer(
-      ExoPlayer exoPlayer,
-      VideoPlayerCallbacks events,
-      TextureRegistry.SurfaceTextureEntry textureEntry,
-      VideoPlayerOptions options,
-      DefaultHttpDataSource.Factory httpDataSourceFactory) {
-    this.videoPlayerEvents = events;
-    this.textureEntry = textureEntry;
-    this.options = options;
-    this.httpDataSourceFactory = httpDataSourceFactory;
-
-    setUpVideoPlayer(exoPlayer);
-  }
-
-  @VisibleForTesting
-  public void configureHttpDataSourceFactory(@NonNull Map<String, String> httpHeaders) {
-    final boolean httpHeadersNotEmpty = !httpHeaders.isEmpty();
-    final String userAgent =
-        httpHeadersNotEmpty && httpHeaders.containsKey(USER_AGENT)
-            ? httpHeaders.get(USER_AGENT)
-            : "ExoPlayer";
-
-    unstableUpdateDataSourceFactory(
-        httpDataSourceFactory, httpHeaders, userAgent, httpHeadersNotEmpty);
   }
 
   private void setUpVideoPlayer(ExoPlayer exoPlayer) {
@@ -163,48 +128,6 @@ final class VideoPlayer {
     }
     if (exoPlayer != null) {
       exoPlayer.release();
-    }
-  }
-
-  @NonNull
-  private static ExoPlayer buildExoPlayer(
-      Context context, DataSource.Factory baseDataSourceFactory) {
-    DataSource.Factory dataSourceFactory =
-        new DefaultDataSource.Factory(context, baseDataSourceFactory);
-    DefaultMediaSourceFactory mediaSourceFactory =
-        new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSourceFactory);
-    return new ExoPlayer.Builder(context).setMediaSourceFactory(mediaSourceFactory).build();
-  }
-
-  @Nullable
-  private static String mimeFromFormatHint(@Nullable String formatHint) {
-    if (formatHint == null) {
-      return null;
-    }
-    switch (formatHint) {
-      case FORMAT_SS:
-        return MimeTypes.APPLICATION_SS;
-      case FORMAT_DASH:
-        return MimeTypes.APPLICATION_MPD;
-      case FORMAT_HLS:
-        return MimeTypes.APPLICATION_M3U8;
-      case FORMAT_OTHER:
-      default:
-        return null;
-    }
-  }
-
-  // TODO: migrate to stable API, see https://github.com/flutter/flutter/issues/147039
-  @OptIn(markerClass = UnstableApi.class)
-  private static void unstableUpdateDataSourceFactory(
-      DefaultHttpDataSource.Factory factory,
-      @NonNull Map<String, String> httpHeaders,
-      String userAgent,
-      boolean httpHeadersNotEmpty) {
-    factory.setUserAgent(userAgent).setAllowCrossProtocolRedirects(true);
-
-    if (httpHeadersNotEmpty) {
-      factory.setDefaultRequestProperties(httpHeaders);
     }
   }
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -15,10 +15,7 @@ import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.PlaybackParameters;
-import androidx.media3.datasource.DataSource;
-import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.exoplayer.ExoPlayer;
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import io.flutter.view.TextureRegistry;
 
 final class VideoPlayer {
@@ -28,7 +25,6 @@ final class VideoPlayer {
   private final VideoPlayerCallbacks videoPlayerEvents;
   private final VideoPlayerOptions options;
 
-
   /**
    * Creates a video player.
    *
@@ -37,17 +33,17 @@ final class VideoPlayer {
    * @param textureEntry texture to render to.
    * @param asset asset to play.
    * @param options options for playback.
-   *
    * @return a video player instance.
    */
   @NonNull
-  static VideoPlayer create (
+  static VideoPlayer create(
       Context context,
       VideoPlayerCallbacks events,
       TextureRegistry.SurfaceTextureEntry textureEntry,
       VideoAsset asset,
       VideoPlayerOptions options) {
-    ExoPlayer.Builder builder = new ExoPlayer.Builder(context).setMediaSourceFactory(asset.getMediaSourceFactory(context));
+    ExoPlayer.Builder builder =
+        new ExoPlayer.Builder(context).setMediaSourceFactory(asset.getMediaSourceFactory(context));
     return new VideoPlayer(builder, events, textureEntry, asset.getMediaItem(), options);
   }
 
@@ -58,7 +54,7 @@ final class VideoPlayer {
       TextureRegistry.SurfaceTextureEntry textureEntry,
       MediaItem mediaItem,
       VideoPlayerOptions options) {
-      this.videoPlayerEvents = events;
+    this.videoPlayerEvents = events;
     this.textureEntry = textureEntry;
     this.options = options;
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
@@ -97,6 +97,7 @@ final class VideoPlayerEventCallbacks implements VideoPlayerCallbacks {
   @Override
   public void onIsPlayingStateUpdate(boolean isPlaying) {
     Map<String, Object> event = new HashMap<>();
+    event.put("event", "isPlayingStateUpdate");
     event.put("isPlaying", isPlaying);
     eventSink.success(event);
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -7,7 +7,9 @@ package io.flutter.plugins.videoplayer;
 import android.content.Context;
 import android.os.Build;
 import android.util.LongSparseArray;
+
 import androidx.annotation.NonNull;
+
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -22,206 +24,217 @@ import io.flutter.plugins.videoplayer.Messages.PositionMessage;
 import io.flutter.plugins.videoplayer.Messages.TextureMessage;
 import io.flutter.plugins.videoplayer.Messages.VolumeMessage;
 import io.flutter.view.TextureRegistry;
+
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.net.ssl.HttpsURLConnection;
 
-/** Android platform implementation of the VideoPlayerPlugin. */
+/**
+ * Android platform implementation of the VideoPlayerPlugin.
+ */
 public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
-  private static final String TAG = "VideoPlayerPlugin";
-  private final LongSparseArray<VideoPlayer> videoPlayers = new LongSparseArray<>();
-  private FlutterState flutterState;
-  private final VideoPlayerOptions options = new VideoPlayerOptions();
+    private static final String TAG = "VideoPlayerPlugin";
+    private final LongSparseArray<VideoPlayer> videoPlayers = new LongSparseArray<>();
+    private FlutterState flutterState;
+    private final VideoPlayerOptions options = new VideoPlayerOptions();
 
-  /** Register this with the v2 embedding for the plugin to respond to lifecycle callbacks. */
-  public VideoPlayerPlugin() {}
-
-  @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-    if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      try {
-        HttpsURLConnection.setDefaultSSLSocketFactory(new CustomSSLSocketFactory());
-      } catch (KeyManagementException | NoSuchAlgorithmException e) {
-        Log.w(
-            TAG,
-            "Failed to enable TLSv1.1 and TLSv1.2 Protocols for API level 19 and below.\n"
-                + "For more information about Socket Security, please consult the following link:\n"
-                + "https://developer.android.com/reference/javax/net/ssl/SSLSocket",
-            e);
-      }
+    /**
+     * Register this with the v2 embedding for the plugin to respond to lifecycle callbacks.
+     */
+    public VideoPlayerPlugin() {
     }
 
-    final FlutterInjector injector = FlutterInjector.instance();
-    this.flutterState =
-        new FlutterState(
-            binding.getApplicationContext(),
-            binding.getBinaryMessenger(),
-            injector.flutterLoader()::getLookupKeyForAsset,
-            injector.flutterLoader()::getLookupKeyForAsset,
-            binding.getTextureRegistry());
-    flutterState.startListening(this, binding.getBinaryMessenger());
-  }
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            try {
+                HttpsURLConnection.setDefaultSSLSocketFactory(new CustomSSLSocketFactory());
+            } catch (KeyManagementException | NoSuchAlgorithmException e) {
+                Log.w(
+                        TAG,
+                        "Failed to enable TLSv1.1 and TLSv1.2 Protocols for API level 19 and below.\n"
+                                + "For more information about Socket Security, please consult the following link:\n"
+                                + "https://developer.android.com/reference/javax/net/ssl/SSLSocket",
+                        e);
+            }
+        }
 
-  @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    if (flutterState == null) {
-      Log.wtf(TAG, "Detached from the engine before registering to it.");
-    }
-    flutterState.stopListening(binding.getBinaryMessenger());
-    flutterState = null;
-    onDestroy();
-  }
-
-  private void disposeAllPlayers() {
-    for (int i = 0; i < videoPlayers.size(); i++) {
-      videoPlayers.valueAt(i).dispose();
-    }
-    videoPlayers.clear();
-  }
-
-  public void onDestroy() {
-    // The whole FlutterView is being destroyed. Here we release resources acquired for all
-    // instances
-    // of VideoPlayer. Once https://github.com/flutter/flutter/issues/19358 is resolved this may
-    // be replaced with just asserting that videoPlayers.isEmpty().
-    // https://github.com/flutter/flutter/issues/20989 tracks this.
-    disposeAllPlayers();
-  }
-
-  public void initialize() {
-    disposeAllPlayers();
-  }
-
-  public @NonNull TextureMessage create(@NonNull CreateMessage arg) {
-    TextureRegistry.SurfaceTextureEntry handle =
-        flutterState.textureRegistry.createSurfaceTexture();
-    EventChannel eventChannel =
-        new EventChannel(
-            flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
-
-    VideoPlayer player;
-    if (arg.getAsset() != null) {
-      String assetLookupKey;
-      if (arg.getPackageName() != null) {
-        assetLookupKey =
-            flutterState.keyForAssetAndPackageName.get(arg.getAsset(), arg.getPackageName());
-      } else {
-        assetLookupKey = flutterState.keyForAsset.get(arg.getAsset());
-      }
-      player =
-          new VideoPlayer(
-              flutterState.applicationContext,
-              VideoPlayerEventCallbacks.bindTo(eventChannel),
-              handle,
-              "asset:///" + assetLookupKey,
-              null,
-              new HashMap<>(),
-              options);
-    } else {
-      Map<String, String> httpHeaders = arg.getHttpHeaders();
-      player =
-          new VideoPlayer(
-              flutterState.applicationContext,
-              VideoPlayerEventCallbacks.bindTo(eventChannel),
-              handle,
-              arg.getUri(),
-              arg.getFormatHint(),
-              httpHeaders,
-              options);
-    }
-    videoPlayers.put(handle.id(), player);
-
-    return new TextureMessage.Builder().setTextureId(handle.id()).build();
-  }
-
-  public void dispose(@NonNull TextureMessage arg) {
-    VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    player.dispose();
-    videoPlayers.remove(arg.getTextureId());
-  }
-
-  public void setLooping(@NonNull LoopingMessage arg) {
-    VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    player.setLooping(arg.getIsLooping());
-  }
-
-  public void setVolume(@NonNull VolumeMessage arg) {
-    VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    player.setVolume(arg.getVolume());
-  }
-
-  public void setPlaybackSpeed(@NonNull PlaybackSpeedMessage arg) {
-    VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    player.setPlaybackSpeed(arg.getSpeed());
-  }
-
-  public void play(@NonNull TextureMessage arg) {
-    VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    player.play();
-  }
-
-  public @NonNull PositionMessage position(@NonNull TextureMessage arg) {
-    VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    PositionMessage result =
-        new PositionMessage.Builder()
-            .setPosition(player.getPosition())
-            .setTextureId(arg.getTextureId())
-            .build();
-    player.sendBufferingUpdate();
-    return result;
-  }
-
-  public void seekTo(@NonNull PositionMessage arg) {
-    VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    player.seekTo(arg.getPosition().intValue());
-  }
-
-  public void pause(@NonNull TextureMessage arg) {
-    VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    player.pause();
-  }
-
-  @Override
-  public void setMixWithOthers(@NonNull MixWithOthersMessage arg) {
-    options.mixWithOthers = arg.getMixWithOthers();
-  }
-
-  private interface KeyForAssetFn {
-    String get(String asset);
-  }
-
-  private interface KeyForAssetAndPackageName {
-    String get(String asset, String packageName);
-  }
-
-  private static final class FlutterState {
-    final Context applicationContext;
-    final BinaryMessenger binaryMessenger;
-    final KeyForAssetFn keyForAsset;
-    final KeyForAssetAndPackageName keyForAssetAndPackageName;
-    final TextureRegistry textureRegistry;
-
-    FlutterState(
-        Context applicationContext,
-        BinaryMessenger messenger,
-        KeyForAssetFn keyForAsset,
-        KeyForAssetAndPackageName keyForAssetAndPackageName,
-        TextureRegistry textureRegistry) {
-      this.applicationContext = applicationContext;
-      this.binaryMessenger = messenger;
-      this.keyForAsset = keyForAsset;
-      this.keyForAssetAndPackageName = keyForAssetAndPackageName;
-      this.textureRegistry = textureRegistry;
+        final FlutterInjector injector = FlutterInjector.instance();
+        this.flutterState =
+                new FlutterState(
+                        binding.getApplicationContext(),
+                        binding.getBinaryMessenger(),
+                        injector.flutterLoader()::getLookupKeyForAsset,
+                        injector.flutterLoader()::getLookupKeyForAsset,
+                        binding.getTextureRegistry());
+        flutterState.startListening(this, binding.getBinaryMessenger());
     }
 
-    void startListening(VideoPlayerPlugin methodCallHandler, BinaryMessenger messenger) {
-      AndroidVideoPlayerApi.setup(messenger, methodCallHandler);
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        if (flutterState == null) {
+            Log.wtf(TAG, "Detached from the engine before registering to it.");
+        }
+        flutterState.stopListening(binding.getBinaryMessenger());
+        flutterState = null;
+        onDestroy();
     }
 
-    void stopListening(BinaryMessenger messenger) {
-      AndroidVideoPlayerApi.setup(messenger, null);
+    private void disposeAllPlayers() {
+        for (int i = 0; i < videoPlayers.size(); i++) {
+            videoPlayers.valueAt(i).dispose();
+        }
+        videoPlayers.clear();
     }
-  }
+
+    public void onDestroy() {
+        // The whole FlutterView is being destroyed. Here we release resources acquired for all
+        // instances
+        // of VideoPlayer. Once https://github.com/flutter/flutter/issues/19358 is resolved this may
+        // be replaced with just asserting that videoPlayers.isEmpty().
+        // https://github.com/flutter/flutter/issues/20989 tracks this.
+        disposeAllPlayers();
+    }
+
+    public void initialize() {
+        disposeAllPlayers();
+    }
+
+    public @NonNull TextureMessage create(@NonNull CreateMessage arg) {
+        TextureRegistry.SurfaceTextureEntry handle =
+                flutterState.textureRegistry.createSurfaceTexture();
+        EventChannel eventChannel =
+                new EventChannel(
+                        flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
+
+        final VideoAsset videoAsset;
+        if (arg.getAsset() != null) {
+            String assetLookupKey;
+            if (arg.getPackageName() != null) {
+                assetLookupKey =
+                        flutterState.keyForAssetAndPackageName.get(arg.getAsset(), arg.getPackageName());
+            } else {
+                assetLookupKey = flutterState.keyForAsset.get(arg.getAsset());
+            }
+            videoAsset = VideoAsset.fromAssetUrl("asset:///" + assetLookupKey);
+        } else {
+            Map<String, String> httpHeaders = arg.getHttpHeaders();
+            VideoAsset.StreamingFormat streamingFormat = VideoAsset.StreamingFormat.Unknown;
+            String formatHint = arg.getFormatHint();
+            if (formatHint != null) {
+                switch (formatHint) {
+                    case "ss":
+                        streamingFormat = VideoAsset.StreamingFormat.Smooth;
+                        break;
+                    case "dash":
+                        streamingFormat = VideoAsset.StreamingFormat.DynamicAdaptive;
+                        break;
+                    case "hls":
+                        streamingFormat = VideoAsset.StreamingFormat.HttpLive;
+                        break;
+                }
+            }
+            videoAsset = VideoAsset.fromRemoteUrl(arg.getUri(), streamingFormat, arg.getHttpHeaders());
+        }
+        videoPlayers.put(handle.id(), VideoPlayer.create(
+                flutterState.applicationContext,
+                VideoPlayerEventCallbacks.bindTo(eventChannel),
+                handle,
+                videoAsset,
+                options));
+
+        return new TextureMessage.Builder().setTextureId(handle.id()).build();
+    }
+
+    public void dispose(@NonNull TextureMessage arg) {
+        VideoPlayer player = videoPlayers.get(arg.getTextureId());
+        player.dispose();
+        videoPlayers.remove(arg.getTextureId());
+    }
+
+    public void setLooping(@NonNull LoopingMessage arg) {
+        VideoPlayer player = videoPlayers.get(arg.getTextureId());
+        player.setLooping(arg.getIsLooping());
+    }
+
+    public void setVolume(@NonNull VolumeMessage arg) {
+        VideoPlayer player = videoPlayers.get(arg.getTextureId());
+        player.setVolume(arg.getVolume());
+    }
+
+    public void setPlaybackSpeed(@NonNull PlaybackSpeedMessage arg) {
+        VideoPlayer player = videoPlayers.get(arg.getTextureId());
+        player.setPlaybackSpeed(arg.getSpeed());
+    }
+
+    public void play(@NonNull TextureMessage arg) {
+        VideoPlayer player = videoPlayers.get(arg.getTextureId());
+        player.play();
+    }
+
+    public @NonNull PositionMessage position(@NonNull TextureMessage arg) {
+        VideoPlayer player = videoPlayers.get(arg.getTextureId());
+        PositionMessage result =
+                new PositionMessage.Builder()
+                        .setPosition(player.getPosition())
+                        .setTextureId(arg.getTextureId())
+                        .build();
+        player.sendBufferingUpdate();
+        return result;
+    }
+
+    public void seekTo(@NonNull PositionMessage arg) {
+        VideoPlayer player = videoPlayers.get(arg.getTextureId());
+        player.seekTo(arg.getPosition().intValue());
+    }
+
+    public void pause(@NonNull TextureMessage arg) {
+        VideoPlayer player = videoPlayers.get(arg.getTextureId());
+        player.pause();
+    }
+
+    @Override
+    public void setMixWithOthers(@NonNull MixWithOthersMessage arg) {
+        options.mixWithOthers = arg.getMixWithOthers();
+    }
+
+    private interface KeyForAssetFn {
+        String get(String asset);
+    }
+
+    private interface KeyForAssetAndPackageName {
+        String get(String asset, String packageName);
+    }
+
+    private static final class FlutterState {
+        final Context applicationContext;
+        final BinaryMessenger binaryMessenger;
+        final KeyForAssetFn keyForAsset;
+        final KeyForAssetAndPackageName keyForAssetAndPackageName;
+        final TextureRegistry textureRegistry;
+
+        FlutterState(
+                Context applicationContext,
+                BinaryMessenger messenger,
+                KeyForAssetFn keyForAsset,
+                KeyForAssetAndPackageName keyForAssetAndPackageName,
+                TextureRegistry textureRegistry) {
+            this.applicationContext = applicationContext;
+            this.binaryMessenger = messenger;
+            this.keyForAsset = keyForAsset;
+            this.keyForAssetAndPackageName = keyForAssetAndPackageName;
+            this.textureRegistry = textureRegistry;
+        }
+
+        void startListening(VideoPlayerPlugin methodCallHandler, BinaryMessenger messenger) {
+            AndroidVideoPlayerApi.setup(messenger, methodCallHandler);
+        }
+
+        void stopListening(BinaryMessenger messenger) {
+            AndroidVideoPlayerApi.setup(messenger, null);
+        }
+    }
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -112,18 +112,18 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
       videoAsset = VideoAsset.fromAssetUrl("asset:///" + assetLookupKey);
     } else {
       Map<String, String> httpHeaders = arg.getHttpHeaders();
-      VideoAsset.StreamingFormat streamingFormat = VideoAsset.StreamingFormat.Unknown;
+      VideoAsset.StreamingFormat streamingFormat = VideoAsset.StreamingFormat.UNKNOWN;
       String formatHint = arg.getFormatHint();
       if (formatHint != null) {
         switch (formatHint) {
           case "ss":
-            streamingFormat = VideoAsset.StreamingFormat.Smooth;
+            streamingFormat = VideoAsset.StreamingFormat.SMOOTH;
             break;
           case "dash":
-            streamingFormat = VideoAsset.StreamingFormat.DynamicAdaptive;
+            streamingFormat = VideoAsset.StreamingFormat.DYNAMIC_ADAPTIVE;
             break;
           case "hls":
-            streamingFormat = VideoAsset.StreamingFormat.HttpLive;
+            streamingFormat = VideoAsset.StreamingFormat.HTTP_LIVE;
             break;
         }
       }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -7,9 +7,7 @@ package io.flutter.plugins.videoplayer;
 import android.content.Context;
 import android.os.Build;
 import android.util.LongSparseArray;
-
 import androidx.annotation.NonNull;
-
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -24,217 +22,211 @@ import io.flutter.plugins.videoplayer.Messages.PositionMessage;
 import io.flutter.plugins.videoplayer.Messages.TextureMessage;
 import io.flutter.plugins.videoplayer.Messages.VolumeMessage;
 import io.flutter.view.TextureRegistry;
-
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
 import java.util.Map;
-
 import javax.net.ssl.HttpsURLConnection;
 
-/**
- * Android platform implementation of the VideoPlayerPlugin.
- */
+/** Android platform implementation of the VideoPlayerPlugin. */
 public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
-    private static final String TAG = "VideoPlayerPlugin";
-    private final LongSparseArray<VideoPlayer> videoPlayers = new LongSparseArray<>();
-    private FlutterState flutterState;
-    private final VideoPlayerOptions options = new VideoPlayerOptions();
+  private static final String TAG = "VideoPlayerPlugin";
+  private final LongSparseArray<VideoPlayer> videoPlayers = new LongSparseArray<>();
+  private FlutterState flutterState;
+  private final VideoPlayerOptions options = new VideoPlayerOptions();
 
-    /**
-     * Register this with the v2 embedding for the plugin to respond to lifecycle callbacks.
-     */
-    public VideoPlayerPlugin() {
+  /** Register this with the v2 embedding for the plugin to respond to lifecycle callbacks. */
+  public VideoPlayerPlugin() {}
+
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+      try {
+        HttpsURLConnection.setDefaultSSLSocketFactory(new CustomSSLSocketFactory());
+      } catch (KeyManagementException | NoSuchAlgorithmException e) {
+        Log.w(
+            TAG,
+            "Failed to enable TLSv1.1 and TLSv1.2 Protocols for API level 19 and below.\n"
+                + "For more information about Socket Security, please consult the following link:\n"
+                + "https://developer.android.com/reference/javax/net/ssl/SSLSocket",
+            e);
+      }
     }
 
-    @Override
-    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            try {
-                HttpsURLConnection.setDefaultSSLSocketFactory(new CustomSSLSocketFactory());
-            } catch (KeyManagementException | NoSuchAlgorithmException e) {
-                Log.w(
-                        TAG,
-                        "Failed to enable TLSv1.1 and TLSv1.2 Protocols for API level 19 and below.\n"
-                                + "For more information about Socket Security, please consult the following link:\n"
-                                + "https://developer.android.com/reference/javax/net/ssl/SSLSocket",
-                        e);
-            }
+    final FlutterInjector injector = FlutterInjector.instance();
+    this.flutterState =
+        new FlutterState(
+            binding.getApplicationContext(),
+            binding.getBinaryMessenger(),
+            injector.flutterLoader()::getLookupKeyForAsset,
+            injector.flutterLoader()::getLookupKeyForAsset,
+            binding.getTextureRegistry());
+    flutterState.startListening(this, binding.getBinaryMessenger());
+  }
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (flutterState == null) {
+      Log.wtf(TAG, "Detached from the engine before registering to it.");
+    }
+    flutterState.stopListening(binding.getBinaryMessenger());
+    flutterState = null;
+    onDestroy();
+  }
+
+  private void disposeAllPlayers() {
+    for (int i = 0; i < videoPlayers.size(); i++) {
+      videoPlayers.valueAt(i).dispose();
+    }
+    videoPlayers.clear();
+  }
+
+  public void onDestroy() {
+    // The whole FlutterView is being destroyed. Here we release resources acquired for all
+    // instances
+    // of VideoPlayer. Once https://github.com/flutter/flutter/issues/19358 is resolved this may
+    // be replaced with just asserting that videoPlayers.isEmpty().
+    // https://github.com/flutter/flutter/issues/20989 tracks this.
+    disposeAllPlayers();
+  }
+
+  public void initialize() {
+    disposeAllPlayers();
+  }
+
+  public @NonNull TextureMessage create(@NonNull CreateMessage arg) {
+    TextureRegistry.SurfaceTextureEntry handle =
+        flutterState.textureRegistry.createSurfaceTexture();
+    EventChannel eventChannel =
+        new EventChannel(
+            flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
+
+    final VideoAsset videoAsset;
+    if (arg.getAsset() != null) {
+      String assetLookupKey;
+      if (arg.getPackageName() != null) {
+        assetLookupKey =
+            flutterState.keyForAssetAndPackageName.get(arg.getAsset(), arg.getPackageName());
+      } else {
+        assetLookupKey = flutterState.keyForAsset.get(arg.getAsset());
+      }
+      videoAsset = VideoAsset.fromAssetUrl("asset:///" + assetLookupKey);
+    } else {
+      Map<String, String> httpHeaders = arg.getHttpHeaders();
+      VideoAsset.StreamingFormat streamingFormat = VideoAsset.StreamingFormat.Unknown;
+      String formatHint = arg.getFormatHint();
+      if (formatHint != null) {
+        switch (formatHint) {
+          case "ss":
+            streamingFormat = VideoAsset.StreamingFormat.Smooth;
+            break;
+          case "dash":
+            streamingFormat = VideoAsset.StreamingFormat.DynamicAdaptive;
+            break;
+          case "hls":
+            streamingFormat = VideoAsset.StreamingFormat.HttpLive;
+            break;
         }
+      }
+      videoAsset = VideoAsset.fromRemoteUrl(arg.getUri(), streamingFormat, arg.getHttpHeaders());
+    }
+    videoPlayers.put(
+        handle.id(),
+        VideoPlayer.create(
+            flutterState.applicationContext,
+            VideoPlayerEventCallbacks.bindTo(eventChannel),
+            handle,
+            videoAsset,
+            options));
 
-        final FlutterInjector injector = FlutterInjector.instance();
-        this.flutterState =
-                new FlutterState(
-                        binding.getApplicationContext(),
-                        binding.getBinaryMessenger(),
-                        injector.flutterLoader()::getLookupKeyForAsset,
-                        injector.flutterLoader()::getLookupKeyForAsset,
-                        binding.getTextureRegistry());
-        flutterState.startListening(this, binding.getBinaryMessenger());
+    return new TextureMessage.Builder().setTextureId(handle.id()).build();
+  }
+
+  public void dispose(@NonNull TextureMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    player.dispose();
+    videoPlayers.remove(arg.getTextureId());
+  }
+
+  public void setLooping(@NonNull LoopingMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    player.setLooping(arg.getIsLooping());
+  }
+
+  public void setVolume(@NonNull VolumeMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    player.setVolume(arg.getVolume());
+  }
+
+  public void setPlaybackSpeed(@NonNull PlaybackSpeedMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    player.setPlaybackSpeed(arg.getSpeed());
+  }
+
+  public void play(@NonNull TextureMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    player.play();
+  }
+
+  public @NonNull PositionMessage position(@NonNull TextureMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    PositionMessage result =
+        new PositionMessage.Builder()
+            .setPosition(player.getPosition())
+            .setTextureId(arg.getTextureId())
+            .build();
+    player.sendBufferingUpdate();
+    return result;
+  }
+
+  public void seekTo(@NonNull PositionMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    player.seekTo(arg.getPosition().intValue());
+  }
+
+  public void pause(@NonNull TextureMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    player.pause();
+  }
+
+  @Override
+  public void setMixWithOthers(@NonNull MixWithOthersMessage arg) {
+    options.mixWithOthers = arg.getMixWithOthers();
+  }
+
+  private interface KeyForAssetFn {
+    String get(String asset);
+  }
+
+  private interface KeyForAssetAndPackageName {
+    String get(String asset, String packageName);
+  }
+
+  private static final class FlutterState {
+    final Context applicationContext;
+    final BinaryMessenger binaryMessenger;
+    final KeyForAssetFn keyForAsset;
+    final KeyForAssetAndPackageName keyForAssetAndPackageName;
+    final TextureRegistry textureRegistry;
+
+    FlutterState(
+        Context applicationContext,
+        BinaryMessenger messenger,
+        KeyForAssetFn keyForAsset,
+        KeyForAssetAndPackageName keyForAssetAndPackageName,
+        TextureRegistry textureRegistry) {
+      this.applicationContext = applicationContext;
+      this.binaryMessenger = messenger;
+      this.keyForAsset = keyForAsset;
+      this.keyForAssetAndPackageName = keyForAssetAndPackageName;
+      this.textureRegistry = textureRegistry;
     }
 
-    @Override
-    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-        if (flutterState == null) {
-            Log.wtf(TAG, "Detached from the engine before registering to it.");
-        }
-        flutterState.stopListening(binding.getBinaryMessenger());
-        flutterState = null;
-        onDestroy();
+    void startListening(VideoPlayerPlugin methodCallHandler, BinaryMessenger messenger) {
+      AndroidVideoPlayerApi.setup(messenger, methodCallHandler);
     }
 
-    private void disposeAllPlayers() {
-        for (int i = 0; i < videoPlayers.size(); i++) {
-            videoPlayers.valueAt(i).dispose();
-        }
-        videoPlayers.clear();
+    void stopListening(BinaryMessenger messenger) {
+      AndroidVideoPlayerApi.setup(messenger, null);
     }
-
-    public void onDestroy() {
-        // The whole FlutterView is being destroyed. Here we release resources acquired for all
-        // instances
-        // of VideoPlayer. Once https://github.com/flutter/flutter/issues/19358 is resolved this may
-        // be replaced with just asserting that videoPlayers.isEmpty().
-        // https://github.com/flutter/flutter/issues/20989 tracks this.
-        disposeAllPlayers();
-    }
-
-    public void initialize() {
-        disposeAllPlayers();
-    }
-
-    public @NonNull TextureMessage create(@NonNull CreateMessage arg) {
-        TextureRegistry.SurfaceTextureEntry handle =
-                flutterState.textureRegistry.createSurfaceTexture();
-        EventChannel eventChannel =
-                new EventChannel(
-                        flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
-
-        final VideoAsset videoAsset;
-        if (arg.getAsset() != null) {
-            String assetLookupKey;
-            if (arg.getPackageName() != null) {
-                assetLookupKey =
-                        flutterState.keyForAssetAndPackageName.get(arg.getAsset(), arg.getPackageName());
-            } else {
-                assetLookupKey = flutterState.keyForAsset.get(arg.getAsset());
-            }
-            videoAsset = VideoAsset.fromAssetUrl("asset:///" + assetLookupKey);
-        } else {
-            Map<String, String> httpHeaders = arg.getHttpHeaders();
-            VideoAsset.StreamingFormat streamingFormat = VideoAsset.StreamingFormat.Unknown;
-            String formatHint = arg.getFormatHint();
-            if (formatHint != null) {
-                switch (formatHint) {
-                    case "ss":
-                        streamingFormat = VideoAsset.StreamingFormat.Smooth;
-                        break;
-                    case "dash":
-                        streamingFormat = VideoAsset.StreamingFormat.DynamicAdaptive;
-                        break;
-                    case "hls":
-                        streamingFormat = VideoAsset.StreamingFormat.HttpLive;
-                        break;
-                }
-            }
-            videoAsset = VideoAsset.fromRemoteUrl(arg.getUri(), streamingFormat, arg.getHttpHeaders());
-        }
-        videoPlayers.put(handle.id(), VideoPlayer.create(
-                flutterState.applicationContext,
-                VideoPlayerEventCallbacks.bindTo(eventChannel),
-                handle,
-                videoAsset,
-                options));
-
-        return new TextureMessage.Builder().setTextureId(handle.id()).build();
-    }
-
-    public void dispose(@NonNull TextureMessage arg) {
-        VideoPlayer player = videoPlayers.get(arg.getTextureId());
-        player.dispose();
-        videoPlayers.remove(arg.getTextureId());
-    }
-
-    public void setLooping(@NonNull LoopingMessage arg) {
-        VideoPlayer player = videoPlayers.get(arg.getTextureId());
-        player.setLooping(arg.getIsLooping());
-    }
-
-    public void setVolume(@NonNull VolumeMessage arg) {
-        VideoPlayer player = videoPlayers.get(arg.getTextureId());
-        player.setVolume(arg.getVolume());
-    }
-
-    public void setPlaybackSpeed(@NonNull PlaybackSpeedMessage arg) {
-        VideoPlayer player = videoPlayers.get(arg.getTextureId());
-        player.setPlaybackSpeed(arg.getSpeed());
-    }
-
-    public void play(@NonNull TextureMessage arg) {
-        VideoPlayer player = videoPlayers.get(arg.getTextureId());
-        player.play();
-    }
-
-    public @NonNull PositionMessage position(@NonNull TextureMessage arg) {
-        VideoPlayer player = videoPlayers.get(arg.getTextureId());
-        PositionMessage result =
-                new PositionMessage.Builder()
-                        .setPosition(player.getPosition())
-                        .setTextureId(arg.getTextureId())
-                        .build();
-        player.sendBufferingUpdate();
-        return result;
-    }
-
-    public void seekTo(@NonNull PositionMessage arg) {
-        VideoPlayer player = videoPlayers.get(arg.getTextureId());
-        player.seekTo(arg.getPosition().intValue());
-    }
-
-    public void pause(@NonNull TextureMessage arg) {
-        VideoPlayer player = videoPlayers.get(arg.getTextureId());
-        player.pause();
-    }
-
-    @Override
-    public void setMixWithOthers(@NonNull MixWithOthersMessage arg) {
-        options.mixWithOthers = arg.getMixWithOthers();
-    }
-
-    private interface KeyForAssetFn {
-        String get(String asset);
-    }
-
-    private interface KeyForAssetAndPackageName {
-        String get(String asset, String packageName);
-    }
-
-    private static final class FlutterState {
-        final Context applicationContext;
-        final BinaryMessenger binaryMessenger;
-        final KeyForAssetFn keyForAsset;
-        final KeyForAssetAndPackageName keyForAssetAndPackageName;
-        final TextureRegistry textureRegistry;
-
-        FlutterState(
-                Context applicationContext,
-                BinaryMessenger messenger,
-                KeyForAssetFn keyForAsset,
-                KeyForAssetAndPackageName keyForAssetAndPackageName,
-                TextureRegistry textureRegistry) {
-            this.applicationContext = applicationContext;
-            this.binaryMessenger = messenger;
-            this.keyForAsset = keyForAsset;
-            this.keyForAssetAndPackageName = keyForAssetAndPackageName;
-            this.textureRegistry = textureRegistry;
-        }
-
-        void startListening(VideoPlayerPlugin methodCallHandler, BinaryMessenger messenger) {
-            AndroidVideoPlayerApi.setup(messenger, methodCallHandler);
-        }
-
-        void stopListening(BinaryMessenger messenger) {
-            AndroidVideoPlayerApi.setup(messenger, null);
-        }
-    }
+  }
 }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/ExoPlayerEventListenerTests.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/ExoPlayerEventListenerTests.java
@@ -1,11 +1,8 @@
 package io.flutter.plugins.videoplayer;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -15,7 +12,6 @@ import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
 import androidx.media3.common.VideoSize;
 import androidx.media3.exoplayer.ExoPlayer;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,153 +21,151 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 
-
 /**
  * Unit tests for {@link ExoPlayerEventListener}.
  *
- * <p>This test suite <em>narrowly verifies</em> that the events emitted by the underlying
- * {@link androidx.media3.exoplayer.ExoPlayer} instance are translated to the callback interface
- * we expect ({@link VideoPlayerCallbacks} and/or interface with the player instance as expected.
+ * <p>This test suite <em>narrowly verifies</em> that the events emitted by the underlying {@link
+ * androidx.media3.exoplayer.ExoPlayer} instance are translated to the callback interface we expect
+ * ({@link VideoPlayerCallbacks} and/or interface with the player instance as expected.
  */
 @RunWith(RobolectricTestRunner.class)
 public final class ExoPlayerEventListenerTests {
-    @Mock
-    private ExoPlayer mockExoPlayer;
-    @Mock
-    private VideoPlayerCallbacks mockCallbacks;
-    private ExoPlayerEventListener eventListener;
+  @Mock private ExoPlayer mockExoPlayer;
+  @Mock private VideoPlayerCallbacks mockCallbacks;
+  private ExoPlayerEventListener eventListener;
 
-    @Rule
-    public MockitoRule initRule = MockitoJUnit.rule();
+  @Rule public MockitoRule initRule = MockitoJUnit.rule();
 
-    @Before
-    public void setUp() {
-        eventListener = new ExoPlayerEventListener(mockExoPlayer, mockCallbacks);
-    }
+  @Before
+  public void setUp() {
+    eventListener = new ExoPlayerEventListener(mockExoPlayer, mockCallbacks);
+  }
 
-    @Test
-    public void onPlaybackStateChangedReadySendInitialized() {
-        VideoSize size = new VideoSize(800, 400, 0, 0);
-        when(mockExoPlayer.getVideoSize()).thenReturn(size);
-        when(mockExoPlayer.getDuration()).thenReturn(10L);
+  @Test
+  public void onPlaybackStateChangedReadySendInitialized() {
+    VideoSize size = new VideoSize(800, 400, 0, 0);
+    when(mockExoPlayer.getVideoSize()).thenReturn(size);
+    when(mockExoPlayer.getDuration()).thenReturn(10L);
 
-        eventListener.onPlaybackStateChanged(Player.STATE_READY);
-        verify(mockCallbacks).onInitialized(800, 400, 10L, 0);
-    }
+    eventListener.onPlaybackStateChanged(Player.STATE_READY);
+    verify(mockCallbacks).onInitialized(800, 400, 10L, 0);
+  }
 
-    @Test
-    public void onPlaybackStateChangedReadyInPortraitMode90DegreesSwapWidthAndHeight() {
-        VideoSize size = new VideoSize(800, 400, 90, 0);
-        when(mockExoPlayer.getVideoSize()).thenReturn(size);
-        when(mockExoPlayer.getDuration()).thenReturn(10L);
+  @Test
+  public void onPlaybackStateChangedReadyInPortraitMode90DegreesSwapWidthAndHeight() {
+    VideoSize size = new VideoSize(800, 400, 90, 0);
+    when(mockExoPlayer.getVideoSize()).thenReturn(size);
+    when(mockExoPlayer.getDuration()).thenReturn(10L);
 
-        eventListener.onPlaybackStateChanged(Player.STATE_READY);
-        verify(mockCallbacks).onInitialized(400, 800, 10L, 0);
-    }
+    eventListener.onPlaybackStateChanged(Player.STATE_READY);
+    verify(mockCallbacks).onInitialized(400, 800, 10L, 0);
+  }
 
-    @Test
-    public void onPlaybackStateChangedReadyInPortraitMode270DegreesSwapWidthAndHeight() {
-        VideoSize size = new VideoSize(800, 400, 270, 0);
-        when(mockExoPlayer.getVideoSize()).thenReturn(size);
-        when(mockExoPlayer.getDuration()).thenReturn(10L);
+  @Test
+  public void onPlaybackStateChangedReadyInPortraitMode270DegreesSwapWidthAndHeight() {
+    VideoSize size = new VideoSize(800, 400, 270, 0);
+    when(mockExoPlayer.getVideoSize()).thenReturn(size);
+    when(mockExoPlayer.getDuration()).thenReturn(10L);
 
-        eventListener.onPlaybackStateChanged(Player.STATE_READY);
-        verify(mockCallbacks).onInitialized(400, 800, 10L, 0);
-    }
+    eventListener.onPlaybackStateChanged(Player.STATE_READY);
+    verify(mockCallbacks).onInitialized(400, 800, 10L, 0);
+  }
 
-    @Test
-    public void onPlaybackStateChangedReadyFlipped180DegreesInformEventHandler() {
-        VideoSize size = new VideoSize(800, 400, 180, 0);
-        when(mockExoPlayer.getVideoSize()).thenReturn(size);
-        when(mockExoPlayer.getDuration()).thenReturn(10L);
+  @Test
+  public void onPlaybackStateChangedReadyFlipped180DegreesInformEventHandler() {
+    VideoSize size = new VideoSize(800, 400, 180, 0);
+    when(mockExoPlayer.getVideoSize()).thenReturn(size);
+    when(mockExoPlayer.getDuration()).thenReturn(10L);
 
-        eventListener.onPlaybackStateChanged(Player.STATE_READY);
-        verify(mockCallbacks).onInitialized(800, 400, 10L, 180);
-    }
+    eventListener.onPlaybackStateChanged(Player.STATE_READY);
+    verify(mockCallbacks).onInitialized(800, 400, 10L, 180);
+  }
 
-    @Test
-    public void onPlaybackStateChangedBufferingSendsBufferingStartAndUpdates() {
-        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
-        eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
+  @Test
+  public void onPlaybackStateChangedBufferingSendsBufferingStartAndUpdates() {
+    when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+    eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
 
-        verify(mockCallbacks).onBufferingStart();
-        verify(mockCallbacks).onBufferingUpdate(10L);
-        verifyNoMoreInteractions(mockCallbacks);
+    verify(mockCallbacks).onBufferingStart();
+    verify(mockCallbacks).onBufferingUpdate(10L);
+    verifyNoMoreInteractions(mockCallbacks);
 
-        // If it's invoked again, only the update event is called.
-        verify(mockCallbacks).onBufferingUpdate(10L);
-        verifyNoMoreInteractions(mockCallbacks);
-    }
+    // If it's invoked again, only the update event is called.
+    verify(mockCallbacks).onBufferingUpdate(10L);
+    verifyNoMoreInteractions(mockCallbacks);
+  }
 
-    @Test
-    public void onPlaybackStateChangedEndedSendsOnCompleted() {
-        eventListener.onPlaybackStateChanged(Player.STATE_ENDED);
+  @Test
+  public void onPlaybackStateChangedEndedSendsOnCompleted() {
+    eventListener.onPlaybackStateChanged(Player.STATE_ENDED);
 
-        verify(mockCallbacks).onCompleted();
-        verifyNoMoreInteractions(mockCallbacks);
-    }
+    verify(mockCallbacks).onCompleted();
+    verifyNoMoreInteractions(mockCallbacks);
+  }
 
-    @Test
-    public void onPlaybackStateChangedEndedAfterBufferingSendsBufferingEndAndOnCompleted() {
-        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
-        eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
-        verify(mockCallbacks).onBufferingStart();
-        verify(mockCallbacks).onBufferingUpdate(10L);
+  @Test
+  public void onPlaybackStateChangedEndedAfterBufferingSendsBufferingEndAndOnCompleted() {
+    when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+    eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
+    verify(mockCallbacks).onBufferingStart();
+    verify(mockCallbacks).onBufferingUpdate(10L);
 
-        eventListener.onPlaybackStateChanged(Player.STATE_ENDED);
-        verify(mockCallbacks).onCompleted();
-        verify(mockCallbacks).onBufferingEnd();
+    eventListener.onPlaybackStateChanged(Player.STATE_ENDED);
+    verify(mockCallbacks).onCompleted();
+    verify(mockCallbacks).onBufferingEnd();
 
-        verifyNoMoreInteractions(mockCallbacks);
-    }
+    verifyNoMoreInteractions(mockCallbacks);
+  }
 
-    @Test
-    public void onPlaybackStateChangedIdleDoNothing() {
-        eventListener.onPlaybackStateChanged(Player.STATE_IDLE);
+  @Test
+  public void onPlaybackStateChangedIdleDoNothing() {
+    eventListener.onPlaybackStateChanged(Player.STATE_IDLE);
 
-        verifyNoInteractions(mockCallbacks);
-    }
+    verifyNoInteractions(mockCallbacks);
+  }
 
-    @Test
-    public void onPlaybackStateChangedIdleAfterBufferingSendsBufferingEnd() {
-        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
-        eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
-        verify(mockCallbacks).onBufferingStart();
-        verify(mockCallbacks).onBufferingUpdate(10L);
+  @Test
+  public void onPlaybackStateChangedIdleAfterBufferingSendsBufferingEnd() {
+    when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+    eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
+    verify(mockCallbacks).onBufferingStart();
+    verify(mockCallbacks).onBufferingUpdate(10L);
 
-        eventListener.onPlaybackStateChanged(Player.STATE_IDLE);
-        verify(mockCallbacks).onBufferingEnd();
+    eventListener.onPlaybackStateChanged(Player.STATE_IDLE);
+    verify(mockCallbacks).onBufferingEnd();
 
-        verifyNoMoreInteractions(mockCallbacks);
-    }
+    verifyNoMoreInteractions(mockCallbacks);
+  }
 
-    @Test
-    public void onErrorVideoErrorWhenBufferingInProgressAlsoEndBuffering() {
-        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
-        eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
-        verify(mockCallbacks).onBufferingStart();
-        verify(mockCallbacks).onBufferingUpdate(10L);
+  @Test
+  public void onErrorVideoErrorWhenBufferingInProgressAlsoEndBuffering() {
+    when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+    eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
+    verify(mockCallbacks).onBufferingStart();
+    verify(mockCallbacks).onBufferingUpdate(10L);
 
-        eventListener.onPlayerError(new PlaybackException("BAD", null, PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED));
-        verify(mockCallbacks).onBufferingEnd();
-        verify(mockCallbacks).onError(eq("VideoError"), contains("BAD"), isNull());
-    }
+    eventListener.onPlayerError(
+        new PlaybackException("BAD", null, PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED));
+    verify(mockCallbacks).onBufferingEnd();
+    verify(mockCallbacks).onError(eq("VideoError"), contains("BAD"), isNull());
+  }
 
-    @Test
-    public void onErrorBehindLiveWindowSeekToDefaultAndPrepare() {
-        eventListener.onPlayerError(new PlaybackException("SORT_OF_OK", null, PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW));
+  @Test
+  public void onErrorBehindLiveWindowSeekToDefaultAndPrepare() {
+    eventListener.onPlayerError(
+        new PlaybackException("SORT_OF_OK", null, PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW));
 
-        verify(mockExoPlayer).seekToDefaultPosition();
-        verify(mockExoPlayer).prepare();
-        verifyNoInteractions(mockCallbacks);
-    }
+    verify(mockExoPlayer).seekToDefaultPosition();
+    verify(mockExoPlayer).prepare();
+    verifyNoInteractions(mockCallbacks);
+  }
 
-    @Test
-    public void onIsPlayingChangedToggled() {
-        eventListener.onIsPlayingChanged(true);
-        verify(mockCallbacks).onIsPlayingStateUpdate(true);
+  @Test
+  public void onIsPlayingChangedToggled() {
+    eventListener.onIsPlayingChanged(true);
+    verify(mockCallbacks).onIsPlayingStateUpdate(true);
 
-        eventListener.onIsPlayingChanged(false);
-        verify(mockCallbacks).onIsPlayingStateUpdate(false);
-    }
+    eventListener.onIsPlayingChanged(false);
+    verify(mockCallbacks).onIsPlayingStateUpdate(false);
+  }
 }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/ExoPlayerEventListenerTests.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/ExoPlayerEventListenerTests.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.videoplayer;
 
 import static org.mockito.ArgumentMatchers.contains;

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/ExoPlayerEventListenerTests.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/ExoPlayerEventListenerTests.java
@@ -1,0 +1,177 @@
+package io.flutter.plugins.videoplayer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import androidx.media3.common.PlaybackException;
+import androidx.media3.common.Player;
+import androidx.media3.common.VideoSize;
+import androidx.media3.exoplayer.ExoPlayer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.robolectric.RobolectricTestRunner;
+
+
+/**
+ * Unit tests for {@link ExoPlayerEventListener}.
+ *
+ * <p>This test suite <em>narrowly verifies</em> that the events emitted by the underlying
+ * {@link androidx.media3.exoplayer.ExoPlayer} instance are translated to the callback interface
+ * we expect ({@link VideoPlayerCallbacks} and/or interface with the player instance as expected.
+ */
+@RunWith(RobolectricTestRunner.class)
+public final class ExoPlayerEventListenerTests {
+    @Mock
+    private ExoPlayer mockExoPlayer;
+    @Mock
+    private VideoPlayerCallbacks mockCallbacks;
+    private ExoPlayerEventListener eventListener;
+
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp() {
+        eventListener = new ExoPlayerEventListener(mockExoPlayer, mockCallbacks);
+    }
+
+    @Test
+    public void onPlaybackStateChangedReadySendInitialized() {
+        VideoSize size = new VideoSize(800, 400, 0, 0);
+        when(mockExoPlayer.getVideoSize()).thenReturn(size);
+        when(mockExoPlayer.getDuration()).thenReturn(10L);
+
+        eventListener.onPlaybackStateChanged(Player.STATE_READY);
+        verify(mockCallbacks).onInitialized(800, 400, 10L, 0);
+    }
+
+    @Test
+    public void onPlaybackStateChangedReadyInPortraitMode90DegreesSwapWidthAndHeight() {
+        VideoSize size = new VideoSize(800, 400, 90, 0);
+        when(mockExoPlayer.getVideoSize()).thenReturn(size);
+        when(mockExoPlayer.getDuration()).thenReturn(10L);
+
+        eventListener.onPlaybackStateChanged(Player.STATE_READY);
+        verify(mockCallbacks).onInitialized(400, 800, 10L, 0);
+    }
+
+    @Test
+    public void onPlaybackStateChangedReadyInPortraitMode270DegreesSwapWidthAndHeight() {
+        VideoSize size = new VideoSize(800, 400, 270, 0);
+        when(mockExoPlayer.getVideoSize()).thenReturn(size);
+        when(mockExoPlayer.getDuration()).thenReturn(10L);
+
+        eventListener.onPlaybackStateChanged(Player.STATE_READY);
+        verify(mockCallbacks).onInitialized(400, 800, 10L, 0);
+    }
+
+    @Test
+    public void onPlaybackStateChangedReadyFlipped180DegreesInformEventHandler() {
+        VideoSize size = new VideoSize(800, 400, 180, 0);
+        when(mockExoPlayer.getVideoSize()).thenReturn(size);
+        when(mockExoPlayer.getDuration()).thenReturn(10L);
+
+        eventListener.onPlaybackStateChanged(Player.STATE_READY);
+        verify(mockCallbacks).onInitialized(800, 400, 10L, 180);
+    }
+
+    @Test
+    public void onPlaybackStateChangedBufferingSendsBufferingStartAndUpdates() {
+        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+        eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
+
+        verify(mockCallbacks).onBufferingStart();
+        verify(mockCallbacks).onBufferingUpdate(10L);
+        verifyNoMoreInteractions(mockCallbacks);
+
+        // If it's invoked again, only the update event is called.
+        verify(mockCallbacks).onBufferingUpdate(10L);
+        verifyNoMoreInteractions(mockCallbacks);
+    }
+
+    @Test
+    public void onPlaybackStateChangedEndedSendsOnCompleted() {
+        eventListener.onPlaybackStateChanged(Player.STATE_ENDED);
+
+        verify(mockCallbacks).onCompleted();
+        verifyNoMoreInteractions(mockCallbacks);
+    }
+
+    @Test
+    public void onPlaybackStateChangedEndedAfterBufferingSendsBufferingEndAndOnCompleted() {
+        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+        eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
+        verify(mockCallbacks).onBufferingStart();
+        verify(mockCallbacks).onBufferingUpdate(10L);
+
+        eventListener.onPlaybackStateChanged(Player.STATE_ENDED);
+        verify(mockCallbacks).onCompleted();
+        verify(mockCallbacks).onBufferingEnd();
+
+        verifyNoMoreInteractions(mockCallbacks);
+    }
+
+    @Test
+    public void onPlaybackStateChangedIdleDoNothing() {
+        eventListener.onPlaybackStateChanged(Player.STATE_IDLE);
+
+        verifyNoInteractions(mockCallbacks);
+    }
+
+    @Test
+    public void onPlaybackStateChangedIdleAfterBufferingSendsBufferingEnd() {
+        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+        eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
+        verify(mockCallbacks).onBufferingStart();
+        verify(mockCallbacks).onBufferingUpdate(10L);
+
+        eventListener.onPlaybackStateChanged(Player.STATE_IDLE);
+        verify(mockCallbacks).onBufferingEnd();
+
+        verifyNoMoreInteractions(mockCallbacks);
+    }
+
+    @Test
+    public void onErrorVideoErrorWhenBufferingInProgressAlsoEndBuffering() {
+        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+        eventListener.onPlaybackStateChanged(Player.STATE_BUFFERING);
+        verify(mockCallbacks).onBufferingStart();
+        verify(mockCallbacks).onBufferingUpdate(10L);
+
+        eventListener.onPlayerError(new PlaybackException("BAD", null, PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED));
+        verify(mockCallbacks).onBufferingEnd();
+        verify(mockCallbacks).onError(eq("VideoError"), contains("BAD"), isNull());
+    }
+
+    @Test
+    public void onErrorBehindLiveWindowSeekToDefaultAndPrepare() {
+        eventListener.onPlayerError(new PlaybackException("SORT_OF_OK", null, PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW));
+
+        verify(mockExoPlayer).seekToDefaultPosition();
+        verify(mockExoPlayer).prepare();
+        verifyNoInteractions(mockCallbacks);
+    }
+
+    @Test
+    public void onIsPlayingChangedToggled() {
+        eventListener.onIsPlayingChanged(true);
+        verify(mockCallbacks).onIsPlayingStateUpdate(true);
+
+        eventListener.onIsPlayingChanged(false);
+        verify(mockCallbacks).onIsPlayingStateUpdate(false);
+    }
+}

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/FakeVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/FakeVideoAsset.java
@@ -7,7 +7,6 @@ package io.flutter.plugins.videoplayer;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.media3.common.MediaItem;
-import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.source.MediaSource;
 import androidx.media3.test.utils.FakeMediaSourceFactory;
 

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/FakeVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/FakeVideoAsset.java
@@ -1,55 +1,41 @@
 package io.flutter.plugins.videoplayer;
 
 import android.content.Context;
-
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.media3.common.AdPlaybackState;
-import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
 import androidx.media3.datasource.DefaultHttpDataSource;
-import androidx.media3.exoplayer.drm.DrmSessionManagerProvider;
 import androidx.media3.exoplayer.source.MediaSource;
-import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy;
-import androidx.media3.test.utils.FakeMediaSource;
 import androidx.media3.test.utils.FakeMediaSourceFactory;
-import androidx.media3.test.utils.FakeTimeline;
-import androidx.media3.test.utils.FakeTrackOutput;
 
-import com.google.common.collect.Lists;
 
-import java.time.Duration;
-import java.util.Collections;
 
-/**
- * A fake implementation of the {@link VideoAsset} class.
- */
+/** A fake implementation of the {@link VideoAsset} class. */
 final class FakeVideoAsset extends VideoAsset {
-    @NonNull
-    private final MediaSource.Factory mediaSourceFactory;
+  @NonNull private final MediaSource.Factory mediaSourceFactory;
 
-    FakeVideoAsset(String assetUrl) {
-        this(assetUrl, new FakeMediaSourceFactory());
-    }
+  FakeVideoAsset(String assetUrl) {
+    this(assetUrl, new FakeMediaSourceFactory());
+  }
 
-    FakeVideoAsset(String assetUrl, @NonNull MediaSource.Factory mediaSourceFactory) {
-        super(assetUrl);
-        this.mediaSourceFactory = mediaSourceFactory;
-    }
+  FakeVideoAsset(String assetUrl, @NonNull MediaSource.Factory mediaSourceFactory) {
+    super(assetUrl);
+    this.mediaSourceFactory = mediaSourceFactory;
+  }
 
-    @NonNull
-    @Override
-    MediaItem getMediaItem() {
-        return new MediaItem.Builder().setUri(assetUrl).build();
-    }
+  @NonNull
+  @Override
+  MediaItem getMediaItem() {
+    return new MediaItem.Builder().setUri(assetUrl).build();
+  }
 
-    @Override
-    MediaSource.Factory getMediaSourceFactory(Context context) {
-        return mediaSourceFactory;
-    }
+  @Override
+  MediaSource.Factory getMediaSourceFactory(Context context) {
+    return mediaSourceFactory;
+  }
 
-    @Override
-    MediaSource.Factory getMediaSourceFactory(Context context, DefaultHttpDataSource.Factory initialFactory) {
-        return getMediaSourceFactory(context);
-    }
+  @Override
+  MediaSource.Factory getMediaSourceFactory(
+      Context context, DefaultHttpDataSource.Factory initialFactory) {
+    return getMediaSourceFactory(context);
+  }
 }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/FakeVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/FakeVideoAsset.java
@@ -1,0 +1,55 @@
+package io.flutter.plugins.videoplayer;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.media3.common.AdPlaybackState;
+import androidx.media3.common.Format;
+import androidx.media3.common.MediaItem;
+import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider;
+import androidx.media3.exoplayer.source.MediaSource;
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy;
+import androidx.media3.test.utils.FakeMediaSource;
+import androidx.media3.test.utils.FakeMediaSourceFactory;
+import androidx.media3.test.utils.FakeTimeline;
+import androidx.media3.test.utils.FakeTrackOutput;
+
+import com.google.common.collect.Lists;
+
+import java.time.Duration;
+import java.util.Collections;
+
+/**
+ * A fake implementation of the {@link VideoAsset} class.
+ */
+final class FakeVideoAsset extends VideoAsset {
+    @NonNull
+    private final MediaSource.Factory mediaSourceFactory;
+
+    FakeVideoAsset(String assetUrl) {
+        this(assetUrl, new FakeMediaSourceFactory());
+    }
+
+    FakeVideoAsset(String assetUrl, @NonNull MediaSource.Factory mediaSourceFactory) {
+        super(assetUrl);
+        this.mediaSourceFactory = mediaSourceFactory;
+    }
+
+    @NonNull
+    @Override
+    MediaItem getMediaItem() {
+        return new MediaItem.Builder().setUri(assetUrl).build();
+    }
+
+    @Override
+    MediaSource.Factory getMediaSourceFactory(Context context) {
+        return mediaSourceFactory;
+    }
+
+    @Override
+    MediaSource.Factory getMediaSourceFactory(Context context, DefaultHttpDataSource.Factory initialFactory) {
+        return getMediaSourceFactory(context);
+    }
+}

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoAssetTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoAssetTest.java
@@ -1,0 +1,115 @@
+package io.flutter.plugins.videoplayer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.net.Uri;
+
+import androidx.media3.common.MediaItem;
+import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link VideoAsset}.
+ *
+ * <p>This test suite <em>narrowly verifies</em> that the {@link VideoAsset} factory methods,
+ * {@link VideoAsset#fromRemoteUrl(String, VideoAsset.StreamingFormat, Map)} and
+ * {@link VideoAsset#fromAssetUrl(String)} follow the contract they have documented.
+ *
+ * <p>In other tests of the player, a fake asset is likely to be used.
+ */
+@RunWith(RobolectricTestRunner.class)
+public final class VideoAssetTest {
+    @Test
+    public void localVideoRequiresAssetUrl() {
+        assertThrows(IllegalArgumentException.class, () -> VideoAsset.fromAssetUrl("https://not.local/video.mp4"));
+    }
+
+    @Test
+    public void localVideoCreatesMediaItem() {
+        VideoAsset asset = VideoAsset.fromAssetUrl("asset:///asset-key");
+        MediaItem mediaItem = asset.getMediaItem();
+
+        assert mediaItem.localConfiguration != null;
+        assertEquals(mediaItem.localConfiguration.uri, Uri.parse("asset:///asset-key"));
+    }
+
+    private static DefaultHttpDataSource.Factory mockHttpFactory() {
+        DefaultHttpDataSource.Factory httpFactory = mock(DefaultHttpDataSource.Factory.class);
+        when(httpFactory.setUserAgent(anyString())).thenReturn(httpFactory);
+        when(httpFactory.setAllowCrossProtocolRedirects(anyBoolean())).thenReturn(httpFactory);
+        when(httpFactory.setDefaultRequestProperties(anyMap())).thenReturn(httpFactory);
+        return httpFactory;
+    }
+
+    @Test
+    public void remoteVideoByDefaultSetsUserAgentAndCrossProtocolRedirects() throws Exception {
+        VideoAsset asset = VideoAsset.fromRemoteUrl(
+                "https://flutter.dev/video.mp4",
+                VideoAsset.StreamingFormat.Unknown,
+                new HashMap<>());
+
+        DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
+        asset.getMediaSourceFactory(
+                ApplicationProvider.getApplicationContext(),
+                mockFactory);
+
+        verify(mockFactory).setUserAgent("ExoPlayer");
+        verify(mockFactory).setAllowCrossProtocolRedirects(true);
+        verify(mockFactory, never()).setDefaultRequestProperties(anyMap());
+    }
+
+    @Test
+    public void remoteVideoOverridesUserAgentIfProvided() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("User-Agent", "FantasticalVideoBot");
+
+        VideoAsset asset = VideoAsset.fromRemoteUrl(
+                "https://flutter.dev/video.mp4",
+                VideoAsset.StreamingFormat.Unknown,
+                headers);
+
+        DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
+        asset.getMediaSourceFactory(
+                ApplicationProvider.getApplicationContext(),
+                mockFactory);
+
+        verify(mockFactory).setUserAgent("FantasticalVideoBot");
+        verify(mockFactory).setAllowCrossProtocolRedirects(true);
+        verify(mockFactory).setDefaultRequestProperties(headers);
+    }
+
+    @Test
+    public void remoteVideoSetsAdditionalHttpHeadersIfProvided() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Cache-Forever", "true");
+
+        VideoAsset asset = VideoAsset.fromRemoteUrl(
+                "https://flutter.dev/video.mp4",
+                VideoAsset.StreamingFormat.Unknown,
+                headers);
+
+        DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
+        asset.getMediaSourceFactory(
+                ApplicationProvider.getApplicationContext(),
+                mockFactory);
+
+        verify(mockFactory).setUserAgent("ExoPlayer");
+        verify(mockFactory).setAllowCrossProtocolRedirects(true);
+        verify(mockFactory).setDefaultRequestProperties(headers);
+    }
+}

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoAssetTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoAssetTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.videoplayer;
 
 import static org.junit.Assert.assertEquals;
@@ -56,9 +60,9 @@ public final class VideoAssetTest {
   }
 
   @Test
-  public void remoteVideoByDefaultSetsUserAgentAndCrossProtocolRedirects() throws Exception {
-    VideoAsset asset =
-        VideoAsset.fromRemoteUrl(
+  public void remoteVideoByDefaultSetsUserAgentAndCrossProtocolRedirects() {
+    RemoteVideoAsset asset =
+        new RemoteVideoAsset(
             "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.Unknown, new HashMap<>());
 
     DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
@@ -70,12 +74,12 @@ public final class VideoAssetTest {
   }
 
   @Test
-  public void remoteVideoOverridesUserAgentIfProvided() throws Exception {
+  public void remoteVideoOverridesUserAgentIfProvided() {
     Map<String, String> headers = new HashMap<>();
     headers.put("User-Agent", "FantasticalVideoBot");
 
-    VideoAsset asset =
-        VideoAsset.fromRemoteUrl(
+    RemoteVideoAsset asset =
+        new RemoteVideoAsset(
             "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.Unknown, headers);
 
     DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
@@ -87,12 +91,12 @@ public final class VideoAssetTest {
   }
 
   @Test
-  public void remoteVideoSetsAdditionalHttpHeadersIfProvided() throws Exception {
+  public void remoteVideoSetsAdditionalHttpHeadersIfProvided() {
     Map<String, String> headers = new HashMap<>();
     headers.put("X-Cache-Forever", "true");
 
-    VideoAsset asset =
-        VideoAsset.fromRemoteUrl(
+    RemoteVideoAsset asset =
+        new RemoteVideoAsset(
             "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.Unknown, headers);
 
     DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoAssetTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoAssetTest.java
@@ -11,105 +11,95 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.net.Uri;
-
 import androidx.media3.common.MediaItem;
 import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.test.core.app.ApplicationProvider;
-
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Unit tests for {@link VideoAsset}.
  *
- * <p>This test suite <em>narrowly verifies</em> that the {@link VideoAsset} factory methods,
- * {@link VideoAsset#fromRemoteUrl(String, VideoAsset.StreamingFormat, Map)} and
- * {@link VideoAsset#fromAssetUrl(String)} follow the contract they have documented.
+ * <p>This test suite <em>narrowly verifies</em> that the {@link VideoAsset} factory methods, {@link
+ * VideoAsset#fromRemoteUrl(String, VideoAsset.StreamingFormat, Map)} and {@link
+ * VideoAsset#fromAssetUrl(String)} follow the contract they have documented.
  *
  * <p>In other tests of the player, a fake asset is likely to be used.
  */
 @RunWith(RobolectricTestRunner.class)
 public final class VideoAssetTest {
-    @Test
-    public void localVideoRequiresAssetUrl() {
-        assertThrows(IllegalArgumentException.class, () -> VideoAsset.fromAssetUrl("https://not.local/video.mp4"));
-    }
+  @Test
+  public void localVideoRequiresAssetUrl() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> VideoAsset.fromAssetUrl("https://not.local/video.mp4"));
+  }
 
-    @Test
-    public void localVideoCreatesMediaItem() {
-        VideoAsset asset = VideoAsset.fromAssetUrl("asset:///asset-key");
-        MediaItem mediaItem = asset.getMediaItem();
+  @Test
+  public void localVideoCreatesMediaItem() {
+    VideoAsset asset = VideoAsset.fromAssetUrl("asset:///asset-key");
+    MediaItem mediaItem = asset.getMediaItem();
 
-        assert mediaItem.localConfiguration != null;
-        assertEquals(mediaItem.localConfiguration.uri, Uri.parse("asset:///asset-key"));
-    }
+    assert mediaItem.localConfiguration != null;
+    assertEquals(mediaItem.localConfiguration.uri, Uri.parse("asset:///asset-key"));
+  }
 
-    private static DefaultHttpDataSource.Factory mockHttpFactory() {
-        DefaultHttpDataSource.Factory httpFactory = mock(DefaultHttpDataSource.Factory.class);
-        when(httpFactory.setUserAgent(anyString())).thenReturn(httpFactory);
-        when(httpFactory.setAllowCrossProtocolRedirects(anyBoolean())).thenReturn(httpFactory);
-        when(httpFactory.setDefaultRequestProperties(anyMap())).thenReturn(httpFactory);
-        return httpFactory;
-    }
+  private static DefaultHttpDataSource.Factory mockHttpFactory() {
+    DefaultHttpDataSource.Factory httpFactory = mock(DefaultHttpDataSource.Factory.class);
+    when(httpFactory.setUserAgent(anyString())).thenReturn(httpFactory);
+    when(httpFactory.setAllowCrossProtocolRedirects(anyBoolean())).thenReturn(httpFactory);
+    when(httpFactory.setDefaultRequestProperties(anyMap())).thenReturn(httpFactory);
+    return httpFactory;
+  }
 
-    @Test
-    public void remoteVideoByDefaultSetsUserAgentAndCrossProtocolRedirects() throws Exception {
-        VideoAsset asset = VideoAsset.fromRemoteUrl(
-                "https://flutter.dev/video.mp4",
-                VideoAsset.StreamingFormat.Unknown,
-                new HashMap<>());
+  @Test
+  public void remoteVideoByDefaultSetsUserAgentAndCrossProtocolRedirects() throws Exception {
+    VideoAsset asset =
+        VideoAsset.fromRemoteUrl(
+            "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.Unknown, new HashMap<>());
 
-        DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
-        asset.getMediaSourceFactory(
-                ApplicationProvider.getApplicationContext(),
-                mockFactory);
+    DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
+    asset.getMediaSourceFactory(ApplicationProvider.getApplicationContext(), mockFactory);
 
-        verify(mockFactory).setUserAgent("ExoPlayer");
-        verify(mockFactory).setAllowCrossProtocolRedirects(true);
-        verify(mockFactory, never()).setDefaultRequestProperties(anyMap());
-    }
+    verify(mockFactory).setUserAgent("ExoPlayer");
+    verify(mockFactory).setAllowCrossProtocolRedirects(true);
+    verify(mockFactory, never()).setDefaultRequestProperties(anyMap());
+  }
 
-    @Test
-    public void remoteVideoOverridesUserAgentIfProvided() throws Exception {
-        Map<String, String> headers = new HashMap<>();
-        headers.put("User-Agent", "FantasticalVideoBot");
+  @Test
+  public void remoteVideoOverridesUserAgentIfProvided() throws Exception {
+    Map<String, String> headers = new HashMap<>();
+    headers.put("User-Agent", "FantasticalVideoBot");
 
-        VideoAsset asset = VideoAsset.fromRemoteUrl(
-                "https://flutter.dev/video.mp4",
-                VideoAsset.StreamingFormat.Unknown,
-                headers);
+    VideoAsset asset =
+        VideoAsset.fromRemoteUrl(
+            "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.Unknown, headers);
 
-        DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
-        asset.getMediaSourceFactory(
-                ApplicationProvider.getApplicationContext(),
-                mockFactory);
+    DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
+    asset.getMediaSourceFactory(ApplicationProvider.getApplicationContext(), mockFactory);
 
-        verify(mockFactory).setUserAgent("FantasticalVideoBot");
-        verify(mockFactory).setAllowCrossProtocolRedirects(true);
-        verify(mockFactory).setDefaultRequestProperties(headers);
-    }
+    verify(mockFactory).setUserAgent("FantasticalVideoBot");
+    verify(mockFactory).setAllowCrossProtocolRedirects(true);
+    verify(mockFactory).setDefaultRequestProperties(headers);
+  }
 
-    @Test
-    public void remoteVideoSetsAdditionalHttpHeadersIfProvided() throws Exception {
-        Map<String, String> headers = new HashMap<>();
-        headers.put("X-Cache-Forever", "true");
+  @Test
+  public void remoteVideoSetsAdditionalHttpHeadersIfProvided() throws Exception {
+    Map<String, String> headers = new HashMap<>();
+    headers.put("X-Cache-Forever", "true");
 
-        VideoAsset asset = VideoAsset.fromRemoteUrl(
-                "https://flutter.dev/video.mp4",
-                VideoAsset.StreamingFormat.Unknown,
-                headers);
+    VideoAsset asset =
+        VideoAsset.fromRemoteUrl(
+            "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.Unknown, headers);
 
-        DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
-        asset.getMediaSourceFactory(
-                ApplicationProvider.getApplicationContext(),
-                mockFactory);
+    DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
+    asset.getMediaSourceFactory(ApplicationProvider.getApplicationContext(), mockFactory);
 
-        verify(mockFactory).setUserAgent("ExoPlayer");
-        verify(mockFactory).setAllowCrossProtocolRedirects(true);
-        verify(mockFactory).setDefaultRequestProperties(headers);
-    }
+    verify(mockFactory).setUserAgent("ExoPlayer");
+    verify(mockFactory).setAllowCrossProtocolRedirects(true);
+    verify(mockFactory).setDefaultRequestProperties(headers);
+  }
 }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacksTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacksTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.videoplayer;
 
 import static org.junit.Assert.assertEquals;

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacksTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacksTest.java
@@ -1,0 +1,151 @@
+package io.flutter.plugins.videoplayer;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests {@link VideoPlayerEventCallbacks}.
+ *
+ * <p>This test suite <em>narrowly verifies</em> that calling the provided event callbacks, such as
+ * {@link VideoPlayerEventCallbacks#onBufferingUpdate(long)}, produces the expected data as an
+ * encoded {@link Map}.
+ *
+ * <p>In other words, this tests that "the Java-side of the event channel works as expected".
+ */
+@RunWith(RobolectricTestRunner.class)
+public final class VideoPlayerEventCallbacksTest {
+    private VideoPlayerEventCallbacks eventCallbacks;
+
+    @Mock
+    private QueuingEventSink mockEventSink;
+
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> eventCaptor;
+
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp() {
+        eventCallbacks = VideoPlayerEventCallbacks.withSink(mockEventSink);
+    }
+
+    @Test
+    public void onInitializedSendsWidthHeightAndDuration() {
+        eventCallbacks.onInitialized(800, 400, 10L, 0);
+
+        verify(mockEventSink).success(eventCaptor.capture());
+
+        Map<String, Object> actual = eventCaptor.getValue();
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("event", "initialized");
+        expected.put("duration", 10L);
+        expected.put("width", 800);
+        expected.put("height", 400);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void onInitializedIncludesRotationCorrectIfNonZero() {
+        eventCallbacks.onInitialized(800, 400, 10L, 180);
+
+        verify(mockEventSink).success(eventCaptor.capture());
+
+        Map<String, Object> actual = eventCaptor.getValue();
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("event", "initialized");
+        expected.put("duration", 10L);
+        expected.put("width", 800);
+        expected.put("height", 400);
+        expected.put("rotationCorrection", 180);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void onBufferingStart() {
+        eventCallbacks.onBufferingStart();
+
+        verify(mockEventSink).success(eventCaptor.capture());
+
+        Map<String, Object> actual = eventCaptor.getValue();
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("event", "bufferingStart");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void onBufferingUpdateProvidesAListWithASingleRange() {
+        eventCallbacks.onBufferingUpdate(10L);
+
+        verify(mockEventSink).success(eventCaptor.capture());
+
+        Map<String, Object> actual = eventCaptor.getValue();
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("event", "bufferingUpdate");
+        expected.put("values", Collections.singletonList(Arrays.asList(0, 10L)));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void onBufferingEnd() {
+        eventCallbacks.onBufferingEnd();
+
+        verify(mockEventSink).success(eventCaptor.capture());
+
+        Map<String, Object> actual = eventCaptor.getValue();
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("event", "bufferingEnd");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void onCompleted() {
+        eventCallbacks.onCompleted();
+
+        verify(mockEventSink).success(eventCaptor.capture());
+
+        Map<String, Object> actual = eventCaptor.getValue();
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("event", "completed");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void onError() {
+        eventCallbacks.onError("code", "message", "details");
+
+        verify(mockEventSink).error(eq("code"), eq("message"), eq("details"));
+    }
+
+    @Test
+    public void onIsPlayingStateUpdate() {
+        eventCallbacks.onIsPlayingStateUpdate(true);
+
+        verify(mockEventSink).success(eventCaptor.capture());
+
+        Map<String, Object> actual = eventCaptor.getValue();
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("event", "isPlayingStateUpdate");
+        expected.put("isPlaying", true);
+        assertEquals(expected, actual);
+    }
+}

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacksTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacksTest.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,11 +18,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Unit tests {@link VideoPlayerEventCallbacks}.
@@ -31,121 +30,118 @@ import java.util.Map;
  */
 @RunWith(RobolectricTestRunner.class)
 public final class VideoPlayerEventCallbacksTest {
-    private VideoPlayerEventCallbacks eventCallbacks;
+  private VideoPlayerEventCallbacks eventCallbacks;
 
-    @Mock
-    private QueuingEventSink mockEventSink;
+  @Mock private QueuingEventSink mockEventSink;
 
-    @Captor
-    private ArgumentCaptor<Map<String, Object>> eventCaptor;
+  @Captor private ArgumentCaptor<Map<String, Object>> eventCaptor;
 
-    @Rule
-    public MockitoRule initRule = MockitoJUnit.rule();
+  @Rule public MockitoRule initRule = MockitoJUnit.rule();
 
-    @Before
-    public void setUp() {
-        eventCallbacks = VideoPlayerEventCallbacks.withSink(mockEventSink);
-    }
+  @Before
+  public void setUp() {
+    eventCallbacks = VideoPlayerEventCallbacks.withSink(mockEventSink);
+  }
 
-    @Test
-    public void onInitializedSendsWidthHeightAndDuration() {
-        eventCallbacks.onInitialized(800, 400, 10L, 0);
+  @Test
+  public void onInitializedSendsWidthHeightAndDuration() {
+    eventCallbacks.onInitialized(800, 400, 10L, 0);
 
-        verify(mockEventSink).success(eventCaptor.capture());
+    verify(mockEventSink).success(eventCaptor.capture());
 
-        Map<String, Object> actual = eventCaptor.getValue();
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("event", "initialized");
-        expected.put("duration", 10L);
-        expected.put("width", 800);
-        expected.put("height", 400);
+    Map<String, Object> actual = eventCaptor.getValue();
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("event", "initialized");
+    expected.put("duration", 10L);
+    expected.put("width", 800);
+    expected.put("height", 400);
 
-        assertEquals(expected, actual);
-    }
+    assertEquals(expected, actual);
+  }
 
-    @Test
-    public void onInitializedIncludesRotationCorrectIfNonZero() {
-        eventCallbacks.onInitialized(800, 400, 10L, 180);
+  @Test
+  public void onInitializedIncludesRotationCorrectIfNonZero() {
+    eventCallbacks.onInitialized(800, 400, 10L, 180);
 
-        verify(mockEventSink).success(eventCaptor.capture());
+    verify(mockEventSink).success(eventCaptor.capture());
 
-        Map<String, Object> actual = eventCaptor.getValue();
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("event", "initialized");
-        expected.put("duration", 10L);
-        expected.put("width", 800);
-        expected.put("height", 400);
-        expected.put("rotationCorrection", 180);
+    Map<String, Object> actual = eventCaptor.getValue();
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("event", "initialized");
+    expected.put("duration", 10L);
+    expected.put("width", 800);
+    expected.put("height", 400);
+    expected.put("rotationCorrection", 180);
 
-        assertEquals(expected, actual);
-    }
+    assertEquals(expected, actual);
+  }
 
-    @Test
-    public void onBufferingStart() {
-        eventCallbacks.onBufferingStart();
+  @Test
+  public void onBufferingStart() {
+    eventCallbacks.onBufferingStart();
 
-        verify(mockEventSink).success(eventCaptor.capture());
+    verify(mockEventSink).success(eventCaptor.capture());
 
-        Map<String, Object> actual = eventCaptor.getValue();
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("event", "bufferingStart");
-        assertEquals(expected, actual);
-    }
+    Map<String, Object> actual = eventCaptor.getValue();
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("event", "bufferingStart");
+    assertEquals(expected, actual);
+  }
 
-    @Test
-    public void onBufferingUpdateProvidesAListWithASingleRange() {
-        eventCallbacks.onBufferingUpdate(10L);
+  @Test
+  public void onBufferingUpdateProvidesAListWithASingleRange() {
+    eventCallbacks.onBufferingUpdate(10L);
 
-        verify(mockEventSink).success(eventCaptor.capture());
+    verify(mockEventSink).success(eventCaptor.capture());
 
-        Map<String, Object> actual = eventCaptor.getValue();
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("event", "bufferingUpdate");
-        expected.put("values", Collections.singletonList(Arrays.asList(0, 10L)));
-        assertEquals(expected, actual);
-    }
+    Map<String, Object> actual = eventCaptor.getValue();
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("event", "bufferingUpdate");
+    expected.put("values", Collections.singletonList(Arrays.asList(0, 10L)));
+    assertEquals(expected, actual);
+  }
 
-    @Test
-    public void onBufferingEnd() {
-        eventCallbacks.onBufferingEnd();
+  @Test
+  public void onBufferingEnd() {
+    eventCallbacks.onBufferingEnd();
 
-        verify(mockEventSink).success(eventCaptor.capture());
+    verify(mockEventSink).success(eventCaptor.capture());
 
-        Map<String, Object> actual = eventCaptor.getValue();
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("event", "bufferingEnd");
-        assertEquals(expected, actual);
-    }
+    Map<String, Object> actual = eventCaptor.getValue();
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("event", "bufferingEnd");
+    assertEquals(expected, actual);
+  }
 
-    @Test
-    public void onCompleted() {
-        eventCallbacks.onCompleted();
+  @Test
+  public void onCompleted() {
+    eventCallbacks.onCompleted();
 
-        verify(mockEventSink).success(eventCaptor.capture());
+    verify(mockEventSink).success(eventCaptor.capture());
 
-        Map<String, Object> actual = eventCaptor.getValue();
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("event", "completed");
-        assertEquals(expected, actual);
-    }
+    Map<String, Object> actual = eventCaptor.getValue();
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("event", "completed");
+    assertEquals(expected, actual);
+  }
 
-    @Test
-    public void onError() {
-        eventCallbacks.onError("code", "message", "details");
+  @Test
+  public void onError() {
+    eventCallbacks.onError("code", "message", "details");
 
-        verify(mockEventSink).error(eq("code"), eq("message"), eq("details"));
-    }
+    verify(mockEventSink).error(eq("code"), eq("message"), eq("details"));
+  }
 
-    @Test
-    public void onIsPlayingStateUpdate() {
-        eventCallbacks.onIsPlayingStateUpdate(true);
+  @Test
+  public void onIsPlayingStateUpdate() {
+    eventCallbacks.onIsPlayingStateUpdate(true);
 
-        verify(mockEventSink).success(eventCaptor.capture());
+    verify(mockEventSink).success(eventCaptor.capture());
 
-        Map<String, Object> actual = eventCaptor.getValue();
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("event", "isPlayingStateUpdate");
-        expected.put("isPlaying", true);
-        assertEquals(expected, actual);
-    }
+    Map<String, Object> actual = eventCaptor.getValue();
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("event", "isPlayingStateUpdate");
+    expected.put("isPlaying", true);
+    assertEquals(expected, actual);
+  }
 }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -173,7 +173,6 @@ public final class VideoPlayerTest {
   public void disposeReleasesTextureAndPlayer() {
     VideoPlayer videoPlayer = createVideoPlayer();
     videoPlayer.dispose();
-    ;
 
     verify(mockTexture).release();
     verify(mockExoPlayer).release();

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -5,355 +5,184 @@
 package io.flutter.plugins.videoplayer;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 
 import android.graphics.SurfaceTexture;
-import androidx.media3.common.PlaybackException;
+
+import androidx.media3.common.AudioAttributes;
+import androidx.media3.common.C;
+import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.Player;
-import androidx.media3.common.VideoSize;
-import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.ExoPlayer;
+
 import io.flutter.view.TextureRegistry;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import org.junit.After;
+
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.MockitoAnnotations;
-import org.mockito.stubbing.Answer;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 
+/**
+ * Unit tests for {@link VideoPlayer}.
+ *
+ * <p>This test suite <em>narrowly verifies</em> that {@link VideoPlayer} interfaces with the
+ * {@link ExoPlayer} interface <em>exactly</em> as it did when the test suite was created. That is,
+ * if the behavior changes, this test will need to change. However, this suite should catch bugs
+ * related to <em>"this is a safe refactor with no behavior changes"</em>.
+ *
+ * <p>It's hypothetically possible to write better tests using
+ * {@link androidx.media3.test.utils.FakeMediaSource}, but you really need a PhD in the Android
+ * media APIs in order to figure out how to set everything up so the player "works".
+ */
 @RunWith(RobolectricTestRunner.class)
-public class VideoPlayerTest {
-  private ExoPlayer fakeExoPlayer;
-  private TextureRegistry.SurfaceTextureEntry fakeSurfaceTextureEntry;
-  private VideoPlayerOptions fakeVideoPlayerOptions;
-  private QueuingEventSink fakeEventSink;
-  private DefaultHttpDataSource.Factory httpDataSourceFactorySpy;
+public final class VideoPlayerTest {
+    private static final String FAKE_ASSET_URL = "https://flutter.dev/movie.mp4";
+    private FakeVideoAsset fakeVideoAsset;
 
-  @Captor private ArgumentCaptor<HashMap<String, Object>> eventCaptor;
+    @Mock
+    private VideoPlayerCallbacks mockEvents;
+    @Mock
+    private TextureRegistry.SurfaceTextureEntry mockTexture;
+    @Mock
+    private ExoPlayer.Builder mockBuilder;
+    @Mock
+    private ExoPlayer mockExoPlayer;
+    @Captor
+    private ArgumentCaptor<AudioAttributes> attributesCaptor;
 
-  private AutoCloseable mocks;
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
 
-  @Before
-  public void before() {
-    mocks = MockitoAnnotations.openMocks(this);
-
-    fakeExoPlayer = mock(ExoPlayer.class);
-    fakeSurfaceTextureEntry = mock(TextureRegistry.SurfaceTextureEntry.class);
-    SurfaceTexture fakeSurfaceTexture = mock(SurfaceTexture.class);
-    when(fakeSurfaceTextureEntry.surfaceTexture()).thenReturn(fakeSurfaceTexture);
-    fakeVideoPlayerOptions = mock(VideoPlayerOptions.class);
-    fakeEventSink = mock(QueuingEventSink.class);
-    httpDataSourceFactorySpy = spy(new DefaultHttpDataSource.Factory());
-  }
-
-  @After
-  public void after() throws Exception {
-    mocks.close();
-  }
-
-  @Test
-  public void videoPlayer_buildsHttpDataSourceFactoryProperlyWhenHttpHeadersNull() {
-    VideoPlayer videoPlayer =
-        new VideoPlayer(
-            fakeExoPlayer,
-            VideoPlayerEventCallbacks.withSink(fakeEventSink),
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            httpDataSourceFactorySpy);
-
-    videoPlayer.configureHttpDataSourceFactory(new HashMap<>());
-
-    verify(httpDataSourceFactorySpy).setUserAgent("ExoPlayer");
-    verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
-    verify(httpDataSourceFactorySpy, never()).setDefaultRequestProperties(any());
-  }
-
-  @Test
-  public void
-      videoPlayer_buildsHttpDataSourceFactoryProperlyWhenHttpHeadersNonNullAndUserAgentSpecified() {
-    VideoPlayer videoPlayer =
-        new VideoPlayer(
-            fakeExoPlayer,
-            VideoPlayerEventCallbacks.withSink(fakeEventSink),
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            httpDataSourceFactorySpy);
-    Map<String, String> httpHeaders =
-        new HashMap<String, String>() {
-          {
-            put("header", "value");
-            put("User-Agent", "userAgent");
-          }
-        };
-
-    videoPlayer.configureHttpDataSourceFactory(httpHeaders);
-
-    verify(httpDataSourceFactorySpy).setUserAgent("userAgent");
-    verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
-    verify(httpDataSourceFactorySpy).setDefaultRequestProperties(httpHeaders);
-  }
-
-  @Test
-  public void
-      videoPlayer_buildsHttpDataSourceFactoryProperlyWhenHttpHeadersNonNullAndUserAgentNotSpecified() {
-    VideoPlayer videoPlayer =
-        new VideoPlayer(
-            fakeExoPlayer,
-            VideoPlayerEventCallbacks.withSink(fakeEventSink),
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            httpDataSourceFactorySpy);
-    Map<String, String> httpHeaders =
-        new HashMap<String, String>() {
-          {
-            put("header", "value");
-          }
-        };
-
-    videoPlayer.configureHttpDataSourceFactory(httpHeaders);
-
-    verify(httpDataSourceFactorySpy).setUserAgent("ExoPlayer");
-    verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
-    verify(httpDataSourceFactorySpy).setDefaultRequestProperties(httpHeaders);
-  }
-
-  private Player.Listener initVideoPlayerAndGetListener() {
-    ArgumentCaptor<Player.Listener> listenerCaptor = ArgumentCaptor.forClass(Player.Listener.class);
-    doNothing().when(fakeExoPlayer).addListener(listenerCaptor.capture());
-
-    // Create a video player that will invoke fakeEventSink as a result of Player.Listener calls.
-    new VideoPlayer(
-        fakeExoPlayer,
-        VideoPlayerEventCallbacks.withSink(fakeEventSink),
-        fakeSurfaceTextureEntry,
-        fakeVideoPlayerOptions,
-        httpDataSourceFactorySpy);
-
-    return Objects.requireNonNull(listenerCaptor.getValue());
-  }
-
-  @Test
-  public void onPlaybackStateBufferingSendBufferedPositionUpdate() {
-    Player.Listener listener = initVideoPlayerAndGetListener();
-    when(fakeExoPlayer.getBufferedPosition()).thenReturn(10L);
-
-    // Send Player.STATE_BUFFERING to trigger the "bufferingUpdate" event.
-    listener.onPlaybackStateChanged(Player.STATE_BUFFERING);
-
-    verify(fakeEventSink, atLeast(1)).success(eventCaptor.capture());
-    List<HashMap<String, Object>> events = eventCaptor.getAllValues();
-
-    Map<String, Object> expected = new HashMap<>();
-    expected.put("event", "bufferingUpdate");
-
-    List<? extends Number> range = Arrays.asList(0, 10L);
-    expected.put("values", Collections.singletonList(range));
-
-    // We received potentially multiple events, find the one that is a "bufferingUpdate".
-    for (Map<String, Object> event : events) {
-      if (event.get("event") == "bufferingUpdate") {
-        assertEquals(expected, event);
-        return;
-      }
+    @Before
+    public void setUp() {
+      fakeVideoAsset = new FakeVideoAsset(FAKE_ASSET_URL);
+      when(mockBuilder.build()).thenReturn(mockExoPlayer);
+      when(mockTexture.surfaceTexture()).thenReturn(mock(SurfaceTexture.class));
     }
 
-    fail("No 'bufferingUpdate' event found: " + events);
-  }
+    private VideoPlayer createVideoPlayer() {
+        return createVideoPlayer(new VideoPlayerOptions());
+    }
 
-  @Test
-  public void sendInitializedSendsExpectedEvent_90RotationDegrees() {
-    Player.Listener listener = initVideoPlayerAndGetListener();
-    VideoSize testVideoSize = new VideoSize(100, 200, 90, 1f);
+    private VideoPlayer createVideoPlayer(VideoPlayerOptions options) {
+        return new VideoPlayer(mockBuilder, mockEvents, mockTexture, fakeVideoAsset.getMediaItem(), options);
+    }
 
-    when(fakeExoPlayer.getVideoSize()).thenReturn(testVideoSize);
-    when(fakeExoPlayer.getDuration()).thenReturn(10L);
+    @Test
+    public void loadsAndPreparesProvidedMediaEnablesAudioFocusByDefault() {
+        VideoPlayer videoPlayer = createVideoPlayer();
 
-    // Send Player.STATE_READY to trigger the "initialized" event.
-    listener.onPlaybackStateChanged(Player.STATE_READY);
+        verify(mockExoPlayer).setMediaItem(fakeVideoAsset.getMediaItem());
+        verify(mockExoPlayer).prepare();
+        verify(mockTexture).surfaceTexture();
+        verify(mockExoPlayer).setVideoSurface(any());
 
-    verify(fakeEventSink).success(eventCaptor.capture());
-    HashMap<String, Object> actual = eventCaptor.getValue();
+        verify(mockExoPlayer).setAudioAttributes(attributesCaptor.capture(), eq(true));
+        assertEquals(attributesCaptor.getValue().contentType, C.AUDIO_CONTENT_TYPE_MOVIE);
 
-    Map<String, Object> expected = new HashMap<>();
-    expected.put("event", "initialized");
-    expected.put("duration", 10L);
-    expected.put("width", 200);
-    expected.put("height", 100);
+        videoPlayer.dispose();
+    }
 
-    assertEquals(expected, actual);
-  }
+    @Test
+    public void loadsAndPreparesProvidedMediaDisablesAudioFocusWhenMixModeSet() {
+        VideoPlayerOptions options = new VideoPlayerOptions();
+        options.mixWithOthers = true;
 
-  @Test
-  public void sendInitializedSendsExpectedEvent_270RotationDegrees() {
-    Player.Listener listener = initVideoPlayerAndGetListener();
-    VideoSize testVideoSize = new VideoSize(100, 200, 270, 1f);
+        VideoPlayer videoPlayer = createVideoPlayer(options);
 
-    when(fakeExoPlayer.getVideoSize()).thenReturn(testVideoSize);
-    when(fakeExoPlayer.getDuration()).thenReturn(10L);
+        verify(mockExoPlayer).setAudioAttributes(attributesCaptor.capture(), eq(false));
+        assertEquals(attributesCaptor.getValue().contentType, C.AUDIO_CONTENT_TYPE_MOVIE);
 
-    // Send Player.STATE_READY to trigger the "initialized" event.
-    listener.onPlaybackStateChanged(Player.STATE_READY);
+        videoPlayer.dispose();
+    }
 
-    verify(fakeEventSink).success(eventCaptor.capture());
-    HashMap<String, Object> actual = eventCaptor.getValue();
+    @Test
+    public void playsAndPausesProvidedMedia() {
+        VideoPlayer videoPlayer = createVideoPlayer();
 
-    Map<String, Object> expected = new HashMap<>();
-    expected.put("event", "initialized");
-    expected.put("duration", 10L);
-    expected.put("width", 200);
-    expected.put("height", 100);
+        videoPlayer.play();
+        verify(mockExoPlayer).setPlayWhenReady(true);
 
-    assertEquals(expected, actual);
-  }
+        videoPlayer.pause();
+        verify(mockExoPlayer).setPlayWhenReady(false);
 
-  @Test
-  public void sendInitializedSendsExpectedEvent_0RotationDegrees() {
-    Player.Listener listener = initVideoPlayerAndGetListener();
-    VideoSize testVideoSize = new VideoSize(100, 200, 0, 1f);
+        videoPlayer.dispose();
+    }
 
-    when(fakeExoPlayer.getVideoSize()).thenReturn(testVideoSize);
-    when(fakeExoPlayer.getDuration()).thenReturn(10L);
+    @Test
+    public void sendsBufferingUpdatesOnDemand() {
+        VideoPlayer videoPlayer = createVideoPlayer();
 
-    // Send Player.STATE_READY to trigger the "initialized" event.
-    listener.onPlaybackStateChanged(Player.STATE_READY);
+        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+        videoPlayer.sendBufferingUpdate();
+        verify(mockEvents).onBufferingUpdate(10L);
 
-    verify(fakeEventSink).success(eventCaptor.capture());
-    HashMap<String, Object> actual = eventCaptor.getValue();
+        videoPlayer.dispose();
+    }
 
-    Map<String, Object> expected = new HashMap<>();
-    expected.put("event", "initialized");
-    expected.put("duration", 10L);
-    expected.put("width", 100);
-    expected.put("height", 200);
+    @Test
+    public void togglesLoopingEnablesAndDisablesRepeatMode() {
+        VideoPlayer videoPlayer = createVideoPlayer();
 
-    assertEquals(expected, actual);
-  }
+        videoPlayer.setLooping(true);
+        verify(mockExoPlayer).setRepeatMode(Player.REPEAT_MODE_ALL);
 
-  @Test
-  public void sendInitializedSendsExpectedEvent_180RotationDegrees() {
-    Player.Listener listener = initVideoPlayerAndGetListener();
-    VideoSize testVideoSize = new VideoSize(100, 200, 180, 1f);
+        videoPlayer.setLooping(false);
+        verify(mockExoPlayer).setRepeatMode(Player.REPEAT_MODE_OFF);
 
-    when(fakeExoPlayer.getVideoSize()).thenReturn(testVideoSize);
-    when(fakeExoPlayer.getDuration()).thenReturn(10L);
+        videoPlayer.dispose();
+    }
 
-    // Send Player.STATE_READY to trigger the "initialized" event.
-    listener.onPlaybackStateChanged(Player.STATE_READY);
+    @Test
+    public void setVolumeIsClampedBetween0and1() {
+        VideoPlayer videoPlayer = createVideoPlayer();
 
-    verify(fakeEventSink).success(eventCaptor.capture());
-    HashMap<String, Object> actual = eventCaptor.getValue();
+        videoPlayer.setVolume(-1.0);
+        verify(mockExoPlayer).setVolume(0f);
 
-    Map<String, Object> expected = new HashMap<>();
-    expected.put("event", "initialized");
-    expected.put("duration", 10L);
-    expected.put("width", 100);
-    expected.put("height", 200);
-    expected.put("rotationCorrection", 180);
+        videoPlayer.setVolume(2.0);
+        verify(mockExoPlayer).setVolume(1f);
 
-    assertEquals(expected, actual);
-  }
+        videoPlayer.setVolume(0.5);
+        verify(mockExoPlayer).setVolume(0.5f);
 
-  @Test
-  public void onIsPlayingChangedSendsExpectedEvent() {
-    VideoPlayer videoPlayer =
-        new VideoPlayer(
-            fakeExoPlayer,
-            VideoPlayerEventCallbacks.withSink(fakeEventSink),
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            httpDataSourceFactorySpy);
+        videoPlayer.dispose();
+    }
 
-    doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  Map<String, Object> event = new HashMap<>();
-                  event.put("event", "isPlayingStateUpdate");
-                  event.put("isPlaying", invocation.getArguments()[0]);
-                  fakeEventSink.success(event);
-                  return null;
-                })
-        .when(fakeExoPlayer)
-        .setPlayWhenReady(anyBoolean());
+    @Test
+    public void setPlaybackSpeedSetsPlaybackParametersWithValue() {
+        VideoPlayer videoPlayer = createVideoPlayer();
 
-    videoPlayer.play();
+        videoPlayer.setPlaybackSpeed(2.5);
+        verify(mockExoPlayer).setPlaybackParameters(new PlaybackParameters(2.5f));
 
-    verify(fakeEventSink).success(eventCaptor.capture());
-    HashMap<String, Object> event1 = eventCaptor.getValue();
+        videoPlayer.dispose();
+    }
 
-    assertEquals(event1.get("event"), "isPlayingStateUpdate");
-    assertEquals(event1.get("isPlaying"), true);
+    @Test
+    public void seekAndGetPosition() {
+        VideoPlayer videoPlayer = createVideoPlayer();
 
-    videoPlayer.pause();
+        videoPlayer.seekTo(10);
+        verify(mockExoPlayer).seekTo(10);
 
-    verify(fakeEventSink, times(2)).success(eventCaptor.capture());
-    HashMap<String, Object> event2 = eventCaptor.getValue();
+        when(mockExoPlayer.getCurrentPosition()).thenReturn(20L);
+        assertEquals(20L, videoPlayer.getPosition());
+    }
 
-    assertEquals(event2.get("event"), "isPlayingStateUpdate");
-    assertEquals(event2.get("isPlaying"), false);
-  }
+    @Test
+    public void disposeReleasesTextureAndPlayer() {
+        VideoPlayer videoPlayer = createVideoPlayer();
+        videoPlayer.dispose();;
 
-  @Test
-  public void behindLiveWindowErrorResetsPlayerToDefaultPosition() {
-    List<Player.Listener> listeners = new LinkedList<>();
-    doAnswer(invocation -> listeners.add(invocation.getArgument(0)))
-        .when(fakeExoPlayer)
-        .addListener(any());
-
-    @SuppressWarnings("unused")
-    VideoPlayer unused =
-        new VideoPlayer(
-            fakeExoPlayer,
-            VideoPlayerEventCallbacks.withSink(fakeEventSink),
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            httpDataSourceFactorySpy);
-
-    PlaybackException exception =
-        new PlaybackException(null, null, PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW);
-    listeners.forEach(listener -> listener.onPlayerError(exception));
-
-    verify(fakeExoPlayer).seekToDefaultPosition();
-    verify(fakeExoPlayer).prepare();
-  }
-
-  @Test
-  public void otherErrorsReportVideoErrorWithErrorString() {
-    List<Player.Listener> listeners = new LinkedList<>();
-    doAnswer(invocation -> listeners.add(invocation.getArgument(0)))
-        .when(fakeExoPlayer)
-        .addListener(any());
-
-    @SuppressWarnings("unused")
-    VideoPlayer unused =
-        new VideoPlayer(
-            fakeExoPlayer,
-            VideoPlayerEventCallbacks.withSink(fakeEventSink),
-            fakeSurfaceTextureEntry,
-            fakeVideoPlayerOptions,
-            httpDataSourceFactorySpy);
-
-    PlaybackException exception =
-        new PlaybackException(
-            "You did bad kid", null, PlaybackException.ERROR_CODE_DECODING_FAILED);
-    listeners.forEach(listener -> listener.onPlayerError(exception));
-
-    verify(fakeEventSink).error(eq("VideoError"), contains("You did bad kid"), any());
-  }
+        verify(mockTexture).release();
+        verify(mockExoPlayer).release();
+    }
 }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -9,15 +9,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import android.graphics.SurfaceTexture;
-
 import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.C;
 import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.Player;
 import androidx.media3.exoplayer.ExoPlayer;
-
 import io.flutter.view.TextureRegistry;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,157 +29,153 @@ import org.robolectric.RobolectricTestRunner;
 /**
  * Unit tests for {@link VideoPlayer}.
  *
- * <p>This test suite <em>narrowly verifies</em> that {@link VideoPlayer} interfaces with the
- * {@link ExoPlayer} interface <em>exactly</em> as it did when the test suite was created. That is,
- * if the behavior changes, this test will need to change. However, this suite should catch bugs
- * related to <em>"this is a safe refactor with no behavior changes"</em>.
+ * <p>This test suite <em>narrowly verifies</em> that {@link VideoPlayer} interfaces with the {@link
+ * ExoPlayer} interface <em>exactly</em> as it did when the test suite was created. That is, if the
+ * behavior changes, this test will need to change. However, this suite should catch bugs related to
+ * <em>"this is a safe refactor with no behavior changes"</em>.
  *
- * <p>It's hypothetically possible to write better tests using
- * {@link androidx.media3.test.utils.FakeMediaSource}, but you really need a PhD in the Android
- * media APIs in order to figure out how to set everything up so the player "works".
+ * <p>It's hypothetically possible to write better tests using {@link
+ * androidx.media3.test.utils.FakeMediaSource}, but you really need a PhD in the Android media APIs
+ * in order to figure out how to set everything up so the player "works".
  */
 @RunWith(RobolectricTestRunner.class)
 public final class VideoPlayerTest {
-    private static final String FAKE_ASSET_URL = "https://flutter.dev/movie.mp4";
-    private FakeVideoAsset fakeVideoAsset;
+  private static final String FAKE_ASSET_URL = "https://flutter.dev/movie.mp4";
+  private FakeVideoAsset fakeVideoAsset;
 
-    @Mock
-    private VideoPlayerCallbacks mockEvents;
-    @Mock
-    private TextureRegistry.SurfaceTextureEntry mockTexture;
-    @Mock
-    private ExoPlayer.Builder mockBuilder;
-    @Mock
-    private ExoPlayer mockExoPlayer;
-    @Captor
-    private ArgumentCaptor<AudioAttributes> attributesCaptor;
+  @Mock private VideoPlayerCallbacks mockEvents;
+  @Mock private TextureRegistry.SurfaceTextureEntry mockTexture;
+  @Mock private ExoPlayer.Builder mockBuilder;
+  @Mock private ExoPlayer mockExoPlayer;
+  @Captor private ArgumentCaptor<AudioAttributes> attributesCaptor;
 
-    @Rule
-    public MockitoRule initRule = MockitoJUnit.rule();
+  @Rule public MockitoRule initRule = MockitoJUnit.rule();
 
-    @Before
-    public void setUp() {
-      fakeVideoAsset = new FakeVideoAsset(FAKE_ASSET_URL);
-      when(mockBuilder.build()).thenReturn(mockExoPlayer);
-      when(mockTexture.surfaceTexture()).thenReturn(mock(SurfaceTexture.class));
-    }
+  @Before
+  public void setUp() {
+    fakeVideoAsset = new FakeVideoAsset(FAKE_ASSET_URL);
+    when(mockBuilder.build()).thenReturn(mockExoPlayer);
+    when(mockTexture.surfaceTexture()).thenReturn(mock(SurfaceTexture.class));
+  }
 
-    private VideoPlayer createVideoPlayer() {
-        return createVideoPlayer(new VideoPlayerOptions());
-    }
+  private VideoPlayer createVideoPlayer() {
+    return createVideoPlayer(new VideoPlayerOptions());
+  }
 
-    private VideoPlayer createVideoPlayer(VideoPlayerOptions options) {
-        return new VideoPlayer(mockBuilder, mockEvents, mockTexture, fakeVideoAsset.getMediaItem(), options);
-    }
+  private VideoPlayer createVideoPlayer(VideoPlayerOptions options) {
+    return new VideoPlayer(
+        mockBuilder, mockEvents, mockTexture, fakeVideoAsset.getMediaItem(), options);
+  }
 
-    @Test
-    public void loadsAndPreparesProvidedMediaEnablesAudioFocusByDefault() {
-        VideoPlayer videoPlayer = createVideoPlayer();
+  @Test
+  public void loadsAndPreparesProvidedMediaEnablesAudioFocusByDefault() {
+    VideoPlayer videoPlayer = createVideoPlayer();
 
-        verify(mockExoPlayer).setMediaItem(fakeVideoAsset.getMediaItem());
-        verify(mockExoPlayer).prepare();
-        verify(mockTexture).surfaceTexture();
-        verify(mockExoPlayer).setVideoSurface(any());
+    verify(mockExoPlayer).setMediaItem(fakeVideoAsset.getMediaItem());
+    verify(mockExoPlayer).prepare();
+    verify(mockTexture).surfaceTexture();
+    verify(mockExoPlayer).setVideoSurface(any());
 
-        verify(mockExoPlayer).setAudioAttributes(attributesCaptor.capture(), eq(true));
-        assertEquals(attributesCaptor.getValue().contentType, C.AUDIO_CONTENT_TYPE_MOVIE);
+    verify(mockExoPlayer).setAudioAttributes(attributesCaptor.capture(), eq(true));
+    assertEquals(attributesCaptor.getValue().contentType, C.AUDIO_CONTENT_TYPE_MOVIE);
 
-        videoPlayer.dispose();
-    }
+    videoPlayer.dispose();
+  }
 
-    @Test
-    public void loadsAndPreparesProvidedMediaDisablesAudioFocusWhenMixModeSet() {
-        VideoPlayerOptions options = new VideoPlayerOptions();
-        options.mixWithOthers = true;
+  @Test
+  public void loadsAndPreparesProvidedMediaDisablesAudioFocusWhenMixModeSet() {
+    VideoPlayerOptions options = new VideoPlayerOptions();
+    options.mixWithOthers = true;
 
-        VideoPlayer videoPlayer = createVideoPlayer(options);
+    VideoPlayer videoPlayer = createVideoPlayer(options);
 
-        verify(mockExoPlayer).setAudioAttributes(attributesCaptor.capture(), eq(false));
-        assertEquals(attributesCaptor.getValue().contentType, C.AUDIO_CONTENT_TYPE_MOVIE);
+    verify(mockExoPlayer).setAudioAttributes(attributesCaptor.capture(), eq(false));
+    assertEquals(attributesCaptor.getValue().contentType, C.AUDIO_CONTENT_TYPE_MOVIE);
 
-        videoPlayer.dispose();
-    }
+    videoPlayer.dispose();
+  }
 
-    @Test
-    public void playsAndPausesProvidedMedia() {
-        VideoPlayer videoPlayer = createVideoPlayer();
+  @Test
+  public void playsAndPausesProvidedMedia() {
+    VideoPlayer videoPlayer = createVideoPlayer();
 
-        videoPlayer.play();
-        verify(mockExoPlayer).setPlayWhenReady(true);
+    videoPlayer.play();
+    verify(mockExoPlayer).setPlayWhenReady(true);
 
-        videoPlayer.pause();
-        verify(mockExoPlayer).setPlayWhenReady(false);
+    videoPlayer.pause();
+    verify(mockExoPlayer).setPlayWhenReady(false);
 
-        videoPlayer.dispose();
-    }
+    videoPlayer.dispose();
+  }
 
-    @Test
-    public void sendsBufferingUpdatesOnDemand() {
-        VideoPlayer videoPlayer = createVideoPlayer();
+  @Test
+  public void sendsBufferingUpdatesOnDemand() {
+    VideoPlayer videoPlayer = createVideoPlayer();
 
-        when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
-        videoPlayer.sendBufferingUpdate();
-        verify(mockEvents).onBufferingUpdate(10L);
+    when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
+    videoPlayer.sendBufferingUpdate();
+    verify(mockEvents).onBufferingUpdate(10L);
 
-        videoPlayer.dispose();
-    }
+    videoPlayer.dispose();
+  }
 
-    @Test
-    public void togglesLoopingEnablesAndDisablesRepeatMode() {
-        VideoPlayer videoPlayer = createVideoPlayer();
+  @Test
+  public void togglesLoopingEnablesAndDisablesRepeatMode() {
+    VideoPlayer videoPlayer = createVideoPlayer();
 
-        videoPlayer.setLooping(true);
-        verify(mockExoPlayer).setRepeatMode(Player.REPEAT_MODE_ALL);
+    videoPlayer.setLooping(true);
+    verify(mockExoPlayer).setRepeatMode(Player.REPEAT_MODE_ALL);
 
-        videoPlayer.setLooping(false);
-        verify(mockExoPlayer).setRepeatMode(Player.REPEAT_MODE_OFF);
+    videoPlayer.setLooping(false);
+    verify(mockExoPlayer).setRepeatMode(Player.REPEAT_MODE_OFF);
 
-        videoPlayer.dispose();
-    }
+    videoPlayer.dispose();
+  }
 
-    @Test
-    public void setVolumeIsClampedBetween0and1() {
-        VideoPlayer videoPlayer = createVideoPlayer();
+  @Test
+  public void setVolumeIsClampedBetween0and1() {
+    VideoPlayer videoPlayer = createVideoPlayer();
 
-        videoPlayer.setVolume(-1.0);
-        verify(mockExoPlayer).setVolume(0f);
+    videoPlayer.setVolume(-1.0);
+    verify(mockExoPlayer).setVolume(0f);
 
-        videoPlayer.setVolume(2.0);
-        verify(mockExoPlayer).setVolume(1f);
+    videoPlayer.setVolume(2.0);
+    verify(mockExoPlayer).setVolume(1f);
 
-        videoPlayer.setVolume(0.5);
-        verify(mockExoPlayer).setVolume(0.5f);
+    videoPlayer.setVolume(0.5);
+    verify(mockExoPlayer).setVolume(0.5f);
 
-        videoPlayer.dispose();
-    }
+    videoPlayer.dispose();
+  }
 
-    @Test
-    public void setPlaybackSpeedSetsPlaybackParametersWithValue() {
-        VideoPlayer videoPlayer = createVideoPlayer();
+  @Test
+  public void setPlaybackSpeedSetsPlaybackParametersWithValue() {
+    VideoPlayer videoPlayer = createVideoPlayer();
 
-        videoPlayer.setPlaybackSpeed(2.5);
-        verify(mockExoPlayer).setPlaybackParameters(new PlaybackParameters(2.5f));
+    videoPlayer.setPlaybackSpeed(2.5);
+    verify(mockExoPlayer).setPlaybackParameters(new PlaybackParameters(2.5f));
 
-        videoPlayer.dispose();
-    }
+    videoPlayer.dispose();
+  }
 
-    @Test
-    public void seekAndGetPosition() {
-        VideoPlayer videoPlayer = createVideoPlayer();
+  @Test
+  public void seekAndGetPosition() {
+    VideoPlayer videoPlayer = createVideoPlayer();
 
-        videoPlayer.seekTo(10);
-        verify(mockExoPlayer).seekTo(10);
+    videoPlayer.seekTo(10);
+    verify(mockExoPlayer).seekTo(10);
 
-        when(mockExoPlayer.getCurrentPosition()).thenReturn(20L);
-        assertEquals(20L, videoPlayer.getPosition());
-    }
+    when(mockExoPlayer.getCurrentPosition()).thenReturn(20L);
+    assertEquals(20L, videoPlayer.getPosition());
+  }
 
-    @Test
-    public void disposeReleasesTextureAndPlayer() {
-        VideoPlayer videoPlayer = createVideoPlayer();
-        videoPlayer.dispose();;
+  @Test
+  public void disposeReleasesTextureAndPlayer() {
+    VideoPlayer videoPlayer = createVideoPlayer();
+    videoPlayer.dispose();
+    ;
 
-        verify(mockTexture).release();
-        verify(mockExoPlayer).release();
-    }
+    verify(mockTexture).release();
+    verify(mockExoPlayer).release();
+  }
 }

--- a/packages/video_player/video_player_android/example/pubspec.yaml
+++ b/packages/video_player/video_player_android/example/pubspec.yaml
@@ -31,7 +31,3 @@ flutter:
   assets:
     - assets/flutter-mark-square-64.png
     - assets/Butterfly-209.mp4
-
-# FIXME: Remove this override before submitting the example.
-dependency_overrides:
-  win32: 5.5.1

--- a/packages/video_player/video_player_android/example/pubspec.yaml
+++ b/packages/video_player/video_player_android/example/pubspec.yaml
@@ -31,3 +31,7 @@ flutter:
   assets:
     - assets/flutter-mark-square-64.png
     - assets/Butterfly-209.mp4
+
+# FIXME: Remove this override before submitting the example.
+dependency_overrides:
+  win32: 5.5.1


### PR DESCRIPTION
I'm working on re-landing https://github.com/flutter/packages/pull/6456, this time without using the `ActivityAware` interface (see https://github.com/flutter/flutter/issues/148417). As part of that work, I'll need to better control the `ExoPlayer` lifecycle and save/restore internal state.

Follows the patterns of some of the previous PRs, i.e.

- https://github.com/flutter/packages/pull/6922
- https://github.com/flutter/packages/pull/6908

The changes in this PR are _mostly_ tests, it was extremely difficult to just add more tests to the already very leaky `VideoPlayer` abstraction which had lots of `@VisibleForTesting` methods and other "holes" to observe state. This PR removes all of that, and adds test coverage where it was missing.

Namely it:

- Adds a new class, `VideoAsset`, that builds and configures the media that `ExoPlayer` uses.
- Removes all "testing" state from `VidePlayer`, keeping it nearly immutable.
- Added tests for most of the classes I've added since, which were mostly missing.

That being said, this is a large change. I'm happy to sit down with either of you and walk through it.

---

Opening as a draft for the moment, since there is a pubspec change needing I want to handle first.