### PR TITLE
[vector_garphics] fix execution on the web with WebAssembly

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.13
+
+* Fix execution on the web with WebAssembly.
+
 ## 1.1.12
 
 * Transfers the package source from https://github.com/dnfield/vector_graphics

--- a/packages/vector_graphics/lib/src/debug.dart
+++ b/packages/vector_graphics/lib/src/debug.dart
@@ -2,4 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export '_debug_io.dart' if (dart.library.html) '_debug_web.dart';
+export '_debug_web.dart' if (dart.library.io) '_debug_io.dart';

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/vector_graphi
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
 # See https://github.com/flutter/flutter/issues/157626 before publishing a new
 # version.
-version: 1.1.12
+version: 1.1.13
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
The `dart.library.html` variable is not available with wasm
Since the web version is (currently) a no-op, flip the condition to
check for dart:io instead
