### PR TITLE
[go_router] Fix replace routes hanging the originating completer

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 15.1.3
 
+* Fixes an issue where `replace` and `pushReplacement` caused the originating route's completer to hang.
+  [flutter#141251](https://github.com/flutter/flutter/issues/141251)
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 15.1.2

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 15.1.3
+## 15.2.0
 
-* Fixes an issue where `replace` and `pushReplacement` caused the originating route's completer to hang.
+- Adds `mapReplacementResult` to `RouteInformationState` and
+  `ImperativeRouteMatch` to resolve an issue where `replace` and
+  `pushReplacement` caused the originating route's completer to hang.
   [flutter#141251](https://github.com/flutter/flutter/issues/141251)
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
+- Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 15.1.2
 
@@ -26,7 +28,7 @@
 ## 14.8.1
 
 - Secured canPop method for the lack of matches in routerDelegate's configuration.
- 
+
 ## 14.8.0
 
 - Adds `preload` parameter to `StatefulShellBranchData.$branch`.
@@ -1190,4 +1192,3 @@
 ## 0.1.0
 
 - squatting on the package name (I'm not too proud to admit it)
-

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -319,10 +319,12 @@ class RouteConfiguration {
     for (final ImperativeRouteMatch imperativeMatch
         in matchList.matches.whereType<ImperativeRouteMatch>()) {
       final ImperativeRouteMatch match = ImperativeRouteMatch(
-          pageKey: imperativeMatch.pageKey,
-          matches: findMatch(imperativeMatch.matches.uri,
-              extra: imperativeMatch.matches.extra),
-          completer: imperativeMatch.completer);
+        pageKey: imperativeMatch.pageKey,
+        matches: findMatch(imperativeMatch.matches.uri,
+            extra: imperativeMatch.matches.extra),
+        completer: imperativeMatch.completer,
+        pipeCompleter: imperativeMatch.pipeCompleter,
+      );
       result = result.push(match);
     }
     return result;

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -12,6 +12,7 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 
 import 'configuration.dart';
+import 'information_provider.dart';
 import 'logging.dart';
 import 'misc/errors.dart';
 import 'path_utils.dart';
@@ -432,9 +433,12 @@ class ShellRouteMatch extends RouteMatchBase {
 /// The route match that represent route pushed through [GoRouter.push].
 class ImperativeRouteMatch extends RouteMatch {
   /// Constructor for [ImperativeRouteMatch].
-  ImperativeRouteMatch(
-      {required super.pageKey, required this.matches, required this.completer})
-      : super(
+  ImperativeRouteMatch({
+    required super.pageKey,
+    required this.matches,
+    required this.completer,
+    required this.pipeCompleter,
+  }) : super(
           route: _getsLastRouteFromMatches(matches),
           matchedLocation: _getsMatchedLocationFromMatches(matches),
         );
@@ -459,6 +463,9 @@ class ImperativeRouteMatch extends RouteMatch {
 
   /// The completer for the future returned by [GoRouter.push].
   final Completer<Object?> completer;
+
+  /// Pipes the completer to the next completer in the chain.
+  final PipeRouteCompleterCallback pipeCompleter;
 
   /// Called when the corresponding [Route] associated with this route match is
   /// completed.
@@ -967,6 +974,8 @@ class _RouteMatchListDecoder
           // https://github.com/flutter/flutter/issues/128122.
           completer: Completer<Object?>(),
           matches: imperativeMatchList,
+          // TODO(nouvist): Sorry, I don't know what convert does.
+          pipeCompleter: <Next>(Completer<Next?> next) => next,
         );
         matchList = matchList.push(imperativeMatch);
       }

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -117,6 +117,7 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
         baseRouteMatchList: state.baseRouteMatchList,
         completer: state.completer,
         type: state.type,
+        pipeCompleter: state.pipeCompleter,
       );
     });
   }
@@ -169,14 +170,14 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
   }
 
   /// Ensures the replacement routes can resolve the originating route completer.
