### PR TITLE
[google_maps_flutter_platform_interface] Fix typo in CameraUpdateNewLatLngBounds.toJson

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.2
+
+* Corrects JSON tag for `CameraUpdateNewLatLngBounds`.
+
 ## 2.9.1
 
 * Splits CameraUpdate into dervied classes for different update cases.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/camera.dart
@@ -251,7 +251,7 @@ class CameraUpdateNewLatLngBounds extends CameraUpdate {
   /// The amount of padding by which the view is inset.
   final double padding;
   @override
-  Object toJson() => <Object>['newLatLngZoom', bounds.toJson(), padding];
+  Object toJson() => <Object>['newLatLngBounds', bounds.toJson(), padding];
 }
 
 /// Defines a camera move to new coordinates with a zoom level.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.9.1
+version: 2.9.2
 
 environment:
   sdk: ^3.3.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/camera_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/camera_test.dart
@@ -30,6 +30,8 @@ void main() {
     expect(cameraUpdate.updateType, CameraUpdateType.newCameraPosition);
     cameraUpdate as CameraUpdateNewCameraPosition;
     expect(cameraUpdate.cameraPosition, cameraPosition);
+    final List<Object> jsonList = cameraUpdate.toJson() as List<Object>;
+    expect(jsonList[0], 'newCameraPosition');
   });
 
   test('CameraUpdate.newLatLng', () {
@@ -39,6 +41,8 @@ void main() {
     expect(cameraUpdate.updateType, CameraUpdateType.newLatLng);
     cameraUpdate as CameraUpdateNewLatLng;
     expect(cameraUpdate.latLng, latLng);
+    final List<Object> jsonList = cameraUpdate.toJson() as List<Object>;
+    expect(jsonList[0], 'newLatLng');
   });
 
   test('CameraUpdate.newLatLngBounds', () {
@@ -52,6 +56,8 @@ void main() {
     cameraUpdate as CameraUpdateNewLatLngBounds;
     expect(cameraUpdate.bounds, latLngBounds);
     expect(cameraUpdate.padding, padding);
+    final List<Object> jsonList = cameraUpdate.toJson() as List<Object>;
+    expect(jsonList[0], 'newLatLngBounds');
   });
 
   test('CameraUpdate.newLatLngZoom', () {
@@ -63,6 +69,8 @@ void main() {
     cameraUpdate as CameraUpdateNewLatLngZoom;
     expect(cameraUpdate.latLng, latLng);
     expect(cameraUpdate.zoom, zoom);
+    final List<Object> jsonList = cameraUpdate.toJson() as List<Object>;
+    expect(jsonList[0], 'newLatLngZoom');
   });
 
   test('CameraUpdate.scrollBy', () {
@@ -74,6 +82,8 @@ void main() {
     cameraUpdate as CameraUpdateScrollBy;
     expect(cameraUpdate.dx, dx);
     expect(cameraUpdate.dy, dy);
+    final List<Object> jsonList = cameraUpdate.toJson() as List<Object>;
+    expect(jsonList[0], 'scrollBy');
   });
 
   test('CameraUpdate.zoomBy', () {
@@ -85,17 +95,23 @@ void main() {
     cameraUpdate as CameraUpdateZoomBy;
     expect(cameraUpdate.amount, amount);
     expect(cameraUpdate.focus, focus);
+    final List<Object> jsonList = cameraUpdate.toJson() as List<Object>;
+    expect(jsonList[0], 'zoomBy');
   });
 
   test('CameraUpdate.zoomIn', () {
     final CameraUpdate cameraUpdate = CameraUpdate.zoomIn();
     expect(cameraUpdate.runtimeType, CameraUpdateZoomIn);
     expect(cameraUpdate.updateType, CameraUpdateType.zoomIn);
+    final List<Object> jsonList = cameraUpdate.toJson() as List<Object>;
+    expect(jsonList[0], 'zoomIn');
   });
 
   test('CameraUpdate.zoomOut', () {
     final CameraUpdate cameraUpdate = CameraUpdate.zoomOut();
     expect(cameraUpdate.runtimeType, CameraUpdateZoomOut);
     expect(cameraUpdate.updateType, CameraUpdateType.zoomOut);
+    final List<Object> jsonList = cameraUpdate.toJson() as List<Object>;
+    expect(jsonList[0], 'zoomOut');
   });
 }


### PR DESCRIPTION
Replace `newLatLngZoom` with `newLatLngBounds` as it should be.

See https://github.com/flutter/packages/pull/7596#pullrequestreview-2297196704

Part of https://github.com/flutter/flutter/issues/152928

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
