### PR TITLE
[google_maps_flutter_platform_interface] Convert `BitmapDescriptor` to typesafe subclasses

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.9.5
+
+* Converts `BitmapDescriptor` to typesafe structures.
+
+
 ## 2.9.4
 
 * Converts `PatternItem` to typesafe structure.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * Converts `BitmapDescriptor` to typesafe structures.
 
-
 ## 2.9.4
 
 * Converts `PatternItem` to typesafe structure.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -76,7 +76,9 @@ class BitmapDescriptor {
         if (jsonList.length == 3) {
           assert(jsonList[2] != null && jsonList[2] is String);
           assert((jsonList[2] as String).isNotEmpty);
+          return AssetBitmap(name: jsonList[1] as String, package: jsonList[2] as String);
         }
+        return AssetBitmap(name: jsonList[1] as String);
       case _fromAssetImage:
         assert(jsonList.length <= 4);
         assert(jsonList[1] != null && jsonList[1] is String);
@@ -329,6 +331,16 @@ class BytesBitmap extends BitmapDescriptor {
   Object toJson() {
     return <Object>[BitmapDescriptor._fromBytes, byteData, if (size != null && kIsWeb) <Object>[size!.width, size!.height]];
   }
+}
+
+class AssetBitmap extends BitmapDescriptor {
+  const AssetBitmap({required this.name, this.package}) : super._(const <Object>[]);
+
+  final String name;
+  final String? package;
+
+  @override
+  Object toJson() => <Object>[BitmapDescriptor._fromAsset, name, if (package != null) package!];
 }
 
 /// Represents a [BitmapDescriptor] base class for map bitmaps.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -30,10 +30,10 @@ enum MapBitmapScaling {
 }
 
 MapBitmapScaling mapBitmapScalingFromString(String mode) => switch (mode) {
-    'auto' => MapBitmapScaling.auto,
-    'none' => MapBitmapScaling.none,
-    _ => throw ArgumentError('Unrecognized MapBitmapScaling $mode', 'mode'),
-  };
+      'auto' => MapBitmapScaling.auto,
+      'none' => MapBitmapScaling.none,
+      _ => throw ArgumentError('Unrecognized MapBitmapScaling $mode', 'mode'),
+    };
 
 // The default pixel ratio for custom bitmaps.
 const double _naturalPixelRatio = 1.0;
