### PR TITLE
Group dependabot github-action update PRs, delete dead docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,19 +7,24 @@ updates:
     directory: "/.ci"
     schedule:
       interval: "weekly"
+    groups:
+      all-docker:
+        patterns: [ "*" ]
     reviewers:
       - "stuartmorgan"
       - "ditman"
     labels:
       - "autosubmit"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all-github-actions:
+        patterns: [ "*" ]
     reviewers:
-      - "keyonghan"
-      - "yusuf-goog"
-      - "ricardoamador"
+      - "stuartmorgan"
     labels:
       - "team"
       - "team: infra"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/.ci"
-    schedule:
-      interval: "weekly"
-    groups:
-      all-docker:
-        patterns: [ "*" ]
-    reviewers:
-      - "stuartmorgan"
-      - "ditman"
-    labels:
-      - "autosubmit"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot now supports [grouping dependencies](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) into one PR instead of one per dependency.

Group github-action updates into one PR. Make github-actions update weekly instead of daily. Remove docker since it was removed in #4822

This means a PR like https://github.com/flutter/packages/pull/7813 will instead be grouped into one.
Here's an example of what that will look like: https://github.com/kubernetes-sigs/cluster-api/pull/11347

__________

<img width="400" alt="Screenshot 2024-11-08 at 11 08 52 AM" src="https://github.com/user-attachments/assets/eebedf69-3fae-409b-9c88-c3afc8036c52">

__________

https://github.com/kubernetes-sigs/cluster-api/blob/e13abeaed2bd3d7b04abd9c9823e2f4185fa6599/.github/dependabot.yaml#L10-L12

I also updated the reviewers to stop the "One or more of the users or teams you specified is not a collaborator" [error](https://github.com/flutter/packages/pull/7813#issuecomment-2399244249).

Part of https://github.com/flutter/flutter/issues/148098

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
