### PR TITLE
[vector_graphics] Moved color and colorFilter effects into the raster cache to reduce rendering overhead.

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.20
+
+* Moved color and colorFilter effects into the raster cache to reduce subsequent rendering overhead.
+
 ## 1.1.19
 
 * Updates minimum supported SDK version to Flutter 3.24/Dart 3.5.

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -2,7 +2,7 @@ name: vector_graphics
 description: A vector graphics rendering package for Flutter using a binary encoding.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-version: 1.1.19
+version: 1.1.20
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
This PR addresses a performance issue in the VectorGraphic widget when using the raster rendering strategy. Specifically, it moves the color and colorFilter effects into the raster cache stage, avoiding the need to apply them via saveLayer during every frame of rendering.

This issue was highlighted in [flutter/flutter#166184](https://github.com/flutter/flutter/issues/166184), where rendering multiple SVGs in raster mode led to excessive overhead due to the use of saveLayer. Rather than being applied during drawing time, these effects can be baked into the cached image once, resulting in faster and more efficient rendering.

> Note: This PR is proposed separately from [flutter/packages#8932](https://github.com/flutter/packages/pull/8932), which introduced a new auto strategy. Although related in purpose (performance improvements), this fix is independent and directly targets the saveLayer overhead problem.

### Before this PR
With the current behavior, SVGs using raster mode with color or colorFilter incur significant rendering costs. For example, rendering 20 SVGs may trigger many sub render passes caused by saveLayer:

<img width="930" alt="before" src="https://github.com/user-attachments/assets/1de4c902-8834-4c4b-95cb-ab866ef378b3" />
The small blocks at the bottom of EntityPass::OnRender represent additional GPU passes (e.g., vkCmdBeginRenderPass, vkQueueSubmit):

<img width="1087" alt="saveLayer render passes" src="https://github.com/user-attachments/assets/972bd72b-0fc4-43dd-bb8c-6349dba4e495" />

### After this PR
The effects are applied once at caching time. As a result, runtime rendering becomes a simple drawImage call, with no subpasses introduced:

<img width="828" alt="after" src="https://github.com/user-attachments/assets/5cc8aa4e-992e-468f-84bb-c6603ffab39d" />



## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
