### PR TITLE
[webview_flutter]: Support WKNavigationType

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Support return NavigationType in NavigationRequest from WKWebview.
+
 ## 4.8.0
 
 * Adds `onHttpError` callback to `NavigationDelegate` to catch HTTP error status codes.

--- a/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
@@ -18,6 +18,7 @@ export 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
         NavigationDecision,
         NavigationRequest,
         NavigationRequestCallback,
+        NavigationType,
         PageEventCallback,
         PlatformNavigationDelegateCreationParams,
         PlatformWebViewControllerCreationParams,

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Support return NavigationType in NavigationRequest from WKWebview.
+
 ## 3.16.6
 
 * Bumps androidx.annotation:annotation from 1.7.1 to 1.8.1.

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
@@ -1476,6 +1476,7 @@ class AndroidNavigationDelegate extends PlatformNavigationDelegate {
       NavigationRequest(
         url: url,
         isMainFrame: isForMainFrame,
+        navigationType: NavigationType.unknown,
       ),
     );
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
+* Support return NavigationType in NavigationRequest from WKWebview.
 
 ## 2.10.0
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/navigation_request.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/navigation_request.dart
@@ -2,12 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'navigation_type.dart';
+
 /// Defines the parameters of the pending navigation callback.
 class NavigationRequest {
   /// Creates a [NavigationRequest].
   const NavigationRequest({
     required this.url,
     required this.isMainFrame,
+    required this.navigationType,
   });
 
   /// The URL of the pending navigation request.
@@ -15,4 +18,8 @@ class NavigationRequest {
 
   /// Indicates whether the request was made in the web site's main frame or a subframe.
   final bool isMainFrame;
+
+  /// An object that contains information about an action that causes navigation
+  /// to occur.
+  final NavigationType navigationType;
 }

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/navigation_type.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/navigation_type.dart
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// An object that contains information about an action that causes navigation
+/// to occur.
+enum NavigationType {
+  /// A link activation.
+  ///
+  /// See [WKNavigationType.linkActivated]
+  linkActivated,
+
+  /// A request to submit a form.
+  ///
+  /// See [WKNavigationType.linkActivated]
+  submitted,
+
+  /// A request for the frame’s next or previous item.
+  ///
+  /// See [WKNavigationType.linkActivated]
+  backForward,
+
+  /// A request to reload the webpage.
+  ///
+  /// See [WKNavigationType.linkActivated]
+  reload,
+
+  /// A request to resubmit a form.
+  ///
+  /// See [WKNavigationType.linkActivated]
+  formResubmitted,
+
+  /// A navigation request that originates for some other reason.
+  ///
+  /// See [WKNavigationType.other]
+  other,
+
+  /// An unknown navigation type (default value for non-wkwebview).
+  ///
+  /// See [WKNavigationType.unknown]
+  unknown,
+}

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/types.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/types.dart
@@ -12,6 +12,7 @@ export 'javascript_mode.dart';
 export 'load_request_params.dart';
 export 'navigation_decision.dart';
 export 'navigation_request.dart';
+export 'navigation_type.dart';
 export 'platform_navigation_delegate_creation_params.dart';
 export 'platform_webview_controller_creation_params.dart';
 export 'platform_webview_cookie_manager_creation_params.dart';

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Support return NavigationType in NavigationRequest from WKWebview.
+
 ## 3.14.0
 
 * Adds Swift Package Manager compatibility.
@@ -88,7 +92,7 @@
 
 * Introduces `NSError.toString` for better diagnostics.
 
-## 3.6.2 
+## 3.6.2
 
 * Fixes unawaited_futures violations.
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
@@ -1043,6 +1043,7 @@ class WebKitNavigationDelegate extends PlatformNavigationDelegate {
               await weakThis.target!._onNavigationRequest!(NavigationRequest(
             url: action.request.url,
             isMainFrame: action.targetFrame.isMainFrame,
+            navigationType: action.navigationType.toFlutterType(),
           ));
           switch (decision) {
             case NavigationDecision.prevent:
@@ -1224,5 +1225,28 @@ class WebKitWebViewPermissionRequest extends PlatformWebViewPermissionRequest {
   /// Prompt the user for permission for the requested resource.
   Future<void> prompt() async {
     _onDecision(WKPermissionDecision.prompt);
+  }
+}
+
+/// WKNavigationType's support method.
+extension WKNavigationTypeExtension on WKNavigationType {
+  /// Translate iOS web kit navigation type into Flutter enum.
+  NavigationType toFlutterType() {
+    switch (this) {
+      case WKNavigationType.linkActivated:
+        return NavigationType.linkActivated;
+      case WKNavigationType.submitted:
+        return NavigationType.submitted;
+      case WKNavigationType.backForward:
+        return NavigationType.backForward;
+      case WKNavigationType.reload:
+        return NavigationType.reload;
+      case WKNavigationType.formResubmitted:
+        return NavigationType.formResubmitted;
+      case WKNavigationType.other:
+        return NavigationType.other;
+      case WKNavigationType.unknown:
+        return NavigationType.unknown;
+    }
   }
 }


### PR DESCRIPTION
Support return NavigationType in NavigationRequest from WKWebview.

Detail:
- In iOS, have no way to determine `onNavigationRequest` was fired by users clicks on a link or programmatically re-direct.
- Integrate [WKNavigationType](https://developer.apple.com/documentation/webkit/wknavigationaction?language=objc) into webview_flutter

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
