### PR TITLE
[camerax] Ignore new `unreachable_switch_default` warning.

### DIFF
--- a/packages/camera/camera_android_camerax/lib/src/capture_request_options.dart
+++ b/packages/camera/camera_android_camerax/lib/src/capture_request_options.dart
@@ -115,7 +115,7 @@ class _CaptureRequestOptionsHostApiImpl extends CaptureRequestOptionsHostApi {
         // This ignore statement is safe beause this error will be useful when
         // a new CaptureRequestKeySupportedType is being added, but the logic in
         // this method has not yet been updated.
-        // ignore: no_default_cases
+        // ignore: no_default_cases, unreachable_switch_default
         default:
           throw ArgumentError(CaptureRequestOptions
               .getUnsupportedCaptureRequestKeyTypeErrorMessage(key));

--- a/packages/camera/camera_android_camerax/lib/src/live_data.dart
+++ b/packages/camera/camera_android_camerax/lib/src/live_data.dart
@@ -185,7 +185,7 @@ class LiveDataFlutterApiImpl implements LiveDataFlutterApi {
       // This ignore statement is safe beause this error will be useful when
       // a new LiveDataSupportedType is being added, but the logic in this method
       // has not yet been updated.
-      // ignore: no_default_cases
+      // ignore: no_default_cases, unreachable_switch_default
       default:
         throw ArgumentError(LiveData.unsupportedLiveDataTypeErrorMessage);
     }

--- a/packages/camera/camera_android_camerax/test/capture_request_options_test.dart
+++ b/packages/camera/camera_android_camerax/test/capture_request_options_test.dart
@@ -132,7 +132,7 @@ void main() {
           // This ignore statement is safe beause this will test when
           // a new CaptureRequestKeySupportedType is being added, but the logic in
           // in the CaptureRequestOptions class has not yet been updated.
-          // ignore: no_default_cases
+          // ignore: no_default_cases, unreachable_switch_default
           default:
             fail(
                 'Option $option contains unrecognized CaptureRequestKeySupportedType key ${option.$1}');


### PR DESCRIPTION
The Dart analyzer will soon be changed so that if the `default` clause of a `switch` statement is determined to be unreachable by the exhaustiveness checker, a new warning of type
`unreachable_switch_default` will be issued. This parallels the behavior of the existing `unreachable_switch_case` warning, which is issued whenever a `case` clause of a `switch` statement is determined to be unreachable.

In the vast majority of cases, the most reasonable way to address the warning is to remove the unreachable `default` clause. However, in a few rare cases, it makes sense to keep the `default` clause, because it's intentionally future-proofing the code in case new possible values are added to the enum being switched on.

Three of these rare cases crop up in the camerax package. This change adds `ignore` comments to avoid a spurious warning.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
