### PR TITLE
[image_picker] Removes use of PHAsset on IOS 14+

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.12+2
+
+* Removes the need for user permissions to pick an image on iOS 14+.
+
 ## 0.8.12+1
 
 * Updates Pigeon for non-nullable collection type support.

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -495,11 +495,11 @@
   [self waitForExpectationsWithTimeout:30 handler:nil];
 }
 
-- (void)testPickImageRequestAuthorization API_AVAILABLE(ios(14)) {
+- (void)testPickImageDoesntRequestAuthorization API_AVAILABLE(ios(14)) {
   id mockPhotoLibrary = OCMClassMock([PHPhotoLibrary class]);
   OCMStub([mockPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelReadWrite])
       .andReturn(PHAuthorizationStatusNotDetermined);
-  OCMExpect([mockPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelReadWrite
+  OCMReject([mockPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelReadWrite
                                                          handler:OCMOCK_ANY]);
 
   FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc] init];
@@ -512,29 +512,6 @@
                    completion:^(NSString *result, FlutterError *error){
                    }];
   OCMVerifyAll(mockPhotoLibrary);
-}
-
-- (void)testPickImageAuthorizationDenied API_AVAILABLE(ios(14)) {
-  id mockPhotoLibrary = OCMClassMock([PHPhotoLibrary class]);
-  OCMStub([mockPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelReadWrite])
-      .andReturn(PHAuthorizationStatusDenied);
-
-  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc] init];
-
-  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"result"];
-
-  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
-                                                            camera:FLTSourceCameraFront]
-                      maxSize:[[FLTMaxSize alloc] init]
-                      quality:nil
-                 fullMetadata:YES
-                   completion:^(NSString *result, FlutterError *error) {
-                     XCTAssertNil(result);
-                     XCTAssertEqualObjects(error.code, @"photo_access_denied");
-                     XCTAssertEqualObjects(error.message, @"The user did not allow photo access.");
-                     [resultExpectation fulfill];
-                   }];
-  [self waitForExpectationsWithTimeout:30 handler:nil];
 }
 
 - (void)testPickMultiImageDuplicateCallCancels API_AVAILABLE(ios(14)) {

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PhotoAssetUtilTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PhotoAssetUtilTests.m
@@ -20,18 +20,6 @@
   XCTAssertNil([FLTImagePickerPhotoAssetUtil getAssetFromImagePickerInfo:mockData]);
 }
 
-- (void)testGetAssetFromPHPickerResultShouldReturnNilIfNotAvailable API_AVAILABLE(ios(14)) {
-  if (@available(iOS 14, *)) {
-    PHPickerResult *mockData;
-    [mockData.itemProvider
-        loadObjectOfClass:[UIImage class]
-        completionHandler:^(__kindof id<NSItemProviderReading> _Nullable image,
-                            NSError *_Nullable error) {
-          XCTAssertNil([FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:mockData]);
-        }];
-  }
-}
-
 - (void)testSaveImageWithOriginalImageData_ShouldSaveWithTheCorrectExtentionAndMetaData {
   // test jpg
   NSData *dataJPG = ImagePickerTestImages.JPGTestData;

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromLimitedGalleryUITests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromLimitedGalleryUITests.m
@@ -104,8 +104,6 @@ const int kLimitedElementWaitingTime = 30;
   }
   [pickButton tap];
 
-  [self handlePermissionInterruption];
-
   // Find an image and tap on it.
   NSPredicate *imagePredicate = [NSPredicate predicateWithFormat:@"label BEGINSWITH 'Photo, '"];
   XCUIElementQuery *imageQuery = [self.app.images matchingPredicate:imagePredicate];
@@ -117,25 +115,6 @@ const int kLimitedElementWaitingTime = 30;
             @(kLimitedElementWaitingTime));
   }
 
-  [aImage tap];
-
-  // Find and tap on the `Done` button.
-  XCUIElement *doneButton = self.app.buttons[@"Done"].firstMatch;
-  if (![doneButton waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
-    os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
-    XCTSkip(@"Permissions popup could not fired so the test is skipped...");
-  }
-  [doneButton tap];
-
-  // Find an image and tap on it to have access to selected photos.
-  aImage = imageQuery.firstMatch;
-
-  os_log_error(OS_LOG_DEFAULT, "description before picking image %@", self.app.debugDescription);
-  if (![aImage waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
-    os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
-    XCTFail(@"Failed due to not able to find an image with %@ seconds",
-            @(kLimitedElementWaitingTime));
-  }
   [aImage tap];
 
   // Find the picked image.

--- a/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPhotoAssetUtil.m
@@ -14,12 +14,6 @@
   return info[UIImagePickerControllerPHAsset];
 }
 
-+ (PHAsset *)getAssetFromPHPickerResult:(PHPickerResult *)result API_AVAILABLE(ios(14)) {
-  PHFetchResult *fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[ result.assetIdentifier ]
-                                                                options:nil];
-  return fetchResult.firstObject;
-}
-
 + (NSURL *)saveVideoFromURL:(NSURL *)videoURL {
   if (![[NSFileManager defaultManager] isReadableFileAtPath:[videoURL path]]) {
     return nil;

--- a/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
@@ -113,11 +113,7 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   pickerViewController.presentationController.delegate = self;
   self.callContext = context;
 
-  if (context.requestFullMetadata) {
-    [self checkPhotoAuthorizationWithPHPicker:pickerViewController];
-  } else {
-    [self showPhotoLibraryWithPHPicker:pickerViewController];
-  }
+  [self showPhotoLibraryWithPHPicker:pickerViewController];
 }
 
 - (void)launchUIImagePickerWithSource:(nonnull FLTSourceSpecification *)source
@@ -381,40 +377,6 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
     }
     case PHAuthorizationStatusAuthorized:
       [self showPhotoLibraryWithImagePicker:imagePickerController];
