### PR TITLE
[ci] Split build_all_packages by JDK version.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -425,7 +425,6 @@ targets:
     recipe: packages/packages
     timeout: 30
     properties:
-      add_recipes_cq: "true"
       version_file: flutter_stable.version
       # This file only builds a *legacy* version of the project.
       target_file: android_build_all_packages_legacy.yaml

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -359,11 +359,12 @@ targets:
         }
 
   ### Android tasks ###
-  - name: Linux_android android_build_all_packages_17plus master
+  - name: Linux_android android_build_all_packages master
     recipe: packages/packages
     timeout: 30
     properties:
       version_file: flutter_master.version
+      # This file only builds a modern version of the project.
       target_file: android_build_all_packages_17plus.yaml
       channel: master
       # The legacy project build requires an older JDK.
@@ -377,10 +378,12 @@ targets:
         }
 
   - name: Linux_android android_build_all_packages_legacy master
+    bringup: true # https://github.com/flutter/packages/pull/7099
     recipe: packages/packages
     timeout: 30
     properties:
       version_file: flutter_master.version
+      # This file only builds a *legacy* version of the project.
       target_file: android_build_all_packages_legacy.yaml
       channel: master
       # The legacy project build requires an older JDK.
@@ -399,6 +402,7 @@ targets:
     properties:
       add_recipes_cq: "true"
       version_file: flutter_stable.version
+      # This builds both legacy, and "modern" projects.
       target_file: android_build_all_packages.yaml
       channel: stable
       # The legacy project build requires an older JDK.

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -385,6 +385,9 @@ targets:
     timeout: 30
     properties:
       version_file: flutter_master.version
+      # TODO(stuartmorgan): Once stable requires JDK 17, and the
+      # legacy project is updated accordingly, this entire target
+      # can be merged back into android_build_all_packages.
       # This file only builds a *legacy* version of the project.
       target_file: android_build_all_packages_legacy.yaml
       channel: master

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -359,12 +359,29 @@ targets:
         }
 
   ### Android tasks ###
-  - name: Linux_android android_build_all_packages master
+  - name: Linux_android android_build_all_packages_17plus master
     recipe: packages/packages
     timeout: 30
     properties:
       version_file: flutter_master.version
-      target_file: android_build_all_packages.yaml
+      target_file: android_build_all_packages_17plus.yaml
+      channel: master
+      # The legacy project build requires an older JDK.
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "version:11"}
+        ]
+      env_variables: >-
+        {
+          "CHANNEL": "master"
+        }
+
+  - name: Linux_android android_build_all_packages_legacy master
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      version_file: flutter_master.version
+      target_file: android_build_all_packages_legacy.yaml
       channel: master
       # The legacy project build requires an older JDK.
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -364,8 +364,7 @@ targets:
     timeout: 30
     properties:
       version_file: flutter_master.version
-      # This file only builds a modern version of the project.
-      target_file: android_build_all_packages_17plus.yaml
+      target_file: android_build_all_packages.yaml
       channel: master
       # The legacy project build requires an older JDK.
       dependencies: >-
@@ -378,6 +377,9 @@ targets:
         }
 
   - name: Linux_android android_build_all_packages_legacy master
+    # When making this `bringup: false`, update the task above to
+    # use target_file: android_build_all_packages_jdk17.yaml and
+    # remove its 'dependencies' section.
     bringup: true # https://github.com/flutter/packages/pull/7099
     recipe: packages/packages
     timeout: 30

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -417,6 +417,29 @@ targets:
           "CHANNEL": "stable"
         }
 
+  - name: Linux_android android_build_all_packages_legacy stable
+    # When making this `bringup: false`, update the task above to
+    # use target_file: android_build_all_packages_jdk17.yaml and
+    # remove its 'dependencies' section.
+    bringup: true # https://github.com/flutter/packages/pull/7099
+    recipe: packages/packages
+    timeout: 30
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      # This file only builds a *legacy* version of the project.
+      target_file: android_build_all_packages_legacy.yaml
+      channel: stable
+      # The legacy project build requires an older JDK.
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "version:11"}
+        ]
+      env_variables: >-
+        {
+          "CHANNEL": "stable"
+        }
+
   - name: Linux_android android_platform_tests_shard_1 master
     recipe: packages/packages
     timeout: 60

--- a/.ci/targets/android_build_all_packages.yaml
+++ b/.ci/targets/android_build_all_packages.yaml
@@ -1,3 +1,5 @@
+# This builds legacy and modern all_packages app, which requires jdk11
+# This will stop working in the next stable!
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh

--- a/.ci/targets/android_build_all_packages_17plus.yaml
+++ b/.ci/targets/android_build_all_packages_17plus.yaml
@@ -1,0 +1,13 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+    infra_step: true # Note infra steps failing prevents "always" from running.
+  - name: create all_packages app
+    script: .ci/scripts/create_all_packages_app.sh
+    infra_step: true # Note infra steps failing prevents "always" from running.
+  - name: build all_packages for Android debug
+    script: .ci/scripts/build_all_packages_app.sh
+    args: ["apk", "debug"]
+  - name: build all_packages for Android release
+    script: .ci/scripts/build_all_packages_app.sh
+    args: ["apk", "release"]

--- a/.ci/targets/android_build_all_packages_jdk17.yaml
+++ b/.ci/targets/android_build_all_packages_jdk17.yaml
@@ -1,3 +1,4 @@
+# This only builds the modern all_packages app, which requires jdk17+
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh

--- a/.ci/targets/android_build_all_packages_legacy.yaml
+++ b/.ci/targets/android_build_all_packages_legacy.yaml
@@ -1,3 +1,4 @@
+# This only builds the legacy all_packages app, which requires jdk11
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh

--- a/.ci/targets/android_build_all_packages_legacy.yaml
+++ b/.ci/targets/android_build_all_packages_legacy.yaml
@@ -1,0 +1,16 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+    infra_step: true # Note infra steps failing prevents "always" from running.
+  - name: create all_packages app - legacy version
+    script: .ci/scripts/create_all_packages_app_legacy.sh
+    # Output dir; must match the final argument to build_all_packages_app_legacy
+    # below.
+    args: ["legacy"]
+  # Only build legacy in one mode, to minimize extra CI time. Debug is chosen
+  # somewhat arbitrarily as likely being slightly faster.
+  - name: build all_packages for Android - legacy version
+    script: .ci/scripts/build_all_packages_app_legacy.sh
+    # The final argument here must match the output directory passed to
+    # create_all_packages_app_legacy above.
+    args: ["apk", "debug", "legacy"]


### PR DESCRIPTION
This PR introduces a new `android_build_all_packages_legacy` in `master` and `stable` to build only the "legacy" version of an Android project using JDK11.

This PR is required to resume rolling the flutter framework, like here:

* https://github.com/flutter/packages/pull/7099

Moving forward, `android_build_all_packages` will use JDK17+ and `android_build_all_packages_legacy` will use JDK11, both in `master` and `stable`, instead of having an unified build.

After this lands, the new tasks need to be taken out of `bringup:true`, and the existing `android_build_all_packages` tasks need to point to the _jdk17.yaml configuration file that is being introduced in this PR.

(The not suffixed `android_build_all_packages.yaml` file may be removed, or replaced with the contents of the _jdk17.yaml one!)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
