### PR TITLE
[various] Disable sandbox in Chrome dart tests

### DIFF
--- a/packages/cross_file/example/dart_test.yaml
+++ b/packages/cross_file/example/dart_test.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#arguments
+override_platforms:
+  chrome:
+    settings:
+      arguments: --no-sandbox

--- a/packages/plugin_platform_interface/dart_test.yaml
+++ b/packages/plugin_platform_interface/dart_test.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#arguments
+override_platforms:
+  chrome:
+    settings:
+      arguments: --no-sandbox

--- a/packages/standard_message_codec/dart_test.yaml
+++ b/packages/standard_message_codec/dart_test.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#arguments
+override_platforms:
+  chrome:
+    settings:
+      arguments: --no-sandbox

--- a/packages/vector_graphics_codec/dart_test.yaml
+++ b/packages/vector_graphics_codec/dart_test.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#arguments
+override_platforms:
+  chrome:
+    settings:
+      arguments: --no-sandbox

--- a/third_party/packages/path_parsing/dart_test.yaml
+++ b/third_party/packages/path_parsing/dart_test.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#arguments
+override_platforms:
+  chrome:
+    settings:
+      arguments: --no-sandbox


### PR DESCRIPTION
`flutter test` automatically disables sandbox in headless mode, but `dart test` does not, and the Linux CI bots no longer support the sandbox, so this turns it off explicitly for packages that don't rely on Flutter (and thus use `dart test`).