### PR TITLE
[ios]Fix compile error when conforming UIApplication to Launcher due to MainActor annotation

### DIFF
--- a/packages/url_launcher/url_launcher_ios/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.1
+
+* Fixes a compile error when comforming UIApplication to Launcher in iOS 18 Beta 3.
+
 ## 6.3.0
 
 * Adds Swift Package Manager compatibility.

--- a/packages/url_launcher/url_launcher_ios/ios/url_launcher_ios/Sources/url_launcher_ios/Launcher.swift
+++ b/packages/url_launcher/url_launcher_ios/ios/url_launcher_ios/Sources/url_launcher_ios/Launcher.swift
@@ -24,12 +24,12 @@ final class DefaultLauncher: Launcher {
   func canOpenURL(_ url: URL) -> Bool {
     return UIApplication.shared.canOpenURL(url)
   }
-  
+
   func open(
     _ url: URL,
     options: [UIApplication.OpenExternalURLOptionsKey: Any],
-    completionHandler completion: ((Bool) -> Void)?)
-  {
+    completionHandler completion: ((Bool) -> Void)?
+  ) {
     UIApplication.shared.open(
       url,
       options: options,

--- a/packages/url_launcher/url_launcher_ios/ios/url_launcher_ios/Sources/url_launcher_ios/Launcher.swift
+++ b/packages/url_launcher/url_launcher_ios/ios/url_launcher_ios/Sources/url_launcher_ios/Launcher.swift
@@ -18,5 +18,21 @@ protocol Launcher {
     completionHandler completion: ((Bool) -> Void)?)
 }
 
-/// Launcher is intentionally a direct passthroguh to UIApplication.
-extension UIApplication: Launcher {}
+// TODO(hellohuanlin): This wrapper is a workaround for iOS 18 Beta 3 where completionHandler is annotated with @MainActor @Sendable, resulting in compile error when conforming UIApplication to Launcher. We should try again in newer betas.
+/// A default URL launcher.
+final class DefaultLauncher: Launcher {
+  func canOpenURL(_ url: URL) -> Bool {
+    return UIApplication.shared.canOpenURL(url)
+  }
+  
+  func open(
+    _ url: URL,
+    options: [UIApplication.OpenExternalURLOptionsKey: Any],
+    completionHandler completion: ((Bool) -> Void)?)
+  {
+    UIApplication.shared.open(
+      url,
+      options: options,
+      completionHandler: completion)
+  }
+}

--- a/packages/url_launcher/url_launcher_ios/ios/url_launcher_ios/Sources/url_launcher_ios/URLLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_ios/ios/url_launcher_ios/Sources/url_launcher_ios/URLLauncherPlugin.swift
@@ -22,7 +22,7 @@ public final class URLLauncherPlugin: NSObject, FlutterPlugin, UrlLauncherApi {
     UIApplication.shared.keyWindow?.rootViewController?.topViewController
   }
 
-  init(launcher: Launcher = UIApplication.shared) {
+  init(launcher: Launcher = DefaultLauncher()) {
     self.launcher = launcher
   }
 

--- a/packages/url_launcher/url_launcher_ios/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_ios
 description: iOS implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.3.0
+version: 6.3.1
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
iOS 18 Beta 3 added `@MainActor @Sendable` for openURL's completion handler: 

```
    @available(iOS 10.0, *)
    open func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any] = [:], completionHandler completion: (@MainActor @Sendable (Bool) -> Void)? = nil)
```

The addition of `@MainActor` is the one that caused the compile error. It was not there for Beta 1. 

This PR we simply use a `DefaultLauncher` wrapper. As expected, passing in a **non-isolated closure** to a function that expects a **main-actor isolated closure** is fine, since non-isolated closure can be called in any isolation context; plus the minimal concurrency checking also silences the Sendable warning.
 
But we should check again in newer betas if we can revert this change. Because this compile error forces some libraries to update for swift concurrency, which seems to be against the whole idea of having 3 different levels of concurrency checking. So I suspect that Apple is still hashing things out and may change it back (either by removing `@MainActor` from signature, or compiler change to allow this conformance under minimal checking) 

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/151467

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
