### PR TITLE
[image_picker_ios] Update image picker UI test query for iOS 18

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates UI test photo element query for iOS 18.
+
 ## 0.8.12
 
 * Re-adds Swift Package Manager compatibility.

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromGalleryUITests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromGalleryUITests.m
@@ -201,7 +201,8 @@ const int kElementWaitingTime = 30;
   // Find an image and tap on it. (IOS 14 UI, images are showing directly)
   XCUIElement *aImage;
   if (@available(iOS 14, *)) {
-    aImage = [self.app.scrollViews.firstMatch.images elementBoundByIndex:1];
+    NSPredicate *imagePredicate = [NSPredicate predicateWithFormat:@"label BEGINSWITH 'Photo, '"];
+    aImage = [self.app.images matchingPredicate:imagePredicate].firstMatch;
   } else {
     XCUIElement *allPhotosCell = self.app.cells[@"All Photos"].firstMatch;
     if (![allPhotosCell waitForExistenceWithTimeout:kElementWaitingTime]) {

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromLimitedGalleryUITests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromLimitedGalleryUITests.m
@@ -108,7 +108,7 @@ const int kLimitedElementWaitingTime = 30;
 
   // Find an image and tap on it.
   NSPredicate *imagePredicate = [NSPredicate predicateWithFormat:@"label BEGINSWITH 'Photo, '"];
-  XCUIElementQuery *imageQuery =[self.app.images matchingPredicate:imagePredicate];
+  XCUIElementQuery *imageQuery = [self.app.images matchingPredicate:imagePredicate];
   XCUIElement *aImage = imageQuery.firstMatch;
   os_log_error(OS_LOG_DEFAULT, "description before picking image %@", self.app.debugDescription);
   if (![aImage waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromLimitedGalleryUITests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromLimitedGalleryUITests.m
@@ -107,7 +107,9 @@ const int kLimitedElementWaitingTime = 30;
   [self handlePermissionInterruption];
 
   // Find an image and tap on it.
-  XCUIElement *aImage = [self.app.scrollViews.firstMatch.images elementBoundByIndex:1];
+  NSPredicate *imagePredicate = [NSPredicate predicateWithFormat:@"label BEGINSWITH 'Photo, '"];
+  XCUIElementQuery *imageQuery =[self.app.images matchingPredicate:imagePredicate];
+  XCUIElement *aImage = imageQuery.firstMatch;
   os_log_error(OS_LOG_DEFAULT, "description before picking image %@", self.app.debugDescription);
   if (![aImage waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
@@ -126,7 +128,7 @@ const int kLimitedElementWaitingTime = 30;
   [doneButton tap];
 
   // Find an image and tap on it to have access to selected photos.
-  aImage = [self.app.scrollViews.firstMatch.images elementBoundByIndex:1];
+  aImage = imageQuery.firstMatch;
 
   os_log_error(OS_LOG_DEFAULT, "description before picking image %@", self.app.debugDescription);
   if (![aImage waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {


### PR DESCRIPTION
The image picker UI changed from iOS 17 -> iOS 18 (beta), and there's an additional scrollview that wasn't present before.
Instead of selecting the first image in the first scroll view, instead select the image with the accessibility label that starts with "Photo":
```
      ↪︎Find: First Match
        Output: {
          Image, 0x10134f070, {{-0.0, 339.7}, {142.2, 142.3}}, label: 'Photo, March 30, 2018, 12:14 PM'
        }
```
This works on previous versions of iOS as well.

Fixes https://github.com/flutter/flutter/issues/150220, found in Xcode 16 beta.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
