### PR TITLE
[google_maps_flutter] Raise `MapUsedAfterWidgetDisposedError` when map controller used after map disposed

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.12.3
+
+* Adds a check that raises `MapUsedAfterWidgetDisposedError`
+  when map controller is used after its widget has been disposed.
+
 ## 2.12.2
 
 * Fixes memory leak by disposing stream subscriptions in `GoogleMapController`.

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.12.2
+version: 2.12.3
 
 environment:
   sdk: ^3.6.0

--- a/packages/google_maps_flutter/google_maps_flutter/test/google_map_controller_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/google_map_controller_test.dart
@@ -32,22 +32,6 @@ void main() {
     );
 
     expect(controller, isNotNull);
-  });
-
-  testWidgets('controller can be used to access underlying map',
-      (WidgetTester tester) async {
-    GoogleMapController? controller;
-
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: GoogleMap(
-          initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
-          onMapCreated: (GoogleMapController value) => controller = value,
-        ),
-      ),
-    );
-
     await expectLater(controller?.getZoomLevel(), isNotNull);
   });
 

--- a/packages/google_maps_flutter/google_maps_flutter/test/google_map_controller_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/google_map_controller_test.dart
@@ -1,0 +1,74 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+import 'fake_google_maps_flutter_platform.dart';
+
+void main() {
+  late FakeGoogleMapsFlutterPlatform platform;
+
+  setUp(() {
+    platform = FakeGoogleMapsFlutterPlatform();
+    GoogleMapsFlutterPlatform.instance = platform;
+  });
+
+  testWidgets('onMapCreated is called with controller',
+      (WidgetTester tester) async {
+    GoogleMapController? controller;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GoogleMap(
+          initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
+          onMapCreated: (GoogleMapController value) => controller = value,
+        ),
+      ),
+    );
+
+    expect(controller, isNotNull);
+  });
+
+  testWidgets('controller can be used to access underlying map',
+      (WidgetTester tester) async {
+    GoogleMapController? controller;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GoogleMap(
+          initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
+          onMapCreated: (GoogleMapController value) => controller = value,
+        ),
+      ),
+    );
+
+    await expectLater(controller?.getZoomLevel(), isNotNull);
+  });
+
+  testWidgets('controller throws when used after dispose',
+      (WidgetTester tester) async {
+    GoogleMapController? controller;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GoogleMap(
+          initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
+          onMapCreated: (GoogleMapController value) => controller = value,
+        ),
+      ),
+    );
+
+    // Now dispose of the map...
+    await tester.pumpWidget(Container());
+
+    await expectLater(() => controller?.getZoomLevel(),
+        throwsA(isA<MapUsedAfterWidgetDisposedError>()));
+  });
+}


### PR DESCRIPTION
This change introduces a new `MapUsedAfterWidgetDisposedError` that facilitates debugging when the user calls a method on `GoogleMapsController` after the associated map has been disposed. This replaces the previous behavior, which would sometimes throw a Platform-side error (`MissingPluginException`, `Unable to establish connection on channel`, etc.).

Although technically non-breaking (we're replacing one error with another), this could be disruptive because the new error is raised eagerly and synchronously, as soon as a call is made. Before, the call could have potentially succeeded (?), and the error was asynchronous (and so, potentially, unawaited and ignored?).

Fixes https://github.com/flutter/flutter/issues/43785.


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
