### PR TITLE
[various] Remove multiDexEnabled

### DIFF
--- a/packages/espresso/example/android/app/build.gradle
+++ b/packages/espresso/example/android/app/build.gradle
@@ -36,7 +36,6 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
     }
 
     buildTypes {

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/build.gradle
@@ -32,7 +32,6 @@ android {
         applicationId "io.flutter.plugins.googlemapsexample"
         minSdkVersion 20
         targetSdkVersion 28
-        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/build.gradle
@@ -33,7 +33,6 @@ android {
         applicationId "io.flutter.plugins.googlemapsexample"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
-        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/google_sign_in/google_sign_in/example/android/app/build.gradle
+++ b/packages/google_sign_in/google_sign_in/example/android/app/build.gradle
@@ -33,7 +33,6 @@ android {
         applicationId "io.flutter.plugins.googlesigninexample"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion 28
-        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/google_sign_in/google_sign_in_android/example/android/app/build.gradle
+++ b/packages/google_sign_in/google_sign_in_android/example/android/app/build.gradle
@@ -33,7 +33,6 @@ android {
         applicationId "io.flutter.plugins.googlesigninexample"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
-        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/image_picker/image_picker/example/android/app/build.gradle
+++ b/packages/image_picker/image_picker/example/android/app/build.gradle
@@ -34,7 +34,6 @@ android {
         applicationId "io.flutter.plugins.imagepicker.example"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion 28
-        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/image_picker/image_picker_android/example/android/app/build.gradle
+++ b/packages/image_picker/image_picker_android/example/android/app/build.gradle
@@ -34,7 +34,6 @@ android {
         applicationId "io.flutter.plugins.imagepicker.example"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
-        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/interactive_media_ads/example/android/app/build.gradle
+++ b/packages/interactive_media_ads/example/android/app/build.gradle
@@ -44,7 +44,6 @@ android {
         applicationId "dev.flutter.packages.interactive_media_ads_example"
         minSdk flutter.minSdkVersion
         targetSdk flutter.targetSdkVersion
-        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/local_auth/local_auth/example/android/app/build.gradle
+++ b/packages/local_auth/local_auth/example/android/app/build.gradle
@@ -36,7 +36,6 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
     }
 
     buildTypes {

--- a/packages/local_auth/local_auth_android/example/android/app/build.gradle
+++ b/packages/local_auth/local_auth_android/example/android/app/build.gradle
@@ -36,7 +36,6 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
     }
 
     buildTypes {


### PR DESCRIPTION
We had manually added `multiDexEnabled` to various plugin example apps over time to fix build failures, but it's not needed for plugins with a `minSdk` of 20+ ([reference](https://developer.android.com/build/multidex)), and Flutter (and thus all of our plugins) requires 21+, so the setting is just cruft.