### PR TITLE
[various] Adds macOS privacy manifests

### DIFF
--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.9.4+1
 
+* Adds privacy manifest.
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.
 
 ## 0.9.4

--- a/packages/file_selector/file_selector_macos/macos/file_selector_macos.podspec
+++ b/packages/file_selector/file_selector_macos/macos/file_selector_macos.podspec
@@ -13,6 +13,7 @@ Displays native macOS open and save panels.
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :http => 'https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_macos' }
   s.source_files     = 'file_selector_macos/Sources/file_selector_macos/**/*.swift'
+  s.resource_bundles = {'file_selector_macos_privacy' => ['file_selector_macos/Sources/file_selector_macos/Resources/PrivacyInfo.xcprivacy']}
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx, '10.14'

--- a/packages/file_selector/file_selector_macos/macos/file_selector_macos/Package.swift
+++ b/packages/file_selector/file_selector_macos/macos/file_selector_macos/Package.swift
@@ -19,7 +19,10 @@ let package = Package(
   targets: [
     .target(
       name: "file_selector_macos",
-      dependencies: []
+      dependencies: [],
+      resources: [
+        .process("Resources")
+      ]
     )
   ]
 )

--- a/packages/file_selector/file_selector_macos/macos/file_selector_macos/Sources/file_selector_macos/Resources/PrivacyInfo.xcprivacy
+++ b/packages/file_selector/file_selector_macos/macos/file_selector_macos/Sources/file_selector_macos/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.4
+version: 0.9.4+1
 
 environment:
   sdk: ^3.3.0

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 3.2.1
 
+* Adds privacy manifest.
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.
 
 ## 3.2.0

--- a/packages/url_launcher/url_launcher_macos/macos/url_launcher_macos.podspec
+++ b/packages/url_launcher/url_launcher_macos/macos/url_launcher_macos.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :http => 'https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_macos' }
   s.source_files     = 'url_launcher_macos/Sources/url_launcher_macos/**/*.swift'
+  s.resource_bundles = {'url_launcher_macos_privacy' => ['url_launcher_macos/Sources/url_launcher_macos/Resources/PrivacyInfo.xcprivacy']}
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx, '10.14'

--- a/packages/url_launcher/url_launcher_macos/macos/url_launcher_macos/Sources/url_launcher_macos/Resources/PrivacyInfo.xcprivacy
+++ b/packages/url_launcher/url_launcher_macos/macos/url_launcher_macos/Sources/url_launcher_macos/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_macos
 description: macOS implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 3.2.0
+version: 3.2.1
 
 environment:
   sdk: ^3.3.0

--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -95,7 +95,8 @@ class PodspecCheckCommand extends PackageLoopingCommand {
       }
     }
 
-    if (pluginSupportsPlatform(platformIOS, package) &&
+    if ((pluginSupportsPlatform(platformIOS, package) ||
+            pluginSupportsPlatform(platformMacOS, package)) &&
         !podspecs.any(_hasPrivacyManifest)) {
       printError('No PrivacyInfo.xcprivacy file specified. Please ensure that '
           'a privacy manifest is included in the build using '

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -605,5 +605,49 @@ void main() {
             <Matcher>[contains('Ran for 1 package(s)')],
           ));
     });
+
+    test('fails when a macOS plugin is missing a privacy manifest', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin1',
+        packagesDir,
+        platformSupport: <String, PlatformDetails>{
+          Platform.macOS: const PlatformDetails(PlatformSupport.inline),
+        },
+      );
+      _writeFakePodspec(plugin, 'macos');
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['podspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+          output,
+          containsAllInOrder(
+            <Matcher>[contains('No PrivacyInfo.xcprivacy file specified.')],
+          ));
+    });
+
+    test('passes when a macOS plugin has a privacy manifest', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin1',
+        packagesDir,
+        platformSupport: <String, PlatformDetails>{
+          Platform.macOS: const PlatformDetails(PlatformSupport.inline),
+        },
+      );
+      _writeFakePodspec(plugin, 'macos', includePrivacyManifest: true);
+
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['podspec-check']);
+
+      expect(
+          output,
+          containsAllInOrder(
+            <Matcher>[contains('Ran for 1 package(s)')],
+          ));
+    });
   });
 }


### PR DESCRIPTION
macOS privacy manifest enforcement is rolling out soon, so this brings all macOS plugins into alignment with our iOS policy of always having a manifest, including updating the repo tooling to enforce that.

Very few plugins are affected because most share the implementation package with iOS, and we didn't do any target platform switching when adding the manifests for iOS, automatically covering macOS as well.

Fixes https://github.com/flutter/flutter/issues/155564

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
