### PR TITLE
[go_router] Update example app to Kotlin 1.9.0

### DIFF
--- a/packages/go_router/example/android/build.gradle
+++ b/packages/go_router/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
The tree is currently closed on an out-of-band failure in the build of this example app:

e: .../transformed/jetified-kotlin-stdlib-1.9.24.jar!/META-INF/kotlin-stdlib-jdk7.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.
e: /b/s/w/ir/cache/gradle/caches/transforms-4/6cce2b947fc9e43cca6b44ff30180b61/transformed/jetified-kotlin-stdlib-1.9.24.jar!/META-INF/kotlin-stdlib-jdk8.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.
e: .../transformed/jetified-kotlin-stdlib-1.9.24.jar!/META-INF/kotlin-stdlib.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.
e: .../transformed/jetified-annotation-jvm-1.9.1.jar!/META-INF/annotation.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.

It appears that this is caused by
https://github.com/flutter/packages/pull/7986 as this example app does depend on `url_launcher`, and that PR therefore change a transitive dependency of this example app, and as Reid discovered that version bump [changed the Kotlin
version](https://android.googlesource.com/platform/frameworks/support/+log/2e6556166965445a8a129114765a3903c063735c..87b88ad088cc9b18d4ab75611fc8b74e8b01c24a/annotation)

There was a Flutter Fix that contained the correct instructions for resolving this, which is what this PR does.