### PR TITLE
[camera_avfoundation] Implementation swift migration - part 8

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.20+4
+
+* Migrates `setVideoFormat`,`stopVideoRecording`, and `stopImageStream` methods to Swift.
+* Migrates stopping accelerometer updates to Swift.
+
 ## 0.9.20+3
 
 * Migrates `setZoomLevel` and `setFlashMode` methods to Swift.

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Migrates `setVideoFormat`,`stopVideoRecording`, and `stopImageStream` methods to Swift.
 * Migrates stopping accelerometer updates to Swift.
+* Migrates `setDescriptionWhileRecording` method to Swift.
+* Adds `createConnection` method implementation to Swift.
 
 ## 0.9.20+3
 

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
@@ -148,11 +148,13 @@ final class DefaultCamera: FLTCam, Camera {
     // When `isRecording` is true `startWriting` was already called so `videoWriter.status`
     // is always either `.writing` or `.failed` and `finishWriting` does not throw exceptions so
     // there is no need to check `videoWriter.status`
-    videoWriter?.finishWriting {
-      if self.videoWriter?.status == .completed {
-        self.updateOrientation()
-        completion(self.videoRecordingPath, nil)
-        self.videoRecordingPath = nil
+    videoWriter?.finishWriting { [weak self] in
+      guard let strongSelf = self else { return }
+
+      if strongSelf.videoWriter?.status == .completed {
+        strongSelf.updateOrientation()
+        completion(strongSelf.videoRecordingPath, nil)
+        strongSelf.videoRecordingPath = nil
       } else {
         completion(
           nil,

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
@@ -13,7 +13,7 @@ final class DefaultCamera: FLTCam, Camera {
   override var videoFormat: FourCharCode {
     didSet {
       captureVideoOutput.videoSettings = [
-        kCVPixelBufferPixelFormatTypeKey as String: NSNumber(value: videoFormat)
+        kCVPixelBufferPixelFormatTypeKey as String: videoFormat
       ]
     }
   }
@@ -72,7 +72,7 @@ final class DefaultCamera: FLTCam, Camera {
     let captureVideoOutput = FLTDefaultCaptureVideoDataOutput(
       captureVideoOutput: AVCaptureVideoDataOutput())
     captureVideoOutput.videoSettings = [
-      kCVPixelBufferPixelFormatTypeKey as String: videoFormat as Any
+      kCVPixelBufferPixelFormatTypeKey as String: videoFormat
     ]
     captureVideoOutput.alwaysDiscardsLateVideoFrames = true
 

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
@@ -133,33 +133,34 @@ final class DefaultCamera: FLTCam, Camera {
   }
 
   func stopVideoRecording(completion: @escaping (String?, FlutterError?) -> Void) {
-    if isRecording {
-      isRecording = false
-
-      // When `isRecording` is true `startWriting` was already called so `videoWriter.status`
-      // is always either `.writing` or `.failed` and `finishWriting` does not throw exceptions so
-      // there is no need to check `videoWriter.status`
-      videoWriter?.finishWriting {
-        if self.videoWriter?.status == .completed {
-          self.updateOrientation()
-          completion(self.videoRecordingPath, nil)
-          self.videoRecordingPath = nil
-        } else {
-          completion(
-            nil,
-            FlutterError(
-              code: "IOError",
-              message: "AVAssetWriter could not finish writing!",
-              details: nil))
-        }
-      }
-    } else {
+    guard isRecording else {
       let error = NSError(
         domain: NSCocoaErrorDomain,
         code: URLError.resourceUnavailable.rawValue,
         userInfo: [NSLocalizedDescriptionKey: "Video is not recording!"]
       )
       completion(nil, DefaultCamera.flutterErrorFromNSError(error))
+      return
+    }
+
+    isRecording = false
+
+    // When `isRecording` is true `startWriting` was already called so `videoWriter.status`
+    // is always either `.writing` or `.failed` and `finishWriting` does not throw exceptions so
+    // there is no need to check `videoWriter.status`
+    videoWriter?.finishWriting {
+      if self.videoWriter?.status == .completed {
+        self.updateOrientation()
+        completion(self.videoRecordingPath, nil)
+        self.videoRecordingPath = nil
+      } else {
+        completion(
+          nil,
+          FlutterError(
+            code: "IOError",
+            message: "AVAssetWriter could not finish writing!",
+            details: nil))
+      }
     }
   }
 

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
@@ -5,6 +5,7 @@
 @import AVFoundation;
 @import Foundation;
 @import Flutter;
+@import CoreMotion;
 
 #import "CameraProperties.h"
 #import "FLTCamConfiguration.h"
@@ -51,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(assign, nonatomic) UIDeviceOrientation lockedCaptureOrientation;
 @property(assign, nonatomic) UIDeviceOrientation deviceOrientation;
 @property(assign, nonatomic) FCPPlatformFlashMode flashMode;
+@property(nonatomic) CMMotionManager *motionManager;
+@property(strong, nonatomic, nullable) NSString *videoRecordingPath;
 
 /// Initializes an `FLTCam` instance with the given configuration.
 /// @param error report to the caller if any error happened creating the camera.
@@ -65,15 +68,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param messenger Nullable messenger for capturing each frame.
 - (void)startVideoRecordingWithCompletion:(void (^)(FlutterError *_Nullable))completion
                     messengerForStreaming:(nullable NSObject<FlutterBinaryMessenger> *)messenger;
-- (void)stopVideoRecordingWithCompletion:(void (^)(NSString *_Nullable,
-                                                   FlutterError *_Nullable))completion;
 
 - (void)setDescriptionWhileRecording:(NSString *)cameraName
                       withCompletion:(void (^)(FlutterError *_Nullable))completion;
 
 - (void)startImageStreamWithMessenger:(NSObject<FlutterBinaryMessenger> *)messenger
                            completion:(nonnull void (^)(FlutterError *_Nullable))completion;
-- (void)stopImageStream;
 - (void)setUpCaptureSessionForAudioIfNeeded;
 
 // Methods exposed for the Swift DefaultCamera subclass

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
@@ -20,7 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// A class that manages camera's state and performs camera operations.
 @interface FLTCam : NSObject
 
-@property(readonly, nonatomic) NSObject<FLTCaptureDevice> *captureDevice;
+// captureDevice is assignable for the Swift DefaultCamera subclass
+@property(strong, nonatomic) NSObject<FLTCaptureDevice> *captureDevice;
 @property(readonly, nonatomic) CGSize previewSize;
 @property(assign, nonatomic) BOOL isPreviewPaused;
 @property(nonatomic, copy, nullable) void (^onFrameAvailable)(void);
@@ -54,6 +55,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(assign, nonatomic) FCPPlatformFlashMode flashMode;
 @property(nonatomic) CMMotionManager *motionManager;
 @property(strong, nonatomic, nullable) NSString *videoRecordingPath;
+@property(nonatomic, copy) CaptureDeviceFactory captureDeviceFactory;
+@property(strong, nonatomic) NSObject<FLTCaptureInput> *captureVideoInput;
+@property(readonly, nonatomic) NSObject<FLTCaptureDeviceInputFactory> *captureDeviceInputFactory;
+/// All FLTCam's state access and capture session related operations should be on run on this queue.
+@property(strong, nonatomic) dispatch_queue_t captureSessionQueue;
 
 /// Initializes an `FLTCam` instance with the given configuration.
 /// @param error report to the caller if any error happened creating the camera.
@@ -68,9 +74,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param messenger Nullable messenger for capturing each frame.
 - (void)startVideoRecordingWithCompletion:(void (^)(FlutterError *_Nullable))completion
                     messengerForStreaming:(nullable NSObject<FlutterBinaryMessenger> *)messenger;
-
-- (void)setDescriptionWhileRecording:(NSString *)cameraName
-                      withCompletion:(void (^)(FlutterError *_Nullable))completion;
 
 - (void)startImageStreamWithMessenger:(NSObject<FlutterBinaryMessenger> *)messenger
                            completion:(nonnull void (^)(FlutterError *_Nullable))completion;

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.20+3
+version: 0.9.20+4
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Migrates camera implementation as part of https://github.com/flutter/flutter/issues/119109

This PR migrates the 5th chunk of `FLTCam` class to Swift:
* `setVideoFormat`
* `stopVideoRecording`
* `stopImageStream`
* stopping accelerometer updates (`deinit`)
* `setDescriptionWhileRecording`
* `createConnection` (adds Swift implementation, FLTCam still depends on private non-static implementation)

NOTE:  `setDescriptionWhileRecording` is migrated close to verbatim, the [issue](https://github.com/flutter/flutter/issues/168134) affecting it remains.

Some properties of the `FLTCam` have to be temporarily made public so that they are accessible in `DefaultCamera`.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
