### PR TITLE
[various] Minor cleanup in recently imported packages

### DIFF
--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -4,6 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/vector_graphi
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
 # See https://github.com/flutter/flutter/issues/157626 before publishing a new
 # version.
+publish_to: none
 version: 1.1.13
 
 environment:

--- a/packages/vector_graphics_codec/pubspec.yaml
+++ b/packages/vector_graphics_codec/pubspec.yaml
@@ -4,6 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/vector_graphi
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
 # See https://github.com/flutter/flutter/issues/157626 before publishing a new
 # version.
+publish_to: none
 version: 1.1.12
 
 environment:

--- a/packages/vector_graphics_compiler/pubspec.yaml
+++ b/packages/vector_graphics_compiler/pubspec.yaml
@@ -4,6 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/vector_graphi
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
 # See https://github.com/flutter/flutter/issues/157626 before publishing a new
 # version.
+publish_to: none
 version: 1.1.12
 
 executables:

--- a/third_party/packages/flutter_svg/README.md
+++ b/third_party/packages/flutter_svg/README.md
@@ -1,6 +1,6 @@
 # flutter_svg
 
-[![Pub](https://img.shields.io/pub/v/flutter_svg.svg)](https://pub.dartlang.org/packages/flutter_svg) [![Coverage Status](https://coveralls.io/repos/github/dnfield/flutter_svg/badge.svg?branch=master)](https://coveralls.io/github/dnfield/flutter_svg?branch=master)
+[![Pub](https://img.shields.io/pub/v/flutter_svg.svg)](https://pub.dartlang.org/packages/flutter_svg)
 
 <!-- markdownlint-disable MD033 -->
 <img src="https://raw.githubusercontent.com/dnfield/flutter_svg/7d374d7107561cbd906d7c0ca26fef02cc01e7c8/example/assets/flutter_logo.svg?sanitize=true" width="200px" alt="Flutter Logo which can be rendered by this package!">

--- a/third_party/packages/path_parsing/CHANGELOG.md
+++ b/third_party/packages/path_parsing/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## 1.0.2
 
-* Transfers the package source from https://github.com/google/process.dart to
-  https://github.com/dnfield/dart_path_parsing.
+* Transfers the package source from https://github.com/dnfield/dart_path_parsing
+  to https://github.com/flutter/packages.
 
 ## 1.0.1
 


### PR DESCRIPTION
Fixes a few minor things from the recent import of dnfield's vector-graphics-related packages:
- Fixes a bad copy/paste in the `path_parsing` CHANGELOG so future versions of the CHANGELOG will be less confusing.
- Removes a coverage link from the `flutter_svg` README that is no longer correct.
- Disabled publishing of `vector_graphics*` until a new versioning plan is made.

Because these are extremely minor, I'm overriding our usual versioning policy; it's fine for the CHANGELOG and README fixes to go out the next time we happen to publish rather than immediately.