### PR TITLE
[camera_avfoundation] Tests backfilling - part 4

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.18+11
+
+* Backfills unit tests for the `FLTCam` class.
+* Refactors implementation to allow mocking of `AVCaptureVideoDataOutput` in tests.
+
 ## 0.9.18+10
 
 * Backfills unit tests for the `FLTCam` class.

--- a/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		E16602952D8471C0003CFE12 /* FLTCamZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16602942D8471C0003CFE12 /* FLTCamZoomTests.swift */; };
 		E1A5F4E32D80259C0005BA64 /* FLTCamSetFlashModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */; };
 		E15139182D80980900FEE47B /* FLTCamSetDeviceOrientationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15139172D80980900FEE47B /* FLTCamSetDeviceOrientationTests.swift */; };
+		E1A5F4E32D80259C0005BA64 /* FLTCamSetFlashModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */; };
 		E1FFEAAD2D6C8DD700B14107 /* MockFLTCam.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAAC2D6C8DD700B14107 /* MockFLTCam.swift */; };
 		E1FFEAAF2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */; };
 		E1FFEAB12D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */; };
@@ -156,6 +157,7 @@
 		E16602942D8471C0003CFE12 /* FLTCamZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamZoomTests.swift; sourceTree = "<group>"; };
 		E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamSetFlashModeTests.swift; sourceTree = "<group>"; };
 		E15139172D80980900FEE47B /* FLTCamSetDeviceOrientationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamSetDeviceOrientationTests.swift; sourceTree = "<group>"; };
+		E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamSetFlashModeTests.swift; sourceTree = "<group>"; };
 		E1FFEAAC2D6C8DD700B14107 /* MockFLTCam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFLTCam.swift; sourceTree = "<group>"; };
 		E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginCreateCameraTests.swift; sourceTree = "<group>"; };
 		E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginInitializeCameraTests.swift; sourceTree = "<group>"; };

--- a/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
@@ -49,10 +49,12 @@
 		97DB234D2D566D0700CEFE66 /* CameraPreviewPauseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DB234C2D566D0700CEFE66 /* CameraPreviewPauseTests.swift */; };
 		E0CDBAC227CD9729002561D9 /* CameraTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E0CDBAC127CD9729002561D9 /* CameraTestUtils.m */; };
 		E11D6A912D82C7740031E6C5 /* FLTCamExposureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11D6A902D82C7740031E6C5 /* FLTCamExposureTests.swift */; };
+		E11D6A8F2D81B81D0031E6C5 /* MockCaptureVideoDataOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11D6A8E2D81B81D0031E6C5 /* MockCaptureVideoDataOutput.swift */; };
 		E12C4FF62D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12C4FF52D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift */; };
 		E12C4FF82D68E85500515E70 /* MockFLTCameraPermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12C4FF72D68E85500515E70 /* MockFLTCameraPermissionManager.swift */; };
 		E16602952D8471C0003CFE12 /* FLTCamZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16602942D8471C0003CFE12 /* FLTCamZoomTests.swift */; };
 		E1A5F4E32D80259C0005BA64 /* FLTCamSetFlashModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */; };
+		E15139182D80980900FEE47B /* FLTCamSetDeviceOrientationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15139172D80980900FEE47B /* FLTCamSetDeviceOrientationTests.swift */; };
 		E1FFEAAD2D6C8DD700B14107 /* MockFLTCam.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAAC2D6C8DD700B14107 /* MockFLTCam.swift */; };
 		E1FFEAAF2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */; };
 		E1FFEAB12D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */; };
@@ -148,10 +150,12 @@
 		E0CDBAC027CD9729002561D9 /* CameraTestUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CameraTestUtils.h; sourceTree = "<group>"; };
 		E0CDBAC127CD9729002561D9 /* CameraTestUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CameraTestUtils.m; sourceTree = "<group>"; };
 		E11D6A902D82C7740031E6C5 /* FLTCamExposureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamExposureTests.swift; sourceTree = "<group>"; };
+		E11D6A8E2D81B81D0031E6C5 /* MockCaptureVideoDataOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCaptureVideoDataOutput.swift; sourceTree = "<group>"; };
 		E12C4FF52D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginDelegatingMethodTests.swift; sourceTree = "<group>"; };
 		E12C4FF72D68E85500515E70 /* MockFLTCameraPermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFLTCameraPermissionManager.swift; sourceTree = "<group>"; };
 		E16602942D8471C0003CFE12 /* FLTCamZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamZoomTests.swift; sourceTree = "<group>"; };
 		E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamSetFlashModeTests.swift; sourceTree = "<group>"; };
+		E15139172D80980900FEE47B /* FLTCamSetDeviceOrientationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamSetDeviceOrientationTests.swift; sourceTree = "<group>"; };
 		E1FFEAAC2D6C8DD700B14107 /* MockFLTCam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFLTCam.swift; sourceTree = "<group>"; };
 		E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginCreateCameraTests.swift; sourceTree = "<group>"; };
 		E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginInitializeCameraTests.swift; sourceTree = "<group>"; };
@@ -212,6 +216,7 @@
 				977A25212D5A49EC00931E34 /* FLTCamFocusTests.swift */,
 				E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */,
 				E16602942D8471C0003CFE12 /* FLTCamZoomTests.swift */,
