### PR TITLE
[flutter_migrate] Remove one set of parens that wrap a single String literal

### DIFF
--- a/packages/flutter_migrate/test/base/terminal_test.dart
+++ b/packages/flutter_migrate/test/base/terminal_test.dart
@@ -19,7 +19,7 @@ void main() {
       );
       bufferLogger.printStatus('0123456789' * 8);
 
-      expect(bufferLogger.statusText, equals(('${'0123456789' * 4}\n') * 2));
+      expect(bufferLogger.statusText, equals('${'0123456789' * 4}\n' * 2));
     });
 
     testWithoutContext('can turn off wrapping', () async {


### PR DESCRIPTION
In order to address dart-lang/linter#4354, we are reporting a few more cases in `unnecessary_parenthesis`. `('text') * 2` is one such case. This change is being made in https://dart-review.googlesource.com/c/sdk/+/376540. (These are the only newly-reported unnecessary parentheses for this change.)

This is the _same_ change as https://github.com/flutter/flutter/pull/152031

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
