### PR TITLE
[ci] Ensure repo tool is autoformatted

### DIFF
--- a/.ci/scripts/plugin_tools_format.sh
+++ b/.ci/scripts/plugin_tools_format.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+set -e
+
+cd script/tool
+dart format --set-exit-if-changed .

--- a/.ci/targets/repo_checks.yaml
+++ b/.ci/targets/repo_checks.yaml
@@ -4,6 +4,8 @@ tasks:
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: tool unit tests
     script: .ci/scripts/plugin_tools_tests.sh
+  - name: tool format
+    script: .ci/scripts/plugin_tools_format.sh
   - name: format
     script: .ci/scripts/tool_runner.sh
     # Skip Swift formatting on Linux builders.

--- a/script/tool/lib/src/fetch_deps_command.dart
+++ b/script/tool/lib/src/fetch_deps_command.dart
@@ -87,10 +87,8 @@ class FetchDepsCommand extends PackageLoopingCommand {
         flutterCommand,
         <String>[
           'precache',
-          if (precacheIOS)
-            '--ios',
-          if (precacheMacOS)
-            '--macos',
+          if (precacheIOS) '--ios',
+          if (precacheMacOS) '--macos',
         ],
       );
       if (precacheExitCode != 0) {

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -485,7 +485,6 @@ void main() {
       );
     });
 
-
     test('building for macOS with Swift Package Manager on master channel',
         () async {
       mockPlatform.isMacOS = true;


### PR DESCRIPTION
Currently the autoformatter check is run per-package, so doesn't include script/tool. This adds a new CI step to check the formatting of the repo tooling, just as we have for running its unit tests.