### PR TITLE
[various] Update example app minSdkVersions

### DIFF
--- a/packages/camera/camera/example/android/app/build.gradle
+++ b/packages/camera/camera/example/android/app/build.gradle
@@ -31,7 +31,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.cameraexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/camera/camera_android/example/android/app/build.gradle
+++ b/packages/camera/camera_android/example/android/app/build.gradle
@@ -31,7 +31,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.cameraexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/camera/camera_android_camerax/example/android/app/build.gradle
+++ b/packages/camera/camera_android_camerax/example/android/app/build.gradle
@@ -36,11 +36,8 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.plugins.cameraxexample"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/file_selector/file_selector_android/example/android/app/build.gradle
+++ b/packages/file_selector/file_selector_android/example/android/app/build.gradle
@@ -33,11 +33,8 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "dev.flutter.packages.file_selector_android_example"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/build.gradle
@@ -30,7 +30,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.googlemapsexample"
-        minSdkVersion 20
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/quick_actions/quick_actions/example/android/app/build.gradle
+++ b/packages/quick_actions/quick_actions/example/android/app/build.gradle
@@ -31,7 +31,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.quickactionsexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/quick_actions/quick_actions_android/example/android/app/build.gradle
+++ b/packages/quick_actions/quick_actions_android/example/android/app/build.gradle
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.quickactionsexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/video_player/video_player/example/android/app/build.gradle
+++ b/packages/video_player/video_player/example/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.videoplayerexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/video_player/video_player_android/example/android/app/build.gradle
+++ b/packages/video_player/video_player_android/example/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.videoplayerexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/webview_flutter/webview_flutter/example/android/app/build.gradle
+++ b/packages/webview_flutter/webview_flutter/example/android/app/build.gradle
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.plugins.webviewflutterexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/webview_flutter/webview_flutter_android/example/android/app/build.gradle
+++ b/packages/webview_flutter/webview_flutter_android/example/android/app/build.gradle
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.plugins.webviewflutterandroidexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Updates all examples apps that haven't yet switch to using `flutter.minSdkVersion` as their value to use that instead of a hard-coded version, as none currently need a version higher than Flutter stable's min version.