### PR TITLE
[url_launcher_android] Update build.gradle compileSdk version to support version 35

### DIFF
--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.15
+
+* Bumps compileSdk version from 34 to 35.
+
 ## 6.3.14
 
 * Bumps androidx.annotation:annotation from 1.9.0 to 1.9.1.

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -26,7 +26,7 @@ android {
         buildConfig true
     }
     namespace 'io.flutter.plugins.urllauncher'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.3.14
+version: 6.3.15
 environment:
   sdk: ^3.5.0
   flutter: ">=3.24.0"


### PR DESCRIPTION
The goal of this PR is to upgrade the url_launcher_android compile SDK version.

Issue:
https://github.com/flutter/flutter/issues/162333
The summary of the issue is that an outdated SDK must be dowloaded to compile apps with url_launcher_android.


## Pre-launch Checklist

- [ yes ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ yes ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ yes ] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ yes ] I signed the [CLA].
- [ yes ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ yes ] I [linked to at least one issue that this PR fixes] in the description above.
- [ yes ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ yes ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ yes ] I updated/added relevant documentation (doc comments with `///`).
- [ test-exempted ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ yes ] All existing and new tests are passing.

