### PR TITLE
[camerax] Correct assumption about preview being correctly rotated by default on API 29

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.9
+
+* Corrects assumption about automatic preview correction happening on API >= 29 to API > 29,
+  based on the fact that the `ImageReader` Impeller backend is not used for the most part on
+  devices running API 29+.
+
 ## 0.6.8+3
 
 * Removes dependency on org.jetbrains.kotlin:kotlin-bom.

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/SystemServicesHostApiImpl.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/SystemServicesHostApiImpl.java
@@ -106,16 +106,16 @@ public class SystemServicesHostApiImpl implements SystemServicesHostApi {
   }
 
   /**
-   * Returns whether or not a {@code SurfaceTexture} backs the {@code Surface} provided to CameraX
-   * to build the camera preview. If it is backed by a {@code Surface}, then the transformation
-   * needed to correctly rotate the preview has already been applied.
+   * Returns whether or not Impeller uses an {@code ImageReader} backend to provide a {@code Surface}
+   * to CameraX to build hte preview. If it is backed by an {@code ImageReader}, then CameraX will not
+   * automatically apply the transformation needed to correct the preview.
    *
-   * <p>This is determined by the engine, who uses {@code SurfaceTexture}s on Android SDKs 29 and
-   * below.
+   * <p>This is determine by the engine, who approximately uses {@code SurfaceTexture}s on Android SDKs
+   * below 29.
    */
   @Override
   @NonNull
   public Boolean isPreviewPreTransformed() {
-    return Build.VERSION.SDK_INT <= 29;
+    return Build.VERSION.SDK_INT < 29;
   }
 }

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/SystemServicesTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/SystemServicesTest.java
@@ -146,7 +146,7 @@ public class SystemServicesTest {
   }
 
   @Test
-  @Config(sdk = 29)
+  @Config(sdk = 28)
   public void isPreviewPreTransformed_returnsTrueWhenRunningSdk29() {
     final SystemServicesHostApiImpl systemServicesHostApi =
         new SystemServicesHostApiImpl(mockBinaryMessenger, mockInstanceManager, mockContext);
@@ -154,7 +154,7 @@ public class SystemServicesTest {
   }
 
   @Test
-  @Config(sdk = 30)
+  @Config(sdk = 29)
   public void isPreviewPreTransformed_returnsFalseWhenRunningAboveSdk29() {
     final SystemServicesHostApiImpl systemServicesHostApi =
         new SystemServicesHostApiImpl(mockBinaryMessenger, mockInstanceManager, mockContext);

--- a/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
+++ b/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
@@ -913,6 +913,10 @@ class AndroidCameraCameraX extends CameraPlatform {
             naturalDeviceOrientationDegrees * signForCameraDirection +
             360) %
         360;
+    print('sensorOrientaiton: $sensorOrientation');
+    print('naturalDeviceOrientationDegrees $naturalDeviceOrientationDegrees');
+    print('signForCameraDirection: $signForCameraDirection');
+    print('rotation $rotation');
     int quarterTurnsToCorrectPreview = rotation ~/ 90;
 
     if (naturalOrientation == DeviceOrientation.landscapeLeft ||

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.8+3
+version: 0.6.9
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Changes assumption about camera preview being automatically corrected by CameraX on API <= 29 to API < 29 based on the fact that an `ImageReader` backs devices running API 29+, on which the camera preview will not automatically be corrected by CameraX. 

Related to https://github.com/flutter/flutter/issues/154241.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
