### PR TITLE
[video_player] Exposes VideoPlayerWebOptions.

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.9.0
+
+* Exports types: `VideoPlayerWebOptions` and `VideoPlayerWebOptionsControls` to
+  customize the `webOptions` field in `VideoPlayerOptions` objects.
+* Forwards `webOptions` to the web implementation.
+
 ## 2.8.7
 
 * Ensures that `value.position` never reports a value larger than `value.duration`.

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -14,7 +14,13 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 import 'src/closed_caption_file.dart';
 
 export 'package:video_player_platform_interface/video_player_platform_interface.dart'
-    show DataSourceType, DurationRange, VideoFormat, VideoPlayerOptions;
+    show
+        DataSourceType,
+        DurationRange,
+        VideoFormat,
+        VideoPlayerOptions,
+        VideoPlayerWebOptions,
+        VideoPlayerWebOptionsControls;
 
 export 'src/closed_caption_file.dart';
 
@@ -435,6 +441,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         kUninitializedTextureId;
     _creatingCompleter!.complete(null);
     final Completer<void> initializingCompleter = Completer<void>();
+
+    // Apply the web-specific options
+    if (kIsWeb && videoPlayerOptions?.webOptions != null) {
+      await _videoPlayerPlatform.setWebOptions(
+        _textureId,
+        videoPlayerOptions!.webOptions!,
+      );
+    }
 
     void eventListener(VideoEvent event) {
       if (_isDisposed) {

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.8.7
+version: 2.9.0
 
 environment:
   sdk: ">=3.2.3 <4.0.0"
@@ -27,7 +27,7 @@ dependencies:
   html: ^0.15.0
   video_player_android: ^2.3.5
   video_player_avfoundation: ^2.5.6
-  video_player_platform_interface: ">=6.1.0 <7.0.0"
+  video_player_platform_interface: ">=6.2.0 <7.0.0"
   video_player_web: ^2.0.0
 
 dev_dependencies:

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   html: ^0.15.0
   video_player_android: ^2.3.5
   video_player_avfoundation: ^2.5.6
-  video_player_platform_interface: ">=6.2.0 <7.0.0"
+  video_player_platform_interface: ^6.2.0
   video_player_web: ^2.0.0
 
 dev_dependencies:

--- a/packages/video_player/video_player/test/video_player_initialization_test.dart
+++ b/packages/video_player/video_player/test/video_player_initialization_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:video_player/video_player.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
@@ -9,18 +10,51 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 import 'video_player_test.dart' show FakeVideoPlayerPlatform;
 
 void main() {
-  // This test needs to run first and therefore needs to be the only test
-  // in this file.
-  test('plugin initialized', () async {
-    TestWidgetsFlutterBinding.ensureInitialized();
-    final FakeVideoPlayerPlatform fakeVideoPlayerPlatform =
-        FakeVideoPlayerPlatform();
-    VideoPlayerPlatform.instance = fakeVideoPlayerPlatform;
+  TestWidgetsFlutterBinding.ensureInitialized();
 
+  late FakeVideoPlayerPlatform fakeVideoPlayerPlatform;
+
+  setUp(() {
+    VideoPlayerPlatform.instance =
+        fakeVideoPlayerPlatform = FakeVideoPlayerPlatform();
+  });
+
+  test('plugin initialized', () async {
     final VideoPlayerController controller = VideoPlayerController.networkUrl(
       Uri.parse('https://127.0.0.1'),
     );
     await controller.initialize();
     expect(fakeVideoPlayerPlatform.calls.first, 'init');
   });
+
+  test('web configuration is applied (web only)', () async {
+    const VideoPlayerWebOptions expected = VideoPlayerWebOptions(
+      allowContextMenu: false,
+      allowRemotePlayback: false,
+      controls: VideoPlayerWebOptionsControls.enabled(),
+    );
+
+    final VideoPlayerController controller = VideoPlayerController.networkUrl(
+      Uri.parse('https://127.0.0.1'),
+      videoPlayerOptions: VideoPlayerOptions(
+        webOptions: expected,
+      ),
+    );
+    await controller.initialize();
+
+    expect(
+      () {
+        fakeVideoPlayerPlatform.calls.singleWhere(
+          (String call) => call == 'setWebOptions',
+        );
+      },
+      returnsNormally,
+      reason: 'setWebOptions must be called exactly once.',
+    );
+    expect(
+      fakeVideoPlayerPlatform.webOptions[controller.textureId],
+      expected,
+      reason: 'web options must be passed to the platform',
+    );
+  }, skip: !kIsWeb);
 }

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -1311,6 +1311,8 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   bool forceInitError = false;
   int nextTextureId = 0;
   final Map<int, Duration> _positions = <int, Duration>{};
+  final Map<int, VideoPlayerWebOptions> webOptions =
+      <int, VideoPlayerWebOptions>{};
 
   @override
   Future<int?> create(DataSource dataSource) async {
@@ -1391,5 +1393,15 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   @override
   Widget buildView(int textureId) {
     return Texture(textureId: textureId);
+  }
+
+  @override
+  Future<void> setWebOptions(
+      int textureId, VideoPlayerWebOptions options) async {
+    if (!kIsWeb) {
+      throw UnimplementedError('setWebOptions() is only available in the web.');
+    }
+    calls.add('setWebOptions');
+    webOptions[textureId] = options;
   }
 }


### PR DESCRIPTION
Exports types `VideoPlayerWebOptions` and `VideoPlayerWebOptionsControls` to customize the `webOptions` field in `VideoPlayerOptions` objects.

Forwards `webOptions` to the web implementation.

## Usage

Can be used as follows:

```dart
_controller = VideoPlayerController.asset(
  'assets/Butterfly-209.mp4',
  videoPlayerOptions: const VideoPlayerOptions(
    webOptions: VideoPlayerWebOptions(
        controls: VideoPlayerWebOptionsControls.enabled(
          allowDownload: false,
          allowFullscreen: false,
          allowPlaybackRate: false,
          allowPictureInPicture: false,
        ),
        allowContextMenu: false,
        allowRemotePlayback: false,
     ),
  ),
);
```

<img width="967" alt="Bildschirmfoto 2023-07-06 um 17 04 59" src="https://github.com/flutter/packages/assets/13286425/0fa92713-11cb-4073-86cf-2ea4ba486a6c">

## Issues

* Fixes: https://github.com/flutter/flutter/issues/150327
* Fixes: https://github.com/flutter/flutter/issues/64397
* Fixes: https://github.com/flutter/flutter/issues/62192
* Fixes part of: https://github.com/flutter/flutter/issues/88151
* Lands: https://github.com/flutter/packages/pull/3259 (adds missing test)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

Co-authored-by: James Leahy <defuncart@gmail.com>