### PR TITLE
[camera_android] getAvailableCameras to handle non-integer camera IDs

### DIFF
--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/CameraUtils.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/CameraUtils.java
@@ -70,15 +70,6 @@ public final class CameraUtils {
     String[] cameraNames = cameraManager.getCameraIdList();
     List<Messages.PlatformCameraDescription> cameras = new ArrayList<>();
     for (String cameraName : cameraNames) {
-      int cameraId;
-      try {
-        cameraId = Integer.parseInt(cameraName, 10);
-      } catch (NumberFormatException e) {
-        cameraId = -1;
-      }
-      if (cameraId < 0) {
-        continue;
-      }
 
       CameraCharacteristics characteristics = cameraManager.getCameraCharacteristics(cameraName);
       int sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);


### PR DESCRIPTION
### Background
Some Android devices, especially those with external or specialized cameras, may use non-integer camera IDs. The existing implementation attempts to parse cameraName as an integer, which causes issues for these devices.

### Changes
- Removed integer parsing of cameraName in the getAvailableCameras method.
- Directly used cameraName as a string for constructing camera descriptions.
- Enhanced compatibility with a broader range of Android devices, ensuring that both numeric and non-numeric camera IDs are supported.

### Testing
- Verified the changes on devices with both integer and non-integer camera IDs to ensure compatibility.

This PR aims to enhance the flexibility and compatibility of the camera plugin with various device configurations.