### PR TITLE
[camera_android] prevent startImageStream OOM error when main thread paused (flutter#166533)

### DIFF
--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.10+3
+
+* Fix flutter#166533 - prevent startImageStream OOM error when main thread paused.
+
 ## 0.10.10+2
 
 * Don't set the FPS range unless video recording. It can cause dark image previews on some devices becuse the auto exposure algorithm is more constrained after fixing the min/max FPS range to the same value. This change has the side effect that providing the `fps` parameter will not affect the camera preview when not video recording. And if you need a lower frame rate in your image streaming handler, you can skip frames by checking the time it passed since the last frame.

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/media/ImageStreamReader.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/media/ImageStreamReader.java
@@ -9,6 +9,7 @@ import android.media.Image;
 import android.media.ImageReader;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
@@ -22,6 +23,7 @@ import java.util.Map;
 
 // Wraps an ImageReader to allow for testing of the image handler.
 public class ImageStreamReader {
+  private static final String TAG = "ImageStreamReader";
 
   /**
    * The image format we are going to send back to dart. Usually it's the same as streamImageFormat
@@ -32,6 +34,13 @@ public class ImageStreamReader {
 
   private final ImageReader imageReader;
   private final ImageStreamReaderUtils imageStreamReaderUtils;
+
+  /**
+   * This solves a memory issue, when the main thread hangs (e.g. when pausing the debugger) while
+   * many frames are being sent using android.os.Handler.post(). This causes an OOM error rather
+   * quickly. So to avoid this we apply some back-pressure.
+   */
+  private static int numImagesInTransit = 0;
 
   /**
    * Creates a new instance of the {@link ImageStreamReader}.
@@ -96,6 +105,13 @@ public class ImageStreamReader {
       @NonNull CameraCaptureProperties captureProps,
       @NonNull EventChannel.EventSink imageStreamSink) {
     try {
+      // The limit was chosen so it would not drop frames for reasonable lags of the main thread.
+      if (numImagesInTransit > 2) {
+        Log.d(TAG, "Dropping frame due to images pending on main thread.");
+        image.close();
+        return;
+      }
+
       Map<String, Object> imageBuffer = new HashMap<>();
 
       // Get plane data ready
@@ -115,11 +131,19 @@ public class ImageStreamReader {
           "sensorSensitivity", sensorSensitivity == null ? null : (double) sensorSensitivity);
 
       final Handler handler = new Handler(Looper.getMainLooper());
-      handler.post(() -> imageStreamSink.success(imageBuffer));
+      ++numImagesInTransit;
+      boolean postResult =
+          handler.post(
+              () -> {
+                imageStreamSink.success(imageBuffer);
+                --numImagesInTransit;
+              });
+
       image.close();
 
     } catch (IllegalStateException e) {
-      // Handle "buffer is inaccessible" errors that can happen on some devices from ImageStreamReaderUtils.yuv420ThreePlanesToNV21()
+      // Handle "buffer is inaccessible" errors that can happen on some devices from
+      // ImageStreamReaderUtils.yuv420ThreePlanesToNV21()
       final Handler handler = new Handler(Looper.getMainLooper());
       handler.post(
           () ->

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 
-version: 0.10.10+2
+version: 0.10.10+3
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
*I have yet not written a test for this.* I am unfamiliar with the testing system, but I am in the process of trying to write one. I thought it'd be good to put this out there first, especially if there are comments on the solution itself. Once I write a test I will edit the pull request. Meanwhile, perhaps someone else more familiar with the system might contribute a test, and that would probably be better than the test I'll come up with.

When streaming images using CameraController.startImageStream(), images are being post()-ed to the main looper even if it's halted. This is common when debugging. This quickly results in an OOM and the app crashes abruptly.

The fix is done by counting the number of images that have been posted to the main thread but have not yet arrived. If too many images are in transit (I arbitrarily chose 3 as the maximum allowable amount) subsequent frames are dropped, until the main thread receives the pending images.

A log message is emitted for each dropped frame.

Fixes flutter/flutter#166533

That issue also provides a demo program.


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
