### PR TITLE
[go_router] Fix replace routes hanging the originating completer (resubmitted 9332)

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 15.1.3
 
+* Fixes an issue where `replace` and `pushReplacement` caused the originating route's completer to hang.
+  [flutter#141251](https://github.com/flutter/flutter/issues/141251)
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 15.1.2

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 15.1.2
+version: 15.1.3
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/imperative_api_test.dart
+++ b/packages/go_router/test/imperative_api_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -293,5 +295,50 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('shell'), findsNothing);
     expect(find.byKey(e), findsOneWidget);
+  });
+
+  testWidgets('completer able to be passed on replace',
+      (WidgetTester tester) async {
+    final List<RouteBase> routes = <RouteBase>[
+      GoRoute(
+        path: '/initial',
+        builder: (BuildContext context, GoRouterState state) =>
+            const DummyScreen(),
+      ),
+      GoRoute(
+        path: '/intermediate',
+        builder: (BuildContext context, GoRouterState state) =>
+            const DummyScreen(),
+      ),
+      GoRoute(
+        path: '/final',
+        builder: (BuildContext context, GoRouterState state) =>
+            const DummyScreen(),
+      ),
+    ];
+
+    final GoRouter router = await createRouter(
+      routes,
+      tester,
+      initialLocation: '/initial',
+    );
+
+    final int random = Random().nextInt(1000);
+
+    final Future<Object?> push = router.push('/intermediate');
+    await tester.pumpAndSettle();
+    expect(router.state.path, '/intermediate');
+
+    final Future<int?> replace = router.replace<int>('/final');
+    await tester.pumpAndSettle();
+    expect(router.state.path, '/final');
+
+    router.pop(random);
+    await tester.pumpAndSettle();
+    expect(router.state.path, '/initial');
+    await tester.pumpAndSettle();
+
+    await expectLater(push, completion(random));
+    await expectLater(replace, completion(random));
   });
 }


### PR DESCRIPTION
The behavior of `replace` and `pushReplacement` involves popping the last route and ignoring the completer, leaving the last route's future unresolved. This PR introduces new behavior for both methods to inherit the last route's completer if the last route is an `ImperativeRouteMatch`.

Expected issue(s) should be fixed by this:
- https://github.com/flutter/flutter/issues/141251

### Previous behavior:
https://github.com/user-attachments/assets/add06187-9bee-4347-8eac-e129c7a53457

### This PR behavior:
https://github.com/user-attachments/assets/98c20fe3-5fea-4db2-ae95-747950650172

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
