### PR TITLE
Revert "[camera_android_camerax] Force new `Surface` for each `SurfaceRequest`"

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.6.19
-
-* Ensures that a new surface is provided every time that one is requested to render the camera preview
-  to fix pausing and resuming the preview.
-
 ## 0.6.18+3
 
 * Fixes incorrect camera preview mirroring for front cameras of devices using the Impeller backend.

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PreviewProxyApi.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/PreviewProxyApi.java
@@ -121,7 +121,7 @@ class PreviewProxyApi extends PigeonApiPreview {
       // Provide surface.
       surfaceProducer.setSize(
           request.getResolution().getWidth(), request.getResolution().getHeight());
-      Surface flutterSurface = surfaceProducer.getForcedNewSurface();
+      Surface flutterSurface = surfaceProducer.getSurface();
       request.provideSurface(
           flutterSurface,
           Executors.newSingleThreadExecutor(),

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PreviewTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/PreviewTest.java
@@ -103,7 +103,7 @@ public class PreviewTest {
         ArgumentCaptor.forClass(TextureRegistry.SurfaceProducer.Callback.class);
 
     when(mockSurfaceRequest.getResolution()).thenReturn(new Size(5, 6));
-    when(mockSurfaceProducer.getForcedNewSurface()).thenReturn(mock(Surface.class));
+    when(mockSurfaceProducer.getSurface()).thenReturn(mock(Surface.class));
 
     final Preview.SurfaceProvider previewSurfaceProvider =
         api.createSurfaceProvider(mockSurfaceProducer, mockSystemServicesManager);
@@ -155,7 +155,7 @@ public class PreviewTest {
 
     when(mockSurfaceRequest.getResolution())
         .thenReturn(new Size(resolutionWidth, resolutionHeight));
-    when(mockSurfaceProducer.getForcedNewSurface()).thenReturn(mockSurface);
+    when(mockSurfaceProducer.getSurface()).thenReturn(mockSurface);
 
     final ArgumentCaptor<Surface> surfaceCaptor = ArgumentCaptor.forClass(Surface.class);
     final ArgumentCaptor<Consumer<SurfaceRequest.Result>> consumerCaptor =

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.6.19
+version: 0.6.18+3
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
Reverts flutter/packages#9360

It uses an API that's not available on `stable`, breaking compilation of the plugin on `stable`.