### PR TITLE
[google_sign_in] Add more serverClientId info to README

### DIFF
--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.0.3
+
+* Add more details and troubleshooting for `serverClientId` configuration
+  via Firebase.
+
 ## 7.0.2
 
 * Adds a README note about potentially confusing error returns from

--- a/packages/google_sign_in/google_sign_in_android/README.md
+++ b/packages/google_sign_in/google_sign_in_android/README.md
@@ -63,5 +63,5 @@ provided on Android" error message, check that:
     automatically when enabling Google Sign In using the Firebase console, but
     if not (or if it was later removed), add a web app to the project and then
     re-download `google-services.json`.
-  * You correctly added followed all of the Gradle configuration steps in the
-    Firebase integration documentation.
+  * You correctly followed all of the Gradle configuration steps in the Firebase
+    integration documentation.

--- a/packages/google_sign_in/google_sign_in_android/README.md
+++ b/packages/google_sign_in/google_sign_in_android/README.md
@@ -22,7 +22,8 @@ To use Google Sign-In, you'll need to register your application, either
 
 * If you are use the `google-services.json` file and Gradle-based registration
   system, no identifiers need to be provided in Dart when initializing the
-  `GoogleSignIn` instance when running on Android.
+  `GoogleSignIn` instance when running on Android, as long as your
+  `google-services.json` contains a web OAuth client entry.
 * If you are not using `google-services.json`, you need to pass the client
   ID of the *web* application you registered as the `serverClientId` when
   initializing the `GoogleSignIn` instance.
@@ -51,6 +52,16 @@ errors include:
 * Sign-in working in one build configuration but not another.
 
 Common sources of configuration errors include:
-* Missing or incorrect `serverClientId`.
 * Missing or incorrect signing SHA for one or more build configurations.
 * Incorrect Android package name on the server side.
+* Missing or incorrect `serverClientId`.
+
+If you are using `google-services.json` and recieve a "serverClientId must be
+provided on Android" error message, check that:
+  * Your `google-services.json` contains a web OAuth client, which should be an
+    `oauth_client` entry with `client_type: 3`. This should have been created
+    automatically when enabling Google Sign In using the Firebase console, but
+    if not (or if it was later removed), add a web app to the project and then
+    re-download `google-services.json`.
+  * You correctly added followed all of the Gradle configuration steps in the
+    Firebase integration documentation.

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_android
 description: Android implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 7.0.2
+version: 7.0.3
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
When I wrote the docs I thought that Firebase would always include a web OAuth client ID, but it appears that this is not always the case (e.g.,
https://stackoverflow.com/questions/55572583/google-services-json-missing-client-type-3) so this adds more docs about what is required for this to work correctly.

Also adds a note that a missing ID error could be due to incorrect gradle configuration, as that's not necessarily clear from the Firebase docs.

Fixes https://github.com/flutter/flutter/issues/172073

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.


[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
