### PR TITLE
[google_maps_flutter_ios] Fix iOS regression where updating a marker hides its info window

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.15.2
+
+* Fixes regression where updating a marker hides its info window.
+
 ## 2.15.1
 
 * Fixes regression in displaying info windows.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.h
@@ -16,7 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(assign, nonatomic, readonly) BOOL consumeTapEvents;
 - (instancetype)initWithMarker:(GMSMarker *)marker
               markerIdentifier:(NSString *)markerIdentifier
-      clusterManagerIdentifier:(nullable NSString *)clusterManagerIdentifier
                        mapView:(GMSMapView *)mapView;
 - (void)showInfoWindow;
 - (void)hideInfoWindow;

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -24,17 +24,18 @@
 
 - (instancetype)initWithMarker:(GMSMarker *)marker
               markerIdentifier:(NSString *)markerIdentifier
-      clusterManagerIdentifier:(nullable NSString *)clusterManagerIdentifier
                        mapView:(GMSMapView *)mapView {
   self = [super init];
   if (self) {
     _marker = marker;
     _markerIdentifier = [markerIdentifier copy];
-    _clusterManagerIdentifier = [clusterManagerIdentifier copy];
     _mapView = mapView;
-    FGMSetIdentifiersToMarkerUserData(_markerIdentifier, _clusterManagerIdentifier, _marker);
   }
   return self;
+}
+
+- (void)setClusterManagerIdentifier:(nullable NSString *)clusterManagerIdentifier {
+  _clusterManagerIdentifier = clusterManagerIdentifier;
 }
 
 - (void)showInfoWindow {
@@ -110,6 +111,7 @@
 - (void)updateFromPlatformMarker:(FGMPlatformMarker *)platformMarker
                        registrar:(NSObject<FlutterPluginRegistrar> *)registrar
                      screenScale:(CGFloat)screenScale {
+  [self setClusterManagerIdentifier:platformMarker.clusterManagerId];
   [self setAlpha:platformMarker.alpha];
   [self setAnchor:FGMGetCGPointForPigeonPoint(platformMarker.anchor)];
   [self setDraggable:platformMarker.draggable];
@@ -127,6 +129,10 @@
   }
 
   [self setVisible:platformMarker.visible];
+
+  // Set the marker's user data with current identifiers.
+  FGMSetIdentifiersToMarkerUserData(self.markerIdentifier, self.clusterManagerIdentifier,
+                                    self.marker);
 }
 
 @end
@@ -173,7 +179,6 @@
   FLTGoogleMapMarkerController *controller =
       [[FLTGoogleMapMarkerController alloc] initWithMarker:marker
                                           markerIdentifier:markerIdentifier
-                                  clusterManagerIdentifier:clusterManagerIdentifier
                                                    mapView:self.mapView];
   [controller updateFromPlatformMarker:markerToAdd
                              registrar:self.registrar
@@ -196,20 +201,35 @@
 
 - (void)changeMarker:(FGMPlatformMarker *)markerToChange {
   NSString *markerIdentifier = markerToChange.markerId;
-  NSString *clusterManagerIdentifier = markerToChange.clusterManagerId;
 
   FLTGoogleMapMarkerController *controller = self.markerIdentifierToController[markerIdentifier];
   if (!controller) {
     return;
   }
+
+  NSString *clusterManagerIdentifier = markerToChange.clusterManagerId;
   NSString *previousClusterManagerIdentifier = [controller clusterManagerIdentifier];
-  if (![previousClusterManagerIdentifier isEqualToString:clusterManagerIdentifier]) {
-    [self removeMarker:markerIdentifier];
-    [self addMarker:markerToChange];
-  } else {
-    [controller updateFromPlatformMarker:markerToChange
-                               registrar:self.registrar
-                             screenScale:[self getScreenScale]];
+  [controller updateFromPlatformMarker:markerToChange
+                             registrar:self.registrar
+                           screenScale:[self getScreenScale]];
+
+  if ([controller.marker conformsToProtocol:@protocol(GMUClusterItem)]) {
+    if (previousClusterManagerIdentifier &&
+        ![previousClusterManagerIdentifier isEqualToString:clusterManagerIdentifier]) {
+      // Remove marker from previous cluster manager if its cluster manager identifier is removed or
+      // changed.
+      GMUClusterManager *clusterManager = [_clusterManagersController
+          clusterManagerWithIdentifier:previousClusterManagerIdentifier];
+      [clusterManager removeItem:(id<GMUClusterItem>)controller.marker];
+    }
+
+    if (clusterManagerIdentifier &&
+        ![previousClusterManagerIdentifier isEqualToString:clusterManagerIdentifier]) {
+      // Add marker to cluster manager if its cluster manager identifier has changed.
+      GMUClusterManager *clusterManager =
+          [_clusterManagersController clusterManagerWithIdentifier:clusterManagerIdentifier];
+      [clusterManager addItem:(id<GMUClusterItem>)controller.marker];
+    }
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -128,11 +128,13 @@
     [self setInfoWindowTitle:infoWindow.title snippet:infoWindow.snippet];
   }
 
-  [self setVisible:platformMarker.visible];
-
   // Set the marker's user data with current identifiers.
   FGMSetIdentifiersToMarkerUserData(self.markerIdentifier, self.clusterManagerIdentifier,
                                     self.marker);
+
+  // Ensure setVisible is called last as it adds the marker to the map,
+  // and must be done after all other parameters are set.
+  [self setVisible:platformMarker.visible];
 }
 
 @end
@@ -215,7 +217,7 @@
 
   if ([controller.marker conformsToProtocol:@protocol(GMUClusterItem)]) {
     if (previousClusterManagerIdentifier &&
-        ![previousClusterManagerIdentifier isEqualToString:clusterManagerIdentifier]) {
+        ![clusterManagerIdentifier isEqualToString:previousClusterManagerIdentifier]) {
       // Remove marker from previous cluster manager if its cluster manager identifier is removed or
       // changed.
       GMUClusterManager *clusterManager = [_clusterManagersController

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.15.1
+version: 2.15.2
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
Fixes a regression introduced on version 2.12.0: _Adds support for marker clustering_ (https://github.com/flutter/packages/pull/6186), where visible info windows are not visible after marker updates.
Adds tests accordingly.

Fixes https://github.com/flutter/flutter/issues/167459
Related to https://github.com/flutter/flutter/issues/159471

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