@@ -82,7 +82,8 @@ abstract class BitmapDescriptor {
         if (jsonList.length == 3) {
           assert(jsonList[2] != null && jsonList[2] is String);
           assert((jsonList[2] as String).isNotEmpty);
-          return AssetBitmap(name: jsonList[1] as String, package: jsonList[2] as String);
+          return AssetBitmap(
+              name: jsonList[1] as String, package: jsonList[2] as String);
         }
         return AssetBitmap(name: jsonList[1] as String);
       case _fromAssetImage:
@@ -94,9 +95,14 @@ abstract class BitmapDescriptor {
           assert(jsonList[3] != null && jsonList[3] is List<dynamic>);
           assert((jsonList[3] as List<dynamic>).length == 2);
           final List<dynamic> sizeList = jsonList[3] as List<dynamic>;
-          return AssetImageBitmap(name: jsonList[1] as String, scale: jsonList[2] as double, size: Size((sizeList[0] as num).toDouble(), (sizeList[1] as num).toDouble()));
+          return AssetImageBitmap(
+              name: jsonList[1] as String,
+              scale: jsonList[2] as double,
+              size: Size((sizeList[0] as num).toDouble(),
+                  (sizeList[1] as num).toDouble()));
         }
-        return AssetImageBitmap(name: jsonList[1] as String, scale: jsonList[2] as double);
+        return AssetImageBitmap(
+            name: jsonList[1] as String, scale: jsonList[2] as double);
       case AssetMapBitmap.type:
         assert(jsonList.length == 2);
         assert(jsonList[1] != null && jsonList[1] is Map<String, dynamic>);
@@ -110,9 +116,16 @@ abstract class BitmapDescriptor {
         assert(jsonMap['imagePixelRatio'] is double);
         assert(!jsonMap.containsKey('width') || jsonMap['width'] is double);
         assert(!jsonMap.containsKey('height') || jsonMap['height'] is double);
-        final double? width = jsonMap.containsKey('width') ? jsonMap['width'] as double : null;
-        final double? height = jsonMap.containsKey('height') ? jsonMap['height'] as double : null;
-        return AssetMapBitmap(jsonMap['assetName'] as String, bitmapScaling: mapBitmapScalingFromString(jsonMap['bitmapScaling'] as String), imagePixelRatio: jsonMap['imagePixelRatio'] as double, width: width, height: height);
+        final double? width =
+            jsonMap.containsKey('width') ? jsonMap['width'] as double : null;
+        final double? height =
+            jsonMap.containsKey('height') ? jsonMap['height'] as double : null;
+        return AssetMapBitmap(jsonMap['assetName'] as String,
+            bitmapScaling:
+                mapBitmapScalingFromString(jsonMap['bitmapScaling'] as String),
+            imagePixelRatio: jsonMap['imagePixelRatio'] as double,
+            width: width,
+            height: height);
       case BytesMapBitmap.type:
         assert(jsonList.length == 2);
         assert(jsonList[1] != null && jsonList[1] is Map<String, dynamic>);
@@ -126,9 +139,16 @@ abstract class BitmapDescriptor {
         assert(jsonMap['imagePixelRatio'] is double);
         assert(!jsonMap.containsKey('width') || jsonMap['width'] is double);
         assert(!jsonMap.containsKey('height') || jsonMap['height'] is double);
-        final double? width = jsonMap.containsKey('width') ? jsonMap['width'] as double : null;
-        final double? height = jsonMap.containsKey('height') ? jsonMap['height'] as double : null;
-        return BytesMapBitmap(jsonMap['byteData'] as Uint8List, bitmapScaling: mapBitmapScalingFromString(jsonMap['bitmapScaling'] as String), width: width, height: height, imagePixelRatio: jsonMap['imagePixelRatio'] as double);
+        final double? width =
+            jsonMap.containsKey('width') ? jsonMap['width'] as double : null;
+        final double? height =
+            jsonMap.containsKey('height') ? jsonMap['height'] as double : null;
+        return BytesMapBitmap(jsonMap['byteData'] as Uint8List,
+            bitmapScaling:
+                mapBitmapScalingFromString(jsonMap['bitmapScaling'] as String),
+            width: width,
+            height: height,
+            imagePixelRatio: jsonMap['imagePixelRatio'] as double);
       default:
         break;
     }
@@ -181,8 +201,7 @@ abstract class BitmapDescriptor {
   static const double hueRose = 330.0;
 
   /// Creates a BitmapDescriptor that refers to the default marker image.
-  static const BitmapDescriptor defaultMarker =
-      DefaultMarker();
+  static const BitmapDescriptor defaultMarker = DefaultMarker();
 
   /// Creates a BitmapDescriptor that refers to a colorization of the default
   /// marker image. For convenience, there is a predefined set of hue values.
@@ -217,7 +236,10 @@ abstract class BitmapDescriptor {
     final AssetBundleImageKey assetBundleImageKey =
         await assetImage.obtainKey(configuration);
     final Size? size = kIsWeb ? configuration.size : null;
-    return AssetImageBitmap(name: assetBundleImageKey.name, scale: assetBundleImageKey.scale, size: size);
+    return AssetImageBitmap(
+        name: assetBundleImageKey.name,
+        scale: assetBundleImageKey.scale,
+        size: size);
   }
 
   /// Creates a BitmapDescriptor using an array of bytes that must be encoded
@@ -320,9 +342,12 @@ class DefaultMarker extends BitmapDescriptor {
 
   @override
   Object toJson() {
-    return (hue == null) ? const <Object>[BitmapDescriptor._defaultMarker] : <Object>[BitmapDescriptor._defaultMarker, hue!];
+    return (hue == null)
+        ? const <Object>[BitmapDescriptor._defaultMarker]
+        : <Object>[BitmapDescriptor._defaultMarker, hue!];
   }
 }
+
 /// A BitmapDescriptor using an array of bytes that must be encoded
 /// as PNG.
 @Deprecated('Use BytesMapBitmap instead')
@@ -332,7 +357,8 @@ class BytesBitmap extends BitmapDescriptor {
   /// This helps the browser to render High-DPI images at the correct size.
   /// `size` is not required (and ignored, if passed) in other platforms.
   @Deprecated('Use BytesMapBitmap instead')
-  const BytesBitmap({required Uint8List byteData, Size? size}) : this._(byteData, kIsWeb ? size : null);
+  const BytesBitmap({required Uint8List byteData, Size? size})
+      : this._(byteData, kIsWeb ? size : null);
 
   @Deprecated('Use BytesMapBitmap instead')
   const BytesBitmap._(this.byteData, this.size) : super._();
@@ -345,7 +371,11 @@ class BytesBitmap extends BitmapDescriptor {
 
   @override
   Object toJson() {
-    return <Object>[BitmapDescriptor._fromBytes, byteData, if (size != null) <Object>[size!.width, size!.height]];
+    return <Object>[
+      BitmapDescriptor._fromBytes,
+      byteData,
+      if (size != null) <Object>[size!.width, size!.height]
+    ];
   }
 }
 
@@ -361,7 +391,11 @@ class AssetBitmap extends BitmapDescriptor {
   final String? package;
 
   @override
-  Object toJson() => <Object>[BitmapDescriptor._fromAsset, name, if (package != null) package!];
+  Object toJson() => <Object>[
+        BitmapDescriptor._fromAsset,
+        name,
+        if (package != null) package!
+      ];
 }
 
 /// A [BitmapDescriptor] from an asset image.
@@ -373,7 +407,8 @@ class AssetImageBitmap extends BitmapDescriptor {
   /// This method takes into consideration various asset resolutions
   /// and scales the images to the right resolution depending on the dpi.
   @Deprecated('Use AssetMapBitmap instead')
-  const AssetImageBitmap({required this.name, required this.scale, this.size}) : super._();
+  const AssetImageBitmap({required this.name, required this.scale, this.size})
+      : super._();
 
   /// Name of the image asset.
   final String name;
@@ -385,7 +420,12 @@ class AssetImageBitmap extends BitmapDescriptor {
   final Size? size;
 
   @override
-  Object toJson() => <Object>[BitmapDescriptor._fromAssetImage, name, scale, if (size != null) <Object>[size!.width, size!.height]];
+  Object toJson() => <Object>[
+        BitmapDescriptor._fromAssetImage,
+        name,
+        scale,
+        if (size != null) <Object>[size!.width, size!.height]
+      ];
 }
 
 /// Represents a [BitmapDescriptor] base class for map bitmaps.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -29,6 +29,7 @@ enum MapBitmapScaling {
   none,
 }
 
+/// Convert a string from provided JSON to a MapBitmapScaling enum.
 MapBitmapScaling mapBitmapScalingFromString(String mode) => switch (mode) {
       'auto' => MapBitmapScaling.auto,
       'none' => MapBitmapScaling.none,
@@ -341,11 +342,9 @@ class DefaultMarker extends BitmapDescriptor {
   final num? hue;
 
   @override
-  Object toJson() {
-    return (hue == null)
-        ? const <Object>[BitmapDescriptor._defaultMarker]
-        : <Object>[BitmapDescriptor._defaultMarker, hue!];
-  }
+  Object toJson() => (hue == null)
+      ? const <Object>[BitmapDescriptor._defaultMarker]
+      : <Object>[BitmapDescriptor._defaultMarker, hue!];
 }
 
 /// A BitmapDescriptor using an array of bytes that must be encoded
@@ -370,13 +369,11 @@ class BytesBitmap extends BitmapDescriptor {
   final Size? size;
 
   @override
-  Object toJson() {
-    return <Object>[
-      BitmapDescriptor._fromBytes,
-      byteData,
-      if (size != null) <Object>[size!.width, size!.height]
-    ];
-  }
+  Object toJson() => <Object>[
+        BitmapDescriptor._fromBytes,
+        byteData,
+        if (size != null) <Object>[size!.width, size!.height]
+      ];
 }
 
 /// A bitmap specified by a name and optional package.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -68,7 +68,7 @@ abstract class BitmapDescriptor {
           assert(jsonList[1] is num);
           final num secondElement = jsonList[1] as num;
           assert(0 <= secondElement && secondElement < 360);
-          return DefaultMarker(secondElement);
+          return DefaultMarker(hue: secondElement);
         }
         return const DefaultMarker();
       case _fromBytes:
@@ -209,7 +209,7 @@ abstract class BitmapDescriptor {
   /// See e.g. [hueYellow].
   static BitmapDescriptor defaultMarkerWithHue(double hue) {
     assert(0.0 <= hue && hue < 360.0);
-    return DefaultMarker(hue);
+    return DefaultMarker(hue: hue);
   }
 
   /// Creates a [BitmapDescriptor] from an asset image.
@@ -336,7 +336,7 @@ abstract class BitmapDescriptor {
 /// A BitmapDescriptor using the default marker.
 class DefaultMarker extends BitmapDescriptor {
   /// Provide an optional [hue] for the default marker.
-  const DefaultMarker([this.hue]) : super._();
+  const DefaultMarker({this.hue}) : super._();
 
   /// Optional hue of the colorization of the default marker.
   final num? hue;

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -50,8 +50,8 @@ const double _naturalPixelRatio = 1.0;
 /// a default marker icon.
 /// Use the [BitmapDescriptor.defaultMarkerWithHue] to create a
 /// [BitmapDescriptor] for a default marker icon with a hue value.
-class BitmapDescriptor {
-  const BitmapDescriptor._(this.json);
+abstract class BitmapDescriptor {
+  const BitmapDescriptor._();
 
   /// The inverse of .toJson.
   // TODO(stuartmorgan): Remove this in the next breaking change.
@@ -306,14 +306,12 @@ class BitmapDescriptor {
     );
   }
 
-  final Object json;
-
   /// Convert the object to a Json format.
-  Object toJson() => json;
+  Object toJson();
 }
 
 class DefaultMarker extends BitmapDescriptor {
-  const DefaultMarker([this.hue]) : super._(const <Object>[]);
+  const DefaultMarker([this.hue]) : super._();
 
   final num? hue;
 
@@ -324,7 +322,7 @@ class DefaultMarker extends BitmapDescriptor {
 }
 
 class BytesBitmap extends BitmapDescriptor {
-  const BytesBitmap({required this.byteData, this.size}) : super._(const <Object>[]);
+  const BytesBitmap({required this.byteData, this.size}) : super._();
 
   final Uint8List byteData;
   final Size? size;
@@ -336,7 +334,7 @@ class BytesBitmap extends BitmapDescriptor {
 }
 
 class AssetBitmap extends BitmapDescriptor {
-  const AssetBitmap({required this.name, this.package}) : super._(const <Object>[]);
+  const AssetBitmap({required this.name, this.package}) : super._();
 
   final String name;
   final String? package;
@@ -346,7 +344,7 @@ class AssetBitmap extends BitmapDescriptor {
 }
 
 class AssetImageBitmap extends BitmapDescriptor {
-  const AssetImageBitmap({required this.name, required this.scale, this.size}) : super._(const <Object>[]);
+  const AssetImageBitmap({required this.name, required this.scale, this.size}) : super._();
 
   final String name;
   final double scale;
@@ -388,7 +386,7 @@ abstract class MapBitmap extends BitmapDescriptor {
     required this.imagePixelRatio,
     this.width,
     this.height,
-  }) : super._(const <Object>[]);
+  }) : super._();
 
   /// The scaling method of the bitmap.
   final MapBitmapScaling bitmapScaling;

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -310,9 +310,12 @@ abstract class BitmapDescriptor {
   Object toJson();
 }
 
+/// A BitmapDescriptor using the default marker.
 class DefaultMarker extends BitmapDescriptor {
+  /// Provide an optional [hue] for the default marker.
   const DefaultMarker([this.hue]) : super._();
 
+  /// Optional hue of the colorization of the default marker.
   final num? hue;
 
   @override
@@ -320,13 +323,24 @@ class DefaultMarker extends BitmapDescriptor {
     return (hue == null) ? const <Object>[BitmapDescriptor._defaultMarker] : <Object>[BitmapDescriptor._defaultMarker, hue!];
   }
 }
-
+/// A BitmapDescriptor using an array of bytes that must be encoded
+/// as PNG.
+@Deprecated('Use BytesMapBitmap instead')
 class BytesBitmap extends BitmapDescriptor {
+  /// On the web, the [size] parameter represents the *physical size* of the
+  /// bitmap, regardless of the actual resolution of the encoded PNG.
+  /// This helps the browser to render High-DPI images at the correct size.
+  /// `size` is not required (and ignored, if passed) in other platforms.
+  @Deprecated('Use BytesMapBitmap instead')
   const BytesBitmap({required Uint8List byteData, Size? size}) : this._(byteData, kIsWeb ? size : null);
 
+  @Deprecated('Use BytesMapBitmap instead')
   const BytesBitmap._(this.byteData, this.size) : super._();
 
+  /// Array of bytes encoding a PNG.
   final Uint8List byteData;
+
+  /// On web, the physical size of the bitmap. Null on all other platforms.
   final Size? size;
 
   @override
@@ -335,27 +349,43 @@ class BytesBitmap extends BitmapDescriptor {
   }
 }
 
+/// A bitmap specified by a name and optional package.
 class AssetBitmap extends BitmapDescriptor {
+  /// Provides an asset name with [name] and optionally a [package].
   const AssetBitmap({required this.name, this.package}) : super._();
 
+  /// Name of the asset backing the bitmap.
   final String name;
+
+  /// Optional package of the asset.
   final String? package;
 
   @override
   Object toJson() => <Object>[BitmapDescriptor._fromAsset, name, if (package != null) package!];
 }
 
+/// A [BitmapDescriptor] from an asset image.
+@Deprecated('Use AssetMapBitmap instead')
 class AssetImageBitmap extends BitmapDescriptor {
-  const AssetImageBitmap({required String name, required double scale, Size? size}) : this._(name, scale, kIsWeb ? size : null);
+  /// Creates a [BitmapDescriptor] from an asset image with specified [name] and [scale], and an optional [size].
+  /// Asset images in flutter are stored per:
+  /// https://flutter.dev/to/resolution-aware-images
+  /// This method takes into consideration various asset resolutions
+  /// and scales the images to the right resolution depending on the dpi.
+  @Deprecated('Use AssetMapBitmap instead')
+  const AssetImageBitmap({required this.name, required this.scale, this.size}) : super._();
 
-  const AssetImageBitmap._(this.name, this.scale, this.size) : super._();
-
+  /// Name of the image asset.
   final String name;
+
+  /// Scaling factor for the asset image.
   final double scale;
+
+  /// Size of the image if using mipmaps.
   final Size? size;
 
   @override
-  Object toJson() => <Object>[BitmapDescriptor._fromAssetImage, name, scale, if (kIsWeb && size != null) <Object>[size!.width, size!.height]];
+  Object toJson() => <Object>[BitmapDescriptor._fromAssetImage, name, scale, if (size != null) <Object>[size!.width, size!.height]];
 }
 
 /// Represents a [BitmapDescriptor] base class for map bitmaps.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -5,6 +5,7 @@
 import 'dart:async' show Future;
 import 'dart:typed_data' show Uint8List;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart'
     show
@@ -30,6 +31,7 @@ enum MapBitmapScaling {
 }
 
 /// Convert a string from provided JSON to a MapBitmapScaling enum.
+@visibleForTesting
 MapBitmapScaling mapBitmapScalingFromString(String mode) => switch (mode) {
       'auto' => MapBitmapScaling.auto,
       'none' => MapBitmapScaling.none,

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -5,8 +5,7 @@
 import 'dart:async' show Future;
 import 'dart:typed_data' show Uint8List;
 
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart'
     show
         AssetBundleImageKey,

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -322,14 +322,16 @@ class DefaultMarker extends BitmapDescriptor {
 }
 
 class BytesBitmap extends BitmapDescriptor {
-  const BytesBitmap({required this.byteData, this.size}) : super._();
+  const BytesBitmap({required Uint8List byteData, Size? size}) : this._(byteData, kIsWeb ? size : null);
+
+  const BytesBitmap._(this.byteData, this.size) : super._();
 
   final Uint8List byteData;
   final Size? size;
 
   @override
   Object toJson() {
-    return <Object>[BitmapDescriptor._fromBytes, byteData, if (size != null && kIsWeb) <Object>[size!.width, size!.height]];
+    return <Object>[BitmapDescriptor._fromBytes, byteData, if (size != null) <Object>[size!.width, size!.height]];
   }
 }
 
@@ -344,7 +346,9 @@ class AssetBitmap extends BitmapDescriptor {
 }
 
 class AssetImageBitmap extends BitmapDescriptor {
-  const AssetImageBitmap({required this.name, required this.scale, this.size}) : super._();
+  const AssetImageBitmap({required String name, required double scale, Size? size}) : this._(name, scale, kIsWeb ? size : null);
+
+  const AssetImageBitmap._(this.name, this.scale, this.size) : super._();
 
   final String name;
   final double scale;

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -126,10 +126,13 @@ class BitmapDescriptor {
         assert(jsonMap['imagePixelRatio'] is double);
         assert(!jsonMap.containsKey('width') || jsonMap['width'] is double);
         assert(!jsonMap.containsKey('height') || jsonMap['height'] is double);
+        final double? width = jsonMap.containsKey('width') ? jsonMap['width'] as double : null;
+        final double? height = jsonMap.containsKey('height') ? jsonMap['height'] as double : null;
+        return BytesMapBitmap(jsonMap['byteData'] as Uint8List, bitmapScaling: mapBitmapScalingFromString(jsonMap['bitmapScaling'] as String), width: width, height: height, imagePixelRatio: jsonMap['imagePixelRatio'] as double);
       default:
         break;
     }
-    return BitmapDescriptor._(json);
+    throw ArgumentError('Unrecognized BitmapDescriptor type ${jsonList[0]}');
   }
 
   static const String _defaultMarker = 'defaultMarker';

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -45,13 +45,13 @@ const double _naturalPixelRatio = 1.0;
 /// Use the [BitmapDescriptor.defaultMarkerWithHue] to create a
 /// [BitmapDescriptor] for a default marker icon with a hue value.
 class BitmapDescriptor {
-  const BitmapDescriptor._(this._json);
+  const BitmapDescriptor._(this.json);
 
   /// The inverse of .toJson.
   // TODO(stuartmorgan): Remove this in the next breaking change.
   @Deprecated('No longer supported')
-  BitmapDescriptor.fromJson(Object json) : _json = json {
-    assert(_json is List<dynamic>);
+  static BitmapDescriptor fromJson(Object json) {
+    assert(json is List<dynamic>);
     final List<dynamic> jsonList = json as List<dynamic>;
     assert(_validTypes.contains(jsonList[0]));
     switch (jsonList[0]) {
@@ -61,7 +61,9 @@ class BitmapDescriptor {
           assert(jsonList[1] is num);
           final num secondElement = jsonList[1] as num;
           assert(0 <= secondElement && secondElement < 360);
+          return DefaultMarker(secondElement);
         }
+        return DefaultMarker();
       case _fromBytes:
         assert(jsonList.length == 2);
         assert(jsonList[1] != null && jsonList[1] is List<int>);
@@ -112,6 +114,7 @@ class BitmapDescriptor {
       default:
         break;
     }
+    return BitmapDescriptor._(json);
   }
 
   static const String _defaultMarker = 'defaultMarker';
@@ -161,14 +164,14 @@ class BitmapDescriptor {
 
   /// Creates a BitmapDescriptor that refers to the default marker image.
   static const BitmapDescriptor defaultMarker =
-      BitmapDescriptor._(<Object>[_defaultMarker]);
+      DefaultMarker();
 
   /// Creates a BitmapDescriptor that refers to a colorization of the default
   /// marker image. For convenience, there is a predefined set of hue values.
   /// See e.g. [hueYellow].
   static BitmapDescriptor defaultMarkerWithHue(double hue) {
     assert(0.0 <= hue && hue < 360.0);
-    return BitmapDescriptor._(<Object>[_defaultMarker, hue]);
+    return DefaultMarker(hue);
   }
 
   /// Creates a [BitmapDescriptor] from an asset image.
@@ -306,10 +309,21 @@ class BitmapDescriptor {
     );
   }
 
-  final Object _json;
+  final Object json;
 
   /// Convert the object to a Json format.
-  Object toJson() => _json;
+  Object toJson() => json;
+}
+
+class DefaultMarker extends BitmapDescriptor {
+  const DefaultMarker([this.hue]) : super._(const <Object>[]);
+
+  final num? hue;
+
+  @override
+  Object toJson() {
+    return (hue == null) ? const <Object>[BitmapDescriptor._defaultMarker] : <Object>[BitmapDescriptor._defaultMarker, hue!];
+  }
 }
 
 /// Represents a [BitmapDescriptor] base class for map bitmaps.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -29,6 +29,12 @@ enum MapBitmapScaling {
   none,
 }
 
+MapBitmapScaling mapBitmapScalingFromString(String mode) => switch (mode) {
+    'auto' => MapBitmapScaling.auto,
+    'none' => MapBitmapScaling.none,
+    _ => throw ArgumentError('Unrecognized MapBitmapScaling $mode', 'mode'),
+  };
+
 // The default pixel ratio for custom bitmaps.
 const double _naturalPixelRatio = 1.0;
 
@@ -104,6 +110,9 @@ class BitmapDescriptor {
         assert(jsonMap['imagePixelRatio'] is double);
         assert(!jsonMap.containsKey('width') || jsonMap['width'] is double);
         assert(!jsonMap.containsKey('height') || jsonMap['height'] is double);
+        final double? width = jsonMap.containsKey('width') ? jsonMap['width'] as double : null;
+        final double? height = jsonMap.containsKey('height') ? jsonMap['height'] as double : null;
+        return AssetMapBitmap(jsonMap['assetName'] as String, bitmapScaling: mapBitmapScalingFromString(jsonMap['bitmapScaling'] as String), imagePixelRatio: jsonMap['imagePixelRatio'] as double, width: width, height: height);
       case BytesMapBitmap.type:
         assert(jsonList.length == 2);
         assert(jsonList[1] != null && jsonList[1] is Map<String, dynamic>);

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -63,11 +63,12 @@ class BitmapDescriptor {
           assert(0 <= secondElement && secondElement < 360);
           return DefaultMarker(secondElement);
         }
-        return DefaultMarker();
+        return const DefaultMarker();
       case _fromBytes:
         assert(jsonList.length == 2);
         assert(jsonList[1] != null && jsonList[1] is List<int>);
         assert((jsonList[1] as List<int>).isNotEmpty);
+        return BytesBitmap(byteData: jsonList[1] as Uint8List);
       case _fromAsset:
         assert(jsonList.length <= 3);
         assert(jsonList[1] != null && jsonList[1] is String);
@@ -225,15 +226,7 @@ class BitmapDescriptor {
   static BitmapDescriptor fromBytes(Uint8List byteData, {Size? size}) {
     assert(byteData.isNotEmpty,
         'Cannot create BitmapDescriptor with empty byteData');
-    return BitmapDescriptor._(<Object>[
-      _fromBytes,
-      byteData,
-      if (kIsWeb && size != null)
-        <Object>[
-          size.width,
-          size.height,
-        ]
-    ]);
+    return BytesBitmap(byteData: byteData, size: size);
   }
 
   /// Creates a [BitmapDescriptor] from an asset using [AssetMapBitmap].
@@ -323,6 +316,18 @@ class DefaultMarker extends BitmapDescriptor {
   @override
   Object toJson() {
     return (hue == null) ? const <Object>[BitmapDescriptor._defaultMarker] : <Object>[BitmapDescriptor._defaultMarker, hue!];
+  }
+}
+
+class BytesBitmap extends BitmapDescriptor {
+  const BytesBitmap({required this.byteData, this.size}) : super._(const <Object>[]);
+
+  final Uint8List byteData;
+  final Size? size;
+
+  @override
+  Object toJson() {
+    return <Object>[BitmapDescriptor._fromBytes, byteData, if (size != null && kIsWeb) <Object>[size!.width, size!.height]];
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.9.4
+version: 2.9.5
 
 environment:
   sdk: ^3.3.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
@@ -21,7 +21,8 @@ void main() {
           BitmapDescriptor.fromJson(json);
 
       expect(descriptorFromJson, isNot(descriptor)); // New instance
-      expect(identical(descriptorFromJson.toJson(), json), isTrue); // Same JSON
+      //expect(identical(descriptorFromJson.toJson(), json), isTrue); // Same JSON
+      expect(descriptorFromJson.toJson(), json);
     });
 
     group('fromBytes constructor', () {

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
@@ -26,6 +26,13 @@ void main() {
     });
 
     group('fromBytes constructor', () {
+      test('returns BytesBitmap', () {
+        final BitmapDescriptor descriptor = BitmapDescriptor.fromBytes(
+          Uint8List.fromList(<int>[1, 2, 3]),
+        );
+        expect(descriptor, isA<BytesBitmap>());
+      });
+
       test('with empty byte array, throws assertion error', () {
         expect(() {
           BitmapDescriptor.fromBytes(Uint8List.fromList(<int>[]));
@@ -36,13 +43,15 @@ void main() {
         final BitmapDescriptor descriptor = BitmapDescriptor.fromBytes(
           Uint8List.fromList(<int>[1, 2, 3]),
         );
-        expect(descriptor, isA<BitmapDescriptor>());
+        expect(descriptor, isA<BytesBitmap>());
         expect(
             descriptor.toJson(),
             equals(<Object>[
               'fromBytes',
               <int>[1, 2, 3],
             ]));
+        descriptor as BytesBitmap;
+        expect(descriptor.byteData, Uint8List.fromList(<int>[1, 2, 3]));
       });
 
       test('with size, not on the web, size is ignored', () {
@@ -57,6 +66,9 @@ void main() {
               'fromBytes',
               <int>[1, 2, 3],
             ]));
+        descriptor as BytesBitmap;
+        expect(descriptor.byteData, Uint8List.fromList(<int>[1, 2, 3]));
+        expect(descriptor.size, null);
       }, skip: kIsWeb);
 
       test('with size, on the web, size is preserved', () {
@@ -72,6 +84,9 @@ void main() {
               <int>[1, 2, 3],
               <int>[40, 20],
             ]));
+        descriptor as BytesBitmap;
+        expect(descriptor.byteData, Uint8List.fromList(<int>[1, 2, 3]));
+        expect(descriptor.size, const Size(40, 20));
       }, skip: !kIsWeb);
     });
 
@@ -79,7 +94,7 @@ void main() {
       group('type validation', () {
         test('correct type', () {
           expect(BitmapDescriptor.fromJson(<dynamic>['defaultMarker']),
-              isA<BitmapDescriptor>());
+              isA<DefaultMarker>());
         });
 
         test('wrong type', () {
@@ -91,12 +106,12 @@ void main() {
       group('defaultMarker', () {
         test('hue is null', () {
           expect(BitmapDescriptor.fromJson(<dynamic>['defaultMarker']),
-              isA<BitmapDescriptor>());
+              isA<DefaultMarker>());
         });
 
         test('hue is number', () {
           expect(BitmapDescriptor.fromJson(<dynamic>['defaultMarker', 158]),
-              isA<BitmapDescriptor>());
+              isA<DefaultMarker>());
         });
 
         test('hue is not number', () {
@@ -121,7 +136,7 @@ void main() {
                 'fromBytes',
                 Uint8List.fromList(<int>[1, 2, 3])
               ]),
-              isA<BitmapDescriptor>());
+              isA<BytesBitmap>());
         });
 
         test('without bytes', () {
@@ -138,7 +153,7 @@ void main() {
           expect(
               BitmapDescriptor.fromJson(
                   <dynamic>['fromAsset', 'some/path.png']),
-              isA<BitmapDescriptor>());
+              isA<AssetBitmap>());
         });
 
         test('name cannot be null or empty', () {
@@ -154,7 +169,7 @@ void main() {
           expect(
               BitmapDescriptor.fromJson(
                   <dynamic>['fromAsset', 'some/path.png', 'some_package']),
-              isA<BitmapDescriptor>());
+              isA<AssetBitmap>());
         });
 
         test('package cannot be null or empty', () {
@@ -173,7 +188,7 @@ void main() {
           expect(
               BitmapDescriptor.fromJson(
                   <dynamic>['fromAssetImage', 'some/path.png', 1.0]),
-              isA<BitmapDescriptor>());
+              isA<AssetImageBitmap>());
         });
 
         test('mipmaps determines dpi', () async {
@@ -225,7 +240,7 @@ void main() {
                 1.0,
                 <dynamic>[640, 480]
               ]),
-              isA<BitmapDescriptor>());
+              isA<AssetImageBitmap>());
         });
 
         test(
@@ -263,7 +278,7 @@ void main() {
                   'height': 1.0,
                 }
               ]),
-              isA<BitmapDescriptor>());
+              isA<BytesMapBitmap>());
         });
 
         test('without bytes', () {
@@ -289,7 +304,7 @@ void main() {
                   'imagePixelRatio': 1.0,
                 }
               ]),
-              isA<BitmapDescriptor>());
+              isA<AssetMapBitmap>());
         });
 
         test('name cannot be null or empty', () {
@@ -346,7 +361,7 @@ void main() {
                   'height': 1.0,
                 }
               ]),
-              isA<BitmapDescriptor>());
+              isA<AssetMapBitmap>());
         });
 
         test('optional width and height parameters must be in proper format',
@@ -429,6 +444,10 @@ void main() {
               'imagePixelRatio': 1.0,
             }
           ]));
