### PR TITLE
150916: Uri APIs should assert when hasScheme is false

### DIFF
--- a/packages/url_launcher/url_launcher/lib/src/url_launcher_uri.dart
+++ b/packages/url_launcher/url_launcher/lib/src/url_launcher_uri.dart
@@ -75,6 +75,7 @@ Future<bool> launchUrl(
 ///   that are always assumed to be supported (such as http(s)), as web pages
 ///   are never allowed to query installed applications.
 Future<bool> canLaunchUrl(Uri url) async {
+  assert(!url.hasScheme, "Uri must have schema");
   return UrlLauncherPlatform.instance.canLaunch(url.toString());
 }
 


### PR DESCRIPTION
Assert the uri for having hasSchema in canLaunchUrl API.

*List which issues are fixed by this PR. You must list at least one issue.*
150916
