### PR TITLE
Ignore .cxx/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ GeneratedPluginRegistrant.*
 .gradle/
 gradlew
 gradlew.bat
+.cxx/
 
 .project
 .classpath


### PR DESCRIPTION
Android builds now create .cxx directories in some cases; this has been added to the app template's ignore file, so should be ignored here as well. As is generally the case for this repo, we ignore it at the root level instead of updating every package.