### PR TITLE
[camera_web] Don't require enumerating cameras on web

### DIFF
--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -376,7 +376,13 @@ class CameraController extends ValueNotifier<CameraValue> {
             .then((CameraInitializedEvent event) => event.focusPointSupported),
       );
     } on PlatformException catch (e) {
+      _unawaited(_deviceOrientationSubscription?.cancel());
+      _cameraId = kUninitializedCameraId;
       throw CameraException(e.code, e.message);
+    } catch (e) {
+      _unawaited(_deviceOrientationSubscription?.cancel());
+      _cameraId = kUninitializedCameraId;
+      rethrow;
     } finally {
       initializeCompleter.complete();
     }
@@ -882,8 +888,10 @@ class CameraController extends ValueNotifier<CameraValue> {
     _unawaited(_deviceOrientationSubscription?.cancel());
     _isDisposed = true;
     super.dispose();
-    if (_initializeFuture != null) {
-      await _initializeFuture;
+    if (_initializeFuture == null) {
+      return;
+    }
+    if (_cameraId != kUninitializedCameraId) {
       await CameraPlatform.instance.dispose(_cameraId);
     }
   }

--- a/packages/camera/camera_web/example/integration_test/camera_error_code_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_error_code_test.dart
@@ -73,13 +73,6 @@ void main() {
         );
       });
 
-      testWidgets('missingMetadata', (WidgetTester tester) async {
-        expect(
-          CameraErrorCode.missingMetadata.toString(),
-          equals('cameraMissingMetadata'),
-        );
-      });
-
       testWidgets('orientationNotSupported', (WidgetTester tester) async {
         expect(
           CameraErrorCode.orientationNotSupported.toString(),

--- a/packages/camera/camera_web/example/integration_test/camera_service_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_service_test.dart
@@ -652,7 +652,7 @@ void main() {
           'returns front '
           'when the facing mode is user', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToLensDirection('user'),
+          mapFacingModeToLensDirection('user'),
           equals(CameraLensDirection.front),
         );
       });
@@ -661,7 +661,7 @@ void main() {
           'returns back '
           'when the facing mode is environment', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToLensDirection('environment'),
+          mapFacingModeToLensDirection('environment'),
           equals(CameraLensDirection.back),
         );
       });
@@ -670,7 +670,7 @@ void main() {
           'returns external '
           'when the facing mode is left', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToLensDirection('left'),
+          mapFacingModeToLensDirection('left'),
           equals(CameraLensDirection.external),
         );
       });
@@ -679,7 +679,7 @@ void main() {
           'returns external '
           'when the facing mode is right', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToLensDirection('right'),
+          mapFacingModeToLensDirection('right'),
           equals(CameraLensDirection.external),
         );
       });
@@ -690,7 +690,7 @@ void main() {
           'returns user '
           'when the facing mode is user', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToCameraType('user'),
+          mapFacingModeToCameraType('user'),
           equals(CameraType.user),
         );
       });
@@ -699,7 +699,7 @@ void main() {
           'returns environment '
           'when the facing mode is environment', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToCameraType('environment'),
+          mapFacingModeToCameraType('environment'),
           equals(CameraType.environment),
         );
       });
@@ -708,7 +708,7 @@ void main() {
           'returns user '
           'when the facing mode is left', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToCameraType('left'),
+          mapFacingModeToCameraType('left'),
           equals(CameraType.user),
         );
       });
@@ -717,7 +717,7 @@ void main() {
           'returns user '
           'when the facing mode is right', (WidgetTester tester) async {
         expect(
-          cameraService.mapFacingModeToCameraType('right'),
+          mapFacingModeToCameraType('right'),
           equals(CameraType.user),
         );
       });
@@ -728,7 +728,7 @@ void main() {
           'returns 4096x2160 '
           'when the resolution preset is max', (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.max),
+          mapResolutionPresetToSize(ResolutionPreset.max),
           equals(const Size(4096, 2160)),
         );
       });
