### PR TITLE
Remove additional (harmless but annoying) native stack traces.

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.7.12
+
+* Fixes a [bug](https://github.com/flutter/flutter/issues/156451) where
+  additional harmless but annoying warnings in the form of native stack traces
+  would be printed when the app was backgrounded. There may be additional
+  warnings that are not yet fixed, but this should address the
+  most common case.
+
 ## 2.7.11
 
 * Fixes a [bug](https://github.com/flutter/flutter/issues/156158) where a

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -97,7 +97,8 @@ final class VideoPlayer implements TextureRegistry.SurfaceProducer.Callback {
 
   @RestrictTo(RestrictTo.Scope.LIBRARY)
   public void onSurfaceDestroyed() {
-    exoPlayer.stop();
+    // Intentionally do not call pause/stop here, because the surface has already been released
+    // at this point (see https://github.com/flutter/flutter/issues/156451).
     savedStateDuring = ExoPlayerState.save(exoPlayer);
     exoPlayer.release();
   }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -201,6 +201,21 @@ public final class VideoPlayerTest {
   }
 
   @Test
+  public void onSurfaceProducerDestroyedDoesNotStopOrPauseVideo() {
+    VideoPlayer videoPlayer = createVideoPlayer();
+
+    verify(mockProducer).setCallback(callbackCaptor.capture());
+    TextureRegistry.SurfaceProducer.Callback producerLifecycle = callbackCaptor.getValue();
+    producerLifecycle.onSurfaceDestroyed();
+
+    verify(mockExoPlayer, never()).stop();
+    verify(mockExoPlayer, never()).pause();
+    verify(mockExoPlayer, never()).setPlayWhenReady(anyBoolean());
+
+    videoPlayer.dispose();
+  }
+
+  @Test
   public void onDisposeSurfaceProducerCallbackIsDisconnected() {
     // Regression test for https://github.com/flutter/flutter/issues/156158.
     VideoPlayer videoPlayer = createVideoPlayer();
@@ -289,7 +304,7 @@ public final class VideoPlayerTest {
 
   // TODO(matanlurey): Replace with inline calls to onSurfaceAvailable once
   // available on stable; see https://github.com/flutter/flutter/issues/155131.
-  // This seperate method only exists to scope the suppression.
+  // This separate method only exists to scope the suppression.
   @SuppressWarnings({"deprecation", "removal"})
   void simulateSurfaceCreation(TextureRegistry.SurfaceProducer.Callback producerLifecycle) {
     producerLifecycle.onSurfaceCreated();

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.7.11
+version: 2.7.12
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/156451.