### PR TITLE
[camera] Disable flaky tests

### DIFF
--- a/packages/camera/camera_android_camerax/test/capture_request_options_test.dart
+++ b/packages/camera/camera_android_camerax/test/capture_request_options_test.dart
@@ -49,7 +49,7 @@ void main() {
         argThat(isA<int>()),
         argThat(isA<Map<int, Object?>>()),
       ));
-    });
+    }, skip: 'Flaky test: https://github.com/flutter/flutter/issues/164132');
 
     test(
         'create makes call on the Java side as expected for suppported null capture request options',

--- a/packages/camera/camera_android_camerax/test/focus_metering_action_test.dart
+++ b/packages/camera/camera_android_camerax/test/focus_metering_action_test.dart
@@ -45,7 +45,8 @@ void main() {
 
       verifyNever(mockApi.create(argThat(isA<int>()), argThat(isA<List<int>>()),
           argThat(isA<bool?>())));
-    });
+    }, skip: 'Flaky test: https://github.com/flutter/flutter/issues/164132');
+
     test('create calls create on the Java side', () {
       final MockTestFocusMeteringActionHostApi mockApi =
           MockTestFocusMeteringActionHostApi();

--- a/packages/camera/camera_android_camerax/test/image_analysis_test.dart
+++ b/packages/camera/camera_android_camerax/test/image_analysis_test.dart
@@ -48,7 +48,8 @@ void main() {
 
       verifyNever(mockApi.create(argThat(isA<int>()), argThat(isA<int>()),
           argThat(isA<ResolutionSelector>())));
-    });
+    }, skip: 'Flaky test: https://github.com/flutter/flutter/issues/164132');
+
     test('create calls create on the Java side', () {
       final MockTestImageAnalysisHostApi mockApi =
           MockTestImageAnalysisHostApi();

--- a/packages/camera/camera_android_camerax/test/image_capture_test.dart
+++ b/packages/camera/camera_android_camerax/test/image_capture_test.dart
@@ -43,7 +43,7 @@ void main() {
 
       verifyNever(mockApi.create(argThat(isA<int>()), argThat(isA<int>()),
           argThat(isA<ResolutionSelector>()), argThat(isA<int>())));
-    });
+    }, skip: 'Flaky test: https://github.com/flutter/flutter/issues/164132');
 
     test('create calls create on the Java side', () async {
       final MockTestImageCaptureHostApi mockApi = MockTestImageCaptureHostApi();

--- a/packages/camera/camera_android_camerax/test/metering_point_test.dart
+++ b/packages/camera/camera_android_camerax/test/metering_point_test.dart
@@ -41,7 +41,7 @@ void main() {
 
       verifyNever(mockApi.create(argThat(isA<int>()), argThat(isA<int>()),
           argThat(isA<int>()), argThat(isA<int>()), argThat(isA<int>())));
-    });
+    }, skip: 'Flaky test: https://github.com/flutter/flutter/issues/164132');
 
     test('create calls create on the Java side', () async {
       final MockTestMeteringPointHostApi mockApi =

--- a/packages/camera/camera_android_camerax/test/preview_test.dart
+++ b/packages/camera/camera_android_camerax/test/preview_test.dart
@@ -40,7 +40,7 @@ void main() {
 
       verifyNever(mockApi.create(argThat(isA<int>()), argThat(isA<int>()),
           argThat(isA<ResolutionSelector>())));
-    });
+    }, skip: 'Flaky test: https://github.com/flutter/flutter/issues/164132');
 
     test('create calls create on the Java side', () async {
       final MockTestPreviewHostApi mockApi = MockTestPreviewHostApi();

--- a/packages/camera/camera_android_camerax/test/recorder_test.dart
+++ b/packages/camera/camera_android_camerax/test/recorder_test.dart
@@ -43,7 +43,7 @@ void main() {
 
       verifyNever(mockApi.create(argThat(isA<int>()), argThat(isA<int>()),
           argThat(isA<int>()), argThat(isA<int>())));
-    });
+    }, skip: 'Flaky test: https://github.com/flutter/flutter/issues/164132');
 
     test('create does call create on the Java side', () async {
       final MockTestRecorderHostApi mockApi = MockTestRecorderHostApi();


### PR DESCRIPTION
Skips the `create does not call create on the Java side` tests due to excessive flake, while the issue is investigated.

https://github.com/flutter/flutter/issues/164132