### PR TITLE
[in_app_purchase] Annotate deprecation in test

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/example/integration_test/in_app_purchase_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/example/integration_test/in_app_purchase_test.dart
@@ -106,6 +106,8 @@ void main() {
     testWidgets('BillingClient.queryPurchaseHistory',
         (WidgetTester tester) async {
       try {
+        // Intentional use of a deprecated method to make sure it still works.
+        // ignore: deprecated_member_use
         await billingClient.queryPurchaseHistory(ProductType.inapp);
       } on MissingPluginException {
         fail('Method channel is not setup correctly');


### PR DESCRIPTION
Annotate an intentional use of a deprecated method in an integration test, so that it doesn't show up in deprecation audits.

See https://github.com/flutter/flutter/blob/main/docs/infra/Packages-Gardener-Rotation.md#deprecations