-  Completer<T?>? _createInheritedCompleter<T>(
-    Completer<T?> current,
+  Completer<T?> _pipeCompleter<T extends Object?>(
+    Completer<T?> currentCompleter,
     RouteMatch lastRouteMatch,
   ) {
     if (lastRouteMatch is ImperativeRouteMatch) {
-      return _InheritedCompleter<T?>(current, lastRouteMatch.completer);
+      return lastRouteMatch.pipeCompleter(currentCompleter);
     } else {
-      return current;
+      return currentCompleter;
     }
   }
 
@@ -185,6 +186,7 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
     required RouteMatchList? baseRouteMatchList,
     required Completer<Object?>? completer,
     required NavigatingType type,
+    required PipeRouteCompleterCallback pipeCompleter,
   }) {
     switch (type) {
       case NavigatingType.push:
@@ -193,11 +195,12 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
             pageKey: _getUniqueValueKey(),
             completer: completer!,
             matches: newMatchList,
+            pipeCompleter: pipeCompleter,
           ),
         );
       case NavigatingType.pushReplacement:
         final RouteMatch routeMatch = baseRouteMatchList!.last;
-        completer = _createInheritedCompleter(completer!, routeMatch);
+        completer = _pipeCompleter(completer!, routeMatch);
         baseRouteMatchList = baseRouteMatchList.remove(routeMatch);
         if (baseRouteMatchList.isEmpty) {
           return newMatchList;
@@ -205,13 +208,14 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
         return baseRouteMatchList.push(
           ImperativeRouteMatch(
             pageKey: _getUniqueValueKey(),
-            completer: completer!,
+            completer: completer,
             matches: newMatchList,
+            pipeCompleter: pipeCompleter,
           ),
         );
       case NavigatingType.replace:
         final RouteMatch routeMatch = baseRouteMatchList!.last;
-        completer = _createInheritedCompleter(completer!, routeMatch);
+        completer = _pipeCompleter(completer!, routeMatch);
         baseRouteMatchList = baseRouteMatchList.remove(routeMatch);
         if (baseRouteMatchList.isEmpty) {
           return newMatchList;
@@ -219,8 +223,9 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
         return baseRouteMatchList.push(
           ImperativeRouteMatch(
             pageKey: routeMatch.pageKey,
-            completer: completer!,
+            completer: completer,
             matches: newMatchList,
+            pipeCompleter: pipeCompleter,
           ),
         );
       case NavigatingType.go:
@@ -237,35 +242,4 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
     return ValueKey<String>(String.fromCharCodes(
         List<int>.generate(32, (_) => _random.nextInt(33) + 89)));
   }
-}
-
-/// Ensures the replacement routes can resolve the originating route completer.
-/// Mainly used by [GoRouteInformationParser._createInheritedCompleter].
-class _InheritedCompleter<T extends Object?> implements Completer<T> {
-  _InheritedCompleter(this._current, this._last);
-
-  final Completer<T> _current;
-  final Completer<Object?> _last;
-
-  @override
-  void complete([FutureOr<T>? value]) {
-    _current.complete(value);
-    if (!_last.isCompleted) {
-      _last.complete(value);
-    }
-  }
-
-  @override
-  void completeError(Object error, [StackTrace? stackTrace]) {
-    _current.completeError(error, stackTrace);
-    if (!_last.isCompleted) {
-      _last.completeError(error, stackTrace);
-    }
-  }
-
-  @override
-  Future<T> get future => _current.future;
-
-  @override
-  bool get isCompleted => _current.isCompleted;
 }

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -387,12 +387,17 @@ class GoRouter implements RouterConfig<RouteMatchList> {
   /// * [replace] which replaces the top-most page of the page stack but treats
   ///   it as the same page. The page key will be reused. This will preserve the
   ///   state and not run any page animation.
-  Future<T?> push<T extends Object?>(String location, {Object? extra}) async {
+  Future<T?> push<T extends Object?>(
+    String location, {
+    Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
+  }) async {
     log('pushing $location');
     return routeInformationProvider.push<T>(
       location,
       base: routerDelegate.currentConfiguration,
       extra: extra,
+      mapReplacementResult: mapReplacementResult,
     );
   }
 
@@ -403,11 +408,16 @@ class GoRouter implements RouterConfig<RouteMatchList> {
     Map<String, String> pathParameters = const <String, String>{},
     Map<String, dynamic> queryParameters = const <String, dynamic>{},
     Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
   }) =>
       push<T>(
-        namedLocation(name,
-            pathParameters: pathParameters, queryParameters: queryParameters),
+        namedLocation(
+          name,
+          pathParameters: pathParameters,
+          queryParameters: queryParameters,
+        ),
         extra: extra,
+        mapReplacementResult: mapReplacementResult,
       );
 
   /// Replaces the top-most page of the page stack with the given URL location
@@ -419,13 +429,17 @@ class GoRouter implements RouterConfig<RouteMatchList> {
   /// * [replace] which replaces the top-most page of the page stack but treats
   ///   it as the same page. The page key will be reused. This will preserve the
   ///   state and not run any page animation.
-  Future<T?> pushReplacement<T extends Object?>(String location,
-      {Object? extra}) {
+  Future<T?> pushReplacement<T extends Object?>(
+    String location, {
+    Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
+  }) {
     log('pushReplacement $location');
     return routeInformationProvider.pushReplacement<T>(
       location,
       base: routerDelegate.currentConfiguration,
       extra: extra,
+      mapReplacementResult: mapReplacementResult,
     );
   }
 
@@ -441,11 +455,16 @@ class GoRouter implements RouterConfig<RouteMatchList> {
     Map<String, String> pathParameters = const <String, String>{},
     Map<String, dynamic> queryParameters = const <String, dynamic>{},
     Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
   }) {
     return pushReplacement<T>(
-      namedLocation(name,
-          pathParameters: pathParameters, queryParameters: queryParameters),
+      namedLocation(
+        name,
+        pathParameters: pathParameters,
+        queryParameters: queryParameters,
+      ),
       extra: extra,
+      mapReplacementResult: mapReplacementResult,
     );
   }
 
@@ -459,12 +478,17 @@ class GoRouter implements RouterConfig<RouteMatchList> {
   /// * [push] which pushes the given location onto the page stack.
   /// * [pushReplacement] which replaces the top-most page of the page stack but
   ///   always uses a new page key.
-  Future<T?> replace<T>(String location, {Object? extra}) {
+  Future<T?> replace<T>(
+    String location, {
+    Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
+  }) {
     log('replace $location');
     return routeInformationProvider.replace<T>(
       location,
       base: routerDelegate.currentConfiguration,
       extra: extra,
+      mapReplacementResult: mapReplacementResult,
     );
   }
 
@@ -484,11 +508,16 @@ class GoRouter implements RouterConfig<RouteMatchList> {
     Map<String, String> pathParameters = const <String, String>{},
     Map<String, dynamic> queryParameters = const <String, dynamic>{},
     Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
   }) {
     return replace(
-      namedLocation(name,
-          pathParameters: pathParameters, queryParameters: queryParameters),
+      namedLocation(
+        name,
+        pathParameters: pathParameters,
+        queryParameters: queryParameters,
+      ),
       extra: extra,
+      mapReplacementResult: mapReplacementResult,
     );
   }
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 15.1.2
+version: 15.1.3
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 15.1.3
+version: 15.2.0
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/imperative_api_test.dart
+++ b/packages/go_router/test/imperative_api_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -293,5 +295,50 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('shell'), findsNothing);
     expect(find.byKey(e), findsOneWidget);
+  });
+
+  testWidgets('completer able to be passed on replace',
+      (WidgetTester tester) async {
+    final List<RouteBase> routes = <RouteBase>[
+      GoRoute(
+        path: '/initial',
+        builder: (BuildContext context, GoRouterState state) =>
+            const DummyScreen(),
+      ),
+      GoRoute(
+        path: '/intermediate',
+        builder: (BuildContext context, GoRouterState state) =>
+            const DummyScreen(),
+      ),
+      GoRoute(
+        path: '/final',
+        builder: (BuildContext context, GoRouterState state) =>
+            const DummyScreen(),
+      ),
+    ];
+
+    final GoRouter router = await createRouter(
+      routes,
+      tester,
+      initialLocation: '/initial',
+    );
+
+    final int random = Random().nextInt(1000);
+
+    final Future<Object?> push = router.push('/intermediate');
+    await tester.pumpAndSettle();
+    expect(router.state.path, '/intermediate');
+
+    final Future<int?> replace = router.replace<int>('/final');
+    await tester.pumpAndSettle();
+    expect(router.state.path, '/final');
+
+    router.pop(random);
+    await tester.pumpAndSettle();
+    expect(router.state.path, '/initial');
+    await tester.pumpAndSettle();
+
+    await expectLater(push, completion(random));
+    await expectLater(replace, completion(random));
   });
 }

