### PR TITLE
[google_maps_flutter] Annotate `zIndex` usage

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -2010,6 +2010,7 @@ Marker _copyMarkerWithClusterManagerId(
     rotation: marker.rotation,
     visible: marker.visible,
     // The deprecated parameter is used here to avoid losing precision.
+    // ignore: deprecated_member_use
     zIndex: marker.zIndex,
     onTap: marker.onTap,
     onDragStart: marker.onDragStart,

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/place_marker.dart
@@ -250,10 +250,10 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
 
   Future<void> _changeZIndex(MarkerId markerId) async {
     final Marker marker = markers[markerId]!;
-    final double current = marker.zIndex;
+    final int current = marker.zIndexInt;
     setState(() {
       markers[markerId] = marker.copyWith(
-        zIndexParam: current == 12.0 ? 0.0 : current + 1.0,
+        zIndexIntParam: current == 12 ? 0 : current + 1,
       );
     });
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -792,6 +792,9 @@ class GoogleMapsFlutterAndroid extends GoogleMapsFlutterPlatform {
       position: _platformLatLngFromLatLng(marker.position),
       rotation: marker.rotation,
       visible: marker.visible,
+      // The deprecated paramater is used to avoid losing precision, since the
+      // Android SDK uses doubles.
+      // ignore: deprecated_member_use
       zIndex: marker.zIndex,
       markerId: marker.markerId.value,
       clusterManagerId: marker.clusterManagerId?.value,

--- a/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
@@ -444,6 +444,7 @@ void main() {
       expect(firstChanged.position.longitude, object2new.position.longitude);
       expect(firstChanged.rotation, object2new.rotation);
       expect(firstChanged.visible, object2new.visible);
+      // ignore: deprecated_member_use
       expect(firstChanged.zIndex, object2new.zIndex);
       expect(firstChanged.markerId, object2new.markerId.value);
       expect(firstChanged.clusterManagerId, object2new.clusterManagerId?.value);
@@ -472,6 +473,7 @@ void main() {
       expect(firstAdded.position.longitude, object3.position.longitude);
       expect(firstAdded.rotation, object3.rotation);
       expect(firstAdded.visible, object3.visible);
+      // ignore: deprecated_member_use
       expect(firstAdded.zIndex, object3.zIndex);
       expect(firstAdded.markerId, object3.markerId.value);
       expect(firstAdded.clusterManagerId, object3.clusterManagerId?.value);

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios14/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios14/integration_test/google_maps_test.dart
@@ -1950,7 +1950,7 @@ Marker _copyMarkerWithClusterManagerId(
     position: marker.position,
     rotation: marker.rotation,
     visible: marker.visible,
-    zIndex: marker.zIndex,
+    zIndexInt: marker.zIndexInt,
     onTap: marker.onTap,
     onDragStart: marker.onDragStart,
     onDrag: marker.onDrag,

--- a/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
@@ -446,7 +446,7 @@ void main() {
       expect(firstChanged.position.longitude, object2new.position.longitude);
       expect(firstChanged.rotation, object2new.rotation);
       expect(firstChanged.visible, object2new.visible);
-      expect(firstChanged.zIndex, object2new.zIndex);
+      expect(firstChanged.zIndex, object2new.zIndexInt);
       expect(firstChanged.markerId, object2new.markerId.value);
       expect(firstChanged.clusterManagerId, object2new.clusterManagerId?.value);
     }
@@ -473,7 +473,7 @@ void main() {
       expect(firstAdded.position.longitude, object3.position.longitude);
       expect(firstAdded.rotation, object3.rotation);
       expect(firstAdded.visible, object3.visible);
-      expect(firstAdded.zIndex, object3.zIndex);
+      expect(firstAdded.zIndex, object3.zIndexInt);
       expect(firstAdded.markerId, object3.markerId.value);
       expect(firstAdded.clusterManagerId, object3.clusterManagerId?.value);
     }

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/marker_clustering_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/marker_clustering_test.dart
@@ -133,6 +133,7 @@ Marker _copyMarkerWithClusterManagerId(
     position: marker.position,
     rotation: marker.rotation,
     visible: marker.visible,
+    // ignore: deprecated_member_use
     zIndex: marker.zIndex,
     onTap: marker.onTap,
     onDragStart: marker.onDragStart,

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -273,6 +273,7 @@ gmaps.InfoWindowOptions? _infoWindowOptionsFromMarker(Marker marker) {
   return gmaps.InfoWindowOptions()
     ..content = container
     // The deprecated parameter is used here to avoid losing precision.
+    // ignore: deprecated_member_use
     ..zIndex = marker.zIndex;
   // TODO(ditman): Compute the pixelOffset of the infoWindow, from the size of the Marker,
   // and the marker.infoWindow.anchor property.
@@ -467,6 +468,7 @@ Future<gmaps.MarkerOptions> _markerOptionsFromMarker(
     )
     ..title = sanitizeHtml(marker.infoWindow.title ?? '')
     // The deprecated parameter is used here to avoid losing precision.
+    // ignore: deprecated_member_use
     ..zIndex = marker.zIndex
     ..visible = marker.visible
     ..opacity = marker.alpha


### PR DESCRIPTION
Marks intentional usage of the deprecated `zIndex`, per https://github.com/flutter/flutter/blob/main/docs/infra/Packages-Gardener-Rotation.md#deprecations

On iOS, switches from `zIndex` to `zIndexInt` since it's converted to an int later anyway. Also switches the Android example app, since clients should be using the int version (and the example only uses integer values anyway).

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
