### PR TITLE
[tool] Allow blank lines in federated package changes

### DIFF
--- a/script/tool/lib/src/federation_safety_check_command.dart
+++ b/script/tool/lib/src/federation_safety_check_command.dart
@@ -212,10 +212,11 @@ class FederationSafetyCheckCommand extends PackageLoopingCommand {
   Future<bool> _changeIsCommentOnly(
       GitVersionFinder git, String repoPath) async {
     final List<String> diff = await git.getDiffContents(targetPath: repoPath);
-    final RegExp changeLine = RegExp(r'^[+-] ');
+    final RegExp changeLine = RegExp(r'^[+-]');
     // This will not catch /**/-style comments, but false negatives are fine
     // (and in practice, we almost never use that comment style in Dart code).
     final RegExp commentLine = RegExp(r'^[+-]\s*//');
+    final RegExp blankLine = RegExp(r'^[+-]\s*$');
     bool foundComment = false;
     for (final String line in diff) {
       if (!changeLine.hasMatch(line) ||
@@ -223,7 +224,7 @@ class FederationSafetyCheckCommand extends PackageLoopingCommand {
           line.startsWith('+++ ')) {
         continue;
       }
-      if (!commentLine.hasMatch(line)) {
+      if (!(commentLine.hasMatch(line) || blankLine.hasMatch(line))) {
         return false;
       }
       foundComment = true;

--- a/script/tool/test/federation_safety_check_command_test.dart
+++ b/script/tool/test/federation_safety_check_command_test.dart
@@ -446,10 +446,12 @@ diff --git a/packages/foo/foo_bar/lib/foo.dart b/packages/foo/foo_bar/lib/foo.da
 index abc123..def456 100644
 --- a/packages/foo/foo_bar/lib/foo.dart
 +++ b/packages/foo/foo_bar/lib/foo.dart
-@@ -51,6 +51,7 @@ Future<bool> launchUrl(
+@@ -51,6 +51,9 @@ Future<bool> launchUrl(
  }
 
  void foo() {
++  // blank lines should also be allowed as part of comment changes.
++
 +  // ignore: exhaustive_cases
    switch(a_foo) {
      case a:


### PR DESCRIPTION
Currently the special-casing for allowing comment-only changes to other packages in a plugin group as part of a single PR, which is necessary for some changes to add `// ignore` directives, allows comment lines, but not blank lines. Blank lines should be allowed since they are safe, and are expected for certain changes (notably, temporary file-level ignores).