### PR TITLE
[vector_graphics_compiler] fix-null-exception

### DIFF
--- a/packages/vector_graphics_compiler/CHANGELOG.md
+++ b/packages/vector_graphics_compiler/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.15
 
-* Fixes an issue where empty tag could throw and broke SVG.
+* Fixes a bug where empty tags caused the parser to crash.
 
 ## 1.1.14
 

--- a/packages/vector_graphics_compiler/CHANGELOG.md
+++ b/packages/vector_graphics_compiler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.15
+
+* Fixes an issue where empty tag could throw and broke SVG.
+
 ## 1.1.14
 
 * Makes the package WASM compatible.

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -895,7 +895,10 @@ class SvgParser {
       return false;
     }
     final ParentNode parent = _parentDrawables.last.drawable;
-    final Path path = pathFunc(this)!;
+    final Path? path = pathFunc(this);
+    if (path == null) {
+      return false;
+    }
     final PathNode drawable = PathNode(path, _currentAttributes);
     checkForIri(drawable);
 

--- a/packages/vector_graphics_compiler/pubspec.yaml
+++ b/packages/vector_graphics_compiler/pubspec.yaml
@@ -2,7 +2,7 @@ name: vector_graphics_compiler
 description: A compiler to convert SVGs to the binary format used by `package:vector_graphics`.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics_compiler
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-version: 1.1.14
+version: 1.1.15
 
 executables:
   vector_graphics_compiler:

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_graphics_compiler/src/svg/numbers.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
+
 import 'test_svg_strings.dart';
 
 void main() {
@@ -1947,6 +1948,19 @@ void main() {
             objectId: 239, paintId: 45, debugString: 'path964'),
       ],
     );
+  });
+
+  test('Parse empty tag', () {
+    const String svgStr = '''
+     <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+        <polygon
+            fill="#0a287d"
+            points=""
+            id="triangle"/>
+     </svg>
+    ''';
+
+    expect(parseWithoutOptimizers(svgStr), isA<VectorInstructions>());
   });
 }
 


### PR DESCRIPTION
The following SVG throw an exception (when using flutter_svg) : https://sweden.a.bigcontent.io/v1/static/10000199.

This SVG contain an empty tag : <polygon xmlns="http://www.w3.org/2000/svg" fill="#0a287d" points="" id="polygon7"/> which lead to the issue.

This PR check if path is null to avoid the issue.

PR from https://github.com/dnfield/vector_graphics/pull/254

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
