### PR TITLE
[multicast_dns] Allow handling socket errors

### DIFF
--- a/packages/multicast_dns/CHANGELOG.md
+++ b/packages/multicast_dns/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.3.2+8
 
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
+* Adds `onSocketError` to `MDnsClient.start`.
 
 ## 0.3.2+7
 

--- a/packages/multicast_dns/lib/multicast_dns.dart
+++ b/packages/multicast_dns/lib/multicast_dns.dart
@@ -84,6 +84,11 @@ class MDnsClient {
   /// for the mDNS query. If not provided, defaults to either `224.0.0.251` or
   /// or `FF02::FB`.
   ///
+  /// On socket errors, the [onSocketError] handler is called with the error
+  /// object and possibly a stack trace. The [onSocketError] callback must be of
+  /// type `void Function(Object error)` or
+  /// `void Function(Object error, StackTrace)`.
+  ///
   /// Subsequent calls to this method are ignored while the mDNS client is in
   /// started state.
   Future<void> start({
@@ -91,6 +96,7 @@ class MDnsClient {
     NetworkInterfacesFactory? interfacesFactory,
     int mDnsPort = mDnsPort,
     InternetAddress? mDnsAddress,
+    Function? onSocketError,
   }) async {
     listenAddress ??= InternetAddress.anyIPv4;
     interfacesFactory ??= allInterfacesFactory;
@@ -152,7 +158,10 @@ class MDnsClient {
       // Join multicast on this interface.
       incoming.joinMulticast(_mDnsAddress!, interface);
     }
-    incoming.listen((RawSocketEvent event) => _handleIncoming(event, incoming));
+    incoming.listen(
+      (RawSocketEvent event) => _handleIncoming(event, incoming),
+      onError: onSocketError,
+    );
     _started = true;
     _starting = false;
   }

--- a/packages/multicast_dns/lib/src/lookup_resolver.dart
+++ b/packages/multicast_dns/lib/src/lookup_resolver.dart
@@ -48,7 +48,7 @@ class LookupResolver {
     return controller.stream;
   }
 
-  /// Parses [ResoureRecord]s received and delivers them to the appropriate
+  /// Parses [ResourceRecord]s received and delivers them to the appropriate
   /// listener(s) added via [addPendingRequest].
   void handleResponse(List<ResourceRecord> response) {
     for (final ResourceRecord r in response) {

--- a/packages/multicast_dns/pubspec.yaml
+++ b/packages/multicast_dns/pubspec.yaml
@@ -2,7 +2,7 @@ name: multicast_dns
 description: Dart package for performing mDNS queries (e.g. Bonjour, Avahi).
 repository: https://github.com/flutter/packages/tree/main/packages/multicast_dns
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+multicast_dns%22
-version: 0.3.2+7
+version: 0.3.2+8
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
### Background

macOS Sequoia requires user consent to do multicast operations, which the Flutter tool does to connect to the Dart VM. We'd like to make the Flutter tool provide a more helpful error message when mDNS fails due to lack of permission. See: https://github.com/flutter/flutter/issues/150131

If the app does not have permission to communicate with devices on the local network, the following happens:

1. Flutter tool starts a [multicast lookup](https://github.com/flutter/flutter/blob/bb2d34126cc8161dbe4a1bf23c925e48b732f670/packages/flutter_tools/lib/src/mdns_discovery.dart#L238-L241)
2. The mDNS client [sends data on the socket](https://github.com/flutter/packages/blob/973e8b59e24ba80d3c36a2bcfa914fcfd5e19943/packages/multicast_dns/lib/multicast_dns.dart#L219)
4. macOS blocks the operation. Dart's native socket implementation throws an `OSError`
5. Dart's `Socket.send` [catches the `OSError`](https://github.com/dart-lang/sdk/blob/da6dc03a15822d83d9180bd766c02d11aacdc06b/sdk/lib/_internal/vm/bin/socket_patch.dart#L1511-L1515), wraps it in a `SocketException`, and [schedules a microtask](https://github.com/dart-lang/sdk/blob/da6dc03a15822d83d9180bd766c02d11aacdc06b/sdk/lib/_internal/vm/bin/socket_patch.dart#L1513) that [reports the exception through the socket's stream](https://github.com/dart-lang/sdk/blob/95f00522676dff03f64fc715cb1835ad451faa4c/sdk/lib/_internal/vm/bin/socket_patch.dart#L3011) ([`Socket` is a `Stream`](https://api.dart.dev/dart-io/Socket-class.html)) 
6. Currently, [the mDNS client does not listen to the socket stream's errors](https://github.com/flutter/packages/blob/973e8b59e24ba80d3c36a2bcfa914fcfd5e19943/packages/multicast_dns/lib/multicast_dns.dart#L155), so [the error is send to the current `Zone`'s uncaught error handler](https://github.com/dart-lang/sdk/blob/95f00522676dff03f64fc715cb1835ad451faa4c/sdk/lib/async/stream_impl.dart#L553).

### Solution

This patch adds a `onSocketError` callback. This allows the caller to catch errors reported by the underlying `Socket` and provide a better error message to the user.

I'm not very happy with this API. Unfortunately, the `SocketException` doesn't give us enough information to match it back to a pending `MDnsClient` request. Please let me know if you have suggestions on a better API to handle this error!

This will help us improve the error message for: https://github.com/flutter/flutter/issues/150131

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
