### PR TITLE
[webview_flutter_wkwebview] Replace Flutter method failure assertion with nslog

### DIFF
--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 3.22.1
 
+* Changes the handling of a Flutter method failure from throwing an assertion error to logging the
+  error.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 3.22.0

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import XCTest
+
+@testable import webview_flutter_wkwebview
+
+class ProxyAPIRegistrarTests: XCTestCase {
+  func testLogFlutterMethodFailureDoesNotThrowAnError() {
+    let registrar = TestProxyApiRegistrar()
+    
+    XCTExpectFailure("Method should log a message and not throw an error.") {
+      XCTAssertThrowsError(registrar.logFlutterMethodFailure(PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod"))
+    }
+  }
+}

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
@@ -9,9 +9,11 @@ import XCTest
 class ProxyAPIRegistrarTests: XCTestCase {
   func testLogFlutterMethodFailureDoesNotThrowAnError() {
     let registrar = TestProxyApiRegistrar()
-    
+
     XCTExpectFailure("Method should log a message and not throw an error.") {
-      XCTAssertThrowsError(registrar.logFlutterMethodFailure(PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod"))
+      XCTAssertThrowsError(
+        registrar.logFlutterMethodFailure(
+          PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod"))
     }
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/webview_flutter_wkwebview/Sources/webview_flutter_wkwebview/ProxyAPIRegistrar.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/webview_flutter_wkwebview/Sources/webview_flutter_wkwebview/ProxyAPIRegistrar.swift
@@ -68,11 +68,10 @@ open class ProxyAPIRegistrar: WebKitLibraryPigeonProxyApiRegistrar {
       details: nil)
   }
 
-  // Creates an assertion failure when a Flutter method receives an error from Dart.
-  fileprivate func assertFlutterMethodFailure(_ error: PigeonError, methodName: String) {
-    assertionFailure(
-      "\(String(describing: error)): Error returned from calling \(methodName): \(String(describing: error.message))"
-    )
+  // Log when a Flutter method receives an error from Dart.
+  func logFlutterMethodFailure(_ error: PigeonError, methodName: String) {
+    NSLog("\(String(describing: error)): Error returned from calling \(methodName): \(String(describing: error.message))")
+    NSLog("%@", Thread.callStackSymbols.joined(separator: "\n"))
   }
 
   /// Handles calling a Flutter method on the main thread.
@@ -83,7 +82,7 @@ open class ProxyAPIRegistrar: WebKitLibraryPigeonProxyApiRegistrar {
   ) {
     DispatchQueue.main.async {
       work { methodName, error in
-        self.assertFlutterMethodFailure(error, methodName: methodName)
+        self.logFlutterMethodFailure(error, methodName: methodName)
       }
     }
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/webview_flutter_wkwebview/Sources/webview_flutter_wkwebview/ProxyAPIRegistrar.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/webview_flutter_wkwebview/Sources/webview_flutter_wkwebview/ProxyAPIRegistrar.swift
@@ -70,7 +70,9 @@ open class ProxyAPIRegistrar: WebKitLibraryPigeonProxyApiRegistrar {
 
   // Log when a Flutter method receives an error from Dart.
   func logFlutterMethodFailure(_ error: PigeonError, methodName: String) {
-    NSLog("\(String(describing: error)): Error returned from calling \(methodName): \(String(describing: error.message))")
+    NSLog(
+      "\(String(describing: error)): Error returned from calling \(methodName): \(String(describing: error.message))"
+    )
     NSLog("%@", Thread.callStackSymbols.joined(separator: "\n"))
   }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		8F0EDFD32E1F4967001938E6 /* ProxyAPIRegistrarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0EDFD22E1F4967001938E6 /* ProxyAPIRegistrarTests.swift */; };
 		8F1488E22D2DE27000191744 /* ScriptMessageHandlerProxyAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1488D02D2DE27000191744 /* ScriptMessageHandlerProxyAPITests.swift */; };
 		8F1488E32D2DE27000191744 /* TestProxyApiRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1488D62D2DE27000191744 /* TestProxyApiRegistrar.swift */; };
 		8F1488E42D2DE27000191744 /* URLRequestProxyAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1488DC2D2DE27000191744 /* URLRequestProxyAPITests.swift */; };
@@ -98,6 +99,7 @@
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		8F0EDFD22E1F4967001938E6 /* ProxyAPIRegistrarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ProxyAPIRegistrarTests.swift; path = ../../darwin/Tests/ProxyAPIRegistrarTests.swift; sourceTree = SOURCE_ROOT; };
 		8F1488C52D2DE27000191744 /* ErrorProxyAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ErrorProxyAPITests.swift; path = ../../darwin/Tests/ErrorProxyAPITests.swift; sourceTree = SOURCE_ROOT; };
 		8F1488C62D2DE27000191744 /* FrameInfoProxyAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FrameInfoProxyAPITests.swift; path = ../../darwin/Tests/FrameInfoProxyAPITests.swift; sourceTree = SOURCE_ROOT; };
 		8F1488C72D2DE27000191744 /* FWFWebViewFlutterWKWebViewExternalAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FWFWebViewFlutterWKWebViewExternalAPITests.swift; path = ../../darwin/Tests/FWFWebViewFlutterWKWebViewExternalAPITests.swift; sourceTree = SOURCE_ROOT; };
@@ -178,6 +180,7 @@
 		68BDCAEA23C3F7CB00D9C032 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
+				8F0EDFD22E1F4967001938E6 /* ProxyAPIRegistrarTests.swift */,
 				8FEC64812DA2C6DC00C48569 /* GetTrustResultResponseProxyAPITests.swift */,
 				8FEC64822DA2C6DC00C48569 /* SecCertificateProxyAPITests.swift */,
 				8FEC64832DA2C6DC00C48569 /* SecTrustProxyAPITests.swift */,
@@ -561,6 +564,7 @@
 				8F1488E82D2DE27000191744 /* ScriptMessageProxyAPITests.swift in Sources */,
 				8F1488E92D2DE27000191744 /* UIViewProxyAPITests.swift in Sources */,
 				8F1488EA2D2DE27000191744 /* SecurityOriginProxyAPITests.swift in Sources */,
+				8F0EDFD32E1F4967001938E6 /* ProxyAPIRegistrarTests.swift in Sources */,
 				8F1488EB2D2DE27000191744 /* PreferencesProxyAPITests.swift in Sources */,
 				8F1488EC2D2DE27000191744 /* FrameInfoProxyAPITests.swift in Sources */,
 				8F1488ED2D2DE27000191744 /* ErrorProxyAPITests.swift in Sources */,

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.22.0
+version: 3.22.1
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
The assertion caused a crash with hot restart if a Flutter method call happened at the same time. Changing this to `NSLog` also allows logging failures when in release mode.

Fixes https://github.com/flutter/flutter/issues/170643

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
