### PR TITLE
[xdg_directories] Add `stateHome` property

### DIFF
--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.5
+## 1.1.0
 
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.
 * Adds `stateHome` property for `XDG_STATE_HOME`.

--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.0.5
 
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.
+* Adds `stateHome` property for `XDG_STATE_HOME`.
 
 ## 1.0.4
 

--- a/packages/xdg_directories/example/lib/main.dart
+++ b/packages/xdg_directories/example/lib/main.dart
@@ -67,6 +67,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 'Config Directories: \n${configDirs.map((Directory directory) => directory.path).toList().join('\n')}\n'),
             Text('Cache Home: \n${cacheHome.path}\n'),
             Text('Runtime Directory: \n${runtimeDir?.path}\n'),
+            Text('State Home: \n${stateHome.path}\n'),
             const SizedBox(
               height: 100,
             ),

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -174,6 +174,13 @@ Directory get dataHome =>
 /// Throws [StateError] if the HOME environment variable is not set.
 Directory? get runtimeDir => _directoryFromEnvironment('XDG_RUNTIME_DIR');
 
+/// The base directory relative to which user-specific state data should be
+/// written. (Corresponds to `$XDG_STATE_HOME`).
+///
+/// Throws [StateError] if the HOME environment variable is not set.
+Directory get stateHome =>
+    _directoryFromEnvironmentWithFallback('XDG_STATE_HOME', '.local/state');
+
 /// Gets the xdg user directory named by `dirName`.
 ///
 /// Use [getUserDirectoryNames] to find out the list of available names.

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -2,7 +2,7 @@ name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
 repository: https://github.com/flutter/packages/tree/main/packages/xdg_directories
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+xdg_directories%22
-version: 1.0.5
+version: 1.1.0
 
 environment:
   sdk: ^3.3.0

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -2,7 +2,7 @@ name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
 repository: https://github.com/flutter/packages/tree/main/packages/xdg_directories
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+xdg_directories%22
-version: 1.0.4
+version: 1.0.5
 
 environment:
   sdk: ^3.3.0

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -38,10 +38,12 @@ void main() {
         '${testPath('usr/local/test_share')}:${testPath('usr/test_share')}';
     fakeEnv['XDG_DATA_HOME'] = testPath('.local/test_share');
     fakeEnv['XDG_RUNTIME_DIR'] = testPath('.local/test_runtime');
+    fakeEnv['XDG_STATE_HOME'] = testPath('.local/test_state');
     Directory(fakeEnv['XDG_CONFIG_HOME']!).createSync(recursive: true);
     Directory(fakeEnv['XDG_CACHE_HOME']!).createSync(recursive: true);
     Directory(fakeEnv['XDG_DATA_HOME']!).createSync(recursive: true);
     Directory(fakeEnv['XDG_RUNTIME_DIR']!).createSync(recursive: true);
+    Directory(fakeEnv['XDG_STATE_HOME']!).createSync(recursive: true);
     File(path.join(fakeEnv['XDG_CONFIG_HOME']!, 'user-dirs.dirs'))
         .writeAsStringSync(r'''
 XDG_DESKTOP_DIR="$HOME/Desktop"
@@ -73,6 +75,7 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     expect(xdg.cacheHome.path, equals(testPath('.cache')));
     expect(xdg.configHome.path, equals(testPath('.config')));
     expect(xdg.dataHome.path, equals(testPath('.local/share')));
+    expect(xdg.stateHome.path, equals(testPath('.local/state')));
     expect(xdg.runtimeDir, isNull);
 
     expectDirList(xdg.configDirs, <String>['/etc/xdg']);
@@ -85,6 +88,7 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     expect(xdg.dataHome.path, equals(testPath('.local/test_share')));
     expect(xdg.runtimeDir, isNotNull);
     expect(xdg.runtimeDir!.path, equals(testPath('.local/test_runtime')));
+    expect(xdg.stateHome.path, equals(testPath('.local/test_state')));
 
     expectDirList(xdg.configDirs, <String>[testPath('etc/test_xdg')]);
     expectDirList(xdg.dataDirs, <String>[


### PR DESCRIPTION
This pull request adds a property called `stateHome` that provides the directory for `XDG_STATE_HOME`.

Fixes https://github.com/flutter/flutter/issues/155494