### PR TITLE
[go_router_builder] Change mixin name

### DIFF
--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+- Make Route mixins public.
+
 ## 3.3.1
 
 - Fixes warnings in generated code of iterable parameters.

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -41,6 +41,9 @@ dart run build_runner build
 Read more about using
 [`build_runner` on pub.dev](https://pub.dev/packages/build_runner).
 
+## Migration Guides
+- [Migrating to 4.0.0](https://flutter.dev/go/go-router-builder-v4-breaking-changes).
+
 ## Overview
 
 `go_router` fundamentally relies on the ability to match a string-based location

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -86,7 +86,7 @@ method.
 
 <?code-excerpt "example/lib/readme_excerpts.dart (HomeRoute)"?>
 ```dart
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 
   @override
@@ -106,7 +106,7 @@ The tree of routes is defined as an attribute on each of the top-level routes:
     TypedGoRoute<FamilyRoute>(path: 'family/:fid'),
   ],
 )
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 
   @override
@@ -122,7 +122,7 @@ class RedirectRoute extends GoRouteData {
 }
 
 @TypedGoRoute<LoginRoute>(path: '/login')
-class LoginRoute extends GoRouteData with _$LoginRoute {
+class LoginRoute extends GoRouteData with $LoginRoute {
   LoginRoute({this.from});
   final String? from;
 
@@ -210,7 +210,7 @@ Parameters (named or positional) not listed in the path of `TypedGoRoute` indica
 <?code-excerpt "example/lib/readme_excerpts.dart (login)"?>
 ```dart
 @TypedGoRoute<LoginRoute>(path: '/login')
-class LoginRoute extends GoRouteData with _$LoginRoute {
+class LoginRoute extends GoRouteData with $LoginRoute {
   LoginRoute({this.from});
   final String? from;
 
@@ -228,7 +228,7 @@ For query parameters with a **non-nullable** type, you can define a default valu
 <?code-excerpt "example/lib/readme_excerpts.dart (MyRoute)"?>
 ```dart
 @TypedGoRoute<MyRoute>(path: '/my-route')
-class MyRoute extends GoRouteData with _$MyRoute {
+class MyRoute extends GoRouteData with $MyRoute {
   MyRoute({this.queryParameter = 'defaultValue'});
   final String queryParameter;
 
@@ -249,7 +249,7 @@ parameter with the special name `$extra`:
 
 <?code-excerpt "example/lib/readme_excerpts.dart (PersonRouteWithExtra)"?>
 ```dart
-class PersonRouteWithExtra extends GoRouteData with _$PersonRouteWithExtra {
+class PersonRouteWithExtra extends GoRouteData with $PersonRouteWithExtra {
   PersonRouteWithExtra(this.$extra);
   final Person? $extra;
 
@@ -281,7 +281,7 @@ You can, of course, combine the use of path, query and $extra parameters:
 ```dart
 @TypedGoRoute<HotdogRouteWithEverything>(path: '/:ketchup')
 class HotdogRouteWithEverything extends GoRouteData
-    with _$HotdogRouteWithEverything {
+    with $HotdogRouteWithEverything {
   HotdogRouteWithEverything(this.ketchup, this.mustard, this.$extra);
   final bool ketchup; // A required path parameter.
   final String? mustard; // An optional query parameter.
@@ -341,7 +341,7 @@ The code generator can convert simple types like `int`, `enum`, and `extension t
 enum BookKind { all, popular, recent }
 
 @TypedGoRoute<BooksRoute>(path: '/books')
-class BooksRoute extends GoRouteData with _$BooksRoute {
+class BooksRoute extends GoRouteData with $BooksRoute {
   BooksRoute({this.kind = BookKind.popular});
   final BookKind kind;
 
@@ -370,7 +370,7 @@ method of the base class instead of the `build` method:
 
 <?code-excerpt "example/lib/readme_excerpts.dart (MyMaterialRouteWithKey)"?>
 ```dart
-class MyMaterialRouteWithKey extends GoRouteData with _$MyMaterialRouteWithKey {
+class MyMaterialRouteWithKey extends GoRouteData with $MyMaterialRouteWithKey {
   const MyMaterialRouteWithKey();
   static const LocalKey _key = ValueKey<String>('my-route-with-key');
   @override
@@ -386,7 +386,7 @@ Overriding the `buildPage` method is also useful for custom transitions:
 
 <?code-excerpt "example/lib/readme_excerpts.dart (FancyRoute)"?>
 ```dart
-class FancyRoute extends GoRouteData with _$FancyRoute {
+class FancyRoute extends GoRouteData with $FancyRoute {
   const FancyRoute();
   @override
   CustomTransitionPage<void> buildPage(
@@ -442,7 +442,7 @@ class MyShellRouteData extends ShellRouteData {
 }
 
 // For GoRoutes:
-class MyGoRouteData extends GoRouteData with _$MyGoRouteData {
+class MyGoRouteData extends GoRouteData with $MyGoRouteData {
   const MyGoRouteData();
 
   static final GlobalKey<NavigatorState> $parentNavigatorKey = rootNavigatorKey;
@@ -463,7 +463,7 @@ Define a relative route by extending `RelativeGoRouteData`.
 <?code-excerpt "example/lib/readme_excerpts.dart (relativeRoute)"?>
 ```dart
 @TypedRelativeGoRoute<DetailsRoute>(path: 'details')
-class DetailsRoute extends RelativeGoRouteData with _$DetailsRoute {
+class DetailsRoute extends RelativeGoRouteData with $DetailsRoute {
   const DetailsRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/all_extension_types.dart
+++ b/packages/go_router_builder/example/lib/all_extension_types.dart
@@ -40,7 +40,7 @@ part 'all_extension_types.g.dart';
   ],
 )
 @immutable
-class AllTypesBaseRoute extends GoRouteData with _$AllTypesBaseRoute {
+class AllTypesBaseRoute extends GoRouteData with $AllTypesBaseRoute {
   const AllTypesBaseRoute();
 
   @override
@@ -59,7 +59,7 @@ extension type const UriExtension(Uri value) {}
 extension type const PersonDetailsExtension(PersonDetails value) {}
 extension type const SportDetailsExtension(SportDetails value) {}
 
-class BigIntExtensionRoute extends GoRouteData with _$BigIntExtensionRoute {
+class BigIntExtensionRoute extends GoRouteData with $BigIntExtensionRoute {
   const BigIntExtensionRoute({
     required this.requiredBigIntField,
     this.bigIntField,
@@ -82,7 +82,7 @@ class BigIntExtensionRoute extends GoRouteData with _$BigIntExtensionRoute {
   );
 }
 
-class BoolExtensionRoute extends GoRouteData with _$BoolExtensionRoute {
+class BoolExtensionRoute extends GoRouteData with $BoolExtensionRoute {
   const BoolExtensionRoute({
     required this.requiredBoolField,
     this.boolField,
@@ -108,7 +108,7 @@ class BoolExtensionRoute extends GoRouteData with _$BoolExtensionRoute {
   );
 }
 
-class DateTimeExtensionRoute extends GoRouteData with _$DateTimeExtensionRoute {
+class DateTimeExtensionRoute extends GoRouteData with $DateTimeExtensionRoute {
   const DateTimeExtensionRoute({
     required this.requiredDateTimeField,
     this.dateTimeField,
@@ -131,7 +131,7 @@ class DateTimeExtensionRoute extends GoRouteData with _$DateTimeExtensionRoute {
   );
 }
 
-class DoubleExtensionRoute extends GoRouteData with _$DoubleExtensionRoute {
+class DoubleExtensionRoute extends GoRouteData with $DoubleExtensionRoute {
   const DoubleExtensionRoute({
     required this.requiredDoubleField,
     this.doubleField,
@@ -157,7 +157,7 @@ class DoubleExtensionRoute extends GoRouteData with _$DoubleExtensionRoute {
   );
 }
 
-class IntExtensionRoute extends GoRouteData with _$IntExtensionRoute {
+class IntExtensionRoute extends GoRouteData with $IntExtensionRoute {
   const IntExtensionRoute({
     required this.requiredIntField,
     this.intField,
@@ -183,7 +183,7 @@ class IntExtensionRoute extends GoRouteData with _$IntExtensionRoute {
   );
 }
 
-class NumExtensionRoute extends GoRouteData with _$NumExtensionRoute {
+class NumExtensionRoute extends GoRouteData with $NumExtensionRoute {
   const NumExtensionRoute({
     required this.requiredNumField,
     this.numField,
@@ -209,7 +209,7 @@ class NumExtensionRoute extends GoRouteData with _$NumExtensionRoute {
   );
 }
 
-class EnumExtensionRoute extends GoRouteData with _$EnumExtensionRoute {
+class EnumExtensionRoute extends GoRouteData with $EnumExtensionRoute {
   const EnumExtensionRoute({
     required this.requiredEnumField,
     this.enumField,
@@ -239,7 +239,7 @@ class EnumExtensionRoute extends GoRouteData with _$EnumExtensionRoute {
 }
 
 class EnhancedEnumExtensionRoute extends GoRouteData
-    with _$EnhancedEnumExtensionRoute {
+    with $EnhancedEnumExtensionRoute {
   const EnhancedEnumExtensionRoute({
     required this.requiredEnumField,
     this.enumField,
@@ -268,7 +268,7 @@ class EnhancedEnumExtensionRoute extends GoRouteData
   );
 }
 
-class StringExtensionRoute extends GoRouteData with _$StringExtensionRoute {
+class StringExtensionRoute extends GoRouteData with $StringExtensionRoute {
   const StringExtensionRoute({
     required this.requiredStringField,
     this.stringField,
@@ -294,7 +294,7 @@ class StringExtensionRoute extends GoRouteData with _$StringExtensionRoute {
   );
 }
 
-class UriExtensionRoute extends GoRouteData with _$UriExtensionRoute {
+class UriExtensionRoute extends GoRouteData with $UriExtensionRoute {
   const UriExtensionRoute({required this.requiredUriField, this.uriField});
 
   final UriExtension requiredUriField;

--- a/packages/go_router_builder/example/lib/all_extension_types.g.dart
+++ b/packages/go_router_builder/example/lib/all_extension_types.g.dart
@@ -12,56 +12,56 @@ List<RouteBase> get $appRoutes => [$allTypesBaseRoute];
 
 RouteBase get $allTypesBaseRoute => GoRouteData.$route(
   path: '/',
-  factory: _$AllTypesBaseRoute._fromState,
+  factory: $AllTypesBaseRoute._fromState,
   routes: [
     GoRouteData.$route(
       path: 'big-int-route/:requiredBigIntField',
-      factory: _$BigIntExtensionRoute._fromState,
+      factory: $BigIntExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'bool-route/:requiredBoolField',
-      factory: _$BoolExtensionRoute._fromState,
+      factory: $BoolExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'date-time-route/:requiredDateTimeField',
-      factory: _$DateTimeExtensionRoute._fromState,
+      factory: $DateTimeExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'double-route/:requiredDoubleField',
-      factory: _$DoubleExtensionRoute._fromState,
+      factory: $DoubleExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'int-route/:requiredIntField',
-      factory: _$IntExtensionRoute._fromState,
+      factory: $IntExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'num-route/:requiredNumField',
-      factory: _$NumExtensionRoute._fromState,
+      factory: $NumExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'double-route/:requiredDoubleField',
-      factory: _$DoubleExtensionRoute._fromState,
+      factory: $DoubleExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'enum-route/:requiredEnumField',
-      factory: _$EnumExtensionRoute._fromState,
+      factory: $EnumExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'enhanced-enum-route/:requiredEnumField',
-      factory: _$EnhancedEnumExtensionRoute._fromState,
+      factory: $EnhancedEnumExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'string-route/:requiredStringField',
-      factory: _$StringExtensionRoute._fromState,
+      factory: $StringExtensionRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'uri-route/:requiredUriField',
-      factory: _$UriExtensionRoute._fromState,
+      factory: $UriExtensionRoute._fromState,
     ),
   ],
 );
 
-mixin _$AllTypesBaseRoute on GoRouteData {
+mixin $AllTypesBaseRoute on GoRouteData {
   static AllTypesBaseRoute _fromState(GoRouterState state) =>
       const AllTypesBaseRoute();
 
@@ -82,7 +82,7 @@ mixin _$AllTypesBaseRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$BigIntExtensionRoute on GoRouteData {
+mixin $BigIntExtensionRoute on GoRouteData {
   static BigIntExtensionRoute _fromState(GoRouterState state) =>
       BigIntExtensionRoute(
         requiredBigIntField:
@@ -118,7 +118,7 @@ mixin _$BigIntExtensionRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$BoolExtensionRoute on GoRouteData {
+mixin $BoolExtensionRoute on GoRouteData {
   static BoolExtensionRoute _fromState(
     GoRouterState state,
   ) => BoolExtensionRoute(
@@ -162,7 +162,7 @@ mixin _$BoolExtensionRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$DateTimeExtensionRoute on GoRouteData {
+mixin $DateTimeExtensionRoute on GoRouteData {
   static DateTimeExtensionRoute _fromState(GoRouterState state) =>
       DateTimeExtensionRoute(
         requiredDateTimeField:
@@ -200,7 +200,7 @@ mixin _$DateTimeExtensionRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$DoubleExtensionRoute on GoRouteData {
+mixin $DoubleExtensionRoute on GoRouteData {
   static DoubleExtensionRoute _fromState(GoRouterState state) =>
       DoubleExtensionRoute(
         requiredDoubleField:
@@ -248,7 +248,7 @@ mixin _$DoubleExtensionRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$IntExtensionRoute on GoRouteData {
+mixin $IntExtensionRoute on GoRouteData {
   static IntExtensionRoute _fromState(GoRouterState state) => IntExtensionRoute(
     requiredIntField:
         int.parse(state.pathParameters['requiredIntField']!) as IntExtension,
@@ -290,7 +290,7 @@ mixin _$IntExtensionRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$NumExtensionRoute on GoRouteData {
+mixin $NumExtensionRoute on GoRouteData {
   static NumExtensionRoute _fromState(GoRouterState state) => NumExtensionRoute(
     requiredNumField:
         num.parse(state.pathParameters['requiredNumField']!) as NumExtension,
@@ -332,7 +332,7 @@ mixin _$NumExtensionRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$EnumExtensionRoute on GoRouteData {
+mixin $EnumExtensionRoute on GoRouteData {
   static EnumExtensionRoute _fromState(GoRouterState state) =>
       EnumExtensionRoute(
         requiredEnumField:
@@ -390,7 +390,7 @@ const _$PersonDetailsEnumMap = {
   PersonDetails.favoriteSport: 'favorite-sport',
 };
 
-mixin _$EnhancedEnumExtensionRoute on GoRouteData {
+mixin $EnhancedEnumExtensionRoute on GoRouteData {
   static EnhancedEnumExtensionRoute _fromState(GoRouterState state) =>
       EnhancedEnumExtensionRoute(
         requiredEnumField:
@@ -448,7 +448,7 @@ const _$SportDetailsEnumMap = {
   SportDetails.hockey: 'hockey',
 };
 
-mixin _$StringExtensionRoute on GoRouteData {
+mixin $StringExtensionRoute on GoRouteData {
   static StringExtensionRoute _fromState(GoRouterState state) =>
       StringExtensionRoute(
         requiredStringField:
@@ -490,7 +490,7 @@ mixin _$StringExtensionRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$UriExtensionRoute on GoRouteData {
+mixin $UriExtensionRoute on GoRouteData {
   static UriExtensionRoute _fromState(GoRouterState state) => UriExtensionRoute(
     requiredUriField:
         Uri.parse(state.pathParameters['requiredUriField']!) as UriExtension,

--- a/packages/go_router_builder/example/lib/all_types.dart
+++ b/packages/go_router_builder/example/lib/all_types.dart
@@ -34,7 +34,7 @@ part 'all_types.g.dart';
   ],
 )
 @immutable
-class AllTypesBaseRoute extends GoRouteData with _$AllTypesBaseRoute {
+class AllTypesBaseRoute extends GoRouteData with $AllTypesBaseRoute {
   const AllTypesBaseRoute();
 
   @override
@@ -42,7 +42,7 @@ class AllTypesBaseRoute extends GoRouteData with _$AllTypesBaseRoute {
       const BasePage<void>(dataTitle: 'Root');
 }
 
-class BigIntRoute extends GoRouteData with _$BigIntRoute {
+class BigIntRoute extends GoRouteData with $BigIntRoute {
   BigIntRoute({required this.requiredBigIntField, this.bigIntField});
 
   final BigInt requiredBigIntField;
@@ -62,7 +62,7 @@ class BigIntRoute extends GoRouteData with _$BigIntRoute {
   );
 }
 
-class BoolRoute extends GoRouteData with _$BoolRoute {
+class BoolRoute extends GoRouteData with $BoolRoute {
   BoolRoute({
     required this.requiredBoolField,
     this.boolField,
@@ -88,7 +88,7 @@ class BoolRoute extends GoRouteData with _$BoolRoute {
   );
 }
 
-class DateTimeRoute extends GoRouteData with _$DateTimeRoute {
+class DateTimeRoute extends GoRouteData with $DateTimeRoute {
   DateTimeRoute({required this.requiredDateTimeField, this.dateTimeField});
 
   final DateTime requiredDateTimeField;
@@ -108,7 +108,7 @@ class DateTimeRoute extends GoRouteData with _$DateTimeRoute {
   );
 }
 
-class DoubleRoute extends GoRouteData with _$DoubleRoute {
+class DoubleRoute extends GoRouteData with $DoubleRoute {
   DoubleRoute({
     required this.requiredDoubleField,
     this.doubleField,
@@ -134,7 +134,7 @@ class DoubleRoute extends GoRouteData with _$DoubleRoute {
   );
 }
 
-class IntRoute extends GoRouteData with _$IntRoute {
+class IntRoute extends GoRouteData with $IntRoute {
   IntRoute({
     required this.requiredIntField,
     this.intField,
@@ -160,7 +160,7 @@ class IntRoute extends GoRouteData with _$IntRoute {
   );
 }
 
-class NumRoute extends GoRouteData with _$NumRoute {
+class NumRoute extends GoRouteData with $NumRoute {
   NumRoute({
     required this.requiredNumField,
     this.numField,
@@ -186,7 +186,7 @@ class NumRoute extends GoRouteData with _$NumRoute {
   );
 }
 
-class EnumRoute extends GoRouteData with _$EnumRoute {
+class EnumRoute extends GoRouteData with $EnumRoute {
   EnumRoute({
     required this.requiredEnumField,
     this.enumField,
@@ -213,7 +213,7 @@ class EnumRoute extends GoRouteData with _$EnumRoute {
   );
 }
 
-class EnhancedEnumRoute extends GoRouteData with _$EnhancedEnumRoute {
+class EnhancedEnumRoute extends GoRouteData with $EnhancedEnumRoute {
   EnhancedEnumRoute({
     required this.requiredEnumField,
     this.enumField,
@@ -240,7 +240,7 @@ class EnhancedEnumRoute extends GoRouteData with _$EnhancedEnumRoute {
   );
 }
 
-class StringRoute extends GoRouteData with _$StringRoute {
+class StringRoute extends GoRouteData with $StringRoute {
   StringRoute({
     required this.requiredStringField,
     this.stringField,
@@ -266,7 +266,7 @@ class StringRoute extends GoRouteData with _$StringRoute {
   );
 }
 
-class UriRoute extends GoRouteData with _$UriRoute {
+class UriRoute extends GoRouteData with $UriRoute {
   UriRoute({required this.requiredUriField, this.uriField});
 
   final Uri requiredUriField;
@@ -286,7 +286,7 @@ class UriRoute extends GoRouteData with _$UriRoute {
   );
 }
 
-class IterableRoute extends GoRouteData with _$IterableRoute {
+class IterableRoute extends GoRouteData with $IterableRoute {
   IterableRoute({
     this.intIterableField,
     this.doubleIterableField,
@@ -360,7 +360,7 @@ class IterableRoute extends GoRouteData with _$IterableRoute {
 }
 
 class IterableRouteWithDefaultValues extends GoRouteData
-    with _$IterableRouteWithDefaultValues {
+    with $IterableRouteWithDefaultValues {
   const IterableRouteWithDefaultValues({
     this.intIterableField = const <int>[0],
     this.doubleIterableField = const <double>[0, 1, 2],

--- a/packages/go_router_builder/example/lib/all_types.g.dart
+++ b/packages/go_router_builder/example/lib/all_types.g.dart
@@ -12,64 +12,64 @@ List<RouteBase> get $appRoutes => [$allTypesBaseRoute];
 
 RouteBase get $allTypesBaseRoute => GoRouteData.$route(
   path: '/',
-  factory: _$AllTypesBaseRoute._fromState,
+  factory: $AllTypesBaseRoute._fromState,
   routes: [
     GoRouteData.$route(
       path: 'big-int-route/:requiredBigIntField',
-      factory: _$BigIntRoute._fromState,
+      factory: $BigIntRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'bool-route/:requiredBoolField',
-      factory: _$BoolRoute._fromState,
+      factory: $BoolRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'date-time-route/:requiredDateTimeField',
-      factory: _$DateTimeRoute._fromState,
+      factory: $DateTimeRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'double-route/:requiredDoubleField',
-      factory: _$DoubleRoute._fromState,
+      factory: $DoubleRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'int-route/:requiredIntField',
-      factory: _$IntRoute._fromState,
+      factory: $IntRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'num-route/:requiredNumField',
-      factory: _$NumRoute._fromState,
+      factory: $NumRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'double-route/:requiredDoubleField',
-      factory: _$DoubleRoute._fromState,
+      factory: $DoubleRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'enum-route/:requiredEnumField',
-      factory: _$EnumRoute._fromState,
+      factory: $EnumRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'enhanced-enum-route/:requiredEnumField',
-      factory: _$EnhancedEnumRoute._fromState,
+      factory: $EnhancedEnumRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'string-route/:requiredStringField',
-      factory: _$StringRoute._fromState,
+      factory: $StringRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'uri-route/:requiredUriField',
-      factory: _$UriRoute._fromState,
+      factory: $UriRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'iterable-route',
-      factory: _$IterableRoute._fromState,
+      factory: $IterableRoute._fromState,
     ),
     GoRouteData.$route(
       path: 'iterable-route-with-default-values',
-      factory: _$IterableRouteWithDefaultValues._fromState,
+      factory: $IterableRouteWithDefaultValues._fromState,
     ),
   ],
 );
 
-mixin _$AllTypesBaseRoute on GoRouteData {
+mixin $AllTypesBaseRoute on GoRouteData {
   static AllTypesBaseRoute _fromState(GoRouterState state) =>
       const AllTypesBaseRoute();
 
@@ -90,7 +90,7 @@ mixin _$AllTypesBaseRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$BigIntRoute on GoRouteData {
+mixin $BigIntRoute on GoRouteData {
   static BigIntRoute _fromState(GoRouterState state) => BigIntRoute(
     requiredBigIntField: BigInt.parse(
       state.pathParameters['requiredBigIntField']!,
@@ -127,7 +127,7 @@ mixin _$BigIntRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$BoolRoute on GoRouteData {
+mixin $BoolRoute on GoRouteData {
   static BoolRoute _fromState(GoRouterState state) => BoolRoute(
     requiredBoolField: _$boolConverter(
       state.pathParameters['requiredBoolField']!,
@@ -173,7 +173,7 @@ mixin _$BoolRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$DateTimeRoute on GoRouteData {
+mixin $DateTimeRoute on GoRouteData {
   static DateTimeRoute _fromState(GoRouterState state) => DateTimeRoute(
     requiredDateTimeField: DateTime.parse(
       state.pathParameters['requiredDateTimeField']!,
@@ -210,7 +210,7 @@ mixin _$DateTimeRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$DoubleRoute on GoRouteData {
+mixin $DoubleRoute on GoRouteData {
   static DoubleRoute _fromState(GoRouterState state) => DoubleRoute(
     requiredDoubleField: double.parse(
       state.pathParameters['requiredDoubleField']!,
@@ -257,7 +257,7 @@ mixin _$DoubleRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$IntRoute on GoRouteData {
+mixin $IntRoute on GoRouteData {
   static IntRoute _fromState(GoRouterState state) => IntRoute(
     requiredIntField: int.parse(state.pathParameters['requiredIntField']!),
     intField: _$convertMapValue(
@@ -301,7 +301,7 @@ mixin _$IntRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$NumRoute on GoRouteData {
+mixin $NumRoute on GoRouteData {
   static NumRoute _fromState(GoRouterState state) => NumRoute(
     requiredNumField: num.parse(state.pathParameters['requiredNumField']!),
     numField: _$convertMapValue(
@@ -345,7 +345,7 @@ mixin _$NumRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$EnumRoute on GoRouteData {
+mixin $EnumRoute on GoRouteData {
   static EnumRoute _fromState(GoRouterState state) => EnumRoute(
     requiredEnumField:
         _$PersonDetailsEnumMap._$fromName(
@@ -399,7 +399,7 @@ const _$PersonDetailsEnumMap = {
   PersonDetails.favoriteSport: 'favorite-sport',
 };
 
-mixin _$EnhancedEnumRoute on GoRouteData {
+mixin $EnhancedEnumRoute on GoRouteData {
   static EnhancedEnumRoute _fromState(GoRouterState state) => EnhancedEnumRoute(
     requiredEnumField:
         _$SportDetailsEnumMap._$fromName(
@@ -454,7 +454,7 @@ const _$SportDetailsEnumMap = {
   SportDetails.hockey: 'hockey',
 };
 
-mixin _$StringRoute on GoRouteData {
+mixin $StringRoute on GoRouteData {
   static StringRoute _fromState(GoRouterState state) => StringRoute(
     requiredStringField: state.pathParameters['requiredStringField']!,
     stringField: state.uri.queryParameters['string-field'],
@@ -489,7 +489,7 @@ mixin _$StringRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$UriRoute on GoRouteData {
+mixin $UriRoute on GoRouteData {
   static UriRoute _fromState(GoRouterState state) => UriRoute(
     requiredUriField: Uri.parse(state.pathParameters['requiredUriField']!),
     uriField: _$convertMapValue(
@@ -523,7 +523,7 @@ mixin _$UriRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$IterableRoute on GoRouteData {
+mixin $IterableRoute on GoRouteData {
   static IterableRoute _fromState(GoRouterState state) => IterableRoute(
     intIterableField:
         state.uri.queryParametersAll['int-iterable-field']
@@ -691,7 +691,7 @@ const _$CookingRecipeEnumMap = {
   CookingRecipe.tacos: 'tacos',
 };
 
-mixin _$IterableRouteWithDefaultValues on GoRouteData {
+mixin $IterableRouteWithDefaultValues on GoRouteData {
   static IterableRouteWithDefaultValues _fromState(GoRouterState state) =>
       IterableRouteWithDefaultValues(
         intIterableField:

--- a/packages/go_router_builder/example/lib/case_sensitive_example.dart
+++ b/packages/go_router_builder/example/lib/case_sensitive_example.dart
@@ -25,7 +25,7 @@ class CaseSensitivityApp extends StatelessWidget {
 }
 
 @TypedGoRoute<CaseSensitiveRoute>(path: '/case-sensitive')
-class CaseSensitiveRoute extends GoRouteData with _$CaseSensitiveRoute {
+class CaseSensitiveRoute extends GoRouteData with $CaseSensitiveRoute {
   const CaseSensitiveRoute();
 
   @override
@@ -37,7 +37,7 @@ class CaseSensitiveRoute extends GoRouteData with _$CaseSensitiveRoute {
   path: '/not-case-sensitive',
   caseSensitive: false,
 )
-class NotCaseSensitiveRoute extends GoRouteData with _$NotCaseSensitiveRoute {
+class NotCaseSensitiveRoute extends GoRouteData with $NotCaseSensitiveRoute {
   const NotCaseSensitiveRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/case_sensitive_example.g.dart
+++ b/packages/go_router_builder/example/lib/case_sensitive_example.g.dart
@@ -12,10 +12,10 @@ List<RouteBase> get $appRoutes => [$caseSensitiveRoute, $notCaseSensitiveRoute];
 
 RouteBase get $caseSensitiveRoute => GoRouteData.$route(
   path: '/case-sensitive',
-  factory: _$CaseSensitiveRoute._fromState,
+  factory: $CaseSensitiveRoute._fromState,
 );
 
-mixin _$CaseSensitiveRoute on GoRouteData {
+mixin $CaseSensitiveRoute on GoRouteData {
   static CaseSensitiveRoute _fromState(GoRouterState state) =>
       const CaseSensitiveRoute();
 
@@ -39,10 +39,10 @@ mixin _$CaseSensitiveRoute on GoRouteData {
 RouteBase get $notCaseSensitiveRoute => GoRouteData.$route(
   path: '/not-case-sensitive',
   caseSensitive: false,
-  factory: _$NotCaseSensitiveRoute._fromState,
+  factory: $NotCaseSensitiveRoute._fromState,
 );
 
-mixin _$NotCaseSensitiveRoute on GoRouteData {
+mixin $NotCaseSensitiveRoute on GoRouteData {
   static NotCaseSensitiveRoute _fromState(GoRouterState state) =>
       const NotCaseSensitiveRoute();
 

--- a/packages/go_router_builder/example/lib/extra_example.dart
+++ b/packages/go_router_builder/example/lib/extra_example.dart
@@ -32,7 +32,7 @@ class Extra {
 }
 
 @TypedGoRoute<RequiredExtraRoute>(path: '/requiredExtra')
-class RequiredExtraRoute extends GoRouteData with _$RequiredExtraRoute {
+class RequiredExtraRoute extends GoRouteData with $RequiredExtraRoute {
   const RequiredExtraRoute({required this.$extra});
 
   final Extra $extra;
@@ -57,7 +57,7 @@ class RequiredExtraScreen extends StatelessWidget {
 }
 
 @TypedGoRoute<OptionalExtraRoute>(path: '/optionalExtra')
-class OptionalExtraRoute extends GoRouteData with _$OptionalExtraRoute {
+class OptionalExtraRoute extends GoRouteData with $OptionalExtraRoute {
   const OptionalExtraRoute({this.$extra});
 
   final Extra? $extra;
@@ -82,7 +82,7 @@ class OptionalExtraScreen extends StatelessWidget {
 }
 
 @TypedGoRoute<SplashRoute>(path: '/splash')
-class SplashRoute extends GoRouteData with _$SplashRoute {
+class SplashRoute extends GoRouteData with $SplashRoute {
   const SplashRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/extra_example.g.dart
+++ b/packages/go_router_builder/example/lib/extra_example.g.dart
@@ -16,10 +16,10 @@ List<RouteBase> get $appRoutes => [
 
 RouteBase get $requiredExtraRoute => GoRouteData.$route(
   path: '/requiredExtra',
-  factory: _$RequiredExtraRoute._fromState,
+  factory: $RequiredExtraRoute._fromState,
 );
 
-mixin _$RequiredExtraRoute on GoRouteData {
+mixin $RequiredExtraRoute on GoRouteData {
   static RequiredExtraRoute _fromState(GoRouterState state) =>
       RequiredExtraRoute($extra: state.extra as Extra);
 
@@ -46,10 +46,10 @@ mixin _$RequiredExtraRoute on GoRouteData {
 
 RouteBase get $optionalExtraRoute => GoRouteData.$route(
   path: '/optionalExtra',
-  factory: _$OptionalExtraRoute._fromState,
+  factory: $OptionalExtraRoute._fromState,
 );
 
-mixin _$OptionalExtraRoute on GoRouteData {
+mixin $OptionalExtraRoute on GoRouteData {
   static OptionalExtraRoute _fromState(GoRouterState state) =>
       OptionalExtraRoute($extra: state.extra as Extra?);
 
@@ -75,9 +75,9 @@ mixin _$OptionalExtraRoute on GoRouteData {
 }
 
 RouteBase get $splashRoute =>
-    GoRouteData.$route(path: '/splash', factory: _$SplashRoute._fromState);
+    GoRouteData.$route(path: '/splash', factory: $SplashRoute._fromState);
 
-mixin _$SplashRoute on GoRouteData {
+mixin $SplashRoute on GoRouteData {
   static SplashRoute _fromState(GoRouterState state) => const SplashRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/go_relative.dart
+++ b/packages/go_router_builder/example/lib/go_relative.dart
@@ -42,21 +42,21 @@ const TypedRelativeGoRoute<DetailsRoute> detailRoute =
     detailRoute,
   ],
 )
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const HomeScreen();
   }
 }
 
-class DashboardRoute extends GoRouteData with _$DashboardRoute {
+class DashboardRoute extends GoRouteData with $DashboardRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const DashboardScreen();
   }
 }
 
-class DetailsRoute extends RelativeGoRouteData with _$DetailsRoute {
+class DetailsRoute extends RelativeGoRouteData with $DetailsRoute {
   const DetailsRoute({required this.detailId});
   final String detailId;
 
@@ -66,7 +66,7 @@ class DetailsRoute extends RelativeGoRouteData with _$DetailsRoute {
   }
 }
 
-class SettingsRoute extends RelativeGoRouteData with _$SettingsRoute {
+class SettingsRoute extends RelativeGoRouteData with $SettingsRoute {
   const SettingsRoute({required this.settingId});
   final String settingId;
 

--- a/packages/go_router_builder/example/lib/go_relative.g.dart
+++ b/packages/go_router_builder/example/lib/go_relative.g.dart
@@ -12,21 +12,21 @@ List<RouteBase> get $appRoutes => [$homeRoute];
 
 RouteBase get $homeRoute => GoRouteData.$route(
   path: '/',
-  factory: _$HomeRoute._fromState,
+  factory: $HomeRoute._fromState,
   routes: [
     GoRouteData.$route(
       path: '/dashboard',
-      factory: _$DashboardRoute._fromState,
+      factory: $DashboardRoute._fromState,
       routes: [
         RelativeGoRouteData.$route(
           path: 'details/:detailId',
 
-          factory: _$DetailsRoute._fromState,
+          factory: $DetailsRoute._fromState,
           routes: [
             RelativeGoRouteData.$route(
               path: 'settings/:settingId',
 
-              factory: _$SettingsRoute._fromState,
+              factory: $SettingsRoute._fromState,
             ),
           ],
         ),
@@ -35,19 +35,19 @@ RouteBase get $homeRoute => GoRouteData.$route(
     RelativeGoRouteData.$route(
       path: 'details/:detailId',
 
-      factory: _$DetailsRoute._fromState,
+      factory: $DetailsRoute._fromState,
       routes: [
         RelativeGoRouteData.$route(
           path: 'settings/:settingId',
 
-          factory: _$SettingsRoute._fromState,
+          factory: $SettingsRoute._fromState,
         ),
       ],
     ),
   ],
 );
 
-mixin _$HomeRoute on GoRouteData {
+mixin $HomeRoute on GoRouteData {
   static HomeRoute _fromState(GoRouterState state) => HomeRoute();
 
   @override
@@ -67,7 +67,7 @@ mixin _$HomeRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$DashboardRoute on GoRouteData {
+mixin $DashboardRoute on GoRouteData {
   static DashboardRoute _fromState(GoRouterState state) => DashboardRoute();
 
   @override
@@ -87,7 +87,7 @@ mixin _$DashboardRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$DetailsRoute on RelativeGoRouteData {
+mixin $DetailsRoute on RelativeGoRouteData {
   static DetailsRoute _fromState(GoRouterState state) =>
       DetailsRoute(detailId: state.pathParameters['detailId']!);
 
@@ -117,7 +117,7 @@ mixin _$DetailsRoute on RelativeGoRouteData {
       context.replace(relativeLocation);
 }
 
-mixin _$SettingsRoute on RelativeGoRouteData {
+mixin $SettingsRoute on RelativeGoRouteData {
   static SettingsRoute _fromState(GoRouterState state) =>
       SettingsRoute(settingId: state.pathParameters['settingId']!);
 

--- a/packages/go_router_builder/example/lib/main.dart
+++ b/packages/go_router_builder/example/lib/main.dart
@@ -80,7 +80,7 @@ class App extends StatelessWidget {
     TypedGoRoute<FamilyCountRoute>(path: 'family-count/:count'),
   ],
 )
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 
   @override
@@ -88,7 +88,7 @@ class HomeRoute extends GoRouteData with _$HomeRoute {
 }
 
 @TypedGoRoute<LoginRoute>(path: '/login')
-class LoginRoute extends GoRouteData with _$LoginRoute {
+class LoginRoute extends GoRouteData with $LoginRoute {
   const LoginRoute({this.fromPage});
 
   final String? fromPage;
@@ -98,7 +98,7 @@ class LoginRoute extends GoRouteData with _$LoginRoute {
       LoginScreen(from: fromPage);
 }
 
-class FamilyRoute extends GoRouteData with _$FamilyRoute {
+class FamilyRoute extends GoRouteData with $FamilyRoute {
   const FamilyRoute(this.fid);
 
   final String fid;
@@ -108,7 +108,7 @@ class FamilyRoute extends GoRouteData with _$FamilyRoute {
       FamilyScreen(family: familyById(fid));
 }
 
-class PersonRoute extends GoRouteData with _$PersonRoute {
+class PersonRoute extends GoRouteData with $PersonRoute {
   const PersonRoute(this.fid, this.pid);
 
   final String fid;
@@ -122,7 +122,7 @@ class PersonRoute extends GoRouteData with _$PersonRoute {
   }
 }
 
-class PersonDetailsRoute extends GoRouteData with _$PersonDetailsRoute {
+class PersonDetailsRoute extends GoRouteData with $PersonDetailsRoute {
   const PersonDetailsRoute(this.fid, this.pid, this.details, {this.$extra});
 
   final String fid;
@@ -148,7 +148,7 @@ class PersonDetailsRoute extends GoRouteData with _$PersonDetailsRoute {
   }
 }
 
-class FamilyCountRoute extends GoRouteData with _$FamilyCountRoute {
+class FamilyCountRoute extends GoRouteData with $FamilyCountRoute {
   const FamilyCountRoute(this.count);
 
   final int count;

--- a/packages/go_router_builder/example/lib/main.g.dart
+++ b/packages/go_router_builder/example/lib/main.g.dart
@@ -12,19 +12,19 @@ List<RouteBase> get $appRoutes => [$homeRoute, $loginRoute];
 
 RouteBase get $homeRoute => GoRouteData.$route(
   path: '/',
-  factory: _$HomeRoute._fromState,
+  factory: $HomeRoute._fromState,
   routes: [
     GoRouteData.$route(
       path: 'family/:fid',
-      factory: _$FamilyRoute._fromState,
+      factory: $FamilyRoute._fromState,
       routes: [
         GoRouteData.$route(
           path: 'person/:pid',
-          factory: _$PersonRoute._fromState,
+          factory: $PersonRoute._fromState,
           routes: [
             GoRouteData.$route(
               path: 'details/:details',
-              factory: _$PersonDetailsRoute._fromState,
+              factory: $PersonDetailsRoute._fromState,
             ),
           ],
         ),
@@ -32,12 +32,12 @@ RouteBase get $homeRoute => GoRouteData.$route(
     ),
     GoRouteData.$route(
       path: 'family-count/:count',
-      factory: _$FamilyCountRoute._fromState,
+      factory: $FamilyCountRoute._fromState,
     ),
   ],
 );
 
-mixin _$HomeRoute on GoRouteData {
+mixin $HomeRoute on GoRouteData {
   static HomeRoute _fromState(GoRouterState state) => const HomeRoute();
 
   @override
@@ -57,7 +57,7 @@ mixin _$HomeRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$FamilyRoute on GoRouteData {
+mixin $FamilyRoute on GoRouteData {
   static FamilyRoute _fromState(GoRouterState state) =>
       FamilyRoute(state.pathParameters['fid']!);
 
@@ -81,7 +81,7 @@ mixin _$FamilyRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$PersonRoute on GoRouteData {
+mixin $PersonRoute on GoRouteData {
   static PersonRoute _fromState(GoRouterState state) => PersonRoute(
     state.pathParameters['fid']!,
     int.parse(state.pathParameters['pid']!),
@@ -108,7 +108,7 @@ mixin _$PersonRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$PersonDetailsRoute on GoRouteData {
+mixin $PersonDetailsRoute on GoRouteData {
   static PersonDetailsRoute _fromState(GoRouterState state) =>
       PersonDetailsRoute(
         state.pathParameters['fid']!,
@@ -146,7 +146,7 @@ const _$PersonDetailsEnumMap = {
   PersonDetails.favoriteSport: 'favorite-sport',
 };
 
-mixin _$FamilyCountRoute on GoRouteData {
+mixin $FamilyCountRoute on GoRouteData {
   static FamilyCountRoute _fromState(GoRouterState state) =>
       FamilyCountRoute(int.parse(state.pathParameters['count']!));
 
@@ -177,9 +177,9 @@ extension<T extends Enum> on Map<T, String> {
 }
 
 RouteBase get $loginRoute =>
-    GoRouteData.$route(path: '/login', factory: _$LoginRoute._fromState);
+    GoRouteData.$route(path: '/login', factory: $LoginRoute._fromState);
 
-mixin _$LoginRoute on GoRouteData {
+mixin $LoginRoute on GoRouteData {
   static LoginRoute _fromState(GoRouterState state) =>
       LoginRoute(fromPage: state.uri.queryParameters['from-page']);
 

--- a/packages/go_router_builder/example/lib/on_exit_example.dart
+++ b/packages/go_router_builder/example/lib/on_exit_example.dart
@@ -27,14 +27,14 @@ class App extends StatelessWidget {
     TypedGoRoute<SubRoute>(path: 'sub-route'),
   ],
 )
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 
   @override
   Widget build(BuildContext context, GoRouterState state) => const HomeScreen();
 }
 
-class SubRoute extends GoRouteData with _$SubRoute {
+class SubRoute extends GoRouteData with $SubRoute {
   const SubRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/on_exit_example.g.dart
+++ b/packages/go_router_builder/example/lib/on_exit_example.g.dart
@@ -12,13 +12,13 @@ List<RouteBase> get $appRoutes => [$homeRoute];
 
 RouteBase get $homeRoute => GoRouteData.$route(
   path: '/',
-  factory: _$HomeRoute._fromState,
+  factory: $HomeRoute._fromState,
   routes: [
-    GoRouteData.$route(path: 'sub-route', factory: _$SubRoute._fromState),
+    GoRouteData.$route(path: 'sub-route', factory: $SubRoute._fromState),
   ],
 );
 
-mixin _$HomeRoute on GoRouteData {
+mixin $HomeRoute on GoRouteData {
   static HomeRoute _fromState(GoRouterState state) => const HomeRoute();
 
   @override
@@ -38,7 +38,7 @@ mixin _$HomeRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$SubRoute on GoRouteData {
+mixin $SubRoute on GoRouteData {
   static SubRoute _fromState(GoRouterState state) => const SubRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/readme_excerpts.dart
+++ b/packages/go_router_builder/example/lib/readme_excerpts.dart
@@ -89,7 +89,7 @@ void otherDoc(BuildContext context) {
   ],
 )
 // #docregion HomeRoute
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 
   @override
@@ -109,7 +109,7 @@ class RedirectRoute extends GoRouteData {
 
 // #docregion login
 @TypedGoRoute<LoginRoute>(path: '/login')
-class LoginRoute extends GoRouteData with _$LoginRoute {
+class LoginRoute extends GoRouteData with $LoginRoute {
   LoginRoute({this.from});
   final String? from;
 
@@ -143,7 +143,7 @@ class HomeScreen extends StatelessWidget {
   }
 }
 
-class FamilyRoute extends GoRouteData with _$FamilyRoute {
+class FamilyRoute extends GoRouteData with $FamilyRoute {
   const FamilyRoute({this.fid});
 
   final String? fid;
@@ -211,7 +211,7 @@ class LoginScreen extends StatelessWidget {
 
 // #docregion MyRoute
 @TypedGoRoute<MyRoute>(path: '/my-route')
-class MyRoute extends GoRouteData with _$MyRoute {
+class MyRoute extends GoRouteData with $MyRoute {
   MyRoute({this.queryParameter = 'defaultValue'});
   final String queryParameter;
 
@@ -234,7 +234,7 @@ class MyScreen extends StatelessWidget {
 
 @TypedGoRoute<PersonRouteWithExtra>(path: '/person')
 // #docregion PersonRouteWithExtra
-class PersonRouteWithExtra extends GoRouteData with _$PersonRouteWithExtra {
+class PersonRouteWithExtra extends GoRouteData with $PersonRouteWithExtra {
   PersonRouteWithExtra(this.$extra);
   final Person? $extra;
 
@@ -258,7 +258,7 @@ class PersonScreen extends StatelessWidget {
 // #docregion HotdogRouteWithEverything
 @TypedGoRoute<HotdogRouteWithEverything>(path: '/:ketchup')
 class HotdogRouteWithEverything extends GoRouteData
-    with _$HotdogRouteWithEverything {
+    with $HotdogRouteWithEverything {
   HotdogRouteWithEverything(this.ketchup, this.mustard, this.$extra);
   final bool ketchup; // A required path parameter.
   final String? mustard; // An optional query parameter.
@@ -289,7 +289,7 @@ class HotdogScreen extends StatelessWidget {
 enum BookKind { all, popular, recent }
 
 @TypedGoRoute<BooksRoute>(path: '/books')
-class BooksRoute extends GoRouteData with _$BooksRoute {
+class BooksRoute extends GoRouteData with $BooksRoute {
   BooksRoute({this.kind = BookKind.popular});
   final BookKind kind;
 
@@ -312,7 +312,7 @@ class BooksScreen extends StatelessWidget {
 
 @TypedGoRoute<MyMaterialRouteWithKey>(path: '/my-material-route-with-key')
 // #docregion MyMaterialRouteWithKey
-class MyMaterialRouteWithKey extends GoRouteData with _$MyMaterialRouteWithKey {
+class MyMaterialRouteWithKey extends GoRouteData with $MyMaterialRouteWithKey {
   const MyMaterialRouteWithKey();
   static const LocalKey _key = ValueKey<String>('my-route-with-key');
   @override
@@ -346,7 +346,7 @@ class MyShellRoutePage extends StatelessWidget {
 
 @TypedGoRoute<FancyRoute>(path: '/fancy')
 // #docregion FancyRoute
-class FancyRoute extends GoRouteData with _$FancyRoute {
+class FancyRoute extends GoRouteData with $FancyRoute {
   const FancyRoute();
   @override
   CustomTransitionPage<void> buildPage(
@@ -390,7 +390,7 @@ class MyShellRouteData extends ShellRouteData {
 }
 
 // For GoRoutes:
-class MyGoRouteData extends GoRouteData with _$MyGoRouteData {
+class MyGoRouteData extends GoRouteData with $MyGoRouteData {
   const MyGoRouteData();
 
   static final GlobalKey<NavigatorState> $parentNavigatorKey = rootNavigatorKey;
@@ -403,7 +403,7 @@ class MyGoRouteData extends GoRouteData with _$MyGoRouteData {
 
 // #docregion relativeRoute
 @TypedRelativeGoRoute<DetailsRoute>(path: 'details')
-class DetailsRoute extends RelativeGoRouteData with _$DetailsRoute {
+class DetailsRoute extends RelativeGoRouteData with $DetailsRoute {
   const DetailsRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/readme_excerpts.g.dart
+++ b/packages/go_router_builder/example/lib/readme_excerpts.g.dart
@@ -23,13 +23,13 @@ List<RouteBase> get $appRoutes => [
 
 RouteBase get $homeRoute => GoRouteData.$route(
   path: '/',
-  factory: _$HomeRoute._fromState,
+  factory: $HomeRoute._fromState,
   routes: [
-    GoRouteData.$route(path: 'family/:fid', factory: _$FamilyRoute._fromState),
+    GoRouteData.$route(path: 'family/:fid', factory: $FamilyRoute._fromState),
   ],
 );
 
-mixin _$HomeRoute on GoRouteData {
+mixin $HomeRoute on GoRouteData {
   static HomeRoute _fromState(GoRouterState state) => const HomeRoute();
 
   @override
@@ -49,7 +49,7 @@ mixin _$HomeRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$FamilyRoute on GoRouteData {
+mixin $FamilyRoute on GoRouteData {
   static FamilyRoute _fromState(GoRouterState state) =>
       FamilyRoute(fid: state.pathParameters['fid']);
 
@@ -74,9 +74,9 @@ mixin _$FamilyRoute on GoRouteData {
 }
 
 RouteBase get $loginRoute =>
-    GoRouteData.$route(path: '/login', factory: _$LoginRoute._fromState);
+    GoRouteData.$route(path: '/login', factory: $LoginRoute._fromState);
 
-mixin _$LoginRoute on GoRouteData {
+mixin $LoginRoute on GoRouteData {
   static LoginRoute _fromState(GoRouterState state) =>
       LoginRoute(from: state.uri.queryParameters['from']);
 
@@ -103,9 +103,9 @@ mixin _$LoginRoute on GoRouteData {
 }
 
 RouteBase get $myRoute =>
-    GoRouteData.$route(path: '/my-route', factory: _$MyRoute._fromState);
+    GoRouteData.$route(path: '/my-route', factory: $MyRoute._fromState);
 
-mixin _$MyRoute on GoRouteData {
+mixin $MyRoute on GoRouteData {
   static MyRoute _fromState(GoRouterState state) => MyRoute(
     queryParameter:
         state.uri.queryParameters['query-parameter'] ?? 'defaultValue',
@@ -138,10 +138,10 @@ mixin _$MyRoute on GoRouteData {
 
 RouteBase get $personRouteWithExtra => GoRouteData.$route(
   path: '/person',
-  factory: _$PersonRouteWithExtra._fromState,
+  factory: $PersonRouteWithExtra._fromState,
 );
 
-mixin _$PersonRouteWithExtra on GoRouteData {
+mixin $PersonRouteWithExtra on GoRouteData {
   static PersonRouteWithExtra _fromState(GoRouterState state) =>
       PersonRouteWithExtra(state.extra as Person?);
 
@@ -168,10 +168,10 @@ mixin _$PersonRouteWithExtra on GoRouteData {
 
 RouteBase get $hotdogRouteWithEverything => GoRouteData.$route(
   path: '/:ketchup',
-  factory: _$HotdogRouteWithEverything._fromState,
+  factory: $HotdogRouteWithEverything._fromState,
 );
 
-mixin _$HotdogRouteWithEverything on GoRouteData {
+mixin $HotdogRouteWithEverything on GoRouteData {
   static HotdogRouteWithEverything _fromState(GoRouterState state) =>
       HotdogRouteWithEverything(
         _$boolConverter(state.pathParameters['ketchup']!),
@@ -215,9 +215,9 @@ bool _$boolConverter(String value) {
 }
 
 RouteBase get $booksRoute =>
-    GoRouteData.$route(path: '/books', factory: _$BooksRoute._fromState);
+    GoRouteData.$route(path: '/books', factory: $BooksRoute._fromState);
 
-mixin _$BooksRoute on GoRouteData {
+mixin $BooksRoute on GoRouteData {
   static BooksRoute _fromState(GoRouterState state) => BooksRoute(
     kind:
         _$convertMapValue(
@@ -274,10 +274,10 @@ extension<T extends Enum> on Map<T, String> {
 
 RouteBase get $myMaterialRouteWithKey => GoRouteData.$route(
   path: '/my-material-route-with-key',
-  factory: _$MyMaterialRouteWithKey._fromState,
+  factory: $MyMaterialRouteWithKey._fromState,
 );
 
-mixin _$MyMaterialRouteWithKey on GoRouteData {
+mixin $MyMaterialRouteWithKey on GoRouteData {
   static MyMaterialRouteWithKey _fromState(GoRouterState state) =>
       const MyMaterialRouteWithKey();
 
@@ -299,9 +299,9 @@ mixin _$MyMaterialRouteWithKey on GoRouteData {
 }
 
 RouteBase get $fancyRoute =>
-    GoRouteData.$route(path: '/fancy', factory: _$FancyRoute._fromState);
+    GoRouteData.$route(path: '/fancy', factory: $FancyRoute._fromState);
 
-mixin _$FancyRoute on GoRouteData {
+mixin $FancyRoute on GoRouteData {
   static FancyRoute _fromState(GoRouterState state) => const FancyRoute();
 
   @override
@@ -328,7 +328,7 @@ RouteBase get $myShellRouteData => ShellRouteData.$route(
     GoRouteData.$route(
       path: 'my-go-route',
       parentNavigatorKey: MyGoRouteData.$parentNavigatorKey,
-      factory: _$MyGoRouteData._fromState,
+      factory: $MyGoRouteData._fromState,
     ),
   ],
 );
@@ -338,7 +338,7 @@ extension $MyShellRouteDataExtension on MyShellRouteData {
       const MyShellRouteData();
 }
 
-mixin _$MyGoRouteData on GoRouteData {
+mixin $MyGoRouteData on GoRouteData {
   static MyGoRouteData _fromState(GoRouterState state) => const MyGoRouteData();
 
   @override
@@ -361,10 +361,10 @@ mixin _$MyGoRouteData on GoRouteData {
 RouteBase get $detailsRoute => RelativeGoRouteData.$route(
   path: 'details',
 
-  factory: _$DetailsRoute._fromState,
+  factory: $DetailsRoute._fromState,
 );
 
-mixin _$DetailsRoute on RelativeGoRouteData {
+mixin $DetailsRoute on RelativeGoRouteData {
   static DetailsRoute _fromState(GoRouterState state) => const DetailsRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/separate_file_route.dart
+++ b/packages/go_router_builder/example/lib/separate_file_route.dart
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs, unreachable_from_main
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'stateful_shell_route_initial_location_example.dart';
+
+class OrdersRouteData extends GoRouteData with $OrdersRouteData {
+  const OrdersRouteData();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const OrdersPageView(label: 'Orders page');
+  }
+}
+
+class OrdersPageView extends StatelessWidget {
+  const OrdersPageView({required this.label, super.key});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(child: Text(label));
+  }
+}

--- a/packages/go_router_builder/example/lib/shell_route_example.dart
+++ b/packages/go_router_builder/example/lib/shell_route_example.dart
@@ -47,7 +47,7 @@ class MyShellRouteData extends ShellRouteData {
   }
 }
 
-class FooRouteData extends GoRouteData with _$FooRouteData {
+class FooRouteData extends GoRouteData with $FooRouteData {
   const FooRouteData();
 
   @override
@@ -56,7 +56,7 @@ class FooRouteData extends GoRouteData with _$FooRouteData {
   }
 }
 
-class BarRouteData extends GoRouteData with _$BarRouteData {
+class BarRouteData extends GoRouteData with $BarRouteData {
   const BarRouteData();
 
   @override
@@ -121,7 +121,7 @@ class BarScreen extends StatelessWidget {
 }
 
 @TypedGoRoute<LoginRoute>(path: '/login')
-class LoginRoute extends GoRouteData with _$LoginRoute {
+class LoginRoute extends GoRouteData with $LoginRoute {
   const LoginRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/shell_route_example.g.dart
+++ b/packages/go_router_builder/example/lib/shell_route_example.g.dart
@@ -13,8 +13,8 @@ List<RouteBase> get $appRoutes => [$myShellRouteData, $loginRoute];
 RouteBase get $myShellRouteData => ShellRouteData.$route(
   factory: $MyShellRouteDataExtension._fromState,
   routes: [
-    GoRouteData.$route(path: '/foo', factory: _$FooRouteData._fromState),
-    GoRouteData.$route(path: '/bar', factory: _$BarRouteData._fromState),
+    GoRouteData.$route(path: '/foo', factory: $FooRouteData._fromState),
+    GoRouteData.$route(path: '/bar', factory: $BarRouteData._fromState),
   ],
 );
 
@@ -23,7 +23,7 @@ extension $MyShellRouteDataExtension on MyShellRouteData {
       const MyShellRouteData();
 }
 
-mixin _$FooRouteData on GoRouteData {
+mixin $FooRouteData on GoRouteData {
   static FooRouteData _fromState(GoRouterState state) => const FooRouteData();
 
   @override
@@ -43,7 +43,7 @@ mixin _$FooRouteData on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$BarRouteData on GoRouteData {
+mixin $BarRouteData on GoRouteData {
   static BarRouteData _fromState(GoRouterState state) => const BarRouteData();
 
   @override
@@ -64,9 +64,9 @@ mixin _$BarRouteData on GoRouteData {
 }
 
 RouteBase get $loginRoute =>
-    GoRouteData.$route(path: '/login', factory: _$LoginRoute._fromState);
+    GoRouteData.$route(path: '/login', factory: $LoginRoute._fromState);
 
-mixin _$LoginRoute on GoRouteData {
+mixin $LoginRoute on GoRouteData {
   static LoginRoute _fromState(GoRouterState state) => const LoginRoute();
 
   @override

--- a/packages/go_router_builder/example/lib/shell_route_with_keys_example.dart
+++ b/packages/go_router_builder/example/lib/shell_route_with_keys_example.dart
@@ -99,7 +99,7 @@ class MyShellRouteScreen extends StatelessWidget {
   }
 }
 
-class HomeRouteData extends GoRouteData with _$HomeRouteData {
+class HomeRouteData extends GoRouteData with $HomeRouteData {
   const HomeRouteData();
 
   @override
@@ -108,7 +108,7 @@ class HomeRouteData extends GoRouteData with _$HomeRouteData {
   }
 }
 
-class UsersRouteData extends GoRouteData with _$UsersRouteData {
+class UsersRouteData extends GoRouteData with $UsersRouteData {
   const UsersRouteData();
 
   @override
@@ -142,7 +142,7 @@ class DialogPage extends Page<void> {
   }
 }
 
-class UserRouteData extends GoRouteData with _$UserRouteData {
+class UserRouteData extends GoRouteData with $UserRouteData {
   const UserRouteData({required this.id});
 
   // Without this static key, the dialog will not cover the navigation rail.

--- a/packages/go_router_builder/example/lib/shell_route_with_keys_example.g.dart
+++ b/packages/go_router_builder/example/lib/shell_route_with_keys_example.g.dart
@@ -14,15 +14,15 @@ RouteBase get $myShellRouteData => ShellRouteData.$route(
   navigatorKey: MyShellRouteData.$navigatorKey,
   factory: $MyShellRouteDataExtension._fromState,
   routes: [
-    GoRouteData.$route(path: '/home', factory: _$HomeRouteData._fromState),
+    GoRouteData.$route(path: '/home', factory: $HomeRouteData._fromState),
     GoRouteData.$route(
       path: '/users',
-      factory: _$UsersRouteData._fromState,
+      factory: $UsersRouteData._fromState,
       routes: [
         GoRouteData.$route(
           path: ':id',
           parentNavigatorKey: UserRouteData.$parentNavigatorKey,
-          factory: _$UserRouteData._fromState,
+          factory: $UserRouteData._fromState,
         ),
       ],
     ),
@@ -34,7 +34,7 @@ extension $MyShellRouteDataExtension on MyShellRouteData {
       const MyShellRouteData();
 }
 
-mixin _$HomeRouteData on GoRouteData {
+mixin $HomeRouteData on GoRouteData {
   static HomeRouteData _fromState(GoRouterState state) => const HomeRouteData();
 
   @override
@@ -54,7 +54,7 @@ mixin _$HomeRouteData on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$UsersRouteData on GoRouteData {
+mixin $UsersRouteData on GoRouteData {
   static UsersRouteData _fromState(GoRouterState state) =>
       const UsersRouteData();
 
@@ -75,7 +75,7 @@ mixin _$UsersRouteData on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$UserRouteData on GoRouteData {
+mixin $UserRouteData on GoRouteData {
   static UserRouteData _fromState(GoRouterState state) =>
       UserRouteData(id: int.parse(state.pathParameters['id']!));
 

--- a/packages/go_router_builder/example/lib/shell_route_with_observers_example.dart
+++ b/packages/go_router_builder/example/lib/shell_route_with_observers_example.dart
@@ -102,7 +102,7 @@ class MyShellRouteScreen extends StatelessWidget {
   }
 }
 
-class HomeRouteData extends GoRouteData with _$HomeRouteData {
+class HomeRouteData extends GoRouteData with $HomeRouteData {
   const HomeRouteData();
 
   @override
@@ -111,7 +111,7 @@ class HomeRouteData extends GoRouteData with _$HomeRouteData {
   }
 }
 
-class UsersRouteData extends GoRouteData with _$UsersRouteData {
+class UsersRouteData extends GoRouteData with $UsersRouteData {
   const UsersRouteData();
 
   @override
@@ -145,7 +145,7 @@ class DialogPage extends Page<void> {
   }
 }
 
-class UserRouteData extends GoRouteData with _$UserRouteData {
+class UserRouteData extends GoRouteData with $UserRouteData {
   const UserRouteData({required this.id});
 
   // Without this static key, the dialog will not cover the navigation rail.

--- a/packages/go_router_builder/example/lib/shell_route_with_observers_example.g.dart
+++ b/packages/go_router_builder/example/lib/shell_route_with_observers_example.g.dart
@@ -14,12 +14,12 @@ RouteBase get $myShellRouteData => ShellRouteData.$route(
   observers: MyShellRouteData.$observers,
   factory: $MyShellRouteDataExtension._fromState,
   routes: [
-    GoRouteData.$route(path: '/home', factory: _$HomeRouteData._fromState),
+    GoRouteData.$route(path: '/home', factory: $HomeRouteData._fromState),
     GoRouteData.$route(
       path: '/users',
-      factory: _$UsersRouteData._fromState,
+      factory: $UsersRouteData._fromState,
       routes: [
-        GoRouteData.$route(path: ':id', factory: _$UserRouteData._fromState),
+        GoRouteData.$route(path: ':id', factory: $UserRouteData._fromState),
       ],
     ),
   ],
@@ -30,7 +30,7 @@ extension $MyShellRouteDataExtension on MyShellRouteData {
       const MyShellRouteData();
 }
 
-mixin _$HomeRouteData on GoRouteData {
+mixin $HomeRouteData on GoRouteData {
   static HomeRouteData _fromState(GoRouterState state) => const HomeRouteData();
 
   @override
@@ -50,7 +50,7 @@ mixin _$HomeRouteData on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$UsersRouteData on GoRouteData {
+mixin $UsersRouteData on GoRouteData {
   static UsersRouteData _fromState(GoRouterState state) =>
       const UsersRouteData();
 
@@ -71,7 +71,7 @@ mixin _$UsersRouteData on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$UserRouteData on GoRouteData {
+mixin $UserRouteData on GoRouteData {
   static UserRouteData _fromState(GoRouterState state) =>
       UserRouteData(id: int.parse(state.pathParameters['id']!));
 

--- a/packages/go_router_builder/example/lib/simple_example.dart
+++ b/packages/go_router_builder/example/lib/simple_example.dart
@@ -30,14 +30,14 @@ class App extends StatelessWidget {
     TypedGoRoute<FamilyRoute>(path: 'family/:familyId'),
   ],
 )
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 
   @override
   Widget build(BuildContext context, GoRouterState state) => const HomeScreen();
 }
 
-class FamilyRoute extends GoRouteData with _$FamilyRoute {
+class FamilyRoute extends GoRouteData with $FamilyRoute {
   const FamilyRoute(this.familyId);
 
   final String familyId;

--- a/packages/go_router_builder/example/lib/simple_example.g.dart
+++ b/packages/go_router_builder/example/lib/simple_example.g.dart
@@ -13,16 +13,16 @@ List<RouteBase> get $appRoutes => [$homeRoute];
 RouteBase get $homeRoute => GoRouteData.$route(
   path: '/',
   name: 'Home',
-  factory: _$HomeRoute._fromState,
+  factory: $HomeRoute._fromState,
   routes: [
     GoRouteData.$route(
       path: 'family/:familyId',
-      factory: _$FamilyRoute._fromState,
+      factory: $FamilyRoute._fromState,
     ),
   ],
 );
 
-mixin _$HomeRoute on GoRouteData {
+mixin $HomeRoute on GoRouteData {
   static HomeRoute _fromState(GoRouterState state) => const HomeRoute();
 
   @override
@@ -42,7 +42,7 @@ mixin _$HomeRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$FamilyRoute on GoRouteData {
+mixin $FamilyRoute on GoRouteData {
   static FamilyRoute _fromState(GoRouterState state) =>
       FamilyRoute(state.pathParameters['familyId']!);
 

--- a/packages/go_router_builder/example/lib/stateful_shell_route_example.dart
+++ b/packages/go_router_builder/example/lib/stateful_shell_route_example.dart
@@ -87,7 +87,7 @@ class BranchBData extends StatefulShellBranchData {
   static const String $restorationScopeId = 'restorationScopeId';
 }
 
-class DetailsARouteData extends GoRouteData with _$DetailsARouteData {
+class DetailsARouteData extends GoRouteData with $DetailsARouteData {
   const DetailsARouteData();
 
   @override
@@ -96,7 +96,7 @@ class DetailsARouteData extends GoRouteData with _$DetailsARouteData {
   }
 }
 
-class DetailsBRouteData extends GoRouteData with _$DetailsBRouteData {
+class DetailsBRouteData extends GoRouteData with $DetailsBRouteData {
   const DetailsBRouteData();
 
   @override

--- a/packages/go_router_builder/example/lib/stateful_shell_route_example.g.dart
+++ b/packages/go_router_builder/example/lib/stateful_shell_route_example.g.dart
@@ -19,7 +19,7 @@ RouteBase get $myShellRouteData => StatefulShellRouteData.$route(
       routes: [
         GoRouteData.$route(
           path: '/detailsA',
-          factory: _$DetailsARouteData._fromState,
+          factory: $DetailsARouteData._fromState,
         ),
       ],
     ),
@@ -29,7 +29,7 @@ RouteBase get $myShellRouteData => StatefulShellRouteData.$route(
       routes: [
         GoRouteData.$route(
           path: '/detailsB',
-          factory: _$DetailsBRouteData._fromState,
+          factory: $DetailsBRouteData._fromState,
         ),
       ],
     ),
@@ -41,7 +41,7 @@ extension $MyShellRouteDataExtension on MyShellRouteData {
       const MyShellRouteData();
 }
 
-mixin _$DetailsARouteData on GoRouteData {
+mixin $DetailsARouteData on GoRouteData {
   static DetailsARouteData _fromState(GoRouterState state) =>
       const DetailsARouteData();
 
@@ -62,7 +62,7 @@ mixin _$DetailsARouteData on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$DetailsBRouteData on GoRouteData {
+mixin $DetailsBRouteData on GoRouteData {
   static DetailsBRouteData _fromState(GoRouterState state) =>
       const DetailsBRouteData();
 

--- a/packages/go_router_builder/example/lib/stateful_shell_route_initial_location_example.dart
+++ b/packages/go_router_builder/example/lib/stateful_shell_route_initial_location_example.dart
@@ -7,6 +7,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import 'separate_file_route.dart';
+
 part 'stateful_shell_route_initial_location_example.g.dart';
 
 void main() => runApp(App());
@@ -78,7 +80,7 @@ class OrdersShellBranchData extends StatefulShellBranchData {
   const OrdersShellBranchData();
 }
 
-class HomeRouteData extends GoRouteData with _$HomeRouteData {
+class HomeRouteData extends GoRouteData with $HomeRouteData {
   const HomeRouteData();
 
   @override
@@ -89,7 +91,7 @@ class HomeRouteData extends GoRouteData with _$HomeRouteData {
 
 enum NotificationsPageSection { latest, old, archive }
 
-class NotificationsRouteData extends GoRouteData with _$NotificationsRouteData {
+class NotificationsRouteData extends GoRouteData with $NotificationsRouteData {
   const NotificationsRouteData({required this.section});
 
   final NotificationsPageSection section;
@@ -97,15 +99,6 @@ class NotificationsRouteData extends GoRouteData with _$NotificationsRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return NotificationsPageView(section: section);
-  }
-}
-
-class OrdersRouteData extends GoRouteData with _$OrdersRouteData {
-  const OrdersRouteData();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) {
-    return const OrdersPageView(label: 'Orders page');
   }
 }
 
@@ -193,17 +186,6 @@ class NotificationsPageView extends StatelessWidget {
 
 class NotificationsSubPageView extends StatelessWidget {
   const NotificationsSubPageView({required this.label, super.key});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(child: Text(label));
-  }
-}
-
-class OrdersPageView extends StatelessWidget {
-  const OrdersPageView({required this.label, super.key});
 
   final String label;
 

--- a/packages/go_router_builder/example/lib/stateful_shell_route_initial_location_example.g.dart
+++ b/packages/go_router_builder/example/lib/stateful_shell_route_initial_location_example.g.dart
@@ -15,7 +15,7 @@ RouteBase get $mainShellRouteData => StatefulShellRouteData.$route(
   branches: [
     StatefulShellBranchData.$branch(
       routes: [
-        GoRouteData.$route(path: '/home', factory: _$HomeRouteData._fromState),
+        GoRouteData.$route(path: '/home', factory: $HomeRouteData._fromState),
       ],
     ),
     StatefulShellBranchData.$branch(
@@ -23,7 +23,7 @@ RouteBase get $mainShellRouteData => StatefulShellRouteData.$route(
       routes: [
         GoRouteData.$route(
           path: '/notifications/:section',
-          factory: _$NotificationsRouteData._fromState,
+          factory: $NotificationsRouteData._fromState,
         ),
       ],
     ),
@@ -31,7 +31,7 @@ RouteBase get $mainShellRouteData => StatefulShellRouteData.$route(
       routes: [
         GoRouteData.$route(
           path: '/orders',
-          factory: _$OrdersRouteData._fromState,
+          factory: $OrdersRouteData._fromState,
         ),
       ],
     ),
@@ -43,7 +43,7 @@ extension $MainShellRouteDataExtension on MainShellRouteData {
       const MainShellRouteData();
 }
 
-mixin _$HomeRouteData on GoRouteData {
+mixin $HomeRouteData on GoRouteData {
   static HomeRouteData _fromState(GoRouterState state) => const HomeRouteData();
 
   @override
@@ -63,7 +63,7 @@ mixin _$HomeRouteData on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$NotificationsRouteData on GoRouteData {
+mixin $NotificationsRouteData on GoRouteData {
   static NotificationsRouteData _fromState(GoRouterState state) =>
       NotificationsRouteData(
         section:
@@ -99,7 +99,7 @@ const _$NotificationsPageSectionEnumMap = {
   NotificationsPageSection.archive: 'archive',
 };
 
-mixin _$OrdersRouteData on GoRouteData {
+mixin $OrdersRouteData on GoRouteData {
   static OrdersRouteData _fromState(GoRouterState state) =>
       const OrdersRouteData();
 

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -881,7 +881,7 @@ RouteBase get $_routeGetterName => ${_invokesRouteConstructor()};
 
   String get _className => routeDataClass.displayName;
 
-  String get _mixinName => '_\$$_className';
+  String get _mixinName => '\$$_className';
 
   String get _extensionName => '\$${_className}Extension';
 

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 3.3.1
+version: 4.0.0
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 

--- a/packages/go_router_builder/test_inputs/bad_path_pattern.dart
+++ b/packages/go_router_builder/test_inputs/bad_path_pattern.dart
@@ -4,7 +4,7 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$BadPathParam {}
+mixin $BadPathParam {}
 
 @TypedGoRoute<BadPathParam>(path: 'bob/:id')
-class BadPathParam extends GoRouteData with _$BadPathParam {}
+class BadPathParam extends GoRouteData with $BadPathParam {}

--- a/packages/go_router_builder/test_inputs/case_sensitivity.dart
+++ b/packages/go_router_builder/test_inputs/case_sensitivity.dart
@@ -4,14 +4,14 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$CaseSensitiveRoute {}
-mixin _$NotCaseSensitiveRoute {}
+mixin $CaseSensitiveRoute {}
+mixin $NotCaseSensitiveRoute {}
 
 @TypedGoRoute<CaseSensitiveRoute>(path: '/case-sensitive-route')
-class CaseSensitiveRoute extends GoRouteData with _$CaseSensitiveRoute {}
+class CaseSensitiveRoute extends GoRouteData with $CaseSensitiveRoute {}
 
 @TypedGoRoute<NotCaseSensitiveRoute>(
   path: '/not-case-sensitive-route',
   caseSensitive: false,
 )
-class NotCaseSensitiveRoute extends GoRouteData with _$NotCaseSensitiveRoute {}
+class NotCaseSensitiveRoute extends GoRouteData with $NotCaseSensitiveRoute {}

--- a/packages/go_router_builder/test_inputs/case_sensitivity.dart.expect
+++ b/packages/go_router_builder/test_inputs/case_sensitivity.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $caseSensitiveRoute => GoRouteData.$route(
       path: '/case-sensitive-route',
-      factory: _$CaseSensitiveRoute._fromState,
+      factory: $CaseSensitiveRoute._fromState,
     );
 
-mixin _$CaseSensitiveRoute on GoRouteData {
+mixin $CaseSensitiveRoute on GoRouteData {
   static CaseSensitiveRoute _fromState(GoRouterState state) =>
       CaseSensitiveRoute();
 
@@ -29,10 +29,10 @@ mixin _$CaseSensitiveRoute on GoRouteData {
 RouteBase get $notCaseSensitiveRoute => GoRouteData.$route(
       path: '/not-case-sensitive-route',
       caseSensitive: false,
-      factory: _$NotCaseSensitiveRoute._fromState,
+      factory: $NotCaseSensitiveRoute._fromState,
     );
 
-mixin _$NotCaseSensitiveRoute on GoRouteData {
+mixin $NotCaseSensitiveRoute on GoRouteData {
   static NotCaseSensitiveRoute _fromState(GoRouterState state) =>
       NotCaseSensitiveRoute();
 

--- a/packages/go_router_builder/test_inputs/default_value.dart
+++ b/packages/go_router_builder/test_inputs/default_value.dart
@@ -4,10 +4,10 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$DefaultValueRoute {}
+mixin $DefaultValueRoute {}
 
 @TypedGoRoute<DefaultValueRoute>(path: '/default-value-route')
-class DefaultValueRoute extends GoRouteData with _$DefaultValueRoute {
+class DefaultValueRoute extends GoRouteData with $DefaultValueRoute {
   DefaultValueRoute({this.param = 0});
   final int param;
 }

--- a/packages/go_router_builder/test_inputs/default_value.dart.expect
+++ b/packages/go_router_builder/test_inputs/default_value.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $defaultValueRoute => GoRouteData.$route(
       path: '/default-value-route',
-      factory: _$DefaultValueRoute._fromState,
+      factory: $DefaultValueRoute._fromState,
     );
 
-mixin _$DefaultValueRoute on GoRouteData {
+mixin $DefaultValueRoute on GoRouteData {
   static DefaultValueRoute _fromState(GoRouterState state) => DefaultValueRoute(
         param:
             _$convertMapValue('param', state.uri.queryParameters, int.parse) ??

--- a/packages/go_router_builder/test_inputs/enum_parameter.dart
+++ b/packages/go_router_builder/test_inputs/enum_parameter.dart
@@ -4,10 +4,10 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$EnumParam {}
+mixin $EnumParam {}
 
 @TypedGoRoute<EnumParam>(path: '/:y')
-class EnumParam extends GoRouteData with _$EnumParam {
+class EnumParam extends GoRouteData with $EnumParam {
   EnumParam({required this.y});
   final EnumTest y;
 }

--- a/packages/go_router_builder/test_inputs/enum_parameter.dart.expect
+++ b/packages/go_router_builder/test_inputs/enum_parameter.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $enumParam => GoRouteData.$route(
       path: '/:y',
-      factory: _$EnumParam._fromState,
+      factory: $EnumParam._fromState,
     );
 
-mixin _$EnumParam on GoRouteData {
+mixin $EnumParam on GoRouteData {
   static EnumParam _fromState(GoRouterState state) => EnumParam(
         y: _$EnumTestEnumMap._$fromName(state.pathParameters['y']!)!,
       );

--- a/packages/go_router_builder/test_inputs/extension_type_parameter.dart
+++ b/packages/go_router_builder/test_inputs/extension_type_parameter.dart
@@ -4,18 +4,18 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$ExtensionTypeParam {}
-mixin _$ExtensionTypeStringParam {}
-mixin _$ExtensionTypeStringDefaultParam {}
-mixin _$ExtensionTypeIntParam {}
-mixin _$ExtensionTypeIntDefaultParam {}
-mixin _$ExtensionTypeDoubleParam {}
-mixin _$ExtensionTypeNumParam {}
-mixin _$ExtensionTypeBoolParam {}
-mixin _$ExtensionTypeEnumType {}
-mixin _$ExtensionTypeBigIntParam {}
-mixin _$ExtensionTypeDateTimeParam {}
-mixin _$ExtensionTypeUriType {}
+mixin $ExtensionTypeParam {}
+mixin $ExtensionTypeStringParam {}
+mixin $ExtensionTypeStringDefaultParam {}
+mixin $ExtensionTypeIntParam {}
+mixin $ExtensionTypeIntDefaultParam {}
+mixin $ExtensionTypeDoubleParam {}
+mixin $ExtensionTypeNumParam {}
+mixin $ExtensionTypeBoolParam {}
+mixin $ExtensionTypeEnumType {}
+mixin $ExtensionTypeBigIntParam {}
+mixin $ExtensionTypeDateTimeParam {}
+mixin $ExtensionTypeUriType {}
 
 @TypedGoRoute<ExtensionTypeParam>(
   path: '/',
@@ -33,12 +33,12 @@ mixin _$ExtensionTypeUriType {}
     TypedGoRoute<ExtensionTypeUriType>(path: 'uri/:uri'),
   ],
 )
-class ExtensionTypeParam extends GoRouteData with _$ExtensionTypeParam {
+class ExtensionTypeParam extends GoRouteData with $ExtensionTypeParam {
   ExtensionTypeParam();
 }
 
 class ExtensionTypeStringParam extends GoRouteData
-    with _$ExtensionTypeStringParam {
+    with $ExtensionTypeStringParam {
   ExtensionTypeStringParam({
     required this.s,
     required this.requiredValue,
@@ -52,14 +52,14 @@ class ExtensionTypeStringParam extends GoRouteData
 }
 
 class ExtensionTypeStringDefaultParam extends GoRouteData
-    with _$ExtensionTypeStringDefaultParam {
+    with $ExtensionTypeStringDefaultParam {
   ExtensionTypeStringDefaultParam({
     this.s = const StringExtensionType('default'),
   });
   final StringExtensionType s;
 }
 
-class ExtensionTypeIntParam extends GoRouteData with _$ExtensionTypeIntParam {
+class ExtensionTypeIntParam extends GoRouteData with $ExtensionTypeIntParam {
   ExtensionTypeIntParam({
     required this.x,
     required this.requiredValue,
@@ -73,13 +73,13 @@ class ExtensionTypeIntParam extends GoRouteData with _$ExtensionTypeIntParam {
 }
 
 class ExtensionTypeIntDefaultParam extends GoRouteData
-    with _$ExtensionTypeIntDefaultParam {
+    with $ExtensionTypeIntDefaultParam {
   ExtensionTypeIntDefaultParam({this.x = const IntExtensionType(42)});
   final IntExtensionType x;
 }
 
 class ExtensionTypeDoubleParam extends GoRouteData
-    with _$ExtensionTypeDoubleParam {
+    with $ExtensionTypeDoubleParam {
   ExtensionTypeDoubleParam({
     required this.d,
     required this.requiredValue,
@@ -92,7 +92,7 @@ class ExtensionTypeDoubleParam extends GoRouteData
   final DoubleExtensionType optionalDefaultValue;
 }
 
-class ExtensionTypeNumParam extends GoRouteData with _$ExtensionTypeNumParam {
+class ExtensionTypeNumParam extends GoRouteData with $ExtensionTypeNumParam {
   ExtensionTypeNumParam({
     required this.n,
     required this.requiredValue,
@@ -105,7 +105,7 @@ class ExtensionTypeNumParam extends GoRouteData with _$ExtensionTypeNumParam {
   final NumExtensionType optionalDefaultValue;
 }
 
-class ExtensionTypeBoolParam extends GoRouteData with _$ExtensionTypeBoolParam {
+class ExtensionTypeBoolParam extends GoRouteData with $ExtensionTypeBoolParam {
   ExtensionTypeBoolParam({
     required this.b,
     required this.requiredValue,
@@ -120,7 +120,7 @@ class ExtensionTypeBoolParam extends GoRouteData with _$ExtensionTypeBoolParam {
 
 enum MyEnum { value1, value2, value3 }
 
-class ExtensionTypeEnumType extends GoRouteData with _$ExtensionTypeEnumType {
+class ExtensionTypeEnumType extends GoRouteData with $ExtensionTypeEnumType {
   ExtensionTypeEnumType({
     required this.value,
     required this.requiredValue,
@@ -134,7 +134,7 @@ class ExtensionTypeEnumType extends GoRouteData with _$ExtensionTypeEnumType {
 }
 
 class ExtensionTypeBigIntParam extends GoRouteData
-    with _$ExtensionTypeBigIntParam {
+    with $ExtensionTypeBigIntParam {
   ExtensionTypeBigIntParam({
     required this.bi,
     required this.requiredValue,
@@ -148,7 +148,7 @@ class ExtensionTypeBigIntParam extends GoRouteData
 }
 
 class ExtensionTypeDateTimeParam extends GoRouteData
-    with _$ExtensionTypeDateTimeParam {
+    with $ExtensionTypeDateTimeParam {
   ExtensionTypeDateTimeParam({
     required this.dt,
     required this.optionalValue,
@@ -159,7 +159,7 @@ class ExtensionTypeDateTimeParam extends GoRouteData
   final DateTimeExtensionType? optionalNullableValue;
 }
 
-class ExtensionTypeUriType extends GoRouteData with _$ExtensionTypeUriType {
+class ExtensionTypeUriType extends GoRouteData with $ExtensionTypeUriType {
   ExtensionTypeUriType({
     required this.uri,
     required this.requiredValue,

--- a/packages/go_router_builder/test_inputs/extension_type_parameter.dart.expect
+++ b/packages/go_router_builder/test_inputs/extension_type_parameter.dart.expect
@@ -1,55 +1,55 @@
 RouteBase get $extensionTypeParam => GoRouteData.$route(
       path: '/',
-      factory: _$ExtensionTypeParam._fromState,
+      factory: $ExtensionTypeParam._fromState,
       routes: [
         GoRouteData.$route(
           path: 'string/:s',
-          factory: _$ExtensionTypeStringParam._fromState,
+          factory: $ExtensionTypeStringParam._fromState,
         ),
         GoRouteData.$route(
           path: 'string_default/:s',
-          factory: _$ExtensionTypeStringDefaultParam._fromState,
+          factory: $ExtensionTypeStringDefaultParam._fromState,
         ),
         GoRouteData.$route(
           path: 'int/:x',
-          factory: _$ExtensionTypeIntParam._fromState,
+          factory: $ExtensionTypeIntParam._fromState,
         ),
         GoRouteData.$route(
           path: 'int_default/:x',
-          factory: _$ExtensionTypeIntDefaultParam._fromState,
+          factory: $ExtensionTypeIntDefaultParam._fromState,
         ),
         GoRouteData.$route(
           path: 'double/:d',
-          factory: _$ExtensionTypeDoubleParam._fromState,
+          factory: $ExtensionTypeDoubleParam._fromState,
         ),
         GoRouteData.$route(
           path: 'num/:n',
-          factory: _$ExtensionTypeNumParam._fromState,
+          factory: $ExtensionTypeNumParam._fromState,
         ),
         GoRouteData.$route(
           path: 'bool/:b',
-          factory: _$ExtensionTypeBoolParam._fromState,
+          factory: $ExtensionTypeBoolParam._fromState,
         ),
         GoRouteData.$route(
           path: 'enum/:value',
-          factory: _$ExtensionTypeEnumType._fromState,
+          factory: $ExtensionTypeEnumType._fromState,
         ),
         GoRouteData.$route(
           path: 'bigint/:bi',
-          factory: _$ExtensionTypeBigIntParam._fromState,
+          factory: $ExtensionTypeBigIntParam._fromState,
         ),
         GoRouteData.$route(
           path: 'datetime/:dt',
-          factory: _$ExtensionTypeDateTimeParam._fromState,
+          factory: $ExtensionTypeDateTimeParam._fromState,
         ),
         GoRouteData.$route(
           path: 'uri/:uri',
-          factory: _$ExtensionTypeUriType._fromState,
+          factory: $ExtensionTypeUriType._fromState,
         ),
       ],
     );
 
-mixin _$ExtensionTypeParam on GoRouteData {
+mixin $ExtensionTypeParam on GoRouteData {
   static ExtensionTypeParam _fromState(GoRouterState state) =>
       ExtensionTypeParam();
 
@@ -72,7 +72,7 @@ mixin _$ExtensionTypeParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeStringParam on GoRouteData {
+mixin $ExtensionTypeStringParam on GoRouteData {
   static ExtensionTypeStringParam _fromState(GoRouterState state) =>
       ExtensionTypeStringParam(
         s: state.pathParameters['s']! as StringExtensionType,
@@ -115,7 +115,7 @@ mixin _$ExtensionTypeStringParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeStringDefaultParam on GoRouteData {
+mixin $ExtensionTypeStringDefaultParam on GoRouteData {
   static ExtensionTypeStringDefaultParam _fromState(GoRouterState state) =>
       ExtensionTypeStringDefaultParam(
         s: state.pathParameters['s'] as StringExtensionType? ??
@@ -144,7 +144,7 @@ mixin _$ExtensionTypeStringDefaultParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeIntParam on GoRouteData {
+mixin $ExtensionTypeIntParam on GoRouteData {
   static ExtensionTypeIntParam _fromState(GoRouterState state) =>
       ExtensionTypeIntParam(
         x: int.parse(state.pathParameters['x']!) as IntExtensionType,
@@ -187,7 +187,7 @@ mixin _$ExtensionTypeIntParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeIntDefaultParam on GoRouteData {
+mixin $ExtensionTypeIntDefaultParam on GoRouteData {
   static ExtensionTypeIntDefaultParam _fromState(GoRouterState state) =>
       ExtensionTypeIntDefaultParam(
         x: int.tryParse(state.pathParameters['x'] ?? '') as IntExtensionType? ??
@@ -216,7 +216,7 @@ mixin _$ExtensionTypeIntDefaultParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeDoubleParam on GoRouteData {
+mixin $ExtensionTypeDoubleParam on GoRouteData {
   static ExtensionTypeDoubleParam _fromState(GoRouterState state) =>
       ExtensionTypeDoubleParam(
         d: double.parse(state.pathParameters['d']!) as DoubleExtensionType,
@@ -260,7 +260,7 @@ mixin _$ExtensionTypeDoubleParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeNumParam on GoRouteData {
+mixin $ExtensionTypeNumParam on GoRouteData {
   static ExtensionTypeNumParam _fromState(GoRouterState state) =>
       ExtensionTypeNumParam(
         n: num.parse(state.pathParameters['n']!) as NumExtensionType,
@@ -303,7 +303,7 @@ mixin _$ExtensionTypeNumParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeBoolParam on GoRouteData {
+mixin $ExtensionTypeBoolParam on GoRouteData {
   static ExtensionTypeBoolParam _fromState(GoRouterState state) =>
       ExtensionTypeBoolParam(
         b: bool.parse(state.pathParameters['b']!) as BoolExtensionType,
@@ -346,7 +346,7 @@ mixin _$ExtensionTypeBoolParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeEnumType on GoRouteData {
+mixin $ExtensionTypeEnumType on GoRouteData {
   static ExtensionTypeEnumType _fromState(GoRouterState state) =>
       ExtensionTypeEnumType(
         value: _$MyEnumEnumMap._$fromName(state.pathParameters['value']!)
@@ -399,7 +399,7 @@ const _$MyEnumEnumMap = {
   MyEnum.value3: 'value3',
 };
 
-mixin _$ExtensionTypeBigIntParam on GoRouteData {
+mixin $ExtensionTypeBigIntParam on GoRouteData {
   static ExtensionTypeBigIntParam _fromState(GoRouterState state) =>
       ExtensionTypeBigIntParam(
         bi: BigInt.parse(state.pathParameters['bi']!) as BigIntExtensionType,
@@ -442,7 +442,7 @@ mixin _$ExtensionTypeBigIntParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeDateTimeParam on GoRouteData {
+mixin $ExtensionTypeDateTimeParam on GoRouteData {
   static ExtensionTypeDateTimeParam _fromState(GoRouterState state) =>
       ExtensionTypeDateTimeParam(
         dt: DateTime.parse(state.pathParameters['dt']!)
@@ -481,7 +481,7 @@ mixin _$ExtensionTypeDateTimeParam on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$ExtensionTypeUriType on GoRouteData {
+mixin $ExtensionTypeUriType on GoRouteData {
   static ExtensionTypeUriType _fromState(GoRouterState state) =>
       ExtensionTypeUriType(
         uri: Uri.parse(state.pathParameters['uri']!) as UriExtensionType,

--- a/packages/go_router_builder/test_inputs/extra_value.dart
+++ b/packages/go_router_builder/test_inputs/extra_value.dart
@@ -4,10 +4,10 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$ExtraValueRoute {}
+mixin $ExtraValueRoute {}
 
 @TypedGoRoute<ExtraValueRoute>(path: '/default-value-route')
-class ExtraValueRoute extends GoRouteData with _$ExtraValueRoute {
+class ExtraValueRoute extends GoRouteData with $ExtraValueRoute {
   ExtraValueRoute({this.param = 0, this.$extra});
   final int param;
   final int? $extra;

--- a/packages/go_router_builder/test_inputs/extra_value.dart.expect
+++ b/packages/go_router_builder/test_inputs/extra_value.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $extraValueRoute => GoRouteData.$route(
       path: '/default-value-route',
-      factory: _$ExtraValueRoute._fromState,
+      factory: $ExtraValueRoute._fromState,
     );
 
-mixin _$ExtraValueRoute on GoRouteData {
+mixin $ExtraValueRoute on GoRouteData {
   static ExtraValueRoute _fromState(GoRouterState state) => ExtraValueRoute(
         param:
             _$convertMapValue('param', state.uri.queryParameters, int.parse) ??

--- a/packages/go_router_builder/test_inputs/go_relative.dart
+++ b/packages/go_router_builder/test_inputs/go_relative.dart
@@ -4,10 +4,10 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$Route1 {}
-mixin _$Route2 {}
-mixin _$RelativeRoute {}
-mixin _$InnerRelativeRoute {}
+mixin $Route1 {}
+mixin $Route2 {}
+mixin $RelativeRoute {}
+mixin $InnerRelativeRoute {}
 
 const TypedRelativeGoRoute<RelativeRoute> relativeRoute =
     TypedRelativeGoRoute<RelativeRoute>(
@@ -21,7 +21,7 @@ const TypedRelativeGoRoute<RelativeRoute> relativeRoute =
   path: 'route-1',
   routes: <TypedRoute<RouteData>>[relativeRoute],
 )
-class Route1 extends GoRouteData with _$Route1 {
+class Route1 extends GoRouteData with $Route1 {
   const Route1();
 }
 
@@ -29,14 +29,14 @@ class Route1 extends GoRouteData with _$Route1 {
   path: 'route-2',
   routes: <TypedRoute<RouteData>>[relativeRoute],
 )
-class Route2 extends GoRouteData with _$Route2 {
+class Route2 extends GoRouteData with $Route2 {
   const Route2();
 }
 
-class RelativeRoute extends RelativeGoRouteData with _$RelativeRoute {
+class RelativeRoute extends RelativeGoRouteData with $RelativeRoute {
   const RelativeRoute();
 }
 
-class InnerRelativeRoute extends RelativeGoRouteData with _$InnerRelativeRoute {
+class InnerRelativeRoute extends RelativeGoRouteData with $InnerRelativeRoute {
   const InnerRelativeRoute();
 }

--- a/packages/go_router_builder/test_inputs/go_relative.dart.expect
+++ b/packages/go_router_builder/test_inputs/go_relative.dart.expect
@@ -1,21 +1,21 @@
 RouteBase get $route1 => GoRouteData.$route(
       path: 'route-1',
-      factory: _$Route1._fromState,
+      factory: $Route1._fromState,
       routes: [
         RelativeGoRouteData.$route(
           path: 'relative-route',
-          factory: _$RelativeRoute._fromState,
+          factory: $RelativeRoute._fromState,
           routes: [
             RelativeGoRouteData.$route(
               path: 'inner-relative-route',
-              factory: _$InnerRelativeRoute._fromState,
+              factory: $InnerRelativeRoute._fromState,
             ),
           ],
         ),
       ],
     );
 
-mixin _$Route1 on GoRouteData {
+mixin $Route1 on GoRouteData {
   static Route1 _fromState(GoRouterState state) => const Route1();
 
   @override
@@ -37,7 +37,7 @@ mixin _$Route1 on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-mixin _$RelativeRoute on RelativeGoRouteData {
+mixin $RelativeRoute on RelativeGoRouteData {
   static RelativeRoute _fromState(GoRouterState state) => const RelativeRoute();
 
   @override
@@ -64,7 +64,7 @@ mixin _$RelativeRoute on RelativeGoRouteData {
       context.replace(relativeLocation);
 }
 
-mixin _$InnerRelativeRoute on RelativeGoRouteData {
+mixin $InnerRelativeRoute on RelativeGoRouteData {
   static InnerRelativeRoute _fromState(GoRouterState state) =>
       const InnerRelativeRoute();
 
@@ -94,22 +94,22 @@ mixin _$InnerRelativeRoute on RelativeGoRouteData {
 
 RouteBase get $route2 => GoRouteData.$route(
       path: 'route-2',
-      factory: _$Route2._fromState,
+      factory: $Route2._fromState,
       routes: [
         RelativeGoRouteData.$route(
           path: 'relative-route',
-          factory: _$RelativeRoute._fromState,
+          factory: $RelativeRoute._fromState,
           routes: [
             RelativeGoRouteData.$route(
               path: 'inner-relative-route',
-              factory: _$InnerRelativeRoute._fromState,
+              factory: $InnerRelativeRoute._fromState,
             ),
           ],
         ),
       ],
     );
 
-mixin _$Route2 on GoRouteData {
+mixin $Route2 on GoRouteData {
   static Route2 _fromState(GoRouterState state) => const Route2();
 
   @override

--- a/packages/go_router_builder/test_inputs/iterable_with_default_value.dart
+++ b/packages/go_router_builder/test_inputs/iterable_with_default_value.dart
@@ -4,11 +4,11 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$IterableDefaultValueRoute {}
+mixin $IterableDefaultValueRoute {}
 
 @TypedGoRoute<IterableDefaultValueRoute>(path: '/iterable-default-value-route')
 class IterableDefaultValueRoute extends GoRouteData
-    with _$IterableDefaultValueRoute {
+    with $IterableDefaultValueRoute {
   IterableDefaultValueRoute({this.param = const <int>[0]});
   final Iterable<int> param;
 }

--- a/packages/go_router_builder/test_inputs/iterable_with_default_value.dart.expect
+++ b/packages/go_router_builder/test_inputs/iterable_with_default_value.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $iterableDefaultValueRoute => GoRouteData.$route(
       path: '/iterable-default-value-route',
-      factory: _$IterableDefaultValueRoute._fromState,
+      factory: $IterableDefaultValueRoute._fromState,
     );
 
-mixin _$IterableDefaultValueRoute on GoRouteData {
+mixin $IterableDefaultValueRoute on GoRouteData {
   static IterableDefaultValueRoute _fromState(GoRouterState state) =>
       IterableDefaultValueRoute(
         param:

--- a/packages/go_router_builder/test_inputs/iterable_with_enum.dart
+++ b/packages/go_router_builder/test_inputs/iterable_with_enum.dart
@@ -4,10 +4,10 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$IterableWithEnumRoute {}
+mixin $IterableWithEnumRoute {}
 
 @TypedGoRoute<IterableWithEnumRoute>(path: '/iterable-with-enum')
-class IterableWithEnumRoute extends GoRouteData with _$IterableWithEnumRoute {
+class IterableWithEnumRoute extends GoRouteData with $IterableWithEnumRoute {
   IterableWithEnumRoute({this.param});
 
   final Iterable<EnumOnlyUsedInIterable>? param;

--- a/packages/go_router_builder/test_inputs/iterable_with_enum.dart.expect
+++ b/packages/go_router_builder/test_inputs/iterable_with_enum.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $iterableWithEnumRoute => GoRouteData.$route(
       path: '/iterable-with-enum',
-      factory: _$IterableWithEnumRoute._fromState,
+      factory: $IterableWithEnumRoute._fromState,
     );
 
-mixin _$IterableWithEnumRoute on GoRouteData {
+mixin $IterableWithEnumRoute on GoRouteData {
   static IterableWithEnumRoute _fromState(GoRouterState state) =>
       IterableWithEnumRoute(
         param: state.uri.queryParametersAll['param']

--- a/packages/go_router_builder/test_inputs/list.dart
+++ b/packages/go_router_builder/test_inputs/list.dart
@@ -4,10 +4,10 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$ListRoute {}
+mixin $ListRoute {}
 
 @TypedGoRoute<ListRoute>(path: '/list-route')
-class ListRoute extends GoRouteData with _$ListRoute {
+class ListRoute extends GoRouteData with $ListRoute {
   ListRoute({
     required this.ids,
     this.nullableIds,

--- a/packages/go_router_builder/test_inputs/list.dart.expect
+++ b/packages/go_router_builder/test_inputs/list.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $listRoute => GoRouteData.$route(
       path: '/list-route',
-      factory: _$ListRoute._fromState,
+      factory: $ListRoute._fromState,
     );
 
-mixin _$ListRoute on GoRouteData {
+mixin $ListRoute on GoRouteData {
   static ListRoute _fromState(GoRouterState state) => ListRoute(
         ids: state.uri.queryParametersAll['ids']
                 ?.map(int.parse)

--- a/packages/go_router_builder/test_inputs/missing_type_annotation.dart
+++ b/packages/go_router_builder/test_inputs/missing_type_annotation.dart
@@ -4,7 +4,7 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$MissingTypeAnnotation {}
+mixin $MissingTypeAnnotation {}
 
 @TypedGoRoute(path: 'bob')
-class MissingTypeAnnotation extends GoRouteData with _$MissingTypeAnnotation {}
+class MissingTypeAnnotation extends GoRouteData with $MissingTypeAnnotation {}

--- a/packages/go_router_builder/test_inputs/named_escaped_route.dart
+++ b/packages/go_router_builder/test_inputs/named_escaped_route.dart
@@ -4,7 +4,7 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$NamedEscapedRoute {}
+mixin $NamedEscapedRoute {}
 
 @TypedGoRoute<NamedEscapedRoute>(path: '/named-route', name: r'named$Route')
-class NamedEscapedRoute extends GoRouteData with _$NamedEscapedRoute {}
+class NamedEscapedRoute extends GoRouteData with $NamedEscapedRoute {}

--- a/packages/go_router_builder/test_inputs/named_escaped_route.dart.expect
+++ b/packages/go_router_builder/test_inputs/named_escaped_route.dart.expect
@@ -1,10 +1,10 @@
 RouteBase get $namedEscapedRoute => GoRouteData.$route(
       path: '/named-route',
       name: r'named$Route',
-      factory: _$NamedEscapedRoute._fromState,
+      factory: $NamedEscapedRoute._fromState,
     );
 
-mixin _$NamedEscapedRoute on GoRouteData {
+mixin $NamedEscapedRoute on GoRouteData {
   static NamedEscapedRoute _fromState(GoRouterState state) =>
       NamedEscapedRoute();
 

--- a/packages/go_router_builder/test_inputs/named_route.dart
+++ b/packages/go_router_builder/test_inputs/named_route.dart
@@ -4,7 +4,7 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$NamedRoute {}
+mixin $NamedRoute {}
 
 @TypedGoRoute<NamedRoute>(path: '/named-route', name: 'namedRoute')
-class NamedRoute extends GoRouteData with _$NamedRoute {}
+class NamedRoute extends GoRouteData with $NamedRoute {}

--- a/packages/go_router_builder/test_inputs/named_route.dart.expect
+++ b/packages/go_router_builder/test_inputs/named_route.dart.expect
@@ -1,10 +1,10 @@
 RouteBase get $namedRoute => GoRouteData.$route(
       path: '/named-route',
       name: 'namedRoute',
-      factory: _$NamedRoute._fromState,
+      factory: $NamedRoute._fromState,
     );
 
-mixin _$NamedRoute on GoRouteData {
+mixin $NamedRoute on GoRouteData {
   static NamedRoute _fromState(GoRouterState state) => NamedRoute();
 
   @override

--- a/packages/go_router_builder/test_inputs/no_mixin.dart.expect
+++ b/packages/go_router_builder/test_inputs/no_mixin.dart.expect
@@ -1,1 +1,1 @@
-Missing mixin clause `with _$HomeRoute`
+Missing mixin clause `with $HomeRoute`

--- a/packages/go_router_builder/test_inputs/no_mixin_relative.dart.expect
+++ b/packages/go_router_builder/test_inputs/no_mixin_relative.dart.expect
@@ -1,1 +1,1 @@
-Missing mixin clause `with _$RelativeRoute`
+Missing mixin clause `with $RelativeRoute`

--- a/packages/go_router_builder/test_inputs/nullable_default_value.dart
+++ b/packages/go_router_builder/test_inputs/nullable_default_value.dart
@@ -4,11 +4,11 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$NullableDefaultValueRoute {}
+mixin $NullableDefaultValueRoute {}
 
 @TypedGoRoute<NullableDefaultValueRoute>(path: '/nullable-default-value-route')
 class NullableDefaultValueRoute extends GoRouteData
-    with _$NullableDefaultValueRoute {
+    with $NullableDefaultValueRoute {
   NullableDefaultValueRoute({this.param = 0});
   final int? param;
 }

--- a/packages/go_router_builder/test_inputs/parameter_generates_a_warning.dart
+++ b/packages/go_router_builder/test_inputs/parameter_generates_a_warning.dart
@@ -5,10 +5,10 @@
 import 'package:go_router/go_router.dart';
 
 @TypedGoRoute<MyRoute>(path: '/product/:id')
-class MyRoute extends GoRouteData with _$MyRoute {
+class MyRoute extends GoRouteData with $MyRoute {
   const MyRoute(this.id);
   final int id;
 }
 
 // avoid error when run analytic
-mixin _$MyRoute {}
+mixin $MyRoute {}

--- a/packages/go_router_builder/test_inputs/parameter_generates_a_warning.dart.expect
+++ b/packages/go_router_builder/test_inputs/parameter_generates_a_warning.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $myRoute => GoRouteData.$route(
       path: '/product/:id',
-      factory: _$MyRoute._fromState,
+      factory: $MyRoute._fromState,
     );
 
-mixin _$MyRoute on GoRouteData {
+mixin $MyRoute on GoRouteData {
   static MyRoute _fromState(GoRouterState state) => MyRoute(
         int.parse(state.pathParameters['id']!),
       );

--- a/packages/go_router_builder/test_inputs/relative_route_with_absolute_path.dart
+++ b/packages/go_router_builder/test_inputs/relative_route_with_absolute_path.dart
@@ -4,9 +4,9 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$RelativeRoute {}
+mixin $RelativeRoute {}
 
 @TypedRelativeGoRoute<RelativeRoute>(path: '/relative-route')
-class RelativeRoute extends RelativeGoRouteData with _$RelativeRoute {
+class RelativeRoute extends RelativeGoRouteData with $RelativeRoute {
   const RelativeRoute();
 }

--- a/packages/go_router_builder/test_inputs/relative_route_with_direct_absolute_sub_route.dart
+++ b/packages/go_router_builder/test_inputs/relative_route_with_direct_absolute_sub_route.dart
@@ -4,15 +4,15 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$HomeRoute {}
-mixin _$RelativeRoute {}
-mixin _$NonRelativeRoute {}
+mixin $HomeRoute {}
+mixin $RelativeRoute {}
+mixin $NonRelativeRoute {}
 
 @TypedGoRoute<HomeRoute>(
   path: '/',
   routes: <TypedRoute<RouteData>>[relativeRoute],
 )
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 }
 
@@ -24,10 +24,10 @@ const TypedRelativeGoRoute<RelativeRoute> relativeRoute =
       ],
     );
 
-class RelativeRoute extends RelativeGoRouteData with _$RelativeRoute {
+class RelativeRoute extends RelativeGoRouteData with $RelativeRoute {
   const RelativeRoute();
 }
 
-class NonRelativeRoute extends GoRouteData with _$NonRelativeRoute {
+class NonRelativeRoute extends GoRouteData with $NonRelativeRoute {
   const NonRelativeRoute();
 }

--- a/packages/go_router_builder/test_inputs/relative_route_with_indirect_absolute_sub_route.dart
+++ b/packages/go_router_builder/test_inputs/relative_route_with_indirect_absolute_sub_route.dart
@@ -4,16 +4,16 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$HomeRoute {}
-mixin _$ShellRoute {}
-mixin _$RelativeRoute {}
-mixin _$AbsoluteRoute {}
+mixin $HomeRoute {}
+mixin $ShellRoute {}
+mixin $RelativeRoute {}
+mixin $AbsoluteRoute {}
 
 @TypedGoRoute<HomeRoute>(
   path: '/',
   routes: <TypedRoute<RouteData>>[relativeRoute],
 )
-class HomeRoute extends GoRouteData with _$HomeRoute {
+class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute();
 }
 
@@ -31,14 +31,14 @@ const TypedGoRoute<AbsoluteRoute> absoluteRoute = TypedGoRoute<AbsoluteRoute>(
   path: 'absolute-route',
 );
 
-class RelativeRoute extends RelativeGoRouteData with _$RelativeRoute {
+class RelativeRoute extends RelativeGoRouteData with $RelativeRoute {
   const RelativeRoute();
 }
 
-class ShellRoute extends ShellRouteData with _$ShellRoute {
+class ShellRoute extends ShellRouteData with $ShellRoute {
   const ShellRoute();
 }
 
-class AbsoluteRoute extends GoRouteData with _$AbsoluteRoute {
+class AbsoluteRoute extends GoRouteData with $AbsoluteRoute {
   const AbsoluteRoute();
 }

--- a/packages/go_router_builder/test_inputs/required_extra_value.dart
+++ b/packages/go_router_builder/test_inputs/required_extra_value.dart
@@ -4,11 +4,11 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$RequiredExtraValueRoute {}
+mixin $RequiredExtraValueRoute {}
 
 @TypedGoRoute<RequiredExtraValueRoute>(path: '/default-value-route')
 class RequiredExtraValueRoute extends GoRouteData
-    with _$RequiredExtraValueRoute {
+    with $RequiredExtraValueRoute {
   RequiredExtraValueRoute({required this.$extra});
   final int $extra;
 }

--- a/packages/go_router_builder/test_inputs/required_extra_value.dart.expect
+++ b/packages/go_router_builder/test_inputs/required_extra_value.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $requiredExtraValueRoute => GoRouteData.$route(
       path: '/default-value-route',
-      factory: _$RequiredExtraValueRoute._fromState,
+      factory: $RequiredExtraValueRoute._fromState,
     );
 
-mixin _$RequiredExtraValueRoute on GoRouteData {
+mixin $RequiredExtraValueRoute on GoRouteData {
   static RequiredExtraValueRoute _fromState(GoRouterState state) =>
       RequiredExtraValueRoute(
         $extra: state.extra as int,

--- a/packages/go_router_builder/test_inputs/required_nullable_type_arguments_extra_value.dart
+++ b/packages/go_router_builder/test_inputs/required_nullable_type_arguments_extra_value.dart
@@ -4,13 +4,13 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$RequiredNullableTypeArgumentsExtraValueRoute {}
+mixin $RequiredNullableTypeArgumentsExtraValueRoute {}
 
 @TypedGoRoute<RequiredNullableTypeArgumentsExtraValueRoute>(
   path: '/default-value-route',
 )
 class RequiredNullableTypeArgumentsExtraValueRoute extends GoRouteData
-    with _$RequiredNullableTypeArgumentsExtraValueRoute {
+    with $RequiredNullableTypeArgumentsExtraValueRoute {
   RequiredNullableTypeArgumentsExtraValueRoute({required this.$extra});
   final List<int?> $extra;
 }

--- a/packages/go_router_builder/test_inputs/required_nullable_type_arguments_extra_value.dart.expect
+++ b/packages/go_router_builder/test_inputs/required_nullable_type_arguments_extra_value.dart.expect
@@ -1,10 +1,10 @@
 RouteBase get $requiredNullableTypeArgumentsExtraValueRoute =>
     GoRouteData.$route(
       path: '/default-value-route',
-      factory: _$RequiredNullableTypeArgumentsExtraValueRoute._fromState,
+      factory: $RequiredNullableTypeArgumentsExtraValueRoute._fromState,
     );
 
-mixin _$RequiredNullableTypeArgumentsExtraValueRoute on GoRouteData {
+mixin $RequiredNullableTypeArgumentsExtraValueRoute on GoRouteData {
   static RequiredNullableTypeArgumentsExtraValueRoute _fromState(
           GoRouterState state) =>
       RequiredNullableTypeArgumentsExtraValueRoute(

--- a/packages/go_router_builder/test_inputs/required_parameters_in_path_cannnot_be_null.dart
+++ b/packages/go_router_builder/test_inputs/required_parameters_in_path_cannnot_be_null.dart
@@ -4,11 +4,11 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$NullableRequiredParamInPath {}
+mixin $NullableRequiredParamInPath {}
 
 @TypedGoRoute<NullableRequiredParamInPath>(path: 'bob/:id')
 class NullableRequiredParamInPath extends GoRouteData
-    with _$NullableRequiredParamInPath {
+    with $NullableRequiredParamInPath {
   NullableRequiredParamInPath({required this.id});
   final int? id;
 }

--- a/packages/go_router_builder/test_inputs/required_parameters_not_in_path_can_be_null.dart
+++ b/packages/go_router_builder/test_inputs/required_parameters_not_in_path_can_be_null.dart
@@ -4,11 +4,11 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$NullableRequiredParamNotInPath {}
+mixin $NullableRequiredParamNotInPath {}
 
 @TypedGoRoute<NullableRequiredParamNotInPath>(path: 'bob')
 class NullableRequiredParamNotInPath extends GoRouteData
-    with _$NullableRequiredParamNotInPath {
+    with $NullableRequiredParamNotInPath {
   NullableRequiredParamNotInPath({required this.id});
   final int? id;
 }

--- a/packages/go_router_builder/test_inputs/required_parameters_not_in_path_can_be_null.dart.expect
+++ b/packages/go_router_builder/test_inputs/required_parameters_not_in_path_can_be_null.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $nullableRequiredParamNotInPath => GoRouteData.$route(
       path: 'bob',
-      factory: _$NullableRequiredParamNotInPath._fromState,
+      factory: $NullableRequiredParamNotInPath._fromState,
     );
 
-mixin _$NullableRequiredParamNotInPath on GoRouteData {
+mixin $NullableRequiredParamNotInPath on GoRouteData {
   static NullableRequiredParamNotInPath _fromState(GoRouterState state) =>
       NullableRequiredParamNotInPath(
         id: _$convertMapValue('id', state.uri.queryParameters, int.tryParse),

--- a/packages/go_router_builder/test_inputs/required_query_parameter.dart
+++ b/packages/go_router_builder/test_inputs/required_query_parameter.dart
@@ -4,11 +4,11 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$NonNullableRequiredParamNotInPath {}
+mixin $NonNullableRequiredParamNotInPath {}
 
 @TypedGoRoute<NonNullableRequiredParamNotInPath>(path: 'bob')
 class NonNullableRequiredParamNotInPath extends GoRouteData
-    with _$NonNullableRequiredParamNotInPath {
+    with $NonNullableRequiredParamNotInPath {
   NonNullableRequiredParamNotInPath({required this.id});
   final int id;
 }

--- a/packages/go_router_builder/test_inputs/required_query_parameter.dart.expect
+++ b/packages/go_router_builder/test_inputs/required_query_parameter.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $nonNullableRequiredParamNotInPath => GoRouteData.$route(
       path: 'bob',
-      factory: _$NonNullableRequiredParamNotInPath._fromState,
+      factory: $NonNullableRequiredParamNotInPath._fromState,
     );
 
-mixin _$NonNullableRequiredParamNotInPath on GoRouteData {
+mixin $NonNullableRequiredParamNotInPath on GoRouteData {
   static NonNullableRequiredParamNotInPath _fromState(GoRouterState state) =>
       NonNullableRequiredParamNotInPath(
         id: int.parse(state.uri.queryParameters['id']!),

--- a/packages/go_router_builder/test_inputs/set.dart
+++ b/packages/go_router_builder/test_inputs/set.dart
@@ -4,10 +4,10 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$SetRoute {}
+mixin $SetRoute {}
 
 @TypedGoRoute<SetRoute>(path: '/set-route')
-class SetRoute extends GoRouteData with _$SetRoute {
+class SetRoute extends GoRouteData with $SetRoute {
   SetRoute({
     required this.ids,
     this.nullableIds,

--- a/packages/go_router_builder/test_inputs/set.dart.expect
+++ b/packages/go_router_builder/test_inputs/set.dart.expect
@@ -1,9 +1,9 @@
 RouteBase get $setRoute => GoRouteData.$route(
       path: '/set-route',
-      factory: _$SetRoute._fromState,
+      factory: $SetRoute._fromState,
     );
 
-mixin _$SetRoute on GoRouteData {
+mixin $SetRoute on GoRouteData {
   static SetRoute _fromState(GoRouterState state) => SetRoute(
         ids: state.uri.queryParametersAll['ids']
                 ?.map(int.parse)

--- a/packages/go_router_builder/test_inputs/unsupported_type.dart
+++ b/packages/go_router_builder/test_inputs/unsupported_type.dart
@@ -4,10 +4,10 @@
 
 import 'package:go_router/go_router.dart';
 
-mixin _$UnsupportedType {}
+mixin $UnsupportedType {}
 
 @TypedGoRoute<UnsupportedType>(path: 'bob/:id')
-class UnsupportedType extends GoRouteData with _$UnsupportedType {
+class UnsupportedType extends GoRouteData with $UnsupportedType {
   UnsupportedType({required this.id});
   final Stopwatch id;
 }


### PR DESCRIPTION
Fixes [#170650](https://github.com/flutter/flutter/issues/170650)

This PR fixes workflows that relied on putting child routes in files different than parent files, which resulted in the (private) mixin being generated in a different file than the route itself.

To avoid releasing a new major version in such a short period, this PR makes the mixin public only if needed. Admittedly makes the behavior somewhat unexpected for the user. @chunhtai @hannah-hyj  I will leave that decision for you, whether that's ok or I should make it always public and release a major version instead.

Since this change just fixes a use-case that already didn't compile in 3.x.x, this PR doesn't bump the major version.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