--- a/packages/go_router/test/imperative_api_test.dart
+++ b/packages/go_router/test/imperative_api_test.dart
@@ -302,18 +302,15 @@ void main() {
     final List<RouteBase> routes = <RouteBase>[
       GoRoute(
         path: '/initial',
-        builder: (BuildContext context, GoRouterState state) =>
-            const DummyScreen(),
+        builder: (_, __) => const DummyScreen(),
       ),
       GoRoute(
         path: '/intermediate',
-        builder: (BuildContext context, GoRouterState state) =>
-            const DummyScreen(),
+        builder: (_, __) => const DummyScreen(),
       ),
       GoRoute(
         path: '/final',
-        builder: (BuildContext context, GoRouterState state) =>
-            const DummyScreen(),
+        builder: (_, __) => const DummyScreen(),
       ),
     ];
 
@@ -323,22 +320,48 @@ void main() {
       initialLocation: '/initial',
     );
 
-    final int random = Random().nextInt(1000);
+    final Random random = Random();
 
-    final Future<Object?> push = router.push('/intermediate');
-    await tester.pumpAndSettle();
-    expect(router.state.path, '/intermediate');
+    /** resolve to null by default **/ {
+      final int result = random.nextInt(1000);
+      final Future<String?> push = router.push('/intermediate');
+      await tester.pumpAndSettle();
+      expect(router.state.path, '/intermediate');
 
-    final Future<int?> replace = router.replace<int>('/final');
-    await tester.pumpAndSettle();
-    expect(router.state.path, '/final');
+      final Future<int?> replace = router.replace<int>('/final');
+      await tester.pumpAndSettle();
+      expect(router.state.path, '/final');
 
-    router.pop(random);
-    await tester.pumpAndSettle();
-    expect(router.state.path, '/initial');
-    await tester.pumpAndSettle();
+      router.pop(result);
+      await tester.pumpAndSettle();
+      expect(router.state.path, '/initial');
+      await tester.pumpAndSettle();
 
-    await expectLater(push, completion(random));
-    await expectLater(replace, completion(random));
+      await expectLater(push, completion(null));
+      await expectLater(replace, completion(result));
+    }
+
+    /** map and resolve **/ {
+      final int result = random.nextInt(1000);
+      final Future<String?> push = router.push(
+        '/intermediate',
+        mapReplacementResult: (Object? result) =>
+            result is num ? result.toString() : null,
+      );
+      await tester.pumpAndSettle();
+      expect(router.state.path, '/intermediate');
+
+      final Future<int?> replace = router.replace<int>('/final');
+      await tester.pumpAndSettle();
+      expect(router.state.path, '/final');
+
+      router.pop(result);
+      await tester.pumpAndSettle();
+      expect(router.state.path, '/initial');
+      await tester.pumpAndSettle();
+
+      await expectLater(push, completion(result.toString()));
+      await expectLater(replace, completion(result));
+    }
   });
 }

