### PR TITLE
[pigeon] Fix C++ enum naming

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 21.0.0
+
+* **Breaking Change** [cpp] Fixes style of enum names. References to enum values
+  will need to be updated to `EnumType.kValue` style, instead of the previous
+  `EnumType.value`.
+
 ## 20.0.2
 
 * [java] Adds `equals` and `hashCode` support for data classes.

--- a/packages/pigeon/example/README.md
+++ b/packages/pigeon/example/README.md
@@ -182,7 +182,7 @@ class PigeonApiImplementation : public ExampleHostApi {
   }
   void SendMessage(const MessageData& message,
                    std::function<void(ErrorOr<bool> reply)> result) {
-    if (message.code == Code.one) {
+    if (message.code == Code.kOne) {
       result(FlutterError("code", "message", "details"));
       return;
     }

--- a/packages/pigeon/example/app/windows/runner/flutter_window.cpp
+++ b/packages/pigeon/example/app/windows/runner/flutter_window.cpp
@@ -29,7 +29,7 @@ class PigeonApiImplementation : public ExampleHostApi {
   }
   void SendMessage(const MessageData& message,
                    std::function<void(ErrorOr<bool> reply)> result) {
-    if (message.code == Code.one) {
+    if (message.code == Code.kOne) {
       result(FlutterError("code", "message", "details"));
       return;
     }

--- a/packages/pigeon/example/app/windows/runner/messages.g.h
+++ b/packages/pigeon/example/app/windows/runner/messages.g.h
@@ -59,7 +59,7 @@ class ErrorOr {
   std::variant<T, FlutterError> v_;
 };
 
-enum class Code { one = 0, two = 1 };
+enum class Code { kOne = 0, kTwo = 1 };
 
 // Generated class from Pigeon that represents data sent in messages.
 class MessageData {

--- a/packages/pigeon/lib/cpp_generator.dart
+++ b/packages/pigeon/lib/cpp_generator.dart
@@ -181,8 +181,9 @@ class CppHeaderGenerator extends StructuredGenerator<CppOptions> {
       enumerate(anEnum.members, (int index, final EnumMember member) {
         addDocumentationComments(
             indent, member.documentationComments, _docCommentSpec);
+        final String valueName = 'k${_pascalCaseFromCamelCase(member.name)}';
         indent.writeln(
-            '${member.name} = $index${index == anEnum.members.length - 1 ? '' : ','}');
+            '$valueName = $index${index == anEnum.members.length - 1 ? '' : ','}');
       });
     });
   }

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '20.0.2';
+const String pigeonVersion = '21.0.0';
 
 /// Prefix for all local variables in methods.
 ///

--- a/packages/pigeon/platform_tests/test_plugin/windows/pigeon/core_tests.gen.h
+++ b/packages/pigeon/platform_tests/test_plugin/windows/pigeon/core_tests.gen.h
@@ -66,11 +66,11 @@ class ErrorOr {
 };
 
 enum class AnEnum {
-  one = 0,
-  two = 1,
-  three = 2,
-  fortyTwo = 3,
-  fourHundredTwentyTwo = 4
+  kOne = 0,
+  kTwo = 1,
+  kThree = 2,
+  kFortyTwo = 3,
+  kFourHundredTwentyTwo = 4
 };
 
 // A class containing all supported types.

--- a/packages/pigeon/platform_tests/test_plugin/windows/test/null_fields_test.cpp
+++ b/packages/pigeon/platform_tests/test_plugin/windows/test/null_fields_test.cpp
@@ -66,13 +66,13 @@ TEST(NullFields, BuildWithValues) {
   reply.set_error("error");
   reply.set_indices(EncodableList({1, 2, 3}));
   reply.set_request(request);
-  reply.set_type(NullFieldsSearchReplyType::success);
+  reply.set_type(NullFieldsSearchReplyType::kSuccess);
 
   EXPECT_EQ(*reply.result(), "result");
   EXPECT_EQ(*reply.error(), "error");
   EXPECT_EQ(reply.indices()->size(), 3);
   EXPECT_EQ(*reply.request()->query(), "hello");
-  EXPECT_EQ(*reply.type(), NullFieldsSearchReplyType::success);
+  EXPECT_EQ(*reply.type(), NullFieldsSearchReplyType::kSuccess);
 }
 
 TEST(NullFields, BuildRequestWithNulls) {
@@ -121,7 +121,7 @@ TEST_F(NullFieldsTest, ReplyFromListWithValues) {
       EncodableValue("error"),
       EncodableValue(EncodableList({1, 2, 3})),
       CustomEncodableValue(request),
-      CustomEncodableValue(NullFieldsSearchReplyType::success),
+      CustomEncodableValue(NullFieldsSearchReplyType::kSuccess),
   };
   NullFieldsSearchReply reply = ReplyFromList(list);
 
@@ -130,7 +130,7 @@ TEST_F(NullFieldsTest, ReplyFromListWithValues) {
   EXPECT_EQ(reply.indices()->size(), 3);
   EXPECT_EQ(*reply.request()->query(), "hello");
   EXPECT_EQ(reply.request()->identifier(), 1);
-  EXPECT_EQ(*reply.type(), NullFieldsSearchReplyType::success);
+  EXPECT_EQ(*reply.type(), NullFieldsSearchReplyType::kSuccess);
 }
 
 TEST_F(NullFieldsTest, ReplyFromListWithNulls) {
@@ -178,7 +178,7 @@ TEST_F(NullFieldsTest, ReplyToMapWithValues) {
   reply.set_error("error");
   reply.set_indices(EncodableList({1, 2, 3}));
   reply.set_request(request);
-  reply.set_type(NullFieldsSearchReplyType::success);
+  reply.set_type(NullFieldsSearchReplyType::kSuccess);
 
   const EncodableList list = ListFromReply(reply);
 

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 20.0.2 # This must match the version in lib/generator_tools.dart
+version: 21.0.0 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ^3.2.0

--- a/packages/pigeon/test/cpp_generator_test.dart
+++ b/packages/pigeon/test/cpp_generator_test.dart
@@ -101,6 +101,10 @@ void main() {
   });
 
   test('naming follows style', () {
+    final Enum anEnum = Enum(name: 'AnEnum', members: <EnumMember>[
+      EnumMember(name: 'one'),
+      EnumMember(name: 'fortyTwo'),
+    ]);
     final Root root = Root(apis: <Api>[
       AstHostApi(name: 'Api', methods: <Method>[
         Method(
@@ -137,9 +141,19 @@ void main() {
               baseName: 'bool',
               isNullable: false,
             ),
-            name: 'outputField')
+            name: 'outputField'),
+        NamedType(
+          type: TypeDeclaration(
+            baseName: anEnum.name,
+            isNullable: false,
+            associatedEnum: anEnum,
+          ),
+          name: 'code',
+        )
       ])
-    ], enums: <Enum>[]);
+    ], enums: <Enum>[
+      anEnum
+    ]);
     {
       final StringBuffer sink = StringBuffer();
       const CppGenerator generator = CppGenerator();
@@ -161,6 +175,9 @@ void main() {
       // Instance variables should be adjusted.
       expect(code, contains('bool input_field_'));
       expect(code, contains('bool output_field_'));
+      // Enum values should be adjusted.
+      expect(code, contains('kOne'));
+      expect(code, contains('kFortyTwo'));
     }
     {
       final StringBuffer sink = StringBuffer();


### PR DESCRIPTION
The C++ generator wasn't adjusting enum value names, so they were just using the Dart camelCase style. This makes them style-guide compliant by adding the `k` prefix and making the first actual letter upper-case.

Fixes https://github.com/flutter/flutter/issues/147328

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
