### PR TITLE
[vector_graphics_compiler] fix a renamed method parameter lint

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
@@ -288,7 +288,8 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
 
   @override
   Node visitPatternNode(PatternNode patternNode, AffineMatrix data) {
-    final AttributedNode? resolvedPattern = patternNode.resolver(patternNode.patternId);
+    final AttributedNode? resolvedPattern =
+        patternNode.resolver(patternNode.patternId);
     if (resolvedPattern == null) {
       return patternNode.child.accept(this, data);
     }

--- a/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
@@ -288,7 +288,7 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
 
   @override
   Node visitPatternNode(PatternNode patternNode, AffineMatrix data) {
-    final AttributedNode? resolvedPattern = patternNode.resolver(node.patternId);
+    final AttributedNode? resolvedPattern = patternNode.resolver(patternNode.patternId);
     if (resolvedPattern == null) {
       return patternNode.child.accept(this, data);
     }

--- a/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
@@ -287,13 +287,13 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
   }
 
   @override
-  Node visitPatternNode(PatternNode node, AffineMatrix data) {
-    final AttributedNode? resolvedPattern = node.resolver(node.patternId);
+  Node visitPatternNode(PatternNode patternNode, AffineMatrix data) {
+    final AttributedNode? resolvedPattern = patternNode.resolver(node.patternId);
     if (resolvedPattern == null) {
-      return node.child.accept(this, data);
+      return patternNode.child.accept(this, data);
     }
-    final Node child = node.child.accept(this, data);
-    final AffineMatrix childTransform = node.concatTransform(data);
+    final Node child = patternNode.child.accept(this, data);
+    final AffineMatrix childTransform = patternNode.concatTransform(data);
     final Node pattern = resolvedPattern.accept(this, childTransform);
 
     return ResolvedPatternNode(
@@ -304,7 +304,7 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
       width: resolvedPattern.attributes.width!,
       height: resolvedPattern.attributes.height!,
       transform: data,
-      id: node.patternId,
+      id: patternNode.patternId,
     );
   }
 

--- a/packages/vector_graphics_compiler/lib/src/svg/visitor.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/visitor.dart
@@ -45,7 +45,7 @@ abstract class Visitor<S, V> {
   S visitEmptyNode(Node node, V data);
 
   /// Visit a [PatternNode].
-  S visitPatternNode(PatternNode node, V data);
+  S visitPatternNode(PatternNode patternNode, V data);
 
   /// Visit a [ResolvedTextPositionNode].
   S visitResolvedTextPositionNode(


### PR DESCRIPTION
An upcoming fix to `avoid_renaming_method_parameters` will flag this rename.

(I updated the base class since that seems more correct.)

For references, here's the fix in flight: https://dart-review.googlesource.com/c/sdk/+/394662


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
