### PR TITLE
[local_auth_darwin] Handle when FaceID hardware is available but permissions have been denied for the app

### DIFF
--- a/packages/local_auth/local_auth_darwin/CHANGELOG.md
+++ b/packages/local_auth/local_auth_darwin/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.4.3
 
+* Handles when biometry hardware is available but permissions have been denied for the app.
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 
 ## 1.4.2

--- a/packages/local_auth/local_auth_darwin/darwin/Tests/FLALocalAuthPluginTests.swift
+++ b/packages/local_auth/local_auth_darwin/darwin/Tests/FLALocalAuthPluginTests.swift
@@ -465,7 +465,6 @@ class FLALocalAuthPluginTests: XCTestCase {
     XCTAssertNil(error)
   }
 
-
   func testDeviceSupportsBiometrics_withBiometryNotAvailableLoadedBiometryType() {
     let stubAuthContext = StubAuthContext()
     let alertFactory = StubAlertFactory()

--- a/packages/local_auth/local_auth_darwin/darwin/Tests/FLALocalAuthPluginTests.swift
+++ b/packages/local_auth/local_auth_darwin/darwin/Tests/FLALocalAuthPluginTests.swift
@@ -447,7 +447,7 @@ class FLALocalAuthPluginTests: XCTestCase {
     XCTAssertNil(error)
   }
 
-  func testDeviceSupportsBiometrics_withNoBiometricHardware() {
+  func testDeviceSupportsBiometrics_withBiometryNotAvailable() {
     let stubAuthContext = StubAuthContext()
     let alertFactory = StubAlertFactory()
     let viewProvider = StubViewProvider()
@@ -456,11 +456,32 @@ class FLALocalAuthPluginTests: XCTestCase {
       alertFactory: alertFactory, viewProvider: viewProvider)
 
     stubAuthContext.expectBiometrics = true
-    stubAuthContext.canEvaluateError = NSError(domain: "error", code: 0)
+    stubAuthContext.canEvaluateError = NSError(
+      domain: "error", code: LAError.biometryNotAvailable.rawValue)
 
     var error: FlutterError?
     let result = plugin.deviceCanSupportBiometricsWithError(&error)
     XCTAssertFalse(result!.boolValue)
+    XCTAssertNil(error)
+  }
+
+
+  func testDeviceSupportsBiometrics_withBiometryNotAvailableLoadedBiometryType() {
+    let stubAuthContext = StubAuthContext()
+    let alertFactory = StubAlertFactory()
+    let viewProvider = StubViewProvider()
+    let plugin = FLALocalAuthPlugin(
+      contextFactory: StubAuthContextFactory(contexts: [stubAuthContext]),
+      alertFactory: alertFactory, viewProvider: viewProvider)
+
+    stubAuthContext.expectBiometrics = true
+    stubAuthContext.biometryType = LABiometryType.touchID
+    stubAuthContext.canEvaluateError = NSError(
+      domain: "error", code: LAError.biometryNotAvailable.rawValue)
+
+    var error: FlutterError?
+    let result = plugin.deviceCanSupportBiometricsWithError(&error)
+    XCTAssertTrue(result!.boolValue)
     XCTAssertNil(error)
   }
 

--- a/packages/local_auth/local_auth_darwin/darwin/local_auth_darwin/Sources/local_auth_darwin/FLALocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_darwin/darwin/local_auth_darwin/Sources/local_auth_darwin/FLALocalAuthPlugin.m
@@ -317,6 +317,10 @@ typedef void (^FLADAuthCompletion)(FLADAuthResultDetails *_Nullable, FlutterErro
     if (authError.code == LAErrorBiometryNotEnrolled) {
       return @YES;
     }
+    // Biometry hardware is available, but possibly permissions were denied.
+    if (authError.code == LAErrorBiometryNotAvailable && context.biometryType != LABiometryTypeNone) {
+      return @YES;
+    }
   }
 
   return @NO;

--- a/packages/local_auth/local_auth_darwin/darwin/local_auth_darwin/Sources/local_auth_darwin/FLALocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_darwin/darwin/local_auth_darwin/Sources/local_auth_darwin/FLALocalAuthPlugin.m
@@ -318,7 +318,8 @@ typedef void (^FLADAuthCompletion)(FLADAuthResultDetails *_Nullable, FlutterErro
       return @YES;
     }
     // Biometry hardware is available, but possibly permissions were denied.
-    if (authError.code == LAErrorBiometryNotAvailable && context.biometryType != LABiometryTypeNone) {
+    if (authError.code == LAErrorBiometryNotAvailable &&
+        context.biometryType != LABiometryTypeNone) {
       return @YES;
     }
   }

--- a/packages/local_auth/local_auth_darwin/pubspec.yaml
+++ b/packages/local_auth/local_auth_darwin/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_darwin
 description: iOS implementation of the local_auth plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/local_auth/local_auth_darwin
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.4.2
+version: 1.4.3
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
LocalAuth  [`-canEvaluatePolicy::`](https://developer.apple.com/documentation/localauthentication/lacontext/canevaluatepolicy(_:error:)?language=objc) returns error `LAErrorBiometryNotAvailable` when either Face ID isn't available at the hardware level, OR the Face ID is available/setup but the permissions for the app were denied.

If it returns `LAErrorBiometryNotAvailable`, also check `biometryType` since this _should_ be none if there really is no biometry, but gets populated with [`LABiometryTypeTouchID`](https://developer.apple.com/documentation/localauthentication/labiometrytype/touchid?language=objc) when the FaceID hardware is available, but permission is denied.  I tried this on a iPhone 16 Pro which has Face ID but not Touch ID support.

Fixes https://github.com/flutter/flutter/issues/160083

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
