### PR TITLE
[flutter_svg] Fix SvgNetworkLoader not closing internal http client

### DIFF
--- a/third_party/packages/flutter_svg/CHANGELOG.md
+++ b/third_party/packages/flutter_svg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.15
+
+* Fix `SvgNetworkLoader` not closing internally created http clients.
+
 ## 2.0.14
 
 * Makes the package WASM compatible.

--- a/third_party/packages/flutter_svg/CHANGELOG.md
+++ b/third_party/packages/flutter_svg/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.15
 
-* Fix `SvgNetworkLoader` not closing internally created http clients.
+* Fixes `SvgNetworkLoader` not closing internally created http clients.
 
 ## 2.0.14
 

--- a/third_party/packages/flutter_svg/lib/src/loaders.dart
+++ b/third_party/packages/flutter_svg/lib/src/loaders.dart
@@ -438,7 +438,11 @@ class SvgNetworkLoader extends SvgLoader<Uint8List> {
   @override
   Future<Uint8List?> prepareMessage(BuildContext? context) async {
     final http.Client client = _httpClient ?? http.Client();
-    return (await client.get(Uri.parse(url), headers: headers)).bodyBytes;
+    final http.Response response = await client.get(Uri.parse(url), headers: headers);
+    if (_httpClient == null) {
+      client.close();
+    }
+    return response.bodyBytes;
   }
 
   @override

--- a/third_party/packages/flutter_svg/lib/src/loaders.dart
+++ b/third_party/packages/flutter_svg/lib/src/loaders.dart
@@ -438,7 +438,8 @@ class SvgNetworkLoader extends SvgLoader<Uint8List> {
   @override
   Future<Uint8List?> prepareMessage(BuildContext? context) async {
     final http.Client client = _httpClient ?? http.Client();
-    final http.Response response = await client.get(Uri.parse(url), headers: headers);
+    final http.Response response =
+        await client.get(Uri.parse(url), headers: headers);
     if (_httpClient == null) {
       client.close();
     }

--- a/third_party/packages/flutter_svg/pubspec.yaml
+++ b/third_party/packages/flutter_svg/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_svg
 description: An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
 repository: https://github.com/flutter/packages/tree/main/third_party/packages/flutter_svg
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_svg%22
-version: 2.0.14
+version: 2.0.15
 
 environment:
   sdk: ^3.4.0

--- a/third_party/packages/flutter_svg/test/loaders_test.dart
+++ b/third_party/packages/flutter_svg/test/loaders_test.dart
@@ -128,18 +128,17 @@ class _TestColorMapper extends ColorMapper {
   }
 }
 
-class VerifyCloseClient implements http.Client {
+class VerifyCloseClient extends Fake implements http.Client {
   bool closeCalled = false;
 
+  @override
   Future<http.Response> get(Uri url, {Map<String, String>? headers}) async {
     return http.Response('', 200);
   }
 
+  @override
   void close() {
     assert(!closeCalled);
     closeCalled = true;
   }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/third_party/packages/flutter_svg/test/loaders_test.dart
+++ b/third_party/packages/flutter_svg/test/loaders_test.dart
@@ -69,12 +69,23 @@ void main() {
       await loader.prepareMessage(null);
 
       expect(createdClients, hasLength(1));
-      expect(createdClients[0].closeCalled, true);
+      expect(createdClients[0].closeCalled, isTrue);
     }, () {
       final VerifyCloseClient client = VerifyCloseClient();
       createdClients.add(client);
       return client;
     });
+  });
+
+  test("SvgNetworkLoader doesn't close passed client", () async {
+    final VerifyCloseClient client = VerifyCloseClient();
+    final SvgNetworkLoader loader = SvgNetworkLoader('',
+        httpClient: client as http.Client,
+    );
+
+    expect(client.closeCalled, isFalse);
+    await loader.prepareMessage(null);
+    expect(client.closeCalled, isFalse);
   });
 }
 

--- a/third_party/packages/flutter_svg/test/loaders_test.dart
+++ b/third_party/packages/flutter_svg/test/loaders_test.dart
@@ -79,8 +79,9 @@ void main() {
 
   test("SvgNetworkLoader doesn't close passed client", () async {
     final VerifyCloseClient client = VerifyCloseClient();
-    final SvgNetworkLoader loader = SvgNetworkLoader('',
-        httpClient: client as http.Client,
+    final SvgNetworkLoader loader = SvgNetworkLoader(
+      '',
+      httpClient: client as http.Client,
     );
 
     expect(client.closeCalled, isFalse);


### PR DESCRIPTION
closes https://github.com/flutter/flutter/issues/158928

Ensures that if a Client is created in `prepareMessage` it is closed after getting the resource.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I [linked to at least one issue that this PR fixes] in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
