### PR TITLE
Add support for passing query parameters into benchmark URIs

### DIFF
--- a/packages/web_benchmarks/CHANGELOG.md
+++ b/packages/web_benchmarks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0
+
+* Adds an optional parameter `queryParameters` to the `serveWebBenchmark` method.
+* Adds an optional parameter `queryParameters` to the `runBenchmarks` method
+for benchmark clients.
+
 ## 2.0.2
 
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.

--- a/packages/web_benchmarks/lib/client.dart
+++ b/packages/web_benchmarks/lib/client.dart
@@ -44,6 +44,7 @@ extension on HTMLElement {
 Future<void> runBenchmarks(
   Map<String, RecorderFactory> benchmarks, {
   String initialPage = defaultInitialPage,
+  Map<String, Object?>? queryParameters,
 }) async {
   // Set local benchmarks.
   _benchmarks = benchmarks;
@@ -60,13 +61,15 @@ Future<void> runBenchmarks(
   await _runBenchmark(nextBenchmark);
 
   final Uri currentUri = Uri.parse(window.location.href);
-  // Create a new URI with the current 'page' value set to [initialPage] to
-  // ensure the benchmark app is reloaded at the proper location.
+  // Create a new URI with the current 'page' value set to [initialPage] and the
+  // query parameters set to [queryParameters] to ensure the benchmark app is
+  // loaded with the proper configuration.
   final String newUri = Uri(
     scheme: currentUri.scheme,
     host: currentUri.host,
     port: currentUri.port,
     path: initialPage,
+    queryParameters: queryParameters,
   ).toString();
 
   // Reloading the window will trigger the next benchmark to run.

--- a/packages/web_benchmarks/lib/server.dart
+++ b/packages/web_benchmarks/lib/server.dart
@@ -40,18 +40,18 @@ const int defaultChromeDebugPort = 10000;
 ///
 /// If [headless] is true, runs Chrome without UI. In particular, this is
 /// useful in environments (e.g. CI) that doesn't have a display.
-/// 
+///
 /// If [treeShakeIcons] is false, '--no-tree-shake-icons' will be passed as a
 /// build argument when building the benchmark app.
-/// 
+///
 /// [initialPage] specifies the 'path' of the URL to load upon opening the
 /// benchmark app in Chrome.
-/// 
+///
 /// [queryParameters] specifies the 'queryParameters' of the URL to load upon
 /// opening the benchmark app in Chrome.
-/// 
+///
 /// [compilationOptions] specify the compiler and renderer to use for the
-/// benchmark app. This can either use dart2wasm & skwasm or 
+/// benchmark app. This can either use dart2wasm & skwasm or
 /// dart2js & canvaskit.
 Future<BenchmarkResults> serveWebBenchmark({
   required io.Directory benchmarkAppDirectory,

--- a/packages/web_benchmarks/lib/server.dart
+++ b/packages/web_benchmarks/lib/server.dart
@@ -32,8 +32,6 @@ const int defaultChromeDebugPort = 10000;
 /// can be different (and typically is) from the production entry point of the
 /// app.
 ///
-/// If [useCanvasKit] is true, builds the app in CanvasKit mode.
-///
 /// [benchmarkServerPort] is the port this benchmark server serves the app on.
 /// By default uses [defaultBenchmarkServerPort].
 ///
@@ -42,6 +40,19 @@ const int defaultChromeDebugPort = 10000;
 ///
 /// If [headless] is true, runs Chrome without UI. In particular, this is
 /// useful in environments (e.g. CI) that doesn't have a display.
+/// 
+/// If [treeShakeIcons] is false, '--no-tree-shake-icons' will be passed as a
+/// build argument when building the benchmark app.
+/// 
+/// [initialPage] specifies the 'path' of the URL to load upon opening the
+/// benchmark app in Chrome.
+/// 
+/// [queryParameters] specifies the 'queryParameters' of the URL to load upon
+/// opening the benchmark app in Chrome.
+/// 
+/// [compilationOptions] specify the compiler and renderer to use for the
+/// benchmark app. This can either use dart2wasm & skwasm or 
+/// dart2js & canvaskit.
 Future<BenchmarkResults> serveWebBenchmark({
   required io.Directory benchmarkAppDirectory,
   required String entryPoint,
@@ -50,6 +61,7 @@ Future<BenchmarkResults> serveWebBenchmark({
   bool headless = true,
   bool treeShakeIcons = true,
   String initialPage = defaultInitialPage,
+  Map<String, Object?>? queryParameters,
   CompilationOptions compilationOptions = const CompilationOptions.js(),
 }) async {
   // Reduce logging level. Otherwise, package:webkit_inspection_protocol is way too spammy.
@@ -64,5 +76,6 @@ Future<BenchmarkResults> serveWebBenchmark({
     compilationOptions: compilationOptions,
     treeShakeIcons: treeShakeIcons,
     initialPage: initialPage,
+    queryParameters: queryParameters,
   ).run();
 }

--- a/packages/web_benchmarks/lib/src/runner.dart
+++ b/packages/web_benchmarks/lib/src/runner.dart
@@ -57,6 +57,7 @@ class BenchmarkServer {
     required this.treeShakeIcons,
     this.compilationOptions = const CompilationOptions.js(),
     this.initialPage = defaultInitialPage,
+    this.queryParameters,
   });
 
   final ProcessManager _processManager = const LocalProcessManager();
@@ -97,8 +98,17 @@ class BenchmarkServer {
   /// The default value is [defaultInitialPage].
   final String initialPage;
 
-  String get _benchmarkAppUrl =>
-      'http://localhost:$benchmarkServerPort/$initialPage';
+  /// The query parameters to include in the URL upon opening the benchmark app
+  /// in Chrome.
+  final Map<String, Object?>? queryParameters;
+
+  String get _benchmarkAppUrl => Uri(
+        scheme: 'http',
+        host: 'localhost',
+        port: benchmarkServerPort,
+        path: initialPage,
+        queryParameters: queryParameters,
+      ).toString();
 
   /// Builds and serves the benchmark app, and collects benchmark results.
   Future<BenchmarkResults> run() async {

--- a/packages/web_benchmarks/pubspec.yaml
+++ b/packages/web_benchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_benchmarks
 description: A benchmark harness for performance-testing Flutter apps in Chrome.
 repository: https://github.com/flutter/packages/tree/main/packages/web_benchmarks
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+web_benchmarks%22
-version: 2.0.2
+version: 2.1.0
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
This will unblock https://github.com/flutter/devtools/pull/8320