--- a/packages/go_router/test/inherited_test.dart
+++ b/packages/go_router/test/inherited_test.dart
@@ -162,10 +162,13 @@ class MockGoRouter extends GoRouter {
   late String latestPushedName;
 
   @override
-  Future<T?> pushNamed<T extends Object?>(String name,
-      {Map<String, String> pathParameters = const <String, String>{},
-      Map<String, dynamic> queryParameters = const <String, dynamic>{},
-      Object? extra}) {
+  Future<T?> pushNamed<T extends Object?>(
+    String name, {
+    Map<String, String> pathParameters = const <String, String>{},
+    Map<String, dynamic> queryParameters = const <String, dynamic>{},
+    Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
+  }) {
     latestPushedName = name;
     return Future<T?>.value();
   }

--- a/packages/go_router/test/match_test.dart
+++ b/packages/go_router/test/match_test.dart
@@ -223,30 +223,62 @@ void main() {
 
     test('can equal and has', () async {
       ImperativeRouteMatch match1 = ImperativeRouteMatch(
-          pageKey: key1, matches: matchList1, completer: completer1);
+        pageKey: key1,
+        matches: matchList1,
+        completer: completer1,
+        pipeCompleter: <Next>(Completer<Next?> next) => next,
+      );
       ImperativeRouteMatch match2 = ImperativeRouteMatch(
-          pageKey: key1, matches: matchList1, completer: completer1);
+        pageKey: key1,
+        matches: matchList1,
+        completer: completer1,
+        pipeCompleter: <Next>(Completer<Next?> next) => next,
+      );
       expect(match1 == match2, isTrue);
       expect(match1.hashCode == match2.hashCode, isTrue);
 
       match1 = ImperativeRouteMatch(
-          pageKey: key1, matches: matchList1, completer: completer1);
+        pageKey: key1,
+        matches: matchList1,
+        completer: completer1,
+        pipeCompleter: <Next>(Completer<Next?> next) => next,
+      );
       match2 = ImperativeRouteMatch(
-          pageKey: key2, matches: matchList1, completer: completer1);
+        pageKey: key2,
+        matches: matchList1,
+        completer: completer1,
+        pipeCompleter: <Next>(Completer<Next?> next) => next,
+      );
       expect(match1 == match2, isFalse);
       expect(match1.hashCode == match2.hashCode, isFalse);
 
       match1 = ImperativeRouteMatch(
-          pageKey: key1, matches: matchList1, completer: completer1);
+        pageKey: key1,
+        matches: matchList1,
+        completer: completer1,
+        pipeCompleter: <Next>(Completer<Next?> next) => next,
+      );
       match2 = ImperativeRouteMatch(
-          pageKey: key1, matches: matchList2, completer: completer1);
+        pageKey: key1,
+        matches: matchList2,
+        completer: completer1,
+        pipeCompleter: <Next>(Completer<Next?> next) => next,
+      );
       expect(match1 == match2, isFalse);
       expect(match1.hashCode == match2.hashCode, isFalse);
 
       match1 = ImperativeRouteMatch(
-          pageKey: key1, matches: matchList1, completer: completer1);
+        pageKey: key1,
+        matches: matchList1,
+        completer: completer1,
+        pipeCompleter: <Next>(Completer<Next?> next) => next,
+      );
       match2 = ImperativeRouteMatch(
-          pageKey: key1, matches: matchList1, completer: completer2);
+        pageKey: key1,
+        matches: matchList1,
+        completer: completer2,
+        pipeCompleter: <Next>(Completer<Next?> next) => next,
+      );
       expect(match1 == match2, isFalse);
       expect(match1.hashCode == match2.hashCode, isFalse);
     });

