### PR TITLE
[ci] Re-enable macOS sandboxing

### DIFF
--- a/packages/flutter_image/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/flutter_image/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/flutter_image/example/macos/Runner/Release.entitlements
+++ b/packages/flutter_image/example/macos/Runner/Release.entitlements
@@ -5,7 +5,6 @@
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/google_sign_in/google_sign_in/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/google_sign_in/google_sign_in/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/google_sign_in/google_sign_in/example/macos/Runner/Release.entitlements
+++ b/packages/google_sign_in/google_sign_in/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/google_sign_in/google_sign_in_ios/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/google_sign_in/google_sign_in_ios/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/google_sign_in/google_sign_in_ios/example/macos/Runner/Release.entitlements
+++ b/packages/google_sign_in/google_sign_in_ios/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/image_picker/image_picker/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/image_picker/image_picker/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/image_picker/image_picker/example/macos/Runner/Release.entitlements
+++ b/packages/image_picker/image_picker/example/macos/Runner/Release.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 </dict>

--- a/packages/in_app_purchase/in_app_purchase/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/in_app_purchase/in_app_purchase/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/in_app_purchase/in_app_purchase/example/macos/Runner/Release.entitlements
+++ b/packages/in_app_purchase/in_app_purchase/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/macos/Runner/Release.entitlements
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/path_provider/path_provider/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/path_provider/path_provider/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/path_provider/path_provider/example/macos/Runner/Release.entitlements
+++ b/packages/path_provider/path_provider/example/macos/Runner/Release.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
     <true/>
 </dict>

--- a/packages/path_provider/path_provider_foundation/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/path_provider/path_provider_foundation/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/path_provider/path_provider_foundation/example/macos/Runner/Release.entitlements
+++ b/packages/path_provider/path_provider_foundation/example/macos/Runner/Release.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
 </dict>

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/macos/Runner/Release.entitlements
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/shared_preferences/shared_preferences/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/shared_preferences/shared_preferences/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/shared_preferences/shared_preferences/example/macos/Runner/Release.entitlements
+++ b/packages/shared_preferences/shared_preferences/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/shared_preferences/shared_preferences_foundation/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/shared_preferences/shared_preferences_foundation/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/shared_preferences/shared_preferences_foundation/example/macos/Runner/Release.entitlements
+++ b/packages/shared_preferences/shared_preferences_foundation/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/url_launcher/url_launcher/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/url_launcher/url_launcher/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/url_launcher/url_launcher/example/macos/Runner/Release.entitlements
+++ b/packages/url_launcher/url_launcher/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/url_launcher/url_launcher_macos/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/url_launcher/url_launcher_macos/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/url_launcher/url_launcher_macos/example/macos/Runner/Release.entitlements
+++ b/packages/url_launcher/url_launcher_macos/example/macos/Runner/Release.entitlements
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/packages/video_player/video_player/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/video_player/video_player/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/packages/video_player/video_player/example/macos/Runner/Release.entitlements
+++ b/packages/video_player/video_player/example/macos/Runner/Release.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/packages/video_player/video_player_avfoundation/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/video_player/video_player_avfoundation/example/macos/Runner/DebugProfile.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/packages/video_player/video_player_avfoundation/example/macos/Runner/Release.entitlements
+++ b/packages/video_player/video_player_avfoundation/example/macos/Runner/Release.entitlements
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<!-- TODO(vashworth): Re-enable sandboxing once https://github.com/flutter/flutter/pull/149618 lands in stable and stable version is updated. -->
-	<false/>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Revert "Disable sandboxing directly for macOS tests (#6880)", commit 4a178f1ad9004e61fc58e5e8b704cee20e0b45d2, now that the `flutter`-level changes have reached `stable`.

Fixes https://github.com/flutter/flutter/issues/149844
