### PR TITLE
[various] Update Android example toolchains

### DIFF
--- a/packages/flutter_markdown/example/android/settings.gradle
+++ b/packages/flutter_markdown/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 plugins {
   id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-  id "com.android.application" version "8.1.0" apply false
+  id "com.android.application" version "8.5.1" apply false
   id "org.jetbrains.kotlin.android" version "1.9.0" apply false
   id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.1"
 }

--- a/packages/flutter_plugin_android_lifecycle/example/android/settings.gradle
+++ b/packages/flutter_plugin_android_lifecycle/example/android/settings.gradle
@@ -30,8 +30,8 @@ buildscript {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.5.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
     id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.1"
 }
 

--- a/packages/go_router/example/android/settings.gradle
+++ b/packages/go_router/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 plugins {
   id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-  id "com.android.application" version "8.1.0" apply false
+  id "com.android.application" version "8.5.1" apply false
   id "org.jetbrains.kotlin.android" version "1.9.0" apply false
   id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.1"
 }

--- a/packages/path_provider/path_provider/example/android/settings.gradle
+++ b/packages/path_provider/path_provider/example/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
     id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.1"
 }
 

--- a/packages/path_provider/path_provider_android/example/android/settings.gradle
+++ b/packages/path_provider/path_provider_android/example/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.5.1" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
     id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.1"
 }
 

--- a/packages/rfw/example/hello/android/settings.gradle
+++ b/packages/rfw/example/hello/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 plugins {
   id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-  id "com.android.application" version "8.1.0" apply false
+  id "com.android.application" version "8.5.1" apply false
   id "org.jetbrains.kotlin.android" version "1.9.0" apply false
   id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.1"
 


### PR DESCRIPTION
Almost all packages in the repository are using AGP 8.5+ and KGP 1.9+, but a few are still using older versions, and Flutter `master` prints warnings that they will be unsupported in future Flutter versions. This updates them to match the rest of the repo, to avoid later breakage.