### PR TITLE
[camera_avfoundation] Tests backfilling - part 3

### DIFF
--- a/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		E0CDBAC227CD9729002561D9 /* CameraTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E0CDBAC127CD9729002561D9 /* CameraTestUtils.m */; };
 		E12C4FF62D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12C4FF52D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift */; };
 		E12C4FF82D68E85500515E70 /* MockFLTCameraPermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12C4FF72D68E85500515E70 /* MockFLTCameraPermissionManager.swift */; };
+		E1A5F4E32D80259C0005BA64 /* FLTCamSetFlashModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */; };
 		E1FFEAAD2D6C8DD700B14107 /* MockFLTCam.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAAC2D6C8DD700B14107 /* MockFLTCam.swift */; };
 		E1FFEAAF2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */; };
 		E1FFEAB12D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */; };
@@ -148,6 +149,7 @@
 		E0CDBAC127CD9729002561D9 /* CameraTestUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CameraTestUtils.m; sourceTree = "<group>"; };
 		E12C4FF52D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginDelegatingMethodTests.swift; sourceTree = "<group>"; };
 		E12C4FF72D68E85500515E70 /* MockFLTCameraPermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFLTCameraPermissionManager.swift; sourceTree = "<group>"; };
+		E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamSetFlashModeTests.swift; sourceTree = "<group>"; };
 		E1FFEAAC2D6C8DD700B14107 /* MockFLTCam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFLTCam.swift; sourceTree = "<group>"; };
 		E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginCreateCameraTests.swift; sourceTree = "<group>"; };
 		E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginInitializeCameraTests.swift; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 				E12C4FF52D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift */,
 				E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */,
 				E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */,
+				E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -540,6 +543,7 @@
 				972CA92D2D5A28C4004B846F /* QueueUtilsTests.swift in Sources */,
 				E1FFEAB12D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift in Sources */,
 				979B3DFB2D5B6BC7009BDE1A /* ExceptionCatcher.m in Sources */,
