### PR TITLE
Adds support for video stabilization to camera_platform_interface

### DIFF
--- a/packages/camera/camera_platform_interface/AUTHORS
+++ b/packages/camera/camera_platform_interface/AUTHORS
@@ -65,3 +65,4 @@ Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
 Mairramer <mairramer.dasilva28@hotmail.com>
+Rui Craveiro <ruicraveiro@squarealfa.com>

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.9.0
 
+* Adds support for video stabilization.
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.
 
 ## 2.8.0
@@ -7,6 +8,7 @@
 * Deprecates `maxVideoDuration`/`maxDuration`, as it was never implemented on
   most platforms, and there is no plan to implement it in the future.
 * Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
+
 
 ## 2.7.4
 

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -503,6 +503,44 @@ class MethodChannelCamera extends CameraPlatform {
   }
 
   @override
+  Future<Iterable<VideoStabilizationMode>> getVideoStabilizationSupportedModes(
+      int cameraId) async {
+    try {
+      final List<Object?>? modes = await _channel.invokeMethod<List<Object?>>(
+        'getVideoStabilizationSupportedModes',
+        <String, dynamic>{
+          'cameraId': cameraId,
+        },
+      );
+
+      if (modes == null) {
+        return <VideoStabilizationMode>[];
+      }
+      return modes
+          .map((Object? e) => VideoStabilizationMode.fromString(e! as String));
+    } on PlatformException catch (e) {
+      throw CameraException(e.code, e.message);
+    }
+  }
+
+  /// Sets the video stabilization mode for the selected camera
+  @override
+  Future<void> setVideoStabilizationMode(
+      int cameraId, VideoStabilizationMode mode) async {
+    try {
+      await _channel.invokeMethod<void>(
+        'setVideoStabilizationMode',
+        <String, dynamic>{
+          'cameraId': cameraId,
+          'mode': mode.name,
+        },
+      );
+    } on PlatformException catch (e) {
+      throw CameraException(e.code, e.message);
+    }
+  }
+
+  @override
   Future<void> pausePreview(int cameraId) async {
     await _channel.invokeMethod<double>(
       'pausePreview',

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -273,10 +273,6 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Gets a list of video stabilization modes that are supported for the selected camera.
-  ///
-  /// Will return the list of supported video stabilization modes
-  /// on Android (when using camera_android_camerax package) and
-  /// on iOS. Will return an empty list on all other platforms.
   Future<Iterable<VideoStabilizationMode>> getVideoStabilizationSupportedModes(
       int cameraId) async {
     throw UnimplementedError(
@@ -284,10 +280,6 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Sets the video stabilization mode for the selected camera.
-  ///
-  /// On Android (when using camera_android_camerax) and on iOS
-  /// the supplied [mode] value should be a mode in the list returned
-  /// by [getVideoStabilizationSupportedModes].
   ///
   /// Throws a [CameraException] when a not supported video stabilization
   /// mode is supplied.

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -272,6 +272,30 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('setZoomLevel() is not implemented.');
   }
 
+  /// Gets a list of video stabilization modes that are supported for the selected camera.
+  ///
+  /// Will return the list of supported video stabilization modes
+  /// on Android (when using camera_android_camerax package) and
+  /// on iOS. Will return an empty list on all other platforms.
+  Future<Iterable<VideoStabilizationMode>> getVideoStabilizationSupportedModes(
+      int cameraId) async {
+    throw UnimplementedError(
+        'getVideoStabilizationSupportedModes() is not implemented.');
+  }
+
+  /// Sets the video stabilization mode for the selected camera.
+  ///
+  /// On Android (when using camera_android_camerax) and on iOS
+  /// the supplied [mode] value should be a mode in the list returned
+  /// by [getVideoStabilizationSupportedModes].
+  ///
+  /// Throws a [CameraException] when a not supported video stabilization
+  /// mode is supplied.
+  Future<void> setVideoStabilizationMode(
+      int cameraId, VideoStabilizationMode mode) async {
+    throw UnimplementedError('setVideoStabilizationMode() is not implemented.');
+  }
+
   /// Pause the active preview on the current frame for the selected camera.
   Future<void> pausePreview(int cameraId) {
     throw UnimplementedError('pausePreview() is not implemented.');

--- a/packages/camera/camera_platform_interface/lib/src/types/types.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/types.dart
@@ -13,3 +13,4 @@ export 'image_format_group.dart';
 export 'media_settings.dart';
 export 'resolution_preset.dart';
 export 'video_capture_options.dart';
+export 'video_stabilization_mode.dart';

--- a/packages/camera/camera_platform_interface/lib/src/types/video_stabilization_mode.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/video_stabilization_mode.dart
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// The possible video stabilization modes that can be capturing video.
+enum VideoStabilizationMode {
+  /// Video stabilization is disabled.
+  off,
+
+  /// Basic video stabilization is enabled.
+  ///
+  /// Maps to CONTROL_VIDEO_STABILIZATION_MODE_ON on Android
+  /// and throws CameraException on iOS.
+  on,
+
+  /// Standard video stabilization is enabled.
+  ///
+  /// Maps to CONTROL_VIDEO_STABILIZATION_MODE_PREVIEW_STABILIZATION on Android
+  /// (camera_android_camerax) and to AVCaptureVideoStabilizationModeStandard
+  /// on iOS.
+  standard,
+
+  /// Cinematic video stabilization is enabled.
+  ///
+  /// Maps to CONTROL_VIDEO_STABILIZATION_MODE_PREVIEW_STABILIZATION on Android
+  /// (camera_android_camerax) and to AVCaptureVideoStabilizationModeCinematic
+  /// on iOS.
+  cinematic,
+
+  /// Extended cinematic video stabilization is enabled.
+  ///
+  /// Maps to AVCaptureVideoStabilizationModeCinematicExtended on iOS and
+  /// throws CameraException on Android.
+  cinematicExtended;
+
+  /// Returns the video stabilization mode for a given String.
+  factory VideoStabilizationMode.fromString(String str) {
+    return VideoStabilizationMode.values
+        .firstWhere((VideoStabilizationMode mode) => mode.name == str);
+  }
+}

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.8.0
+version: 2.9.0
 
 environment:
   sdk: ^3.3.0

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -1014,6 +1014,151 @@ void main() {
                     'Illegal zoom error')));
       });
 
