### PR TITLE
[camera] Skip another flaky Android test

### DIFF
--- a/packages/camera/camera_android_camerax/test/recorder_test.dart
+++ b/packages/camera/camera_android_camerax/test/recorder_test.dart
@@ -71,7 +71,7 @@ void main() {
 
       verify(mockApi.create(argThat(isA<int>()), aspectRatio, bitRate,
           qualitySelectorIdentifier));
-    });
+    }, skip: 'Flaky test: https://github.com/flutter/flutter/issues/164132');
 
     test('getDefaultQualitySelector returns expected QualitySelector',
         () async {


### PR DESCRIPTION
This test is showing the same flake as the recently-skipped "detached create does not call create on the Java side" tests.

See https://github.com/flutter/flutter/issues/164132