### PR TITLE
[pigeon] Update testing and docs

### DIFF
--- a/packages/pigeon/CONTRIBUTING.md
+++ b/packages/pigeon/CONTRIBUTING.md
@@ -21,8 +21,10 @@ generators with that AST.
 * [ast.dart](./lib/ast.dart) - The data structure for representing the Abstract Syntax Tree.
 * [dart_generator.dart](./lib/dart_generator.dart) - The Dart code generator.
 * [java_generator.dart](./lib/java_generator.dart) - The Java code generator.
+* [kotlin_generator.dart](./lib/kotlin_generator.dart) - The Kotlin code generator.
 * [objc_generator.dart](./lib/objc_generator.dart) - The Objective-C code
   generator (header and source files).
+* [swift_generator.dart](./lib/swift_generator.dart) - The Swift code generator.
 * [cpp_generator.dart](./lib/cpp_generator.dart) - The C++ code generator.
 * [generator_tools.dart](./lib/generator_tools.dart) - Shared code between generators.
 * [pigeon_cl.dart](./lib/pigeon_cl.dart) - The top-level function executed by
@@ -48,6 +50,11 @@ Pigeon has 3 types of tests, you'll find them all in
 * Integration tests - These tests generate code, then compile the generated
   code, then execute the generated code.  It can be thought of as unit-tests run
   against the generated code.  Examples: [platform_tests](./platform_tests)
+
+For local testing, always use `test.dart` rather than `run_tests.dart`, as
+`run_tests.dart` is specifically a CI entrypoint. When iterating on a specific
+generator, you will likely want to use the `-t` flag to specific only the
+relevant tests. Pass `-l` to get a list of available tests for the `-t` flag.
 
 ## Generated Source Code Example
 

--- a/packages/pigeon/tool/shared/test_runner.dart
+++ b/packages/pigeon/tool/shared/test_runner.dart
@@ -49,6 +49,7 @@ Future<void> runTests(
       print('# Running $test');
       final int testCode = await info.function();
       if (testCode != 0) {
+        print('# Failed, exit code: $testCode');
         exit(testCode);
       }
       print('');


### PR DESCRIPTION
Minor improvements for contributors:
- Explicitly log failure of a test suite. Depeending on the generator and the failure, it may not be obvious (e.g., gtest crashes, which just don't have any output).
- Clarify `test.dart` vs `run_tests.dart`, and mention the `-t` and `-l` flags.
- Add newer generators to the source list.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