+      descriptor as AssetMapBitmap;
+      expect(descriptor.assetName, 'red_square.png');
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.0);
     });
 
     test('construct with imagePixelRatio', () async {
@@ -436,6 +455,7 @@ void main() {
           AssetMapBitmap('red_square.png', imagePixelRatio: 1.2345);
 
       expect(descriptor, isA<BitmapDescriptor>());
+      expect(descriptor, isA<AssetMapBitmap>());
       expect(
           descriptor.toJson(),
           equals(<Object>[
@@ -446,6 +466,10 @@ void main() {
               'imagePixelRatio': 1.2345,
             }
           ]));
+      descriptor as AssetMapBitmap;
+      expect(descriptor.assetName, 'red_square.png');
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.2345);
     });
 
     test('construct with width', () async {
@@ -454,6 +478,7 @@ void main() {
           AssetMapBitmap('red_square.png', width: width);
 
       expect(descriptor, isA<BitmapDescriptor>());
+      expect(descriptor, isA<AssetMapBitmap>());
       expect(
           descriptor.toJson(),
           equals(<Object>[
@@ -465,6 +490,11 @@ void main() {
               'width': width,
             }
           ]));
+      descriptor as AssetMapBitmap;
+      expect(descriptor.assetName, 'red_square.png');
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.0);
+      expect(descriptor.width, width);
     });
 
     test('create', () async {
@@ -482,6 +512,10 @@ void main() {
               'imagePixelRatio': 1.0
             }
           ]));
