### PR TITLE
[tool] Run config-only build for iOS/macOS native-test

### DIFF
--- a/script/tool/test/native_test_command_test.dart
+++ b/script/tool/test/native_test_command_test.dart
@@ -135,6 +135,21 @@ void main() {
           null);
     }
 
+    // Returns the ProcessCall to expect for generating the native project files
+    // with a --config-only build on iOS or macOS.
+    ProcessCall getConfigOnlyDarwinBuildCall(
+        Directory package, FlutterPlatform platform) {
+      return ProcessCall(
+          'flutter',
+          <String>[
+            'build',
+            if (platform == FlutterPlatform.ios) 'ios' else 'macos',
+            '--debug',
+            '--config-only',
+          ],
+          package.path);
+    }
+
     // Returns the ProcessCall to expect for running the tests in the
     // workspace [platform]/Runner.xcworkspace, with the given extra flags.
     ProcessCall getRunTestCall(
@@ -246,6 +261,8 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             getTargetCheckCall(pluginExampleDirectory, 'macos'),
+            getConfigOnlyDarwinBuildCall(
+                pluginExampleDirectory, FlutterPlatform.macos),
             getRunTestCall(pluginExampleDirectory, 'macos',
                 extraFlags: <String>['-only-testing:RunnerUITests']),
           ]));
@@ -317,6 +334,8 @@ void main() {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               getTargetCheckCall(pluginExampleDirectory, 'ios'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.ios),
               getRunTestCall(pluginExampleDirectory, 'ios',
                   destination: 'foo_destination'),
             ]));
@@ -354,6 +373,8 @@ void main() {
                   ],
                   null),
               getTargetCheckCall(pluginExampleDirectory, 'ios'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.ios),
               getRunTestCall(pluginExampleDirectory, 'ios',
                   destination: 'id=$_simulatorDeviceId'),
             ]));
@@ -421,6 +442,8 @@ void main() {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               getTargetCheckCall(pluginExampleDirectory, 'macos'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.macos),
               getRunTestCall(pluginExampleDirectory, 'macos'),
             ]));
       });
@@ -1305,6 +1328,8 @@ public class FlutterActivityTest {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               getTargetCheckCall(pluginExampleDirectory, 'macos'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.macos),
               getRunTestCall(pluginExampleDirectory, 'macos',
                   extraFlags: <String>['-only-testing:RunnerTests']),
             ]));
@@ -1340,6 +1365,8 @@ public class FlutterActivityTest {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               getTargetCheckCall(pluginExampleDirectory, 'macos'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.macos),
               getRunTestCall(pluginExampleDirectory, 'macos',
                   extraFlags: <String>['-only-testing:RunnerUITests']),
             ]));
@@ -1609,9 +1636,13 @@ public class FlutterActivityTest {
                   ],
                   androidFolder.path),
               getTargetCheckCall(pluginExampleDirectory, 'ios'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.ios),
               getRunTestCall(pluginExampleDirectory, 'ios',
                   destination: 'foo_destination'),
               getTargetCheckCall(pluginExampleDirectory, 'macos'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.macos),
               getRunTestCall(pluginExampleDirectory, 'macos'),
             ]));
       });
@@ -1648,6 +1679,8 @@ public class FlutterActivityTest {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               getTargetCheckCall(pluginExampleDirectory, 'macos'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.macos),
               getRunTestCall(pluginExampleDirectory, 'macos'),
             ]));
       });
@@ -1684,6 +1717,8 @@ public class FlutterActivityTest {
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
               getTargetCheckCall(pluginExampleDirectory, 'ios'),
+              getConfigOnlyDarwinBuildCall(
+                  pluginExampleDirectory, FlutterPlatform.ios),
               getRunTestCall(pluginExampleDirectory, 'ios',
                   destination: 'foo_destination'),
             ]));


### PR DESCRIPTION
Follow-up to https://github.com/flutter/packages/pull/9075. On iOS and macOS, `native-test` also requires an unconditional project file generatino in debug mode now, to ensure that the debug Xcode build of the tests will not fail due to a build mode mismatch.

Unblocks the flutter/flutter->flutter/packages roller.