### PR TITLE
[image_picker] Reference alternate macOS implementations

### DIFF
--- a/packages/image_picker/image_picker_macos/CHANGELOG.md
+++ b/packages/image_picker/image_picker_macos/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.2.1+2
 
+* Updates README to reference alternate implementations.
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 
 ## 0.2.1+1

--- a/packages/image_picker/image_picker_macos/README.md
+++ b/packages/image_picker/image_picker_macos/README.md
@@ -7,16 +7,18 @@ A macOS implementation of [`image_picker`][1].
 `ImageSource.camera` is not supported unless a `cameraDelegate` is set.
 
 ### pickImage()
+
 The arguments `maxWidth`, `maxHeight`, and `imageQuality` are not currently supported.
 
 ### pickVideo()
+
 The argument `maxDuration` is not currently supported.
 
 ## Usage
 
 ### Import the package
 
-This package is [endorsed][2], which means you can simply use `file_selector`
+This package is [endorsed][2], which means you can simply use `image_picker`
 normally. This package will be automatically included in your app when you do,
 so you do not need to add it to your `pubspec.yaml`.
 
@@ -32,7 +34,15 @@ need to add a read-only file acces [entitlement][4]:
     <true/>
 ```
 
+## Alternatives
+
+If you would prefer an implementation that uses the dedicated photo picker UI
+available in newer versions of macOS, which is more similar to the iOS
+experience, you may want to consider using
+[an alternate, unendorsed implementation built by the community][5].
+
 [1]: https://pub.dev/packages/image_picker
 [2]: https://flutter.dev/to/endorsed-federated-plugin
 [3]: https://pub.dev/packages/file_selector
 [4]: https://flutter.dev/to/macos-entitlements
+[5]: https://pub.dev/packages?q=topic%3Aimage-picker+platform%3Amacos

--- a/packages/image_picker/image_picker_macos/pubspec.yaml
+++ b/packages/image_picker/image_picker_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_macos
 description: macOS platform implementation of image_picker
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.2.1+1
+version: 0.2.1+2
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
Since we don't currently plan to fix
https://github.com/flutter/flutter/issues/125829 in our implementation, and there is now a community implementation that does, reference that in the README and provide a link to quickly locate alternate implementations.

Also fixes a copy-paste mistake that was referencing the wrong app-facing plugin in the instructions.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