+				E15139172D80980900FEE47B /* FLTCamSetDeviceOrientationTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -254,6 +259,7 @@
 				970ADABF2D6764CC00EFDCD9 /* MockEventChannel.swift */,
 				E12C4FF72D68E85500515E70 /* MockFLTCameraPermissionManager.swift */,
 				970ADABD2D6740A900EFDCD9 /* MockWritableData.swift */,
+				E11D6A8E2D81B81D0031E6C5 /* MockCaptureVideoDataOutput.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -557,6 +563,7 @@
 				7F8FD22F2D4D0B88001AF2C1 /* MockFlutterBinaryMessenger.m in Sources */,
 				E12C4FF82D68E85500515E70 /* MockFLTCameraPermissionManager.swift in Sources */,
 				97922B0D2D6380C300A9B4CF /* SampleBufferTests.swift in Sources */,
+				E15139182D80980900FEE47B /* FLTCamSetDeviceOrientationTests.swift in Sources */,
 				972CA92B2D5A1D8C004B846F /* CameraPropertiesTests.swift in Sources */,
 				E0CDBAC227CD9729002561D9 /* CameraTestUtils.m in Sources */,
 				978296CF2D5F744B0009BDD3 /* PhotoCaptureTests.swift in Sources */,
@@ -577,6 +584,7 @@
 				978D90B42D5F630300CD817E /* StreamingTests.swift in Sources */,
 				7F29EB412D281C7E00740257 /* MockCaptureSession.m in Sources */,
 				7FCEDD352D43C2B900EA1CA8 /* MockDeviceOrientationProvider.m in Sources */,
+				E11D6A8F2D81B81D0031E6C5 /* MockCaptureVideoDataOutput.swift in Sources */,
 				977CAC9F2D5E5180001E5DC3 /* ThreadSafeEventChannelTests.swift in Sources */,
 				7FCEDD362D43C2B900EA1CA8 /* MockCaptureDevice.m in Sources */,
 				7F8FD22C2D4D07DD001AF2C1 /* MockFlutterTextureRegistry.m in Sources */,

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraSettingsTests.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraSettingsTests.swift
@@ -101,11 +101,10 @@ private final class TestMediaSettingsAVWrapper: FLTCamMediaSettingsAVWrapper {
   }
 
   override func recommendedVideoSettingsForAssetWriter(
-    withFileType fileType: AVFileType, for output: AVCaptureVideoDataOutput
+    withFileType fileType: AVFileType, for output: FLTCaptureVideoDataOutput
   ) -> [String: Any]? {
     return [:]
   }
