### PR TITLE
[video_player] Disable flaky `testAudioOnlyHLSControls`

### DIFF
--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
@@ -616,6 +616,7 @@ NSObject<FlutterPluginRegistry> *GetPluginRegistry(void) {
 }
 
 - (void)testAudioOnlyHLSControls {
+  XCTSkip(@"Flaky; see https://github.com/flutter/flutter/issues/164381");
   NSObject<FlutterPluginRegistrar> *registrar =
       [GetPluginRegistry() registrarForPlugin:@"TestAudioOnlyHLSControls"];
 


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/164381