### PR TITLE
[various] Bump androidx.test:core to 1.4.0

### DIFF
--- a/packages/file_selector/file_selector_android/android/build.gradle
+++ b/packages/file_selector/file_selector_android/android/build.gradle
@@ -38,7 +38,7 @@ android {
         implementation 'androidx.annotation:annotation:1.9.1'
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'org.mockito:mockito-inline:5.1.0'
-        testImplementation 'androidx.test:core:1.3.0'
+        testImplementation 'androidx.test:core:1.4.0'
         testImplementation "org.robolectric:robolectric:4.12.1"
     }
 

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/build.gradle
@@ -57,7 +57,7 @@ android {
         testImplementation 'junit:junit:4.13.2'
         androidTestImplementation 'androidx.test:runner:1.2.0'
         androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-        api 'androidx.test:core:1.2.0'
+        api 'androidx.test:core:1.4.0'
         testImplementation 'com.google.android.gms:play-services-maps:17.0.0'
     }
     namespace 'io.flutter.plugins.googlemapsexample'

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
@@ -44,7 +44,7 @@ android {
         androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'org.mockito:mockito-core:5.1.1'
-        testImplementation 'androidx.test:core:1.2.0'
+        testImplementation 'androidx.test:core:1.4.0'
         testImplementation "org.robolectric:robolectric:4.10.3"
     }
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/build.gradle
@@ -58,7 +58,7 @@ android {
         testImplementation 'junit:junit:4.13.2'
         androidTestImplementation 'androidx.test:runner:1.2.0'
         androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-        api 'androidx.test:core:1.2.0'
+        api 'androidx.test:core:1.4.0'
         testImplementation 'com.google.android.gms:play-services-maps:17.0.0'
         testImplementation 'com.google.maps.android:android-maps-utils:3.6.0'
     }

--- a/packages/google_sign_in/google_sign_in/example/android/app/build.gradle
+++ b/packages/google_sign_in/google_sign_in/example/android/app/build.gradle
@@ -61,5 +61,5 @@ dependencies {
     testImplementation'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    api 'androidx.test:core:1.2.0'
+    api 'androidx.test:core:1.4.0'
 }

--- a/packages/google_sign_in/google_sign_in_android/example/android/app/build.gradle
+++ b/packages/google_sign_in/google_sign_in_android/example/android/app/build.gradle
@@ -61,5 +61,5 @@ dependencies {
     testImplementation'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    api 'androidx.test:core:1.2.0'
+    api 'androidx.test:core:1.4.0'
 }

--- a/packages/image_picker/image_picker/example/android/app/build.gradle
+++ b/packages/image_picker/image_picker/example/android/app/build.gradle
@@ -61,5 +61,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    api 'androidx.test:core:1.2.0'
+    api 'androidx.test:core:1.4.0'
 }

--- a/packages/interactive_media_ads/android/build.gradle
+++ b/packages/interactive_media_ads/android/build.gradle
@@ -54,7 +54,7 @@ android {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation "org.mockito.kotlin:mockito-kotlin:5.4.0"
         testImplementation 'org.mockito:mockito-inline:5.1.0'
-        testImplementation 'androidx.test:core:1.3.0'
+        testImplementation 'androidx.test:core:1.4.0'
     }
 
     lintOptions {

--- a/packages/quick_actions/quick_actions/example/android/app/build.gradle
+++ b/packages/quick_actions/quick_actions/example/android/app/build.gradle
@@ -54,5 +54,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    api 'androidx.test:core:1.2.0'
+    api 'androidx.test:core:1.4.0'
 }

--- a/packages/quick_actions/quick_actions_android/example/android/app/build.gradle
+++ b/packages/quick_actions/quick_actions_android/example/android/app/build.gradle
@@ -22,7 +22,7 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-def androidXTestVersion = '1.2.0'
+def androidXTestVersion = '1.4.0'
 
 android {
     namespace 'io.flutter.plugins.quickactionsexample'
@@ -54,7 +54,6 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     api "androidx.test:core:$androidXTestVersion"
 

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -66,6 +66,6 @@ dependencies {
     implementation 'androidx.browser:browser:1.8.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.1.1'
-    testImplementation 'androidx.test:core:1.0.0'
+    testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.10.3'
 }

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -47,7 +47,7 @@ android {
         implementation "androidx.media3:media3-exoplayer-rtsp:${exoplayer_version}"
         implementation "androidx.media3:media3-exoplayer-smoothstreaming:${exoplayer_version}"
         testImplementation 'junit:junit:4.13.2'
-        testImplementation 'androidx.test:core:1.3.0'
+        testImplementation 'androidx.test:core:1.4.0'
         testImplementation 'org.mockito:mockito-inline:5.0.0'
         testImplementation 'org.robolectric:robolectric:4.10.3'
         testImplementation "androidx.media3:media3-test-utils:${exoplayer_version}"

--- a/packages/webview_flutter/webview_flutter/example/android/app/build.gradle
+++ b/packages/webview_flutter/webview_flutter/example/android/app/build.gradle
@@ -57,5 +57,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    api 'androidx.test:core:1.2.0'
+    api 'androidx.test:core:1.4.0'
 }

--- a/packages/webview_flutter/webview_flutter_android/android/build.gradle
+++ b/packages/webview_flutter/webview_flutter_android/android/build.gradle
@@ -53,7 +53,7 @@ android {
         implementation 'androidx.webkit:webkit:1.12.1'
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'org.mockito:mockito-inline:5.1.0'
-        testImplementation 'androidx.test:core:1.3.0'
+        testImplementation 'androidx.test:core:1.4.0'
     }
 
     testOptions {


### PR DESCRIPTION
This is pulled out of https://github.com/flutter/packages/pull/8693 to land on its own while the other issues with that PR are investigated, since it's a useful change regardless.

This updates all packages in the repo to have `androidx.test:core` 1.4.0 if it's not already higher. This fixes a latent problem where older versions of `androidx.test.core` aren't compatible with targeting the current SDK, because it has activities that are not annotated as exported. This issue is currently being masked by the dependency on `integration_test`, which forced a higher version of that package, but `integration_test` will stop exporting that dependency onto the app as of recent master, dropping all the packages here back to a too-old `androidx.test:core`.