### PR TITLE
[google_sign_in] Don't crash a misconfigured iOS app

### DIFF
--- a/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.1
+
+* Returns configuration errors as `PlatformException`s in Dart instead of
+  crashing the app.
+
 ## 6.0.0
 
 * **BREAKING CHANGE**: Switches to implementing version 3.0 of the platform

--- a/packages/google_sign_in/google_sign_in_ios/darwin/Tests/GoogleSignInTests.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/Tests/GoogleSignInTests.m
@@ -371,26 +371,26 @@
   [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
-- (void)testSignInException {
+- (void)testSignInExceptionReturnsError {
   OCMExpect([self configureMock:self.mockSignIn
                 forSignInWithHint:OCMOCK_ANY
                  additionalScopes:OCMOCK_ANY
                        completion:OCMOCK_ANY])
       .andThrow([NSException exceptionWithName:@"MockName" reason:@"MockReason" userInfo:nil]);
 
-  __block FlutterError *error;
-  XCTAssertThrows([self.plugin
-      signInWithScopeHint:@[]
-                    nonce:nil
-               completion:^(FSISignInResult *result, FlutterError *signInError) {
-                 // Unexpected errors, such as runtime exceptions, are returned as FlutterError.
-                 XCTAssertNil(result);
-                 error = signInError;
-               }]);
-
-  XCTAssertEqualObjects(error.code, @"google_sign_in");
-  XCTAssertEqualObjects(error.message, @"MockReason");
-  XCTAssertEqualObjects(error.details, @"MockName");
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.plugin signInWithScopeHint:@[]
+                             nonce:nil
+                        completion:^(FSISignInResult *result, FlutterError *error) {
+                          // Unexpected errors, such as runtime exceptions, are returned as
+                          // FlutterError.
+                          XCTAssertNil(result);
+                          XCTAssertEqualObjects(error.code, @"google_sign_in");
+                          XCTAssertEqualObjects(error.message, @"MockReason");
+                          XCTAssertEqualObjects(error.details, @"MockName");
+                          [expectation fulfill];
+                        }];
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
 #pragma mark - refreshedAuthorizationTokens

--- a/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios/FLTGoogleSignInPlugin.m
@@ -196,7 +196,6 @@ static FSIGoogleSignInErrorCode FSIPigeonErrorCodeForGIDSignInErrorCode(NSIntege
               }];
   } @catch (NSException *e) {
     completion(nil, [FlutterError errorWithCode:@"google_sign_in" message:e.reason details:e.name]);
-    [e raise];
   }
 }
 

--- a/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_ios
 description: iOS implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 6.0.0
+version: 6.0.1
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
In https://github.com/flutter/plugins/pull/1180 the plugin was deliberately made to crash when misconfigured. The reasoning was that the app shouldn't be released this way, which is true, but crashing the entire app means that a developer has to use Xcode to debug the app to understand what's happening, which is a very poor user experience.

The PR indicated that the error would be printed from the Dart side after that PR, but that's not actually what happens; method channel returns are asynchronous, whereas crashing the app on the native side with an unhandled exception happens immediately, so even though the native side does call the completion, the async process of that completion being received on the Dart side as a `PlatformException` was never happening, and the crash was silent outside the context of a native debugger.

This removes the throw, so that it can be received as a Dart exception, which is much easier for most developers to debug.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