-      break;
-    case PHAuthorizationStatusDenied:
-    case PHAuthorizationStatusRestricted:
-    default:
-      [self errorNoPhotoAccess:status];
-      break;
-  }
-}
-
-- (void)checkPhotoAuthorizationWithPHPicker:(PHPickerViewController *)pickerViewController
-    API_AVAILABLE(ios(14)) {
-  PHAccessLevel requestedAccessLevel = PHAccessLevelReadWrite;
-  PHAuthorizationStatus status =
-      [PHPhotoLibrary authorizationStatusForAccessLevel:requestedAccessLevel];
-  switch (status) {
-    case PHAuthorizationStatusNotDetermined: {
-      [PHPhotoLibrary
-          requestAuthorizationForAccessLevel:requestedAccessLevel
-                                     handler:^(PHAuthorizationStatus status) {
-                                       dispatch_async(dispatch_get_main_queue(), ^{
-                                         if (status == PHAuthorizationStatusAuthorized) {
-                                           [self showPhotoLibraryWithPHPicker:pickerViewController];
-                                         } else if (status == PHAuthorizationStatusLimited) {
-                                           [self showPhotoLibraryWithPHPicker:pickerViewController];
-                                         } else {
-                                           [self errorNoPhotoAccess:status];
-                                         }
-                                       });
-                                     }];
-      break;
-    }
-    case PHAuthorizationStatusAuthorized:
-    case PHAuthorizationStatusLimited:
-      [self showPhotoLibraryWithPHPicker:pickerViewController];
       break;
     case PHAuthorizationStatusDenied:
     case PHAuthorizationStatusRestricted:

--- a/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTPHPickerSaveImageToPathOperation.m
@@ -128,64 +128,20 @@ API_AVAILABLE(ios(14))
 - (void)processImage:(NSData *)pickerImageData API_AVAILABLE(ios(14)) {
   UIImage *localImage = [[UIImage alloc] initWithData:pickerImageData];
 
-  PHAsset *originalAsset;
-  // Only if requested, fetch the full "PHAsset" metadata, which requires  "Photo Library Usage"
-  // permissions.
-  if (self.requestFullMetadata) {
-    originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:self.result];
-  }
-
   if (self.maxWidth != nil || self.maxHeight != nil) {
     localImage = [FLTImagePickerImageUtil scaledImage:localImage
                                              maxWidth:self.maxWidth
                                             maxHeight:self.maxHeight
                                   isMetadataAvailable:YES];
   }
-  if (originalAsset) {
-    void (^resultHandler)(NSData *imageData, NSString *dataUTI, NSDictionary *info) =
-        ^(NSData *_Nullable imageData, NSString *_Nullable dataUTI, NSDictionary *_Nullable info) {
-          // maxWidth and maxHeight are used only for GIF images.
-          NSString *savedPath = [FLTImagePickerPhotoAssetUtil
-              saveImageWithOriginalImageData:imageData
-                                       image:localImage
-                                    maxWidth:self.maxWidth
-                                   maxHeight:self.maxHeight
-                                imageQuality:self.desiredImageQuality];
-          [self completeOperationWithPath:savedPath error:nil];
-        };
-    if (@available(iOS 13.0, *)) {
-      [[PHImageManager defaultManager]
-          requestImageDataAndOrientationForAsset:originalAsset
-                                         options:nil
-                                   resultHandler:^(NSData *_Nullable imageData,
-                                                   NSString *_Nullable dataUTI,
-                                                   CGImagePropertyOrientation orientation,
-                                                   NSDictionary *_Nullable info) {
-                                     resultHandler(imageData, dataUTI, info);
-                                   }];
-    } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      [[PHImageManager defaultManager]
-          requestImageDataForAsset:originalAsset
-                           options:nil
-                     resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
-                                     UIImageOrientation orientation, NSDictionary *_Nullable info) {
-                       resultHandler(imageData, dataUTI, info);
-                     }];
-#pragma clang diagnostic pop
-    }
-  } else {
-    // Image picked without an original asset (e.g. User pick image without permission)
-    // maxWidth and maxHeight are used only for GIF images.
-    NSString *savedPath =
-        [FLTImagePickerPhotoAssetUtil saveImageWithOriginalImageData:pickerImageData
-                                                               image:localImage
-                                                            maxWidth:self.maxWidth
-                                                           maxHeight:self.maxHeight
-                                                        imageQuality:self.desiredImageQuality];
-    [self completeOperationWithPath:savedPath error:nil];
-  }
+  // maxWidth and maxHeight are used only for GIF images.
+  NSString *savedPath =
+      [FLTImagePickerPhotoAssetUtil saveImageWithOriginalImageData:pickerImageData
+                                                              image:localImage
+                                                          maxWidth:self.maxWidth
+                                                          maxHeight:self.maxHeight
+                                                      imageQuality:self.desiredImageQuality];
+  [self completeOperationWithPath:savedPath error:nil];
 }
 
 /// Processes the video.

--- a/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/include/image_picker_ios/FLTImagePickerPhotoAssetUtil.h
+++ b/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/include/image_picker_ios/FLTImagePickerPhotoAssetUtil.h
@@ -14,8 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable PHAsset *)getAssetFromImagePickerInfo:(NSDictionary *)info;
 
-+ (nullable PHAsset *)getAssetFromPHPickerResult:(PHPickerResult *)result API_AVAILABLE(ios(14));
-
 // Saves video to temporary URL. Returns nil on failure;
 + (NSURL *)saveVideoFromURL:(NSURL *)videoURL;
 

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.12+1
+version: 0.8.12+2
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
Original PR https://github.com/flutter/packages/pull/8020

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
