### PR TITLE
[google_sign_in] Update to GoogleSignIn-iOS 9

### DIFF
--- a/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.1.0
+
+* Updates to `GoogleSignIn` 9.0.
+* Adds support for the `nonce` parameter.
+
 ## 6.0.1
 
 * Returns configuration errors as `PlatformException`s in Dart instead of

--- a/packages/google_sign_in/google_sign_in_ios/darwin/Tests/GoogleSignInTests.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/Tests/GoogleSignInTests.m
@@ -291,6 +291,7 @@
                                                                          serverClientId:nil
                                                                            hostedDomain:nil]
                                  error:&initializationError];
+  XCTAssertNil(initializationError);
 
   id mockUser = OCMClassMock([GIDGoogleUser class]);
   OCMStub([mockUser userID]).andReturn(@"mockID");
@@ -326,6 +327,7 @@
                                                                          serverClientId:nil
                                                                            hostedDomain:nil]
                                  error:&initializationError];
+  XCTAssertNil(initializationError);
 
   id mockUser = OCMClassMock([GIDGoogleUser class]);
   OCMStub([mockUser userID]).andReturn(@"mockID");

--- a/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios.podspec
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios.podspec
@@ -16,11 +16,10 @@ Enables Google Sign-In in Flutter apps.
   s.public_header_files = 'google_sign_in_ios/Sources/google_sign_in_ios/include/**/*.h'
   s.module_map = 'google_sign_in_ios/Sources/google_sign_in_ios/include/FLTGoogleSignInPlugin.modulemap'
 
-  # AppAuth and GTMSessionFetcher are GoogleSignIn transitive dependencies.
-  # Depend on versions which defines modules.
-  s.dependency 'AppAuth', '>= 1.7.4'
+  # GTMSessionFetcher is a GoogleSignIn transitive dependency, added here as a
+  # direct dependency to ensure a version which defines modules.
   s.dependency 'GTMSessionFetcher', '>= 3.4.0'
-  s.dependency 'GoogleSignIn', '~> 8.0'
+  s.dependency 'GoogleSignIn', '~> 9.0'
   s.static_framework = true
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'

--- a/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Package.swift
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/google/GoogleSignIn-iOS.git",
-      from: "8.0.0")
+      from: "9.0.0")
   ],
   targets: [
     .target(

--- a/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios/FLTGoogleSignInPlugin.m
@@ -276,18 +276,17 @@ static FSIGoogleSignInErrorCode FSIPigeonErrorCodeForGIDSignInErrorCode(NSIntege
                  nonce:(nullable NSString *)nonce
             completion:(void (^)(GIDSignInResult *_Nullable signInResult,
                                  NSError *_Nullable error))completion {
-  // TODO(stuartmorgan): Add the nonce parameter to the calls below once it's available; it was
-  // added after 8.0, and based on https://github.com/google/GoogleSignIn-iOS/releases appears to
-  // be slated for an 8.1 release. See https://github.com/flutter/flutter/issues/85439.
 #if TARGET_OS_OSX
   [self.signIn signInWithPresentingWindow:self.registrar.view.window
                                      hint:hint
                          additionalScopes:additionalScopes
+                                    nonce:nonce
                                completion:completion];
 #else
   [self.signIn signInWithPresentingViewController:[self topViewController]
                                              hint:hint
                                  additionalScopes:additionalScopes
+                                            nonce:nonce
                                        completion:completion];
 #endif
 }

--- a/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_ios
 description: iOS implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 6.0.1
+version: 6.1.0
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Updates the dependency on the GoogleSignIn iOS SDK to the recently released 9.0. Some specific benefits include:
- Allows wiring up the nonce parameter on iOS, which was plumbed most of the way through already since the PR had landed upstream when nonce was added to `google_sign_in`, but not fully connected since it wasn't released.
- Avoids transitive dependency conflicts with plugins that use AppAuth 2.x.

Fixes https://github.com/flutter/flutter/issues/172453 Finishes https://github.com/flutter/flutter/issues/85439 for iOS

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
