### PR TITLE
Remove matan from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -62,9 +62,8 @@ packages/video_player/video_player_web/**                @ditman
 packages/webview_flutter/webview_flutter_web/**          @ditman
 
 # - Android
-# TODO(matanlurey): Remove @matanlurey after https://github.com/flutter/flutter/issues/151018.
-packages/camera/camera_android/**                        @camsim99 @matanlurey
-packages/camera/camera_android_camerax/**                @camsim99 @matanlurey
+packages/camera/camera_android/**                        @camsim99
+packages/camera/camera_android_camerax/**                @camsim99
 packages/espresso/**                                     @reidbaker
 packages/file_selector/file_selector_android/**          @gmackall
 packages/flutter_plugin_android_lifecycle/**             @reidbaker


### PR DESCRIPTION
Now that the patches have landed there isn't a lot of value in me getting notified about every change to each package. I'm of course still happy to help, but I'll have to be reached in a different way than the `CODEOWNERS` mechanism :)