### PR TITLE
[tool] Remove Android x86 compilation

### DIFF
--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -400,7 +400,6 @@ this command.
             'android-arm',
             'android-arm64',
             'android-x64',
-            'android-x86'
           ];
           final int exitCode = await project.runCommand(
             'app:connectedAndroidTest',

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -66,7 +66,7 @@ void main() {
       final List<String> devices = <String>[
         if (hasIOSDevice) '{"id": "$_fakeIOSDevice", "targetPlatform": "ios"}',
         if (hasAndroidDevice)
-          '{"id": "$_fakeAndroidDevice", "targetPlatform": "android-x86"}',
+          '{"id": "$_fakeAndroidDevice", "targetPlatform": "android-x64"}',
       ];
       final String output =
           '''${includeBanner ? updateBanner : ''}[${devices.join(',')}]''';

--- a/script/tool/test/native_test_command_test.dart
+++ b/script/tool/test/native_test_command_test.dart
@@ -21,7 +21,7 @@ import 'mocks.dart';
 import 'util.dart';
 
 const String _allAbiFlag =
-    '-Ptarget-platform=android-arm,android-arm64,android-x64,android-x86';
+    '-Ptarget-platform=android-arm,android-arm64,android-x64';
 
 const String _androidIntegrationTestFilter =
     '-Pandroid.testInstrumentationRunnerArguments.'


### PR DESCRIPTION
Remvoe x86 from the ABI set when compiling Android integration tests, as x86 is no longer supported for Flutter builds.

See https://github.com/flutter/flutter/pull/170191