### PR TITLE
[tool] Move changed file detection to base command class

### DIFF
--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -17,6 +17,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   }) {
     argParser.addMultiOption(_customAnalysisFlag,
         help:

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -48,6 +48,7 @@ class BuildExamplesCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   }) {
     argParser.addFlag(platformLinux);
     argParser.addFlag(platformMacOS);

--- a/script/tool/lib/src/common/git_version_finder.dart
+++ b/script/tool/lib/src/common/git_version_finder.dart
@@ -28,15 +28,6 @@ class GitVersionFinder {
   /// The base branche used to find a merge point if baseSha is not provided.
   final String _baseBranch;
 
-  static bool _isPubspec(String file) {
-    return file.trim().endsWith('pubspec.yaml');
-  }
-
-  /// Get a list of all the pubspec.yaml file that is changed.
-  Future<List<String>> getChangedPubSpecs() async {
-    return (await getChangedFiles()).where(_isPubspec).toList();
-  }
-
   /// Get a list of all the changed files.
   Future<List<String>> getChangedFiles(
       {bool includeUncommitted = false}) async {

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
 import 'core.dart';
+import 'git_version_finder.dart';
 import 'output_utils.dart';
 import 'package_command.dart';
 import 'repository_package.dart';
@@ -226,6 +227,17 @@ abstract class PackageLoopingCommand extends PackageCommand {
   /// The suggested indentation for printed output.
   String get indentation => hasLongOutput ? '' : '  ';
 
+  /// The base SHA used to calculate changed files.
+  ///
+  /// This is guaranteed to be populated before [initializeRun] is called.
+  late String baseSha;
+
+  /// The repo-relative paths (using Posix separators) of all files changed
+  /// relative to [baseSha].
+  ///
+  /// This is guaranteed to be populated before [initializeRun] is called.
+  late List<String> changedFiles;
+
   // ----------------------------------------
 
   @override
@@ -263,6 +275,11 @@ abstract class PackageLoopingCommand extends PackageCommand {
         : getDartSdkForFlutterSdk(minFlutterVersion);
 
     final DateTime runStart = DateTime.now();
+
+    // Populate the list of changed files for subclasses to use.
+    final GitVersionFinder gitVersionFinder = await retrieveVersionFinder();
+    baseSha = await gitVersionFinder.getBaseSha();
+    changedFiles = await gitVersionFinder.getChangedFiles();
 
     await initializeRun();
 

--- a/script/tool/lib/src/custom_test_command.dart
+++ b/script/tool/lib/src/custom_test_command.dart
@@ -21,6 +21,7 @@ class CustomTestCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   });
 
   @override

--- a/script/tool/lib/src/dart_test_command.dart
+++ b/script/tool/lib/src/dart_test_command.dart
@@ -27,6 +27,7 @@ class DartTestCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   }) {
     argParser.addOption(
       kEnableExperiment,

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -27,6 +27,7 @@ class DriveExamplesCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   }) {
     argParser.addFlag(platformAndroid,
         help: 'Runs the Android implementation of the examples',

--- a/script/tool/lib/src/federation_safety_check_command.dart
+++ b/script/tool/lib/src/federation_safety_check_command.dart
@@ -59,9 +59,8 @@ class FederationSafetyCheckCommand extends PackageLoopingCommand {
   @override
   Future<void> initializeRun() async {
     final GitVersionFinder gitVersionFinder = await retrieveVersionFinder();
-    final String baseSha = await gitVersionFinder.getBaseSha();
     print('Validating changes relative to "$baseSha"\n');
-    for (final String path in await gitVersionFinder.getChangedFiles()) {
+    for (final String path in changedFiles) {
       // Git output always uses Posix paths.
       final List<String> allComponents = p.posix.split(path);
       final int packageIndex = allComponents.indexOf('packages');

--- a/script/tool/lib/src/fetch_deps_command.dart
+++ b/script/tool/lib/src/fetch_deps_command.dart
@@ -27,6 +27,7 @@ class FetchDepsCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   }) {
     argParser.addFlag(_dartFlag, defaultsTo: true, help: 'Run "pub get"');
     argParser.addFlag(_supportingTargetPlatformsOnlyFlag,

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -23,6 +23,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   }) {
     argParser.addOption(
       _gCloudProjectArg,

--- a/script/tool/lib/src/fix_command.dart
+++ b/script/tool/lib/src/fix_command.dart
@@ -13,6 +13,7 @@ class FixCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   });
 
   @override

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -49,6 +49,7 @@ class FormatCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   }) {
     argParser.addFlag(_failonChangeArg, hide: true);
     argParser.addFlag(_dartArg, help: 'Format Dart files', defaultsTo: true);

--- a/script/tool/lib/src/gradle_check_command.dart
+++ b/script/tool/lib/src/gradle_check_command.dart
@@ -19,7 +19,10 @@ final Version minKotlinVersion = Version(1, 7, 10);
 /// A command to enforce gradle file conventions and best practices.
 class GradleCheckCommand extends PackageLoopingCommand {
   /// Creates an instance of the gradle check command.
-  GradleCheckCommand(super.packagesDir);
+  GradleCheckCommand(
+    super.packagesDir, {
+    super.gitDir,
+  });
 
   @override
   final String name = 'gradle-check';

--- a/script/tool/lib/src/lint_android_command.dart
+++ b/script/tool/lib/src/lint_android_command.dart
@@ -18,6 +18,7 @@ class LintAndroidCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   });
 
   @override

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -45,6 +45,7 @@ class NativeTestCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
     Abi? abi,
   })  : _abi = abi ?? Abi.current(),
         _xcode = Xcode(processRunner: processRunner, log: true) {

--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -25,6 +25,7 @@ class PodspecCheckCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   });
 
   @override

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -23,6 +23,7 @@ class PublishCheckCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
     http.Client? httpClient,
   }) : _pubVersionFinder =
             PubVersionFinder(httpClient: httpClient ?? http.Client()) {

--- a/script/tool/lib/src/publish_command.dart
+++ b/script/tool/lib/src/publish_command.dart
@@ -17,7 +17,6 @@ import 'package:yaml/yaml.dart';
 
 import 'common/core.dart';
 import 'common/file_utils.dart';
-import 'common/git_version_finder.dart';
 import 'common/output_utils.dart';
 import 'common/package_command.dart';
 import 'common/package_looping_command.dart';
@@ -175,12 +174,12 @@ class PublishCommand extends PackageLoopingCommand {
   @override
   Stream<PackageEnumerationEntry> getPackagesToProcess() async* {
     if (getBoolArg(_allChangedFlag)) {
-      final GitVersionFinder gitVersionFinder = await retrieveVersionFinder();
-      final String baseSha = await gitVersionFinder.getBaseSha();
       print(
           'Publishing all packages that have changed relative to "$baseSha"\n');
-      final List<String> changedPubspecs =
-          await gitVersionFinder.getChangedPubSpecs();
+
+      final List<String> changedPubspecs = changedFiles
+          .where((String file) => file.trim().endsWith('pubspec.yaml'))
+          .toList();
 
       for (final String pubspecPath in changedPubspecs) {
         // git outputs a relativa, Posix-style path.

--- a/script/tool/lib/src/remove_dev_dependencies_command.dart
+++ b/script/tool/lib/src/remove_dev_dependencies_command.dart
@@ -15,7 +15,10 @@ import 'common/repository_package.dart';
 /// clients of the library, but not for development of the library.
 class RemoveDevDependenciesCommand extends PackageLoopingCommand {
   /// Creates a publish metadata updater command instance.
-  RemoveDevDependenciesCommand(super.packagesDir);
+  RemoveDevDependenciesCommand(
+    super.packagesDir, {
+    super.gitDir,
+  });
 
   @override
   final String name = 'remove-dev-dependencies';

--- a/script/tool/lib/src/update_dependency_command.dart
+++ b/script/tool/lib/src/update_dependency_command.dart
@@ -32,6 +32,7 @@ class UpdateDependencyCommand extends PackageLoopingCommand {
   UpdateDependencyCommand(
     super.packagesDir, {
     super.processRunner,
+    super.gitDir,
     http.Client? httpClient,
   }) : _pubVersionFinder =
             PubVersionFinder(httpClient: httpClient ?? http.Client()) {

--- a/script/tool/lib/src/update_min_sdk_command.dart
+++ b/script/tool/lib/src/update_min_sdk_command.dart
@@ -15,7 +15,10 @@ const int _exitUnknownVersion = 3;
 /// A command to update the minimum Flutter and Dart SDKs of packages.
 class UpdateMinSdkCommand extends PackageLoopingCommand {
   /// Creates a publish metadata updater command instance.
-  UpdateMinSdkCommand(super.packagesDir) {
+  UpdateMinSdkCommand(
+    super.packagesDir, {
+    super.gitDir,
+  }) {
     argParser.addOption(_flutterMinFlag,
         mandatory: true,
         help: 'The minimum version of Flutter to set SDK constraints to.');

--- a/script/tool/lib/src/xcode_analyze_command.dart
+++ b/script/tool/lib/src/xcode_analyze_command.dart
@@ -16,6 +16,7 @@ class XcodeAnalyzeCommand extends PackageLoopingCommand {
     super.packagesDir, {
     super.processRunner,
     super.platform,
+    super.gitDir,
   }) : _xcode = Xcode(processRunner: processRunner, log: true) {
     argParser.addFlag(platformIOS, help: 'Analyze iOS');
     argParser.addFlag(platformMacOS, help: 'Analyze macOS');

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -4,29 +4,29 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/analyze_command.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late MockPlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
     mockPlatform = MockPlatform();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-    processRunner = RecordingProcessRunner();
+    final GitDir gitDir;
+    (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks(platform: mockPlatform);
     final AnalyzeCommand analyzeCommand = AnalyzeCommand(
       packagesDir,
       processRunner: processRunner,
+      gitDir: gitDir,
       platform: mockPlatform,
     );
 

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/build_examples_command.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -15,21 +15,21 @@ import 'util.dart';
 
 void main() {
   group('build-example', () {
-    late FileSystem fileSystem;
     late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      processRunner = RecordingProcessRunner();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final BuildExamplesCommand command = BuildExamplesCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner = CommandRunner<void>(

--- a/script/tool/test/common/git_version_finder_test.dart
+++ b/script/tool/test/common/git_version_finder_test.dart
@@ -56,18 +56,6 @@ file2/file2.cc
     expect(changedFiles, equals(<String>['file1/file1.cc', 'file2/file2.cc']));
   });
 
-  test('get correct pubspec change based on git diff', () async {
-    gitDiffResponse = '''
-file1/pubspec.yaml
-file2/file2.cc
-''';
-    final GitVersionFinder finder =
-        GitVersionFinder(gitDir, baseSha: 'some base sha');
-    final List<String> changedFiles = await finder.getChangedPubSpecs();
-
-    expect(changedFiles, equals(<String>['file1/pubspec.yaml']));
-  });
-
   test('use correct base sha if not specified', () async {
     mergeBaseResponse = 'shaqwiueroaaidf12312jnadf123nd';
     gitDiffResponse = '''

--- a/script/tool/test/common/gradle_test.dart
+++ b/script/tool/test/common/gradle_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/gradle.dart';
 import 'package:test/test.dart';
 
@@ -11,18 +10,17 @@ import '../mocks.dart';
 import '../util.dart';
 
 void main() {
-  late FileSystem fileSystem;
+  late Directory packagesDir;
   late RecordingProcessRunner processRunner;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    processRunner = RecordingProcessRunner();
+    (:packagesDir, :processRunner, gitProcessRunner: _, gitDir: _) =
+        configureBaseCommandMocks();
   });
 
   group('isConfigured', () {
     test('reports true when configured on Windows', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-          'plugin', fileSystem.directory('/'),
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           extraFiles: <String>['android/gradlew.bat']);
       final GradleProject project = GradleProject(
         plugin,
@@ -34,8 +32,7 @@ void main() {
     });
 
     test('reports true when configured on non-Windows', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-          'plugin', fileSystem.directory('/'),
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           extraFiles: <String>['android/gradlew']);
       final GradleProject project = GradleProject(
         plugin,
@@ -47,8 +44,7 @@ void main() {
     });
 
     test('reports false when not configured on Windows', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-          'plugin', fileSystem.directory('/'),
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           extraFiles: <String>['android/foo']);
       final GradleProject project = GradleProject(
         plugin,
@@ -60,8 +56,7 @@ void main() {
     });
 
     test('reports true when configured on non-Windows', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-          'plugin', fileSystem.directory('/'),
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           extraFiles: <String>['android/foo']);
       final GradleProject project = GradleProject(
         plugin,
@@ -75,8 +70,7 @@ void main() {
 
   group('runCommand', () {
     test('runs without arguments', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-          'plugin', fileSystem.directory('/'),
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           extraFiles: <String>['android/gradlew']);
       final GradleProject project = GradleProject(
         plugin,
@@ -103,8 +97,7 @@ void main() {
     });
 
     test('runs with arguments', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-          'plugin', fileSystem.directory('/'),
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           extraFiles: <String>['android/gradlew']);
       final GradleProject project = GradleProject(
         plugin,
@@ -136,8 +129,7 @@ void main() {
     });
 
     test('runs with the correct wrapper on Windows', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-          'plugin', fileSystem.directory('/'),
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           extraFiles: <String>['android/gradlew.bat']);
       final GradleProject project = GradleProject(
         plugin,
@@ -164,8 +156,7 @@ void main() {
     });
 
     test('returns error codes', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-          'plugin', fileSystem.directory('/'),
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           extraFiles: <String>['android/gradlew.bat']);
       final GradleProject project = GradleProject(
         plugin,

--- a/script/tool/test/common/package_looping_command_test.dart
+++ b/script/tool/test/common/package_looping_command_test.dart
@@ -7,7 +7,6 @@ import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/output_utils.dart';
 import 'package:flutter_plugin_tools/src/common/package_looping_command.dart';
@@ -77,17 +76,16 @@ String _filenameForType(_ResultFileType type) {
 }
 
 void main() {
-  late FileSystem fileSystem;
   late MockPlatform mockPlatform;
   late Directory packagesDir;
   late Directory thirdPartyPackagesDir;
 
   setUp(() {
+    mockPlatform = MockPlatform();
+    (:packagesDir, processRunner: _, gitProcessRunner: _, gitDir: _) =
+        configureBaseCommandMocks(platform: mockPlatform);
     // Correct color handling is part of the behavior being tested here.
     useColorForOutput = true;
-    fileSystem = MemoryFileSystem();
-    mockPlatform = MockPlatform();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
     thirdPartyPackagesDir = packagesDir.parent
         .childDirectory('third_party')
         .childDirectory('packages');

--- a/script/tool/test/common/package_state_utils_test.dart
+++ b/script/tool/test/common/package_state_utils_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/git_version_finder.dart';
 import 'package:flutter_plugin_tools/src/common/package_state_utils.dart';
 import 'package:test/fake.dart';
@@ -11,12 +10,11 @@ import 'package:test/test.dart';
 import '../util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late Directory packagesDir;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    (:packagesDir, processRunner: _, gitProcessRunner: _, gitDir: _) =
+        configureBaseCommandMocks();
   });
 
   group('checkPackageChangeState', () {

--- a/script/tool/test/common/plugin_utils_test.dart
+++ b/script/tool/test/common/plugin_utils_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:test/test.dart';
@@ -11,12 +10,11 @@ import 'package:test/test.dart';
 import '../util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late Directory packagesDir;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    (:packagesDir, processRunner: _, gitProcessRunner: _, gitDir: _) =
+        configureBaseCommandMocks();
   });
 
   group('pluginSupportsPlatform', () {

--- a/script/tool/test/common/pub_utils_test.dart
+++ b/script/tool/test/common/pub_utils_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/pub_utils.dart';
 import 'package:test/test.dart';
 
@@ -11,14 +10,12 @@ import '../mocks.dart';
 import '../util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-    processRunner = RecordingProcessRunner();
+    (:packagesDir, :processRunner, gitProcessRunner: _, gitDir: _) =
+        configureBaseCommandMocks();
   });
 
   test('runs with Dart for a non-Flutter package by default', () async {

--- a/script/tool/test/common/repository_package_test.dart
+++ b/script/tool/test/common/repository_package_test.dart
@@ -10,12 +10,11 @@ import 'package:test/test.dart';
 import '../util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late Directory packagesDir;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    (:packagesDir, processRunner: _, gitProcessRunner: _, gitDir: _) =
+        configureBaseCommandMocks();
   });
 
   group('displayName', () {
@@ -49,7 +48,7 @@ void main() {
 
     test('always uses Posix-style paths', () async {
       final Directory windowsPackagesDir = createPackagesDirectory(
-          fileSystem: MemoryFileSystem(style: FileSystemStyle.windows));
+          MemoryFileSystem(style: FileSystemStyle.windows));
 
       expect(
         RepositoryPackage(windowsPackagesDir.childDirectory('foo')).displayName,

--- a/script/tool/test/create_all_packages_app_command_test.dart
+++ b/script/tool/test/create_all_packages_app_command_test.dart
@@ -6,7 +6,6 @@ import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/create_all_packages_app_command.dart';
 import 'package:platform/platform.dart';
@@ -20,17 +19,15 @@ void main() {
   late CommandRunner<void> runner;
   late CreateAllPackagesAppCommand command;
   late Platform mockPlatform;
-  late FileSystem fileSystem;
   late Directory testRoot;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
 
   setUp(() {
     mockPlatform = MockPlatform(isMacOS: true);
-    fileSystem = MemoryFileSystem();
-    testRoot = fileSystem.systemTempDirectory.createTempSync();
-    packagesDir = testRoot.childDirectory('packages');
-    processRunner = RecordingProcessRunner();
+    (:packagesDir, :processRunner, gitProcessRunner: _, gitDir: _) =
+        configureBaseCommandMocks(platform: mockPlatform);
+    testRoot = packagesDir.parent;
 
     command = CreateAllPackagesAppCommand(
       packagesDir,
@@ -530,7 +527,7 @@ android {
 
     test('handles --output-dir', () async {
       final Directory customOutputDir =
-          fileSystem.systemTempDirectory.createTempSync();
+          testRoot.fileSystem.systemTempDirectory.createTempSync();
       writeFakeFlutterCreateOutput(customOutputDir);
       createFakePlugin('plugina', packagesDir);
 

--- a/script/tool/test/custom_test_command_test.dart
+++ b/script/tool/test/custom_test_command_test.dart
@@ -4,16 +4,15 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/custom_test_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late MockPlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
@@ -21,14 +20,15 @@ void main() {
 
   group('posix', () {
     setUp(() {
-      fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      processRunner = RecordingProcessRunner();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final CustomTestCommand analyzeCommand = CustomTestCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner = CommandRunner<void>(
@@ -219,14 +219,15 @@ void main() {
 
   group('Windows', () {
     setUp(() {
-      fileSystem = MemoryFileSystem(style: FileSystemStyle.windows);
       mockPlatform = MockPlatform(isWindows: true);
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      processRunner = RecordingProcessRunner();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final CustomTestCommand analyzeCommand = CustomTestCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner = CommandRunner<void>(

--- a/script/tool/test/dart_test_command_test.dart
+++ b/script/tool/test/dart_test_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/dart_test_command.dart';
+import 'package:git/git.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
@@ -16,21 +16,21 @@ import 'util.dart';
 
 void main() {
   group('TestCommand', () {
-    late FileSystem fileSystem;
     late Platform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      processRunner = RecordingProcessRunner();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final DartTestCommand command = DartTestCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner = CommandRunner<void>('test_test', 'Test for $DartTestCommand');

--- a/script/tool/test/dependabot_check_command_test.dart
+++ b/script/tool/test/dependabot_check_command_test.dart
@@ -4,28 +4,23 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/dependabot_check_command.dart';
-import 'package:mockito/mockito.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
-import 'common/package_command_test.mocks.dart';
 import 'util.dart';
 
 void main() {
   late CommandRunner<void> runner;
-  late FileSystem fileSystem;
   late Directory root;
   late Directory packagesDir;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    root = fileSystem.currentDirectory;
-    packagesDir = root.childDirectory('packages');
-
-    final MockGitDir gitDir = MockGitDir();
-    when(gitDir.path).thenReturn(root.path);
+    final GitDir gitDir;
+    (:packagesDir, processRunner: _, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks();
+    root = packagesDir.parent;
 
     final DependabotCheckCommand command = DependabotCheckCommand(
       packagesDir,

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -8,10 +8,10 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
+import 'package:git/git.dart';
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
@@ -24,19 +24,22 @@ const String _fakeAndroidDevice = 'emulator-1234';
 
 void main() {
   group('test drive_example_command', () {
-    late FileSystem fileSystem;
     late Platform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      processRunner = RecordingProcessRunner();
-      final DriveExamplesCommand command = DriveExamplesCommand(packagesDir,
-          processRunner: processRunner, platform: mockPlatform);
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
+      final DriveExamplesCommand command = DriveExamplesCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+        gitDir: gitDir,
+      );
 
       runner = CommandRunner<void>(
           'drive_examples_command', 'Test for drive_example_command');

--- a/script/tool/test/fetch_deps_command_test.dart
+++ b/script/tool/test/fetch_deps_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/fetch_deps_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -15,21 +15,22 @@ import 'util.dart';
 
 void main() {
   group('FetchDepsCommand', () {
-    FileSystem fileSystem;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late MockPlatform mockPlatform;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       mockPlatform = MockPlatform();
-      processRunner = RecordingProcessRunner();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
+
       final FetchDepsCommand command = FetchDepsCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner =

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:flutter_plugin_tools/src/firebase_test_lab_command.dart';
+import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -16,21 +16,21 @@ import 'util.dart';
 
 void main() {
   group('FirebaseTestLabCommand', () {
-    FileSystem fileSystem;
     late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      processRunner = RecordingProcessRunner();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner = CommandRunner<void>(

--- a/script/tool/test/fix_command_test.dart
+++ b/script/tool/test/fix_command_test.dart
@@ -4,30 +4,30 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/fix_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late MockPlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
     mockPlatform = MockPlatform();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-    processRunner = RecordingProcessRunner();
+    final GitDir gitDir;
+    (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks(platform: mockPlatform);
     final FixCommand command = FixCommand(
       packagesDir,
       processRunner: processRunner,
       platform: mockPlatform,
+      gitDir: gitDir,
     );
 
     runner = CommandRunner<void>('fix_command', 'Test for fix_command');

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:flutter_plugin_tools/src/format_command.dart';
+import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -15,7 +15,6 @@ import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late MockPlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
@@ -25,14 +24,15 @@ void main() {
   late String kotlinFormatPath;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
     mockPlatform = MockPlatform();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-    processRunner = RecordingProcessRunner();
+    final GitDir gitDir;
+    (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks(platform: mockPlatform);
     analyzeCommand = FormatCommand(
       packagesDir,
       processRunner: processRunner,
       platform: mockPlatform,
+      gitDir: gitDir,
     );
 
     // Create the Java and Kotlin formatter files that the command checks for,
@@ -40,11 +40,11 @@ void main() {
     final p.Context path = analyzeCommand.path;
     javaFormatPath = path.join(path.dirname(path.fromUri(mockPlatform.script)),
         'google-java-format-1.3-all-deps.jar');
-    fileSystem.file(javaFormatPath).createSync(recursive: true);
+    packagesDir.fileSystem.file(javaFormatPath).createSync(recursive: true);
     kotlinFormatPath = path.join(
         path.dirname(path.fromUri(mockPlatform.script)),
         'ktfmt-0.46-jar-with-dependencies.jar');
-    fileSystem.file(kotlinFormatPath).createSync(recursive: true);
+    packagesDir.fileSystem.file(kotlinFormatPath).createSync(recursive: true);
 
     runner = CommandRunner<void>('format_command', 'Test for format_command');
     runner.addCommand(analyzeCommand);

--- a/script/tool/test/gradle_check_command_test.dart
+++ b/script/tool/test/gradle_check_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/gradle_check_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';
@@ -16,15 +16,15 @@ const String _defaultFakeNamespace = 'dev.flutter.foo';
 
 void main() {
   late CommandRunner<void> runner;
-  late FileSystem fileSystem;
   late Directory packagesDir;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    packagesDir = fileSystem.currentDirectory.childDirectory('packages');
-    createPackagesDirectory(parentDir: packagesDir.parent);
+    final GitDir gitDir;
+    (:packagesDir, processRunner: _, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks();
     final GradleCheckCommand command = GradleCheckCommand(
       packagesDir,
+      gitDir: gitDir,
     );
 
     runner = CommandRunner<void>(

--- a/script/tool/test/license_check_command_test.dart
+++ b/script/tool/test/license_check_command_test.dart
@@ -4,33 +4,28 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/license_check_command.dart';
-import 'package:mockito/mockito.dart';
+import 'package:git/git.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
-import 'common/package_command_test.mocks.dart';
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
   group('LicenseCheckCommand', () {
     late CommandRunner<void> runner;
-    late FileSystem fileSystem;
     late Platform platform;
+    late Directory packagesDir;
     late Directory root;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
       platform = MockPlatformWithSeparator();
-      final Directory packagesDir =
-          fileSystem.currentDirectory.childDirectory('packages');
+      final GitDir gitDir;
+      (:packagesDir, processRunner: _, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: platform);
       root = packagesDir.parent;
-
-      final MockGitDir gitDir = MockGitDir();
-      when(gitDir.path).thenReturn(packagesDir.parent.path);
 
       final LicenseCheckCommand command = LicenseCheckCommand(
         packagesDir,

--- a/script/tool/test/lint_android_command_test.dart
+++ b/script/tool/test/lint_android_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/lint_android_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -15,21 +15,21 @@ import 'util.dart';
 
 void main() {
   group('LintAndroidCommand', () {
-    FileSystem fileSystem;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late MockPlatform mockPlatform;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       mockPlatform = MockPlatform();
-      processRunner = RecordingProcessRunner();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final LintAndroidCommand command = LintAndroidCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner = CommandRunner<void>(

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/list_command.dart';
 import 'package:test/test.dart';
 
@@ -13,15 +12,14 @@ import 'util.dart';
 
 void main() {
   group('ListCommand', () {
-    late FileSystem fileSystem;
     late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+      (:packagesDir, processRunner: _, gitProcessRunner: _, gitDir: _) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final ListCommand command =
           ListCommand(packagesDir, platform: mockPlatform);
 

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/podspec_check_command.dart';
+import 'package:git/git.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
@@ -75,22 +75,21 @@ end
 
 void main() {
   group('PodspecCheckCommand', () {
-    FileSystem fileSystem;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late MockPlatform mockPlatform;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-
       mockPlatform = MockPlatform(isMacOS: true);
-      processRunner = RecordingProcessRunner();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final PodspecCheckCommand command = PodspecCheckCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner =

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -4,9 +4,9 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/pubspec_check_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -136,21 +136,20 @@ false_secrets:
 void main() {
   group('test pubspec_check_command', () {
     late CommandRunner<void> runner;
-    late RecordingProcessRunner processRunner;
-    late FileSystem fileSystem;
     late MockPlatform mockPlatform;
     late Directory packagesDir;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform();
-      packagesDir = fileSystem.currentDirectory.childDirectory('packages');
-      createPackagesDirectory(parentDir: packagesDir.parent);
-      processRunner = RecordingProcessRunner();
+      final RecordingProcessRunner processRunner;
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final PubspecCheckCommand command = PubspecCheckCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner = CommandRunner<void>(
@@ -1851,21 +1850,20 @@ ${_topicsSection()}
 
   group('test pubspec_check_command on Windows', () {
     late CommandRunner<void> runner;
-    late RecordingProcessRunner processRunner;
-    late FileSystem fileSystem;
     late MockPlatform mockPlatform;
     late Directory packagesDir;
 
     setUp(() {
-      fileSystem = MemoryFileSystem(style: FileSystemStyle.windows);
       mockPlatform = MockPlatform(isWindows: true);
-      packagesDir = fileSystem.currentDirectory.childDirectory('packages');
-      createPackagesDirectory(parentDir: packagesDir.parent);
-      processRunner = RecordingProcessRunner();
+      final RecordingProcessRunner processRunner;
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
       final PubspecCheckCommand command = PubspecCheckCommand(
         packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
+        gitDir: gitDir,
       );
 
       runner = CommandRunner<void>(

--- a/script/tool/test/readme_check_command_test.dart
+++ b/script/tool/test/readme_check_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/readme_check_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -15,21 +15,20 @@ import 'util.dart';
 
 void main() {
   late CommandRunner<void> runner;
-  late RecordingProcessRunner processRunner;
-  late FileSystem fileSystem;
   late MockPlatform mockPlatform;
   late Directory packagesDir;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
     mockPlatform = MockPlatform();
-    packagesDir = fileSystem.currentDirectory.childDirectory('packages');
-    createPackagesDirectory(parentDir: packagesDir.parent);
-    processRunner = RecordingProcessRunner();
+    final RecordingProcessRunner processRunner;
+    final GitDir gitDir;
+    (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks(platform: mockPlatform);
     final ReadmeCheckCommand command = ReadmeCheckCommand(
       packagesDir,
       processRunner: processRunner,
       platform: mockPlatform,
+      gitDir: gitDir,
     );
 
     runner = CommandRunner<void>(

--- a/script/tool/test/remove_dev_dependencies_command_test.dart
+++ b/script/tool/test/remove_dev_dependencies_command_test.dart
@@ -4,23 +4,24 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/remove_dev_dependencies_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late Directory packagesDir;
   late CommandRunner<void> runner;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    final GitDir gitDir;
+    (:packagesDir, processRunner: _, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks();
 
     final RemoveDevDependenciesCommand command = RemoveDevDependenciesCommand(
       packagesDir,
+      gitDir: gitDir,
     );
     runner = CommandRunner<void>('trim_dev_dependencies_command',
         'Test for trim_dev_dependencies_command');

--- a/script/tool/test/repo_package_info_check_command_test.dart
+++ b/script/tool/test/repo_package_info_check_command_test.dart
@@ -4,28 +4,23 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/repo_package_info_check_command.dart';
-import 'package:mockito/mockito.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
-import 'common/package_command_test.mocks.dart';
 import 'util.dart';
 
 void main() {
   late CommandRunner<void> runner;
-  late FileSystem fileSystem;
   late Directory root;
   late Directory packagesDir;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    root = fileSystem.currentDirectory;
-    packagesDir = root.childDirectory('packages');
-
-    final MockGitDir gitDir = MockGitDir();
-    when(gitDir.path).thenReturn(root.path);
+    final GitDir gitDir;
+    (:packagesDir, processRunner: _, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks();
+    root = packagesDir.fileSystem.currentDirectory;
 
     final RepoPackageInfoCheckCommand command = RepoPackageInfoCheckCommand(
       packagesDir,

--- a/script/tool/test/update_dependency_command_test.dart
+++ b/script/tool/test/update_dependency_command_test.dart
@@ -6,9 +6,9 @@ import 'dart:convert';
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/update_dependency_command.dart';
+import 'package:git/git.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -18,19 +18,19 @@ import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  FileSystem fileSystem;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
   Future<http.Response> Function(http.Request request)? mockHttpResponse;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    processRunner = RecordingProcessRunner();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    final GitDir gitDir;
+    (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks();
     final UpdateDependencyCommand command = UpdateDependencyCommand(
       packagesDir,
       processRunner: processRunner,
+      gitDir: gitDir,
       httpClient:
           MockClient((http.Request request) => mockHttpResponse!(request)),
     );

--- a/script/tool/test/update_excerpts_command_test.dart
+++ b/script/tool/test/update_excerpts_command_test.dart
@@ -4,32 +4,29 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/update_excerpts_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
-import 'common/package_command_test.mocks.dart';
 import 'mocks.dart';
 import 'util.dart';
 
 void runAllTests(MockPlatform platform) {
-  late FileSystem fileSystem;
   late Directory packagesDir;
   late CommandRunner<void> runner;
 
   setUp(() {
-    fileSystem = MemoryFileSystem(
-        style: platform.isWindows
-            ? FileSystemStyle.windows
-            : FileSystemStyle.posix);
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    final RecordingProcessRunner processRunner;
+    final GitDir gitDir;
+    (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks(platform: platform);
     runner = CommandRunner<void>('', '')
       ..addCommand(UpdateExcerptsCommand(
         packagesDir,
         platform: platform,
-        processRunner: RecordingProcessRunner(),
-        gitDir: MockGitDir(),
+        processRunner: processRunner,
+        gitDir: gitDir,
       ));
   });
 

--- a/script/tool/test/update_min_sdk_command_test.dart
+++ b/script/tool/test/update_min_sdk_command_test.dart
@@ -4,23 +4,24 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/update_min_sdk_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';
 
 void main() {
-  late FileSystem fileSystem;
   late Directory packagesDir;
   late CommandRunner<void> runner;
 
   setUp(() {
-    fileSystem = MemoryFileSystem();
-    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    final GitDir gitDir;
+    (:packagesDir, processRunner: _, gitProcessRunner: _, :gitDir) =
+        configureBaseCommandMocks();
 
     final UpdateMinSdkCommand command = UpdateMinSdkCommand(
       packagesDir,
+      gitDir: gitDir,
     );
     runner = CommandRunner<void>(
         'update_min_sdk_command', 'Test for update_min_sdk_command');

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -14,6 +14,7 @@ import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:flutter_plugin_tools/src/common/repository_package.dart';
+import 'package:git/git.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
@@ -31,19 +32,11 @@ const String _defaultFlutterConstraint = '>=2.5.0';
 String getFlutterCommand(Platform platform) =>
     platform.isWindows ? 'flutter.bat' : 'flutter';
 
-/// Creates a packages directory in the given location.
-///
-/// If [parentDir] is set the packages directory will be created there,
-/// otherwise [fileSystem] must be provided and it will be created an arbitrary
-/// location in that filesystem.
-Directory createPackagesDirectory(
-    {Directory? parentDir, FileSystem? fileSystem}) {
-  assert(parentDir != null || fileSystem != null,
-      'One of parentDir or fileSystem must be provided');
-  assert(fileSystem == null || fileSystem is MemoryFileSystem,
-      'If using a real filesystem, parentDir must be provided');
+/// Creates a packages directory at an arbitrary location in the given
+/// filesystem.
+Directory createPackagesDirectory(FileSystem fileSystem) {
   final Directory packagesDir =
-      (parentDir ?? fileSystem!.currentDirectory).childDirectory('packages');
+      fileSystem.currentDirectory.childDirectory('packages');
   packagesDir.createSync();
   return packagesDir;
 }
@@ -493,4 +486,46 @@ class ProcessCall {
     final List<String> command = <String>[executable, ...args];
     return '"${command.join(' ')}" in $workingDir';
   }
+}
+
+/// Sets up standard mocking common to most command unit test setUp methods,
+/// including a packages directory in an in-memory filesystem, and a mock
+/// process handling (including git commands sent by GitDir).
+///
+/// The returned GitDir instance forwards to a mock process runner, as described
+/// in [createForwardingMockGitDir]. This process runner is separate, so that
+/// tests can easily treat most git commands called as internal implementation
+/// details, and assert on the exact list of non-git commands that are run.
+({
+  Directory packagesDir,
+  RecordingProcessRunner processRunner,
+  RecordingProcessRunner gitProcessRunner,
+  GitDir gitDir,
+}) configureBaseCommandMocks({
+  Platform? platform,
+  RecordingProcessRunner? customProcessRunner,
+  RecordingProcessRunner? customGitProcessRunner,
+}) {
+  final FileSystem fileSystem = MemoryFileSystem(
+      style: (platform?.isWindows ?? false)
+          ? FileSystemStyle.windows
+          : FileSystemStyle.posix);
+  final Directory packagesDir = createPackagesDirectory(fileSystem);
+
+  final RecordingProcessRunner processRunner =
+      customProcessRunner ?? RecordingProcessRunner();
+
+  final RecordingProcessRunner gitProcessRunner =
+      customGitProcessRunner ?? RecordingProcessRunner();
+  final GitDir gitDir = createForwardingMockGitDir(
+    packagesDir: packagesDir,
+    processRunner: gitProcessRunner,
+  );
+
+  return (
+    packagesDir: packagesDir,
+    processRunner: processRunner,
+    gitProcessRunner: gitProcessRunner,
+    gitDir: gitDir,
+  );
 }

--- a/script/tool/test/xcode_analyze_command_test.dart
+++ b/script/tool/test/xcode_analyze_command_test.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/xcode_analyze_command.dart';
+import 'package:git/git.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -17,19 +17,22 @@ import 'util.dart';
 // doing all the process mocking and validation.
 void main() {
   group('test xcode_analyze_command', () {
-    late FileSystem fileSystem;
     late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform(isMacOS: true);
-      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      processRunner = RecordingProcessRunner();
-      final XcodeAnalyzeCommand command = XcodeAnalyzeCommand(packagesDir,
-          processRunner: processRunner, platform: mockPlatform);
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) =
+          configureBaseCommandMocks(platform: mockPlatform);
+      final XcodeAnalyzeCommand command = XcodeAnalyzeCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+        gitDir: gitDir,
+      );
 
       runner = CommandRunner<void>(
           'xcode_analyze_command', 'Test for xcode_analyze_command');


### PR DESCRIPTION
Consolidates the code to find all changed file paths into the `PackageLoopingCommand` class that is the base of almost all of the repo tooling commands. This in a preparatory PR for a future change to allow each command to define a list of files or file patterns that definitively *don't* affect that test, so that CI can be smarter about what tests to run (e.g., not running expensive integration tests for README changes).

A side effect of this change is that tests of almost all commands now need a mock `GitDir` instance. This would add a lot of copy/pasted boilerplate to the test setup, and there is already too much of that, so instead this refactors common test setup:
- Creating a memory file system
- Populating it with a packages directory
- Creating a RecordingProcessRunner to mock out process calls
- Creating a mock GitDir that forwards to a RecordingProcessRunner

into a helper method (using records and destructuring to easily return multiple values). While some tests don't need all of these steps, those that don't can easily ignore parts of it, and it will make it much easier to update tests in the future if they need them, and it makes the setup much more consistent which makes it easier to reason about test setup in general.

Prep for https://github.com/flutter/flutter/issues/136394

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
