### PR TITLE
Revert "[ci] Remove in_app_purchase_storekit from Xcode analyzer exclusion list"

### DIFF
--- a/script/configs/exclude_xcode_deprecation.yaml
+++ b/script/configs/exclude_xcode_deprecation.yaml
@@ -1,0 +1,2 @@
+# TODO(louisehsu): Remove deprecation check when StoreKit 2 is adopted. https://github.com/flutter/flutter/issues/116383
+- in_app_purchase_storekit


### PR DESCRIPTION
Reverts flutter/packages#9429
This somehow passed in presubmit but failed in postsubmit:

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8710980990085669745/+/u/Run_package_tests/xcode_analyze_deprecation/stdout