### PR TITLE
[file_selector_macos] Do not set nameFieldStringValue for NSOpenPanel

### DIFF
--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.9.4+3
 
+* Updates configuration to not set `nameFieldStringValue` for `NSOpenPanel`.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 0.9.4+2

--- a/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -92,7 +92,6 @@ class ExampleTests: XCTestCase {
       canChooseFiles: true,
       baseOptions: SavePanelOptions(
         directoryPath: "/some/dir",
-        nameFieldStringValue: "a name",
         prompt: "Open it!"))
     plugin.displayOpenPanel(options: options) { result in
       switch result {
@@ -108,7 +107,6 @@ class ExampleTests: XCTestCase {
     XCTAssertNotNil(panelController.openPanel)
     if let panel = panelController.openPanel {
       XCTAssertEqual(panel.directoryURL?.path, "/some/dir")
-      XCTAssertEqual(panel.nameFieldStringValue, "a name")
       XCTAssertEqual(panel.prompt, "Open it!")
     }
   }
@@ -343,6 +341,7 @@ class ExampleTests: XCTestCase {
     let called = XCTestExpectation()
     let options = SavePanelOptions(
       directoryPath: "/some/dir",
+      nameFieldStringValue: "a name",
       prompt: "Save it!")
     plugin.displaySavePanel(options: options) { result in
       switch result {
@@ -358,6 +357,7 @@ class ExampleTests: XCTestCase {
     XCTAssertNotNil(panelController.savePanel)
     if let panel = panelController.savePanel {
       XCTAssertEqual(panel.directoryURL?.path, "/some/dir")
+      XCTAssertEqual(panel.nameFieldStringValue, "a name")
       XCTAssertEqual(panel.prompt, "Save it!")
     }
   }

--- a/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -92,6 +92,7 @@ class ExampleTests: XCTestCase {
       canChooseFiles: true,
       baseOptions: SavePanelOptions(
         directoryPath: "/some/dir",
+        nameFieldStringValue: "a name",
         prompt: "Open it!"))
     plugin.displayOpenPanel(options: options) { result in
       switch result {
@@ -107,6 +108,8 @@ class ExampleTests: XCTestCase {
     XCTAssertNotNil(panelController.openPanel)
     if let panel = panelController.openPanel {
       XCTAssertEqual(panel.directoryURL?.path, "/some/dir")
+      // nameFieldStringValue is not set for NSOpenPanel, only for NSSavePanel
+      XCTAssertNotEqual(panel.nameFieldStringValue, "a name")
       XCTAssertEqual(panel.prompt, "Open it!")
     }
   }

--- a/packages/file_selector/file_selector_macos/macos/file_selector_macos/Sources/file_selector_macos/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/file_selector_macos/Sources/file_selector_macos/FileSelectorPlugin.swift
@@ -92,7 +92,9 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin, FileSelectorApi {
       panel.directoryURL = URL(fileURLWithPath: directoryPath)
     }
     if let suggestedName = options.nameFieldStringValue {
-      panel.nameFieldStringValue = suggestedName
+      if !(panel is NSOpenPanel) {
+        panel.nameFieldStringValue = suggestedName
+      }
     }
     if let prompt = options.prompt {
       panel.prompt = prompt

--- a/packages/file_selector/file_selector_macos/macos/file_selector_macos/Sources/file_selector_macos/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/file_selector_macos/Sources/file_selector_macos/FileSelectorPlugin.swift
@@ -92,6 +92,10 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin, FileSelectorApi {
       panel.directoryURL = URL(fileURLWithPath: directoryPath)
     }
     if let suggestedName = options.nameFieldStringValue {
+
+      // nameFieldStringValue is not used in NSOpenPanel (see header). Setting it will cause a log
+      // ("Ignoring NSSavePanel method sent to NSOpenPanel: setNameFieldStringValue:") that may be
+      // confusing to users.
       if !(panel is NSOpenPanel) {
         panel.nameFieldStringValue = suggestedName
       }

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.4+2
+version: 0.9.4+3
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
file_selector_macos is trying to set [`nameFieldStringValue`](https://developer.apple.com/documentation/appkit/nssavepanel/namefieldstringvalue) for an `NSOpenPanel`. However, `nameFieldStringValue` does not support `NSOpenPanel`, it only supports `NSSavePanel`.

This PR does not set `nameFieldStringValue` if using `NSOpenPanel`. It also updates the tests to verify it works for `NSSavePanel` and not `NSOpenPanel`.

![Screenshot 2025-05-27 at 11 10 40 AM](https://github.com/user-attachments/assets/6af2016b-da93-482d-a5a2-5aeeac1abb47)

Fixes https://github.com/flutter/flutter/issues/169510.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
