### PR TITLE
Roll `avd_cipd_verison` to latest to use the `crashreport` tool.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -31,7 +31,7 @@ platform_properties:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "open_jdk", "version": "version:17"},
           {"dependency": "curl", "version": "version:7.64.0"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8759428741582061553"}
+          {"dependency": "avd_cipd_version", "version": "build_id:8739520057779466577"}
         ]
   linux_android_legacy:
     properties:
@@ -44,7 +44,7 @@ platform_properties:
           {"dependency": "open_jdk", "version": "version:17"},
           {"dependency": "curl", "version": "version:7.64.0"},
           {"dependency": "android_virtual_device", "version": "generic_android22.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8759428741582061553"}
+          {"dependency": "avd_cipd_version", "version": "build_id:8739520057779466577"}
         ]
   linux_desktop:
     properties:


### PR DESCRIPTION
Same as https://github.com/flutter/flutter/pull/153520 but for `flutter/packages`.