### PR TITLE
[various] Enable `permissive-` for Windows plugin examples

### DIFF
--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.2.6+2
 
+* Fixes compile errors under strict standards mode.
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 
 ## 0.2.6+1

--- a/packages/camera/camera_windows/example/windows/CMakeLists.txt
+++ b/packages/camera/camera_windows/example/windows/CMakeLists.txt
@@ -34,6 +34,9 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
+  # Enable strict standards mode in the example app, since issues it finds
+  # may become errors by default in future compiler versions.
+  target_compile_options(${TARGET} PRIVATE /permissive-)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_windows
 description: A Flutter plugin for getting information about and controlling the camera on Windows.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.2.6+1
+version: 0.2.6+2
 
 environment:
   sdk: ^3.4.0

--- a/packages/camera/camera_windows/windows/capture_device_info.h
+++ b/packages/camera/camera_windows/windows/capture_device_info.h
@@ -25,8 +25,7 @@ class CaptureDeviceInfo {
 
   // Parses display name and device id from unique device name format.
   // Format: "display_name <device_id>".
-  bool CaptureDeviceInfo::ParseDeviceInfoFromCameraName(
-      const std::string& camera_name);
+  bool ParseDeviceInfoFromCameraName(const std::string& camera_name);
 
   // Updates display name.
   void SetDisplayName(const std::string& display_name) {

--- a/packages/file_selector/file_selector_windows/CHANGELOG.md
+++ b/packages/file_selector/file_selector_windows/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.9.3+4
 
+* Fixes compile errors under strict standards mode.
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 
 ## 0.9.3+3

--- a/packages/file_selector/file_selector_windows/example/windows/CMakeLists.txt
+++ b/packages/file_selector/file_selector_windows/example/windows/CMakeLists.txt
@@ -34,6 +34,9 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
+  # Enable strict standards mode in the example app, since issues it finds
+  # may become errors by default in future compiler versions.
+  target_compile_options(${TARGET} PRIVATE /permissive-)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_windows
 description: Windows implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.3+3
+version: 0.9.3+4
 
 environment:
   sdk: ^3.4.0

--- a/packages/file_selector/file_selector_windows/windows/file_selector_plugin.cpp
+++ b/packages/file_selector/file_selector_windows/windows/file_selector_plugin.cpp
@@ -221,8 +221,9 @@ ErrorOr<FileDialogResult> ShowDialog(
       mode == DialogMode::save ? CLSID_FileSaveDialog : CLSID_FileOpenDialog;
   DialogWrapper dialog(dialog_factory, dialog_type);
   if (!SUCCEEDED(dialog.last_result())) {
-    return FlutterError("System error", "Could not create dialog",
-                        EncodableValue(dialog.last_result()));
+    return FlutterError(
+        "System error", "Could not create dialog",
+        EncodableValue(std::in_place_type<int32_t>, dialog.last_result()));
   }
 
   FILEOPENDIALOGOPTIONS dialog_options = 0;
@@ -253,8 +254,9 @@ ErrorOr<FileDialogResult> ShowDialog(
   std::optional<FileDialogResult> result = dialog.Show(parent_window);
   if (!result) {
     if (dialog.last_result() != HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
-      return FlutterError("System error", "Could not show dialog",
-                          EncodableValue(dialog.last_result()));
+      return FlutterError(
+          "System error", "Could not show dialog",
+          EncodableValue(std::in_place_type<int32_t>, dialog.last_result()));
     } else {
       return FileDialogResult(EncodableList(), nullptr);
     }

--- a/packages/image_picker/image_picker_windows/example/windows/CMakeLists.txt
+++ b/packages/image_picker/image_picker_windows/example/windows/CMakeLists.txt
@@ -34,6 +34,9 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
+  # Enable strict standards mode in the example app, since issues it finds
+  # may become errors by default in future compiler versions.
+  target_compile_options(${TARGET} PRIVATE /permissive-)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()

--- a/packages/image_picker/image_picker_windows/example/windows/CMakeLists.txt
+++ b/packages/image_picker/image_picker_windows/example/windows/CMakeLists.txt
@@ -34,9 +34,6 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
-  # Enable strict standards mode in the example app, since issues it finds
-  # may become errors by default in future compiler versions.
-  target_compile_options(${TARGET} PRIVATE /permissive-)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()

--- a/packages/local_auth/local_auth_windows/example/windows/CMakeLists.txt
+++ b/packages/local_auth/local_auth_windows/example/windows/CMakeLists.txt
@@ -34,6 +34,9 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
+  # Enable strict standards mode in the example app, since issues it finds
+  # may become errors by default in future compiler versions.
+  target_compile_options(${TARGET} PRIVATE /permissive-)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()

--- a/packages/path_provider/path_provider_windows/example/windows/CMakeLists.txt
+++ b/packages/path_provider/path_provider_windows/example/windows/CMakeLists.txt
@@ -34,6 +34,9 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
+  # Enable strict standards mode in the example app, since issues it finds
+  # may become errors by default in future compiler versions.
+  target_compile_options(${TARGET} PRIVATE /permissive-)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()

--- a/packages/pigeon/platform_tests/test_plugin/example/windows/CMakeLists.txt
+++ b/packages/pigeon/platform_tests/test_plugin/example/windows/CMakeLists.txt
@@ -41,6 +41,9 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
+  # Enable strict standards mode in the example app, since issues it finds
+  # may become errors by default in future compiler versions.
+  target_compile_options(${TARGET} PRIVATE /permissive-)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()

--- a/packages/pigeon/platform_tests/test_plugin/windows/test_plugin.cpp
+++ b/packages/pigeon/platform_tests/test_plugin/windows/test_plugin.cpp
@@ -90,18 +90,18 @@ ErrorOr<AllTypes> TestPlugin::EchoAllTypes(const AllTypes& everything) {
 ErrorOr<std::optional<AllNullableTypes>> TestPlugin::EchoAllNullableTypes(
     const AllNullableTypes* everything) {
   if (!everything) {
-    return std::nullopt;
+    return std::optional<AllNullableTypes>(std::nullopt);
   }
-  return *everything;
+  return std::optional<AllNullableTypes>(*everything);
 }
 
 ErrorOr<std::optional<AllNullableTypesWithoutRecursion>>
 TestPlugin::EchoAllNullableTypesWithoutRecursion(
     const AllNullableTypesWithoutRecursion* everything) {
   if (!everything) {
-    return std::nullopt;
+    return std::optional<AllNullableTypesWithoutRecursion>(std::nullopt);
   }
-  return *everything;
+  return std::optional<AllNullableTypesWithoutRecursion>(*everything);
 }
 
 ErrorOr<std::optional<flutter::EncodableValue>> TestPlugin::ThrowError() {
@@ -288,193 +288,193 @@ TestPlugin::SendMultipleNullableTypesWithoutRecursion(
 ErrorOr<std::optional<int64_t>> TestPlugin::EchoNullableInt(
     const int64_t* a_nullable_int) {
   if (!a_nullable_int) {
-    return std::nullopt;
+    return std::optional<int64_t>(std::nullopt);
   }
-  return *a_nullable_int;
+  return std::optional<int64_t>(*a_nullable_int);
 };
 
 ErrorOr<std::optional<double>> TestPlugin::EchoNullableDouble(
     const double* a_nullable_double) {
   if (!a_nullable_double) {
-    return std::nullopt;
+    return std::optional<double>(std::nullopt);
   }
-  return *a_nullable_double;
+  return std::optional<double>(*a_nullable_double);
 };
 
 ErrorOr<std::optional<bool>> TestPlugin::EchoNullableBool(
     const bool* a_nullable_bool) {
   if (!a_nullable_bool) {
-    return std::nullopt;
+    return std::optional<bool>(std::nullopt);
   }
-  return *a_nullable_bool;
+  return std::optional<bool>(*a_nullable_bool);
 };
 
 ErrorOr<std::optional<std::string>> TestPlugin::EchoNullableString(
     const std::string* a_nullable_string) {
   if (!a_nullable_string) {
-    return std::nullopt;
+    return std::optional<std::string>(std::nullopt);
   }
-  return *a_nullable_string;
+  return std::optional<std::string>(*a_nullable_string);
 };
 
 ErrorOr<std::optional<std::vector<uint8_t>>> TestPlugin::EchoNullableUint8List(
     const std::vector<uint8_t>* a_nullable_uint8_list) {
   if (!a_nullable_uint8_list) {
-    return std::nullopt;
+    return std::optional<std::vector<uint8_t>>(std::nullopt);
   }
-  return *a_nullable_uint8_list;
+  return std::optional<std::vector<uint8_t>>(*a_nullable_uint8_list);
 };
 
 ErrorOr<std::optional<EncodableValue>> TestPlugin::EchoNullableObject(
     const EncodableValue* a_nullable_object) {
   if (!a_nullable_object) {
-    return std::nullopt;
+    return std::optional<EncodableValue>(std::nullopt);
   }
-  return *a_nullable_object;
+  return std::optional<EncodableValue>(*a_nullable_object);
 };
 
 ErrorOr<std::optional<EncodableList>> TestPlugin::EchoNullableList(
     const EncodableList* a_nullable_list) {
   if (!a_nullable_list) {
-    return std::nullopt;
+    return std::optional<EncodableList>(std::nullopt);
   }
-  return *a_nullable_list;
+  return std::optional<EncodableList>(*a_nullable_list);
 };
 
 ErrorOr<std::optional<EncodableList>> TestPlugin::EchoNullableEnumList(
     const EncodableList* enum_list) {
   if (!enum_list) {
-    return std::nullopt;
+    return std::optional<EncodableList>(std::nullopt);
   }
-  return *enum_list;
+  return std::optional<EncodableList>(*enum_list);
 };
 
 ErrorOr<std::optional<EncodableList>> TestPlugin::EchoNullableClassList(
     const EncodableList* class_list) {
   if (!class_list) {
-    return std::nullopt;
+    return std::optional<EncodableList>(std::nullopt);
   }
-  return *class_list;
+  return std::optional<EncodableList>(*class_list);
 };
 
 ErrorOr<std::optional<EncodableList>> TestPlugin::EchoNullableNonNullEnumList(
     const EncodableList* enum_list) {
   if (!enum_list) {
-    return std::nullopt;
+    return std::optional<EncodableList>(std::nullopt);
   }
-  return *enum_list;
+  return std::optional<EncodableList>(*enum_list);
 };
 
 ErrorOr<std::optional<EncodableList>> TestPlugin::EchoNullableNonNullClassList(
     const EncodableList* class_list) {
   if (!class_list) {
-    return std::nullopt;
+    return std::optional<EncodableList>(std::nullopt);
   }
-  return *class_list;
+  return std::optional<EncodableList>(*class_list);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableMap(
     const EncodableMap* map) {
   if (!map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *map;
+  return std::optional<EncodableMap>(*map);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableStringMap(
     const EncodableMap* string_map) {
   if (!string_map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *string_map;
+  return std::optional<EncodableMap>(*string_map);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableIntMap(
     const EncodableMap* int_map) {
   if (!int_map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *int_map;
+  return std::optional<EncodableMap>(*int_map);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableEnumMap(
     const EncodableMap* enum_map) {
   if (!enum_map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *enum_map;
+  return std::optional<EncodableMap>(*enum_map);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableClassMap(
     const EncodableMap* class_map) {
   if (!class_map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *class_map;
+  return std::optional<EncodableMap>(*class_map);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableNonNullStringMap(
     const EncodableMap* string_map) {
   if (!string_map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *string_map;
+  return std::optional<EncodableMap>(*string_map);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableNonNullIntMap(
     const EncodableMap* int_map) {
   if (!int_map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *int_map;
+  return std::optional<EncodableMap>(*int_map);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableNonNullEnumMap(
     const EncodableMap* enum_map) {
   if (!enum_map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *enum_map;
+  return std::optional<EncodableMap>(*enum_map);
 };
 
 ErrorOr<std::optional<EncodableMap>> TestPlugin::EchoNullableNonNullClassMap(
     const EncodableMap* class_map) {
   if (!class_map) {
-    return std::nullopt;
+    return std::optional<EncodableMap>(std::nullopt);
   }
-  return *class_map;
+  return std::optional<EncodableMap>(*class_map);
 };
 
 ErrorOr<std::optional<AnEnum>> TestPlugin::EchoNullableEnum(
     const AnEnum* an_enum) {
   if (!an_enum) {
-    return std::nullopt;
+    return std::optional<AnEnum>(std::nullopt);
   }
-  return *an_enum;
+  return std::optional<AnEnum>(*an_enum);
 }
 
 ErrorOr<std::optional<AnotherEnum>> TestPlugin::EchoAnotherNullableEnum(
     const AnotherEnum* another_enum) {
   if (!another_enum) {
-    return std::nullopt;
+    return std::optional<AnotherEnum>(std::nullopt);
   }
-  return *another_enum;
+  return std::optional<AnotherEnum>(*another_enum);
 }
 
 ErrorOr<std::optional<int64_t>> TestPlugin::EchoOptionalNullableInt(
     const int64_t* a_nullable_int) {
   if (!a_nullable_int) {
-    return std::nullopt;
+    return std::optional<int64_t>(std::nullopt);
   }
-  return *a_nullable_int;
+  return std::optional<int64_t>(*a_nullable_int);
 }
 
 ErrorOr<std::optional<std::string>> TestPlugin::EchoNamedNullableString(
     const std::string* a_nullable_string) {
   if (!a_nullable_string) {
-    return std::nullopt;
+    return std::optional<std::string>(std::nullopt);
   }
-  return *a_nullable_string;
+  return std::optional<std::string>(*a_nullable_string);
 }
 
 void TestPlugin::NoopAsync(

--- a/packages/url_launcher/url_launcher_windows/example/windows/CMakeLists.txt
+++ b/packages/url_launcher/url_launcher_windows/example/windows/CMakeLists.txt
@@ -34,6 +34,9 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
+  # Enable strict standards mode in the example app, since issues it finds
+  # may become errors by default in future compiler versions.
+  target_compile_options(${TARGET} PRIVATE /permissive-)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()


### PR DESCRIPTION
As the Visual Studio C++ compiler moves toward increasingly standards-compliant behavior, things it allows may become errors in the future (as seen in https://github.com/flutter/flutter/issues/163296 and the issues it references). To avoid a whole class of future problems, this enables `/permissive-` for the example apps of all of our Windows plugins that have native code, and fixes the resulting violations.

Fixes https://github.com/flutter/flutter/issues/163296

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
