### PR TITLE
[pigeon] Removes the `@protected` annotation from the InstanceManager field of the   `PigeonInternalProxyApiBaseClass`

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 22.6.2
+
+* Removes the `@protected` annotation from the InstanceManager field of the
+  `PigeonInternalProxyApiBaseClass`.
+
 ## 22.6.1
 
 * [gobject] Moves class declarations to the header to work around a bug in some

--- a/packages/pigeon/lib/dart/templates.dart
+++ b/packages/pigeon/lib/dart/templates.dart
@@ -255,7 +255,6 @@ abstract class $proxyApiBaseClassName {
   final BinaryMessenger? $_proxyApiBaseClassMessengerVarName;
 
   /// Maintains instances stored to communicate with native language objects.
-  @protected
   final $dartInstanceManagerClassName $_proxyApiBaseClassInstanceManagerVarName;
 
   /// Instantiates and returns a functionally identical object to oneself.

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -14,7 +14,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '22.6.1';
+const String pigeonVersion = '22.6.2';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/platform_tests/shared_test_plugin_code/lib/src/generated/proxy_api_tests.gen.dart
+++ b/packages/pigeon/platform_tests/shared_test_plugin_code/lib/src/generated/proxy_api_tests.gen.dart
@@ -54,7 +54,6 @@ abstract class PigeonInternalProxyApiBaseClass {
   final BinaryMessenger? pigeon_binaryMessenger;
 
   /// Maintains instances stored to communicate with native language objects.
-  @protected
   final PigeonInstanceManager pigeon_instanceManager;
 
   /// Instantiates and returns a functionally identical object to oneself.

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 22.6.1 # This must match the version in lib/generator_tools.dart
+version: 22.6.2 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ^3.3.0

--- a/packages/pigeon/test/dart/proxy_api_test.dart
+++ b/packages/pigeon/test/dart/proxy_api_test.dart
@@ -203,7 +203,7 @@ void main() {
         );
       });
 
-      test('InstanceManager variable', () {
+      test('InstanceManager field', () {
         final Root root = Root(apis: <Api>[
           AstProxyApi(
             name: 'Api',

--- a/packages/pigeon/test/dart/proxy_api_test.dart
+++ b/packages/pigeon/test/dart/proxy_api_test.dart
@@ -177,6 +177,62 @@ void main() {
       );
     });
 
+    group('ProxyApi base class', () {
+      test('class name', () {
+        final Root root = Root(apis: <Api>[
+          AstProxyApi(
+            name: 'Api',
+            constructors: <Constructor>[],
+            fields: <ApiField>[],
+            methods: <Method>[],
+          )
+        ], classes: <Class>[], enums: <Enum>[]);
+        final StringBuffer sink = StringBuffer();
+        const DartGenerator generator = DartGenerator();
+        generator.generate(
+          const DartOptions(),
+          root,
+          sink,
+          dartPackageName: DEFAULT_PACKAGE_NAME,
+        );
+        final String code = sink.toString();
+
+        expect(
+          code,
+          contains(r'abstract class PigeonInternalProxyApiBaseClass'),
+        );
+      });
+
+      test('InstanceManager variable', () {
+        final Root root = Root(apis: <Api>[
+          AstProxyApi(
+            name: 'Api',
+            constructors: <Constructor>[],
+            fields: <ApiField>[],
+            methods: <Method>[],
+          )
+        ], classes: <Class>[], enums: <Enum>[]);
+        final StringBuffer sink = StringBuffer();
+        const DartGenerator generator = DartGenerator();
+        generator.generate(
+          const DartOptions(),
+          root,
+          sink,
+          dartPackageName: DEFAULT_PACKAGE_NAME,
+        );
+        final String code = sink.toString();
+        final String collapsedCode = _collapseNewlineAndIndentation(code);
+
+        expect(
+          collapsedCode,
+          contains(
+            '/// Maintains instances stored to communicate with native language objects. '
+            'final PigeonInstanceManager pigeon_instanceManager;',
+          ),
+        );
+      });
+    });
+
     group('inheritance', () {
       test('extends', () {
         final AstProxyApi api2 = AstProxyApi(


### PR DESCRIPTION
It's common to access the `InstanceManager` when creating platform views, so this removes the `@protected` annotation to prevent lint warnings.

See https://github.com/flutter/packages/pull/7794#discussion_r1828288959

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
