### PR TITLE
[flutter_markdown] Soft wrapping in blockquotes

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3+3
+
+* Makes paragraphs in blockquotes soft-wrap like a normal `<blockquote>` instead of hard-wrapping like a `<pre>` block.
+
 ## 0.7.3+2
 
 * Resolves an issue where code blocks in markdown were not highlighted during selection.

--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.3+3
+## 0.7.4
 
 * Makes paragraphs in blockquotes soft-wrap like a normal `<blockquote>` instead of hard-wrapping like a `<pre>` block.
 

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -362,7 +362,7 @@ class MarkdownBuilder implements md.NodeVisitor {
           style: _isInBlockquote
               ? styleSheet.blockquote!.merge(_inlines.last.style)
               : _inlines.last.style,
-          text: _isInBlockquote ? text.text : trimText(text.text),
+          text: trimText(text.text),
           recognizer: _linkHandlers.isNotEmpty ? _linkHandlers.last : null,
         ),
         textAlign: _textAlignForBlockTag(_currentBlockTag),

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.7.3+3
+version: 0.7.4
 
 environment:
   sdk: ^3.3.0

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.7.3+2
+version: 0.7.3+3
 
 environment:
   sdk: ^3.3.0

--- a/packages/flutter_markdown/test/blockquote_test.dart
+++ b/packages/flutter_markdown/test/blockquote_test.dart
@@ -24,6 +24,20 @@ void defineTests() {
         expectTextStrings(widgets, <String>['quote']);
       },
     );
+    
+    testWidgets(
+      'soft wrapping in blockquote',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          boilerplate(
+            const MarkdownBody(data: '> soft\n> wrap'),
+          ),
+        );
+
+        final Iterable<Widget> widgets = tester.allWidgets;
+        expectTextStrings(widgets, <String>['soft wrap']);
+      },
+    );
 
     testWidgets(
       'should work with styling',

--- a/packages/flutter_markdown/test/blockquote_test.dart
+++ b/packages/flutter_markdown/test/blockquote_test.dart
@@ -24,7 +24,7 @@ void defineTests() {
         expectTextStrings(widgets, <String>['quote']);
       },
     );
-    
+
     testWidgets(
       'soft wrapping in blockquote',
       (WidgetTester tester) async {


### PR DESCRIPTION
Makes `flutter_markdown` treat paragraphs in blockquotes like a normal paragraph with respect to soft wrapping.

Currently, line breaks in blockquotes translate directly to line breaks in the output. This happens regardless of the Markdown Specification chosen. Such behavior is different from most Markdown implementations, including the reference ones cited in [flutter_markdown ](https://pub.dev/packages/flutter_markdown) ([Dart Markdown Live Editor](https://dart-lang.github.io/markdown/) and the [Markdown Live Preview](https://markdownlivepreview.com/)).

Example:

```
> my
> blockquote
```

Currently renders like:

> my
> blockquote

And this PR fixes it to become:

> my blockquote

Note: previewing in this GitHub editor, I get the hard-wrap behavior. However, [Dart Markdown Live Editor](https://dart-lang.github.io/markdown/) gives the soft-wrap behavior in all flavors, even when "GitHub Flavored Markdown" is selected. Reading the GFM spec [there's an example](https://github.github.com/gfm/#example-222) that to me implies that soft-wrapping is the correct thing in GFM, plus that's what I gather from reading [6.12](https://github.github.com/gfm/#hard-line-breaks) and [6.13](https://github.github.com/gfm/#soft-line-breaks). However, if for some reason we should hard-wrap in GFM, it should be just a matter of checking the chosen `extensionSet` when deciding whether to call `trimText()`. Seems clear to me hard-wrapping shouldn't ever be the only behavior.

Issues: this fixes https://github.com/flutter/flutter/issues/156554

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`). -- *nothing to update or add I guess*
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing. -- *couldn't get some more obscure tests to pass, but don't think it's my PR's fault*

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
