### PR TITLE
[google_maps_flutter] Annotate deprecated member usage

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/integration_test/src/maps_controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/integration_test/src/maps_controller.dart
@@ -162,6 +162,8 @@ void runTests() {
 
     const String mapStyle =
         '[{"elementType":"geometry","stylers":[{"color":"#242f3e"}]}]';
+    // Intentionally testing the deprecated code path.
+    // ignore: deprecated_member_use
     await controller.setMapStyle(mapStyle);
   });
 
@@ -184,6 +186,8 @@ void runTests() {
     final GoogleMapController controller = await controllerCompleter.future;
 
     try {
+      // Intentionally testing the deprecated code path.
+      // ignore: deprecated_member_use
       await controller.setMapStyle('invalid_value');
       fail('expected MapStyleException');
     } on MapStyleException catch (e) {
@@ -208,6 +212,8 @@ void runTests() {
     );
     final GoogleMapController controller = await controllerCompleter.future;
 
+    // Intentionally testing the deprecated code path.
+    // ignore: deprecated_member_use
     await controller.setMapStyle(null);
   });
 
@@ -471,6 +477,8 @@ void runTests() {
     final Set<Marker> markers = <Marker>{
       Marker(
           markerId: const MarkerId('1'),
+          // Intentionally testing the deprecated code path.
+          // ignore: deprecated_member_use
           icon: await BitmapDescriptor.fromAssetImage(
             imageConfiguration,
             'assets/red_square.png',
@@ -493,6 +501,8 @@ void runTests() {
     final Set<Marker> markers = <Marker>{
       Marker(
           markerId: const MarkerId('1'),
+          // Intentionally testing the deprecated code path.
+          // ignore: deprecated_member_use
           icon: BitmapDescriptor.fromBytes(
             bytes,
             size: const Size(100, 100),

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -1405,6 +1405,8 @@ void googleMapsTests() {
     final Set<Marker> markers = <Marker>{
       Marker(
           markerId: const MarkerId('1'),
+          // Intentionally testing the deprecated code path.
+          // ignore: deprecated_member_use
           icon: await BitmapDescriptor.fromAssetImage(
             imageConfiguration,
             'assets/red_square.png',
@@ -1427,6 +1429,8 @@ void googleMapsTests() {
     final Set<Marker> markers = <Marker>{
       Marker(
           markerId: const MarkerId('1'),
+          // Intentionally testing the deprecated code path.
+          // ignore: deprecated_member_use
           icon: BitmapDescriptor.fromBytes(
             bytes,
             size: const Size(100, 100),

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -885,6 +885,8 @@ class GoogleMapsFlutterAndroid extends GoogleMapsFlutterPlatform {
       case final DefaultMarker marker:
         return PlatformBitmap(
             bitmap: PlatformBitmapDefaultMarker(hue: marker.hue?.toDouble()));
+      // Clients may still use this deprecated format, so it must be supported.
+      // ignore: deprecated_member_use
       case final BytesBitmap bytes:
         return PlatformBitmap(
             bitmap: PlatformBitmapBytes(
@@ -895,6 +897,8 @@ class GoogleMapsFlutterAndroid extends GoogleMapsFlutterPlatform {
       case final AssetBitmap asset:
         return PlatformBitmap(
             bitmap: PlatformBitmapAsset(name: asset.name, pkg: asset.package));
+      // Clients may still use this deprecated format, so it must be supported.
+      // ignore: deprecated_member_use
       case final AssetImageBitmap asset:
         return PlatformBitmap(
             bitmap: PlatformBitmapAssetImage(

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios14/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios14/integration_test/google_maps_test.dart
@@ -1245,6 +1245,8 @@ void main() {
     final Set<Marker> markers = <Marker>{
       Marker(
           markerId: const MarkerId('1'),
+          // Intentionally testing the deprecated code path.
+          // ignore: deprecated_member_use
           icon: await BitmapDescriptor.fromAssetImage(
             imageConfiguration,
             'assets/red_square.png',
@@ -1268,6 +1270,8 @@ void main() {
   testWidgets('markerWithLegacyBytes', (WidgetTester tester) async {
     tester.view.devicePixelRatio = 2.0;
     final Uint8List bytes = const Base64Decoder().convert(iconImageBase64);
+    // Intentionally testing the deprecated code path.
+    // ignore: deprecated_member_use
     final BitmapDescriptor icon = BitmapDescriptor.fromBytes(
       bytes,
     );

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
@@ -773,6 +773,8 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
       case final DefaultMarker marker:
         return PlatformBitmap(
             bitmap: PlatformBitmapDefaultMarker(hue: marker.hue?.toDouble()));
+      // Clients may still use this deprecated format, so it must be supported.
+      // ignore: deprecated_member_use
       case final BytesBitmap bytes:
         final Size? size = bytes.size;
         return PlatformBitmap(
@@ -782,6 +784,8 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
       case final AssetBitmap asset:
         return PlatformBitmap(
             bitmap: PlatformBitmapAsset(name: asset.name, pkg: asset.package));
+      // Clients may still use this deprecated format, so it must be supported.
+      // ignore: deprecated_member_use
       case final AssetImageBitmap asset:
         final Size? size = asset.size;
         return PlatformBitmap(

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
@@ -194,9 +194,10 @@ class GoogleMapController {
   /// own configuration and are rendered on top of a GMap instance later. This
   /// happens in the second half of this method.
   ///
-  /// This method is eagerly called from the [GoogleMapsPlugin.buildView] method
-  /// so the internal [GoogleMapsController] of a Web Map initializes as soon as
-  /// possible. Check [_attachMapEvents] to see how this controller notifies the
+  /// This method is eagerly called from the
+  /// [GoogleMapsPlugin.buildViewWithConfiguration] method so the internal
+  /// [GoogleMapsController] of a Web Map initializes as soon as possible.
+  /// Check [_attachMapEvents] to see how this controller notifies the
   /// plugin of it being fully ready (through the `onTilesloaded.first` event).
   ///
   /// Failure to call this method would result in the GMap not rendering at all,


### PR DESCRIPTION
There are several intentional uses of deprecated members from other packages within the plugin group, so annotate them so that they don't show up in the regular team audits:
- App-facing package integration tests of the deprecated style method.
- Handling of deprecated marker bitmap formats.

These turned up in the [routine repo audit](https://github.com/flutter/flutter/blob/main/docs/infra/Packages-Gardener-Rotation.md#deprecations).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
