### PR TITLE
[image_picker] Fix getMedia on Linux

### DIFF
--- a/packages/image_picker/image_picker_linux/CHANGELOG.md
+++ b/packages/image_picker/image_picker_linux/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.2.1+2
 
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
+* Fixes `getMedia` mime types.
 
 ## 0.2.1+1
 

--- a/packages/image_picker/image_picker_linux/lib/image_picker_linux.dart
+++ b/packages/image_picker/image_picker_linux/lib/image_picker_linux.dart
@@ -161,7 +161,9 @@ class ImagePickerLinux extends CameraDelegatingImagePickerPlatform {
   @override
   Future<List<XFile>> getMedia({required MediaOptions options}) async {
     const XTypeGroup typeGroup = XTypeGroup(
-        label: 'images and videos', extensions: <String>['image/*', 'video/*']);
+      label: 'Images and videos',
+      mimeTypes: <String>['image/*', 'video/*'],
+    );
 
     List<XFile> files;
 

--- a/packages/image_picker/image_picker_linux/pubspec.yaml
+++ b/packages/image_picker/image_picker_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_linux
 description: Linux platform implementation of image_picker
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.2.1+1
+version: 0.2.1+2
 
 environment:
   sdk: ^3.4.0

--- a/packages/image_picker/image_picker_linux/test/image_picker_linux_test.dart
+++ b/packages/image_picker/image_picker_linux/test/image_picker_linux_test.dart
@@ -133,7 +133,7 @@ void main() {
       final VerificationResult result = verify(
           mockFileSelectorPlatform.openFiles(
               acceptedTypeGroups: captureAnyNamed('acceptedTypeGroups')));
-      expect(capturedTypeGroups(result)[0].extensions,
+      expect(capturedTypeGroups(result)[0].mimeTypes,
           <String>['image/*', 'video/*']);
     });
 


### PR DESCRIPTION
The previous version had a typo where it specified the mime types using the `extensions` field.

~~part of https://github.com/flutter/flutter/issues/148635~~

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under.
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [ ] All existing and new tests are passing.