### PR TITLE
[quick_actions] Restore the appShortcutLaunchActivityAfterStarting test in quick_actions_android

### DIFF
--- a/packages/quick_actions/quick_actions_android/example/android/app/src/androidTest/java/io/flutter/plugins/quickactionsexample/QuickActionsTest.java
+++ b/packages/quick_actions/quick_actions_android/example/android/app/src/androidTest/java/io/flutter/plugins/quickactionsexample/QuickActionsTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -87,8 +86,6 @@ public class QuickActionsTest {
   }
 
   @Test
-  @Ignore(
-      "This is crashing in Firebase Test Lab. See https://github.com/flutter/flutter/issues/170141")
   public void appShortcutLaunchActivityAfterStarting() {
     // Arrange
     List<ShortcutInfo> shortcuts = createMockShortcuts();


### PR DESCRIPTION
This was temporarily disabled due to https://github.com/flutter/flutter/issues/170141, which should be fixed now.