### PR TITLE
[ci] Lengthen custom tests timeout

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -341,7 +341,7 @@ targets:
 
   - name: Linux_android custom_package_tests master
     recipe: packages/packages
-    timeout: 30
+    timeout: 60
     dimensions:
       kvm: "1"
     properties:
@@ -367,7 +367,7 @@ targets:
 
   - name: Linux_android custom_package_tests stable
     recipe: packages/packages
-    timeout: 30
+    timeout: 60
     dimensions:
       kvm: "1"
     properties:


### PR DESCRIPTION
This test has been at the edge of its time limit for a while, and is now consistently timing out. Longer term we should see if we can shorten the Pigeon test time (it accounts for about 20 minutes), but for now, increase the timeout so that it doesn't fail.