### PR TITLE
[camera_avfoundation] Fix locking exposure on iOS/Tests backfilling - part 5

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.19
+
+* Fixes exposure mode locked not working
+
 ## 0.9.18+9
 
 * Backfills unit tests for `CameraPlugin` class.

--- a/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera_avfoundation/example/ios/Runner.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		E12C4FF62D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12C4FF52D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift */; };
 		E12C4FF82D68E85500515E70 /* MockFLTCameraPermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12C4FF72D68E85500515E70 /* MockFLTCameraPermissionManager.swift */; };
 		E1A5F4E32D80259C0005BA64 /* FLTCamSetFlashModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */; };
+		E11D6A912D82C7740031E6C5 /* FLTCamSetExposureModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11D6A902D82C7740031E6C5 /* FLTCamSetExposureModeTests.swift */; };
 		E1FFEAAD2D6C8DD700B14107 /* MockFLTCam.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAAC2D6C8DD700B14107 /* MockFLTCam.swift */; };
 		E1FFEAAF2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */; };
 		E1FFEAB12D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */; };
@@ -150,6 +151,7 @@
 		E12C4FF52D68C69000515E70 /* CameraPluginDelegatingMethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginDelegatingMethodTests.swift; sourceTree = "<group>"; };
 		E12C4FF72D68E85500515E70 /* MockFLTCameraPermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFLTCameraPermissionManager.swift; sourceTree = "<group>"; };
 		E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamSetFlashModeTests.swift; sourceTree = "<group>"; };
+		E11D6A902D82C7740031E6C5 /* FLTCamSetExposureModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLTCamSetExposureModeTests.swift; sourceTree = "<group>"; };
 		E1FFEAAC2D6C8DD700B14107 /* MockFLTCam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFLTCam.swift; sourceTree = "<group>"; };
 		E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginCreateCameraTests.swift; sourceTree = "<group>"; };
 		E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPluginInitializeCameraTests.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				E1FFEAAE2D6CDA8C00B14107 /* CameraPluginCreateCameraTests.swift */,
 				E1FFEAB02D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift */,
 				E1A5F4E22D80259C0005BA64 /* FLTCamSetFlashModeTests.swift */,
+				E11D6A902D82C7740031E6C5 /* FLTCamSetExposureModeTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -539,6 +542,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E11D6A912D82C7740031E6C5 /* FLTCamSetExposureModeTests.swift in Sources */,
 				97BD4A0E2D5CC5AE00F857D5 /* CameraSettingsTests.swift in Sources */,
 				972CA92D2D5A28C4004B846F /* QueueUtilsTests.swift in Sources */,
 				E1FFEAB12D6CDE5B00B14107 /* CameraPluginInitializeCameraTests.swift in Sources */,

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSetExposureModeTests.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/FLTCamSetExposureModeTests.swift
@@ -1,0 +1,57 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import XCTest
+
+@testable import camera_avfoundation
+
+final class FLTCamSetExposureModeTests: XCTestCase {
+  private func createCamera() -> (FLTCam, MockCaptureDevice) {
+    let mockDevice = MockCaptureDevice()
+
+    let configuration = FLTCreateTestCameraConfiguration()
+    configuration.captureDeviceFactory = { mockDevice }
+    let camera = FLTCreateCamWithConfiguration(configuration)
+
+    return (camera, mockDevice)
+  }
+
+  func testSetExposureModeLocked_setsLockedExposureMode() {
+    let (camera, mockDevice) = createCamera()
+
+    mockDevice.setExposureModeStub = { mode in
+      XCTAssertEqual(mode, .locked)
+    }
+
+    camera.setExposureMode(.locked)
+  }
+
+  func testSetExposureModeAuto_setsContinousAutoExposureMode_ifSupported() {
+    let (camera, mockDevice) = createCamera()
+
+    // All exposure modes are supported
+    mockDevice.isExposureModeSupportedStub = { _ in true }
+
+    mockDevice.setExposureModeStub = { mode in
+      XCTAssertEqual(mode, .continuousAutoExposure)
+    }
+
+    camera.setExposureMode(.auto)
+  }
+
+  func testSetExposureModeAuto_setsAutoExposeMode_ifNotSupported() {
+    let (camera, mockDevice) = createCamera()
+
+    // Continous auto exposure is not supported
+    mockDevice.isExposureModeSupportedStub = { mode in
+      mode != .continuousAutoExposure
+    }
+
+    mockDevice.setExposureModeStub = { mode in
+      XCTAssertEqual(mode, .autoExpose)
+    }
+
+    camera.setExposureMode(.auto)
+  }
+}

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureDevice.h
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureDevice.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 // Exposure
 @property(nonatomic, assign) BOOL exposurePointOfInterestSupported;
 @property(nonatomic, assign) AVCaptureExposureMode exposureMode;
