### PR TITLE
Disable non-functional, deprecated `package_api_docs` lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -131,7 +131,7 @@ linter:
     # - one_member_abstracts # too many false positives
     - only_throw_errors # this does get disabled in a few places where we have legacy code that uses strings et al
     - overridden_fields
-    - package_api_docs
+    # - package_api_docs # Deprecated (https://github.com/dart-lang/linter/issues/5107)
     - package_names
     - package_prefixed_library_names
     # - parameter_assignments # we do this commonly

--- a/packages/web_benchmarks/testing/test_app/analysis_options.yaml
+++ b/packages/web_benchmarks/testing/test_app/analysis_options.yaml
@@ -3,5 +3,4 @@ include: ../../../../analysis_options.yaml
 linter:
   rules:
     # This is test code. Do not enforce docs.
-    package_api_docs: false
     public_member_api_docs: false


### PR DESCRIPTION
Reference: https://github.com/dart-lang/linter/issues/5107