+				E1A5F4E32D80259C0005BA64 /* FLTCamSetFlashModeTests.swift in Sources */,
 				7FD83D2B2D5BA65B00F4DB7C /* MockCaptureConnection.m in Sources */,
 				977A25242D5A511600931E34 /* CameraPermissionTests.swift in Sources */,
 				970ADABE2D6740A900EFDCD9 /* MockWritableData.swift in Sources */,

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSetFlashModeTests.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSetFlashModeTests.swift
@@ -1,0 +1,147 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import AVFoundation
+import XCTest
+
+@testable import camera_avfoundation
+
+final class FLTCamSetFlashModeTests: XCTestCase {
+  private func createCamera() -> (FLTCam, MockCaptureDevice, MockCapturePhotoOutput) {
+    let mockDevice = MockCaptureDevice()
+    let mockCapturePhotoOutput = MockCapturePhotoOutput()
+
+    let configuration = FLTCreateTestCameraConfiguration()
+    configuration.captureDeviceFactory = { mockDevice }
+    let camera = FLTCreateCamWithConfiguration(configuration)
+    camera.capturePhotoOutput = mockCapturePhotoOutput
+
+    return (camera, mockDevice, mockCapturePhotoOutput)
+  }
+
+  func testSetFlashModeWithTorchMode_setsTrochModeOn() {
+    let (camera, mockDevice, _) = createCamera()
+
+    mockDevice.hasTorch = true
+    mockDevice.isTorchAvailable = true
+
+    var setTorchModeCalled = false
+    mockDevice.setTorchModeStub = { torchMode in
+      XCTAssertEqual(torchMode, .on)
+      setTorchModeCalled = true
+    }
+
+    let expectation = expectation(description: "Call completed")
+
+    camera.setFlashMode(.torch) { error in
+      XCTAssertNil(error)
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 30)
+
+    XCTAssertTrue(setTorchModeCalled)
+  }
+
+  func testSetFlashModeWithTorchMode_returnError_ifHasNoTorch() {
+    let (camera, mockDevice, _) = createCamera()
+
+    mockDevice.hasTorch = false
+
+    let expectation = expectation(description: "Call completed")
+
+    camera.setFlashMode(.torch) { error in
+      XCTAssertNotNil(error)
+      XCTAssertEqual(error?.code, "setFlashModeFailed")
+      XCTAssertEqual(error?.message, "Device does not support torch mode")
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 30)
+  }
+
+  func testSetFlashModeWithTorchMode_returnError_ifTorchIsNotAvailable() {
+    let (camera, mockDevice, _) = createCamera()
+
+    mockDevice.hasTorch = true
+    mockDevice.isTorchAvailable = false
+
+    let expectation = expectation(description: "Call completed")
+
+    camera.setFlashMode(.torch) { error in
+      XCTAssertNotNil(error)
+      XCTAssertEqual(error?.code, "setFlashModeFailed")
+      XCTAssertEqual(error?.message, "Torch mode is currently not available")
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 30)
+  }
+
+  func testSetFlashModeWithNonTorchMode_setsTrochModeOff_ifTorchModeIsEnabled() {
+    let (camera, mockDevice, mockCapturePhotoOutput) = createCamera()
+
+    mockCapturePhotoOutput.supportedFlashModes = [
+      NSNumber(value: AVCaptureDevice.FlashMode.auto.rawValue)
+    ]
+
+    mockDevice.hasFlash = true
+    // Torch mode is enabled
+    mockDevice.getTorchModeStub = { .on }
+
+    var setTorchModeCalled = false
+    mockDevice.setTorchModeStub = { torchMode in
+      XCTAssertEqual(torchMode, .off)
+      setTorchModeCalled = true
+    }
+
+    let expectation = expectation(description: "Call completed")
+
+    camera.setFlashMode(.auto) { error in
+      XCTAssertNil(error)
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 30)
+
+    XCTAssertTrue(setTorchModeCalled)
+  }
+
+  func testSetFlashModeWithNonTorchMode_returnError_ifHasNoFlash() {
+    let (camera, mockDevice, _) = createCamera()
+
+    mockDevice.hasFlash = false
+
+    let expectation = expectation(description: "Call completed")
+
+    camera.setFlashMode(.auto) { error in
+      XCTAssertNotNil(error)
+      XCTAssertEqual(error?.code, "setFlashModeFailed")
+      XCTAssertEqual(error?.message, "Device does not have flash capabilities")
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 30)
+  }
+
+  func testSetFlashModeWithNonTorchMode_returnError_ifModeIsNotSupported() {
+    let (camera, mockDevice, mockCapturePhotoOutput) = createCamera()
+
+    // No flash modes are supported
+    mockCapturePhotoOutput.supportedFlashModes = []
+
+    mockDevice.hasFlash = true
+
+    let expectation = expectation(description: "Call completed")
+
+    camera.setFlashMode(.auto) { error in
+      XCTAssertNotNil(error)
+      XCTAssertEqual(error?.code, "setFlashModeFailed")
+      XCTAssertEqual(error?.message, "Device does not support this specific flash mode")
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 30)
+  }
+}

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureDevice.h
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureDevice.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Overrides the default implementation of setting torch mode.
 /// @param mode The torch mode being set
 @property(nonatomic, copy) void (^setTorchModeStub)(AVCaptureTorchMode mode);
+@property(nonatomic, copy) AVCaptureTorchMode (^getTorchModeStub)(void);
 @property(nonatomic, assign) BOOL flashModeSupported;
 
 // Focus

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureDevice.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureDevice.m
@@ -35,6 +35,13 @@
   }
 }
 
+- (AVCaptureTorchMode)torchMode {
+  if (self.getTorchModeStub) {
+    return self.getTorchModeStub();
+  }
+  return AVCaptureTorchModeOff;
+}
+
 - (BOOL)isFocusModeSupported:(AVCaptureFocusMode)mode {
   if (self.isFocusModeSupportedStub) {
     return self.isFocusModeSupportedStub(mode);

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/PhotoCaptureTests.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/PhotoCaptureTests.swift
@@ -157,7 +157,7 @@ final class PhotoCaptureTests: XCTestCase {
     let captureDeviceMock = MockCaptureDevice()
     captureDeviceMock.hasTorch = true
     captureDeviceMock.isTorchAvailable = true
-    captureDeviceMock.torchMode = .auto
+    captureDeviceMock.getTorchModeStub = { .auto }
     captureDeviceMock.setTorchModeStub = { mode in
       if mode == .on {
         setTorchExpectation.fulfill()


### PR DESCRIPTION
Backfills tests for the `FLTCam` class as part of https://github.com/flutter/flutter/issues/119109

Adds tests for the `setFlashMode` method of the `FLTCam` class.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under.
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
