### PR TITLE
[camera_android_camerax] Remove nonnull annotation from getDefaultPointSize

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.10+1
+
+* Removes nonnull annotation from MeteringPointHostApiImpl#getDefaultPointSize.
+
 ## 0.6.10
 
 * Removes logic that explicitly removes `READ_EXTERNAL_STORAGE` permission that may be implied

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/MeteringPointHostApiImpl.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/MeteringPointHostApiImpl.java
@@ -83,7 +83,6 @@ public class MeteringPointHostApiImpl implements MeteringPointHostApi {
      * Returns the default point size of the {@link MeteringPoint} width and height, which is a
      * normalized percentage of the sensor width/height.
      */
-    @NonNull
     public float getDefaultPointSize() {
       return MeteringPointFactory.getDefaultPointSize();
     }

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.10
+version: 0.6.10+1
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
The primitive float type cannot be null, so the annotation is meaningless.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [NA] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [NA] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
