### PR TITLE
[camerax] Revert "Explicitly remove READ_EXTERNAL_STORAGE permission"

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Removes logic to explicitly remove `READ_EXTERNAL_STORAGE` permission that may be implied
   from `WRITE_EXTERNAL_STORAGE` and updates the README to tell users how to manually
-  remove it from the app's merged manifest.
+  remove it from their app's merged manifest if they wish.
 
 ## 0.6.9+2
 

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.10
 
-* Removes logic to explicitly remove `READ_EXTERNAL_STORAGE` permission that may be implied
+* Removes logic that explicitly removes `READ_EXTERNAL_STORAGE` permission that may be implied
   from `WRITE_EXTERNAL_STORAGE` and updates the README to tell users how to manually
   remove it from their app's merged manifest if they wish.
 

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.10
+
+* Removes logic to explicitly remove `READ_EXTERNAL_STORAGE` permission that may be implied
+  from `WRITE_EXTERNAL_STORAGE` and updates the README to tell users how to manually
+  remove it from the app's merged manifest.
+
 ## 0.6.9+2
 
 * Updates Java compatibility version to 11.

--- a/packages/camera/camera_android_camerax/README.md
+++ b/packages/camera/camera_android_camerax/README.md
@@ -57,14 +57,16 @@ and thus that parameter will silently be ignored.
 
 In order to save captured images and videos to files on Android 10 and below, CameraX
 requires specifying the `WRITE_EXTERNAL_STORAGE` permission (see [the CameraX documentation][10]).
-This is already done in the plugin, so no further action is required on your end. To understand the
-implications of specificying this permission, see [the `WRITE_EXTERNAL_STORAGE` documentation][11].
+This is already done in the plugin, so no further action is required on your end. To understand
+the implications of specificying this permission, see [the `WRITE_EXTERNAL_STORAGE` documentation][11].
 
 Please note that the [`READ_EXTERNAL_STORAGE`][13] permission may be implied from `WRITE_EXTERNAL_STORAGE`
 permission and thus, be included in the merged Android manifest of your app. If you do not want the
