### PR TITLE
[extension_gsi] Support the latest version of googleapis_auth

### DIFF
--- a/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
+++ b/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.13
 
+* Support the latest version of `package:googleapis_auth`.
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 
 ## 2.0.12

--- a/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
+++ b/packages/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.13
 
-* Support the latest version of `package:googleapis_auth`.
+* Supports the latest version of `package:googleapis_auth`.
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 
 ## 2.0.12

--- a/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
+++ b/packages/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
@@ -8,7 +8,7 @@ name: extension_google_sign_in_as_googleapis_auth
 description: A bridge package between google_sign_in and googleapis_auth, to create Authenticated Clients from google_sign_in user credentials.
 repository: https://github.com/flutter/packages/tree/main/packages/extension_google_sign_in_as_googleapis_auth
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+extension_google_sign_in_as_googleapis_auth%22
-version: 2.0.12
+version: 2.0.13
 
 environment:
   sdk: ^3.4.0
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   google_sign_in: ">=5.0.0 <7.0.0"
-  googleapis_auth: ^1.1.0
+  googleapis_auth: '>=1.1.0 <3.0.0'
   http: ">=0.13.0 <2.0.0"
   meta: ^1.3.0
 


### PR DESCRIPTION
Allows using the extension with v2.0.0 of `googleapis_auth`, which has just been published:

https://pub.dev/packages/googleapis_auth/changelog#200
