### PR TITLE
[local_auth_android]:chore: enable AndroidX support

### DIFF
--- a/packages/local_auth/local_auth_android/android/gradle.properties
+++ b/packages/local_auth/local_auth_android/android/gradle.properties
@@ -1,0 +1,16 @@
+android.enableJetifier=true
+android.useAndroidX=true
+
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. For more details, visit
+# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
+# org.gradle.parallel=true
+#Tue May 06 20:43:31 CST 2025


### PR DESCRIPTION
chore: enable AndroidX support

- Add `android.useAndroidX=true` and `android.enableJetifier=true` to `android/gradle.properties`
- Mirror the same AndroidX settings in `example/android/gradle.properties`
- Ensure compatibility with AndroidX dependencies during testing and runtime