### PR TITLE
[shared_preferences] Limit Android decoding

### DIFF
--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.4
+
+* Restrict types when decoding preferences.
+
 ## 2.3.3
 
 * Updates Java compatibility version to 11.

--- a/packages/shared_preferences/shared_preferences_android/android/src/main/java/io/flutter/plugins/sharedpreferences/LegacySharedPreferencesPlugin.java
+++ b/packages/shared_preferences/shared_preferences_android/android/src/main/java/io/flutter/plugins/sharedpreferences/LegacySharedPreferencesPlugin.java
@@ -197,7 +197,7 @@ public class LegacySharedPreferencesPlugin implements FlutterPlugin, SharedPrefe
     public @NonNull List<String> decode(@NonNull String listString) throws RuntimeException {
       try {
         ObjectInputStream stream =
-            new ObjectInputStream(new ByteArrayInputStream(Base64.decode(listString, 0)));
+            new StringListObjectInputStream(new ByteArrayInputStream(Base64.decode(listString, 0)));
         return (List<String>) stream.readObject();
       } catch (IOException | ClassNotFoundException e) {
         throw new RuntimeException(e);

--- a/packages/shared_preferences/shared_preferences_android/android/src/main/kotlin/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.kt
+++ b/packages/shared_preferences/shared_preferences_android/android/src/main/kotlin/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.kt
@@ -20,7 +20,6 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.BinaryMessenger
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
@@ -250,25 +249,17 @@ class SharedPreferencesPlugin() : FlutterPlugin, SharedPreferencesAsyncApi {
   /** Class that provides tools for encoding and decoding List<String> to String and back. */
   class ListEncoder : SharedPreferencesListEncoder {
     override fun encode(list: List<String>): String {
-      try {
-        val byteStream = ByteArrayOutputStream()
-        val stream = ObjectOutputStream(byteStream)
-        stream.writeObject(list)
-        stream.flush()
-        return Base64.encodeToString(byteStream.toByteArray(), 0)
-      } catch (e: RuntimeException) {
-        throw RuntimeException(e)
-      }
+      val byteStream = ByteArrayOutputStream()
+      val stream = ObjectOutputStream(byteStream)
+      stream.writeObject(list)
+      stream.flush()
+      return Base64.encodeToString(byteStream.toByteArray(), 0)
     }
 
     override fun decode(listString: String): List<String> {
-      try {
-        val byteArray = Base64.decode(listString, 0)
-        val stream = ObjectInputStream(ByteArrayInputStream(byteArray))
-        return (stream.readObject() as List<*>).filterIsInstance<String>()
-      } catch (e: RuntimeException) {
-        throw RuntimeException(e)
-      }
+      val byteArray = Base64.decode(listString, 0)
+      val stream = StringListObjectInputStream(ByteArrayInputStream(byteArray))
+      return (stream.readObject() as List<*>).filterIsInstance<String>()
     }
   }
 }

--- a/packages/shared_preferences/shared_preferences_android/android/src/main/kotlin/io/flutter/plugins/sharedpreferences/StringListObjectInputStream.kt
+++ b/packages/shared_preferences/shared_preferences_android/android/src/main/kotlin/io/flutter/plugins/sharedpreferences/StringListObjectInputStream.kt
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.sharedpreferences
+
+import java.io.IOException
+import java.io.InputStream
+import java.io.ObjectInputStream
+import java.io.ObjectStreamClass
+
+/**
+ * An ObjectInputStream that only allows string lists, to prevent injected prefs from instantiating
+ * arbitrary objects.
+ */
+class StringListObjectInputStream(input: InputStream) : ObjectInputStream(input) {
+  @Throws(ClassNotFoundException::class, IOException::class)
+  override fun resolveClass(desc: ObjectStreamClass?): Class<*>? {
+    val allowList =
+        setOf(
+            "java.util.Arrays\$ArrayList",
+            "java.util.ArrayList",
+            "java.lang.String",
+            "[Ljava.lang.String;")
+    val name = desc?.name
+    if (name != null && !allowList.contains(name)) {
+      throw ClassNotFoundException(desc.name)
+    }
+    return super.resolveClass(desc)
+  }
+}

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.3.3
+version: 2.3.4
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
When decoding stored preferences for `List<String>` support, only allow lists and strings to avoid potentially instantiating other object types.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
