### PR TITLE
[google_maps_flutter] Skip more hanging iOS tests

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/integration_test/src/maps_inspector.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/integration_test/src/maps_inspector.dart
@@ -866,9 +866,12 @@ void runTests() {
     variant: _cameraUpdateTypeVariants,
     // TODO(jokerttu): Remove skip once the web implementation is available,
     // https://github.com/flutter/flutter/issues/159265
-    // TODO(stuartmorgan): Remove skip for Android platform once Maps API key is
-    // available for LUCI, https://github.com/flutter/flutter/issues/131071
-    skip: kIsWeb || isAndroid,
+    skip: kIsWeb ||
+        // TODO(stuartmorgan): Remove skip for Android platform once Maps API key is
+        // available for LUCI, https://github.com/flutter/flutter/issues/131071
+        isAndroid ||
+        // Hanging in CI, https://github.com/flutter/flutter/issues/166139
+        isIOS,
   );
 }
 


### PR DESCRIPTION
Now `testAnimateCameraWithDuration` is failing as well, as I had expected previously. It's not clear why it didn't fail in the PR where I disabled the `WithoutDuration` variant but is failing now.

Part of https://github.com/flutter/flutter/issues/166139