### PR TITLE
[tool] Run a config-only build before Xcode analyze

### DIFF
--- a/script/tool/lib/src/common/flutter_command_utils.dart
+++ b/script/tool/lib/src/common/flutter_command_utils.dart
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:platform/platform.dart';
+
+import 'process_runner.dart';
+import 'repository_package.dart';
+
+/// Runs the appropriate `flutter build --config-only` command for the given
+/// target platform and build mode, to ensure that all of the native build files
+/// are present for that mode.
+///
+/// If [streamOutput] is false, output will only be printed if the command
+/// fails.
+Future<bool> runConfigOnlyBuild(
+  RepositoryPackage package,
+  ProcessRunner processRunner,
+  Platform platform,
+  FlutterPlatform targetPlatform, {
+  bool buildDebug = false,
+  List<String> extraArgs = const <String>[],
+}) async {
+  final String flutterCommand = platform.isWindows ? 'flutter.bat' : 'flutter';
+
+  final String target = switch (targetPlatform) {
+    FlutterPlatform.android => 'apk',
+    FlutterPlatform.ios => 'ios',
+    FlutterPlatform.linux => 'linux',
+    FlutterPlatform.macos => 'macos',
+    FlutterPlatform.web => 'web',
+    FlutterPlatform.windows => 'windows',
+  };
+
+  final int exitCode = await processRunner.runAndStream(
+      flutterCommand,
+      <String>[
+        'build',
+        target,
+        if (buildDebug) '--debug',
+        '--config-only',
+        ...extraArgs,
+      ],
+      workingDir: package.directory);
+  return exitCode == 0;
+}

--- a/script/tool/lib/src/lint_android_command.dart
+++ b/script/tool/lib/src/lint_android_command.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'common/core.dart';
+import 'common/flutter_command_utils.dart';
 import 'common/gradle.dart';
 import 'common/output_utils.dart';
 import 'common/package_looping_command.dart';
