### PR TITLE
[video_player] Add poster attribute for html video tag in video_player_platform_interface

### DIFF
--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 6.3.1
 
+* Add html 5 video poster support as a VideoPlayerWebOptions.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 6.3.0

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 6.3.1
+## 6.4.0
 
-* Add html 5 video poster support as a VideoPlayerWebOptions.
+* Adds HTML5 video poster support as a VideoPlayerWebOptions.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 6.3.0

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -442,7 +442,7 @@ class VideoPlayerWebOptions {
   final bool allowRemotePlayback;
 
   /// The URL of the poster image to be displayed before the video starts
-  final String? poster;
+  final Uri? poster;
 }
 
 /// [VideoPlayerWebOptions] can be used to set how control options are displayed

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -429,6 +429,7 @@ class VideoPlayerWebOptions {
     this.controls = const VideoPlayerWebOptionsControls.disabled(),
     this.allowContextMenu = true,
     this.allowRemotePlayback = true,
+    this.poster,
   });
 
   /// Additional settings for how control options are displayed
@@ -439,6 +440,9 @@ class VideoPlayerWebOptions {
 
   /// Whether remote playback is allowed
   final bool allowRemotePlayback;
+
+  /// The URL of the poster image to be displayed before the video starts
+  final String? poster;
 }
 
 /// [VideoPlayerWebOptions] can be used to set how control options are displayed

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/video_player/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.3.1
+version: 6.4.0
 
 environment:
   sdk: ^3.6.0

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/video_player/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.3.0
+version: 6.3.1
 
 environment:
   sdk: ^3.6.0

--- a/packages/video_player/video_player_platform_interface/test/video_player_web_options_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/video_player_web_options_test.dart
@@ -29,4 +29,24 @@ void main() {
       expect(options.allowRemotePlayback, isTrue);
     },
   );
+
+  group('VideoPlayerOptions poster', () {
+    test(
+      'defaults to null',
+      () {
+        const VideoPlayerWebOptions options = VideoPlayerWebOptions();
+        expect(options.poster, null);
+      },
+    );
+
+    test(
+      'with a value',
+      () {
+        const VideoPlayerWebOptions options = VideoPlayerWebOptions(
+          poster: 'https://example.com/poster.jpg',
+        );
+        expect(options.poster, 'https://example.com/poster.jpg');
+      },
+    );
+  });
 }

--- a/packages/video_player/video_player_platform_interface/test/video_player_web_options_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/video_player_web_options_test.dart
@@ -42,10 +42,10 @@ void main() {
     test(
       'with a value',
       () {
-        const VideoPlayerWebOptions options = VideoPlayerWebOptions(
-          poster: 'https://example.com/poster.jpg',
+        final VideoPlayerWebOptions options = VideoPlayerWebOptions(
+          poster: Uri.parse('https://example.com/poster.jpg'),
         );
-        expect(options.poster, 'https://example.com/poster.jpg');
+        expect(options.poster, Uri.parse('https://example.com/poster.jpg'));
       },
     );
   });


### PR DESCRIPTION
This PR adds support for the poster attribute on web by introducing a poster field in VideoPlayerWebOptions. It allows setting a thumbnail image for videos using the native HTML5 poster property, improving the out-of-the-box web experience.

This PR is is the changes to platform_interface for this [one](https://github.com/flutter/packages/pull/8940)

Solve this issue:
https://github.com/flutter/flutter/issues/166232

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
