### PR TITLE
[quick_actions] Add guidance for correcting task management/back press behavior for apps with launcher activities

### DIFF
--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.15+1
+
+* Updates README to include guidance on using the plugin with a launcher activity.
+
 ## 1.0.15
 
 * Updates lint checks to ignore NewerVersionAvailable.

--- a/packages/quick_actions/quick_actions_android/README.md
+++ b/packages/quick_actions/quick_actions_android/README.md
@@ -11,6 +11,25 @@ so you do not need to add it to your `pubspec.yaml`.
 However, if you `import` this package to use any of its APIs directly, you
 should add it to your `pubspec.yaml` as usual.
 
+## Usage with launcher activities
+
+If your app implements an activity that launches the main `FlutterActivity`
+(`MainActivity.java`/`MainActivity.kt` by default), then you may need to change
+the launch mode of your launcher activity to achieve the desired back press behavior
+and task management. To have your app maintain the same behavior of
+`quick_actions_android` with/without a launcher activity, set the launch mode of
+your launcher activity to `singleInstance` in
+`your_app/android/app/src/mainAndroidManifest.xml`:
+
+```
+<activity
+        ...
+        android:launchMode="singleInstance">
+```
+
+See the [Tasks and the back stack][4] Android documentation for more information
+on the back stack and launch modes.
+
 ## Contributing
 
 If you would like to contribute to the plugin, check out our [contribution guide][3].
@@ -18,3 +37,4 @@ If you would like to contribute to the plugin, check out our [contribution guide
 [1]: https://pub.dev/packages/quick_actions
 [2]: https://flutter.dev/to/endorsed-federated-plugin
 [3]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
+[4]: https://developer.android.com/guide/components/activities/tasks-and-back-stack#TaskLaunchModes

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_android
 description: An implementation for the Android platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/quick_actions/quick_actions_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 1.0.15
+version: 1.0.15+1
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
### What
Adds a note about correcting the task management/back press behavior for apps that use a launcher activities to the README. Fixes https://github.com/flutter/flutter/issues/152883.

### Why
If apps use a launcher activity, then launching shortcuts created by the plugin may not behave as expected because the plugin expects to launch the main `FlutterActivity`, for which it configures the launch mode, but instead launches the launcher activity, which it does not account for. To fix this, the launcher activity itself needs to have a launch mode configuration that makes sense for the app. If the launcher activity only launches the main `FlutterActivity` without any additional logic, to maintain the exact same behavior of the plugin with/without a launcher activity, the launcher activity can use the `singleInstance` launch mode. In more complex launcher activities, other modes may need to be used, though.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
