### PR TITLE
[go_router] Support for top level `onEnter` callback.

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
+* Updated the minimum supported SDK version to Flutter 3.22/Dart 3.4.
+* Added new top level `onEnter` callback for controlling incoming route navigation.
 
 ## 14.6.2
 

--- a/packages/go_router/example/lib/top_level_on_enter.dart
+++ b/packages/go_router/example/lib/top_level_on_enter.dart
@@ -1,0 +1,154 @@
+// Copyright 2013 The Flutter Authors.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+void main() => runApp(const App());
+
+/// The main application widget.
+class App extends StatelessWidget {
+  /// Constructs an [App].
+  const App({super.key});
+
+  /// The title of the app.
+  static const String title = 'GoRouter Example: Top-level onEnter';
+
+  @override
+  Widget build(BuildContext context) => MaterialApp.router(
+        routerConfig: GoRouter(
+          initialLocation: '/home',
+
+          /// A callback invoked for every route navigation attempt.
+          ///
+          /// If the callback returns `false`, the navigation is blocked.
+          /// Use this to handle authentication, referrals, or other route-based logic.
+          onEnter: (BuildContext context, GoRouterState state) {
+            // Save the referral code (if provided) and block navigation to the /referral route.
+            if (state.uri.path == '/referral') {
+              saveReferralCode(context, state.uri.queryParameters['code']);
+              return false;
+            }
+
+            return true; // Allow navigation for all other routes.
+          },
+
+          /// The list of application routes.
+          routes: <GoRoute>[
+            GoRoute(
+              path: '/login',
+              builder: (BuildContext context, GoRouterState state) =>
+                  const LoginScreen(),
+            ),
+            GoRoute(
+              path: '/home',
+              builder: (BuildContext context, GoRouterState state) =>
+                  const HomeScreen(),
+            ),
+            GoRoute(
+              path: '/settings',
+              builder: (BuildContext context, GoRouterState state) =>
+                  const SettingsScreen(),
+            ),
+          ],
+        ),
+        title: title,
+      );
+}
+
+/// The login screen widget.
+class LoginScreen extends StatelessWidget {
+  /// Constructs a [LoginScreen].
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(title: const Text(App.title)),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              ElevatedButton(
+                onPressed: () => context.go('/home'),
+                child: const Text('Go to Home'),
+              ),
+              ElevatedButton(
+                onPressed: () => context.go('/settings'),
+                child: const Text('Go to Settings'),
+              ),
+            ],
+          ),
+        ),
+      );
+}
+
+/// The home screen widget.
+class HomeScreen extends StatelessWidget {
+  /// Constructs a [HomeScreen].
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(title: const Text(App.title)),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              ElevatedButton(
+                onPressed: () => context.go('/login'),
+                child: const Text('Go to Login'),
+              ),
+              ElevatedButton(
+                onPressed: () => context.go('/settings'),
+                child: const Text('Go to Settings'),
+              ),
+              ElevatedButton(
+                // This would typically be triggered by an incoming deep link.
+                onPressed: () => context.go('/referral?code=12345'),
+                child: const Text('Save Referral Code'),
+              ),
+            ],
+          ),
+        ),
+      );
+}
+
+/// The settings screen widget.
+class SettingsScreen extends StatelessWidget {
+  /// Constructs a [SettingsScreen].
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(title: const Text(App.title)),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              ElevatedButton(
+                onPressed: () => context.go('/login'),
+                child: const Text('Go to Login'),
+              ),
+              ElevatedButton(
+                onPressed: () => context.go('/home'),
+                child: const Text('Go to Home'),
+              ),
+            ],
+          ),
+        ),
+      );
+}
+
+/// Saves a referral code.
+///
+/// Displays a [SnackBar] with the referral code for demonstration purposes.
+/// Replace this with real referral handling logic.
+void saveReferralCode(BuildContext context, String? code) {
+  if (code != null) {
+    // Here you can implement logic to save the referral code as needed.
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Referral code saved: $code')),
+    );
+  }
+}

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -20,6 +20,9 @@ import 'state.dart';
 typedef GoRouterRedirect = FutureOr<String?> Function(
     BuildContext context, GoRouterState state);
 