@@ -41,12 +42,9 @@ class LintAndroidCommand extends PackageLoopingCommand {
           processRunner: processRunner, platform: platform);
 
       if (!project.isConfigured()) {
-        final int exitCode = await processRunner.runAndStream(
-          flutterCommand,
-          <String>['build', 'apk', '--config-only'],
-          workingDir: example.directory,
-        );
-        if (exitCode != 0) {
+        final bool buildSuccess = await runConfigOnlyBuild(
+            example, processRunner, platform, FlutterPlatform.android);
+        if (!buildSuccess) {
           printError('Unable to configure Gradle project.');
           return PackageResult.fail(<String>['Unable to configure Gradle.']);
         }

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 
 import 'common/cmake.dart';
 import 'common/core.dart';
+import 'common/flutter_command_utils.dart';
 import 'common/gradle.dart';
 import 'common/output_utils.dart';
 import 'common/package_looping_command.dart';
@@ -330,12 +331,13 @@ this command.
         platform: platform,
       );
       if (!project.isConfigured()) {
-        final int exitCode = await processRunner.runAndStream(
-          flutterCommand,
-          <String>['build', 'apk', '--config-only'],
-          workingDir: example.directory,
+        final bool buildSuccess = await runConfigOnlyBuild(
+          example,
+          processRunner,
+          platform,
+          FlutterPlatform.android,
         );
-        if (exitCode != 0) {
+        if (!buildSuccess) {
           printError('Unable to configure Gradle project.');
           failed = true;
           continue;

--- a/script/tool/lib/src/xcode_analyze_command.dart
+++ b/script/tool/lib/src/xcode_analyze_command.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'common/core.dart';
+import 'common/flutter_command_utils.dart';
 import 'common/output_utils.dart';
 import 'common/package_looping_command.dart';
 import 'common/plugin_utils.dart';
@@ -74,19 +75,21 @@ class XcodeAnalyzeCommand extends PackageLoopingCommand {
 
     final List<String> failures = <String>[];
     if (testIOS &&
-        !await _analyzePlugin(package, 'iOS', extraFlags: <String>[
-          '-destination',
-          'generic/platform=iOS Simulator',
-          if (minIOSVersion.isNotEmpty)
-            'IPHONEOS_DEPLOYMENT_TARGET=$minIOSVersion',
-        ])) {
+        !await _analyzePlugin(package, FlutterPlatform.ios,
+            extraFlags: <String>[
+              '-destination',
+              'generic/platform=iOS Simulator',
+              if (minIOSVersion.isNotEmpty)
+                'IPHONEOS_DEPLOYMENT_TARGET=$minIOSVersion',
+            ])) {
       failures.add('iOS');
     }
     if (testMacOS &&
-        !await _analyzePlugin(package, 'macOS', extraFlags: <String>[
-          if (minMacOSVersion.isNotEmpty)
-            'MACOSX_DEPLOYMENT_TARGET=$minMacOSVersion',
-        ])) {
+        !await _analyzePlugin(package, FlutterPlatform.macos,
+            extraFlags: <String>[
+              if (minMacOSVersion.isNotEmpty)
+                'MACOSX_DEPLOYMENT_TARGET=$minMacOSVersion',
+            ])) {
       failures.add('macOS');
     }
 
@@ -101,22 +104,40 @@ class XcodeAnalyzeCommand extends PackageLoopingCommand {
   /// Analyzes [plugin] for [targetPlatform], returning true if it passed analysis.
   Future<bool> _analyzePlugin(
     RepositoryPackage plugin,
-    String targetPlatform, {
+    FlutterPlatform targetPlatform, {
     List<String> extraFlags = const <String>[],
   }) async {
+    final String platformString =
+        targetPlatform == FlutterPlatform.ios ? 'iOS' : 'macOS';
     bool passing = true;
     for (final RepositoryPackage example in plugin.getExamples()) {
+      // Unconditionally re-run build with --debug --config-only, to ensure that
+      // the project is in a debug state even if it was previously configured.
+      print('Running flutter build --config-only...');
+      final bool buildSuccess = await runConfigOnlyBuild(
+        example,
+        processRunner,
+        platform,
+        targetPlatform,
+        buildDebug: true,
+      );
+      if (!buildSuccess) {
+        printError('Unable to prepare native project files.');
+        passing = false;
+        continue;
+      }
+
       // Running tests and static analyzer.
       final String examplePath = getRelativePosixPath(example.directory,
           from: plugin.directory.parent);
-      print('Running $targetPlatform tests and analyzer for $examplePath...');
+      print('Running $platformString tests and analyzer for $examplePath...');
       final int exitCode = await _xcode.runXcodeBuild(
         example.directory,
-        targetPlatform,
+        platformString,
         // Clean before analyzing to remove cached swiftmodules from previous
         // runs, which can cause conflicts.
         actions: <String>['clean', 'analyze'],
-        workspace: '${targetPlatform.toLowerCase()}/Runner.xcworkspace',
+        workspace: '${platformString.toLowerCase()}/Runner.xcworkspace',
         scheme: 'Runner',
         configuration: 'Debug',
         hostPlatform: platform,
@@ -126,9 +147,9 @@ class XcodeAnalyzeCommand extends PackageLoopingCommand {
         ],
       );
       if (exitCode == 0) {
-        printSuccess('$examplePath ($targetPlatform) passed analysis.');
+        printSuccess('$examplePath ($platformString) passed analysis.');
       } else {
-        printError('$examplePath ($targetPlatform) failed analysis.');
+        printError('$examplePath ($platformString) failed analysis.');
         passing = false;
       }
     }

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -167,11 +167,7 @@ public class MainActivityTest {
           ProcessCall(
               'flutter',
               const <String>['build', 'apk', '--debug', '--config-only'],
-              plugin1
-                  .getExamples()
-                  .first
-                  .platformDirectory(FlutterPlatform.android)
-                  .path),
+              plugin1.getExamples().first.directory.path),
           ProcessCall(
               'gcloud',
               'auth activate-service-account --key-file=/path/to/key'
@@ -196,11 +192,7 @@ public class MainActivityTest {
           ProcessCall(
               'flutter',
               const <String>['build', 'apk', '--debug', '--config-only'],
-              plugin2
-                  .getExamples()
-                  .first
-                  .platformDirectory(FlutterPlatform.android)
-                  .path),
+              plugin2.getExamples().first.directory.path),
           ProcessCall(
               '/packages/plugin2/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true'.split(' '),
@@ -264,11 +256,7 @@ public class MainActivityTest {
           ProcessCall(
               'flutter',
               const <String>['build', 'apk', '--debug', '--config-only'],
-              plugin
-                  .getExamples()
-                  .first
-                  .platformDirectory(FlutterPlatform.android)
-                  .path),
+              plugin.getExamples().first.directory.path),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true'.split(' '),
@@ -694,11 +682,7 @@ class MainActivityTest {
           ProcessCall(
             'flutter',
             'build apk --debug --config-only'.split(' '),
-            plugin
-                .getExamples()
-                .first
-                .platformDirectory(FlutterPlatform.android)
-                .path,
+            plugin.getExamples().first.directory.path,
           ),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
@@ -878,11 +862,7 @@ class MainActivityTest {
                 '--config-only',
                 '--enable-experiment=exp1'
               ],
-              plugin
-                  .getExamples()
-                  .first
-                  .platformDirectory(FlutterPlatform.android)
-                  .path),
+              plugin.getExamples().first.directory.path),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true -Pextra-front-end-options=--enable-experiment%3Dexp1 -Pextra-gen-snapshot-options=--enable-experiment%3Dexp1'

--- a/script/tool/test/xcode_analyze_command_test.dart
+++ b/script/tool/test/xcode_analyze_command_test.dart
@@ -106,6 +106,15 @@ void main() {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               ProcessCall(
+                  'flutter',
+                  const <String>[
+                    'build',
+                    'ios',
+                    '--debug',
+                    '--config-only',
+                  ],
+                  pluginExampleDirectory.path),
+              ProcessCall(
                   'xcrun',
                   const <String>[
                     'xcodebuild',
@@ -146,6 +155,15 @@ void main() {
         expect(
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
+              ProcessCall(
+                  'flutter',
+                  const <String>[
+                    'build',
+                    'ios',
+                    '--debug',
+                    '--config-only',
+                  ],
+                  pluginExampleDirectory.path),
               ProcessCall(
                   'xcrun',
                   const <String>[
@@ -246,6 +264,15 @@ void main() {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               ProcessCall(
+                  'flutter',
+                  const <String>[
+                    'build',
+                    'macos',
+                    '--debug',
+                    '--config-only',
+                  ],
+                  pluginExampleDirectory.path),
+              ProcessCall(
                   'xcrun',
                   const <String>[
                     'xcodebuild',
@@ -280,6 +307,15 @@ void main() {
         expect(
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
+              ProcessCall(
+                  'flutter',
+                  const <String>[
+                    'build',
+                    'macos',
+                    '--debug',
+                    '--config-only',
+                  ],
+                  pluginExampleDirectory.path),
               ProcessCall(
                   'xcrun',
                   const <String>[
@@ -354,6 +390,15 @@ void main() {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               ProcessCall(
+                  'flutter',
+                  const <String>[
+                    'build',
+                    'ios',
+                    '--debug',
+                    '--config-only',
+                  ],
+                  pluginExampleDirectory.path),
+              ProcessCall(
                   'xcrun',
                   const <String>[
                     'xcodebuild',
@@ -368,6 +413,15 @@ void main() {
                     '-destination',
                     'generic/platform=iOS Simulator',
                     'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
+                  ],
+                  pluginExampleDirectory.path),
+              ProcessCall(
+                  'flutter',
+                  const <String>[
+                    'build',
+                    'macos',
+                    '--debug',
+                    '--config-only',
                   ],
                   pluginExampleDirectory.path),
               ProcessCall(
@@ -412,6 +466,15 @@ void main() {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               ProcessCall(
+                  'flutter',
+                  const <String>[
+                    'build',
+                    'macos',
+                    '--debug',
+                    '--config-only',
+                  ],
+                  pluginExampleDirectory.path),
+              ProcessCall(
                   'xcrun',
                   const <String>[
                     'xcodebuild',
@@ -451,6 +514,15 @@ void main() {
         expect(
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
+              ProcessCall(
+                  'flutter',
+                  const <String>[
+                    'build',
+                    'ios',
+                    '--debug',
+                    '--config-only',
+                  ],
+                  pluginExampleDirectory.path),
               ProcessCall(
                   'xcrun',
                   const <String>[


### PR DESCRIPTION
Currently xcode-analyze relies on the native project files already having been generated. This is unreliably locally, and now is problematic on CI as well since Xcode builds now (as of https://github.com/flutter/flutter/pull/165916) must match the last build mode, so analysis will fail if the previous CI step built in release mode (as is currently the case).

This adds a config-only build call in debug mode before analyzing. Since running a config-only build is a common operation in the tool, this extracts a helper to abstract the logic.

Unblocks the flutter/flutter->flutter/packages roller.