### PR TITLE
[ci] Add Gemini Code Assist review config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,13 @@
+# Minimize verbosity.
+have_fun: false
+code_review:
+  # For now, use the default of MEDIUM for testing. Based on desired verbosity,
+  # we can change this to LOW or HIGH in the future.
+  comment_severity_threshold: MEDIUM
+  pull_request_opened:
+    # Explicitly set help to false in case the default changes in the future, as
+    # having a help message on every PR would be spammy.
+    help: false
+    # These tend to be verbose, and since we expect PR authors to clearly
+    # describe their PRs this would be at best duplicative.
+    summary: false

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,23 @@
+# Flutter Packages Style Guide
+
+## Introduction
+
+This style guide outlines the coding conventions for contributions to the
+flutter/packages repository.
+
+## Style Guides
+
+Code should follow the relevant style guides, and use the correct
+auto-formatter, for each language, as described in
+[the repository contributing guide's Style section](https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style).
+
+## Best Practices
+
+- Code should follow the guidance and principles described in
+  [the flutter/packages contribution guide](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md).
+- Code should be tested. Changes to plugin packages, which include code written
+  in C, C++, Java, Kotlin, Objective-C, or Swift, should have appropriate tests
+  as described in [the plugin test guidance](https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md).
+- PR descriptions should include the Pre-Review Checklist from
+  [the PR template](https://github.com/flutter/packages/blob/main/.github/PULL_REQUEST_TEMPLATE.md),
+  with all of the steps completed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,14 @@
 
 If you need help, consider asking for advice on the #hackers-new channel on [Discord].
 
+**Note**: The Flutter team is currently trialing the use of
+[Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code).
+Comments from the `gemini-code-assist` bot should not be taken as authoritative
+feedback from the Flutter team. If you find its comments useful you can
+update your code accordingly, but if you are unsure or disagree with the
+feedback, please feel free to wait for a Flutter team member's review for
+guidance on which automated comments should be addressed.
+
 [^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.
 
 <!-- Links -->


### PR DESCRIPTION
This adds initial configuration files for [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code) in preparation for turing it on for this repository on a trial basis. These config files are based on [the official
docs](https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github)

It also adds a note to the PR template to provide some notice/guidance to contributors about how to use automated feedback, to clarify the role of the automated reviews and hopefully minimize potential issues in case the bot leaves incorrect feedback.