-
 }
 
 final class CameraSettingsTests: XCTestCase {

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSetDeviceOrientationTests.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSetDeviceOrientationTests.swift
@@ -1,0 +1,109 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import AVFoundation
+import XCTest
+
+@testable import camera_avfoundation
+
+final class FLTCamSetDeviceOrientationTests: XCTestCase {
+  private func createCamera() -> (FLTCam, MockCaptureConnection, MockCaptureConnection) {
+    let configuration = FLTCreateTestCameraConfiguration()
+    let camera = FLTCreateCamWithConfiguration(configuration)
+
+    let mockCapturePhotoOutput = MockCapturePhotoOutput()
+    let mockPhotoCaptureConnection = MockCaptureConnection()
+    mockPhotoCaptureConnection.isVideoOrientationSupported = true
+
+    mockCapturePhotoOutput.connectionWithMediaTypeStub = { _ in mockPhotoCaptureConnection }
+    camera.capturePhotoOutput = mockCapturePhotoOutput
+
+    let mockCaptureVideoDataOutput = MockCaptureVideoDataOutput()
+    let mockVideoCaptureConnection = MockCaptureConnection()
+    mockVideoCaptureConnection.isVideoOrientationSupported = true
+
+    mockCaptureVideoDataOutput.connectionWithMediaTypeStub = { _ in mockVideoCaptureConnection }
+    camera.captureVideoOutput = mockCaptureVideoDataOutput
+
+    return (camera, mockPhotoCaptureConnection, mockVideoCaptureConnection)
+  }
+
+  func testSetDeviceOrientation_setsOrientationsOfCaptureConnections() {
+    let (camera, mockPhotoCaptureConnection, mockVideoCaptureConnection) = createCamera()
+    var photoSetVideoOrientationCalled = false
+    mockPhotoCaptureConnection.setVideoOrientationStub = { orientation in
+      // Device orientation is flipped compared to video orientation. When UIDeviceOrientation
+      // is landscape left the video orientation should be landscape right.
+      XCTAssertEqual(orientation, .landscapeRight)
+      photoSetVideoOrientationCalled = true
+    }
+
+    var videoSetVideoOrientationCalled = false
+    mockVideoCaptureConnection.setVideoOrientationStub = { orientation in
+      // Device orientation is flipped compared to video orientation. When UIDeviceOrientation
+      // is landscape left the video orientation should be landscape right.
+      XCTAssertEqual(orientation, .landscapeRight)
+      videoSetVideoOrientationCalled = true
+    }
+
+    camera.setDeviceOrientation(.landscapeLeft)
+
+    XCTAssertTrue(photoSetVideoOrientationCalled)
+    XCTAssertTrue(videoSetVideoOrientationCalled)
+  }
+
+  func
+    testSetDeviceOrientation_setsLockedOrientationsOfCaptureConnection_ifCaptureOrientationIsLocked()
+  {
+    let (camera, mockPhotoCaptureConnection, mockVideoCaptureConnection) = createCamera()
+    var photoSetVideoOrientationCalled = false
+    mockPhotoCaptureConnection.setVideoOrientationStub = { orientation in
+      XCTAssertEqual(orientation, .portraitUpsideDown)
+      photoSetVideoOrientationCalled = true
+    }
+
+    var videoSetVideoOrientationCalled = false
+    mockVideoCaptureConnection.setVideoOrientationStub = { orientation in
+      XCTAssertEqual(orientation, .portraitUpsideDown)
+      videoSetVideoOrientationCalled = true
+    }
+
+    camera.lockCapture(FCPPlatformDeviceOrientation.portraitDown)
+
+    camera.setDeviceOrientation(.landscapeLeft)
+
+    XCTAssertTrue(photoSetVideoOrientationCalled)
+    XCTAssertTrue(videoSetVideoOrientationCalled)
+  }
+
+  func testSetDeviceOrientation_doesNotSetOrientations_ifRecordingIsInProgress() {
+    let (camera, mockPhotoCaptureConnection, mockVideoCaptureConnection) = createCamera()
+
+    camera.startVideoRecording(completion: { _ in }, messengerForStreaming: nil)
+
+    mockPhotoCaptureConnection.setVideoOrientationStub = { _ in XCTFail() }
+    mockVideoCaptureConnection.setVideoOrientationStub = { _ in XCTFail() }
+
+    camera.setDeviceOrientation(.landscapeLeft)
+  }
+
+  func testSetDeviceOrientation_doesNotSetOrientations_forDuplicateUpdates() {
+    let (camera, mockPhotoCaptureConnection, mockVideoCaptureConnection) = createCamera()
+    var photoSetVideoOrientationCallCount = 0
+    mockPhotoCaptureConnection.setVideoOrientationStub = { _ in
+      photoSetVideoOrientationCallCount += 1
+    }
+
+    var videoSetVideoOrientationCallCount = 0
+    mockVideoCaptureConnection.setVideoOrientationStub = { _ in
+      videoSetVideoOrientationCallCount += 1
+    }
+
+    camera.setDeviceOrientation(.landscapeRight)
+    camera.setDeviceOrientation(.landscapeRight)
+
+    XCTAssertEqual(photoSetVideoOrientationCallCount, 1)
+    XCTAssertEqual(videoSetVideoOrientationCallCount, 1)
+  }
+}

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureConnection.h
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureConnection.h
@@ -19,6 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign, getter=isVideoMirroringSupported) BOOL supportsVideoMirroring;
 @property(nonatomic, assign, getter=isVideoOrientationSupported) BOOL supportsVideoOrientation;
 
+// Stub that is called when the corresponding public method is called.
+@property(nonatomic, copy) void (^setVideoOrientationStub)(AVCaptureVideoOrientation);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureConnection.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureConnection.m
@@ -6,4 +6,12 @@
 
 @implementation MockCaptureConnection
 
+- (void)setVideoOrientation:(AVCaptureVideoOrientation)videoOrientation {
+  if (self.setVideoOrientationStub) {
+    _setVideoOrientationStub(videoOrientation);
+  } else {
+    _videoOrientation = videoOrientation;
+  }
+}
+
 @end

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCapturePhotoOutput.h
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCapturePhotoOutput.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MockCapturePhotoOutput : NSObject <FLTCapturePhotoOutput>
 
 // Properties re-declared as read/write so a mocked value can be set during testing.
-@property(nonatomic, strong) AVCapturePhotoOutput *photoOutput;
+@property(nonatomic, strong) AVCapturePhotoOutput *avOutput;
 @property(nonatomic, strong) NSArray<AVVideoCodecType> *availablePhotoCodecTypes;
 @property(nonatomic, assign) BOOL highResolutionCaptureEnabled;
 @property(nonatomic, strong) NSArray<NSNumber *> *supportedFlashModes;
@@ -20,6 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
 // Stub that is called when the corresponding public method is called.
 @property(nonatomic, copy) void (^capturePhotoWithSettingsStub)
     (AVCapturePhotoSettings *, NSObject<AVCapturePhotoCaptureDelegate> *);