+      test('Should get empty list from getVideoStabilizationSupportedModes',
+          () async {
+        // Arrange
+        final MethodChannelMock channel = MethodChannelMock(
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{
+            'getVideoStabilizationSupportedModes': <String>[],
+          },
+        );
+
+        // Act
+        final Iterable<VideoStabilizationMode> modes =
+            await camera.getVideoStabilizationSupportedModes(
+          cameraId,
+        );
+
+        // Assert
+        expect(modes, <VideoStabilizationMode>[]);
+
+        expect(channel.log, <Matcher>[
+          isMethodCall('getVideoStabilizationSupportedModes',
+              arguments: <String, Object?>{
+                'cameraId': cameraId,
+              }),
+        ]);
+      });
+
+      test(
+          'Should get list containing off from getVideoStabilizationSupportedModes',
+          () async {
+        // Arrange
+        final MethodChannelMock channel = MethodChannelMock(
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{
+            'getVideoStabilizationSupportedModes': <String>['off'],
+          },
+        );
+
+        // Act
+        final Iterable<VideoStabilizationMode> modes =
+            await camera.getVideoStabilizationSupportedModes(
+          cameraId,
+        );
+
+        // Assert
+        expect(modes, <VideoStabilizationMode>[VideoStabilizationMode.off]);
+
+        expect(channel.log, <Matcher>[
+          isMethodCall('getVideoStabilizationSupportedModes',
+              arguments: <String, Object?>{
+                'cameraId': cameraId,
+              }),
+        ]);
+      });
+
+      test(
+          'Should get list containing all from getVideoStabilizationSupportedModes',
+          () async {
+        // Arrange
+        final MethodChannelMock channel = MethodChannelMock(
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{
+            'getVideoStabilizationSupportedModes': <String>[
+              'off',
+              'on',
+              'standard',
+              'cinematic',
+              'cinematicExtended',
+            ],
+          },
+        );
+
+        // Act
+        final Iterable<VideoStabilizationMode> modes =
+            await camera.getVideoStabilizationSupportedModes(
+          cameraId,
+        );
+
+        // Assert
+        expect(modes, <VideoStabilizationMode>[
+          VideoStabilizationMode.off,
+          VideoStabilizationMode.on,
+          VideoStabilizationMode.standard,
+          VideoStabilizationMode.cinematic,
+          VideoStabilizationMode.cinematicExtended,
+        ]);
+
+        expect(channel.log, <Matcher>[
+          isMethodCall('getVideoStabilizationSupportedModes',
+              arguments: <String, Object?>{
+                'cameraId': cameraId,
+              }),
+        ]);
+      });
+
+      test('Should set the video stabilization mode', () async {
+        // Arrange
+        final MethodChannelMock channel = MethodChannelMock(
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{'setVideoStabilizationMode': null},
+        );
+
+        // Act
+        await camera.setVideoStabilizationMode(
+          cameraId,
+          VideoStabilizationMode.off,
+        );
+        await camera.setVideoStabilizationMode(
+          cameraId,
+          VideoStabilizationMode.standard,
+        );
+        await camera.setVideoStabilizationMode(
+          cameraId,
+          VideoStabilizationMode.cinematic,
+        );
+        await camera.setVideoStabilizationMode(
+          cameraId,
+          VideoStabilizationMode.cinematicExtended,
+        );
+
+        // Assert
+        expect(channel.log, <Matcher>[
+          isMethodCall('setVideoStabilizationMode',
+              arguments: <String, Object?>{
+                'cameraId': cameraId,
+                'mode': VideoStabilizationMode.off.name,
+              }),
+          isMethodCall('setVideoStabilizationMode',
+              arguments: <String, Object?>{
+                'cameraId': cameraId,
+                'mode': VideoStabilizationMode.standard.name,
+              }),
+          isMethodCall('setVideoStabilizationMode',
+              arguments: <String, Object?>{
+                'cameraId': cameraId,
+                'mode': VideoStabilizationMode.cinematic.name,
+              }),
+          isMethodCall('setVideoStabilizationMode',
+              arguments: <String, Object?>{
+                'cameraId': cameraId,
+                'mode': VideoStabilizationMode.cinematicExtended.name,
+              }),
+        ]);
+      });
+
       test('Should lock the capture orientation', () async {
         // Arrange
         final MethodChannelMock channel = MethodChannelMock(

--- a/packages/camera/camera_platform_interface/test/types/video_stabilization_mode_test.dart
+++ b/packages/camera/camera_platform_interface/test/types/video_stabilization_mode_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:camera_platform_interface/src/types/video_stabilization_mode.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('VideoStabilizationMode should contain 3 options', () {
+    const List<VideoStabilizationMode> values = VideoStabilizationMode.values;
+
+    expect(values.length, 5);
+  });
+
+  test('VideoStabilizationMode enum should have items in correct index', () {
+    const List<VideoStabilizationMode> values = VideoStabilizationMode.values;
+
+    expect(values[0], VideoStabilizationMode.off);
+    expect(values[1], VideoStabilizationMode.on);
+    expect(values[2], VideoStabilizationMode.standard);
+    expect(values[3], VideoStabilizationMode.cinematic);
+    expect(values[4], VideoStabilizationMode.cinematicExtended);
+  });
+
+  test('deserializeVideoStabilizationMode() should deserialize correctly', () {
+    expect(
+        VideoStabilizationMode.fromString('off'), VideoStabilizationMode.off);
+    expect(VideoStabilizationMode.fromString('on'), VideoStabilizationMode.on);
+    expect(VideoStabilizationMode.fromString('standard'),
+        VideoStabilizationMode.standard);
+    expect(VideoStabilizationMode.fromString('cinematic'),
+        VideoStabilizationMode.cinematic);
+    expect(VideoStabilizationMode.fromString('cinematicExtended'),
+        VideoStabilizationMode.cinematicExtended);
+  });
+}


### PR DESCRIPTION
Adds support for video stabilization to camera_platform_interface.

This is the platform interface package PR derived from the combined PR https://github.com/flutter/packages/pull/7108.

The video stabilization modes are defined in the new VideoStabilizationMode enum defined in camera_platform_interface:
```dart
/// The possible video stabilization modes that can be capturing video.
enum VideoStabilizationMode {
  /// Video stabilization is disabled.
  off,

  /// Basic video stabilization is enabled.
  /// Maps to CONTROL_VIDEO_STABILIZATION_MODE_ON on Android
  /// and throws CameraException on iOS.
  on,

  /// Standard video stabilization is enabled.
  /// Maps to CONTROL_VIDEO_STABILIZATION_MODE_PREVIEW_STABILIZATION on Android
  /// (camera_android_camerax) and to AVCaptureVideoStabilizationModeStandard
  /// on iOS.
  standard,

  /// Cinematic video stabilization is enabled.
  /// Maps to CONTROL_VIDEO_STABILIZATION_MODE_PREVIEW_STABILIZATION on Android
  /// (camera_android_camerax) and to AVCaptureVideoStabilizationModeCinematic
  /// on iOS.
  cinematic,

  /// Extended cinematic video stabilization is enabled.
  /// Maps to AVCaptureVideoStabilizationModeCinematicExtended on iOS and
  /// throws CameraException on Android.
  cinematicExtended,
}
```

*List which issues are fixed by this PR. You must list at least one issue.*
Partially implements https://github.com/flutter/flutter/issues/89525


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
