### PR TITLE
[camera_android_camerax] Swap out `BroadcastReceiver` for `OrientationEventListener`

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.17
+
+* Replaces `BroadcastReceiver` usage with an `OrientationEventListener` to detect changes in device
+  orientation to fix issue where some devices do not report changes in device configuration if it
+  is rotated between the same sort of orientation (landscape/portrait).
+
 ## 0.6.16
 
 * Fixes incorrect camera preview rotation for landscape-oriented devices.

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
@@ -59,7 +59,7 @@ public class DeviceOrientationManager {
   @VisibleForTesting
   @NonNull
   /**
-   * Create an {@link OrientationEventListener} that will call the callback method of the {@link
+   * Creates an {@link OrientationEventListener} that will call the callback method of the {@link
    * DeviceOrientationManagerProxyApi} whenever it is notified of a new device orientation and this
    * {@code DeviceOrientationManager} instance determines that the orientation of the device {@link
    * Configuration} has changed.

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
@@ -59,7 +59,7 @@ public class DeviceOrientationManager {
   @VisibleForTesting
   @NonNull
   /**
-   * Createa an {@link OrientationEventListener} that will call the callback method of the {@link
+   * Create an {@link OrientationEventListener} that will call the callback method of the {@link
    * DeviceOrientationManagerProxyApi} whenever it is notified of a new device orientation and this
    * {@DeviceOrientationManager} instance determines that the orientation of the device {@link
    * Configuration} has changed.

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
@@ -17,6 +17,8 @@ import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.DeviceOrientation;
 import java.util.Objects;
 
+import android.util.Log;
+
 /**
  * Support class to help to determine the media orientation based on the orientation of the device.
  */
@@ -53,8 +55,11 @@ public class DeviceOrientationManager {
 
     broadcastReceiver =
         new BroadcastReceiver() {
+          int i = 0;
           @Override
           public void onReceive(Context context, Intent intent) {
+            Log.e("CAMILLE::ONRECEIVE", "onReceive + " + Integer.toString(i));
+            i++;
             handleUIOrientationChange();
           }
         };
@@ -136,6 +141,9 @@ public class DeviceOrientationManager {
   PlatformChannel.DeviceOrientation getUIOrientation() {
     final int rotation = getDefaultRotation();
     final int orientation = getContext().getResources().getConfiguration().orientation;
+
+    Log.e("CAMILLE", "rotation: " + Integer.toString(rotation));
+    Log.e("CAMILLE", "orientation: " + Integer.toString(orientation));
 
     switch (orientation) {
       case Configuration.ORIENTATION_PORTRAIT:

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
@@ -58,6 +58,12 @@ public class DeviceOrientationManager {
 
   @VisibleForTesting
   @NonNull
+  /**
+   * Createa an {@link OrientationEventListener} that will call the callback method of the {@link
+   * DeviceOrientationManagerProxyApi} whenever it is notified of a new device orientation and this
+   * {@DeviceOrientationManager} instance determines that the orientation of the device {@link
+   * Configuration} has changed.
+   */
   protected OrientationEventListener createOrientationEventListener() {
     return new OrientationEventListener(getContext()) {
       @Override

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
@@ -61,7 +61,7 @@ public class DeviceOrientationManager {
   /**
    * Create an {@link OrientationEventListener} that will call the callback method of the {@link
    * DeviceOrientationManagerProxyApi} whenever it is notified of a new device orientation and this
-   * {@DeviceOrientationManager} instance determines that the orientation of the device {@link
+   * {@code DeviceOrientationManager} instance determines that the orientation of the device {@link
    * Configuration} has changed.
    */
   protected OrientationEventListener createOrientationEventListener() {

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/DeviceOrientationManager.java
@@ -98,7 +98,7 @@ public class DeviceOrientationManager {
   }
 
   /**
-   * Handles orientation changes coming from either the device's sensors.
+   * Handles orientation changes coming from the device's sensors.
    *
    * <p>This method is visible for testing purposes only and should never be used outside this
    * class.

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/DeviceOrientationManagerTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/DeviceOrientationManagerTest.java
@@ -70,7 +70,8 @@ public class DeviceOrientationManagerTest {
     doNothing().when(deviceOrientationManagerSpy).handleUIOrientationChange();
 
     deviceOrientationManagerSpy.start();
-    deviceOrientationManagerSpy.orientationEventListener.onOrientationChanged(3);
+    deviceOrientationManagerSpy.orientationEventListener.onOrientationChanged(
+        /* some device orientation */ 3);
 
     verify(deviceOrientationManagerSpy).handleUIOrientationChange();
   }

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/DeviceOrientationManagerTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/DeviceOrientationManagerTest.java
@@ -7,9 +7,10 @@ package io.flutter.plugins.camerax;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,15 +19,14 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.provider.Settings;
 import android.view.Display;
+import android.view.OrientationEventListener;
 import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.DeviceOrientation;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.MockedStatic;
 
 public class DeviceOrientationManagerTest {
   private Activity mockActivity;
@@ -63,22 +63,32 @@ public class DeviceOrientationManagerTest {
   }
 
   @Test
-  public void handleUIOrientationChange_shouldSendMessageWhenSensorAccessIsAllowed() {
-    try (MockedStatic<Settings.System> mockedSystem = mockStatic(Settings.System.class)) {
-      mockedSystem
-          .when(
-              () ->
-                  Settings.System.getInt(any(), eq(Settings.System.ACCELEROMETER_ROTATION), eq(0)))
-          .thenReturn(0);
-      setUpUIOrientationMocks(Configuration.ORIENTATION_LANDSCAPE, Surface.ROTATION_0);
+  public void start_createsExpectedOrientationEventListener() {
+    DeviceOrientationManager deviceOrientationManagerSpy = spy(deviceOrientationManager);
 
-      deviceOrientationManager.handleUIOrientationChange();
-    }
+    doNothing().when(deviceOrientationManagerSpy).handleUIOrientationChange();
 
-    verify(mockApi, times(1))
-        .onDeviceOrientationChanged(
-            eq(deviceOrientationManager), eq(DeviceOrientation.LANDSCAPE_LEFT.toString()), any());
+    deviceOrientationManagerSpy.start();
+    deviceOrientationManagerSpy.orientationEventListener.onOrientationChanged(3);
+
+    verify(deviceOrientationManagerSpy).handleUIOrientationChange();
   }
+
+  @Test
+  public void start_enablesOrientationEventListener() {
+    DeviceOrientationManager deviceOrientationManagerSpy = spy(deviceOrientationManager);
+    OrientationEventListener mockOrientationEventListener = mock(OrientationEventListener.class);
+
+    when(deviceOrientationManagerSpy.createOrientationEventListener())
+        .thenReturn(mockOrientationEventListener);
+
+    deviceOrientationManagerSpy.start();
+
+    verify(mockOrientationEventListener).enable();
+  }
+
+  @Test
+  public void stop_disablesOrientationListenerAndClearsLastOrientation() {}
 
   @Test
   public void handleOrientationChange_shouldSendMessageWhenOrientationIsUpdated() {

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/DeviceOrientationManagerTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/DeviceOrientationManagerTest.java
@@ -5,6 +5,7 @@
 package io.flutter.plugins.camerax;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -88,7 +89,15 @@ public class DeviceOrientationManagerTest {
   }
 
   @Test
-  public void stop_disablesOrientationListenerAndClearsLastOrientation() {}
+  public void stop_disablesOrientationListener() {
+    OrientationEventListener mockOrientationEventListener = mock(OrientationEventListener.class);
+    deviceOrientationManager.orientationEventListener = mockOrientationEventListener;
+
+    deviceOrientationManager.stop();
+
+    verify(mockOrientationEventListener).disable();
+    assertNull(deviceOrientationManager.orientationEventListener);
+  }
 
   @Test
   public void handleOrientationChange_shouldSendMessageWhenOrientationIsUpdated() {

--- a/packages/camera/camera_android_camerax/lib/src/surface_texture_rotated_preview.dart
+++ b/packages/camera/camera_android_camerax/lib/src/surface_texture_rotated_preview.dart
@@ -58,6 +58,9 @@ final class _SurfaceTextureRotatedPreviewState
   Future<int> _getCurrentDefaultDisplayRotationQuarterTurns() async {
     final int currentDefaultDisplayRotationQuarterTurns =
         await widget.deviceOrientationManager.getDefaultDisplayRotation();
+    final String uiOrientation =
+        await widget.deviceOrientationManager.getUiOrientation();
+    print('>>>>>>>>>>>>>>>>CAMILLE uiOrientation: $uiOrientation');
     return getQuarterTurnsFromSurfaceRotationConstant(
         currentDefaultDisplayRotationQuarterTurns);
   }
@@ -78,6 +81,7 @@ final class _SurfaceTextureRotatedPreviewState
       }
 
       setState(() {
+        print('>>>>>>>>>>>>CAMILLE new device orientation event: $event');
         preappliedRotationQuarterTurns =
             getPreAppliedQuarterTurnsRotationFromDeviceOrientation(event);
         defaultDisplayRotationQuarterTurns =
@@ -104,6 +108,8 @@ final class _SurfaceTextureRotatedPreviewState
             // (see camera/camera/lib/src/camera_preview.dart) that is not
             // correct for this plugin.
             final int currentDefaultDisplayRotation = snapshot.data!;
+            print(
+                '>>>>>>>>>>>>>>>>>CAMILLE currentDefaultDisplayRotation: $currentDefaultDisplayRotation');
             final int rotationCorrection =
                 currentDefaultDisplayRotation - preappliedRotationQuarterTurns;
 

--- a/packages/camera/camera_android_camerax/lib/src/surface_texture_rotated_preview.dart
+++ b/packages/camera/camera_android_camerax/lib/src/surface_texture_rotated_preview.dart
@@ -58,9 +58,6 @@ final class _SurfaceTextureRotatedPreviewState
   Future<int> _getCurrentDefaultDisplayRotationQuarterTurns() async {
     final int currentDefaultDisplayRotationQuarterTurns =
         await widget.deviceOrientationManager.getDefaultDisplayRotation();
-    final String uiOrientation =
-        await widget.deviceOrientationManager.getUiOrientation();
-    print('>>>>>>>>>>>>>>>>CAMILLE uiOrientation: $uiOrientation');
     return getQuarterTurnsFromSurfaceRotationConstant(
         currentDefaultDisplayRotationQuarterTurns);
   }
@@ -81,7 +78,6 @@ final class _SurfaceTextureRotatedPreviewState
       }
 
       setState(() {
-        print('>>>>>>>>>>>>CAMILLE new device orientation event: $event');
         preappliedRotationQuarterTurns =
             getPreAppliedQuarterTurnsRotationFromDeviceOrientation(event);
         defaultDisplayRotationQuarterTurns =
@@ -108,8 +104,6 @@ final class _SurfaceTextureRotatedPreviewState
             // (see camera/camera/lib/src/camera_preview.dart) that is not
             // correct for this plugin.
             final int currentDefaultDisplayRotation = snapshot.data!;
-            print(
-                '>>>>>>>>>>>>>>>>>CAMILLE currentDefaultDisplayRotation: $currentDefaultDisplayRotation');
             final int rotationCorrection =
                 currentDefaultDisplayRotation - preappliedRotationQuarterTurns;
 

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.16
+version: 0.6.17
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Replaces usage of [`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) (that is registered with the [`ACTION_CONFIGURATION_CHANGED`](https://developer.android.com/reference/android/content/Intent#ACTION_CONFIGURATION_CHANGED) intent) with an [`OrientationEventListener`](https://developer.android.com/reference/android/view/OrientationEventListener) to notify the plugin of changes in device orientation.

Using an `OrientationEventListener` allows the plugin to more regularly to orientation updates, whereas listening to the  `ACTION_CONFIGURATION_CHANGED` only reports changes in device configuration. This is an issue because sometimes, a device changing from a landscape orientation to another landscape orientation is not considered a change in configuration.

Fixes https://github.com/flutter/flutter/issues/168565.
Inherently fixes https://github.com/flutter/flutter/issues/163818 (no more `BroadcastReceiver`).
Should also inherently fix https://github.com/flutter/flutter/issues/162854 (no more `BroadcastReceiver`, but don't worry--we already stop listening to changes in device orientation when the plugin is disposed).

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
