### PR TITLE
[webview_flutter_wkwebview] Extended Web View API on iOS to add flexibility when working with local HTML content

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.9.0
+
+* Adds support for `PlatformWebViewController.loadFileWithParams`.
+* Introduces `AndroidLoadFileParams`, a platform-specific extension of `LoadFileParams` for Android that adds support for `headers`.
+
 ## 4.8.2
 
 * Bumps gradle from 8.9.0 to 8.11.1.

--- a/packages/webview_flutter/webview_flutter_android/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  webview_flutter_platform_interface: ^2.13.0
+  webview_flutter_platform_interface: ^2.14.0
 
 dev_dependencies:
   espresso: ^0.4.0

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
@@ -18,6 +18,41 @@ import 'android_webkit_constants.dart';
 import 'platform_views_service_proxy.dart';
 import 'weak_reference_utils.dart';
 
+/// Object specifying parameters for loading a local file in a
+/// [AndroidWebViewController].
+@immutable
+base class AndroidLoadFileParams extends LoadFileParams {
+  /// Constructs a [AndroidLoadFileParams], the subclass of a [LoadFileParams].
+  AndroidLoadFileParams({
+    required String absoluteFilePath,
+    this.headers = const <String, String>{},
+  }) : super(
+          absoluteFilePath: absoluteFilePath.startsWith('file://')
+              ? absoluteFilePath
+              : Uri.file(absoluteFilePath).toString(),
+        );
+
+  /// Constructs a [AndroidLoadFileParams] using a [LoadFileParams].
+  factory AndroidLoadFileParams.fromLoadFileParams(
+    LoadFileParams params, {
+    Map<String, String> headers = const <String, String>{},
+  }) {
+    return AndroidLoadFileParams(
+      absoluteFilePath: params.absoluteFilePath,
+      headers: headers,
+    );
+  }
+
+  /// Additional HTTP headers to be included when loading the local file.
+  ///
+  /// If not provided at initialization time, doesn't add any additional headers.
+  ///
+  /// On Android, WebView supports adding headers when loading local or remote
+  /// content. This can be useful for scenarios like authentication,
+  /// content-type overrides, or custom request context.
+  final Map<String, String> headers;
+}
+
 /// Object specifying creation parameters for creating a [AndroidWebViewController].
 ///
 /// When adding additional fields make sure they can be null or have a default
@@ -386,12 +421,29 @@ class AndroidWebViewController extends PlatformWebViewController {
   Future<void> loadFile(
     String absoluteFilePath,
   ) {
-    final String url = absoluteFilePath.startsWith('file://')
-        ? absoluteFilePath
-        : Uri.file(absoluteFilePath).toString();
+    return loadFileWithParams(
+      AndroidLoadFileParams(
+        absoluteFilePath: absoluteFilePath,
+      ),
+    );
+  }
 
-    _webView.settings.setAllowFileAccess(true);
-    return _webView.loadUrl(url, <String, String>{});
+  @override
+  Future<void> loadFileWithParams(
+    LoadFileParams params,
+  ) async {
+    switch (params) {
+      case final AndroidLoadFileParams params:
+        await Future.wait(<Future<void>>[
+          _webView.settings.setAllowFileAccess(true),
+          _webView.loadUrl(params.absoluteFilePath, params.headers),
+        ]);
+
+      default:
+        await loadFileWithParams(
+          AndroidLoadFileParams.fromLoadFileParams(params),
+        );
+    }
   }
 
   @override

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.8.2
+version: 4.9.0
 
 environment:
   sdk: ^3.6.0
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.10.0
-  webview_flutter_platform_interface: ^2.13.0
+  webview_flutter_platform_interface: ^2.14.0
 
 dev_dependencies:
   build_runner: ^2.1.4

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
@@ -274,7 +274,7 @@ void main() {
           ));
     }
 
