### PR TITLE
[file_selector_android] Use Espresso 4.0

### DIFF
--- a/packages/file_selector/file_selector_android/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_android/example/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  espresso: ^0.2.0
+  espresso: ^0.4.0
   flutter_test:
     sdk: flutter
   integration_test:


### PR DESCRIPTION
**Update espresso dependency**

I think this is changelog exempt since I am not intending the change to teach/show anything to consumers of the app and it is an example only change. The main reason is to make sure that the 4.0 version of espresso is used in flutter owned code (and to see if the tests fail) 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

