### PR TITLE
Allow custom blocks to be something other than `Column` or `SizedBox`

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.5
+## 0.7.4+1
 
 * Makes it so that custom blocks are not limited to being a Column or
   SizedBox.

--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.5
+
+* Added the ability to extend the list of allowed customizable block tags with the
+  `customBlockTags` attribute on `MarkdownBuilder`.
+
 ## 0.7.4
 
 * Makes paragraphs in blockquotes soft-wrap like a normal `<blockquote>` instead of hard-wrapping like a `<pre>` block.

--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.7.5
 
-* Added the ability to extend the list of allowed customizable block tags with the
-  `customBlockTags` attribute on `MarkdownBuilder`.
+* Makes it so that custom blocks are not limited to being a Column or
+  SizedBox.
 
 ## 0.7.4
 

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -383,7 +383,6 @@ class MarkdownBuilder implements md.NodeVisitor {
       _addAnonymousBlockIfNeeded();
 
       final _BlockElement current = _blocks.removeLast();
-      Widget child;
 
       Widget defaultChild() {
         if (current.children.isNotEmpty) {
@@ -399,18 +398,13 @@ class MarkdownBuilder implements md.NodeVisitor {
         }
       }
 
-      if (builders.containsKey(tag)) {
-        final Widget? builderChild =
-            builders[tag]!.visitElementAfterWithContext(
-          delegate.context,
-          element,
-          styleSheet.styles[tag],
-          _inlines.isNotEmpty ? _inlines.last.style : null,
-        );
-        child = builderChild ?? defaultChild();
-      } else {
-        child = defaultChild();
-      }
+      Widget child = builders[tag]?.visitElementAfterWithContext(
+            delegate.context,
+            element,
+            styleSheet.styles[tag],
+            _inlines.isNotEmpty ? _inlines.last.style : null,
+          ) ??
+          defaultChild();
 
       if (_isListTag(tag)) {
         assert(_listIndents.isNotEmpty);

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -156,7 +156,7 @@ class MarkdownBuilder implements md.NodeVisitor {
   final MarkdownListItemCrossAxisAlignment listItemCrossAxisAlignment;
 
   /// Collection of custom block tags to be used building block widgets.
-  final List<String>? customBlockTags;
+  final List<String> customBlockTags;
 
   /// Called when the user changes selection when [selectable] is set to true.
   final MarkdownOnSelectionChangedCallback? onSelectionChanged;
@@ -182,7 +182,7 @@ class MarkdownBuilder implements md.NodeVisitor {
 
   bool _isBlockTag(String? tag) =>
       _kBlockTags.contains(tag) ||
-      (customBlockTags ?? <String>[]).contains(tag);
+      customBlockTags.contains(tag);
 
   /// Returns widgets that display the given Markdown nodes.
   ///

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -33,8 +33,6 @@ final List<String> _kBlockTags = <String>[
 
 const List<String> _kListTags = <String>['ul', 'ol'];
 
-bool _isBlockTag(String? tag) => _kBlockTags.contains(tag);
-
 bool _isListTag(String tag) => _kListTags.contains(tag);
 
 class _BlockElement {
@@ -111,6 +109,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     required this.builders,
     required this.paddingBuilders,
     required this.listItemCrossAxisAlignment,
+    required this.customBlockTags,
     this.fitContent = false,
     this.onSelectionChanged,
     this.onTapText,
@@ -156,6 +155,9 @@ class MarkdownBuilder implements md.NodeVisitor {
   /// does not allow for intrinsic height measurements.
   final MarkdownListItemCrossAxisAlignment listItemCrossAxisAlignment;
 
+  /// Collection of custom block tags to be used building block widgets.
+  final List<String>? customBlockTags;
+
   /// Called when the user changes selection when [selectable] is set to true.
   final MarkdownOnSelectionChangedCallback? onSelectionChanged;
 
@@ -177,6 +179,10 @@ class MarkdownBuilder implements md.NodeVisitor {
   String? _currentBlockTag;
   String? _lastVisitedTag;
   bool _isInBlockquote = false;
+
+  bool _isBlockTag(String? tag) =>
+      _kBlockTags.contains(tag) ||
+      (customBlockTags ?? <String>[]).contains(tag);
 
   /// Returns widgets that display the given Markdown nodes.
   ///
@@ -395,6 +401,19 @@ class MarkdownBuilder implements md.NodeVisitor {
         );
       } else {
         child = const SizedBox();
+      }
+
+      if (builders.containsKey(tag)) {
+        final Widget? builderChild =
+            builders[tag]!.visitElementAfterWithContext(
+          delegate.context,
+          element,
+          styleSheet.styles[tag],
+          _inlines.isNotEmpty ? _inlines.last.style : null,
+        );
+        if (builderChild != null) {
+          child = builderChild;
+        }
       }
 
       if (_isListTag(tag)) {

--- a/packages/flutter_markdown/lib/src/widget.dart
+++ b/packages/flutter_markdown/lib/src/widget.dart
@@ -217,7 +217,6 @@ abstract class MarkdownWidget extends StatefulWidget {
     this.onTapLink,
     this.onTapText,
     this.imageDirectory,
-    this.customBlockTags,
     this.blockSyntaxes,
     this.inlineSyntaxes,
     this.extensionSet,
@@ -269,9 +268,6 @@ abstract class MarkdownWidget extends StatefulWidget {
 
   /// Collection of custom block syntax types to be used parsing the Markdown data.
   final List<md.BlockSyntax>? blockSyntaxes;
-
-  /// Collection of custom block tags to be used building block widgets.
-  final List<String>? customBlockTags;
 
   /// Collection of custom inline syntax types to be used parsing the Markdown data.
   final List<md.InlineSyntax>? inlineSyntaxes;
@@ -397,7 +393,6 @@ class _MarkdownWidgetState extends State<MarkdownWidget>
       imageBuilder: widget.imageBuilder,
       checkboxBuilder: widget.checkboxBuilder,
       bulletBuilder: widget.bulletBuilder,
-      customBlockTags: widget.customBlockTags,
       builders: widget.builders,
       paddingBuilders: widget.paddingBuilders,
       fitContent: widget.fitContent,
@@ -469,7 +464,6 @@ class MarkdownBody extends MarkdownWidget {
     super.onTapLink,
     super.onTapText,
     super.imageDirectory,
-    super.customBlockTags,
     super.blockSyntaxes,
     super.inlineSyntaxes,
     super.extensionSet,
@@ -525,7 +519,6 @@ class Markdown extends MarkdownWidget {
     super.onTapLink,
     super.onTapText,
     super.imageDirectory,
-    super.customBlockTags,
     super.blockSyntaxes,
     super.inlineSyntaxes,
     super.extensionSet,

--- a/packages/flutter_markdown/lib/src/widget.dart
+++ b/packages/flutter_markdown/lib/src/widget.dart
@@ -217,6 +217,7 @@ abstract class MarkdownWidget extends StatefulWidget {
     this.onTapLink,
     this.onTapText,
     this.imageDirectory,
+    this.customBlockTags,
     this.blockSyntaxes,
     this.inlineSyntaxes,
     this.extensionSet,
@@ -268,6 +269,9 @@ abstract class MarkdownWidget extends StatefulWidget {
 
   /// Collection of custom block syntax types to be used parsing the Markdown data.
   final List<md.BlockSyntax>? blockSyntaxes;
+
+  /// Collection of custom block tags to be used building block widgets.
+  final List<String>? customBlockTags;
 
   /// Collection of custom inline syntax types to be used parsing the Markdown data.
   final List<md.InlineSyntax>? inlineSyntaxes;
@@ -393,6 +397,7 @@ class _MarkdownWidgetState extends State<MarkdownWidget>
       imageBuilder: widget.imageBuilder,
       checkboxBuilder: widget.checkboxBuilder,
       bulletBuilder: widget.bulletBuilder,
+      customBlockTags: widget.customBlockTags,
       builders: widget.builders,
       paddingBuilders: widget.paddingBuilders,
       fitContent: widget.fitContent,
@@ -464,6 +469,7 @@ class MarkdownBody extends MarkdownWidget {
     super.onTapLink,
     super.onTapText,
     super.imageDirectory,
+    super.customBlockTags,
     super.blockSyntaxes,
     super.inlineSyntaxes,
     super.extensionSet,
@@ -519,6 +525,7 @@ class Markdown extends MarkdownWidget {
     super.onTapLink,
     super.onTapText,
     super.imageDirectory,
+    super.customBlockTags,
     super.blockSyntaxes,
     super.inlineSyntaxes,
     super.extensionSet,

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Markdown renderer for Flutter. Create rich text output,
   formatted with simple Markdown tags.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_markdown
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_markdown%22
-version: 0.7.4
+version: 0.7.4+1
 
 environment:
   sdk: ^3.3.0

--- a/packages/flutter_markdown/test/custom_syntax_test.dart
+++ b/packages/flutter_markdown/test/custom_syntax_test.dart
@@ -48,7 +48,6 @@ void defineTests() {
               builders: <String, MarkdownElementBuilder>{
                 'note': NoteBuilder(),
               },
-              customBlockTags: const <String>['note'],
             ),
           ),
         );
@@ -77,7 +76,6 @@ void defineTests() {
               builders: <String, MarkdownElementBuilder>{
                 'custom': CustomTagBlockBuilder(),
               },
-              customBlockTags: const <String>['custom'],
             ),
           ),
         );
@@ -413,6 +411,11 @@ class NoteSyntax extends md.BlockSyntax {
 }
 
 class CustomTagBlockBuilder extends MarkdownElementBuilder {
+  @override
+  bool isBlockElement() {
+    return true;
+  }
+
   @override
   Widget visitElementAfterWithContext(
     BuildContext context,

--- a/packages/flutter_markdown/test/custom_syntax_test.dart
+++ b/packages/flutter_markdown/test/custom_syntax_test.dart
@@ -48,9 +48,40 @@ void defineTests() {
               builders: <String, MarkdownElementBuilder>{
                 'note': NoteBuilder(),
               },
+              customBlockTags: const <String>['note'],
             ),
           ),
         );
+        final ColoredBox container =
+            tester.widgetList(find.byType(ColoredBox)).first as ColoredBox;
+        expect(container.color, Colors.red);
+        expect(container.child, isInstanceOf<Text>());
+        expect((container.child! as Text).data, blockContent);
+      },
+    );
+
+    testWidgets(
+      'Block with custom tag',
+      (WidgetTester tester) async {
+        const String textBefore = 'Before ';
+        const String textAfter = ' After';
+        const String blockContent = 'Custom content rendered in a ColoredBox';
+
+        await tester.pumpWidget(
+          boilerplate(
+            Markdown(
+              data:
+                  '$textBefore\n{{custom}}\n$blockContent\n{{/custom}}\n$textAfter',
+              extensionSet: md.ExtensionSet.none,
+              blockSyntaxes: <md.BlockSyntax>[CustomTagBlockSyntax()],
+              builders: <String, MarkdownElementBuilder>{
+                'custom': CustomTagBlockBuilder(),
+              },
+              customBlockTags: const <String>['custom'],
+            ),
+          ),
+        );
+
         final ColoredBox container =
             tester.widgetList(find.byType(ColoredBox)).first as ColoredBox;
         expect(container.color, Colors.red);
@@ -379,4 +410,52 @@ class NoteSyntax extends md.BlockSyntax {
 
   @override
   RegExp get pattern => RegExp(r'^\[!NOTE] ');
+}
+
+class CustomTagBlockBuilder extends MarkdownElementBuilder {
+  @override
+  Widget visitElementAfterWithContext(
+    BuildContext context,
+    md.Element element,
+    TextStyle? preferredStyle,
+    TextStyle? parentStyle,
+  ) {
+    if (element.tag == 'custom') {
+      final String content = element.attributes['content']!;
+      return ColoredBox(
+          color: Colors.red, child: Text(content, style: preferredStyle));
+    }
+    return const SizedBox.shrink();
+  }
+}
+
+class CustomTagBlockSyntax extends md.BlockSyntax {
+  @override
+  bool canParse(md.BlockParser parser) {
+    return parser.current.content.startsWith('{{custom}}');
+  }
+
+  @override
+  RegExp get pattern => RegExp(r'\{\{custom\}\}([\s\S]*?)\{\{/custom\}\}');
+
+  @override
+  md.Node parse(md.BlockParser parser) {
+    parser.advance();
+
+    final StringBuffer buffer = StringBuffer();
+    while (
+        !parser.current.content.startsWith('{{/custom}}') && !parser.isDone) {
+      buffer.writeln(parser.current.content);
+      parser.advance();
+    }
+
+    if (!parser.isDone) {
+      parser.advance();
+    }
+
+    final String content = buffer.toString().trim();
+    final md.Element element = md.Element.empty('custom');
+    element.attributes['content'] = content;
+    return element;
+  }
 }

--- a/packages/flutter_markdown/test/custom_syntax_test.dart
+++ b/packages/flutter_markdown/test/custom_syntax_test.dart
@@ -412,9 +412,7 @@ class NoteSyntax extends md.BlockSyntax {
 
 class CustomTagBlockBuilder extends MarkdownElementBuilder {
   @override
-  bool isBlockElement() {
-    return true;
-  }
+  bool isBlockElement() => true;
 
   @override
   Widget visitElementAfterWithContext(


### PR DESCRIPTION
# Description

This adds support for allowing block tags recognized by the Markdown processor to insert something other than just a `Column` or a `SizedBox` (the defaults for blocks with children, and without). Without this ability, custom builders can't insert their own widgets to, say, make it be a colored container instead.

This addresses a customer request.

Fixes https://github.com/flutter/flutter/issues/135848