### PR TITLE
[file_selector] Fix Linux cancel regression

### DIFF
--- a/packages/file_selector/file_selector_linux/CHANGELOG.md
+++ b/packages/file_selector/file_selector_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3+1
+
+* Fixes a regression in 0.9.3 with handling of canceled dialogs.
+
 ## 0.9.3
 
 * Updates method channel implementation to use Pigeon.

--- a/packages/file_selector/file_selector_linux/linux/file_selector_plugin.cc
+++ b/packages/file_selector/file_selector_linux/linux/file_selector_plugin.cc
@@ -134,11 +134,15 @@ static FfsFileSelectorApiShowFileChooserResponse* handle_show_file_chooser(
     return ffs_file_selector_api_show_file_chooser_response_new_error(
         kBadArgumentsError, "Unable to create dialog from arguments", nullptr);
   }
+  return show_file_chooser(GTK_FILE_CHOOSER_NATIVE(dialog),
+                           gtk_native_dialog_run);
+}
 
-  gint response = gtk_native_dialog_run(GTK_NATIVE_DIALOG(dialog));
-  g_autoptr(FlValue) result = nullptr;
+FfsFileSelectorApiShowFileChooserResponse* show_file_chooser(
+    GtkFileChooserNative* dialog, gint (*run_dialog)(GtkNativeDialog*)) {
+  gint response = run_dialog(GTK_NATIVE_DIALOG(dialog));
+  g_autoptr(FlValue) result = fl_value_new_list();
   if (response == GTK_RESPONSE_ACCEPT) {
-    result = fl_value_new_list();
     g_autoptr(GSList) filenames =
         gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog));
     for (GSList* link = filenames; link != nullptr; link = link->next) {

--- a/packages/file_selector/file_selector_linux/linux/file_selector_plugin_private.h
+++ b/packages/file_selector/file_selector_linux/linux/file_selector_plugin_private.h
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
 
 #include "include/file_selector_linux/file_selector_plugin.h"
 #include "messages.g.h"
@@ -17,3 +18,9 @@
 GtkFileChooserNative* create_dialog_of_type(
     GtkWindow* window, FfsPlatformFileChooserActionType type,
     FfsPlatformFileChooserOptions* options);
+
+// TODO(stuartmorgan): Fold this into handle_show_file_chooser as part of the
+// above TODO. This only exists to allow testing response generation without
+// mocking out all of the GTK calls.
+FfsFileSelectorApiShowFileChooserResponse* show_file_chooser(
+    GtkFileChooserNative* dialog, gint (*run_dialog)(GtkNativeDialog*));

--- a/packages/file_selector/file_selector_linux/linux/test/file_selector_plugin_test.cc
+++ b/packages/file_selector/file_selector_linux/linux/test/file_selector_plugin_test.cc
@@ -218,3 +218,25 @@ TEST(FileSelectorPlugin, TestGetMultipleDirectories) {
   EXPECT_EQ(gtk_file_chooser_get_select_multiple(GTK_FILE_CHOOSER(dialog)),
             true);
 }
+
+static gint mock_run_dialog_cancel(GtkNativeDialog* dialog) {
+  return GTK_RESPONSE_CANCEL;
+}
+
+TEST(FileSelectorPlugin, TestGetDirectoryCancel) {
+  g_autoptr(FfsPlatformFileChooserOptions) options =
+      ffs_platform_file_chooser_options_new(nullptr, nullptr, nullptr, nullptr,
+                                            nullptr);
+
+  g_autoptr(GtkFileChooserNative) dialog = create_dialog_of_type(
+      nullptr,
+      FILE_SELECTOR_LINUX_PLATFORM_FILE_CHOOSER_ACTION_TYPE_CHOOSE_DIRECTORY,
+      options);
+
+  ASSERT_NE(dialog, nullptr);
+
+  g_autoptr(FfsFileSelectorApiShowFileChooserResponse) response =
+      show_file_chooser(dialog, mock_run_dialog_cancel);
+
+  EXPECT_NE(response, nullptr);
+}

--- a/packages/file_selector/file_selector_linux/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_linux
 description: Liunx implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.3
+version: 0.9.3+1
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
Fixes a regression introduced during the Pigeon conversion where canceling a dialog would fail assertions due to accidentally returning a null list instead of an empty list.

Fixes https://github.com/flutter/flutter/issues/158430

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
