### PR TITLE
[rfw] Increase tolerance for material widget tests

### DIFF
--- a/packages/rfw/test/material_widgets_test.dart
+++ b/packages/rfw/test/material_widgets_test.dart
@@ -26,7 +26,9 @@ void main() {
 
   setUpAll(() {
     setUpTolerantComparator(
-        testPath: 'test/material_widget_test.dart', precisionTolerance: 0.01);
+      testPath: 'test/material_widget_test.dart',
+      precisionTolerance: 0.00002,
+    );
   });
 
   testWidgets('Material widgets', (WidgetTester tester) async {

--- a/packages/rfw/test/material_widgets_test.dart
+++ b/packages/rfw/test/material_widgets_test.dart
@@ -24,10 +24,12 @@ void main() {
       ..update(materialName, createMaterialWidgets());
   }
 
-  testWidgets('Material widgets', (WidgetTester tester) async {
+  setUpAll(() {
     setUpTolerantComparator(
         testPath: 'test/material_widget_test.dart', precisionTolerance: 0.01);
+  });
 
+  testWidgets('Material widgets', (WidgetTester tester) async {
     final Runtime runtime = setupRuntime();
     final DynamicContent data = DynamicContent();
     final List<String> eventLog = <String>[];

--- a/packages/rfw/test/material_widgets_test.dart
+++ b/packages/rfw/test/material_widgets_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:rfw/formats.dart' show parseLibraryFile;
 import 'package:rfw/rfw.dart';
 
+import 'tolerant_comparator.dart'
+    if (dart.library.js_interop) 'tolerant_comparator_web.dart';
 import 'utils.dart';
 
 void main() {

--- a/packages/rfw/test/material_widgets_test.dart
+++ b/packages/rfw/test/material_widgets_test.dart
@@ -23,6 +23,9 @@ void main() {
   }
 
   testWidgets('Material widgets', (WidgetTester tester) async {
+    setUpTolerantComparator(
+        testPath: 'test/material_widget_test.dart', precisionTolerance: 0.01);
+
     final Runtime runtime = setupRuntime();
     final DynamicContent data = DynamicContent();
     final List<String> eventLog = <String>[];

--- a/packages/rfw/test/tolerant_comparator.dart
+++ b/packages/rfw/test/tolerant_comparator.dart
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Sets [_TolerantGoldenFileComparator] as the default golden file comparator
+/// in tests.
+void setUpTolerantComparator(
+    {required String testPath, required double precisionTolerance}) {
+  final GoldenFileComparator oldComparator = goldenFileComparator;
+  final _TolerantGoldenFileComparator newComparator =
+      _TolerantGoldenFileComparator(Uri.parse(testPath),
+          precisionTolerance: precisionTolerance);
+
+  goldenFileComparator = newComparator;
+
+  addTearDown(() => goldenFileComparator = oldComparator);
+}
+
+class _TolerantGoldenFileComparator extends LocalFileComparator {
+  _TolerantGoldenFileComparator(
+    super.testFile, {
+    required double precisionTolerance,
+  })  : assert(
+          0 <= precisionTolerance && precisionTolerance <= 1,
+          'precisionTolerance must be between 0 and 1',
+        ),
+        _precisionTolerance = precisionTolerance;
+
+  /// How much the golden image can differ from the test image.
+  ///
+  /// It is expected to be between 0 and 1. Where 0 is no difference (the same image)
+  /// and 1 is the maximum difference (completely different images).
+  final double _precisionTolerance;
+
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+    final ComparisonResult result = await GoldenFileComparator.compareLists(
+      imageBytes,
+      await getGoldenBytes(golden),
+    );
+
+    final bool passed =
+        result.passed || result.diffPercent <= _precisionTolerance;
+    if (passed) {
+      result.dispose();
+      return true;
+    }
+
+    final String error = await generateFailureOutput(result, golden, basedir);
+    result.dispose();
+    throw FlutterError(error);
+  }
+}

--- a/packages/rfw/test/tolerant_comparator_web.dart
+++ b/packages/rfw/test/tolerant_comparator_web.dart
@@ -1,0 +1,6 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+void setUpTolerantComparator(
+    {required String testPath, required double precisionTolerance}) {}

--- a/packages/rfw/test/utils.dart
+++ b/packages/rfw/test/utils.dart
@@ -5,6 +5,7 @@
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 // Detects if we're running the tests on the main channel.
 //
@@ -21,3 +22,55 @@ bool get isMainChannel {
 
 // See Contributing section of README.md file.
 final bool runGoldens = !kIsWeb && Platform.isLinux && isMainChannel;
+
+/// Sets [_TolerantGoldenFileComparator] as the default golden file comparator
+/// in tests.
+void setUpTolerantComparator(
+    {required String testPath, required double precisionTolerance}) {
+  if (!kIsWeb) {
+    final GoldenFileComparator oldComparator = goldenFileComparator;
+    final _TolerantGoldenFileComparator newComparator =
+        _TolerantGoldenFileComparator(Uri.parse(testPath),
+            precisionTolerance: precisionTolerance);
+
+    goldenFileComparator = newComparator;
+
+    addTearDown(() => goldenFileComparator = oldComparator);
+  }
+}
+
+class _TolerantGoldenFileComparator extends LocalFileComparator {
+  _TolerantGoldenFileComparator(
+    super.testFile, {
+    required double precisionTolerance,
+  })  : assert(
+          0 <= precisionTolerance && precisionTolerance <= 1,
+          'precisionTolerance must be between 0 and 1',
+        ),
+        _precisionTolerance = precisionTolerance;
+
+  /// How much the golden image can differ from the test image.
+  ///
+  /// It is expected to be between 0 and 1. Where 0 is no difference (the same image)
+  /// and 1 is the maximum difference (completely different images).
+  final double _precisionTolerance;
+
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+    final ComparisonResult result = await GoldenFileComparator.compareLists(
+      imageBytes,
+      await getGoldenBytes(golden),
+    );
+
+    final bool passed =
+        result.passed || result.diffPercent <= _precisionTolerance;
+    if (passed) {
+      result.dispose();
+      return true;
+    }
+
+    final String error = await generateFailureOutput(result, golden, basedir);
+    result.dispose();
+    throw FlutterError(error);
+  }
+}

--- a/packages/rfw/test/utils.dart
+++ b/packages/rfw/test/utils.dart
@@ -5,7 +5,6 @@
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_test/flutter_test.dart';
 
 // Detects if we're running the tests on the main channel.
 //
@@ -22,55 +21,3 @@ bool get isMainChannel {
 
 // See Contributing section of README.md file.
 final bool runGoldens = !kIsWeb && Platform.isLinux && isMainChannel;
-
-/// Sets [_TolerantGoldenFileComparator] as the default golden file comparator
-/// in tests.
-void setUpTolerantComparator(
-    {required String testPath, required double precisionTolerance}) {
-  if (!kIsWeb) {
-    final GoldenFileComparator oldComparator = goldenFileComparator;
-    final _TolerantGoldenFileComparator newComparator =
-        _TolerantGoldenFileComparator(Uri.parse(testPath),
-            precisionTolerance: precisionTolerance);
-
-    goldenFileComparator = newComparator;
-
-    addTearDown(() => goldenFileComparator = oldComparator);
-  }
-}
-
-class _TolerantGoldenFileComparator extends LocalFileComparator {
-  _TolerantGoldenFileComparator(
-    super.testFile, {
-    required double precisionTolerance,
-  })  : assert(
-          0 <= precisionTolerance && precisionTolerance <= 1,
-          'precisionTolerance must be between 0 and 1',
-        ),
-        _precisionTolerance = precisionTolerance;
-
-  /// How much the golden image can differ from the test image.
-  ///
-  /// It is expected to be between 0 and 1. Where 0 is no difference (the same image)
-  /// and 1 is the maximum difference (completely different images).
-  final double _precisionTolerance;
-
-  @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
-    final ComparisonResult result = await GoldenFileComparator.compareLists(
-      imageBytes,
-      await getGoldenBytes(golden),
-    );
-
-    final bool passed =
-        result.passed || result.diffPercent <= _precisionTolerance;
-    if (passed) {
-      result.dispose();
-      return true;
-    }
-
-    final String error = await generateFailureOutput(result, golden, basedir);
-    result.dispose();
-    throw FlutterError(error);
-  }
-}


### PR DESCRIPTION
This PR introduces a tolerance for rfw material widget tests to fix the golden test error in https://github.com/flutter/flutter/issues/151611.

Part of a fix for https://github.com/flutter/flutter/issues/151659.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
