### PR TITLE
[shared_preferences] Allow reading int as long in SharedPreferences #165781

### DIFF
--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.9
+
+* Enables callers to use `getInt` to read preference of type `int` that was written to shared preferences by native code without passing though plugin code.
+
 ## 2.4.8
 
 * Updates compileSdk 34 to flutter.compileSdkVersion.

--- a/packages/shared_preferences/shared_preferences_android/android/src/main/kotlin/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.kt
+++ b/packages/shared_preferences/shared_preferences_android/android/src/main/kotlin/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.kt
@@ -23,6 +23,7 @@ import io.flutter.plugin.common.BinaryMessenger
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.ObjectOutputStream
+import java.lang.ClassCastException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
@@ -379,7 +380,12 @@ class SharedPreferencesBackend(
   override fun getInt(key: String, options: SharedPreferencesPigeonOptions): Long? {
     val preferences = createSharedPreferences(options)
     return if (preferences.contains(key)) {
-      preferences.getLong(key, 0)
+      try {
+        preferences.getLong(key, 0)
+      } catch (e: ClassCastException) {
+        // Retry with getInt in case the preference was written by native code directly.
+        preferences.getInt(key, 0).toLong()
+      }
     } else {
       null
     }

--- a/packages/shared_preferences/shared_preferences_android/example/android/app/src/main/java/dev/flutter/plugins/shared_preferences_example/MainActivity.java
+++ b/packages/shared_preferences/shared_preferences_android/example/android/app/src/main/java/dev/flutter/plugins/shared_preferences_example/MainActivity.java
@@ -17,9 +17,10 @@ public class MainActivity extends FlutterActivity {
     SharedPreferences preferences =
         PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 
-    // This call adds a preference for later testing in the Dart integration tests.
+    // These calls add preferences for later testing in the Dart integration tests.
     preferences
         .edit()
+        .putInt("thisIntIsWrittenInTheExampleAppJavaCode", 5)
         .putString("thisStringIsWrittenInTheExampleAppJavaCode", "testString")
         .commit();
   }

--- a/packages/shared_preferences/shared_preferences_android/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_android/example/integration_test/shared_preferences_test.dart
@@ -914,4 +914,16 @@ void main() {
             'thisStringIsWrittenInTheExampleAppJavaCode', options),
         'testString');
   });
+
+  testWidgets('Shared Preferences can read ints by conversion to long',
+      (WidgetTester _) async {
+    final SharedPreferencesAsyncAndroidOptions options =
+        getOptions(useDataStore: false);
+    final SharedPreferencesAsyncPlatform preferences = getPreferences();
+
+    expect(
+        await preferences.getInt(
+            'thisIntIsWrittenInTheExampleAppJavaCode', options),
+        5);
+  });
 }

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.4.8
+version: 2.4.9
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Resolves issue [#165781](https://github.com/flutter/flutter/issues/165781) by falling back to reading preference as an int then upcasted to a Long.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
