### PR TITLE
[ci] Update to Xcode 15.2 and iOS 17.2

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -95,7 +95,7 @@ platform_properties:
       cpu: arm64
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "15a240d"
+          "sdk_version": "15c500b"
         }
   mac_x64:
     properties:
@@ -108,7 +108,7 @@ platform_properties:
       cpu: x86
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "15a240d"
+          "sdk_version": "15c500b"
         }
 
 targets:

--- a/.ci/scripts/create_simulator.sh
+++ b/.ci/scripts/create_simulator.sh
@@ -9,7 +9,7 @@ set -o pipefail
 # The name here must match remove_simulator.sh
 readonly DEVICE_NAME=Flutter-iPhone
 readonly DEVICE=com.apple.CoreSimulator.SimDeviceType.iPhone-14
-readonly OS=com.apple.CoreSimulator.SimRuntime.iOS-17-0
+readonly OS=com.apple.CoreSimulator.SimRuntime.iOS-17-2
 
 # Delete any existing devices named Flutter-iPhone. Having more than one may
 # cause issues when builds target the device.

--- a/.ci/targets/ios_platform_tests.yaml
+++ b/.ci/targets/ios_platform_tests.yaml
@@ -22,7 +22,7 @@ tasks:
   - name: native test
     script: .ci/scripts/tool_runner.sh
     # Simulator name and version must match name and version in create_simulator.sh
-    args: ["native-test", "--ios", "--ios-destination", "platform=iOS Simulator,name=Flutter-iPhone,OS=17.0"]
+    args: ["native-test", "--ios", "--ios-destination", "platform=iOS Simulator,name=Flutter-iPhone,OS=17.2"]
   - name: boot simulator
     # Ensure simulator is still booted
     script: .ci/scripts/boot_simulator.sh

--- a/packages/pigeon/tool/shared/test_suites.dart
+++ b/packages/pigeon/tool/shared/test_suites.dart
@@ -296,8 +296,8 @@ Future<int> _runIOSPluginUnitTests(String testPluginPath) async {
 
   const String deviceName = 'Pigeon-Test-iPhone';
   const String deviceType = 'com.apple.CoreSimulator.SimDeviceType.iPhone-14';
-  const String deviceRuntime = 'com.apple.CoreSimulator.SimRuntime.iOS-17-0';
-  const String deviceOS = '17.0';
+  const String deviceRuntime = 'com.apple.CoreSimulator.SimRuntime.iOS-17-2';
+  const String deviceOS = '17.2';
   await _createSimulator(deviceName, deviceType, deviceRuntime);
   return runXcodeBuild(
     '$examplePath/ios',


### PR DESCRIPTION
Update Xcode from 15.0 to 15.2 in an attempt to stop the Mac build timeouts.  Simulators will run on default runtime iOS 17.2.

My investigation is at https://github.com/flutter/flutter/issues/150642#issuecomment-2228950616

> Given we aren't seeing timeouts on Android runs, and the last time [we saw something similar,](https://github.com/flutter/flutter/issues/119750) we resolved it by updating the version of Xcode
> 
> I'm tempted to do the same and update Xcode to see if there's something funky running Xcode 15.0 on macOS 14.5. I can try Xcode 15.2 (15C500b) which _should_ run on both of our macOS 14.5 and macOS 13.6 machines.

See also https://github.com/flutter/flutter/issues/119750



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