-`READ_EXTERNAL_STORAGE` permission to be included in the merged Android manifest of your app and your
-app nor any of the plugins that it depends on require it, then you may remove it by adding the following
-to your app's `AndroidManifest.xml`:
+`READ_EXTERNAL_STORAGE` permission to be included in the merged Android manifest of your app, then you can
+do the following to remove it:
+
+1. Ensure that your app nor any of the plugins that it depends on require the `READ_EXTERNAL_STORAGE` permission.
+2. Add the following to your app's `your_app/android/app/src/main/AndroidManifest.xml`:
 
 ```xml
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"

--- a/packages/camera/camera_android_camerax/README.md
+++ b/packages/camera/camera_android_camerax/README.md
@@ -57,13 +57,13 @@ and thus that parameter will silently be ignored.
 
 In order to save captured images and videos to files on Android 10 and below, CameraX
 requires specifying the `WRITE_EXTERNAL_STORAGE` permission (see [the CameraX documentation][10]).
-This is already done in the plugin, so no further action is required on your end. To understand
-the implications of specificying this permission, see [the `WRITE_EXTERNAL_STORAGE` documentation][11].
+This is already done in the plugin, so no further action is required on your end.
 
-Please note that the [`READ_EXTERNAL_STORAGE`][13] permission may be implied from `WRITE_EXTERNAL_STORAGE`
-permission and thus, be included in the merged Android manifest of your app. If you do not want the
-`READ_EXTERNAL_STORAGE` permission to be included in the merged Android manifest of your app, then you can
-do the following to remove it:
+To understand the privacy impact of specifying the `WRITE_EXTERNAL_STORAGE` permission, see the
+[`WRITE_EXTERNAL_STORAGE` documentation][11]. We have seen apps also have the `READ_EXTERNAL_STORAGE`
+permission automatically added to the merged Android manifest; it appears to be implied from
+`WRITE_EXTERNAL_STORAGE`. If you do not want the `READ_EXTERNAL_STORAGE` permission to be included
+in the merged Android manifest of your app, then take the following steps to remove it:
 
 1. Ensure that your app nor any of the plugins that it depends on require the `READ_EXTERNAL_STORAGE` permission.
 2. Add the following to your app's `your_app/android/app/src/main/AndroidManifest.xml`:

--- a/packages/camera/camera_android_camerax/README.md
+++ b/packages/camera/camera_android_camerax/README.md
@@ -60,7 +60,7 @@ requires specifying the `WRITE_EXTERNAL_STORAGE` permission (see [the CameraX do
 This is already done in the plugin, so no further action is required on your end.
 
 To understand the privacy impact of specifying the `WRITE_EXTERNAL_STORAGE` permission, see the
-[`WRITE_EXTERNAL_STORAGE` documentation][11]. We have seen apps also have the `READ_EXTERNAL_STORAGE`
+[`WRITE_EXTERNAL_STORAGE` documentation][11]. We have seen apps also have the [`READ_EXTERNAL_STORAGE`][13]
 permission automatically added to the merged Android manifest; it appears to be implied from
 `WRITE_EXTERNAL_STORAGE`. If you do not want the `READ_EXTERNAL_STORAGE` permission to be included
 in the merged Android manifest of your app, then take the following steps to remove it:

--- a/packages/camera/camera_android_camerax/README.md
+++ b/packages/camera/camera_android_camerax/README.md
@@ -57,8 +57,19 @@ and thus that parameter will silently be ignored.
 
 In order to save captured images and videos to files on Android 10 and below, CameraX
 requires specifying the `WRITE_EXTERNAL_STORAGE` permission (see [the CameraX documentation][10]).
-This is already done in the plugin, so no further action is required on your end. To understand
-the implications of specificying this permission, see [the `WRITE_EXTERNAL_STORAGE` documentation][11].
+This is already done in the plugin, so no further action is required on your end. To understand the
+implications of specificying this permission, see [the `WRITE_EXTERNAL_STORAGE` documentation][11].
+
+Please note that the [`READ_EXTERNAL_STORAGE`][13] permission may be implied from `WRITE_EXTERNAL_STORAGE`
+permission and thus, be included in the merged Android manifest of your app. If you do not want the
+`READ_EXTERNAL_STORAGE` permission to be included in the merged Android manifest of your app and your
+app nor any of the plugins that it depends on require it, then you may remove it by adding the following
+to your app's `AndroidManifest.xml`:
+
+```xml
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+    tools:node="remove" />
+```
 
 ### Allowing image streaming in the background
 
@@ -91,4 +102,5 @@ For more information on contributing to this plugin, see [`CONTRIBUTING.md`](CON
 [10]: https://developer.android.com/media/camera/camerax/architecture#permissions
 [11]: https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE
 [12]: https://developer.android.com/reference/android/Manifest.permission#FOREGROUND_SERVICE_CAMERA
+[13]: https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE
 [148013]: https://github.com/flutter/flutter/issues/148013

--- a/packages/camera/camera_android_camerax/android/src/main/AndroidManifest.xml
+++ b/packages/camera/camera_android_camerax/android/src/main/AndroidManifest.xml
@@ -1,11 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
   package="io.flutter.plugins.camerax">
   <uses-feature android:name="android.hardware.camera.any" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
     android:maxSdkVersion="28" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
-    tools:node="remove" />
 </manifest>

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.9+2
+version: 0.6.10
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Reverts logic to remove `READ_EXTERNAL_STORAGE` permission from merged Android manifest (between plugins and Flutter app) by default. Turns out that this logic conflicts with Flutter plugins/apps that actually require the `READ_EXTERNAL_STORAGE` permission.

Specifically, reverts https://github.com/flutter/packages/pull/4716 and adds documentation so that users know how to manually remove `READ_EXTERNAL_STORAGE`  from the merged manifest if they wish. 

Fixes https://github.com/flutter/flutter/issues/156198 and adds documentation to address https://github.com/flutter/flutter/issues/131116.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
