### PR TITLE
[various] Clean up C++ formatting

### DIFF
--- a/packages/camera/camera_windows/windows/capture_controller.cpp
+++ b/packages/camera/camera_windows/windows/capture_controller.cpp
@@ -39,7 +39,7 @@ CaptureControllerImpl::CaptureControllerImpl(
     : capture_controller_listener_(listener),
       media_settings_(
           PlatformMediaSettings(PlatformResolutionPreset::kMax, true)),
-      CaptureController(){};
+      CaptureController() {}
 
 CaptureControllerImpl::~CaptureControllerImpl() {
   ResetCaptureController();

--- a/packages/camera/camera_windows/windows/test/mocks.h
+++ b/packages/camera/camera_windows/windows/test/mocks.h
@@ -130,7 +130,7 @@ class MockCameraFactory : public CameraFactory {
 class MockCamera : public Camera {
  public:
   MockCamera(const std::string& device_id)
-      : device_id_(device_id), Camera(device_id){};
+      : device_id_(device_id), Camera(device_id) {}
 
   ~MockCamera() = default;
 
@@ -217,7 +217,7 @@ class MockCamera : public Camera {
 
 class MockCaptureControllerFactory : public CaptureControllerFactory {
  public:
-  MockCaptureControllerFactory(){};
+  MockCaptureControllerFactory() {}
   virtual ~MockCaptureControllerFactory() = default;
 
   // Disallow copy and move.
@@ -263,14 +263,14 @@ class MockCameraPlugin : public CameraPlugin {
  public:
   MockCameraPlugin(flutter::TextureRegistrar* texture_registrar,
                    flutter::BinaryMessenger* messenger)
-      : CameraPlugin(texture_registrar, messenger){};
+      : CameraPlugin(texture_registrar, messenger) {}
 
   // Creates a plugin instance with the given CameraFactory instance.
   // Exists for unit testing with mock implementations.
   MockCameraPlugin(flutter::TextureRegistrar* texture_registrar,
                    flutter::BinaryMessenger* messenger,
                    std::unique_ptr<CameraFactory> camera_factory)
-      : CameraPlugin(texture_registrar, messenger, std::move(camera_factory)){};
+      : CameraPlugin(texture_registrar, messenger, std::move(camera_factory)) {}
 
   ~MockCameraPlugin() = default;
 
@@ -290,7 +290,7 @@ class MockCameraPlugin : public CameraPlugin {
 
 class MockCaptureSource : public IMFCaptureSource {
  public:
-  MockCaptureSource(){};
+  MockCaptureSource() {}
   ~MockCaptureSource() = default;
 
   // IUnknown
@@ -357,7 +357,7 @@ class MockCaptureSource : public IMFCaptureSource {
 // Uses IMFMediaSourceEx which has SetD3DManager method.
 class MockMediaSource : public IMFMediaSourceEx {
  public:
-  MockMediaSource(){};
+  MockMediaSource() {}
   ~MockMediaSource() = default;
 
   // IUnknown
@@ -853,7 +853,7 @@ class FakeMediaType : public FakeIMFAttributesBase<IMFMediaType> {
       : major_type_(major_type),
         sub_type_(sub_type),
         width_(width),
-        height_(height){};
+        height_(height) {}
 
   // IMFAttributes
   HRESULT GetUINT64(REFGUID key, UINT64* value) override {

--- a/packages/local_auth/local_auth_windows/windows/local_auth_plugin.cpp
+++ b/packages/local_auth/local_auth_windows/windows/local_auth_plugin.cpp
@@ -45,7 +45,7 @@ namespace local_auth_windows {
 class UserConsentVerifierImpl : public UserConsentVerifier {
  public:
   explicit UserConsentVerifierImpl(std::function<HWND()> window_provider)
-      : get_root_window_(std::move(window_provider)){};
+      : get_root_window_(std::move(window_provider)) {}
   virtual ~UserConsentVerifierImpl() = default;
 
   // Calls the native Windows API to get the user's consent

--- a/packages/local_auth/local_auth_windows/windows/test/mocks.h
+++ b/packages/local_auth/local_auth_windows/windows/test/mocks.h
@@ -19,7 +19,7 @@ using ::testing::_;
 
 class MockUserConsentVerifier : public UserConsentVerifier {
  public:
-  explicit MockUserConsentVerifier(){};
+  explicit MockUserConsentVerifier() {}
   virtual ~MockUserConsentVerifier() = default;
 
   MOCK_METHOD(winrt::Windows::Foundation::IAsyncOperation<


### PR DESCRIPTION
Some C++ no-body constructors had stray `;`s after them, which cause weird formatting. This removes them all, which is purely a formatting change with no runtime implications.