### PR TITLE
[google_maps_flutter_platform_interface] Fix bitmap descriptor getter

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.11.2
+
+* Update the `BitmapDescriptor` to add `getAssetName` functions for retrieving asset information.
+
 ## 2.11.1
 
 * Updates READMEs and API docs.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -233,14 +233,15 @@ abstract class BitmapDescriptor {
     if (!mipmaps && devicePixelRatio != null) {
       return AssetImageBitmap(name: assetName, scale: devicePixelRatio);
     }
-    final AssetImage assetImage = AssetImage(assetName, package: package, bundle: bundle);
-    final AssetBundleImageKey assetBundleImageKey = await assetImage.obtainKey(configuration);
+    final AssetImage assetImage =
+        AssetImage(assetName, package: package, bundle: bundle);
+    final AssetBundleImageKey assetBundleImageKey =
+        await assetImage.obtainKey(configuration);
     final Size? size = kIsWeb ? configuration.size : null;
     return AssetImageBitmap(
-      name: assetBundleImageKey.name,
-      scale: assetBundleImageKey.scale,
-      size: size
-    );
+        name: assetBundleImageKey.name,
+        scale: assetBundleImageKey.scale,
+        size: size);
   }
 
   /// Creates a BitmapDescriptor using an array of bytes that must be encoded
@@ -392,7 +393,7 @@ class AssetBitmap extends BitmapDescriptor {
 
   /// Optional package of the asset.
   final String? package;
-  
+
   @override
   String? getAssetName() {
     return name;
@@ -426,7 +427,7 @@ class AssetImageBitmap extends BitmapDescriptor {
 
   /// Size of the image if using mipmaps.
   final Size? size;
-  
+
   @override
   String? getAssetName() {
     return name;

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -233,15 +233,14 @@ abstract class BitmapDescriptor {
     if (!mipmaps && devicePixelRatio != null) {
       return AssetImageBitmap(name: assetName, scale: devicePixelRatio);
     }
-    final AssetImage assetImage =
-        AssetImage(assetName, package: package, bundle: bundle);
-    final AssetBundleImageKey assetBundleImageKey =
-        await assetImage.obtainKey(configuration);
+    final AssetImage assetImage = AssetImage(assetName, package: package, bundle: bundle);
+    final AssetBundleImageKey assetBundleImageKey = await assetImage.obtainKey(configuration);
     final Size? size = kIsWeb ? configuration.size : null;
     return AssetImageBitmap(
-        name: assetBundleImageKey.name,
-        scale: assetBundleImageKey.scale,
-        size: size);
+      name: assetBundleImageKey.name,
+      scale: assetBundleImageKey.scale,
+      size: size
+    );
   }
 
   /// Creates a BitmapDescriptor using an array of bytes that must be encoded
@@ -330,6 +329,12 @@ abstract class BitmapDescriptor {
     );
   }
 
+  /// Returns the asset name used to create this BitmapDescriptor, if available.
+  /// Returns null if this BitmapDescriptor was not created from an asset.
+  String? getAssetName() {
+    return null;
+  }
+
   /// Convert the object to a Json format.
   Object toJson();
 }
@@ -387,6 +392,11 @@ class AssetBitmap extends BitmapDescriptor {
 
   /// Optional package of the asset.
   final String? package;
+  
+  @override
+  String? getAssetName() {
+    return name;
+  }
 
   @override
   Object toJson() => <Object>[
@@ -416,6 +426,11 @@ class AssetImageBitmap extends BitmapDescriptor {
 
   /// Size of the image if using mipmaps.
   final Size? size;
+  
+  @override
+  String? getAssetName() {
+    return name;
+  }
 
   @override
   Object toJson() => <Object>[
@@ -764,6 +779,11 @@ class AssetMapBitmap extends MapBitmap {
         bitmapScaling: bitmapScaling,
         width: width ?? configuration.size?.width,
         height: height ?? configuration.size?.height);
+  }
+
+  @override
+  String? getAssetName() {
+    return assetName;
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.11.1
+version: 2.11.2
 
 environment:
   sdk: ^3.4.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/bitmap_test.dart
@@ -447,6 +447,7 @@ void main() {
       expect(descriptor.assetName, 'red_square.png');
       expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
       expect(descriptor.imagePixelRatio, 1.0);
+      expect(descriptor.getAssetName(), 'red_square.png');
     });
 
     test('construct with imagePixelRatio', () async {
@@ -598,6 +599,13 @@ void main() {
       expect(descriptor.bitmapScaling, MapBitmapScaling.auto);
       expect(descriptor.imagePixelRatio, 1.0);
       expect(descriptor.height, 200.0);
+    });
+
+    test('getAssetName returns null for non-asset descriptors', () {
+      final BitmapDescriptor descriptor = BytesMapBitmap(
+        Uint8List.fromList(<int>[1, 2, 3]),
+      );
+      expect(descriptor.getAssetName(), isNull);
     });
   },
       // TODO(stuartmorgan): Investigate timeout on web.


### PR DESCRIPTION
When you create a marker with a predefined asset like this, for example:

```dart
  Future<BitmapDescriptor> _getCustomMarker(bool isInPolygon, String assetFilePathColor, String assetFilePathGray) async {
    String imageAssetPath = isInPolygon ? assetFilePathColor : assetFilePathGray;
    
    return BitmapDescriptor.asset(
      const ImageConfiguration(size: Size(48, 48)),
      imageAssetPath,
    );
  }
```

Once the object is in our possession, we can't find the image assigned to this BitmapDescriptor. So I've added the ability to make a getter `getAssetName` to a ``BitmapDescriptor`` to retrieve the image in which it was built.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
