### PR TITLE
[shared_preferences_tool] Loosen vm_service constraint to allow for 15

### DIFF
--- a/packages/shared_preferences/shared_preferences_tool/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_tool/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_tool
 description: "DevTools extension for package:shared_preferences. Manage SharedPreferences efficiently. Edit, search, and view keys."
 publish_to: 'none'
 
-version: 1.0.0+2
+version: 1.0.1
 
 environment:
   sdk: '>=3.6.0 <4.0.0'

--- a/packages/shared_preferences/shared_preferences_tool/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_tool/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_tool
 description: "DevTools extension for package:shared_preferences. Manage SharedPreferences efficiently. Edit, search, and view keys."
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
   sdk: '>=3.6.0 <4.0.0'
@@ -12,7 +12,7 @@ dependencies:
   devtools_extensions: ^0.3.0
   flutter:
     sdk: flutter
-  vm_service: ^14.3.0
+  vm_service: '>=14.3.0 <16.0.0'
 
 dev_dependencies:
   build_runner: ^2.4.10


### PR DESCRIPTION
This is causing the `flutter-analyze-try` Dart try bot to [fail](https://ci.chromium.org/ui/p/dart/builders/try/flutter-analyze-try/26500/overview) due to [upgrading the version pinned by flutter](https://github.com/flutter/flutter/commit/3e3bb9fdd586e71bc7fb797ee7158b53a54cd634).