@@ -738,7 +738,7 @@ void main() {
           'when the resolution preset is ultraHigh',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
+          mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
           equals(const Size(4096, 2160)),
         );
       });
@@ -748,7 +748,7 @@ void main() {
           'when the resolution preset is veryHigh',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.veryHigh),
+          mapResolutionPresetToSize(ResolutionPreset.veryHigh),
           equals(const Size(1920, 1080)),
         );
       });
@@ -757,7 +757,7 @@ void main() {
           'returns 1280x720 '
           'when the resolution preset is high', (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.high),
+          mapResolutionPresetToSize(ResolutionPreset.high),
           equals(const Size(1280, 720)),
         );
       });
@@ -766,7 +766,7 @@ void main() {
           'returns 720x480 '
           'when the resolution preset is medium', (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.medium),
+          mapResolutionPresetToSize(ResolutionPreset.medium),
           equals(const Size(720, 480)),
         );
       });
@@ -775,7 +775,7 @@ void main() {
           'returns 320x240 '
           'when the resolution preset is low', (WidgetTester tester) async {
         expect(
-          cameraService.mapResolutionPresetToSize(ResolutionPreset.low),
+          mapResolutionPresetToSize(ResolutionPreset.low),
           equals(const Size(320, 240)),
         );
       });
@@ -787,7 +787,7 @@ void main() {
           'when the device orientation is portraitUp',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapDeviceOrientationToOrientationType(
+          mapDeviceOrientationToOrientationType(
             DeviceOrientation.portraitUp,
           ),
           equals(OrientationType.portraitPrimary),
@@ -799,7 +799,7 @@ void main() {
           'when the device orientation is landscapeLeft',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapDeviceOrientationToOrientationType(
+          mapDeviceOrientationToOrientationType(
             DeviceOrientation.landscapeLeft,
           ),
           equals(OrientationType.landscapePrimary),
@@ -811,7 +811,7 @@ void main() {
           'when the device orientation is portraitDown',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapDeviceOrientationToOrientationType(
+          mapDeviceOrientationToOrientationType(
             DeviceOrientation.portraitDown,
           ),
           equals(OrientationType.portraitSecondary),
@@ -823,7 +823,7 @@ void main() {
           'when the device orientation is landscapeRight',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapDeviceOrientationToOrientationType(
+          mapDeviceOrientationToOrientationType(
             DeviceOrientation.landscapeRight,
           ),
           equals(OrientationType.landscapeSecondary),
@@ -837,7 +837,7 @@ void main() {
           'when the orientation type is portraitPrimary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitPrimary,
           ),
           equals(DeviceOrientation.portraitUp),
@@ -849,7 +849,7 @@ void main() {
           'when the orientation type is landscapePrimary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.landscapePrimary,
           ),
           equals(DeviceOrientation.landscapeLeft),
@@ -861,7 +861,7 @@ void main() {
           'when the orientation type is portraitSecondary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitSecondary,
           ),
           equals(DeviceOrientation.portraitDown),
@@ -873,7 +873,7 @@ void main() {
           'when the orientation type is portraitSecondary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitSecondary,
           ),
           equals(DeviceOrientation.portraitDown),
@@ -885,7 +885,7 @@ void main() {
           'when the orientation type is landscapeSecondary',
           (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             OrientationType.landscapeSecondary,
           ),
           equals(DeviceOrientation.landscapeRight),
@@ -896,7 +896,7 @@ void main() {
           'returns portraitUp '
           'for an unknown orientation type', (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
+          mapOrientationTypeToDeviceOrientation(
             'unknown',
           ),
           equals(DeviceOrientation.portraitUp),

--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -893,7 +893,7 @@ void main() {
           return MediaTrackSettings(facingMode: 'environment');
         }.toJS;
 
-        when(() => cameraService.mapFacingModeToLensDirection('environment'))
+        when(() => mapFacingModeToLensDirection('environment'))
             .thenReturn(CameraLensDirection.external);
 
         expect(

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -437,7 +437,7 @@ class Camera {
     final String? facingMode = defaultVideoTrackSettings.facingModeNullable;
 
     if (facingMode != null && facingMode.isNotEmpty) {
-      return _cameraService.mapFacingModeToLensDirection(facingMode);
+      return mapFacingModeToLensDirection(facingMode);
     } else {
       return null;
     }

--- a/packages/camera/camera_web/lib/src/camera_service.dart
+++ b/packages/camera/camera_web/lib/src/camera_service.dart
@@ -40,63 +40,7 @@ class CameraService {
           )
           .toDart;
     } on web.DOMException catch (e) {
-      switch (e.name) {
-        case 'NotFoundError':
-        case 'DevicesNotFoundError':
-          throw CameraWebException(
-            cameraId,
-            CameraErrorCode.notFound,
-            'No camera found for the given camera options.',
-          );
-        case 'NotReadableError':
-        case 'TrackStartError':
-          throw CameraWebException(
-            cameraId,
-            CameraErrorCode.notReadable,
-            'The camera is not readable due to a hardware error '
-            'that prevented access to the device.',
-          );
-        case 'OverconstrainedError':
-        case 'ConstraintNotSatisfiedError':
-          throw CameraWebException(
-            cameraId,
-            CameraErrorCode.overconstrained,
-            'The camera options are impossible to satisfy.',
-          );
-        case 'NotAllowedError':
-        case 'PermissionDeniedError':
-          throw CameraWebException(
-            cameraId,
-            CameraErrorCode.permissionDenied,
-            'The camera cannot be used or the permission '
-            'to access the camera is not granted.',
-          );
-        case 'TypeError':
-          throw CameraWebException(
-            cameraId,
-            CameraErrorCode.type,
-            'The camera options are incorrect or attempted '
-            'to access the media input from an insecure context.',
-          );
-        case 'AbortError':
-          throw CameraWebException(
-            cameraId,
-            CameraErrorCode.abort,
-            'Some problem occurred that prevented the camera from being used.',
-          );
-        case 'SecurityError':
-          throw CameraWebException(
-            cameraId,
-            CameraErrorCode.security,
-            'The user media support is disabled in the current browser.',
-          );
-        default:
-          throw CameraWebException(
-            cameraId,
-            CameraErrorCode.unknown,
-            'An unknown error occurred when fetching the camera stream.',
-          );
-      }
+      throw _mapDomException(cameraId, e.name);
     } catch (_) {
       throw CameraWebException(
         cameraId,
@@ -219,148 +163,222 @@ class CameraService {
 
     return facingMode;
   }
+}
 
-  /// Maps the given [facingMode] to [CameraLensDirection].
-  ///
-  /// The following values for the facing mode are supported:
-  /// https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings/facingMode
-  CameraLensDirection mapFacingModeToLensDirection(String facingMode) {
-    switch (facingMode) {
-      case 'user':
-        return CameraLensDirection.front;
-      case 'environment':
-        return CameraLensDirection.back;
-      case 'left':
-      case 'right':
-      default:
-        return CameraLensDirection.external;
-    }
+CameraWebException _mapDomException(int cameraId, String name) {
+  switch (name) {
+    case 'NotFoundError':
+    case 'DevicesNotFoundError':
+      throw CameraWebException(
+        cameraId,
+        CameraErrorCode.notFound,
+        'No camera found for the given camera options.',
+      );
+    case 'NotReadableError':
+    case 'TrackStartError':
+      throw CameraWebException(
+        cameraId,
+        CameraErrorCode.notReadable,
+        'The camera is not readable due to a hardware error '
+        'that prevented access to the device.',
+      );
+    case 'OverconstrainedError':
+    case 'ConstraintNotSatisfiedError':
+      throw CameraWebException(
+        cameraId,
+        CameraErrorCode.overconstrained,
+        'The camera options are impossible to satisfy.',
+      );
+    case 'NotAllowedError':
+    case 'PermissionDeniedError':
+      throw CameraWebException(
+        cameraId,
+        CameraErrorCode.permissionDenied,
+        'The camera cannot be used or the permission '
+        'to access the camera is not granted.',
+      );
+    case 'TypeError':
+      throw CameraWebException(
+        cameraId,
+        CameraErrorCode.type,
+        'The camera options are incorrect or attempted '
+        'to access the media input from an insecure context.',
+      );
+    case 'AbortError':
+      throw CameraWebException(
+        cameraId,
+        CameraErrorCode.abort,
+        'Some problem occurred that prevented the camera from being used.',
+      );
+    case 'SecurityError':
+      throw CameraWebException(
+        cameraId,
+        CameraErrorCode.security,
+        'The user media support is disabled in the current browser.',
+      );
+    default:
+      throw CameraWebException(
+        cameraId,
+        CameraErrorCode.unknown,
+        'An unknown error occurred when fetching the camera stream.',
+      );
+  }
+}
+
+/// Maps the given [facingMode] to [CameraLensDirection].
+///
+/// The following values for the facing mode are supported:
+/// https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings/facingMode
+CameraLensDirection mapFacingModeToLensDirection(String facingMode) {
+  switch (facingMode) {
+    case 'user':
+      return CameraLensDirection.front;
+    case 'environment':
+      return CameraLensDirection.back;
+    case 'left':
+    case 'right':
+    default:
+      return CameraLensDirection.external;
+  }
+}
+
+/// Maps the given [facingMode] to [CameraType].
+///
+/// See [CameraMetadata.facingMode] for more details.
+CameraType mapFacingModeToCameraType(String facingMode) {
+  switch (facingMode) {
+    case 'user':
+      return CameraType.user;
+    case 'environment':
+      return CameraType.environment;
+    case 'left':
+    case 'right':
+    default:
+      return CameraType.user;
+  }
+}
+
+/// Maps the given [lensDirection] to [CameraType].
+///
+/// See [CameraMetadata.facingMode] for more details.
+CameraType mapLensDirectionToCameraType(CameraLensDirection lensDirection) {
+  switch (lensDirection) {
+    case CameraLensDirection.front:
+      return CameraType.user;
+    case CameraLensDirection.back:
+      return CameraType.environment;
+    case CameraLensDirection.external:
+      return CameraType.user;
+  }
+}
+
+/// Maps the given [resolutionPreset] to [Size].
+Size mapResolutionPresetToSize(ResolutionPreset resolutionPreset) {
+  switch (resolutionPreset) {
+    case ResolutionPreset.max:
+    case ResolutionPreset.ultraHigh:
+      return const Size(4096, 2160);
+    case ResolutionPreset.veryHigh:
+      return const Size(1920, 1080);
+    case ResolutionPreset.high:
+      return const Size(1280, 720);
+    case ResolutionPreset.medium:
+      return const Size(720, 480);
+    case ResolutionPreset.low:
+      return const Size(320, 240);
+  }
+  // The enum comes from a different package, which could get a new value at
+  // any time, so provide a fallback that ensures this won't break when used
+  // with a version that contains new values. This is deliberately outside
+  // the switch rather than a `default` so that the linter will flag the
+  // switch as needing an update.
+  // ignore: dead_code
+  return const Size(320, 240);
+}
+
+const int _kiloBits = 1000;
+const int _megaBits = _kiloBits * _kiloBits;
+
+/// Maps the given [resolutionPreset] to video bitrate.
+int mapResolutionPresetToVideoBitrate(ResolutionPreset resolutionPreset) {
+  switch (resolutionPreset) {
+    case ResolutionPreset.max:
+    case ResolutionPreset.ultraHigh:
+      return 8 * _megaBits;
+    case ResolutionPreset.veryHigh:
+      return 4 * _megaBits;
+    case ResolutionPreset.high:
+      return 1 * _megaBits;
+    case ResolutionPreset.medium:
+      return 400 * _kiloBits;
+    case ResolutionPreset.low:
+      return 200 * _kiloBits;
   }
 
-  /// Maps the given [facingMode] to [CameraType].
-  ///
-  /// See [CameraMetadata.facingMode] for more details.
-  CameraType mapFacingModeToCameraType(String facingMode) {
-    switch (facingMode) {
-      case 'user':
-        return CameraType.user;
-      case 'environment':
-        return CameraType.environment;
-      case 'left':
-      case 'right':
-      default:
-        return CameraType.user;
-    }
+  // The enum comes from a different package, which could get a new value at
+  // any time, so provide a fallback that ensures this won't break when used
+  // with a version that contains new values. This is deliberately outside
+  // the switch rather than a `default` so that the linter will flag the
+  // switch as needing an update.
+  // ignore: dead_code
+  return 1 * _megaBits;
+}
+
+/// Maps the given [resolutionPreset] to audio bitrate.
+int mapResolutionPresetToAudioBitrate(ResolutionPreset resolutionPreset) {
+  switch (resolutionPreset) {
+    case ResolutionPreset.max:
+    case ResolutionPreset.ultraHigh:
+      return 128 * _kiloBits;
+    case ResolutionPreset.veryHigh:
+      return 128 * _kiloBits;
+    case ResolutionPreset.high:
+      return 64 * _kiloBits;
+    case ResolutionPreset.medium:
+      return 48 * _kiloBits;
+    case ResolutionPreset.low:
+      return 32 * _kiloBits;
   }
 
-  /// Maps the given [resolutionPreset] to [Size].
-  Size mapResolutionPresetToSize(ResolutionPreset resolutionPreset) {
-    switch (resolutionPreset) {
-      case ResolutionPreset.max:
-      case ResolutionPreset.ultraHigh:
-        return const Size(4096, 2160);
-      case ResolutionPreset.veryHigh:
-        return const Size(1920, 1080);
-      case ResolutionPreset.high:
-        return const Size(1280, 720);
-      case ResolutionPreset.medium:
-        return const Size(720, 480);
-      case ResolutionPreset.low:
-        return const Size(320, 240);
-    }
-    // The enum comes from a different package, which could get a new value at
-    // any time, so provide a fallback that ensures this won't break when used
-    // with a version that contains new values. This is deliberately outside
-    // the switch rather than a `default` so that the linter will flag the
-    // switch as needing an update.
-    // ignore: dead_code
-    return const Size(320, 240);
+  // The enum comes from a different package, which could get a new value at
+  // any time, so provide a fallback that ensures this won't break when used
+  // with a version that contains new values. This is deliberately outside
+  // the switch rather than a `default` so that the linter will flag the
+  // switch as needing an update.
+  // ignore: dead_code
+  return 64 * _kiloBits;
+}
+
+/// Maps the given [deviceOrientation] to [OrientationType].
+String mapDeviceOrientationToOrientationType(
+  DeviceOrientation deviceOrientation,
+) {
+  switch (deviceOrientation) {
+    case DeviceOrientation.portraitUp:
+      return OrientationType.portraitPrimary;
+    case DeviceOrientation.landscapeLeft:
+      return OrientationType.landscapePrimary;
+    case DeviceOrientation.portraitDown:
+      return OrientationType.portraitSecondary;
+    case DeviceOrientation.landscapeRight:
+      return OrientationType.landscapeSecondary;
   }
+}
 
-  static const int _kiloBits = 1000;
-  static const int _megaBits = _kiloBits * _kiloBits;
-
-  /// Maps the given [resolutionPreset] to video bitrate.
-  int mapResolutionPresetToVideoBitrate(ResolutionPreset resolutionPreset) {
-    switch (resolutionPreset) {
-      case ResolutionPreset.max:
-      case ResolutionPreset.ultraHigh:
-        return 8 * _megaBits;
-      case ResolutionPreset.veryHigh:
-        return 4 * _megaBits;
-      case ResolutionPreset.high:
-        return 1 * _megaBits;
-      case ResolutionPreset.medium:
-        return 400 * _kiloBits;
-      case ResolutionPreset.low:
-        return 200 * _kiloBits;
-    }
-
-    // The enum comes from a different package, which could get a new value at
-    // any time, so provide a fallback that ensures this won't break when used
-    // with a version that contains new values. This is deliberately outside
-    // the switch rather than a `default` so that the linter will flag the
-    // switch as needing an update.
-    // ignore: dead_code
-    return 1 * _megaBits;
-  }
-
-  /// Maps the given [resolutionPreset] to audio bitrate.
-  int mapResolutionPresetToAudioBitrate(ResolutionPreset resolutionPreset) {
-    switch (resolutionPreset) {
-      case ResolutionPreset.max:
-      case ResolutionPreset.ultraHigh:
-        return 128 * _kiloBits;
-      case ResolutionPreset.veryHigh:
-        return 128 * _kiloBits;
-      case ResolutionPreset.high:
-        return 64 * _kiloBits;
-      case ResolutionPreset.medium:
-        return 48 * _kiloBits;
-      case ResolutionPreset.low:
-        return 32 * _kiloBits;
-    }
-
-    // The enum comes from a different package, which could get a new value at
-    // any time, so provide a fallback that ensures this won't break when used
-    // with a version that contains new values. This is deliberately outside
-    // the switch rather than a `default` so that the linter will flag the
-    // switch as needing an update.
-    // ignore: dead_code
-    return 64 * _kiloBits;
-  }
-
-  /// Maps the given [deviceOrientation] to [OrientationType].
-  String mapDeviceOrientationToOrientationType(
-    DeviceOrientation deviceOrientation,
-  ) {
-    switch (deviceOrientation) {
-      case DeviceOrientation.portraitUp:
-        return OrientationType.portraitPrimary;
-      case DeviceOrientation.landscapeLeft:
-        return OrientationType.landscapePrimary;
-      case DeviceOrientation.portraitDown:
-        return OrientationType.portraitSecondary;
-      case DeviceOrientation.landscapeRight:
-        return OrientationType.landscapeSecondary;
-    }
-  }
-
-  /// Maps the given [orientationType] to [DeviceOrientation].
-  DeviceOrientation mapOrientationTypeToDeviceOrientation(
-    String orientationType,
-  ) {
-    switch (orientationType) {
-      case OrientationType.portraitPrimary:
-        return DeviceOrientation.portraitUp;
-      case OrientationType.landscapePrimary:
-        return DeviceOrientation.landscapeLeft;
-      case OrientationType.portraitSecondary:
-        return DeviceOrientation.portraitDown;
-      case OrientationType.landscapeSecondary:
-        return DeviceOrientation.landscapeRight;
-      default:
-        return DeviceOrientation.portraitUp;
-    }
+/// Maps the given [orientationType] to [DeviceOrientation].
+DeviceOrientation mapOrientationTypeToDeviceOrientation(
+  String orientationType,
+) {
+  switch (orientationType) {
+    case OrientationType.portraitPrimary:
+      return DeviceOrientation.portraitUp;
+    case OrientationType.landscapePrimary:
+      return DeviceOrientation.landscapeLeft;
+    case OrientationType.portraitSecondary:
+      return DeviceOrientation.portraitDown;
+    case OrientationType.landscapeSecondary:
+      return DeviceOrientation.landscapeRight;
+    default:
+      return DeviceOrientation.portraitUp;
   }
 }

--- a/packages/camera/camera_web/lib/src/types/camera_error_code.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_error_code.dart
@@ -44,10 +44,6 @@ class CameraErrorCode {
   /// The user media support is disabled in the current browser.
   static const CameraErrorCode security = CameraErrorCode._('cameraSecurity');
 
-  /// The camera metadata is missing.
-  static const CameraErrorCode missingMetadata =
-      CameraErrorCode._('cameraMissingMetadata');
-
   /// The camera orientation is not supported.
   static const CameraErrorCode orientationNotSupported =
       CameraErrorCode._('orientationNotSupported');


### PR DESCRIPTION
Enumerating available cameras on web requires permission and activates hardware. This PR allows initializing the camera controller without having to enumerate available cameras first.

https://github.com/flutter/flutter/issues/145541

*Continues where https://github.com/flutter/packages/pull/6369 left off*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].