### PR TITLE
[vector_graphics*] Relax dependency constraints of vector_graphics, vector_graphics_codec, vector_graphics_compiler, flutter_svg 

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.14
 
-* Relax dependency constraint on vector_graphics_codec.
+* Relaxes dependency constraint on vector_graphics_codec.
 
 ## 1.1.13
 

--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.14
+
+* Relax dependency constraint on vector_graphics_codec.
+
 ## 1.1.13
 
 * Fix execution on the web with WebAssembly.

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -2,10 +2,7 @@ name: vector_graphics
 description: A vector graphics rendering package for Flutter using a binary encoding.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-# See https://github.com/flutter/flutter/issues/157626 before publishing a new
-# version.
-publish_to: none
-version: 1.1.13
+version: 1.1.14
 
 environment:
   sdk: ^3.4.0
@@ -15,14 +12,12 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.0.0
-  # See https://github.com/flutter/flutter/issues/157626
-  vector_graphics_codec: ">=1.1.11+1 <= 1.1.12"
+  vector_graphics_codec: "^1.1.11+1"
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  # See https://github.com/flutter/flutter/issues/157626
-  vector_graphics_compiler: ">=1.1.11+1 <= 1.1.12"
+  vector_graphics_compiler: "^1.1.11+1"
 
 platforms:
   android:

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.0.0
-  vector_graphics_codec: "^1.1.11+1"
+  vector_graphics_codec: ^1.1.11+1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  vector_graphics_compiler: "^1.1.11+1"
+  vector_graphics_compiler: ^1.1.11+1
 
 platforms:
   android:

--- a/packages/vector_graphics_codec/pubspec.yaml
+++ b/packages/vector_graphics_codec/pubspec.yaml
@@ -2,9 +2,6 @@ name: vector_graphics_codec
 description: An encoding library for the binary format used in `package:vector_graphics`
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics_codec
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-# See https://github.com/flutter/flutter/issues/157626 before publishing a new
-# version.
-publish_to: none
 version: 1.1.12
 
 environment:

--- a/packages/vector_graphics_compiler/CHANGELOG.md
+++ b/packages/vector_graphics_compiler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.13
+
+* Relax dependency constraint on vector_graphics_codec.
+
 ## 1.1.12
 
 * Transfers the package source from https://github.com/dnfield/vector_graphics

--- a/packages/vector_graphics_compiler/CHANGELOG.md
+++ b/packages/vector_graphics_compiler/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.13
 
-* Relax dependency constraint on vector_graphics_codec.
+* Relaxes dependency constraint on vector_graphics_codec.
 
 ## 1.1.12
 

--- a/packages/vector_graphics_compiler/pubspec.yaml
+++ b/packages/vector_graphics_compiler/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   path_parsing: ^1.0.1
-  vector_graphics_codec: "^1.1.11+1"
+  vector_graphics_codec: ^1.1.11+1
   # This uses an exact upper range because it is an external dependency (see
   # https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#dependencies
   # for more information), and this mitigates transitive risk exposure to

--- a/packages/vector_graphics_compiler/pubspec.yaml
+++ b/packages/vector_graphics_compiler/pubspec.yaml
@@ -2,10 +2,7 @@ name: vector_graphics_compiler
 description: A compiler to convert SVGs to the binary format used by `package:vector_graphics`.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics_compiler
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-# See https://github.com/flutter/flutter/issues/157626 before publishing a new
-# version.
-publish_to: none
-version: 1.1.12
+version: 1.1.13
 
 executables:
   vector_graphics_compiler:
@@ -18,8 +15,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   path_parsing: ^1.0.1
-  # See https://github.com/flutter/flutter/issues/157626
-  vector_graphics_codec: ">=1.1.11+1 <= 1.1.12"
+  vector_graphics_codec: "^1.1.11+1"
   # This uses an exact upper range because it is an external dependency (see
   # https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#dependencies
   # for more information), and this mitigates transitive risk exposure to

--- a/third_party/packages/flutter_svg/CHANGELOG.md
+++ b/third_party/packages/flutter_svg/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.12
+
+* Relax the dependency constraints on vector_graphics, vector_graphics_codec,
+  and vector_graphics_compiler.
+
 ## 2.0.11
 
 * Transfers the package source from https://github.com/dnfield/flutter_svg

--- a/third_party/packages/flutter_svg/CHANGELOG.md
+++ b/third_party/packages/flutter_svg/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.12
 
-* Relax the dependency constraints on vector_graphics, vector_graphics_codec,
+* Relaxes the dependency constraints on vector_graphics, vector_graphics_codec,
   and vector_graphics_compiler.
 
 ## 2.0.11

--- a/third_party/packages/flutter_svg/pubspec.yaml
+++ b/third_party/packages/flutter_svg/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.0.0
-  vector_graphics: "^1.1.11+1"
-  vector_graphics_codec: "^1.1.11+1"
-  vector_graphics_compiler: "^1.1.11+1"
+  vector_graphics: ^1.1.11+1
+  vector_graphics_codec: ^1.1.11+1
+  vector_graphics_compiler: ^1.1.11+1
 
 dev_dependencies:
   flutter_test:

--- a/third_party/packages/flutter_svg/pubspec.yaml
+++ b/third_party/packages/flutter_svg/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_svg
 description: An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
 repository: https://github.com/flutter/packages/tree/main/third_party/packages/flutter_svg
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_svg%22
-version: 2.0.11
+version: 2.0.12
 
 environment:
   sdk: ^3.4.0
@@ -12,10 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.0.0
-  # See https://github.com/flutter/flutter/issues/157626
-  vector_graphics: ">=1.1.11+1 <= 1.1.12"
-  vector_graphics_codec: ">=1.1.11+1 <= 1.1.12"
-  vector_graphics_compiler: ">=1.1.11+1 <= 1.1.12"
+  vector_graphics: "^1.1.11+1"
+  vector_graphics_codec: "^1.1.11+1"
+  vector_graphics_compiler: "^1.1.11+1"
 
 dev_dependencies:
   flutter_test:

--- a/third_party/packages/flutter_svg/pubspec.yaml
+++ b/third_party/packages/flutter_svg/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_svg
 description: An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
 repository: https://github.com/flutter/packages/tree/main/third_party/packages/flutter_svg
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_svg%22
-version: 2.0.12
+version: 2.0.13
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
Relax the dependency constrraints of the vector graphics packages. Since there are no actual changes to the vector_graphics_codec package and the listed version is already published, I don't think it needs a version bump to remove the publish key.

Fixes https://github.com/flutter/flutter/issues/157626

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

