### PR TITLE
[ci] Move Wasm test shards out of bringup.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -247,7 +247,6 @@ targets:
 
   # Wasm unit tests in master
   - name: Linux_web web_dart_unit_test_wasm_shard_1 master
-    bringup: true
     recipe: packages/packages
     timeout: 60
     properties:
@@ -263,7 +262,6 @@ targets:
         }
 
   - name: Linux_web web_dart_unit_test_wasm_shard_2 master
-    bringup: true
     recipe: packages/packages
     timeout: 60
     properties:
@@ -923,7 +921,6 @@ targets:
 
   # Wasm integration tests in master
   - name: Linux_web web_platform_tests_wasm_shard_1 master
-    bringup: true
     recipe: packages/packages
     timeout: 60
     properties:
@@ -938,7 +935,6 @@ targets:
         }
 
   - name: Linux_web web_platform_tests_wasm_shard_2 master
-    bringup: true
     recipe: packages/packages
     timeout: 60
     properties:
@@ -953,7 +949,6 @@ targets:
         }
 
   - name: Linux_web web_platform_tests_wasm_shard_3 master
-    bringup: true
     recipe: packages/packages
     timeout: 60
     properties:


### PR DESCRIPTION
This PR moves the new Wasm shards out of bringup, so they become part of the normal testing flow.

Here's some information about the last ~90 builds in the staging builder:

* Unit tests, master channel
  * [Shard 1](https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_web%20web_dart_unit_test_wasm_shard_1%20master?limit=200)
  * [Shard 2](https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_web%20web_dart_unit_test_wasm_shard_2%20master?limit=200)
* Integration tests, master channel 
  * [Shard 1](https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_web%20web_platform_tests_wasm_shard_1%20master?limit=200)
  * [Shard 2](https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_web%20web_platform_tests_wasm_shard_2%20master?limit=200)
  * [Shard 3](https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_web%20web_platform_tests_wasm_shard_3%20master?limit=200)

## Issues

* Continuation of https://github.com/flutter/packages/pull/8111
* Completes https://github.com/flutter/flutter/issues/151664
* Closes https://github.com/flutter/flutter/issues/127730

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
