### PR TITLE
[go_router] fix: PopScope not honored for initial Routes inside ShellRoutes

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 14.6.2
+
+- Fixed `PopScope`, and `WillPopScop` was not handled properly in root Shell routes.
+
 ## 14.6.1
 
 - Fixed `PopScope`, and `WillPopScop` was not handled properly in the Root routes.
@@ -9,7 +13,6 @@
 ## 14.5.0
 
 - Adds preload support to StatefulShellRoute, configurable via `preload` parameter on StatefulShellBranch.
-
 
 ## 14.4.1
 
@@ -29,7 +32,7 @@
 
 ## 14.2.8
 
-- Updated custom_stateful_shell_route example to better support swiping in TabView as well as demonstration of the use of PageView. 
+- Updated custom_stateful_shell_route example to better support swiping in TabView as well as demonstration of the use of PageView.
 
 ## 14.2.7
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 14.6.1
+version: 14.6.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/pop_scope_test.dart
+++ b/packages/go_router/test/pop_scope_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  testWidgets('back button respects PopScope', (WidgetTester tester) async {
+    final UniqueKey home = UniqueKey();
+
+    bool onPopCalled = false;
+
+    final List<GoRoute> routes = <GoRoute>[
+      GoRoute(
+        path: '/',
+        builder: (BuildContext context, GoRouterState state) => PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (bool didPop, Object? result) {
+            onPopCalled = true;
+          },
+          child: DummyScreen(key: home),
+        ),
+      ),
+    ];
+
+    final GoRouter router = await createRouter(routes, tester);
+
+    expect(await router.routerDelegate.popRoute(), true);
+    await tester.pumpAndSettle();
+
+    expect(onPopCalled, isTrue);
+
+    expect(find.byKey(home), findsOneWidget);
+  });
+
+  testWidgets('back button is respects PopScope in ShellRoute',
+      (WidgetTester tester) async {
+    bool onPopCalled = false;
+
+    final UniqueKey home = UniqueKey();
+
+    final List<RouteBase> routes = <RouteBase>[
+      ShellRoute(
+        builder: (BuildContext contex, GoRouterState state, Widget child) =>
+            child,
+        routes: <RouteBase>[
+          GoRoute(
+            path: '/',
+            builder: (BuildContext context, GoRouterState state) => PopScope(
+              canPop: false,
+              onPopInvokedWithResult: (bool didPop, Object? result) {
+                onPopCalled = true;
+              },
+              child: DummyScreen(key: home),
+            ),
+          ),
+        ],
+      ),
+    ];
+
+    final GoRouter router = await createRouter(routes, tester);
+
+    expect(await router.routerDelegate.popRoute(), true);
+    await tester.pumpAndSettle();
+
+    expect(onPopCalled, isTrue);
+
+    expect(find.byKey(home), findsOneWidget);
+  });
+}

--- a/packages/go_router/test/pop_scope_test.dart
+++ b/packages/go_router/test/pop_scope_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2024 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'package:flutter/widgets.dart';

--- a/packages/go_router/test/pop_scope_test.dart
+++ b/packages/go_router/test/pop_scope_test.dart
@@ -1,3 +1,6 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';


### PR DESCRIPTION
This includes fixes to honor ShellRoutes with PopScope routes [#140869](https://github.com/flutter/flutter/issues/140869) see the last couple comments.

Pot. also touches #8045 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
