### PR TITLE
Bump `path_provider_android` to `^2.2.5` due to Android v1 embedder.

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.1.5
 
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.
+* Updates minimum required `path_provider_android` to [2.2.5](https://pub.dev/packages/path_provider_android/changelog#225) as the v1 Android embedder is no longer available.
 
 ## 2.1.4
 

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.1.5
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
   flutter: ">=3.19.0"
 
 flutter:

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.5
 
 environment:
   sdk: ^3.4.0
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.0"
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.4
+version: 2.1.5
 
 environment:
   sdk: ^3.3.0

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -25,7 +25,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  path_provider_android: ^2.2.0
+  path_provider_android: ^2.2.5
   path_provider_foundation: ^2.3.2
   path_provider_linux: ^2.2.0
   path_provider_platform_interface: ^2.1.0


### PR DESCRIPTION
https://github.com/flutter/engine/pull/52022 removed the Android v1 embedder.

I'm seeing locally that older versions of `path_provider_android` fail due to missing symbols:
```txt
flutter run                   
Launching lib/main.dart on sdk gphone64 arm64 in debug mode...
You are applying Flutter's main Gradle plugin imperatively using the apply script method, which is deprecated and will be removed in a future release. Migrate to applying Gradle plugins with the declarative plugins block: https://flutter.dev/to/flutter-gradle-plugin-apply

Warning: This project is still reading the deprecated '.flutter-plugins. file.
In an upcoming stable release support for this file will be completely removed and your build will fail.
See https:/flutter.dev/to/flutter-plugins-configuration.
/Users/matanl/.pub-cache/hosted/pub.dev/path_provider_android-2.2.2/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java:39: error: cannot find symbol
      @NonNull io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
                                                      ^
  symbol:   class Registrar
  location: interface PluginRegistry
1 error

FAILURE: Build failed with an exception.
```

To be a good citizen, let's make sure users of `path_provider` get a good `path_provider_android`.