+/// The signature of the onEnter callback.
+typedef OnEnter = bool Function(BuildContext context, GoRouterState state);
+
 /// The route configuration for GoRouter configured by the app.
 class RouteConfiguration {
   /// Constructs a [RouteConfiguration].
@@ -27,6 +30,7 @@ class RouteConfiguration {
     this._routingConfig, {
     required this.navigatorKey,
     this.extraCodec,
+    this.onEnter,
   }) {
     _onRoutingTableChanged();
     _routingConfig.addListener(_onRoutingTableChanged);
@@ -245,6 +249,35 @@ class RouteConfiguration {
   ///  * [extra_codec](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/extra_codec.dart)
   ///    example.
   final Codec<Object?, Object?>? extraCodec;
+
+  /// A callback invoked for every incoming route before it is processed.
+  ///
+  /// This callback allows you to control navigation by inspecting the incoming
+  /// route and conditionally preventing the navigation. If the callback returns
+  /// `true`, the GoRouter proceeds with the regular navigation and redirection
+  /// logic. If the callback returns `false`, the navigation is canceled.
+  ///
+  /// When a deep link opens the app and `onEnter` returns `false`,  GoRouter
+  /// will automatically redirect to the initial route or '/'.
+  ///
+  /// Example:
+  /// ```dart
+  /// final GoRouter router = GoRouter(
+  ///   routes: [...],
+  ///   onEnter: (BuildContext context, Uri uri) {
+  ///     if (uri.path == '/login' && isUserLoggedIn()) {
+  ///       return false; // Prevent navigation to /login
+  ///     }
+  ///     if (uri.path == '/referral') {
+  ///       // Save the referral code and prevent navigation
+  ///       saveReferralCode(uri.queryParameters['code']);
+  ///       return false;
+  ///     }
+  ///     return true; // Allow navigation
+  ///   },
+  /// );
+  /// ```
+  final OnEnter? onEnter;
 
   final Map<String, String> _nameToPath = <String, String>{};
 

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -122,6 +122,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
   /// The `routes` must not be null and must contain an [GoRouter] to match `/`.
   factory GoRouter({
     required List<RouteBase> routes,
+    OnEnter? onEnter,
     Codec<Object?, Object?>? extraCodec,
     GoExceptionHandler? onException,
     GoRouterPageBuilder? errorPageBuilder,
@@ -146,6 +147,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
             redirect: redirect ?? RoutingConfig._defaultRedirect,
             redirectLimit: redirectLimit),
       ),
+      onEnter: onEnter,
       extraCodec: extraCodec,
       onException: onException,
       errorPageBuilder: errorPageBuilder,
@@ -169,6 +171,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
   GoRouter.routingConfig({
     required ValueListenable<RoutingConfig> routingConfig,
     Codec<Object?, Object?>? extraCodec,
+    OnEnter? onEnter,
     GoExceptionHandler? onException,
     GoRouterPageBuilder? errorPageBuilder,
     GoRouterWidgetBuilder? errorBuilder,
@@ -206,6 +209,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
       _routingConfig,
       navigatorKey: navigatorKey,
       extraCodec: extraCodec,
+      onEnter: onEnter,
     );
 
     final ParserExceptionHandler? parserExceptionHandler;
@@ -224,6 +228,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
     routeInformationParser = GoRouteInformationParser(
       onParserException: parserExceptionHandler,
       configuration: configuration,
+      initialLocation: initialLocation,
     );
 
     routeInformationProvider = GoRouteInformationProvider(
@@ -565,6 +570,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
 /// A routing config that is never going to change.
 class _ConstantRoutingConfig extends ValueListenable<RoutingConfig> {
   const _ConstantRoutingConfig(this.value);
+
   @override
   void addListener(VoidCallback listener) {
     // Intentionally empty because listener will never be called.


### PR DESCRIPTION
**Description:**  
This PR introduces top level `onEnter` callback in `RouteConfiguration` to allow developers to intercept and conditionally block navigation based on incoming routes. It adds an example (`top_level_on_enter.dart`) demonstrating its usage, such as handling referral code from `/referral`.

**What This PR Changes:**  

- Adds the `onEnter` callback (`typedef OnEnter`) to intercept route navigation before processing.
- Implements logic for `onEnter` in `GoRouteInformationParser`.
- Updates `RouteConfiguration` to include the `onEnter` callback.
- Adds a new example, `top_level_on_enter.dart`, to demonstrate the feature.
- Adds a test case to verify the `onEnter` callback functionality.

**Simple usage example:**
```
final GoRouter router = GoRouter(
  onEnter: (BuildContext context, Uri uri) {
    // Save the referral code (if provided) and block navigation to /referral.
    if (uri.path == '/referral') {
      saveReferralCode(context, uri.queryParameters['code']);
      return false;
    }

    return true; // Allow navigation for all other routes.
  },
  routes: [ ... ],
);
```

**Impact:**  
Enables developers to implement route-specific logic, such as support for handling action-based deep links without navigation ([160602](https://github.com/flutter/flutter/issues/160602))

## Pre-launch Checklist:

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g., `[go_router]`.
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.