-@property(nonatomic, assign) BOOL exposureModeSupported;
+@property(nonatomic, copy) BOOL (^isExposureModeSupportedStub)(AVCaptureExposureMode mode);
 /// Overrides the default implementation of setting exposure mode.
 /// @param mode The exposure mode being set
 @property(nonatomic, copy) void (^setExposureModeStub)(AVCaptureExposureMode mode);

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureDevice.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockCaptureDevice.m
@@ -111,7 +111,11 @@
 }
 
 - (BOOL)isExposureModeSupported:(AVCaptureExposureMode)mode {
-  return self.exposureModeSupported;
+  if (self.isExposureModeSupportedStub) {
+    return self.isExposureModeSupportedStub(mode);
+  } else {
+    return NO;
+  }
 }
 
 @synthesize device;

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockFLTCam.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/Mocks/MockFLTCam.swift
@@ -5,7 +5,6 @@
 final class MockFLTCam: FLTCam {
   var setOnFrameAvailableStub: ((() -> Void) -> Void)?
   var setDartApiStub: ((FCPCameraEventApi) -> Void)?
-  var setExposureModeStub: ((FCPPlatformExposureMode) -> Void)?
   var setFocusModeStub: ((FCPPlatformFocusMode) -> Void)?
   var getMinimumAvailableZoomFactorStub: (() -> CGFloat)?
   var getMaximumAvailableZoomFactorStub: (() -> CGFloat)?
@@ -24,6 +23,7 @@ final class MockFLTCam: FLTCam {
   var lockCaptureStub: ((FCPPlatformDeviceOrientation) -> Void)?
   var unlockCaptureOrientationStub: (() -> Void)?
   var setFlashModeStub: ((FCPPlatformFlashMode, ((FlutterError?) -> Void)?) -> Void)?
+  var setExposureModeStub: ((FCPPlatformExposureMode) -> Void)?
   var receivedImageStreamDataStub: (() -> Void)?
   var pausePreviewStub: (() -> Void)?
   var resumePreviewStub: (() -> Void)?
@@ -51,16 +51,6 @@ final class MockFLTCam: FLTCam {
     }
     set {
       setDartApiStub?(newValue)
-    }
-  }
-
-  /// The `setExposureMode` ObjC method is converted to property accessor in Swift translation
-  override var exposureMode: FCPPlatformExposureMode {
-    get {
-      return super.exposureMode
-    }
-    set {
-      setExposureModeStub?(newValue)
     }
   }
 
@@ -157,6 +147,10 @@ final class MockFLTCam: FLTCam {
     _ mode: FCPPlatformFlashMode, withCompletion completion: @escaping (FlutterError?) -> Void
   ) {
     setFlashModeStub?(mode, completion)
+  }
+
+  override func setExposureMode(_ mode: FCPPlatformExposureMode) {
+    setExposureModeStub?(mode)
   }
 
   override func receivedImageStreamData() {

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCam.m
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FLTCam.m
@@ -989,7 +989,7 @@ static void selectBestFormatForRequestedFrameRate(
   [_captureDevice lockForConfiguration:nil];
   switch (_exposureMode) {
     case FCPPlatformExposureModeLocked:
-      [_captureDevice setExposureMode:AVCaptureExposureModeAutoExpose];
+      [_captureDevice setExposureMode:AVCaptureExposureModeLocked];
       break;
     case FCPPlatformExposureModeAuto:
       if ([_captureDevice isExposureModeSupported:AVCaptureExposureModeContinuousAutoExposure]) {

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCam.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCam.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The API instance used to communicate with the Dart side of the plugin. Once initially set, this
 /// should only ever be accessed on the main thread.
 @property(nonatomic) FCPCameraEventApi *dartAPI;
-@property(assign, nonatomic) FCPPlatformExposureMode exposureMode;
+@property(readonly, nonatomic) FCPPlatformExposureMode exposureMode;
 @property(assign, nonatomic) FCPPlatformFocusMode focusMode;
 @property(assign, nonatomic) FCPPlatformFlashMode flashMode;
 // Format used for video and image streaming.

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/QueueUtils.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/QueueUtils.h
@@ -7,7 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Queue-specific context data to be associated with the capture session queue.
-extern const char* FLTCaptureSessionQueueSpecific;
+extern const char *FLTCaptureSessionQueueSpecific;
 
 /// Ensures the given block to be run on the main queue.
 /// If caller site is already on the main queue, the block will be run

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.18+9
+version: 0.9.19
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
Fixes the incorrect mapping of FCPPlatformExposureMode**Locked** to AVCaptureExposureMode**AutoExpose**. The locking of the exposure didn't essentially work before. If continuous auth exposure was supported on the device is switched to the non-continuous auto but nothing else.

Resolves the tracking issue https://github.com/flutter/flutter/issues/165117 and is a part of tests backfilling for the https://github.com/flutter/flutter/issues/119109

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under.
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
