### PR TITLE
[various] Updates packages to use flutter.compileSdkVersion

### DIFF
--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.10+1
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 0.10.10
 
 * Adds API support query for image streaming.

--- a/packages/camera/camera_android/android/build.gradle
+++ b/packages/camera/camera_android/android/build.gradle
@@ -31,7 +31,7 @@ buildFeatures {
         buildConfig true
     }
     namespace 'io.flutter.plugins.camera'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 21

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 
-version: 0.10.10
+version: 0.10.10+1
 
 environment:
   sdk: ^3.5.0

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.14+1
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 0.6.14
 
 * Fixes incorrect camera preview rotation.

--- a/packages/camera/camera_android_camerax/android/build.gradle
+++ b/packages/camera/camera_android_camerax/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.android.library'
 android {
     namespace 'io.flutter.plugins.camerax'
     // CameraX dependencies require compilation against version 33 or later.
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.14
+version: 0.6.14+1
 
 environment:
   sdk: ^3.6.0

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+6
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 0.4.0+5
 
 * Bumps com.squareup.okhttp3, com.google.code.gson, and com.google.truth.

--- a/packages/espresso/android/build.gradle
+++ b/packages/espresso/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'com.example.espresso'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -3,7 +3,7 @@ description: Java classes for testing Flutter apps using Espresso.
   Allows driving Flutter widgets from a native Espresso test.
 repository: https://github.com/flutter/packages/tree/main/packages/espresso
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+espresso%22
-version: 0.4.0+5
+version: 0.4.0+6
 
 environment:
   sdk: ^3.5.0

--- a/packages/file_selector/file_selector_android/CHANGELOG.md
+++ b/packages/file_selector/file_selector_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1+13
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 0.5.1+12
 
 * Fixes a security issue related to improperly trusting filenames provided by a `ContentProvider`.

--- a/packages/file_selector/file_selector_android/android/build.gradle
+++ b/packages/file_selector/file_selector_android/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'dev.flutter.packages.file_selector_android'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/packages/file_selector/file_selector_android/pubspec.yaml
+++ b/packages/file_selector/file_selector_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_android
 description: Android implementation of the file_selector package.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.5.1+12
+version: 0.5.1+13
 
 environment:
   sdk: ^3.5.0

--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.25
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 2.0.24
 
 * Updates annotation to 1.9.1.

--- a/packages/flutter_plugin_android_lifecycle/android/build.gradle
+++ b/packages/flutter_plugin_android_lifecycle/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'io.flutter.plugins.flutter_plugin_android_lifecycle'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_android_lifecycle
 description: Flutter plugin for accessing an Android Lifecycle within other plugins.
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_plugin_android_lifecycle
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_plugin_android_lifecycle%22
-version: 2.0.24
+version: 2.0.25
 
 environment:
   sdk: ^3.5.0

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.14.14
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 2.14.13
 
 * Updates READMEs and API docs.

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'io.flutter.plugins.googlemaps'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 20

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_android
 description: Android implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.14.13
+version: 2.14.14
 
 environment:
   sdk: ^3.5.0

--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.36
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 6.1.35
 
 * Removes the dependency on the Guava library.

--- a/packages/google_sign_in/google_sign_in_android/android/build.gradle
+++ b/packages/google_sign_in/google_sign_in_android/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'io.flutter.plugins.googlesignin'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_android
 description: Android implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 6.1.35
+version: 6.1.36
 
 environment:
   sdk: ^3.5.0

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.12+22
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 0.8.12+21
 
 * Ensures that platform messages on background queues are handled in order.

--- a/packages/image_picker/image_picker_android/android/build.gradle
+++ b/packages/image_picker/image_picker_android/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'io.flutter.plugins.imagepicker'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.12+21
+version: 0.8.12+22
 
 environment:
   sdk: ^3.5.0

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+1
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 0.4.0
 
 * Updates Google Play Billing Library from 6.2.0 to 7.1.1.

--- a/packages/in_app_purchase/in_app_purchase_android/android/build.gradle
+++ b/packages/in_app_purchase/in_app_purchase_android/android/build.gradle
@@ -27,8 +27,8 @@ android {
     }
 
     namespace 'io.flutter.plugins.inapppurchase'
-    
-    compileSdk 34
+
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdk 21

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.4.0
+version: 0.4.0+1
 
 environment:
   sdk: ^3.5.0

--- a/packages/interactive_media_ads/CHANGELOG.md
+++ b/packages/interactive_media_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3+8
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 0.2.3+7
 
 * Bumps gradle-plugin to 2.1.10.

--- a/packages/interactive_media_ads/android/build.gradle
+++ b/packages/interactive_media_ads/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'dev.flutter.packages.interactive_media_ads'
 
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/packages/interactive_media_ads/pubspec.yaml
+++ b/packages/interactive_media_ads/pubspec.yaml
@@ -2,7 +2,7 @@ name: interactive_media_ads
 description: A Flutter plugin for using the Interactive Media Ads SDKs on Android and iOS.
 repository: https://github.com/flutter/packages/tree/main/packages/interactive_media_ads
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+interactive_media_ads%22
-version: 0.2.3+7 # This must match the version in
+version: 0.2.3+8 # This must match the version in
   # `android/src/main/kotlin/dev/flutter/packages/interactive_media_ads/AdsRequestProxyApi.kt` and
   # `ios/interactive_media_ads/Sources/interactive_media_ads/AdsRequestProxyAPIDelegate.swift`
 

--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.48
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 1.0.47
 
 * Adds compatibility with `intl` 0.20.0.

--- a/packages/local_auth/local_auth_android/android/build.gradle
+++ b/packages/local_auth/local_auth_android/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'io.flutter.plugins.localauth'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.47
+version: 1.0.48
 
 environment:
   sdk: ^3.5.0

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.16
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 2.2.15
 
 * Removes unnecessary native code.

--- a/packages/path_provider/path_provider_android/android/build.gradle
+++ b/packages/path_provider/path_provider_android/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'io.flutter.plugins.pathprovider'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_android
 description: Android implementation of the path_provider plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.2.15
+version: 2.2.16
 
 environment:
   sdk: ^3.5.0

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 24.2.2
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 24.2.1
 
 * [dart] Fixes potential race condition caused by a ProxyApi constructor message call being made in

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'com.example.alternate_language_test_plugin'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/packages/pigeon/platform_tests/test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.example.test_plugin'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 24.2.1 # This must match the version in lib/src/generator_tools.dart
+version: 24.2.2 # This must match the version in lib/src/generator_tools.dart
 
 environment:
   sdk: ^3.4.0

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.20
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 1.0.19
 
 * Updates `pigeon` dependency to version 24.

--- a/packages/quick_actions/quick_actions_android/android/build.gradle
+++ b/packages/quick_actions/quick_actions_android/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'io.flutter.plugins.quickactions'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_android
 description: An implementation for the Android platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/quick_actions/quick_actions_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 1.0.19
+version: 1.0.20
 
 environment:
   sdk: ^3.5.0

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.7
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 2.4.6
 
 * Ensures that platform messages on background queues are handled in order.

--- a/packages/shared_preferences/shared_preferences_android/android/build.gradle
+++ b/packages/shared_preferences/shared_preferences_android/android/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'io.flutter.plugins.sharedpreferences'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.4.6
+version: 2.4.7
 
 environment:
   sdk: ^3.5.0

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.15
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 6.3.14
 
 * Bumps androidx.annotation:annotation from 1.9.0 to 1.9.1.

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -26,7 +26,7 @@ android {
         buildConfig true
     }
     namespace 'io.flutter.plugins.urllauncher'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.3.14
+version: 6.3.15
 environment:
   sdk: ^3.5.0
   flutter: ">=3.24.0"

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.7.18
 
+* Updates compileSdk 34 to flutter.compileSdkVersion.
 * Suppresses deprecation and removal warnings for
   `TextureRegistry.SurfaceProducer.onSurfaceDestroyed`.
 

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'io.flutter.plugins.videoplayer'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 21

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.7.17
+version: 2.7.18
 
 environment:
   sdk: ^3.6.0

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.3
+
+* Updates compileSdk 34 to flutter.compileSdkVersion.
+
 ## 4.3.2
 
 * Bumps gradle-plugin to 2.1.10.

--- a/packages/webview_flutter/webview_flutter_android/android/build.gradle
+++ b/packages/webview_flutter/webview_flutter_android/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'io.flutter.plugins.webviewflutter'
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.3.2
+version: 4.3.3
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
- **Updates compileSdk 34 to flutter.compileSdkVersion.**

Related to flutter/flutter/issues/149836
Want to wait a couple of days after 
https://github.com/flutter/packages/pull/8700 lands before landing. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
