### PR TITLE
[camera_android] Don't override default fps range when not recording

### DIFF
--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -225,30 +225,6 @@ class Camera
             dartMessenger,
             videoCaptureSettings.resolutionPreset);
 
-    Integer recordingFps = null;
-
-    if (videoCaptureSettings.fps != null && videoCaptureSettings.fps.intValue() > 0) {
-      recordingFps = videoCaptureSettings.fps;
-    } else {
-
-      if (SdkCapabilityChecker.supportsEncoderProfiles()) {
-        EncoderProfiles encoderProfiles = getRecordingProfile();
-        if (encoderProfiles != null && encoderProfiles.getVideoProfiles().size() > 0) {
-          recordingFps = encoderProfiles.getVideoProfiles().get(0).getFrameRate();
-        }
-      } else {
-        CamcorderProfile camcorderProfile = getRecordingProfileLegacy();
-        recordingFps = null != camcorderProfile ? camcorderProfile.videoFrameRate : null;
-      }
-    }
-
-    if (recordingFps != null && recordingFps.intValue() > 0) {
-
-      final FpsRangeFeature fpsRange = new FpsRangeFeature(cameraProperties);
-      fpsRange.setValue(new Range<Integer>(recordingFps, recordingFps));
-      this.cameraFeatures.setFpsRange(fpsRange);
-    }
-
     // Create capture callback.
     captureTimeouts = new CaptureTimeoutsWrapper(3000, 3000);
     captureProps = new CameraCaptureProperties();
@@ -324,6 +300,32 @@ class Camera
                     ? getDeviceOrientationManager().getVideoOrientation()
                     : getDeviceOrientationManager().getVideoOrientation(lockedOrientation))
             .build();
+  }
+
+  private void setFpsCameraFeature(CameraProperties cameraProperties) {
+    Integer recordingFps = null;
+
+    if (videoCaptureSettings.fps != null && videoCaptureSettings.fps.intValue() > 0) {
+      recordingFps = videoCaptureSettings.fps;
+    } else {
+
+      if (SdkCapabilityChecker.supportsEncoderProfiles()) {
+        EncoderProfiles encoderProfiles = getRecordingProfile();
+        if (encoderProfiles != null && encoderProfiles.getVideoProfiles().size() > 0) {
+          recordingFps = encoderProfiles.getVideoProfiles().get(0).getFrameRate();
+        }
+      } else {
+        CamcorderProfile camcorderProfile = getRecordingProfileLegacy();
+        recordingFps = null != camcorderProfile ? camcorderProfile.videoFrameRate : null;
+      }
+    }
+
+    if (recordingFps != null && recordingFps.intValue() > 0) {
+      
+      final FpsRangeFeature fpsRange = new FpsRangeFeature(cameraProperties);
+      fpsRange.setValue(new Range<Integer>(recordingFps, recordingFps));
+      this.cameraFeatures.setFpsRange(fpsRange);
+    }
   }
 
   @SuppressLint("MissingPermission")
@@ -851,6 +853,9 @@ class Camera
     // Re-create autofocus feature so it's using continuous capture focus mode now.
     cameraFeatures.setAutoFocus(
         cameraFeatureFactory.createAutoFocusFeature(cameraProperties, false));
+    // Reset to non recording fps range (the default)
+    cameraFeatures.setFpsRange(cameraFeatureFactory.createFpsRangeFeature(cameraProperties));
+
     recordingVideo = false;
     try {
       closeRenderer();
@@ -1252,6 +1257,8 @@ class Camera
     // Re-create autofocus feature so it's using video focus mode now.
     cameraFeatures.setAutoFocus(
         cameraFeatureFactory.createAutoFocusFeature(cameraProperties, true));
+    // Update camera features with the desired fps range
+    setFpsCameraFeature(cameraProperties);
   }
 
   private void setStreamHandler(EventChannel imageStreamChannel) {
@@ -1375,6 +1382,7 @@ class Camera
             videoCaptureSettings.resolutionPreset);
     cameraFeatures.setAutoFocus(
         cameraFeatureFactory.createAutoFocusFeature(cameraProperties, true));
+    setFpsCameraFeature(cameraProperties);
     try {
       open(imageFormatGroup);
     } catch (CameraAccessException e) {

--- a/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraTest_getRecordingProfileTest.java
+++ b/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraTest_getRecordingProfileTest.java
@@ -86,10 +86,7 @@ public class CameraTest_getRecordingProfileTest {
 
     CamcorderProfile actualRecordingProfile = camera.getRecordingProfileLegacy();
 
-    // First time: getRecordingProfileLegacy() is called in `before()` when
-    // camera constructor tries to determine default recording Fps.
-    // Second time: in this test case.
-    verify(mockResolutionFeature, times(2)).getRecordingProfileLegacy();
+    verify(mockResolutionFeature, times(1)).getRecordingProfileLegacy();
     assertEquals(mockCamcorderProfile, actualRecordingProfile);
   }
 
@@ -104,7 +101,7 @@ public class CameraTest_getRecordingProfileTest {
 
     EncoderProfiles actualRecordingProfile = camera.getRecordingProfile();
 
-    verify(mockResolutionFeature, times(2)).getRecordingProfile();
+    verify(mockResolutionFeature, times(1)).getRecordingProfile();
     assertEquals(mockRecordingProfile, actualRecordingProfile);
   }
 


### PR DESCRIPTION
In production I have an app using the `camera_android` plugin that just uses the frame streaming feature. I've been pinning version `0.10.8+18` for a while because we found an issue after updating to `0.10.9`. Some users reported a dark camera preview. 

After some investigation, I believe the issue is because of the call to `this.cameraFeatures.setFpsRange` in the `Camera` constructor. That is the only difference in behavior that .9 and .8+18 have.

Fixes  https://github.com/flutter/flutter/issues/165491

## Pre-Review Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
