### PR TITLE
[camera_avfoundation] Fix incorrect types in image stream events

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 0.9.20
+
+* Fixes incorrect types in image stream events.
+
 ## 0.9.19+3
 
 * Fixes race condition when starting image stream.
-
 
 ## 0.9.19+2
 

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/StreamingTests.swift
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/StreamingTests.swift
@@ -123,4 +123,41 @@ final class StreamingTests: XCTestCase {
 
     waitForExpectations(timeout: 30, handler: nil)
   }
+
+  func testImageStreamEventFormat() {
+    let (camera, testAudioOutput, sampleBuffer, testAudioConnection) = createCamera()
+
+    let expectation = expectation(description: "Received a valid event")
+
+    let handlerMock = MockImageStreamHandler()
+    handlerMock.eventSinkStub = { event in
+      let imageBuffer = event as! [String: Any]
+
+      XCTAssertTrue(imageBuffer["width"] is NSNumber)
+      XCTAssertTrue(imageBuffer["height"] is NSNumber)
+      XCTAssertTrue(imageBuffer["format"] is NSNumber)
+      XCTAssertTrue(imageBuffer["lensAperture"] is NSNumber)
+      XCTAssertTrue(imageBuffer["sensorExposureTime"] is NSNumber)
+      XCTAssertTrue(imageBuffer["sensorSensitivity"] is NSNumber)
+
+      let planes = imageBuffer["planes"] as! [[String: Any]]
+      let planeBuffer = planes[0]
+
+      XCTAssertTrue(planeBuffer["bytesPerRow"] is NSNumber)
+      XCTAssertTrue(planeBuffer["width"] is NSNumber)
+      XCTAssertTrue(planeBuffer["height"] is NSNumber)
+      XCTAssertTrue(planeBuffer["bytes"] is FlutterStandardTypedData)
+
+      expectation.fulfill()
+    }
+    let messenger = MockFlutterBinaryMessenger()
+    camera.startImageStream(with: messenger, imageStreamHandler: handlerMock) { _ in }
+
+    waitForQueueRoundTrip(with: DispatchQueue.main)
+    XCTAssertEqual(camera.isStreamingImages, true)
+
+    camera.captureOutput(testAudioOutput, didOutput: sampleBuffer, from: testAudioConnection)
+
+    waitForExpectations(timeout: 30, handler: nil)
+  }
 }

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
@@ -105,10 +105,9 @@ final class DefaultCamera: FLTCam, Camera {
           "height": imageHeight,
           "format": videoFormat,
           "planes": planes,
-          "lensAperture": captureDevice.lensAperture,
-          "sensorExposureTime": NSNumber(
-            value: captureDevice.exposureDuration().seconds * 1_000_000_000),
-          "sensorSensitivity": NSNumber(value: captureDevice.iso()),
+          "lensAperture": Double(captureDevice.lensAperture()),
+          "sensorExposureTime": Int(captureDevice.exposureDuration().seconds * 1_000_000_000),
+          "sensorSensitivity": Double(captureDevice.iso()),
         ]
 
         DispatchQueue.main.async {

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.19+3
+version: 0.9.20
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Fixes the types used in the image stream events. Most importantly, it corrects the `lensAperture` to `lensAperture**()**` that caused a crash. Some other arguments were also updated to match exactly the types expected by the parsing in `type_conversions.dart`.

Resolves: https://github.com/flutter/flutter/issues/170240

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