+      descriptor as AssetMapBitmap;
+      expect(descriptor.assetName, 'red_square.png');
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.0);
     },
         // TODO(stuartmorgan): Investigate timeout on web.
         skip: kIsWeb);
@@ -494,6 +528,7 @@ void main() {
           await AssetMapBitmap.create(imageConfiguration, 'red_square.png');
 
       expect(descriptor, isA<BitmapDescriptor>());
+      expect(descriptor, isA<AssetMapBitmap>());
       expect(
           descriptor.toJson(),
           equals(<Object>[
@@ -506,7 +541,14 @@ void main() {
               'height': 200.0
             }
           ]));
+      descriptor as AssetMapBitmap;
+      expect(descriptor.assetName, 'red_square.png');
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.0);
+      expect(descriptor.width, 100.0);
+      expect(descriptor.height, 200.0);
     });
+
     test('create with width', () async {
       const ImageConfiguration imageConfiguration = ImageConfiguration.empty;
       final BitmapDescriptor descriptor = await AssetMapBitmap.create(
@@ -514,6 +556,7 @@ void main() {
           width: 100);
 
       expect(descriptor, isA<BitmapDescriptor>());
+      expect(descriptor, isA<AssetMapBitmap>());
       expect(
           descriptor.toJson(),
           equals(<Object>[
@@ -525,7 +568,13 @@ void main() {
               'width': 100.0,
             }
           ]));
+      descriptor as AssetMapBitmap;
+      expect(descriptor.assetName, 'red_square.png');
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.0);
+      expect(descriptor.width, 100.0);
     });
