### PR TITLE
[local_auth] Allow empty localizedReason for Android

### DIFF
--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.47
+
+* Allowing empty localizedReason for Android
+
 ## 1.0.46
 
 * Updates Java compatibility version to 11.

--- a/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -70,6 +70,10 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
 
     BiometricPrompt.PromptInfo.Builder promptBuilder =
         new BiometricPrompt.PromptInfo.Builder()
+            .setDescription(
+                strings.getReason().isEmpty()
+                    ? null
+                    : strings.getReason())
             .setDescription(strings.getReason())
             .setTitle(strings.getSignInTitle())
             .setSubtitle(strings.getBiometricHint())

--- a/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -74,7 +74,6 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
                 strings.getReason().isEmpty()
                     ? null
                     : strings.getReason())
-            .setDescription(strings.getReason())
             .setTitle(strings.getSignInTitle())
             .setSubtitle(strings.getBiometricHint())
             .setConfirmationRequired(options.getSensitiveTransaction());

--- a/packages/local_auth/local_auth_android/lib/local_auth_android.dart
+++ b/packages/local_auth/local_auth_android/lib/local_auth_android.dart
@@ -34,7 +34,7 @@ class LocalAuthAndroid extends LocalAuthPlatform {
     required Iterable<AuthMessages> authMessages,
     AuthenticationOptions options = const AuthenticationOptions(),
   }) async {
-    assert(localizedReason.isNotEmpty);
+    /// no empty check assertion because [localizedReason] can be empty for android
     final AuthResult result = await _api.authenticate(
         AuthOptions(
             biometricOnly: options.biometricOnly,

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.46
+version: 1.0.47
 
 environment:
   sdk: ^3.5.0

--- a/packages/local_auth/local_auth_android/test/local_auth_test.dart
+++ b/packages/local_auth/local_auth_android/test/local_auth_test.dart
@@ -91,6 +91,16 @@ void main() {
 
   group('authenticate', () {
     group('strings', () {
+      test('With empty reason', () async {
+        when(api.authenticate(any, any))
+            .thenAnswer((_) async => AuthResult.success);
+
+        const String reason = '';
+        final bool result = await plugin.authenticate(
+            localizedReason: reason, authMessages: <AuthMessages>[]);
+
+        expect(result, true);
+      });
       test('passes default values when nothing is provided', () async {
         when(api.authenticate(any, any))
             .thenAnswer((_) async => AuthResult.success);


### PR DESCRIPTION
localizedReason should be optional for Android. There could be use case where we only want to show a single piece of text on the biometric prompt. Currently showing 2 pieces of texts is mandatory.

## Proposal

Only set the description parameter to the BiometricPrompt if a non empty String is passed in the call.

code:

AuthenticationHelper.java

use
```java
.setDescription(strings.getReason().isEmpty() ? null : strings.getReason())
```

instead of

```java
.setDescription(strings.getReason())
```

** screenshots attached in the original issue

Fixes https://github.com/flutter/flutter/issues/116885

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
