### PR TITLE
Enable multi-cell/single-cell text selection in Simple Table example

### DIFF
--- a/packages/two_dimensional_scrollables/example/lib/table_view/simple_table.dart
+++ b/packages/two_dimensional_scrollables/example/lib/table_view/simple_table.dart
@@ -19,8 +19,15 @@ class TableExample extends StatefulWidget {
   State<TableExample> createState() => _TableExampleState();
 }
 
+enum _TableSelection {
+  multiCell,
+  singleCell,
+  disabled,
+}
+
 class _TableExampleState extends State<TableExample> {
   late final ScrollController _verticalController = ScrollController();
+  _TableSelection _selectionMode = _TableSelection.disabled;
   int _rowCount = 20;
 
   @override
@@ -34,49 +41,107 @@ class _TableExampleState extends State<TableExample> {
     return Scaffold(
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 50.0),
-        child: TableView.builder(
-          verticalDetails: ScrollableDetails.vertical(
-            controller: _verticalController,
-          ),
-          cellBuilder: _buildCell,
-          columnCount: 20,
-          columnBuilder: _buildColumnSpan,
-          rowCount: _rowCount,
-          rowBuilder: _buildRowSpan,
-        ),
+        child: _selectionMode == _TableSelection.multiCell
+                              ? SelectionArea(
+                                  child: TableView.builder( 
+                                    verticalDetails: ScrollableDetails.vertical(
+                                      controller: _verticalController,
+                                    ),
+                                    cellBuilder: _buildCell,
+                                    columnCount: 20,
+                                    columnBuilder: _buildColumnSpan,
+                                    rowCount: _rowCount,
+                                    rowBuilder: _buildRowSpan,
+                                  ),
+                                )
+                              : TableView.builder(
+                                  verticalDetails: ScrollableDetails.vertical(
+                                    controller: _verticalController,
+                                  ),
+                                  cellBuilder: _buildCell,
+                                  columnCount: 20,
+                                  columnBuilder: _buildColumnSpan,
+                                  rowCount: _rowCount,
+                                  rowBuilder: _buildRowSpan,
+                                ),
       ),
       persistentFooterButtons: <Widget>[
-        TextButton(
-          onPressed: () {
-            _verticalController.jumpTo(0);
-          },
-          child: const Text('Jump to Top'),
-        ),
-        TextButton(
-          onPressed: () {
-            _verticalController.jumpTo(
-              _verticalController.position.maxScrollExtent,
-            );
-          },
-          child: const Text('Jump to Bottom'),
-        ),
-        TextButton(
-          onPressed: () {
-            setState(() {
-              _rowCount += 10;
-            });
-          },
-          child: const Text('Add 10 Rows'),
+        OverflowBar(
+          alignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('Selection'),
+                SegmentedButton<_TableSelection>(
+                  segments: const <ButtonSegment<_TableSelection>>[
+                    ButtonSegment<_TableSelection>(
+                        value: _TableSelection.multiCell,
+                        label: Text('Multi-Cell'),
+                        icon: Icon(Icons.layers)),
+                    ButtonSegment<_TableSelection>(
+                        value: _TableSelection.singleCell,
+                        label: Text('Single-Cell'),
+                        icon: Icon(Icons.crop_square)),
+                    ButtonSegment<_TableSelection>(
+                        value: _TableSelection.disabled,
+                        label: Text('Disabled'),
+                        icon: Icon(Icons.disabled_by_default)),
+                  ],
+                  selected: <_TableSelection>{_selectionMode},
+                  onSelectionChanged: (Set<_TableSelection> newSelection) {
+                    setState(() {
+                      // By default there is only a single segment that can be
+                      // selected at one time, so its value is always the first
+                      // item in the selected set.
+                      _selectionMode = newSelection.first;
+                    });
+                  },
+                ),
+              ],
+            ),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextButton(
+                  onPressed: () {
+                    _verticalController.jumpTo(0);
+                  },
+                  child: const Text('Jump to Top'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    _verticalController.jumpTo(
+                      _verticalController.position.maxScrollExtent,
+                    );
+                  },
+                  child: const Text('Jump to Bottom'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _rowCount += 10;
+                    });
+                  },
+                  child: const Text('Add 10 Rows'),
+                ),
+              ],
+            ),
+          ],
         ),
       ],
     );
   }
 
   TableViewCell _buildCell(BuildContext context, TableVicinity vicinity) {
+    Widget result = Center(
+      child: Text('Tile c: ${vicinity.column}, r: ${vicinity.row}'),
+    );
+    if (_selectionMode == _TableSelection.singleCell) {
+      result = SelectionArea(child: result);
+    }
     return TableViewCell(
-      child: Center(
-        child: Text('Tile c: ${vicinity.column}, r: ${vicinity.row}'),
-      ),
+      child: result,
     );
   }
 


### PR DESCRIPTION
This change adds a `SegmentedButton` to enable different variations of text selection for the example.
* Multi-cell selection, enables selection across the entire table, allowing you to select across cells.
* Single-cell selection, enables selection on individual cells, so the selection cannot escape the cell it started in.
* Disabled, disables selection across the entire table.

Text selection in a table is a common use-case that we should showcase.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.