-    test('loadFile without file prefix', () async {
+    test('Initializing WebView settings on controller creation', () async {
       final MockWebView mockWebView = MockWebView();
       final MockWebSettings mockWebSettings = MockWebSettings();
       createControllerWithMocks(
@@ -292,56 +292,209 @@ void main() {
       verify(mockWebSettings.setUseWideViewPort(false)).called(1);
     });
 
-    test('loadFile without file prefix', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockWebSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-        mockSettings: mockWebSettings,
-      );
+    group('loadFile', () {
+      test('Without file prefix', () async {
+        final MockWebView mockWebView = MockWebView();
+        final MockWebSettings mockWebSettings = MockWebSettings();
+        final AndroidWebViewController controller = createControllerWithMocks(
+          mockWebView: mockWebView,
+          mockSettings: mockWebSettings,
+        );
 
-      await controller.loadFile('/path/to/file.html');
+        await controller.loadFile('/path/to/file.html');
 
-      verify(mockWebSettings.setAllowFileAccess(true)).called(1);
-      verify(mockWebView.loadUrl(
-        'file:///path/to/file.html',
-        <String, String>{},
-      )).called(1);
+        verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+        verify(mockWebView.loadUrl(
+          'file:///path/to/file.html',
+          <String, String>{},
+        )).called(1);
+      });
+
+      test('Without file prefix and characters to be escaped', () async {
+        final MockWebView mockWebView = MockWebView();
+        final MockWebSettings mockWebSettings = MockWebSettings();
+        final AndroidWebViewController controller = createControllerWithMocks(
+          mockWebView: mockWebView,
+          mockSettings: mockWebSettings,
+        );
+
+        await controller.loadFile('/path/to/?_<_>_.html');
+
+        verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+        verify(mockWebView.loadUrl(
+          'file:///path/to/%3F_%3C_%3E_.html',
+          <String, String>{},
+        )).called(1);
+      });
+
+      test('With file prefix', () async {
+        final MockWebView mockWebView = MockWebView();
+        final MockWebSettings mockWebSettings = MockWebSettings();
+        final AndroidWebViewController controller = createControllerWithMocks(
+          mockWebView: mockWebView,
+        );
+
+        when(mockWebView.settings).thenReturn(mockWebSettings);
+
+        await controller.loadFile('file:///path/to/file.html');
+
+        verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+        verify(mockWebView.loadUrl(
+          'file:///path/to/file.html',
+          <String, String>{},
+        )).called(1);
+      });
     });
 
-    test('loadFile without file prefix and characters to be escaped', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockWebSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-        mockSettings: mockWebSettings,
-      );
+    group('loadFileWithParams', () {
+      group('Using LoadFileParams model', () {
+        test('Without file prefix', () async {
+          final MockWebView mockWebView = MockWebView();
+          final MockWebSettings mockWebSettings = MockWebSettings();
+          final AndroidWebViewController controller = createControllerWithMocks(
+            mockWebView: mockWebView,
+            mockSettings: mockWebSettings,
+          );
 
-      await controller.loadFile('/path/to/?_<_>_.html');
+          await controller.loadFileWithParams(
+            const LoadFileParams(absoluteFilePath: '/path/to/file.html'),
+          );
 
-      verify(mockWebSettings.setAllowFileAccess(true)).called(1);
-      verify(mockWebView.loadUrl(
-        'file:///path/to/%3F_%3C_%3E_.html',
-        <String, String>{},
-      )).called(1);
-    });
+          verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+          verify(mockWebView.loadUrl(
+            'file:///path/to/file.html',
+            <String, String>{},
+          )).called(1);
+        });
 
-    test('loadFile with file prefix', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockWebSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
+        test('Without file prefix and characters to be escaped', () async {
+          final MockWebView mockWebView = MockWebView();
+          final MockWebSettings mockWebSettings = MockWebSettings();
+          final AndroidWebViewController controller = createControllerWithMocks(
+            mockWebView: mockWebView,
+            mockSettings: mockWebSettings,
+          );
 
-      when(mockWebView.settings).thenReturn(mockWebSettings);
+          await controller.loadFileWithParams(
+            const LoadFileParams(absoluteFilePath: '/path/to/?_<_>_.html'),
+          );
 
-      await controller.loadFile('file:///path/to/file.html');
+          verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+          verify(mockWebView.loadUrl(
+            'file:///path/to/%3F_%3C_%3E_.html',
+            <String, String>{},
+          )).called(1);
+        });
 
-      verify(mockWebSettings.setAllowFileAccess(true)).called(1);
-      verify(mockWebView.loadUrl(
-        'file:///path/to/file.html',
-        <String, String>{},
-      )).called(1);
+        test('With file prefix', () async {
+          final MockWebView mockWebView = MockWebView();
+          final MockWebSettings mockWebSettings = MockWebSettings();
+          final AndroidWebViewController controller = createControllerWithMocks(
+            mockWebView: mockWebView,
+            mockSettings: mockWebSettings,
+          );
+
+          await controller.loadFileWithParams(
+            const LoadFileParams(absoluteFilePath: 'file:///path/to/file.html'),
+          );
+
+          verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+          verify(mockWebView.loadUrl(
+            'file:///path/to/file.html',
+            <String, String>{},
+          )).called(1);
+        });
+      });
+
+      group('Using WebKitLoadFileParams model', () {
+        test('Without file prefix', () async {
+          final MockWebView mockWebView = MockWebView();
+          final MockWebSettings mockWebSettings = MockWebSettings();
+          final AndroidWebViewController controller = createControllerWithMocks(
+            mockWebView: mockWebView,
+            mockSettings: mockWebSettings,
+          );
+
+          await controller.loadFileWithParams(
+            AndroidLoadFileParams(absoluteFilePath: '/path/to/file.html'),
+          );
+
+          verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+          verify(mockWebView.loadUrl(
+            'file:///path/to/file.html',
+            <String, String>{},
+          )).called(1);
+        });
+
+        test('Without file prefix and characters to be escaped', () async {
+          final MockWebView mockWebView = MockWebView();
+          final MockWebSettings mockWebSettings = MockWebSettings();
+          final AndroidWebViewController controller = createControllerWithMocks(
+            mockWebView: mockWebView,
+            mockSettings: mockWebSettings,
+          );
+
+          await controller.loadFileWithParams(
+            AndroidLoadFileParams(absoluteFilePath: '/path/to/?_<_>_.html'),
+          );
+
+          verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+          verify(mockWebView.loadUrl(
+            'file:///path/to/%3F_%3C_%3E_.html',
+            <String, String>{},
+          )).called(1);
+        });
+
+        test('With file prefix', () async {
+          final MockWebView mockWebView = MockWebView();
+          final MockWebSettings mockWebSettings = MockWebSettings();
+          final AndroidWebViewController controller = createControllerWithMocks(
+            mockWebView: mockWebView,
+            mockSettings: mockWebSettings,
+          );
+
+          await controller.loadFileWithParams(
+            AndroidLoadFileParams(
+                absoluteFilePath: 'file:///path/to/file.html'),
+          );
+
+          verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+          verify(mockWebView.loadUrl(
+            'file:///path/to/file.html',
+            <String, String>{},
+          )).called(1);
+        });
+
+        test('With additional headers', () async {
+          final MockWebView mockWebView = MockWebView();
+          final MockWebSettings mockWebSettings = MockWebSettings();
+          final AndroidWebViewController controller = createControllerWithMocks(
+            mockWebView: mockWebView,
+            mockSettings: mockWebSettings,
+          );
+
+          await controller.loadFileWithParams(
+            AndroidLoadFileParams(
+              absoluteFilePath: 'file:///path/to/file.html',
+              headers: const <String, String>{
+                'Authorization': 'Bearer test_token',
+                'Cache-Control': 'no-cache',
+                'X-Custom-Header': 'test-value',
+              },
+            ),
+          );
+
+          verify(mockWebSettings.setAllowFileAccess(true)).called(1);
+          verify(mockWebView.loadUrl(
+            'file:///path/to/file.html',
+            const <String, String>{
+              'Authorization': 'Bearer test_token',
+              'Cache-Control': 'no-cache',
+              'X-Custom-Header': 'test-value',
+            },
+          )).called(1);
+        });
+      });
     });
 
     test('loadFlutterAsset when asset does not exist', () async {

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.23.0
+
+* Adds support for `PlatformWebViewController.loadFileWithParams`.
+* Introduces `WebKitLoadFileParams`, a platform-specific extension of `LoadFileParams` for iOS and macOS that adds support for `readAccessPath`.
+
 ## 3.22.1
 
 * Changes the handling of a Flutter method failure from throwing an assertion error to logging the

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider: ^2.0.6
-  webview_flutter_platform_interface: ^2.13.0
+  webview_flutter_platform_interface: ^2.14.0
   webview_flutter_wkwebview:
     # When depending on this package from a real application you should use:
     #   webview_flutter: ^x.y.z

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.22.1
+version: 3.23.0
 
 environment:
   sdk: ^3.6.0
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   meta: ^1.10.0
   path: ^1.8.0
-  webview_flutter_platform_interface: ^2.13.0
+  webview_flutter_platform_interface: ^2.14.0
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
@@ -341,6 +341,40 @@ void main() {
       verify(mockWebView.loadFileUrl('/path/to/file.html', '/path/to'));
     });
 
+    group('loadFileWithParams', () {
+      test('Using LoadFileParams model', () async {
+        final MockUIViewWKWebView mockWebView = MockUIViewWKWebView();
+
+        final WebKitWebViewController controller = createControllerWithMocks(
+          createMockWebView: (_, {dynamic observeValue}) => mockWebView,
+        );
+
+        await controller.loadFileWithParams(
+          const LoadFileParams(absoluteFilePath: '/path/to/file.html'),
+        );
+        verify(mockWebView.loadFileUrl('/path/to/file.html', '/path/to'));
+      });
+
+      test('Using WebKitLoadFileParams with custom readAccessPath', () async {
+        final MockUIViewWKWebView mockWebView = MockUIViewWKWebView();
+
+        final WebKitWebViewController controller = createControllerWithMocks(
+          createMockWebView: (_, {dynamic observeValue}) => mockWebView,
+        );
+
+        await controller.loadFileWithParams(
+          WebKitLoadFileParams(
+            absoluteFilePath: '/path/to/file.html',
+            readAccessPath: '/path/to/resources/',
+          ),
+        );
+        verify(mockWebView.loadFileUrl(
+          '/path/to/file.html',
+          '/path/to/resources/',
+        ));
+      });
+    });
+
     test('loadFlutterAsset', () async {
       final MockUIViewWKWebView mockWebView = MockUIViewWKWebView();
 


### PR DESCRIPTION
## Overview

The `readAccessURLProvider` property has been added to the `WebKitWebViewControllerCreationParams` class. This function allows customization of the path to associated resources when loading a local HTML page using `loadFile` on iOS.

### What Is the Issue

Fixes https://github.com/flutter/flutter/issues/136479

The native `WKWebView` takes two arguments when loading local HTML pages:

1. **The file URL** – The local HTML file to be loaded.
2. **The read access URL** – A file or directory that `WKWebView` can access (e.g., .css, .js files).

Currently, the Flutter implementation always sets the parent folder of the specified HTML file as the read access directory. This behavior is not configurable, which limits how local web content can be structured.

For example, the following structure does not work because the .css and .js files are not in the parent directory of the HTML file:
```
/app_resources/
│── styles/
│    ├── main.css
│
│── scripts/
│    ├── app.js
│
│── pages/
     ├── index.html  (Loaded file)
```
With the existing behavior, `WKWebView` cannot `access styles/main.css` and `scripts/app.js` because the parent folder of `index.html` (`/pages/`) does not contain them.

### How This Resolves the Issue

The `readAccessURLProvider` property has been added to the `WebKitWebViewControllerCreationParams` class. This property accepts a function that takes the path of the HTML file being loaded and returns the path to the associated resources.

![Screenshot at Mar 04 14-49-46](https://github.com/user-attachments/assets/be9ce41f-4a8c-4e91-b73c-041e22f59d29)

Each time `loadFile` is called, the controller invokes this function and passes its result as the second argument to the underlying `WKWebView` implementation.

By default, the function returns the parent directory of the specified HTML file, preserving the existing behavior when no custom provider is set.

### Impact on End Users

1. Developers can now explicitly specify the directory that `WKWebView` should allow access to when loading a local HTML page, providing greater flexibility in organizing assets.
2. The existing API signature remains unchanged, ensuring that the update does not require any modifications to existing codebases unless the new functionality is utilized.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
