### PR TITLE
Have Gemini ignore Flutter version pin

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -11,3 +11,6 @@ code_review:
     # These tend to be verbose, and since we expect PR authors to clearly
     # describe their PRs this would be at best duplicative.
     summary: false
+ignore_patterns:
+  - .ci/flutter_master.version
+  - .ci/flutter_stable.version


### PR DESCRIPTION
Set an initial ignore list for Gemini reviews that includes the two Flutter version pins. This is an experiment to see if having a PR that contains only ignored files will be ignored by Gemini, so that we don't end up with [this comment](https://github.com/flutter/packages/pull/9646#pullrequestreview-3033902418) on every roll.