+
     test('create with height', () async {
       const ImageConfiguration imageConfiguration = ImageConfiguration.empty;
       final BitmapDescriptor descriptor = await AssetMapBitmap.create(
@@ -533,6 +582,7 @@ void main() {
           height: 200);
 
       expect(descriptor, isA<BitmapDescriptor>());
+      expect(descriptor, isA<AssetMapBitmap>());
       expect(
           descriptor.toJson(),
           equals(<Object>[
@@ -544,6 +594,11 @@ void main() {
               'height': 200.0
             }
           ]));
+      descriptor as AssetMapBitmap;
+      expect(descriptor.assetName, 'red_square.png');
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.0);
+      expect(descriptor.height, 200.0);
     });
   },
       // TODO(stuartmorgan): Investigate timeout on web.
@@ -561,6 +616,7 @@ void main() {
         Uint8List.fromList(<int>[1, 2, 3]),
       );
       expect(descriptor, isA<BitmapDescriptor>());
+      expect(descriptor, isA<BytesMapBitmap>());
       expect(
           descriptor.toJson(),
           equals(<Object>[
@@ -571,6 +627,10 @@ void main() {
               'imagePixelRatio': 1.0,
             }
           ]));
+      descriptor as BytesMapBitmap;
+      expect(descriptor.byteData, Uint8List.fromList(<int>[1, 2, 3]));
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.0);
     });
 
     test('construct with width', () {
@@ -580,6 +640,7 @@ void main() {
         width: width,
       );
 
+      expect(descriptor, isA<BytesMapBitmap>());
       expect(
           descriptor.toJson(),
           equals(<Object>[
@@ -591,6 +652,11 @@ void main() {
               'width': 100.0
             }
           ]));
+      descriptor as BytesMapBitmap;
+      expect(descriptor.byteData, Uint8List.fromList(<int>[1, 2, 3]));
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.0);
+      expect(descriptor.width, 100.0);
     });
 
     test('construct with imagePixelRatio', () {
@@ -599,6 +665,7 @@ void main() {
         imagePixelRatio: 1.2345,
       );
 
+      expect(descriptor, isA<BytesMapBitmap>());
       expect(
           descriptor.toJson(),
           equals(<Object>[
@@ -609,6 +676,10 @@ void main() {
               'imagePixelRatio': 1.2345
             }
           ]));
+      descriptor as BytesMapBitmap;
+      expect(descriptor.byteData, Uint8List.fromList(<int>[1, 2, 3]));
+      expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
+      expect(descriptor.imagePixelRatio, 1.2345);
     });
   });
 }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
@@ -21,7 +21,6 @@ void main() {
           BitmapDescriptor.fromJson(json);
 
       expect(descriptorFromJson, isNot(descriptor)); // New instance
-      //expect(identical(descriptorFromJson.toJson(), json), isTrue); // Same JSON
       expect(descriptorFromJson.toJson(), json);
     });
 
@@ -681,5 +680,11 @@ void main() {
       expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
       expect(descriptor.imagePixelRatio, 1.2345);
     });
+  });
+
+  test('mapBitmapScaling from String', () {
+    expect(mapBitmapScalingFromString('auto'), MapBitmapScaling.auto);
+    expect(mapBitmapScalingFromString('none'), MapBitmapScaling.none);
+    expect(() => mapBitmapScalingFromString('invalid'), throwsArgumentError);
   });
 }


### PR DESCRIPTION
`BitmapDescriptor` is currently just a wrapper around JSON, with the exception of two of its subclasses. This converts all cases to typesafe structures without breaking the current API.

Part of https://github.com/flutter/flutter/issues/155122

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
