### PR TITLE
[path_provider_foundation] Temporary directory using the wrong directory

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 
+## 2.1.6
+
+* Switches `getTemporaryDirectory` from `NSCachesDirectory` to `FileManager.SearchPathDirectory.temporaryDirectory`
+  for iOS and macOS.
+
 ## 2.1.5
 
 * Updates minimum supported SDK version to Flutter 3.19/Dart 3.3.

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -46,7 +46,7 @@ PathProviderPlatform get _platform => PathProviderPlatform.instance;
 /// directory is scoped to the calling application.
 ///
 /// Example implementations:
-/// - `NSCachesDirectory` on iOS and macOS.
+/// - `NSTemporaryDirectory` on iOS and macOS.
 /// - `Context.getCacheDir` on Android.
 ///
 /// Throws a [MissingPlatformDirectoryException] if the system is unable to

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -46,7 +46,7 @@ PathProviderPlatform get _platform => PathProviderPlatform.instance;
 /// directory is scoped to the calling application.
 ///
 /// Example implementations:
-/// - `NSTemporaryDirectory` on iOS and macOS.
+/// - `FileManager.SearchPathDirectory.temporaryDirectory` on iOS and macOS.
 /// - `Context.getCacheDir` on Android.
 ///
 /// Throws a [MissingPlatformDirectoryException] if the system is unable to

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.5
+version: 2.1.6
 
 environment:
   sdk: ^3.4.0
@@ -26,7 +26,7 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider_android: ^2.2.5
-  path_provider_foundation: ^2.3.2
+  path_provider_foundation: ^2.4.2
   path_provider_linux: ^2.2.0
   path_provider_platform_interface: ^2.1.0
   path_provider_windows: ^2.2.0

--- a/packages/path_provider/path_provider_foundation/CHANGELOG.md
+++ b/packages/path_provider/path_provider_foundation/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
 
+## 2.4.2
+
+* Switches `getTemporaryDirectory` from `NSCachesDirectory` to `FileManager.SearchPathDirectory.temporaryDirectory`
+  for iOS and macOS.
+
 ## 2.4.1
 
 * Updates to Pigeon v22.

--- a/packages/path_provider/path_provider_foundation/darwin/RunnerTests/RunnerTests.swift
+++ b/packages/path_provider/path_provider_foundation/darwin/RunnerTests/RunnerTests.swift
@@ -19,7 +19,7 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(
       path,
       NSSearchPathForDirectoriesInDomains(
-        FileManager.SearchPathDirectory.cachesDirectory,
+        FileManager.SearchPathDirectory.temporaryDirectory,
         FileManager.SearchPathDomainMask.userDomainMask,
         true
       ).first)

--- a/packages/path_provider/path_provider_foundation/darwin/path_provider_foundation/Sources/path_provider_foundation/PathProviderPlugin.swift
+++ b/packages/path_provider/path_provider_foundation/darwin/path_provider_foundation/Sources/path_provider_foundation/PathProviderPlugin.swift
@@ -61,7 +61,7 @@ private func fileManagerDirectoryForType(_ type: DirectoryType) -> FileManager.S
   case .library:
     return FileManager.SearchPathDirectory.libraryDirectory
   case .temp:
-    return FileManager.SearchPathDirectory.cachesDirectory
+    return FileManager.SearchPathDirectory.temporaryDirectory
   }
 }
 

--- a/packages/path_provider/path_provider_foundation/pubspec.yaml
+++ b/packages/path_provider/path_provider_foundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_foundation
 description: iOS and macOS implementation of the path_provider plugin
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider_foundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.4.1
+version: 2.4.2
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
I've identified that my app is incorrectly using FileManager.SearchPathDirectory.cachesDirectory for temporary files storage instead of the recommended FileManager.SearchPathDirectory.temporaryDirectory as outlined in Apple's File System Programming Guide https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1.

According to Apple's documentation, the temporary directory FileManager.SearchPathDirectory.temporaryDirectory is intended only for very short-lived files that may be deleted whenever the app isn't running.

https://github.com/flutter/flutter/issues/167311

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
