### PR TITLE
[shared_preferences] fix stringlist bug

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+* Fixes `getStringList` bug with List<Object> cast exception.
+
 ## 2.3.0
 
 * Adds `SharedPreferencesAsync` and `SharedPreferencesWithCache` APIs.

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.1
 
-* Fixes `getStringList` bug with `List<Object>` cast exception.
+* Fixes `getStringList` bug with `List<Object?>` cast exception.
 
 ## 2.3.0
 

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.1
 
-* Fixes `getStringList` bug with List<Object> cast exception.
+* Fixes `getStringList` bug with `List<Object>` cast exception.
 
 ## 2.3.0
 

--- a/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -587,13 +587,13 @@ void main() {
         expect(preferences.getStringList(listKey), testList);
       });
 
-      testWidgets('get StringList handles List<Object>',
+      testWidgets('get StringList handles List<Object?>',
           (WidgetTester _) async {
         final (
           SharedPreferencesWithCache preferences,
           Map<String, Object?> cache
         ) = await getPreferences();
-        final List<Object> listObject = <Object>['one', 'two'];
+        final List<Object?> listObject = <Object?>['one', 'two'];
         cache[listKey] = listObject;
         expect(preferences.getStringList(listKey), listObject);
       });

--- a/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -587,6 +587,17 @@ void main() {
         expect(preferences.getStringList(listKey), testList);
       });
 
+      testWidgets('get StringList handles List<Object>',
+          (WidgetTester _) async {
+        final (
+          SharedPreferencesWithCache preferences,
+          Map<String, Object?> cache
+        ) = await getPreferences();
+        final List<Object> listObject = <Object>['one', 'two'];
+        cache[listKey] = listObject;
+        expect(preferences.getStringList(listKey), listObject);
+      });
+
       testWidgets('reloading', (WidgetTester _) async {
         final (
           SharedPreferencesWithCache preferences,

--- a/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_async.dart
+++ b/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_async.dart
@@ -308,7 +308,7 @@ class SharedPreferencesWithCache {
           '$key is not included in the PreferencesFilter allowlist');
     }
     // Make a copy of the list so that later mutations won't propagate
-    return (_cache[key] as List<Object>?)?.cast<String>().toList();
+    return (_cache[key] as List<Object?>?)?.cast<String>().toList();
   }
 
   /// Saves a boolean [value] to the cache and platform.

--- a/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_async.dart
+++ b/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_async.dart
@@ -307,9 +307,8 @@ class SharedPreferencesWithCache {
       throw ArgumentError(
           '$key is not included in the PreferencesFilter allowlist');
     }
-    final List<String>? list = _cache[key] as List<String>?;
     // Make a copy of the list so that later mutations won't propagate
-    return list?.toList();
+    return (_cache[key] as List<Object>?)?.cast<String>().toList();
   }
 
   /// Saves a boolean [value] to the cache and platform.

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.3.0
+version: 2.3.1
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
I tested this a few different ways and there was never any savings by not casting when the list is already `List<String>`.

fixes https://github.com/flutter/flutter/issues/152607