### PR TITLE
[camera] Fix unit test asserting external value

### DIFF
--- a/packages/camera/camera/test/camera_value_test.dart
+++ b/packages/camera/camera/test/camera_value_test.dart
@@ -146,8 +146,22 @@ void main() {
         description: FakeController.fakeDescription,
       );
 
-      expect(cameraValue.toString(),
-          'CameraValue(isRecordingVideo: false, isInitialized: false, errorDescription: null, previewSize: Size(10.0, 10.0), isStreamingImages: false, flashMode: FlashMode.auto, exposureMode: ExposureMode.auto, focusMode: FocusMode.auto, exposurePointSupported: true, focusPointSupported: true, deviceOrientation: DeviceOrientation.portraitUp, lockedCaptureOrientation: DeviceOrientation.portraitUp, recordingOrientation: DeviceOrientation.portraitUp, isPreviewPaused: true, previewPausedOrientation: DeviceOrientation.portraitUp, description: CameraDescription(, CameraLensDirection.back, 0))');
+      expect(
+          cameraValue.toString(),
+          'CameraValue(isRecordingVideo: false, isInitialized: false, '
+          'errorDescription: null, previewSize: Size(10.0, 10.0), '
+          'isStreamingImages: false, flashMode: FlashMode.auto, '
+          'exposureMode: ExposureMode.auto, focusMode: FocusMode.auto, '
+          'exposurePointSupported: true, focusPointSupported: true, '
+          'deviceOrientation: DeviceOrientation.portraitUp, '
+          'lockedCaptureOrientation: DeviceOrientation.portraitUp, '
+          'recordingOrientation: DeviceOrientation.portraitUp, '
+          'isPreviewPaused: true, '
+          'previewPausedOrientation: DeviceOrientation.portraitUp, '
+          // CameraDescription.toString is defined in the platform interface
+          // package, so don't assert a specific value for it, only that
+          // whatever it returns is inserted as expected.
+          'description: ${FakeController.fakeDescription})');
     });
   });
 }


### PR DESCRIPTION
A unit test in the app-facing package that predates federation is asserting an expected string that includes constant text that is controlled by a `toString` method from the platform interface package. This fixes the test to only assert the parts that are within the package's control.

Unblocks https://github.com/flutter/packages/pull/8723

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under.
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
