### PR TITLE
[multicast_dns] MDnsClient::listen supports onError callback

### DIFF
--- a/packages/multicast_dns/CHANGELOG.md
+++ b/packages/multicast_dns/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2+9
+
+* Optional error callback for `MDnsClient::start` to prevent uncatched exceptions.
+
 ## 0.3.2+8
 
 * Fixes stack overflows ocurring during the parsing of domain names in MDNS messages.

--- a/packages/multicast_dns/CHANGELOG.md
+++ b/packages/multicast_dns/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.2+9
+## 0.3.3
 
 * Adds an optional error callback for `MDnsClient::start` to prevent uncaught exceptions.
 

--- a/packages/multicast_dns/CHANGELOG.md
+++ b/packages/multicast_dns/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.2+9
 
-* Optional error callback for `MDnsClient::start` to prevent uncatched exceptions.
+* Adds an optional error callback for `MDnsClient::start` to prevent uncaught exceptions.
 
 ## 0.3.2+8
 

--- a/packages/multicast_dns/lib/multicast_dns.dart
+++ b/packages/multicast_dns/lib/multicast_dns.dart
@@ -84,6 +84,12 @@ class MDnsClient {
   /// for the mDNS query. If not provided, defaults to either `224.0.0.251` or
   /// or `FF02::FB`.
   ///
+  /// The [onError] function allows to provide a callback function, called in
+  /// case of a stream error. If omitted any errors on the stream are considered
+  /// unhandled, and will be passed to the current [Zone]'s error handler. By
+  /// default unhandled async errors are treated as if they were uncaught top-level
+  /// errors.
+  ///
   /// Subsequent calls to this method are ignored while the mDNS client is in
   /// started state.
   Future<void> start({
@@ -91,6 +97,7 @@ class MDnsClient {
     NetworkInterfacesFactory? interfacesFactory,
     int mDnsPort = mDnsPort,
     InternetAddress? mDnsAddress,
+    Function? onError,
   }) async {
     listenAddress ??= InternetAddress.anyIPv4;
     interfacesFactory ??= allInterfacesFactory;
@@ -152,7 +159,10 @@ class MDnsClient {
       // Join multicast on this interface.
       incoming.joinMulticast(_mDnsAddress!, interface);
     }
-    incoming.listen((RawSocketEvent event) => _handleIncoming(event, incoming));
+    incoming.listen(
+      (RawSocketEvent event) => _handleIncoming(event, incoming),
+      onError: onError,
+    );
     _started = true;
     _starting = false;
   }

--- a/packages/multicast_dns/lib/multicast_dns.dart
+++ b/packages/multicast_dns/lib/multicast_dns.dart
@@ -84,11 +84,9 @@ class MDnsClient {
   /// for the mDNS query. If not provided, defaults to either `224.0.0.251` or
   /// or `FF02::FB`.
   ///
-  /// The [onError] function allows to provide a callback function, called in
-  /// case of a stream error. If omitted any errors on the stream are considered
-  /// unhandled, and will be passed to the current [Zone]'s error handler. By
-  /// default unhandled async errors are treated as if they were uncaught top-level
-  /// errors.
+  /// If provided, [onError] will be called in case of a stream error. If
+  /// omitted any errors on the stream are considered unhandled, and will be
+  /// passed to the current [Zone]'s error handler.
   ///
   /// Subsequent calls to this method are ignored while the mDNS client is in
   /// started state.

--- a/packages/multicast_dns/pubspec.yaml
+++ b/packages/multicast_dns/pubspec.yaml
@@ -2,7 +2,7 @@ name: multicast_dns
 description: Dart package for performing mDNS queries (e.g. Bonjour, Avahi).
 repository: https://github.com/flutter/packages/tree/main/packages/multicast_dns
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+multicast_dns%22
-version: 0.3.2+8
+version: 0.3.2+9
 
 environment:
   sdk: ^3.4.0

--- a/packages/multicast_dns/pubspec.yaml
+++ b/packages/multicast_dns/pubspec.yaml
@@ -2,7 +2,7 @@ name: multicast_dns
 description: Dart package for performing mDNS queries (e.g. Bonjour, Avahi).
 repository: https://github.com/flutter/packages/tree/main/packages/multicast_dns
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+multicast_dns%22
-version: 0.3.2+9
+version: 0.3.3
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
MDnsClient::Listen now supports an optional onError callback function,
called in case of a stream error. If omitted any errors on the stream
are considered unhandled, and will be passed to the current [Zone]'s
error handler. By default unhandled async errors are treated as if they
were uncaught top-level errors.

This fixes an unhandled exception occuring (tested on Android), when the
network is disconnected.

Fixes https://github.com/flutter/flutter/issues/165482

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

How can a test be added? It would need  to disconnect the device from WLAN beforehand.