### PR TITLE
[video_player] Use CADisplayLink on macOS 14.0+

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.7.2
 
+* Uses `CADisplayLink` on macOS 14.0+.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 * Refactors native code for improved testing.
 

--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
@@ -137,39 +137,33 @@
 
 #pragma mark -
 
-/** Test implementation of FVPDisplayLinkFactory that returns a provided display link instance.  */
+@interface StubFVPDisplayLink : NSObject <FVPDisplayLink>
+@property(nonatomic, assign) BOOL running;
+@end
+
+@implementation StubFVPDisplayLink
+- (CFTimeInterval)duration {
+  return 1.0 / 60.0;
+}
+@end
+
+/** Test implementation of FVPDisplayLinkFactory that returns a stub display link instance.  */
 @interface StubFVPDisplayLinkFactory : NSObject <FVPDisplayLinkFactory>
-
 /** This display link to return. */
-@property(nonatomic, strong) FVPDisplayLink *displayLink;
+@property(nonatomic, strong) StubFVPDisplayLink *displayLink;
 @property(nonatomic, copy) void (^fireDisplayLink)(void);
-
-- (instancetype)initWithDisplayLink:(FVPDisplayLink *)displayLink;
-
 @end
 
 @implementation StubFVPDisplayLinkFactory
-- (instancetype)initWithDisplayLink:(FVPDisplayLink *)displayLink {
+- (instancetype)init {
   self = [super init];
-  _displayLink = displayLink;
+  _displayLink = [[StubFVPDisplayLink alloc] init];
   return self;
 }
-- (FVPDisplayLink *)displayLinkWithRegistrar:(id<FlutterPluginRegistrar>)registrar
-                                    callback:(void (^)(void))callback {
+- (NSObject<FVPDisplayLink> *)displayLinkWithRegistrar:(id<FlutterPluginRegistrar>)registrar
+                                              callback:(void (^)(void))callback {
   self.fireDisplayLink = callback;
   return self.displayLink;
-}
-
-@end
-
-/** Non-test implementation of the diplay link factory. */
-@interface FVPDefaultDisplayLinkFactory : NSObject <FVPDisplayLinkFactory>
-@end
-
-@implementation FVPDefaultDisplayLinkFactory
-- (FVPDisplayLink *)displayLinkWithRegistrar:(id<FlutterPluginRegistrar>)registrar
-                                    callback:(void (^)(void))callback {
-  return [[FVPDisplayLink alloc] initWithRegistrar:registrar callback:callback];
 }
 
 @end
@@ -251,12 +245,7 @@
       OCMProtocolMock(@protocol(FlutterTextureRegistry));
   NSObject<FlutterPluginRegistrar> *registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
   OCMStub([registrar textures]).andReturn(mockTextureRegistry);
-  FVPDisplayLink *mockDisplayLink =
-      OCMPartialMock([[FVPDisplayLink alloc] initWithRegistrar:registrar
-                                                      callback:^(){
-                                                      }]);
-  StubFVPDisplayLinkFactory *stubDisplayLinkFactory =
-      [[StubFVPDisplayLinkFactory alloc] initWithDisplayLink:mockDisplayLink];
+  StubFVPDisplayLinkFactory *stubDisplayLinkFactory = [[StubFVPDisplayLinkFactory alloc] init];
   AVPlayerItemVideoOutput *mockVideoOutput = OCMPartialMock([[AVPlayerItemVideoOutput alloc] init]);
   FVPVideoPlayerPlugin *videoPlayerPlugin = [[FVPVideoPlayerPlugin alloc]
        initWithAVFactory:[[StubFVPAVFactory alloc] initWithPlayer:nil output:mockVideoOutput]
@@ -285,12 +274,7 @@
       OCMProtocolMock(@protocol(FlutterTextureRegistry));
   NSObject<FlutterPluginRegistrar> *registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
   OCMStub([registrar textures]).andReturn(mockTextureRegistry);
-  FVPDisplayLink *mockDisplayLink =
-      OCMPartialMock([[FVPDisplayLink alloc] initWithRegistrar:registrar
-                                                      callback:^(){
-                                                      }]);
-  StubFVPDisplayLinkFactory *stubDisplayLinkFactory =
-      [[StubFVPDisplayLinkFactory alloc] initWithDisplayLink:mockDisplayLink];
+  StubFVPDisplayLinkFactory *stubDisplayLinkFactory = [[StubFVPDisplayLinkFactory alloc] init];
   AVPlayerItemVideoOutput *mockVideoOutput = OCMPartialMock([[AVPlayerItemVideoOutput alloc] init]);
   FVPVideoPlayerPlugin *videoPlayerPlugin = [[FVPVideoPlayerPlugin alloc]
        initWithAVFactory:[[StubFVPAVFactory alloc] initWithPlayer:nil output:mockVideoOutput]
@@ -324,7 +308,7 @@
   [self waitForExpectationsWithTimeout:30.0 handler:nil];
 
   // Seeking to a new position should start the display link temporarily.
-  OCMVerify([mockDisplayLink setRunning:YES]);
+  XCTAssertTrue(stubDisplayLinkFactory.displayLink.running);
   FVPTextureBasedVideoPlayer *player =
       (FVPTextureBasedVideoPlayer *)videoPlayerPlugin.playersByIdentifier[playerIdentifier];
   // Wait for the player's position to update, it shouldn't take long.
@@ -347,7 +331,7 @@
   stubDisplayLinkFactory.fireDisplayLink();
   CFRelease([player copyPixelBuffer]);
   // Since a frame was found, and the video is paused, the display link should be paused again.
-  OCMVerify([mockDisplayLink setRunning:NO]);
+  XCTAssertFalse(stubDisplayLinkFactory.displayLink.running);
 }
 
 - (void)testInitStartsDisplayLinkTemporarily {
@@ -355,12 +339,7 @@
       OCMProtocolMock(@protocol(FlutterTextureRegistry));
   NSObject<FlutterPluginRegistrar> *registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
   OCMStub([registrar textures]).andReturn(mockTextureRegistry);
-  FVPDisplayLink *mockDisplayLink =
-      OCMPartialMock([[FVPDisplayLink alloc] initWithRegistrar:registrar
-                                                      callback:^(){
-                                                      }]);
-  StubFVPDisplayLinkFactory *stubDisplayLinkFactory =
-      [[StubFVPDisplayLinkFactory alloc] initWithDisplayLink:mockDisplayLink];
+  StubFVPDisplayLinkFactory *stubDisplayLinkFactory = [[StubFVPDisplayLinkFactory alloc] init];
   AVPlayerItemVideoOutput *mockVideoOutput = OCMPartialMock([[AVPlayerItemVideoOutput alloc] init]);
   StubAVPlayer *stubAVPlayer = [[StubAVPlayer alloc] init];
   FVPVideoPlayerPlugin *videoPlayerPlugin = [[FVPVideoPlayerPlugin alloc]
@@ -384,7 +363,7 @@
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&createError];
 
   // Init should start the display link temporarily.
-  OCMVerify([mockDisplayLink setRunning:YES]);
+  XCTAssertTrue(stubDisplayLinkFactory.displayLink.running);
 
   // Simulate a buffer being available.
   OCMStub([mockVideoOutput hasNewPixelBufferForItemTime:kCMTimeZero])
@@ -401,7 +380,7 @@
   stubDisplayLinkFactory.fireDisplayLink();
   CFRelease([player copyPixelBuffer]);
   // Since a frame was found, and the video is paused, the display link should be paused again.
-  OCMVerify([mockDisplayLink setRunning:NO]);
+  XCTAssertFalse(stubDisplayLinkFactory.displayLink.running);
 }
 
 - (void)testSeekToWhilePlayingDoesNotStopDisplayLink {
@@ -409,12 +388,7 @@
       OCMProtocolMock(@protocol(FlutterTextureRegistry));
   NSObject<FlutterPluginRegistrar> *registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
   OCMStub([registrar textures]).andReturn(mockTextureRegistry);
-  FVPDisplayLink *mockDisplayLink =
-      OCMPartialMock([[FVPDisplayLink alloc] initWithRegistrar:registrar
-                                                      callback:^(){
-                                                      }]);
-  StubFVPDisplayLinkFactory *stubDisplayLinkFactory =
-      [[StubFVPDisplayLinkFactory alloc] initWithDisplayLink:mockDisplayLink];
+  StubFVPDisplayLinkFactory *stubDisplayLinkFactory = [[StubFVPDisplayLinkFactory alloc] init];
   AVPlayerItemVideoOutput *mockVideoOutput = OCMPartialMock([[AVPlayerItemVideoOutput alloc] init]);
   FVPVideoPlayerPlugin *videoPlayerPlugin = [[FVPVideoPlayerPlugin alloc]
        initWithAVFactory:[[StubFVPAVFactory alloc] initWithPlayer:nil output:mockVideoOutput]
@@ -446,7 +420,7 @@
                    [initializedExpectation fulfill];
                  }];
   [self waitForExpectationsWithTimeout:30.0 handler:nil];
-  OCMVerify([mockDisplayLink setRunning:YES]);
+  XCTAssertTrue(stubDisplayLinkFactory.displayLink.running);
 
   FVPTextureBasedVideoPlayer *player =
       (FVPTextureBasedVideoPlayer *)videoPlayerPlugin.playersByIdentifier[playerIdentifier];
@@ -470,7 +444,7 @@
   stubDisplayLinkFactory.fireDisplayLink();
   CFRelease([player copyPixelBuffer]);
   // Since the video was playing, the display link should not be paused after getting a buffer.
-  OCMVerify(never(), [mockDisplayLink setRunning:NO]);
+  XCTAssertTrue(stubDisplayLinkFactory.displayLink.running);
 }
 
 - (void)testPauseWhileWaitingForFrameDoesNotStopDisplayLink {
@@ -478,12 +452,7 @@
       OCMProtocolMock(@protocol(FlutterTextureRegistry));
   NSObject<FlutterPluginRegistrar> *registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
   OCMStub([registrar textures]).andReturn(mockTextureRegistry);
-  FVPDisplayLink *mockDisplayLink =
-      OCMPartialMock([[FVPDisplayLink alloc] initWithRegistrar:registrar
-                                                      callback:^(){
-                                                      }]);
-  StubFVPDisplayLinkFactory *stubDisplayLinkFactory =
-      [[StubFVPDisplayLinkFactory alloc] initWithDisplayLink:mockDisplayLink];
+  StubFVPDisplayLinkFactory *stubDisplayLinkFactory = [[StubFVPDisplayLinkFactory alloc] init];
   AVPlayerItemVideoOutput *mockVideoOutput = OCMPartialMock([[AVPlayerItemVideoOutput alloc] init]);
   FVPVideoPlayerPlugin *videoPlayerPlugin = [[FVPVideoPlayerPlugin alloc]
        initWithAVFactory:[[StubFVPAVFactory alloc] initWithPlayer:nil output:mockVideoOutput]
@@ -510,7 +479,7 @@
   [videoPlayerPlugin pausePlayer:playerIdentifier.integerValue error:&playPauseError];
 
   // Since a buffer hasn't been available yet, the pause should not have stopped the display link.
-  OCMVerify(never(), [mockDisplayLink setRunning:NO]);
+  XCTAssertTrue(stubDisplayLinkFactory.displayLink.running);
 }
 
 - (void)testDeregistersFromPlayer {
@@ -1004,11 +973,7 @@
       OCMProtocolMock(@protocol(FlutterTextureRegistry));
   OCMStub([registrar textures]).andReturn(mockTextureRegistry);
 
-  FVPDisplayLink *displayLink = [[FVPDisplayLink alloc] initWithRegistrar:registrar
-                                                                 callback:^(){
-                                                                 }];
-  StubFVPDisplayLinkFactory *stubDisplayLinkFactory =
-      [[StubFVPDisplayLinkFactory alloc] initWithDisplayLink:displayLink];
+  StubFVPDisplayLinkFactory *stubDisplayLinkFactory = [[StubFVPDisplayLinkFactory alloc] init];
   AVPlayerItemVideoOutput *mockVideoOutput = OCMPartialMock([[AVPlayerItemVideoOutput alloc] init]);
   FVPVideoPlayerPlugin *videoPlayerPlugin = [[FVPVideoPlayerPlugin alloc]
        initWithAVFactory:[[StubFVPAVFactory alloc] initWithPlayer:nil output:mockVideoOutput]

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPCADisplayLink.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPCADisplayLink.m
@@ -7,7 +7,7 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
-/// A proxy object to act as a CADisplayLink target, to avoid retain loops, since FVPDisplayLink
+/// A proxy object to act as a CADisplayLink target, to avoid retain loops, since FVPCADisplayLink
 /// owns its CADisplayLink, but CADisplayLink retains its target.
 @interface FVPDisplayLinkTarget : NSObject
 @property(nonatomic) void (^callback)(void);
@@ -35,20 +35,29 @@
 
 #pragma mark -
 
-@interface FVPDisplayLink ()
+@interface FVPCADisplayLink ()
 // The underlying display link implementation.
 @property(nonatomic) CADisplayLink *displayLink;
 @property(nonatomic) FVPDisplayLinkTarget *target;
 @end
 
-@implementation FVPDisplayLink
+@implementation FVPCADisplayLink
 
 - (instancetype)initWithRegistrar:(id<FlutterPluginRegistrar>)registrar
                          callback:(void (^)(void))callback {
   self = [super init];
   if (self) {
     _target = [[FVPDisplayLinkTarget alloc] initWithCallback:callback];
+#if TARGET_OS_IOS
     _displayLink = [CADisplayLink displayLinkWithTarget:_target selector:@selector(onDisplayLink:)];
+#else
+    // Use the view if one is wired up, otherwise fall back to the main screen.
+    // TODO(stuartmorgan): Consider an API to inform plugins about attached view changes.
+    NSView *view = registrar.view;
+    _displayLink = view ? [view displayLinkWithTarget:_target selector:@selector(onDisplayLink:)]
+                        : [NSScreen.mainScreen displayLinkWithTarget:_target
+                                                            selector:@selector(onDisplayLink:)];
+#endif
     [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
     _displayLink.paused = YES;
   }

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPCADisplayLink.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPCADisplayLink.m
@@ -9,6 +9,7 @@
 
 /// A proxy object to act as a CADisplayLink target, to avoid retain loops, since FVPCADisplayLink
 /// owns its CADisplayLink, but CADisplayLink retains its target.
+API_AVAILABLE(ios(4.0), macos(14.0))
 @interface FVPDisplayLinkTarget : NSObject
 @property(nonatomic) void (^callback)(void);
 

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPTextureBasedVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPTextureBasedVideoPlayer.m
@@ -9,7 +9,7 @@
 // The updater that drives callbacks to the engine to indicate that a new frame is ready.
 @property(nonatomic) FVPFrameUpdater *frameUpdater;
 // The display link that drives frameUpdater.
-@property(nonatomic) FVPDisplayLink *displayLink;
+@property(nonatomic) NSObject<FVPDisplayLink> *displayLink;
 // The latest buffer obtained from video output. This is stored so that it can be returned from
 // copyPixelBuffer again if nothing new is available, since the engine has undefined behavior when
 // returning NULL.
@@ -34,7 +34,7 @@
 @implementation FVPTextureBasedVideoPlayer
 - (instancetype)initWithAsset:(NSString *)asset
                  frameUpdater:(FVPFrameUpdater *)frameUpdater
-                  displayLink:(FVPDisplayLink *)displayLink
+                  displayLink:(NSObject<FVPDisplayLink> *)displayLink
                     avFactory:(id<FVPAVFactory>)avFactory
                  viewProvider:(NSObject<FVPViewProvider> *)viewProvider
                    onDisposed:(void (^)(int64_t))onDisposed {
@@ -49,7 +49,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                frameUpdater:(FVPFrameUpdater *)frameUpdater
-                displayLink:(FVPDisplayLink *)displayLink
+                displayLink:(NSObject<FVPDisplayLink> *)displayLink
                 httpHeaders:(nonnull NSDictionary<NSString *, NSString *> *)headers
                   avFactory:(id<FVPAVFactory>)avFactory
                viewProvider:(NSObject<FVPViewProvider> *)viewProvider
@@ -70,7 +70,7 @@
 
 - (instancetype)initWithPlayerItem:(AVPlayerItem *)item
                       frameUpdater:(FVPFrameUpdater *)frameUpdater
-                       displayLink:(FVPDisplayLink *)displayLink
+                       displayLink:(NSObject<FVPDisplayLink> *)displayLink
                          avFactory:(id<FVPAVFactory>)avFactory
                       viewProvider:(NSObject<FVPViewProvider> *)viewProvider
                         onDisposed:(void (^)(int64_t))onDisposed {

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -38,7 +38,7 @@
   if (@available(macOS 14.0, *)) {
     return [[FVPCADisplayLink alloc] initWithRegistrar:registrar callback:callback];
   }
-  return [[FVPCVDisplayLink alloc] initWithRegistrar:registrar callback:callback];
+  return [[FVPCoreVideoDisplayLink alloc] initWithRegistrar:registrar callback:callback];
 #endif
 }
 

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -30,9 +30,16 @@
 @end
 
 @implementation FVPDefaultDisplayLinkFactory
-- (FVPDisplayLink *)displayLinkWithRegistrar:(id<FlutterPluginRegistrar>)registrar
-                                    callback:(void (^)(void))callback {
-  return [[FVPDisplayLink alloc] initWithRegistrar:registrar callback:callback];
+- (NSObject<FVPDisplayLink> *)displayLinkWithRegistrar:(id<FlutterPluginRegistrar>)registrar
+                                              callback:(void (^)(void))callback {
+#if TARGET_OS_IOS
+  return [[FVPCADisplayLink alloc] initWithRegistrar:registrar callback:callback];
+#else
+  if (@available(macOS 14.0, *)) {
+    return [[FVPCADisplayLink alloc] initWithRegistrar:registrar callback:callback];
+  }
+  return [[FVPCVDisplayLink alloc] initWithRegistrar:registrar callback:callback];
+#endif
 }
 
 @end
@@ -198,7 +205,7 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
 - (nullable FVPTextureBasedVideoPlayer *)texturePlayerWithOptions:
     (nonnull FVPCreationOptions *)options {
   FVPFrameUpdater *frameUpdater = [[FVPFrameUpdater alloc] initWithRegistry:_registry];
-  FVPDisplayLink *displayLink =
+  NSObject<FVPDisplayLink> *displayLink =
       [self.displayLinkFactory displayLinkWithRegistrar:_registrar
                                                callback:^() {
                                                  [frameUpdater displayLinkFired];

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPDisplayLink.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPDisplayLink.h
@@ -39,7 +39,7 @@
 
 #if TARGET_OS_OSX
 // An implementation of FVPDisplayLink using CVDisplayLink.
-@interface FVPCVDisplayLink : NSObject <FVPDisplayLink>
+@interface FVPCoreVideoDisplayLink : NSObject <FVPDisplayLink>
 
 /// Initializes a display link that calls the given callback when fired.
 ///

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPDisplayLink.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPDisplayLink.h
@@ -24,6 +24,7 @@
 @end
 
 // An implementation of FVPDisplayLink using CADisplayLink.
+API_AVAILABLE(ios(4.0), macos(14.0))
 @interface FVPCADisplayLink : NSObject <FVPDisplayLink>
 
 /// Initializes a display link that calls the given callback when fired.

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPDisplayLink.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPDisplayLink.h
@@ -11,7 +11,7 @@
 #endif
 
 // A cross-platform display link abstraction.
-@interface FVPDisplayLink : NSObject
+@protocol FVPDisplayLink <NSObject>
 
 /// Whether the display link is currently running (i.e., firing events).
 ///
@@ -20,6 +20,11 @@
 
 /// The time interval between screen refresh updates.
 @property(nonatomic, readonly) CFTimeInterval duration;
+
+@end
+
+// An implementation of FVPDisplayLink using CADisplayLink.
+@interface FVPCADisplayLink : NSObject <FVPDisplayLink>
 
 /// Initializes a display link that calls the given callback when fired.
 ///
@@ -31,3 +36,19 @@
 - (instancetype)init NS_UNAVAILABLE;
 
 @end
+
+#if TARGET_OS_OSX
+// An implementation of FVPDisplayLink using CVDisplayLink.
+@interface FVPCVDisplayLink : NSObject <FVPDisplayLink>
+
+/// Initializes a display link that calls the given callback when fired.
+///
+/// The display link starts paused, so must be started, by setting 'running' to YES, before the
+/// callback will fire.
+- (instancetype)initWithRegistrar:(id<FlutterPluginRegistrar>)registrar
+                         callback:(void (^)(void))callback NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+#endif

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPFrameUpdater.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPFrameUpdater.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The Flutter texture registry used to notify about new frames.
 @property(nonatomic, weak, readonly) NSObject<FlutterTextureRegistry> *registry;
 /// The display link that drives frameUpdater.
-@property(nonatomic) FVPDisplayLink *displayLink;
+@property(nonatomic) NSObject<FVPDisplayLink> *displayLink;
 /// The time interval between screen refresh updates. Display link duration is in an undefined state
 /// until displayLinkFired is called at least once so it should not be used directly.
 @property(atomic) CFTimeInterval frameDuration;

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPTextureBasedVideoPlayer.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPTextureBasedVideoPlayer.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// display link, HTTP headers, AV factory, and registrar.
 - (instancetype)initWithURL:(NSURL *)url
                frameUpdater:(FVPFrameUpdater *)frameUpdater
-                displayLink:(FVPDisplayLink *)displayLink
+                displayLink:(NSObject<FVPDisplayLink> *)displayLink
                 httpHeaders:(nonnull NSDictionary<NSString *, NSString *> *)headers
                   avFactory:(id<FVPAVFactory>)avFactory
                viewProvider:(NSObject<FVPViewProvider> *)viewProvider
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// display link, AV factory, and registrar.
 - (instancetype)initWithAsset:(NSString *)asset
                  frameUpdater:(FVPFrameUpdater *)frameUpdater
-                  displayLink:(FVPDisplayLink *)displayLink
+                  displayLink:(NSObject<FVPDisplayLink> *)displayLink
                     avFactory:(id<FVPAVFactory>)avFactory
                  viewProvider:(NSObject<FVPViewProvider> *)viewProvider
                    onDisposed:(void (^)(int64_t))onDisposed;

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayerPlugin_Test.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayerPlugin_Test.h
@@ -10,8 +10,8 @@
 
 // Protocol for an AVPlayer instance factory. Used for injecting display links in tests.
 @protocol FVPDisplayLinkFactory
-- (FVPDisplayLink *)displayLinkWithRegistrar:(id<FlutterPluginRegistrar>)registrar
-                                    callback:(void (^)(void))callback;
+- (NSObject<FVPDisplayLink> *)displayLinkWithRegistrar:(id<FlutterPluginRegistrar>)registrar
+                                              callback:(void (^)(void))callback;
 @end
 
 #pragma mark -

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_macos/FVPCVDisplayLink.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_macos/FVPCVDisplayLink.m
@@ -7,7 +7,12 @@
 #import <CoreVideo/CoreVideo.h>
 #import <Foundation/Foundation.h>
 
-@interface FVPDisplayLink ()
+// CVDisplayLink is deprecated; this implementation is only use on macOS < 14.0, so deprecation
+// warnings aren't useful in this file.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+@interface FVPCVDisplayLink ()
 // The underlying display link implementation.
 @property(nonatomic, assign) CVDisplayLinkRef displayLink;
 // A dispatch source to move display link callbacks to the main thread.
@@ -25,7 +30,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
   return kCVReturnSuccess;
 }
 
-@implementation FVPDisplayLink
+@implementation FVPCVDisplayLink
 
 - (instancetype)initWithRegistrar:(id<FlutterPluginRegistrar>)registrar
                          callback:(void (^)(void))callback {
@@ -90,3 +95,5 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 }
 
 @end
+
+#pragma clang diagnostic pop

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_macos/FVPCoreVideoDisplayLink.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_macos/FVPCoreVideoDisplayLink.m
@@ -7,12 +7,12 @@
 #import <CoreVideo/CoreVideo.h>
 #import <Foundation/Foundation.h>
 
-// CVDisplayLink is deprecated; this implementation is only use on macOS < 14.0, so deprecation
+// CVDisplayLink is deprecated; this implementation is only used on macOS < 14.0, so deprecation
 // warnings aren't useful in this file.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
-@interface FVPCVDisplayLink ()
+@interface FVPCoreVideoDisplayLink ()
 // The underlying display link implementation.
 @property(nonatomic, assign) CVDisplayLinkRef displayLink;
 // A dispatch source to move display link callbacks to the main thread.
@@ -30,7 +30,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
   return kCVReturnSuccess;
 }
 
-@implementation FVPCVDisplayLink
+@implementation FVPCoreVideoDisplayLink
 
 - (instancetype)initWithRegistrar:(id<FlutterPluginRegistrar>)registrar
                          callback:(void (^)(void))callback {

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.7.1
+version: 2.7.2
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Marks the CVDisplayLink-based implementation that was previously used on macOS in all cases with deprecation suppressions, and switches macOS 14+ to share the CADisplayLink-based implementation that is currently used for iOS.

Fixes https://github.com/flutter/flutter/issues/171391

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
