### PR TITLE
[shared_preferences] moving sharedPreferencesAsync/withCache to a new file

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.3
+
+* Moves `SharedPreferencesAsync` and `SharedPreferencesWithCache` APIs to a new file 
+  to use this API use this `import 'package:shared_preferences/shared_preferences_async_with_cache.dart';`
+  
 ## 2.3.2
 
 * Removes outdated testing information from README.

--- a/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences_aync_with_cache.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/shared_preferences/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/main.dart
@@ -7,7 +7,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences_async_with_cache.dart';
 
 void main() {
   runApp(const MyApp());

--- a/packages/shared_preferences/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/main.dart
@@ -7,7 +7,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences_async_with_cache.dart';
+import 'package:shared_preferences/shared_preferences_aync_with_cache.dart';
 
 void main() {
   runApp(const MyApp());

--- a/packages/shared_preferences/shared_preferences/example/lib/readme_excerpts.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/readme_excerpts.dart
@@ -4,7 +4,8 @@
 
 // ignore_for_file: public_member_api_docs, unused_local_variable, invalid_use_of_visible_for_testing_member
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:shared_preferences/shared_preferences_async_with_cache.dart';
+import 'package:shared_preferences/shared_preferences_aync_with_cache.dart';
+
 
 Future<void> readmeSnippets() async {
   // #docregion Write

--- a/packages/shared_preferences/shared_preferences/example/lib/readme_excerpts.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/readme_excerpts.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: public_member_api_docs, unused_local_variable, invalid_use_of_visible_for_testing_member
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences_async_with_cache.dart';
 
 Future<void> readmeSnippets() async {
   // #docregion Write

--- a/packages/shared_preferences/shared_preferences/lib/shared_preferences_aync_with_cache.dart
+++ b/packages/shared_preferences/shared_preferences/lib/shared_preferences_aync_with_cache.dart
@@ -2,5 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-export 'src/shared_preferences_legacy.dart';
+export 'src/shared_preferences_async.dart';

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.3.2
+version: 2.3.3
 
 environment:
   sdk: ^3.4.0

--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_async_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_async_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences_aync_with_cache.dart';
 import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 import 'package:shared_preferences_platform_interface/types.dart';


### PR DESCRIPTION
fixes : [#155487](https://github.com/flutter/flutter/issues/155487)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
