### PR TITLE
[camera_avfoundation] handle interruptions and use single offset

### DIFF
--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -174,7 +174,7 @@ class CameraValue {
   }) {
     return CameraValue(
       isInitialized: isInitialized ?? this.isInitialized,
-      errorDescription: errorDescription,
+      errorDescription: errorDescription ?? this.errorDescription,
       previewSize: previewSize ?? this.previewSize,
       isRecordingVideo: isRecordingVideo ?? this.isRecordingVideo,
       isTakingPicture: isTakingPicture ?? this.isTakingPicture,
@@ -351,6 +351,15 @@ class CameraController extends ValueNotifier<CameraValue> {
           .first
           .then((CameraInitializedEvent event) {
         initializeCompleter.complete(event);
+      }));
+
+      _unawaited(CameraPlatform.instance
+          .onCameraError(_cameraId)
+          .first
+          .then((CameraErrorEvent event) {
+        value = value.copyWith(
+          errorDescription: event.description,
+        );
       }));
 
       await CameraPlatform.instance.initializeCamera(

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.18+14
+
+* Handle video and audio interruptions and errors.
+* Use a single time offset for both video and audio.
+
 ## 0.9.18+1
 
 * Refactors implementations to reduce usage of OCMock in internal testing.

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.h
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/CameraTestUtils.h
@@ -47,8 +47,16 @@ extern FLTCam *FLTCreateCamWithVideoDimensionsForFormat(
 /// @return a test sample buffer.
 extern CMSampleBufferRef FLTCreateTestSampleBuffer(void);
 
+/// Creates a test sample buffer with timing.
+/// @return a test sample buffer.
+extern CMSampleBufferRef FLTCreateTestSampleBufferWithTiming(CMTime timestamp, CMTime duration);
+
 /// Creates a test audio sample buffer.
 /// @return a test audio sample buffer.
 extern CMSampleBufferRef FLTCreateTestAudioSampleBuffer(void);
+
+/// Creates a test audio sample buffer with timing.
+/// @return a test audio sample buffer.
+extern CMSampleBufferRef FLTCreateTestAudioSampleBufferWithTiming(CMTime timestamp, CMTime duration);
 
 NS_ASSUME_NONNULL_END

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCam_Test.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/include/camera_avfoundation/FLTCam_Test.h
@@ -40,6 +40,9 @@ typedef id<FLTCaptureDeviceControlling> (^CaptureDeviceFactory)(void);
 /// True when images from the camera are being streamed.
 @property(assign, nonatomic) BOOL isStreamingImages;
 
+@property(readonly, nonatomic) AVCaptureSession *videoCaptureSession;
+@property(readonly, nonatomic) AVCaptureSession *audioCaptureSession;
+
 /// A dictionary to retain all in-progress FLTSavePhotoDelegates. The key of the dictionary is the
 /// AVCapturePhotoSettings's uniqueID for each photo capture operation, and the value is the
 /// FLTSavePhotoDelegate that handles the result of each photo capture operation. Note that photo

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.18+1
+version: 0.9.18+14
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
Handle interruptions of capture sessions by doing "internal pause". Another possibility would be to remove audio input from the session but this would be too specific for interruptions caused by an incoming call or alarm. Or to stop video recording as the native ios camera app does but this would require some additional event.

Handle asynchronous error notifications posted about capture sessions. This can happen for example when there is an incoming phone call and the camera starts recording with audio. For this specific case would be enough to just call `startRunning` on capture sessions but that is too specific and would require ability to restart capture session from dart side as seems there is no good way how to test when such phone call or other such event ends, and trying to restart it for example every second inside `FLTCam` does not look like good idea. Instead the camera controller enters an error state and can be recovered by disposing and recreating which should be more generic.

Use single offset for both video and audio as separate offsets can cause unsynchronized video with audio. Seems audio timestamps tend to be ignored except for the first sample so prefer them for calculating offset to avoid desynchronization. Avoid errors when trying to append samples with timestamp less or equal to the previous sample. Fix a bug when after adjusting offset also last sample time needs to be updated to avoid adding past offsets multiple times.

- fixes https://github.com/flutter/flutter/issues/149978
- fixes https://github.com/flutter/flutter/issues/151253

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
