### PR TITLE
[format_command] Improve fallback logic for swift-format and add tests

### DIFF
--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -270,13 +270,11 @@ class FormatCommand extends PackageLoopingCommand {
     throw ToolExit(_exitDependencyMissing);
   }
 
-
-
-
   Future<String> _findValidSwiftFormat() async {
     // Check if --swift-format-path is provided
     final String swiftFormatPathArg = getStringArg(_swiftFormatPathArg);
-    if (swiftFormatPathArg.isNotEmpty && await _hasDependency(swiftFormatPathArg)) {
+    if (swiftFormatPathArg.isNotEmpty &&
+        await _hasDependency(swiftFormatPathArg)) {
       return swiftFormatPathArg;
     }
 
@@ -286,7 +284,8 @@ class FormatCommand extends PackageLoopingCommand {
     }
 
     // Fallback to xcrun --find swift-format
-    final io.ProcessResult result = await io.Process.run('xcrun', ['--find', 'swift-format']);
+    final io.ProcessResult result =
+        await io.Process.run('xcrun', ['--find', 'swift-format']);
     if (result.exitCode == 0 && result.stdout.toString().isNotEmpty) {
       final String swiftFormatFromXcrun = result.stdout.toString().trim();
       if (await _hasDependency(swiftFormatFromXcrun)) {
@@ -296,9 +295,8 @@ class FormatCommand extends PackageLoopingCommand {
 
     // If all checks fail, show an error and exit
     printError(
-      'Unable to locate "swift-format". Ensure it is available in your PATH, '
-      'or provide a valid path using --$_swiftFormatPathArg.'
-    );
+        'Unable to locate "swift-format". Ensure it is available in your PATH, '
+        'or provide a valid path using --$_swiftFormatPathArg.');
     throw ToolExit(_exitDependencyMissing);
   }
 

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -618,7 +618,8 @@ void main() {
 
     test('uses --swift-format-path if provided and valid', () async {
       final String validSwiftFormatPath = '/valid/path/to/swift-format';
-      processRunner.mockProcessesForExecutable[validSwiftFormatPath] = <FakeProcessInfo>[
+      processRunner.mockProcessesForExecutable[validSwiftFormatPath] =
+          <FakeProcessInfo>[
         FakeProcessInfo(MockProcess(exitCode: 0), <String>['--version']),
       ];
 
@@ -637,12 +638,14 @@ void main() {
           commandError = e;
         },
       );
-      
-      expect(commandError, isNull, reason: 'No error should occur if --swift-format-path is valid.');
+
+      expect(commandError, isNull,
+          reason: 'No error should occur if --swift-format-path is valid.');
     });
 
     test('uses swift-format from system PATH if available', () async {
-      processRunner.mockProcessesForExecutable['swift-format'] = <FakeProcessInfo>[
+      processRunner.mockProcessesForExecutable['swift-format'] =
+          <FakeProcessInfo>[
         FakeProcessInfo(MockProcess(exitCode: 0), <String>['--version']),
       ];
 
@@ -662,7 +665,8 @@ void main() {
         },
       );
 
-      expect(commandError, isNull, reason: 'No error should occur if swift-format is in PATH.');
+      expect(commandError, isNull,
+          reason: 'No error should occur if swift-format is in PATH.');
     });
 
     test('uses xcrun to find swift-format if not in PATH', () async {
@@ -676,7 +680,8 @@ void main() {
         ),
       ];
 
-      processRunner.mockProcessesForExecutable['/found/path/to/swift-format'] = <FakeProcessInfo>[
+      processRunner.mockProcessesForExecutable['/found/path/to/swift-format'] =
+          <FakeProcessInfo>[
         FakeProcessInfo(MockProcess(exitCode: 0), <String>['--version']),
       ];
 
@@ -696,9 +701,10 @@ void main() {
         },
       );
 
-      expect(commandError, isNull, reason: 'No error should occur if xcrun successfully finds swift-format.');
+      expect(commandError, isNull,
+          reason:
+              'No error should occur if xcrun successfully finds swift-format.');
     });
-
 
     test('fails if swift-format lint finds issues', () async {
       const List<String> files = <String>[


### PR DESCRIPTION
## Description
This pull request improves the fallback logic for locating the swift-format command in response to changes introduced with Xcode 16. Specifically:

The format command now:
  1. Checks if --swift-format-path is provided and valid.
  2. Falls back to checking for swift-format in the system PATH.
  3. Uses xcrun --find swift-format as a final fallback.
  4. Properly fails with a clear error message if none of the above methods succeed.

This ensures compatibility with Xcode 16, which now packages swift-format with the default toolchain.

## Relevant Issue
[#153803](https://github.com/flutter/flutter/issues/153803#issue-2476716538)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.