### PR TITLE
[two_dimensional_scrollables] Fix TreeView null dereference during paint

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## NEXT
 
+## 0.3.4
+
 * Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
+* Fixes a bug where collapsing a node in a TreeView with other offscreen nodes would dereference a null value.
 
 ## 0.3.3
 

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
@@ -318,9 +318,12 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
     );
     _horizontalOverflows = maxHorizontalExtent > 0.0;
 
+    final double verticalLeadingExtent = verticalOffset.pixels;
+    final double verticalTrailingExtent =
+        _rowMetrics[_lastRow!]!.trailingOffset - viewportDimension.height;
     final double maxVerticalExtent = math.max(
       0.0,
-      _rowMetrics[_lastRow!]!.trailingOffset - viewportDimension.height,
+      math.max(verticalLeadingExtent, verticalTrailingExtent),
     );
     _verticalOverflows = maxVerticalExtent > 0.0;
 

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.3.3
+version: 0.3.4
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/tree_test.dart
@@ -886,6 +886,96 @@ void main() {
         expect(find.text('tres'), findsNothing);
       });
     });
+
+    testWidgets('Expand then collapse with offscreen nodes (top)',
+        (WidgetTester tester) async {
+      final ScrollController verticalController = ScrollController();
+      final TreeViewController controller = TreeViewController();
+      addTearDown(verticalController.dispose);
+
+      final List<TreeViewNode<String>> tree = <TreeViewNode<String>>[
+        TreeViewNode<String>(
+          'alpha',
+          children: <TreeViewNode<String>>[
+            TreeViewNode<String>('a'),
+            TreeViewNode<String>('b'),
+            TreeViewNode<String>('c'),
+          ],
+        ),
+        TreeViewNode<String>(
+          'beta',
+          children: <TreeViewNode<String>>[
+            TreeViewNode<String>('d'),
+            TreeViewNode<String>('e'),
+            TreeViewNode<String>('f'),
+          ],
+        ),
+        TreeViewNode<String>(
+          'gamma',
+          children: <TreeViewNode<String>>[
+            TreeViewNode<String>('g'),
+            TreeViewNode<String>('h'),
+            TreeViewNode<String>('i'),
+          ],
+        ),
+        TreeViewNode<String>(
+          'delta',
+          children: <TreeViewNode<String>>[
+            TreeViewNode<String>('j'),
+            TreeViewNode<String>('k'),
+            TreeViewNode<String>('l'),
+          ],
+        ),
+      ];
+
+      await tester.pumpWidget(MaterialApp(
+        home: TreeView<String>(
+          tree: tree,
+          controller: controller,
+          toggleAnimationStyle: AnimationStyle.noAnimation,
+          verticalDetails: ScrollableDetails.vertical(
+            controller: verticalController,
+          ),
+          treeNodeBuilder: (
+            BuildContext context,
+            TreeViewNode<Object?> node,
+            AnimationStyle animationStyle,
+          ) =>
+              GestureDetector(
+            onTap: () => controller.toggleNode(node),
+            child: TreeView.defaultTreeNodeBuilder(
+              context,
+              node,
+              animationStyle,
+            ),
+          ),
+        ),
+      ));
+
+      // Expand a few nodes
+      await tester.tap(find.text('alpha'));
+      await tester.tap(find.text('beta'));
+      await tester.tap(find.text('gamma'));
+      await tester.tap(find.text('delta'));
+      await tester.pumpAndSettle();
+
+      // Scroll down to hide some of them
+      expect(verticalController.position.pixels, 0.0);
+      const double defaultRowExtent = 40;
+      verticalController.jumpTo(3 * defaultRowExtent + 10);
+      await tester.pump();
+      expect(find.text('alpha'), findsNothing);
+
+      // Collapse the bottommost node
+      expect(find.text('j'), findsOneWidget);
+      expect(find.text('k'), findsOneWidget);
+      expect(find.text('l'), findsOneWidget);
+      await tester.tap(find.text('delta'));
+      await tester.pumpAndSettle();
+      expect(find.text('j'), findsNothing);
+      expect(find.text('k'), findsNothing);
+      expect(find.text('l'), findsNothing);
+    });
   });
 
   group('TreeViewport', () {


### PR DESCRIPTION
Collapsing a node when there were other nodes offscreen was causing an unexpected null dereference during painting. This PR fixes the bug and adds a test.

The bug was caused by erroneous computation of the max vertical scroll extent. Previously, the code computed this considering only scroll extent in the trailing (down) direction; it may also be the case that there is a larger scroll extent in the leading (up) direction.

The miscalculation resulted in subsequent error computing the first visible row as a row that is actually offscreen, and thus does not have a render box. The row render box is asserted to be non-null during painting.

Fixes https://github.com/flutter/flutter/issues/149182 and https://github.com/flutter/flutter/issues/164981

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
