### PR TITLE
[vector_graphics] handle errors from bytes loader

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.15
+
+* Updates error handling in VectorGraphicWidget to handle errors when the bytes of the graphic cannot be loaded.
+
 ## 1.1.14
 
 * Relaxes dependency constraint on vector_graphics_codec.

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -2,7 +2,7 @@ name: vector_graphics
 description: A vector graphics rendering package for Flutter using a binary encoding.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-version: 1.1.14
+version: 1.1.15
 
 environment:
   sdk: ^3.4.0

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -653,6 +653,28 @@ void main() {
     expect(matrix.row0.x, -1);
     expect(matrix.row1.y, 1);
   });
+
+  testWidgets('VectorGraphicsWidget can handle errors from bytes loader',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      VectorGraphic(
+        loader: const ThrowingBytesLoader(),
+        width: 100,
+        height: 100,
+        errorBuilder:
+            (BuildContext context, Object error, StackTrace stackTrace) {
+          return const Directionality(
+            textDirection: TextDirection.ltr,
+            child: Text('Error is handled'),
+          );
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Error is handled'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class TestBundle extends Fake implements AssetBundle {
@@ -718,4 +740,13 @@ class TestBytesLoader extends BytesLoader {
 
   @override
   String toString() => 'TestBytesLoader: $source';
+}
+
+class ThrowingBytesLoader extends BytesLoader {
+  const ThrowingBytesLoader();
+
+  @override
+  Future<ByteData> loadBytes(BuildContext? context) {
+    throw UnimplementedError('Test exception');
+  }
 }


### PR DESCRIPTION
This PR updates the VectorGraphicsWidget to handle errors from the underlying bytes loader using the existing error handling in its implementation.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/158862

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
