### PR TITLE
[various] Unpin some dev dependencies

### DIFF
--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   plugin_platform_interface: ^2.1.7
 
 topics:

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -31,7 +31,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^9.1.0
 
 topics:

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   build_runner: ^2.4.9
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^18.0.0
 
 topics:

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   build_runner: ^2.4.9
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^21.0.0
 
 topics:

--- a/packages/file_selector/file_selector_android/pubspec.yaml
+++ b/packages/file_selector/file_selector_android/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   build_runner: ^2.1.4
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^9.2.4
 
 topics:

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   build_runner: ^2.3.0
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^19.0.0
 
 topics:

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   build_runner: ^2.3.2
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^10.1.3
 
 topics:

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   build_runner: ^2.3.0
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^22.4.1
 
 topics:

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   standard_message_codec: ^0.0.1+3
 
 topics:

--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -21,6 +21,6 @@ dependencies:
 
 dev_dependencies:
   collection: ^1.16.0
-  file_testing: 3.0.0
+  file_testing: ^3.0.0
   lints: ^2.0.0
   test: ^1.16.0

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   build_runner: ^2.3.3
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^22.1.0
   plugin_platform_interface: ^2.1.7
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   build_runner: ^2.4.11
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^20.0.1
   plugin_platform_interface: ^2.1.7
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   async: ^2.5.0
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - google-maps

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   http: ^1.2.2
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 flutter:
   assets:

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -36,7 +36,7 @@ dev_dependencies:
   http: ">=0.13.0 <2.0.0"
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - authentication

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^10.1.0
 
 topics:

--- a/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^11.0.1
 
 topics:

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - authentication

--- a/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   http: ">=0.13.0 <2.0.0"
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   web: ^1.0.0
 
 flutter:

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -41,7 +41,7 @@ dev_dependencies:
   cross_file: ^0.3.1+1 # Mockito generates a direct include.
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   plugin_platform_interface: ^2.1.7
 
 topics:

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^17.0.0
 
 topics:

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^17.0.0
 
 topics:

--- a/packages/image_picker/image_picker_linux/pubspec.yaml
+++ b/packages/image_picker/image_picker_linux/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   build_runner: ^2.1.5
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - image-picker

--- a/packages/image_picker/image_picker_macos/pubspec.yaml
+++ b/packages/image_picker/image_picker_macos/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   build_runner: ^2.1.5
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - image-picker

--- a/packages/image_picker/image_picker_windows/pubspec.yaml
+++ b/packages/image_picker/image_picker_windows/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   build_runner: ^2.1.5
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - image-picker

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   json_serializable: ^6.3.1
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^17.1.1
   test: ^1.16.0
 

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - in-app-purchase

--- a/packages/interactive_media_ads/pubspec.yaml
+++ b/packages/interactive_media_ads/pubspec.yaml
@@ -30,7 +30,7 @@ dev_dependencies:
   build_runner: ^2.1.4
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^22.2.0
 
 topics:

--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -34,7 +34,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   plugin_platform_interface: ^2.1.7
 
 topics:

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   build_runner: ^2.3.3
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^22.4.0
 
 topics:

--- a/packages/local_auth/local_auth_darwin/pubspec.yaml
+++ b/packages/local_auth/local_auth_darwin/pubspec.yaml
@@ -31,7 +31,7 @@ dev_dependencies:
   build_runner: ^2.3.3
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^22.4.0
 
 topics:

--- a/packages/local_auth/local_auth_platform_interface/pubspec.yaml
+++ b/packages/local_auth/local_auth_platform_interface/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - authentication

--- a/packages/metrics_center/pubspec.yaml
+++ b/packages/metrics_center/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.1
   fake_async: ^1.2.0
-  mockito: 5.4.4
+  mockito: ^5.4.4
   test: ^1.17.11
 
 topics:

--- a/packages/path_provider/path_provider_foundation/pubspec.yaml
+++ b/packages/path_provider/path_provider_foundation/pubspec.yaml
@@ -30,7 +30,7 @@ dev_dependencies:
   build_runner: ^2.3.2
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   path: ^1.8.0
   pigeon: ^10.1.3
 

--- a/packages/pigeon/platform_tests/shared_test_plugin_code/pubspec.yaml
+++ b/packages/pigeon/platform_tests/shared_test_plugin_code/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
-  mockito: 5.4.4
+  mockito: ^5.4.4
   test: ^1.16.0
 
 topics:

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   plugin_platform_interface: ^2.1.7
 
 topics:

--- a/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - quick-actions

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   plugin_platform_interface: ^2.1.7
 
 flutter:

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   plugin_platform_interface: ^2.1.7
   test: ^1.16.3
 

--- a/packages/url_launcher/url_launcher_android/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/example/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   plugin_platform_interface: ^2.1.7
 
 flutter:

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^10.0.0
   plugin_platform_interface: ^2.1.7
   test: ^1.16.3

--- a/packages/url_launcher/url_launcher_ios/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_ios/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   build_runner: ^2.3.3
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^11.0.1
   plugin_platform_interface: ^2.1.7
   test: ^1.16.3

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - links

--- a/packages/url_launcher/url_launcher_web/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/example/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   url_launcher_platform_interface: ^2.2.0
   url_launcher_web:
     path: ../

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   build_runner: ^2.1.5
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   plugin_platform_interface: ^2.1.7
 
 topics:

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   build_runner: ^2.1.4
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^11.0.0
 
 topics:

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
   build_runner: ^2.1.8
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - html

--- a/packages/webview_flutter/webview_flutter_web/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_web/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   build_runner: ^2.1.5
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
 
 topics:
   - html

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -31,7 +31,7 @@ dev_dependencies:
   build_runner: ^2.1.5
   flutter_test:
     sdk: flutter
-  mockito: 5.4.4
+  mockito: ^5.4.4
   pigeon: ^18.0.0
 
 topics:

--- a/script/configs/allowed_pinned_deps.yaml
+++ b/script/configs/allowed_pinned_deps.yaml
@@ -15,12 +15,3 @@
 # This should be removed; see
 # https://github.com/flutter/flutter/issues/130897
 - provider
-
-## Allowed by default
-
-# Dart-owned
-- dart_style
-- mockito
-
-# Google-owned
-- file_testing

--- a/script/configs/allowed_unpinned_deps.yaml
+++ b/script/configs/allowed_unpinned_deps.yaml
@@ -44,6 +44,7 @@
 - markdown
 - meta
 - mime
+- mockito
 - path
 - platform
 - shelf
@@ -60,6 +61,7 @@
 - _discoveryapis_commons
 - adaptive_navigation
 - file
+- file_testing
 - googleapis
 - googleapis_auth
 - json_annotation

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.3
   matcher: ^0.12.10
-  mockito: '>=5.3.2 <=5.5.0'
+  mockito: ^5.4.4
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Several dev dependencies, most notably mockito, were only allow as exactly pinned versions, in order to avoid out-of-band breakage due to deprecations in minor version updates. Now that the policy for Flutter repos has changed to not include deprecation warnings in analysis, this is no longer an issue, so we can relax these dependencies to follow the more normal pattern of using ranges.