--- a/packages/go_router/test/matching_test.dart
+++ b/packages/go_router/test/matching_test.dart
@@ -95,9 +95,11 @@ void main() {
     final RouteMatchList list1 = configuration.findMatch(Uri.parse('/a'));
     final RouteMatchList list2 = configuration.findMatch(Uri.parse('/b'));
     list1.push(ImperativeRouteMatch(
-        pageKey: const ValueKey<String>('/b-p0'),
-        matches: list2,
-        completer: Completer<Object?>()));
+      pageKey: const ValueKey<String>('/b-p0'),
+      matches: list2,
+      completer: Completer<Object?>(),
+      pipeCompleter: <Next>(Completer<Next?> next) => next,
+    ));
 
     final Map<Object?, Object?> encoded = codec.encode(list1);
     final RouteMatchList decoded = codec.decode(encoded);

--- a/packages/go_router/test/test_helpers.dart
+++ b/packages/go_router/test/test_helpers.dart
@@ -114,7 +114,11 @@ class GoRouterPushSpy extends GoRouter {
   Object? extra;
 
   @override
-  Future<T?> push<T extends Object?>(String location, {Object? extra}) {
+  Future<T?> push<T extends Object?>(
+    String location, {
+    Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
+  }) {
     myLocation = location;
     this.extra = extra;
     return Future<T?>.value(extra as T?);
@@ -138,6 +142,7 @@ class GoRouterPushNamedSpy extends GoRouter {
     Map<String, String> pathParameters = const <String, String>{},
     Map<String, dynamic> queryParameters = const <String, dynamic>{},
     Object? extra,
+    MapRouteResultCallback<T?>? mapReplacementResult,
   }) {
     this.name = name;
     this.pathParameters = pathParameters;


### PR DESCRIPTION
The behavior of `replace` and `pushReplacement` involves popping the last route and ignoring the completer, leaving the last route's future unresolved. This PR introduces new behavior for both methods to inherit the last route's completer if the last route is an `ImperativeRouteMatch`.

Expected issue(s) should be fixed by this:
- https://github.com/flutter/flutter/issues/141251

### Previous behavior:
https://github.com/user-attachments/assets/add06187-9bee-4347-8eac-e129c7a53457

### This PR behavior:
https://github.com/user-attachments/assets/98c20fe3-5fea-4db2-ae95-747950650172

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