+
+// Stub that is called when the corresponding public method is called.
+@property(nonatomic, copy) NSObject<FLTCaptureConnection> * (^connectionWithMediaTypeStub)
+    (AVMediaType);
 
 @end
 

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCapturePhotoOutput.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCapturePhotoOutput.m
@@ -12,8 +12,13 @@
   }
 }
 
-- (nullable AVCaptureConnection *)connectionWithMediaType:(nonnull AVMediaType)mediaType {
-  return nil;
+- (nullable NSObject<FLTCaptureConnection> *)connectionWithMediaType:
+    (nonnull AVMediaType)mediaType {
+  if (self.connectionWithMediaTypeStub) {
+    return self.connectionWithMediaTypeStub(mediaType);
+  } else {
+    return NULL;
+  }
 }
 
 @end

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureVideoDataOutput.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureVideoDataOutput.swift
@@ -6,8 +6,8 @@
 /// implementation.
 class MockCaptureVideoDataOutput: NSObject, FLTCaptureVideoDataOutput {
 
-  var avOutput: AVCaptureVideoDataOutput = AVCaptureVideoDataOutput()
-  var alwaysDiscardsLateVideoFrames: Bool = false
+  var avOutput = AVCaptureVideoDataOutput()
+  var alwaysDiscardsLateVideoFrames = false
   var videoSettings: [String: Any] = [:]
 
   var connectionWithMediaTypeStub: ((AVMediaType) -> FLTCaptureConnection?)?

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureVideoDataOutput.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureVideoDataOutput.swift
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Mock implementation of `FLTCaptureVideoDataOutput` protocol which allows injecting a custom
+/// implementation.
+class MockCaptureVideoDataOutput: NSObject, FLTCaptureVideoDataOutput {
+
+  var avOutput: AVCaptureVideoDataOutput = AVCaptureVideoDataOutput()
+  var alwaysDiscardsLateVideoFrames: Bool = false
+  var videoSettings: [String: Any] = [:]
+
+  var connectionWithMediaTypeStub: ((AVMediaType) -> FLTCaptureConnection?)?
+
+  func connection(withMediaType mediaType: AVMediaType) -> FLTCaptureConnection? {
+    return connectionWithMediaTypeStub?(mediaType)
+  }
+
+  func setSampleBufferDelegate(
+    _ sampleBufferDelegate: AVCaptureVideoDataOutputSampleBufferDelegate?,
+    queue sampleBufferCallbackQueue: DispatchQueue?
+  ) {}
+}

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCamMediaSettingsAVWrapper.m
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCamMediaSettingsAVWrapper.m
@@ -55,8 +55,9 @@
 
 - (nullable NSDictionary<NSString *, id> *)
     recommendedVideoSettingsForAssetWriterWithFileType:(AVFileType)fileType
-                                             forOutput:(AVCaptureVideoDataOutput *)output {
-  return [output recommendedVideoSettingsForAssetWriterWithOutputFileType:fileType];
+                                             forOutput:
+                                                 (NSObject<FLTCaptureVideoDataOutput> *)output {
+  return [output.avOutput recommendedVideoSettingsForAssetWriterWithOutputFileType:fileType];
 }
 
 @end

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCaptureConnection.m
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCaptureConnection.m
@@ -4,9 +4,11 @@
 
 #import "./include/camera_avfoundation/FLTCaptureConnection.h"
 
-@implementation FLTDefaultCaptureConnection {
-  AVCaptureConnection *_connection;
-}
+@interface FLTDefaultCaptureConnection ()
+@property(nonatomic, strong) AVCaptureConnection *connection;
+@end
+
+@implementation FLTDefaultCaptureConnection
 
 - (instancetype)initWithConnection:(AVCaptureConnection *)connection {
   self = [super init];
@@ -17,31 +19,31 @@
 }
 
 - (BOOL)isVideoMirroringSupported {
-  return _connection.isVideoMirroringSupported;
+  return self.connection.isVideoMirroringSupported;
 }
 
 - (BOOL)isVideoOrientationSupported {
-  return _connection.isVideoOrientationSupported;
+  return self.connection.isVideoOrientationSupported;
 }
 
 - (void)setVideoMirrored:(BOOL)videoMirrored {
-  _connection.videoMirrored = videoMirrored;
+  self.connection.videoMirrored = videoMirrored;
 }
 
 - (BOOL)isVideoMirrored {
-  return _connection.isVideoMirrored;
+  return self.connection.isVideoMirrored;
 }
 
 - (void)setVideoOrientation:(AVCaptureVideoOrientation)videoOrientation {
-  _connection.videoOrientation = videoOrientation;
+  self.connection.videoOrientation = videoOrientation;
 }
 
 - (AVCaptureVideoOrientation)videoOrientation {
-  return _connection.videoOrientation;
+  return self.connection.videoOrientation;
 }
 
 - (NSArray<AVCaptureInputPort *> *)inputPorts {
-  return _connection.inputPorts;
+  return self.connection.inputPorts;
 }
 
 @end

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCaptureConnection.m
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCaptureConnection.m
@@ -4,11 +4,9 @@
 
 #import "./include/camera_avfoundation/FLTCaptureConnection.h"
 
-@interface FLTDefaultCaptureConnection ()
-@property(nonatomic, strong) AVCaptureConnection *connection;
-@end
-
-@implementation FLTDefaultCaptureConnection
+@implementation FLTDefaultCaptureConnection {
+  AVCaptureConnection *_connection;
+}
 
 - (instancetype)initWithConnection:(AVCaptureConnection *)connection {
   self = [super init];

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCapturePhotoOutput.m
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCapturePhotoOutput.m
@@ -5,44 +5,46 @@
 #import "./include/camera_avfoundation/FLTCapturePhotoOutput.h"
 
 @implementation FLTDefaultCapturePhotoOutput {
-  AVCapturePhotoOutput *_photoOutput;
+  AVCapturePhotoOutput *_avOutput;
 }
 
 - (instancetype)initWithPhotoOutput:(AVCapturePhotoOutput *)photoOutput {
   self = [super init];
   if (self) {
-    _photoOutput = photoOutput;
+    _avOutput = photoOutput;
   }
   return self;
 }
 
-- (AVCapturePhotoOutput *)photoOutput {
-  return _photoOutput;
+- (AVCapturePhotoOutput *)avOutput {
+  return _avOutput;
 }
 
 - (NSArray<AVVideoCodecType> *)availablePhotoCodecTypes {
-  return _photoOutput.availablePhotoCodecTypes;
+  return _avOutput.availablePhotoCodecTypes;
 }
 
 - (BOOL)highResolutionCaptureEnabled {
-  return _photoOutput.isHighResolutionCaptureEnabled;
+  return _avOutput.isHighResolutionCaptureEnabled;
 }
 
 - (void)setHighResolutionCaptureEnabled:(BOOL)enabled {
-  [_photoOutput setHighResolutionCaptureEnabled:enabled];
+  [_avOutput setHighResolutionCaptureEnabled:enabled];
 }
 
 - (void)capturePhotoWithSettings:(AVCapturePhotoSettings *)settings
                         delegate:(NSObject<AVCapturePhotoCaptureDelegate> *)delegate {
-  [_photoOutput capturePhotoWithSettings:settings delegate:delegate];
+  [_avOutput capturePhotoWithSettings:settings delegate:delegate];
 }
 
-- (nullable AVCaptureConnection *)connectionWithMediaType:(nonnull AVMediaType)mediaType {
-  return [_photoOutput connectionWithMediaType:mediaType];
+- (nullable NSObject<FLTCaptureConnection> *)connectionWithMediaType:
+    (nonnull AVMediaType)mediaType {
+  return [[FLTDefaultCaptureConnection alloc]
+      initWithConnection:[_avOutput connectionWithMediaType:mediaType]];
 }
 
 - (NSArray<NSNumber *> *)supportedFlashModes {
-  return _photoOutput.supportedFlashModes;
+  return _avOutput.supportedFlashModes;
 }
 
 @end

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCapturePhotoOutput.m
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCapturePhotoOutput.m
@@ -4,9 +4,11 @@
 
 #import "./include/camera_avfoundation/FLTCapturePhotoOutput.h"
 
-@implementation FLTDefaultCapturePhotoOutput {
-  AVCapturePhotoOutput *_avOutput;
-}
+@interface FLTDefaultCapturePhotoOutput ()
+@property(nonatomic, strong) AVCapturePhotoOutput *avOutput;
+@end
+
+@implementation FLTDefaultCapturePhotoOutput
 
 - (instancetype)initWithPhotoOutput:(AVCapturePhotoOutput *)photoOutput {
   self = [super init];
@@ -16,35 +18,31 @@
   return self;
 }
 
-- (AVCapturePhotoOutput *)avOutput {
-  return _avOutput;
-}
-
 - (NSArray<AVVideoCodecType> *)availablePhotoCodecTypes {
-  return _avOutput.availablePhotoCodecTypes;
+  return self.avOutput.availablePhotoCodecTypes;
 }
 
 - (BOOL)highResolutionCaptureEnabled {
-  return _avOutput.isHighResolutionCaptureEnabled;
+  return self.avOutput.isHighResolutionCaptureEnabled;
 }
 
 - (void)setHighResolutionCaptureEnabled:(BOOL)enabled {
-  [_avOutput setHighResolutionCaptureEnabled:enabled];
+  [self.avOutput setHighResolutionCaptureEnabled:enabled];
 }
 
 - (void)capturePhotoWithSettings:(AVCapturePhotoSettings *)settings
                         delegate:(NSObject<AVCapturePhotoCaptureDelegate> *)delegate {
-  [_avOutput capturePhotoWithSettings:settings delegate:delegate];
+  [self.avOutput capturePhotoWithSettings:settings delegate:delegate];
 }
 
 - (nullable NSObject<FLTCaptureConnection> *)connectionWithMediaType:
     (nonnull AVMediaType)mediaType {
   return [[FLTDefaultCaptureConnection alloc]
-      initWithConnection:[_avOutput connectionWithMediaType:mediaType]];
+      initWithConnection:[self.avOutput connectionWithMediaType:mediaType]];
 }
 
 - (NSArray<NSNumber *> *)supportedFlashModes {
-  return _avOutput.supportedFlashModes;
+  return self.avOutput.supportedFlashModes;
 }
 
 @end

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCaptureVideoDataOutput.m
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCaptureVideoDataOutput.m
@@ -4,9 +4,11 @@
 
 #import "./include/camera_avfoundation/FLTCaptureVideoDataOutput.h"
 
-@implementation FLTDefaultCaptureVideoDataOutput {
-  AVCaptureVideoDataOutput *_avOutput;
-}
+@interface FLTDefaultCaptureVideoDataOutput ()
+@property(nonatomic, strong) AVCaptureVideoDataOutput *avOutput;
+@end
+
+@implementation FLTDefaultCaptureVideoDataOutput
 
 - (instancetype)initWithCaptureVideoOutput:(AVCaptureVideoDataOutput *)videoOutput {
   self = [super init];
@@ -16,36 +18,32 @@
   return self;
 }
 
-- (AVCaptureVideoDataOutput *)avOutput {
-  return _avOutput;
-}
-
 - (BOOL)alwaysDiscardsLateVideoFrames {
-  return _avOutput.alwaysDiscardsLateVideoFrames;
+  return self.avOutput.alwaysDiscardsLateVideoFrames;
 }
 
 - (void)setAlwaysDiscardsLateVideoFrames:(BOOL)alwaysDiscardsLateVideoFrames {
-  _avOutput.alwaysDiscardsLateVideoFrames = alwaysDiscardsLateVideoFrames;
+  self.avOutput.alwaysDiscardsLateVideoFrames = alwaysDiscardsLateVideoFrames;
 }
 
 - (NSDictionary<NSString *, id> *)videoSettings {
-  return _avOutput.videoSettings;
+  return self.avOutput.videoSettings;
 }
 
 - (void)setVideoSettings:(NSDictionary<NSString *, id> *)videoSettings {
-  _avOutput.videoSettings = videoSettings;
+  self.avOutput.videoSettings = videoSettings;
 }
 
 - (nullable NSObject<FLTCaptureConnection> *)connectionWithMediaType:
     (nonnull AVMediaType)mediaType {
   return [[FLTDefaultCaptureConnection alloc]
-      initWithConnection:[_avOutput connectionWithMediaType:mediaType]];
+      initWithConnection:[self.avOutput connectionWithMediaType:mediaType]];
 }
 
 - (void)setSampleBufferDelegate:
             (nullable id<AVCaptureVideoDataOutputSampleBufferDelegate>)sampleBufferDelegate
                           queue:(nullable dispatch_queue_t)sampleBufferCallbackQueue {
-  [_avOutput setSampleBufferDelegate:sampleBufferDelegate queue:sampleBufferCallbackQueue];
+  [self.avOutput setSampleBufferDelegate:sampleBufferDelegate queue:sampleBufferCallbackQueue];
 }
 
 @end

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCaptureVideoDataOutput.m
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCaptureVideoDataOutput.m
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "./include/camera_avfoundation/FLTCaptureVideoDataOutput.h"
+
+@implementation FLTDefaultCaptureVideoDataOutput {
+  AVCaptureVideoDataOutput *_avOutput;
+}
+
+- (instancetype)initWithCaptureVideoOutput:(AVCaptureVideoDataOutput *)videoOutput {
+  self = [super init];
+  if (self) {
+    _avOutput = videoOutput;
+  }
+  return self;
+}
+
+- (AVCaptureVideoDataOutput *)avOutput {
+  return _avOutput;
+}
+
+- (BOOL)alwaysDiscardsLateVideoFrames {
+  return _avOutput.alwaysDiscardsLateVideoFrames;
+}
+
+- (void)setAlwaysDiscardsLateVideoFrames:(BOOL)alwaysDiscardsLateVideoFrames {
+  _avOutput.alwaysDiscardsLateVideoFrames = alwaysDiscardsLateVideoFrames;
+}
+
+- (NSDictionary<NSString *, id> *)videoSettings {
+  return _avOutput.videoSettings;
+}
+
+- (void)setVideoSettings:(NSDictionary<NSString *, id> *)videoSettings {
+  _avOutput.videoSettings = videoSettings;
+}
+
+- (nullable NSObject<FLTCaptureConnection> *)connectionWithMediaType:
+    (nonnull AVMediaType)mediaType {
+  return [[FLTDefaultCaptureConnection alloc]
+      initWithConnection:[_avOutput connectionWithMediaType:mediaType]];
+}
+
+- (void)setSampleBufferDelegate:
+            (nullable id<AVCaptureVideoDataOutputSampleBufferDelegate>)sampleBufferDelegate
+                          queue:(nullable dispatch_queue_t)sampleBufferCallbackQueue {
+  [_avOutput setSampleBufferDelegate:sampleBufferDelegate queue:sampleBufferCallbackQueue];
+}
+
+@end

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCamMediaSettingsAVWrapper.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCamMediaSettingsAVWrapper.h
@@ -8,6 +8,7 @@
 #import "FLTAssetWriter.h"
 #import "FLTCaptureDevice.h"
 #import "FLTCaptureSession.h"
+#import "FLTCaptureVideoDataOutput.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -107,12 +108,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @abstract Specifies the recommended video settings for `AVCaptureVideoDataOutput`.
  * @param fileType Specifies the UTI of the file type to be written (see AVMediaFormat.h for a list
  * of file format UTIs).
- * @param output The `AVCaptureVideoDataOutput` instance.
+ * @param output The `FLTCaptureVideoDataOutput` instance.
  * @result A fully populated dictionary of keys and values that are compatible with AVAssetWriter.
  */
 - (nullable NSDictionary<NSString *, id> *)
     recommendedVideoSettingsForAssetWriterWithFileType:(AVFileType)fileType
-                                             forOutput:(AVCaptureVideoDataOutput *)output;
+                                             forOutput:
+                                                 (NSObject<FLTCaptureVideoDataOutput> *)output;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCam_Test.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCam_Test.h
@@ -6,6 +6,7 @@
 #import "FLTCaptureConnection.h"
 #import "FLTCaptureDevice.h"
 #import "FLTCapturePhotoOutput.h"
+#import "FLTCaptureVideoDataOutput.h"
 #import "FLTDeviceOrientationProviding.h"
 #import "FLTSavePhotoDelegate.h"
 
@@ -26,7 +27,7 @@
 @interface FLTCam ()
 
 /// The output for video capturing.
-@property(readonly, nonatomic) AVCaptureVideoDataOutput *captureVideoOutput;
+@property(strong, nonatomic) NSObject<FLTCaptureVideoDataOutput> *captureVideoOutput;
 
 /// The output for photo capturing. Exposed setter for unit tests.
 @property(strong, nonatomic) NSObject<FLTCapturePhotoOutput> *capturePhotoOutput;

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureConnection.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureConnection.h
@@ -10,10 +10,19 @@ NS_ASSUME_NONNULL_BEGIN
 /// `AVCaptureConnection` in tests.
 @protocol FLTCaptureConnection <NSObject>
 
+/// Corresponds to the `videoMirrored` property of `AVCaptureConnection`
 @property(nonatomic, getter=isVideoMirrored) BOOL videoMirrored;
+
+/// Corresponds to the `videoOrientation` property of `AVCaptureConnection`
 @property(nonatomic) AVCaptureVideoOrientation videoOrientation;
+
+/// Corresponds to the `inputPorts` property of `AVCaptureConnection`
 @property(nonatomic, readonly) NSArray<AVCaptureInputPort *> *inputPorts;
+
+/// Corresponds to the `supportsVideoMirroring` property of `AVCaptureConnection`
 @property(nonatomic, readonly, getter=isVideoMirroringSupported) BOOL supportsVideoMirroring;
+
+/// Corresponds to the `supportsVideoOrientation` property of `AVCaptureConnection`
 @property(nonatomic, readonly, getter=isVideoOrientationSupported) BOOL supportsVideoOrientation;
 
 @end

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureConnection.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureConnection.h
@@ -10,10 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// `AVCaptureConnection` in tests.
 @protocol FLTCaptureConnection <NSObject>
 
-/// Underlying `AVCaptureConnection` instance. All methods and properties are passed through to
-/// this.
-@property(nonatomic, readonly) AVCaptureConnection *connection;
-
 @property(nonatomic, getter=isVideoMirrored) BOOL videoMirrored;
 @property(nonatomic) AVCaptureVideoOrientation videoOrientation;
 @property(nonatomic, readonly) NSArray<AVCaptureInputPort *> *inputPorts;

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureOutput.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureOutput.h
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import Foundation;
+@import AVFoundation;
+
+#import "FLTCaptureConnection.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A protocol which is a direct passthrough to `AVCapturePhotoOutput`. It exists to allow mocking
+/// `AVCapturePhotoOutput` in tests.
+@protocol FLTCaptureOutput <NSObject>
+
+///// The underlying instance of `AVCapturePhotoOutput`.
+//@property(nonatomic, readonly) AVCaptureOutput *avOutput;
+
+- (nullable NSObject<FLTCaptureConnection> *)connectionWithMediaType:(AVMediaType)mediaType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCapturePhotoOutput.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCapturePhotoOutput.h
@@ -5,16 +5,16 @@
 @import Foundation;
 @import AVFoundation;
 
-#import "FLTCapturePhotoOutput.h"
+#import "FLTCaptureOutput.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// A protocol which is a direct passthrough to `AVCapturePhotoOutput`. It exists to allow mocking
 /// `AVCapturePhotoOutput` in tests.
-@protocol FLTCapturePhotoOutput <NSObject>
+@protocol FLTCapturePhotoOutput <FLTCaptureOutput>
 
 /// The underlying instance of `AVCapturePhotoOutput`.
-@property(nonatomic, readonly) AVCapturePhotoOutput *photoOutput;
+@property(nonatomic, readonly) AVCapturePhotoOutput *avOutput;
 
 @property(nonatomic, readonly) NSArray<AVVideoCodecType> *availablePhotoCodecTypes;
 @property(nonatomic, assign) BOOL highResolutionCaptureEnabled;
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)capturePhotoWithSettings:(AVCapturePhotoSettings *)settings
                         delegate:(NSObject<AVCapturePhotoCaptureDelegate> *)delegate;
-- (nullable AVCaptureConnection *)connectionWithMediaType:(AVMediaType)mediaType;
 
 @end
 

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCapturePhotoOutput.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCapturePhotoOutput.h
@@ -16,10 +16,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// The underlying instance of `AVCapturePhotoOutput`.
 @property(nonatomic, readonly) AVCapturePhotoOutput *avOutput;
 
+/// Corresponds to the `availablePhotoCodecTypes` property of `AVCapturePhotoOutput`
 @property(nonatomic, readonly) NSArray<AVVideoCodecType> *availablePhotoCodecTypes;
+
+/// Corresponds to the `highResolutionCaptureEnabled` property of `AVCapturePhotoOutput`
 @property(nonatomic, assign) BOOL highResolutionCaptureEnabled;
+
+/// Corresponds to the `supportedFlashModes` property of `AVCapturePhotoOutput`
 @property(nonatomic, readonly) NSArray<NSNumber *> *supportedFlashModes;
 
+/// Corresponds to the `capturePhotoWithSettings` method of `AVCapturePhotoOutput`
 - (void)capturePhotoWithSettings:(AVCapturePhotoSettings *)settings
                         delegate:(NSObject<AVCapturePhotoCaptureDelegate> *)delegate;
 

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureVideoDataOutput.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureVideoDataOutput.h
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import Foundation;
+@import AVFoundation;
+
+#import "FLTCaptureOutput.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A protocol which is a direct passthrough to `AVCaptureVideoDataOutput`. It exists to allow
+/// mocking `AVCaptureVideoDataOutput` in tests.
+@protocol FLTCaptureVideoDataOutput <FLTCaptureOutput>
+
+/// The underlying instance of `AVCaptureVideoDataOutput`.
+@property(nonatomic, readonly) AVCaptureVideoDataOutput *avOutput;
+
+@property(nonatomic) BOOL alwaysDiscardsLateVideoFrames;
+
+@property(nonatomic, copy, null_resettable) NSDictionary<NSString *, id> *videoSettings;
+
+- (void)setSampleBufferDelegate:
+            (nullable id<AVCaptureVideoDataOutputSampleBufferDelegate>)sampleBufferDelegate
+                          queue:(nullable dispatch_queue_t)sampleBufferCallbackQueue;
+
+@end
+
+/// A default implementation of `FLTCaptureVideoDataOutput` which wraps an instance of
+/// `AVCaptureVideoDataOutput`.
+@interface FLTDefaultCaptureVideoDataOutput : NSObject <FLTCaptureVideoDataOutput>
+
+/// Initializes an instance of `FLTDefaultCaptureVideDataOutput` with the given
+/// `AVCaptureVideoDataOutput`. All method and property calls will be forwarded to the given
+/// `videoOutput`.
+- (instancetype)initWithCaptureVideoOutput:(AVCaptureVideoDataOutput *)videoOutput;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureVideoDataOutput.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCaptureVideoDataOutput.h
@@ -16,10 +16,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// The underlying instance of `AVCaptureVideoDataOutput`.
 @property(nonatomic, readonly) AVCaptureVideoDataOutput *avOutput;
 
+/// Corresponds to the `alwaysDiscardsLateVideoFrames` property of `AVCaptureVideoDataOutput`
 @property(nonatomic) BOOL alwaysDiscardsLateVideoFrames;
 
+/// Corresponds to the `videoSettings` property of `AVCaptureVideoDataOutput`
 @property(nonatomic, copy, null_resettable) NSDictionary<NSString *, id> *videoSettings;
 
+/// Corresponds to the `setSampleBufferDelegate` method of `AVCaptureVideoDataOutput`
 - (void)setSampleBufferDelegate:
             (nullable id<AVCaptureVideoDataOutputSampleBufferDelegate>)sampleBufferDelegate
                           queue:(nullable dispatch_queue_t)sampleBufferCallbackQueue;

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.18+10
+version: 0.9.18+11
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
Backfills tests for the `FLTCam` class as part of https://github.com/flutter/flutter/issues/119109

Adds tests for the `setDeviceOrientation` method of the `FLTCam` class. I had to add `FLTCaptureVideoDataOutput` and `FLTCaptureOutput` wrappers around AVFoundation classes to make it mockable (similar to the existing `FLTCapturePhotoOutput`wrapper)

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under.
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
