### PR TITLE
[go_router] Use library prefix for meta

### DIFF
--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -9,7 +9,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
+import 'package:meta/meta.dart' as meta;
 
 import 'configuration.dart';
 import 'logging.dart';
@@ -402,7 +402,7 @@ class ShellRouteMatch extends RouteMatchBase {
   ///
   /// This is typically used when pushing or popping [RouteMatchBase] from
   /// [RouteMatchList].
-  @internal
+  @meta.internal
   ShellRouteMatch copyWith({
     required List<RouteMatchBase>? matches,
   }) {
@@ -766,7 +766,7 @@ class RouteMatchList with Diagnosticable {
   /// returns false.
   ///
   /// This method visit recursively into shell route matches.
-  @internal
+  @meta.internal
   void visitRouteMatches(RouteMatchVisitor visitor) {
     _visitRouteMatches(matches, visitor);
   }
@@ -786,7 +786,7 @@ class RouteMatchList with Diagnosticable {
   }
 
   /// Create a new [RouteMatchList] with given parameter replaced.
-  @internal
+  @meta.internal
   RouteMatchList copyWith({
     List<RouteMatchBase>? matches,
     Uri? uri,
@@ -841,7 +841,7 @@ class RouteMatchList with Diagnosticable {
 /// suitable for using with [StandardMessageCodec].
 ///
 /// The primary use of this class is for state restoration and browser history.
-@internal
+@meta.internal
 class RouteMatchListCodec extends Codec<RouteMatchList, Map<Object?, Object?>> {
   /// Creates a new [RouteMatchListCodec] object.
   RouteMatchListCodec(RouteConfiguration configuration)

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
+import 'package:meta/meta.dart' as meta;
 
 import 'configuration.dart';
 import 'match.dart';
@@ -459,7 +459,7 @@ class GoRoute extends RouteBase {
       extractPathParameters(pathParameters, match);
 
   /// The path parameters in this route.
-  @internal
+  @meta.internal
   final List<String> pathParameters = <String>[];
 
   @override


### PR DESCRIPTION
We plan to export the `internal` attribute from `package:flutter/foundation.dart`.

Currently, `go_router` has files that import both `package:meta/meta.dart` and `package:flutter/foundation.dart`. This causes [lint failures](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8712222978061136193/+/u/run_test.dart_for_flutter_plugins_shard_and_subshard_analyze/stdout) when `foundation` exports `internal`:

```
   info - lib/src/match.dart:12:8 - The import of 'package:meta/meta.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/foundation.dart'. Try removing the import directive. - unnecessary_import
   info - lib/src/route.dart:10:8 - The import of 'package:meta/meta.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/foundation.dart'. Try removing the import directive. - unnecessary_import
```

This updates go_router to use a library prefix for `package:meta` in affected files to make the lints happy.

This change is a refactoring and does not affect semantics and is exempt from the test, version change, and CHANGELOG policies.

Part of https://github.com/flutter/flutter/issues/167668

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
