### PR TITLE
[two_dimensional_scrollables] Fix TreeView bug when animation duration is zero

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Fixes a bug where the TreeView would not update correctly when the animation duration is zero.
+
 ## 0.3.1
 
 * Adds generics to the callbacks and builders of TreeView.

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
@@ -891,7 +891,8 @@ class _TreeViewState<T> extends State<TreeView<T>>
       // and immediately update the active nodes. This prevents the app from freezing
       // due to the tree being incorrectly updated when the animation duration is zero.
       // This is because, in this case, the node's children are no longer active.
-      if (widget.toggleAnimationStyle == AnimationStyle.noAnimation || widget.toggleAnimationStyle?.duration == Duration.zero) {
+      if (widget.toggleAnimationStyle == AnimationStyle.noAnimation ||
+          widget.toggleAnimationStyle?.duration == Duration.zero) {
         _unpackActiveNodes();
         return;
       }

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
@@ -886,6 +886,16 @@ class _TreeViewState<T> extends State<TreeView<T>>
       if (widget.onNodeToggle != null) {
         widget.onNodeToggle!(node);
       }
+
+      // If animation is disabled or the duration is zero, we skip the animation
+      // and immediately update the active nodes. This prevents the app from freezing
+      // due to the tree being incorrectly updated when the animation duration is zero.
+      // This is because, in this case, the node's children are no longer active.
+      if (widget.toggleAnimationStyle == AnimationStyle.noAnimation || widget.toggleAnimationStyle?.duration == Duration.zero) {
+        _unpackActiveNodes();
+        return;
+      }
+
       final AnimationController controller =
           _currentAnimationForParent[node]?.controller ??
               AnimationController(

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
@@ -890,8 +890,7 @@ class _TreeViewState<T> extends State<TreeView<T>>
       // If animation is disabled or duration is zero, skip the animation
       // and update the active nodes immediately. This ensures the tree
       // is updated correctly when the node's children are no longer active.
-      if (widget.toggleAnimationStyle == AnimationStyle.noAnimation ||
-          widget.toggleAnimationStyle?.duration == Duration.zero) {
+      if (widget.toggleAnimationStyle?.duration == Duration.zero) {
         _unpackActiveNodes();
         return;
       }

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
@@ -891,10 +891,7 @@ class _TreeViewState<T> extends State<TreeView<T>>
       // and update the active nodes immediately. This ensures the tree
       // is updated correctly when the node's children are no longer active.
       if (widget.toggleAnimationStyle == AnimationStyle.noAnimation ||
-          (node._expanded &&
-              widget.toggleAnimationStyle?.duration == Duration.zero) ||
-          (!node._expanded &&
-              widget.toggleAnimationStyle?.reverseDuration == Duration.zero)) {
+          widget.toggleAnimationStyle?.duration == Duration.zero) {
         _unpackActiveNodes();
         return;
       }

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/tree.dart
@@ -887,12 +887,14 @@ class _TreeViewState<T> extends State<TreeView<T>>
         widget.onNodeToggle!(node);
       }
 
-      // If animation is disabled or the duration is zero, we skip the animation
-      // and immediately update the active nodes. This prevents the app from freezing
-      // due to the tree being incorrectly updated when the animation duration is zero.
-      // This is because, in this case, the node's children are no longer active.
+      // If animation is disabled or duration is zero, skip the animation
+      // and update the active nodes immediately. This ensures the tree
+      // is updated correctly when the node's children are no longer active.
       if (widget.toggleAnimationStyle == AnimationStyle.noAnimation ||
-          widget.toggleAnimationStyle?.duration == Duration.zero) {
+          (node._expanded &&
+              widget.toggleAnimationStyle?.duration == Duration.zero) ||
+          (!node._expanded &&
+              widget.toggleAnimationStyle?.reverseDuration == Duration.zero)) {
         _unpackActiveNodes();
         return;
       }

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -719,7 +719,8 @@ void main() {
       expect(treeView.treeRowBuilder, isA<TreeViewRowBuilder<String>>());
     });
 
-    testWidgets('TreeViewNode should expand/collapse correctly when the animation duration is set to zero.',
+    testWidgets(
+        'TreeViewNode should expand/collapse correctly when the animation duration is set to zero.',
         (WidgetTester tester) async {
       final TreeViewController controller = TreeViewController();
       final List<TreeViewNode<String>> tree = <TreeViewNode<String>>[

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -719,7 +719,9 @@ void main() {
       expect(treeView.treeRowBuilder, isA<TreeViewRowBuilder<String>>());
     });
 
-    testWidgets('TreeSliverNode should close all children when collapsed when animation is completed', (WidgetTester tester) async {
+    testWidgets(
+        'TreeSliverNode should close all children when collapsed when animation is completed',
+        (WidgetTester tester) async {
       final TreeViewController controller = TreeViewController();
       final List<TreeViewNode<String>> tree = <TreeViewNode<String>>[
         TreeViewNode<String>('First'),
@@ -752,31 +754,31 @@ void main() {
 
       await tester.pumpWidget(MaterialApp(
         home: TreeView<String>(
-              tree: tree,
-              controller: controller,
-              toggleAnimationStyle: AnimationStyle(
-                curve: Curves.easeInOut,
-                duration: Duration.zero,
+          tree: tree,
+          controller: controller,
+          toggleAnimationStyle: AnimationStyle(
+            curve: Curves.easeInOut,
+            duration: Duration.zero,
+          ),
+          treeNodeBuilder: (
+            BuildContext context,
+            TreeViewNode<Object?> node,
+            AnimationStyle animationStyle,
+          ) {
+            final Widget child = GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: () => controller.toggleNode(node),
+              child: TreeView.defaultTreeNodeBuilder(
+                context,
+                node,
+                animationStyle,
               ),
-              treeNodeBuilder: (
-                BuildContext context,
-                TreeViewNode<Object?> node,
-                AnimationStyle animationStyle,
-              ) {
-                final Widget child = GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onTap: () => controller.toggleNode(node),
-                  child: TreeView.defaultTreeNodeBuilder(
-                    context,
-                    node,
-                    animationStyle,
-                  ),
-                );
+            );
 
-                return child;
-              },
-            ),
-        ));
+            return child;
+          },
+        ),
+      ));
 
       expect(find.text('First'), findsOneWidget);
       expect(find.text('Second'), findsOneWidget);

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -719,8 +719,7 @@ void main() {
       expect(treeView.treeRowBuilder, isA<TreeViewRowBuilder<String>>());
     });
 
-    testWidgets(
-        'TreeSliverNode should close all children when collapsed when animation is completed',
+    testWidgets('TreeViewNode should expand/collapse correctly when the animation duration is set to zero.',
         (WidgetTester tester) async {
       final TreeViewController controller = TreeViewController();
       final List<TreeViewNode<String>> tree = <TreeViewNode<String>>[

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -718,6 +718,99 @@ void main() {
       expect(treeView.treeNodeBuilder, isA<TreeViewNodeBuilder<String>>());
       expect(treeView.treeRowBuilder, isA<TreeViewRowBuilder<String>>());
     });
+
+    testWidgets('TreeSliverNode should close all children when collapsed when animation is completed', (WidgetTester tester) async {
+      final TreeViewController controller = TreeViewController();
+      final List<TreeViewNode<String>> tree = <TreeViewNode<String>>[
+        TreeViewNode<String>('First'),
+        TreeViewNode<String>(
+          'Second',
+          children: <TreeViewNode<String>>[
+            TreeViewNode<String>(
+              'alpha',
+              children: <TreeViewNode<String>>[
+                TreeViewNode<String>('uno'),
+                TreeViewNode<String>('dos'),
+                TreeViewNode<String>('tres'),
+              ],
+            ),
+            TreeViewNode<String>('beta'),
+            TreeViewNode<String>('kappa'),
+          ],
+        ),
+        TreeViewNode<String>(
+          'Third',
+          expanded: true,
+          children: <TreeViewNode<String>>[
+            TreeViewNode<String>('gamma'),
+            TreeViewNode<String>('delta'),
+            TreeViewNode<String>('epsilon'),
+          ],
+        ),
+        TreeViewNode<String>('Fourth'),
+      ];
+
+      await tester.pumpWidget(MaterialApp(
+        home: TreeView<String>(
+              tree: tree,
+              controller: controller,
+              toggleAnimationStyle: AnimationStyle(
+                curve: Curves.easeInOut,
+                duration: Duration.zero,
+              ),
+              treeNodeBuilder: (
+                BuildContext context,
+                TreeViewNode<Object?> node,
+                AnimationStyle animationStyle,
+              ) {
+                final Widget child = GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: () => controller.toggleNode(node),
+                  child: TreeView.defaultTreeNodeBuilder(
+                    context,
+                    node,
+                    animationStyle,
+                  ),
+                );
+
+                return child;
+              },
+            ),
+        ));
+
+      expect(find.text('First'), findsOneWidget);
+      expect(find.text('Second'), findsOneWidget);
+      expect(find.text('Third'), findsOneWidget);
+      expect(find.text('Fourth'), findsOneWidget);
+      expect(find.text('alpha'), findsNothing);
+      expect(find.text('beta'), findsNothing);
+      expect(find.text('kappa'), findsNothing);
+      expect(find.text('gamma'), findsOneWidget);
+      expect(find.text('delta'), findsOneWidget);
+      expect(find.text('epsilon'), findsOneWidget);
+      expect(find.text('uno'), findsNothing);
+      expect(find.text('dos'), findsNothing);
+      expect(find.text('tres'), findsNothing);
+
+      await tester.tap(find.text('Second'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('alpha'), findsOneWidget);
+
+      await tester.tap(find.text('alpha'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('uno'), findsOneWidget);
+      expect(find.text('dos'), findsOneWidget);
+      expect(find.text('tres'), findsOneWidget);
+
+      await tester.tap(find.text('alpha'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('uno'), findsNothing);
+      expect(find.text('dos'), findsNothing);
+      expect(find.text('tres'), findsNothing);
+    });
   });
 
   group('TreeViewport', () {

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -722,6 +722,7 @@ void main() {
     testWidgets(
         'TreeViewNode should expand/collapse correctly when the animation duration is set to zero.',
         (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/154292
       final TreeViewController controller = TreeViewController();
       final List<TreeViewNode<String>> tree = <TreeViewNode<String>>[
         TreeViewNode<String>('First'),


### PR DESCRIPTION
Fixes [#153889 ](https://github.com/flutter/flutter/issues/154292) an issue where nodes were being removed incorrectly when using `AnimationStyle.noAnimation `or the animation duration was zero seconds, which previously caused the erratic behavior due to hidden state updates. Similar to https://github.com/flutter/flutter/pull/153890.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
