### PR TITLE
[video_player] Re-enables `asset videos live stream duration != 0` test for Android

### DIFF
--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -56,15 +56,6 @@ void main() {
     testWidgets(
       'live stream duration != 0',
       (WidgetTester tester) async {
-        // This test requires network access, and won't pass until a LUCI recipe
-        // change is made.
-        // TODO(camsim99): Remove once https://github.com/flutter/flutter/issues/160797 is fixed.
-        if (!kIsWeb && Platform.isAndroid) {
-          markTestSkipped(
-              'Skipping due to https://github.com/flutter/flutter/issues/160797');
-          return;
-        }
-
         final VideoPlayerController networkController =
             VideoPlayerController.networkUrl(
           Uri.parse(


### PR DESCRIPTION
Re-enables `asset videos live stream duration != 0` test that was previously disabled do to emulators having revoked access to the network.

Looks like this passed in https://firebase.corp.google.com/project/flutter-infra-staging/testlab/histories/bh.7dcabc1142c31699/matrices/7642642580824193465/executions/bs.d4c88757f607fa85/testcases/10/test-cases from https://ci.chromium.org/ui/p/flutter/builders/try/Linux_android%20android_device_tests_shard_1%20master/14302/overview but let me know if I'm wrong!

Fixes https://github.com/flutter/flutter/issues/160797; see that issue for more details.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
