### PR TITLE
[shared_preferences] Fix confusing language in README

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3
+
+* Clarifies scope of prefix handling in README.
+
 ## 2.3.2
 
 * Removes outdated testing information from README.

--- a/packages/shared_preferences/shared_preferences/README.md
+++ b/packages/shared_preferences/shared_preferences/README.md
@@ -160,7 +160,7 @@ A tool to make this process easier can be tracked here: https://github.com/flutt
 
 #### Adding, Removing, or changing prefixes on SharedPreferences
 
-By default, the `SharedPreferences` plugin will only read (and write) preferences
+By default, the `SharedPreferences` class will only read (and write) preferences
 that begin with the prefix `flutter.`. This is all handled internally by the plugin
 and does not require manually adding this prefix.
 

--- a/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_legacy.dart
+++ b/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_legacy.dart
@@ -28,7 +28,8 @@ class SharedPreferences {
   static SharedPreferencesStorePlatform get _store =>
       SharedPreferencesStorePlatform.instance;
 
-  /// Sets the prefix that is attached to all keys for all shared preferences.
+  /// Sets the prefix that is attached to all keys for all shared preferences
+  /// read or written via this class.
   ///
   /// This changes the inputs when adding data to preferences as well as
   /// setting the filter that determines what data will be returned

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.3.2
+version: 2.3.3
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
One use of "class" instead of "plugin" to refer to the `SharedPreferences` class specifically slipped through review. This updates it to make it clear that it's talking about a specific class, not the plugin.

Also updates the `setPrefix:` doc comment to clarify that it only applies to that class, now that the addition of other classes to the API surface has made that ambiguous.

Fixes https://github.com/flutter/flutter/issues/158404

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
