### PR TITLE
[tool] Ensure that leak_tracker_flutter_testing is dev-only

### DIFF
--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -564,6 +564,7 @@ class PubspecCheckCommand extends PackageLoopingCommand {
       'build_runner',
       'integration_test',
       'flutter_test',
+      'leak_tracker_flutter_testing',
       'mockito',
       'pigeon',
       'test',

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -1769,6 +1769,7 @@ ${_topicsSection()}
           'build_runner',
           'integration_test',
           'flutter_test',
+          'leak_tracker_flutter_testing',
           'mockito',
           'pigeon',
           'test',


### PR DESCRIPTION
Adds `leak_tracker_flutter_testing` to the list of dependencies that can only be added to `dev_dependencies`.