### PR TITLE
[url_launcher]: (Web) When click on `Link` widget without calling `followLink` function still takes browser to that link

### DIFF
--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1
+
+* Fixes when click on `Link` widget without calling `followLink` function still takes browser to that link.
+
 ## 2.4.0
 
 * Enhances handling of out-of-order events.

--- a/packages/url_launcher/url_launcher_web/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/link.dart
@@ -499,6 +499,7 @@ class LinkViewController extends PlatformViewController {
 
     _element.setAttribute('aria-hidden', 'true');
     _element.setAttribute('tabIndex', '-1');
+    _element.setAttribute('onclick', 'event.preventDefault();');
 
     final Map<String, dynamic> args = <String, dynamic>{
       'id': viewId,

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.4.0
+version: 2.4.1
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION

### Bug

If you wrap a ElevatedButton with Link widget on web, and don't pass followLink function to ElevatedButton, when you click on that ElevatedButton button, it still takes user to that link.

### Sample Code
```dart
import 'package:flutter/material.dart';
import 'package:url_launcher/link.dart' as ul;

class GoogleButton extends StatelessWidget {
  const GoogleButton();

  @override
  Widget build(final BuildContext context) {
    return ul.Link(
      uri: Uri.parse('https://google.com'),
      target: ul.LinkTarget.blank,
      builder: (context, followLink) => ElevatedButton(
        onPressed: null,
        child: Text('Open Google'),
      ),
    );
  }
}
```

The issue was happening because `Link` widget is creating below element on web:
```html
<a rel="noreferrer noopener" aria-hidden="true" tabindex="-1" href="https://google.com" target="_blank" style="opacity: 0; display: block; width: 100%; height: 100%; cursor: unset;"></a>
```
Even when i am not passing `followLink` to `onPressed`, it still opens google in new tab. 

### Fix

We need to pass `onclick="event.preventDefault();"` to `a` html element so that it won't open link on it own.

This is how it looks after the fix:
```html
<a rel="noreferrer noopener" aria-hidden="true" tabindex="-1" href="https://google.com" target="_blank" style="opacity: 0; display: block; width: 100%; height: 100%; cursor: unset;" onclick="event.preventDefault();"></a>
```

* Fix Issue: [[url_launcher] [Web] Clicking on Link without calling followLink function still takes user to that link](https://github.com/flutter/flutter/issues/162927)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
