### PR TITLE
[pigeon] correct usage of extended generics in generator methods

### DIFF
--- a/packages/pigeon/lib/src/cpp/cpp_generator.dart
+++ b/packages/pigeon/lib/src/cpp/cpp_generator.dart
@@ -98,7 +98,7 @@ class CppOptions {
 /// Options that control how C++ code will be generated.
 ///
 /// For internal use only.
-class InternalCppOptions extends PigeonInternalOptions {
+class InternalCppOptions extends InternalOptions {
   /// Creates a [InternalCppOptions] object.
   const InternalCppOptions({
     required this.headerIncludePath,

--- a/packages/pigeon/lib/src/dart/dart_generator.dart
+++ b/packages/pigeon/lib/src/dart/dart_generator.dart
@@ -87,7 +87,7 @@ class DartOptions {
 }
 
 /// Options that control how Dart code will be generated.
-class InternalDartOptions extends PigeonInternalOptions {
+class InternalDartOptions extends InternalOptions {
   /// Constructor for InternalDartOptions.
   const InternalDartOptions({
     this.copyrightHeader,

--- a/packages/pigeon/lib/src/generator.dart
+++ b/packages/pigeon/lib/src/generator.dart
@@ -6,21 +6,21 @@ import 'ast.dart';
 import 'generator_tools.dart';
 
 /// The internal options used by the generator.
-abstract class PigeonInternalOptions {
+abstract class InternalOptions {
   /// Constructor.
-  const PigeonInternalOptions();
+  const InternalOptions();
 }
 
 /// An abstract base class of generators.
 ///
 /// This provides the structure that is common across generators for different languages.
-abstract class Generator<PigeonInternalOptions> {
+abstract class Generator<T extends InternalOptions> {
   /// Constructor.
   const Generator();
 
   /// Generates files for specified language with specified [generatorOptions]
   void generate(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     StringSink sink, {
     required String dartPackageName,
@@ -28,14 +28,14 @@ abstract class Generator<PigeonInternalOptions> {
 }
 
 /// An abstract base class that enforces code generation across platforms.
-abstract class StructuredGenerator<PigeonInternalOptions>
-    extends Generator<PigeonInternalOptions> {
+abstract class StructuredGenerator<T extends InternalOptions>
+    extends Generator<T> {
   /// Constructor.
   const StructuredGenerator();
 
   @override
   void generate(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     StringSink sink, {
     required String dartPackageName,
@@ -126,7 +126,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Adds specified headers to [indent].
   void writeFilePrologue(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -134,7 +134,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes specified imports to [indent].
   void writeFileImports(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -144,7 +144,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
   ///
   /// This method is not required, and does not need to be overridden.
   void writeOpenNamespace(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -154,7 +154,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
   ///
   /// This method is not required, and does not need to be overridden.
   void writeCloseNamespace(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -164,7 +164,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
   ///
   /// This method is not required, and does not need to be overridden.
   void writeGeneralUtilities(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -174,7 +174,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
   ///
   /// Can be overridden to add extra code before/after enums.
   void writeEnums(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -192,7 +192,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes a single Enum to [indent]. This is needed in most generators.
   void writeEnum(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     Enum anEnum, {
@@ -203,7 +203,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
   ///
   /// Can be overridden to add extra code before/after apis.
   void writeDataClasses(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -221,7 +221,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes the custom codec to [indent].
   void writeGeneralCodec(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -229,7 +229,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes a single data class to [indent].
   void writeDataClass(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     Class classDefinition, {
@@ -238,7 +238,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes a single class encode method to [indent].
   void writeClassEncode(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     Class classDefinition, {
@@ -247,7 +247,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes a single class decode method to [indent].
   void writeClassDecode(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     Class classDefinition, {
@@ -256,7 +256,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes a single class decode method to [indent].
   void writeClassEquality(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     Class classDefinition, {
@@ -267,7 +267,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
   ///
   /// Can be overridden to add extra code before/after classes.
   void writeApis(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -312,7 +312,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes a single Flutter Api to [indent].
   void writeFlutterApi(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     AstFlutterApi api, {
@@ -321,7 +321,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes a single Host Api to [indent].
   void writeHostApi(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     AstHostApi api, {
@@ -330,7 +330,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes the implementation of an `InstanceManager` to [indent].
   void writeInstanceManager(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -339,7 +339,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
   /// Writes the implementation of the API for the `InstanceManager` to
   /// [indent].
   void writeInstanceManagerApi(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent, {
     required String dartPackageName,
@@ -356,14 +356,14 @@ abstract class StructuredGenerator<PigeonInternalOptions>
   /// needs to create its own codec (it has methods/fields/constructor that use
   /// a data class) it should extend this codec and not `StandardMessageCodec`.
   void writeProxyApiBaseCodec(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
   ) {}
 
   /// Writes a single Proxy Api to [indent].
   void writeProxyApi(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     AstProxyApi api, {
@@ -372,7 +372,7 @@ abstract class StructuredGenerator<PigeonInternalOptions>
 
   /// Writes a single event channel Api to [indent].
   void writeEventChannelApi(
-    PigeonInternalOptions generatorOptions,
+    T generatorOptions,
     Root root,
     Indent indent,
     AstEventChannelApi api, {

--- a/packages/pigeon/lib/src/generator_tools.dart
+++ b/packages/pigeon/lib/src/generator_tools.dart
@@ -10,6 +10,7 @@ import 'dart:mirrors';
 import 'package:yaml/yaml.dart' as yaml;
 
 import 'ast.dart';
+import 'generator.dart';
 
 /// The current version of pigeon.
 ///
@@ -794,7 +795,7 @@ enum FileType {
 /// Options for [Generator]s that have multiple output file types.
 ///
 /// Specifies which file to write as well as wraps all language options.
-class OutputFileOptions<T> {
+class OutputFileOptions<T extends InternalOptions> extends InternalOptions {
   /// Constructor.
   OutputFileOptions({required this.fileType, required this.languageOptions});
 

--- a/packages/pigeon/lib/src/gobject/gobject_generator.dart
+++ b/packages/pigeon/lib/src/gobject/gobject_generator.dart
@@ -74,7 +74,7 @@ class GObjectOptions {
 }
 
 /// Options that control how GObject code will be generated.
-class InternalGObjectOptions extends PigeonInternalOptions {
+class InternalGObjectOptions extends InternalOptions {
   /// Creates a [InternalGObjectOptions] object
   const InternalGObjectOptions({
     required this.headerIncludePath,

--- a/packages/pigeon/lib/src/java/java_generator.dart
+++ b/packages/pigeon/lib/src/java/java_generator.dart
@@ -90,7 +90,7 @@ class JavaOptions {
 }
 
 /// Options that control how Java code will be generated.
-class InternalJavaOptions extends PigeonInternalOptions {
+class InternalJavaOptions extends InternalOptions {
   /// Creates a [InternalJavaOptions] object
   const InternalJavaOptions({
     required this.javaOut,

--- a/packages/pigeon/lib/src/kotlin/kotlin_generator.dart
+++ b/packages/pigeon/lib/src/kotlin/kotlin_generator.dart
@@ -99,7 +99,7 @@ class KotlinOptions {
 }
 
 ///
-class InternalKotlinOptions extends PigeonInternalOptions {
+class InternalKotlinOptions extends InternalOptions {
   /// Creates a [InternalKotlinOptions] object
   const InternalKotlinOptions({
     this.package,

--- a/packages/pigeon/lib/src/objc/objc_generator.dart
+++ b/packages/pigeon/lib/src/objc/objc_generator.dart
@@ -93,7 +93,7 @@ class ObjcOptions {
 }
 
 /// Options that control how Objective-C code will be generated.
-class InternalObjcOptions extends PigeonInternalOptions {
+class InternalObjcOptions extends InternalOptions {
   /// Parametric constructor for InternalObjcOptions.
   const InternalObjcOptions({
     required this.headerIncludePath,

--- a/packages/pigeon/lib/src/swift/swift_generator.dart
+++ b/packages/pigeon/lib/src/swift/swift_generator.dart
@@ -79,7 +79,7 @@ class SwiftOptions {
 }
 
 /// Options that control how Swift code will be generated.
-class InternalSwiftOptions extends PigeonInternalOptions {
+class InternalSwiftOptions extends InternalOptions {
   /// Creates a [InternalSwiftOptions] object
   const InternalSwiftOptions({
     this.copyrightHeader,


### PR DESCRIPTION
This update is necessary for an impending linter change. 

Corrects improper usage of generics in the options for generators