### PR TITLE
[camera] Add API support query for image streaming (app-facing)

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.11.1
 
 * Adds API support query for image streaming.
-* Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
+* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 * Updates example to dispose animation controllers and curved animations.
 
 ## 0.11.0+2

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.11.1
 
+* Adds API support query for image streaming.
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 * Updates example to dispose animation controllers and curved animations.
 

--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -480,13 +480,12 @@ class CameraController extends ValueNotifier<CameraValue> {
   /// Throws a [CameraException] if image streaming or video recording has
   /// already started.
   ///
-  /// The `startImageStream` method is only available on Android and iOS (other
-  /// platforms won't be supported in current setup).
+  /// The `startImageStream` method is only available on platforms that
+  /// report support for image streaming via [supportsImageStreaming].
   ///
   // TODO(bmparr): Add settings for resolution and fps.
   Future<void> startImageStream(onLatestImageAvailable onAvailable) async {
-    assert(defaultTargetPlatform == TargetPlatform.android ||
-        defaultTargetPlatform == TargetPlatform.iOS);
+    assert(supportsImageStreaming());
     _throwIfNotInitialized('startImageStream');
     if (value.isRecordingVideo) {
       throw CameraException(
@@ -518,11 +517,10 @@ class CameraController extends ValueNotifier<CameraValue> {
   /// Throws a [CameraException] if image streaming was not started or video
   /// recording was started.
   ///
-  /// The `stopImageStream` method is only available on Android and iOS (other
-  /// platforms won't be supported in current setup).
+  /// The `stopImageStream` method is only available on platforms that
+  /// report support for image streaming via [supportsImageStreaming].
   Future<void> stopImageStream() async {
-    assert(defaultTargetPlatform == TargetPlatform.android ||
-        defaultTargetPlatform == TargetPlatform.iOS);
+    assert(supportsImageStreaming());
     _throwIfNotInitialized('stopImageStream');
     if (!value.isStreamingImages) {
       throw CameraException(
@@ -870,6 +868,10 @@ class CameraController extends ValueNotifier<CameraValue> {
       throw CameraException(e.code, e.message);
     }
   }
+
+  /// Check whether the camera platform supports image streaming.
+  bool supportsImageStreaming() =>
+      CameraPlatform.instance.supportsImageStreaming();
 
   /// Releases the resources of this camera.
   @override

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.11.0+2
+version: 0.11.1
 
 environment:
   sdk: ^3.4.0
@@ -21,9 +21,9 @@ flutter:
         default_package: camera_web
 
 dependencies:
-  camera_android_camerax: ^0.6.5
-  camera_avfoundation: ^0.9.15
-  camera_platform_interface: ^2.6.0
+  camera_android_camerax: ^0.6.13
+  camera_avfoundation: ^0.9.18
+  camera_platform_interface: ^2.9.0
   camera_web: ^0.3.3
   flutter:
     sdk: flutter

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.11.1
 
 environment:
-  sdk: ^3.4.0
-  flutter: ">=3.22.0"
+  sdk: ^3.6.0
+  flutter: ">=3.27.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera/test/camera_image_stream_test.dart
+++ b/packages/camera/camera/test/camera_image_stream_test.dart
@@ -100,8 +100,11 @@ void main() {
 
     await cameraController.startImageStream((CameraImage image) {});
 
-    expect(mockPlatform.streamCallLog,
-        <String>['onStreamedFrameAvailable', 'listen']);
+    expect(mockPlatform.streamCallLog, <String>[
+      'supportsImageStreaming',
+      'onStreamedFrameAvailable',
+      'listen'
+    ]);
   });
 
   test('stopImageStream() throws $CameraException when uninitialized', () {
@@ -160,8 +163,13 @@ void main() {
     await cameraController.startImageStream((CameraImage image) {});
     await cameraController.stopImageStream();
 
-    expect(mockPlatform.streamCallLog,
-        <String>['onStreamedFrameAvailable', 'listen', 'cancel']);
+    expect(mockPlatform.streamCallLog, <String>[
+      'supportsImageStreaming',
+      'onStreamedFrameAvailable',
+      'listen',
+      'supportsImageStreaming',
+      'cancel'
+    ]);
   });
 
   test('startVideoRecording() can stream images', () async {
@@ -233,6 +241,12 @@ class MockStreamingCameraPlatform extends MockCameraPlatform {
 
   void _onFrameStreamListen() {
     streamCallLog.add('listen');
+  }
+
+  @override
+  bool supportsImageStreaming() {
+    streamCallLog.add('supportsImageStreaming');
+    return true;
   }
 
   FutureOr<void> _onFrameStreamCancel() async {

--- a/packages/camera/camera/test/camera_preview_test.dart
+++ b/packages/camera/camera/test/camera_preview_test.dart
@@ -132,6 +132,9 @@ class FakeController extends ValueNotifier<CameraValue>
 
   @override
   CameraDescription get description => value.description;
+
+  @override
+  bool supportsImageStreaming() => true;
 }
 
 void main() {


### PR DESCRIPTION
Final step for introducing the `supportsImageStreaming` query method. Expose it through `CameraController`.

Previous steps:
 - #8250
 - #8307

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
