### PR TITLE
Update test to not depend on `Color.toString()`

### DIFF
--- a/packages/rfw/test/argument_decoders_test.dart
+++ b/packages/rfw/test/argument_decoders_test.dart
@@ -392,7 +392,7 @@ void main() {
     expect(
       (tester.widgetList<DecoratedBox>(find.byType(DecoratedBox)).toList()[0].decoration as BoxDecoration).image.toString(),
       'DecorationImage(NetworkImage("x-invalid://", scale: 1.0), '
-      'ColorFilter.mode(Color(0xff8811ff), BlendMode.xor), Alignment.center, scale 1.0, '
+      'ColorFilter.mode(${const Color(0xff8811ff)}, BlendMode.xor), Alignment.center, scale 1.0, '
       'opacity 1.0, FilterQuality.high)',
     );
 


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/55231, the implementation of `Color.toString()` has changed. Update the test to not depend on the exact implementation.
