### PR TITLE
Replace `onSurfaceCreated` with `onSurfaceAvailable`.

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.11
+
+* Replaces deprecated Android embedder APIs (`onSurfaceCreated` -> `onSurfaceAvailable`).
+* Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
+
 ## 0.6.10+3
 
 * Bumps com.google.guava:guava from 33.3.1-android to 33.4.0-android.

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PreviewHostApiImpl.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PreviewHostApiImpl.java
@@ -83,10 +83,7 @@ public class PreviewHostApiImpl implements PreviewHostApi {
         surfaceProducer.setCallback(
             new TextureRegistry.SurfaceProducer.Callback() {
               @Override
-              // TODO(matanlurey): Replace with onSurfaceAvailable once available on stable;
-              // https://github.com/flutter/flutter/issues/155131.
-              @SuppressWarnings({"deprecation", "removal"})
-              public void onSurfaceCreated() {
+              public void onSurfaceAvailable() {
                 // Do nothing. The Preview.SurfaceProvider will handle this whenever a new
                 // Surface is needed.
               }

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PreviewTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PreviewTest.java
@@ -133,8 +133,8 @@ public class PreviewTest {
 
     reset(mockSurfaceRequest);
 
-    // Verify callback's onSurfaceCreated does not interact with the SurfaceRequest.
-    simulateSurfaceCreation(callback);
+    // Verify callback's onSurfaceAvailable does not interact with the SurfaceRequest.
+    callback.onSurfaceAvailable();
     verifyNoMoreInteractions(mockSurfaceRequest);
   }
 
@@ -261,13 +261,5 @@ public class PreviewTest {
     hostApi.setTargetRotation(instanceIdentifier, Long.valueOf(targetRotation));
 
     verify(mockPreview).setTargetRotation(targetRotation);
-  }
-
-  // TODO(matanlurey): Replace with inline calls to onSurfaceAvailable once
-  // available on stable; see https://github.com/flutter/flutter/issues/155131.
-  // This seperate method only exists to scope the suppression.
-  @SuppressWarnings({"deprecation", "removal"})
-  void simulateSurfaceCreation(TextureRegistry.SurfaceProducer.Callback producerLifecycle) {
-    producerLifecycle.onSurfaceCreated();
   }
 }

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,10 +2,10 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.10+3
+version: 0.6.11
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
   flutter: ">=3.24.0"
 
 flutter:

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.17
+
+* Replaces deprecated Android embedder APIs (`onSurfaceCreated` -> `onSurfaceAvailable`).
+* Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
+
 ## 2.7.16
 
 * Updates internal Pigeon API to use newer features.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -85,9 +85,7 @@ final class VideoPlayer implements TextureRegistry.SurfaceProducer.Callback {
   }
 
   @RestrictTo(RestrictTo.Scope.LIBRARY)
-  // TODO(matanlurey): https://github.com/flutter/flutter/issues/155131.
-  @SuppressWarnings({"deprecation", "removal"})
-  public void onSurfaceCreated() {
+  public void onSurfaceAvailable() {
     if (savedStateDuring != null) {
       exoPlayer = createVideoPlayer();
       savedStateDuring.restore(exoPlayer);

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,10 +2,10 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.7.16
+version: 2.7.17
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
   flutter: ">=3.24.0"
 
 flutter:


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/155131.

This replaces overrides of `SurfaceProducer.onSurfaceCreated` with `SurfaceProducer.onSurfaceAvailable`.

Both packages that use the API have their minimum SDKs bumped to use the API, and an automatic release pending.