### PR TITLE
[vector_graphics] Fix raster cache size calculation and incorporate ColorFilter/Opacity effects into cache

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.19
+
+* Fix incorrect scaling under Transform in raster mode and reduce extra rendering cost from ColorFilter/Opacity in raster mode.
+
 ## 1.1.18
 
 * Allow transition between placeholder and loaded image to have an animation.

--- a/packages/vector_graphics/lib/src/vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/vector_graphics.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -455,12 +454,6 @@ class _VectorGraphicWidgetState extends State<VectorGraphic> {
 
       assert(width != null && height != null);
 
-      double scale = 1.0;
-      scale = math.min(
-        pictureInfo.size.width / width!,
-        pictureInfo.size.height / height!,
-      );
-
       if (_webRenderObject) {
         child = _RawWebVectorGraphicWidget(
           pictureInfo: pictureInfo,
@@ -474,7 +467,6 @@ class _VectorGraphicWidgetState extends State<VectorGraphic> {
           assetKey: _pictureInfo!.key,
           colorFilter: widget.colorFilter,
           opacity: widget.opacity,
-          scale: scale,
         );
       } else {
         child = _RawPictureVectorGraphicWidget(
@@ -554,13 +546,11 @@ class _RawVectorGraphicWidget extends SingleChildRenderObjectWidget {
     required this.pictureInfo,
     required this.colorFilter,
     required this.opacity,
-    required this.scale,
     required this.assetKey,
   });
 
   final PictureInfo pictureInfo;
   final ColorFilter? colorFilter;
-  final double scale;
   final Animation<double>? opacity;
   final Object assetKey;
 
@@ -572,7 +562,6 @@ class _RawVectorGraphicWidget extends SingleChildRenderObjectWidget {
       colorFilter,
       MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0,
       opacity,
-      scale,
     );
   }
 
@@ -586,8 +575,7 @@ class _RawVectorGraphicWidget extends SingleChildRenderObjectWidget {
       ..assetKey = assetKey
       ..colorFilter = colorFilter
       ..devicePixelRatio = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0
-      ..opacity = opacity
-      ..scale = scale;
+      ..opacity = opacity;
   }
 }
 

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -2,7 +2,7 @@ name: vector_graphics
 description: A vector graphics rendering package for Flutter using a binary encoding.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-version: 1.1.18
+version: 1.1.19
 
 environment:
   sdk: ^3.4.0

--- a/packages/vector_graphics/test/render_vector_graphics_test.dart
+++ b/packages/vector_graphics/test/render_vector_graphics_test.dart
@@ -46,7 +46,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
@@ -67,7 +66,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     final RenderVectorGraphic renderVectorGraphicB = RenderVectorGraphic(
       pictureInfo,
@@ -75,7 +73,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphicA.layout(BoxConstraints.tight(const Size(50, 50)));
     renderVectorGraphicB.layout(BoxConstraints.tight(const Size(50, 50)));
@@ -96,7 +93,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     final RenderVectorGraphic renderVectorGraphicB = RenderVectorGraphic(
       pictureInfo,
@@ -104,7 +100,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphicA.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakeHistoryPaintingContext context = FakeHistoryPaintingContext();
@@ -131,7 +126,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     final RenderVectorGraphic renderVectorGraphicB = RenderVectorGraphic(
       pictureInfo,
@@ -139,7 +133,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphicA.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakeHistoryPaintingContext context = FakeHistoryPaintingContext();
@@ -156,14 +149,13 @@ void main() {
     expect(identical(context.canvas.images[0], context.canvas.images[1]), true);
   });
 
-  test('Changing color filter does not re-rasterize', () async {
+  test('Changing color filter does re-rasterize', () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
       'test',
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
@@ -175,11 +167,11 @@ void main() {
         const ui.ColorFilter.mode(Colors.red, ui.BlendMode.colorBurn);
     renderVectorGraphic.paint(context, Offset.zero);
 
-    expect(firstImage.debugDisposed, false);
+    expect(firstImage.debugDisposed, true);
 
     renderVectorGraphic.paint(context, Offset.zero);
 
-    expect(context.canvas.lastImage, equals(firstImage));
+    expect(context.canvas.lastImage, isNot(firstImage));
   });
 
   test('Changing device pixel ratio does re-rasterize and dispose old raster',
@@ -190,7 +182,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
@@ -215,7 +206,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
@@ -223,7 +213,7 @@ void main() {
 
     final ui.Image firstImage = context.canvas.lastImage!;
 
-    renderVectorGraphic.scale = 2.0;
+    context.canvas.scale(2.0, 2.0);
     renderVectorGraphic.paint(context, Offset.zero);
 
     expect(firstImage.debugDisposed, true);
@@ -233,23 +223,23 @@ void main() {
     expect(context.canvas.lastImage!.debugDisposed, false);
   });
 
-  test('The raster size is increased by the inverse picture scale', () async {
+  test('The raster size is increased by the canvas scale', () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
       'test',
       null,
       1.0,
       null,
-      0.5, // twice as many pixels
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
+    context.canvas.scale(2.0, 2.0);
     renderVectorGraphic.paint(context, Offset.zero);
 
     // Dst rect is always size of RO.
     expect(context.canvas.lastDst, const Rect.fromLTWH(0, 0, 50, 50));
     expect(
-        context.canvas.lastSrc, const Rect.fromLTWH(0, 0, 50 / 0.5, 50 / 0.5));
+        context.canvas.lastSrc, const Rect.fromLTWH(0, 0, 50 * 2.0, 50 * 2.0));
   });
 
   test('The raster size is increased by the device pixel ratio', () async {
@@ -259,7 +249,6 @@ void main() {
       null,
       2.0,
       null,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
@@ -278,10 +267,10 @@ void main() {
       null,
       2.0,
       null,
-      0.5,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
+    context.canvas.scale(2.0, 2.0);
     renderVectorGraphic.paint(context, Offset.zero);
 
     // Dst rect is always size of RO.
@@ -297,7 +286,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
@@ -318,7 +306,6 @@ void main() {
       null,
       1.0,
       opacity,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
@@ -344,13 +331,13 @@ void main() {
       null,
       1.0,
       opacity,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
     renderVectorGraphic.paint(context, Offset.zero);
 
-    expect(context.canvas.lastPaint?.color, const Color.fromRGBO(0, 0, 0, 0.5));
+    // opaque is used to generate raster cache.
+    expect(context.canvas.lastPaint?.color, const Color.fromRGBO(0, 0, 0, 1.0));
   });
 
   test('Disposing render object disposes picture', () async {
@@ -360,7 +347,6 @@ void main() {
       null,
       1.0,
       null,
-      1.0,
     );
     renderVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
     final FakePaintingContext context = FakePaintingContext();
@@ -381,7 +367,6 @@ void main() {
       null,
       1.0,
       opacity,
-      1.0,
     );
     final PipelineOwner pipelineOwner = PipelineOwner();
     expect(opacity._listeners, hasLength(1));
@@ -403,7 +388,9 @@ void main() {
     final ui.PictureRecorder recorder = ui.PictureRecorder();
     ui.Canvas(recorder);
     final ui.Image image = await recorder.endRecording().toImage(1, 1);
-    final RasterData data = RasterData(image, 1, const RasterKey('test', 1, 1));
+    final Paint paint = Paint();
+    final RasterData data =
+        RasterData(image, 1, RasterKey('test', 1, 1, paint));
 
     data.dispose();
 
@@ -426,6 +413,101 @@ void main() {
     expect(context.canvas.totalSaves, 1);
     expect(context.canvas.totalSaveLayers, 1);
   });
+
+  testWidgets('Changing offset does not re-rasterize in auto strategy',
+      (WidgetTester tester) async {
+    final RenderVectorGraphic renderAutoVectorGraphic = RenderVectorGraphic(
+      pictureInfo,
+      'testOffset',
+      null,
+      1.0,
+      null,
+    );
+    renderAutoVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
+    final FakePaintingContext context = FakePaintingContext();
+
+    renderAutoVectorGraphic.paint(context, Offset.zero);
+    expect(context.canvas.lastImage, isNotNull);
+
+    final ui.Image? oldImage = context.canvas.lastImage;
+
+    renderAutoVectorGraphic.paint(context, const Offset(20, 30));
+    expect(context.canvas.lastImage, isNotNull);
+    expect(context.canvas.lastImage, equals(oldImage));
+
+    renderAutoVectorGraphic.dispose();
+  });
+
+  testWidgets('RenderAutoVectorGraphic re-rasterizes when opacity changes',
+      (WidgetTester tester) async {
+    final FixedOpacityAnimation opacity = FixedOpacityAnimation(0.2);
+    final RenderVectorGraphic renderAutoVectorGraphic = RenderVectorGraphic(
+      pictureInfo,
+      'testOpacity',
+      null,
+      1.0,
+      opacity,
+    );
+
+    renderAutoVectorGraphic.layout(BoxConstraints.tight(const Size(50, 50)));
+    final FakePaintingContext context = FakePaintingContext();
+    renderAutoVectorGraphic.paint(context, Offset.zero);
+
+    final ui.Image? oldImage = context.canvas.lastImage;
+
+    opacity.value = 0.5;
+    opacity.notifyListeners();
+
+    // Changing opacity requires painting.
+    expect(renderAutoVectorGraphic.debugNeedsPaint, true);
+
+    // Changing opacity need create new raster cache.
+    renderAutoVectorGraphic.paint(context, Offset.zero);
+    expect(context.canvas.lastImage, isNotNull);
+
+    expect(context.canvas.lastImage, isNot(oldImage));
+
+    renderAutoVectorGraphic.dispose();
+  });
+
+  testWidgets(
+      'Identical widgets reuse raster cache when available in auto startegy',
+      (WidgetTester tester) async {
+    final RenderVectorGraphic renderAutoVectorGraphic1 = RenderVectorGraphic(
+      pictureInfo,
+      'testOffset',
+      null,
+      1.0,
+      null,
+    );
+    final RenderVectorGraphic renderAutoVectorGraphic2 = RenderVectorGraphic(
+      pictureInfo,
+      'testOffset',
+      null,
+      1.0,
+      null,
+    );
+    renderAutoVectorGraphic1.layout(BoxConstraints.tight(const Size(50, 50)));
+    renderAutoVectorGraphic2.layout(BoxConstraints.tight(const Size(50, 50)));
+
+    final FakePaintingContext context = FakePaintingContext();
+
+    renderAutoVectorGraphic1.paint(context, Offset.zero);
+
+    final ui.Image? image1 = context.canvas.lastImage;
+
+    renderAutoVectorGraphic2.paint(context, Offset.zero);
+
+    final ui.Image? image2 = context.canvas.lastImage;
+
+    expect(image1, isNotNull);
+    expect(image2, isNotNull);
+
+    expect(image1, equals(image2));
+
+    renderAutoVectorGraphic1.dispose();
+    renderAutoVectorGraphic2.dispose();
+  });
 }
 
 class FakeCanvas extends Fake implements Canvas {
@@ -437,6 +519,8 @@ class FakeCanvas extends Fake implements Canvas {
   int saveCount = 0;
   int totalSaves = 0;
   int totalSaveLayers = 0;
+  double scaleX = 1.0;
+  double scaleY = 1.0;
 
   @override
   void drawImageRect(ui.Image image, Rect src, Rect dst, Paint paint) {
@@ -481,6 +565,24 @@ class FakeCanvas extends Fake implements Canvas {
       {ui.ClipOp clipOp = ui.ClipOp.intersect, bool doAntiAlias = true}) {
     lastClipRect = rect;
   }
+
+  @override
+  void scale(double sx, [double? sy]) {
+    scaleX = sx;
+    scaleY = sx;
+    if (sy != null) {
+      scaleY = sy;
+    }
+  }
+
+  @override
+  void translate(double dx, double dy) {}
+
+  @override
+  Float64List getTransform() {
+    return Float64List.fromList(
+        <double>[scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+  }
 }
 
 class FakeHistoryCanvas extends Fake implements Canvas {
@@ -489,6 +591,12 @@ class FakeHistoryCanvas extends Fake implements Canvas {
   @override
   void drawImageRect(ui.Image image, Rect src, Rect dst, Paint paint) {
     images.add(image);
+  }
+
+  @override
+  Float64List getTransform() {
+    return Float64List.fromList(
+        <double>[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
   }
 }
 


### PR DESCRIPTION
This PR fixes the bugs mentioned in [#8932](https://github.com/flutter/packages/pull/8932).

1. The raster cache size generated by `vector_graphics` takes `BoxFit` into account but does not consider the impact of the `Transform` widget. In practice, the raster cache size can be derived directly from the canvas's scale, which naturally reflects all visual transformations—including BoxFit, Transform, and any other factors affecting the final display size of the component. This PR replaces the previous size calculation with one based on the canvas scale.

2. Currently, the raster cache does not include `ColorFilter` or `Opacity,` meaning that rendering overhead remains high when either is present, due to the need for additional offscreen rendering passes. However, in real-world scenarios—especially when using SVG assets—it's very common to apply `ColorFilter` for tinting. This PR incorporates `ColorFilter` and `Opacity` effects into the raster cache, reducing the overall rendering cost.

Of course, this PR also aims to address issue [#166184](https://github.com/flutter/flutter/issues/166184).

Regarding point 2, before applying the fix, the trace output was as follows:
<img width="947" alt="image" src="https://github.com/user-attachments/assets/e0df8d49-a7a2-417e-b6a6-da2e3fe0840d" />

At that time, two SVGs were causing two vkQueueSubmit calls, resulting in two offscreen renderings, which took approximately 2ms.

After the fix, the trace output is as follows:

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/360e6a17-bfab-4d99-9113-a1be059ec48b" />

The vkQueueSubmit calls are no longer present, and the processing time has decreased to 0.6ms.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
