### PR TITLE
[google_maps_flutter] Skip test that hangs iOS CI

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/integration_test/src/maps_inspector.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/integration_test/src/maps_inspector.dart
@@ -711,7 +711,9 @@ void runTests() {
     variant: _cameraUpdateTypeVariants,
     // TODO(stuartmorgan): Remove skip for Android platform once Maps API key is
     // available for LUCI, https://github.com/flutter/flutter/issues/131071
-    skip: isAndroid,
+    skip: isAndroid ||
+        // Hanging in CI, https://github.com/flutter/flutter/issues/166139
+        isIOS,
   );
 
   /// Tests animating the camera with specified durations to verify timing


### PR DESCRIPTION
This test stared hanging in CI due to OOB failure. Skipping to re-open the tree while it's investigated.

See https://github.com/flutter/flutter/issues/166139