### PR TITLE
[video_player] Move more Java logic to Dart

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.10
+
+* Restructures internal logic to move more code to Dart.
+
 ## 2.8.9
 
 * Restructures the communication between Dart and Java code.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/HttpVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/HttpVideoAsset.java
@@ -20,19 +20,19 @@ import androidx.media3.exoplayer.source.MediaSource;
 import java.util.Map;
 
 final class HttpVideoAsset extends VideoAsset {
-  private static final String DEFAULT_USER_AGENT = "ExoPlayer";
-  private static final String HEADER_USER_AGENT = "User-Agent";
-
   @NonNull private final StreamingFormat streamingFormat;
   @NonNull private final Map<String, String> httpHeaders;
+  @Nullable private final String userAgent;
 
   HttpVideoAsset(
       @Nullable String assetUrl,
       @NonNull StreamingFormat streamingFormat,
-      @NonNull Map<String, String> httpHeaders) {
+      @NonNull Map<String, String> httpHeaders,
+      @Nullable String userAgent) {
     super(assetUrl);
     this.streamingFormat = streamingFormat;
     this.httpHeaders = httpHeaders;
+    this.userAgent = userAgent;
   }
 
   @NonNull
@@ -75,10 +75,6 @@ final class HttpVideoAsset extends VideoAsset {
   @VisibleForTesting
   MediaSource.Factory getMediaSourceFactory(
       Context context, DefaultHttpDataSource.Factory initialFactory) {
-    String userAgent = DEFAULT_USER_AGENT;
-    if (!httpHeaders.isEmpty() && httpHeaders.containsKey(HEADER_USER_AGENT)) {
-      userAgent = httpHeaders.get(HEADER_USER_AGENT);
-    }
     unstableUpdateDataSourceFactory(initialFactory, httpHeaders, userAgent);
     DataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, initialFactory);
     return new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSourceFactory);

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -77,6 +77,19 @@ public class Messages {
     }
   }
 
+  /** Pigeon equivalent of video_platform_interface's VideoFormat. */
+  public enum PlatformVideoFormat {
+    DASH(0),
+    HLS(1),
+    SS(2);
+
+    final int index;
+
+    PlatformVideoFormat(final int index) {
+      this.index = index;
+    }
+  }
+
   /**
    * Information passed to the platform view creation.
    *
@@ -181,13 +194,13 @@ public class Messages {
       this.packageName = setterArg;
     }
 
-    private @Nullable String formatHint;
+    private @Nullable PlatformVideoFormat formatHint;
 
-    public @Nullable String getFormatHint() {
+    public @Nullable PlatformVideoFormat getFormatHint() {
       return formatHint;
     }
 
-    public void setFormatHint(@Nullable String setterArg) {
+    public void setFormatHint(@Nullable PlatformVideoFormat setterArg) {
       this.formatHint = setterArg;
     }
 
@@ -265,10 +278,10 @@ public class Messages {
         return this;
       }
 
-      private @Nullable String formatHint;
+      private @Nullable PlatformVideoFormat formatHint;
 
       @CanIgnoreReturnValue
-      public @NonNull Builder setFormatHint(@Nullable String setterArg) {
+      public @NonNull Builder setFormatHint(@Nullable PlatformVideoFormat setterArg) {
         this.formatHint = setterArg;
         return this;
       }
@@ -322,7 +335,7 @@ public class Messages {
       Object packageName = pigeonVar_list.get(2);
       pigeonResult.setPackageName((String) packageName);
       Object formatHint = pigeonVar_list.get(3);
-      pigeonResult.setFormatHint((String) formatHint);
+      pigeonResult.setFormatHint((PlatformVideoFormat) formatHint);
       Object httpHeaders = pigeonVar_list.get(4);
       pigeonResult.setHttpHeaders((Map<String, String>) httpHeaders);
       Object viewType = pigeonVar_list.get(5);
@@ -345,8 +358,13 @@ public class Messages {
             return value == null ? null : PlatformVideoViewType.values()[((Long) value).intValue()];
           }
         case (byte) 130:
-          return PlatformVideoViewCreationParams.fromList((ArrayList<Object>) readValue(buffer));
+          {
+            Object value = readValue(buffer);
+            return value == null ? null : PlatformVideoFormat.values()[((Long) value).intValue()];
+          }
         case (byte) 131:
+          return PlatformVideoViewCreationParams.fromList((ArrayList<Object>) readValue(buffer));
+        case (byte) 132:
           return CreateMessage.fromList((ArrayList<Object>) readValue(buffer));
         default:
           return super.readValueOfType(type, buffer);
@@ -358,11 +376,14 @@ public class Messages {
       if (value instanceof PlatformVideoViewType) {
         stream.write(129);
         writeValue(stream, value == null ? null : ((PlatformVideoViewType) value).index);
-      } else if (value instanceof PlatformVideoViewCreationParams) {
+      } else if (value instanceof PlatformVideoFormat) {
         stream.write(130);
+        writeValue(stream, value == null ? null : ((PlatformVideoFormat) value).index);
+      } else if (value instanceof PlatformVideoViewCreationParams) {
+        stream.write(131);
         writeValue(stream, ((PlatformVideoViewCreationParams) value).toList());
       } else if (value instanceof CreateMessage) {
-        stream.write(131);
+        stream.write(132);
         writeValue(stream, ((CreateMessage) value).toList());
       } else {
         super.writeValue(stream, value);

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -164,34 +164,17 @@ public class Messages {
 
   /** Generated class from Pigeon that represents data sent in messages. */
   public static final class CreateMessage {
-    private @Nullable String asset;
+    private @NonNull String uri;
 
-    public @Nullable String getAsset() {
-      return asset;
-    }
-
-    public void setAsset(@Nullable String setterArg) {
-      this.asset = setterArg;
-    }
-
-    private @Nullable String uri;
-
-    public @Nullable String getUri() {
+    public @NonNull String getUri() {
       return uri;
     }
 
-    public void setUri(@Nullable String setterArg) {
+    public void setUri(@NonNull String setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"uri\" is null.");
+      }
       this.uri = setterArg;
-    }
-
-    private @Nullable String packageName;
-
-    public @Nullable String getPackageName() {
-      return packageName;
-    }
-
-    public void setPackageName(@Nullable String setterArg) {
-      this.packageName = setterArg;
     }
 
     private @Nullable PlatformVideoFormat formatHint;
@@ -239,9 +222,7 @@ public class Messages {
         return false;
       }
       CreateMessage that = (CreateMessage) o;
-      return Objects.equals(asset, that.asset)
-          && Objects.equals(uri, that.uri)
-          && Objects.equals(packageName, that.packageName)
+      return uri.equals(that.uri)
           && Objects.equals(formatHint, that.formatHint)
           && httpHeaders.equals(that.httpHeaders)
           && Objects.equals(viewType, that.viewType);
@@ -249,32 +230,16 @@ public class Messages {
 
     @Override
     public int hashCode() {
-      return Objects.hash(asset, uri, packageName, formatHint, httpHeaders, viewType);
+      return Objects.hash(uri, formatHint, httpHeaders, viewType);
     }
 
     public static final class Builder {
 
-      private @Nullable String asset;
-
-      @CanIgnoreReturnValue
-      public @NonNull Builder setAsset(@Nullable String setterArg) {
-        this.asset = setterArg;
-        return this;
-      }
-
       private @Nullable String uri;
 
       @CanIgnoreReturnValue
-      public @NonNull Builder setUri(@Nullable String setterArg) {
+      public @NonNull Builder setUri(@NonNull String setterArg) {
         this.uri = setterArg;
-        return this;
-      }
-
-      private @Nullable String packageName;
-
-      @CanIgnoreReturnValue
-      public @NonNull Builder setPackageName(@Nullable String setterArg) {
-        this.packageName = setterArg;
         return this;
       }
 
@@ -304,9 +269,7 @@ public class Messages {
 
       public @NonNull CreateMessage build() {
         CreateMessage pigeonReturn = new CreateMessage();
-        pigeonReturn.setAsset(asset);
         pigeonReturn.setUri(uri);
-        pigeonReturn.setPackageName(packageName);
         pigeonReturn.setFormatHint(formatHint);
         pigeonReturn.setHttpHeaders(httpHeaders);
         pigeonReturn.setViewType(viewType);
@@ -316,10 +279,8 @@ public class Messages {
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<>(6);
-      toListResult.add(asset);
+      ArrayList<Object> toListResult = new ArrayList<>(4);
       toListResult.add(uri);
-      toListResult.add(packageName);
       toListResult.add(formatHint);
       toListResult.add(httpHeaders);
       toListResult.add(viewType);
@@ -328,17 +289,13 @@ public class Messages {
 
     static @NonNull CreateMessage fromList(@NonNull ArrayList<Object> pigeonVar_list) {
       CreateMessage pigeonResult = new CreateMessage();
-      Object asset = pigeonVar_list.get(0);
-      pigeonResult.setAsset((String) asset);
-      Object uri = pigeonVar_list.get(1);
+      Object uri = pigeonVar_list.get(0);
       pigeonResult.setUri((String) uri);
-      Object packageName = pigeonVar_list.get(2);
-      pigeonResult.setPackageName((String) packageName);
-      Object formatHint = pigeonVar_list.get(3);
+      Object formatHint = pigeonVar_list.get(1);
       pigeonResult.setFormatHint((PlatformVideoFormat) formatHint);
-      Object httpHeaders = pigeonVar_list.get(4);
+      Object httpHeaders = pigeonVar_list.get(2);
       pigeonResult.setHttpHeaders((Map<String, String>) httpHeaders);
-      Object viewType = pigeonVar_list.get(5);
+      Object viewType = pigeonVar_list.get(3);
       pigeonResult.setViewType((PlatformVideoViewType) viewType);
       return pigeonResult;
     }
@@ -402,6 +359,9 @@ public class Messages {
     void dispose(@NonNull Long playerId);
 
     void setMixWithOthers(@NonNull Boolean mixWithOthers);
+
+    @NonNull
+    String getLookupKeyForAsset(@NonNull String asset, @Nullable String packageName);
 
     /** The codec used by AndroidVideoPlayerApi. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -510,6 +470,32 @@ public class Messages {
                 try {
                   api.setMixWithOthers(mixWithOthersArg);
                   wrapped.add(0, null);
+                } catch (Throwable exception) {
+                  wrapped = wrapError(exception);
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger,
+                "dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.getLookupKeyForAsset"
+                    + messageChannelSuffix,
+                getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String assetArg = (String) args.get(0);
+                String packageNameArg = (String) args.get(1);
+                try {
+                  String output = api.getLookupKeyForAsset(assetArg, packageNameArg);
+                  wrapped.add(0, output);
                 } catch (Throwable exception) {
                   wrapped = wrapError(exception);
                 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -200,6 +200,16 @@ public class Messages {
       this.httpHeaders = setterArg;
     }
 
+    private @Nullable String userAgent;
+
+    public @Nullable String getUserAgent() {
+      return userAgent;
+    }
+
+    public void setUserAgent(@Nullable String setterArg) {
+      this.userAgent = setterArg;
+    }
+
     private @Nullable PlatformVideoViewType viewType;
 
     public @Nullable PlatformVideoViewType getViewType() {
@@ -225,12 +235,13 @@ public class Messages {
       return uri.equals(that.uri)
           && Objects.equals(formatHint, that.formatHint)
           && httpHeaders.equals(that.httpHeaders)
+          && Objects.equals(userAgent, that.userAgent)
           && Objects.equals(viewType, that.viewType);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(uri, formatHint, httpHeaders, viewType);
+      return Objects.hash(uri, formatHint, httpHeaders, userAgent, viewType);
     }
 
     public static final class Builder {
@@ -259,6 +270,14 @@ public class Messages {
         return this;
       }
 
+      private @Nullable String userAgent;
+
+      @CanIgnoreReturnValue
+      public @NonNull Builder setUserAgent(@Nullable String setterArg) {
+        this.userAgent = setterArg;
+        return this;
+      }
+
       private @Nullable PlatformVideoViewType viewType;
 
       @CanIgnoreReturnValue
@@ -272,6 +291,7 @@ public class Messages {
         pigeonReturn.setUri(uri);
         pigeonReturn.setFormatHint(formatHint);
         pigeonReturn.setHttpHeaders(httpHeaders);
+        pigeonReturn.setUserAgent(userAgent);
         pigeonReturn.setViewType(viewType);
         return pigeonReturn;
       }
@@ -279,10 +299,11 @@ public class Messages {
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<>(4);
+      ArrayList<Object> toListResult = new ArrayList<>(5);
       toListResult.add(uri);
       toListResult.add(formatHint);
       toListResult.add(httpHeaders);
+      toListResult.add(userAgent);
       toListResult.add(viewType);
       return toListResult;
     }
@@ -295,7 +316,9 @@ public class Messages {
       pigeonResult.setFormatHint((PlatformVideoFormat) formatHint);
       Object httpHeaders = pigeonVar_list.get(2);
       pigeonResult.setHttpHeaders((Map<String, String>) httpHeaders);
-      Object viewType = pigeonVar_list.get(3);
+      Object userAgent = pigeonVar_list.get(3);
+      pigeonResult.setUserAgent((String) userAgent);
+      Object viewType = pigeonVar_list.get(4);
       pigeonResult.setViewType((PlatformVideoViewType) viewType);
       return pigeonResult;
     }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/RtspVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/RtspVideoAsset.java
@@ -26,7 +26,8 @@ final class RtspVideoAsset extends VideoAsset {
   // TODO: Migrate to stable API, see https://github.com/flutter/flutter/issues/147039.
   @OptIn(markerClass = UnstableApi.class)
   @Override
-  public MediaSource.Factory getMediaSourceFactory(Context context) {
+  @NonNull
+  public MediaSource.Factory getMediaSourceFactory(@NonNull Context context) {
     return new RtspMediaSource.Factory();
   }
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
@@ -40,8 +40,9 @@ public abstract class VideoAsset {
   static VideoAsset fromRemoteUrl(
       @Nullable String remoteUrl,
       @NonNull StreamingFormat streamingFormat,
-      @NonNull Map<String, String> httpHeaders) {
-    return new HttpVideoAsset(remoteUrl, streamingFormat, new HashMap<>(httpHeaders));
+      @NonNull Map<String, String> httpHeaders,
+      @Nullable String userAgent) {
+    return new HttpVideoAsset(remoteUrl, streamingFormat, new HashMap<>(httpHeaders), userAgent);
   }
 
   /**

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacks.java
@@ -8,10 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.plugin.common.EventChannel;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 final class VideoPlayerEventCallbacks implements VideoPlayerCallbacks {
@@ -66,12 +63,9 @@ final class VideoPlayerEventCallbacks implements VideoPlayerCallbacks {
 
   @Override
   public void onBufferingUpdate(long bufferedPosition) {
-    // iOS supports a list of buffered ranges, so we send as a list with a single range.
     Map<String, Object> event = new HashMap<>();
     event.put("event", "bufferingUpdate");
-
-    List<? extends Number> range = Arrays.asList(0, bufferedPosition);
-    event.put("values", Collections.singletonList(range));
+    event.put("position", bufferedPosition);
     eventSink.success(event);
   }
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -113,7 +113,8 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
             break;
         }
       }
-      videoAsset = VideoAsset.fromRemoteUrl(uri, streamingFormat, arg.getHttpHeaders());
+      videoAsset =
+          VideoAsset.fromRemoteUrl(uri, streamingFormat, arg.getHttpHeaders(), arg.getUserAgent());
     }
 
     long id;

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -14,6 +14,7 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugins.videoplayer.Messages.AndroidVideoPlayerApi;
 import io.flutter.plugins.videoplayer.Messages.CreateMessage;
+import io.flutter.plugins.videoplayer.Messages.PlatformVideoFormat;
 import io.flutter.plugins.videoplayer.Messages.VideoPlayerInstanceApi;
 import io.flutter.plugins.videoplayer.platformview.PlatformVideoViewFactory;
 import io.flutter.plugins.videoplayer.platformview.PlatformViewVideoPlayer;
@@ -103,16 +104,16 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
       videoAsset = VideoAsset.fromRtspUrl(arg.getUri());
     } else {
       VideoAsset.StreamingFormat streamingFormat = VideoAsset.StreamingFormat.UNKNOWN;
-      String formatHint = arg.getFormatHint();
+      PlatformVideoFormat formatHint = arg.getFormatHint();
       if (formatHint != null) {
         switch (formatHint) {
-          case "ss":
+          case SS:
             streamingFormat = VideoAsset.StreamingFormat.SMOOTH;
             break;
-          case "dash":
+          case DASH:
             streamingFormat = VideoAsset.StreamingFormat.DYNAMIC_ADAPTIVE;
             break;
-          case "hls":
+          case HLS:
             streamingFormat = VideoAsset.StreamingFormat.HTTP_LIVE;
             break;
         }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoAssetTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoAssetTest.java
@@ -6,9 +6,9 @@ package io.flutter.plugins.videoplayer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -55,17 +55,21 @@ public final class VideoAssetTest {
 
   private static DefaultHttpDataSource.Factory mockHttpFactory() {
     DefaultHttpDataSource.Factory httpFactory = mock(DefaultHttpDataSource.Factory.class);
-    when(httpFactory.setUserAgent(anyString())).thenReturn(httpFactory);
+    when(httpFactory.setUserAgent(any())).thenReturn(httpFactory);
     when(httpFactory.setAllowCrossProtocolRedirects(anyBoolean())).thenReturn(httpFactory);
     when(httpFactory.setDefaultRequestProperties(anyMap())).thenReturn(httpFactory);
     return httpFactory;
   }
 
   @Test
-  public void remoteVideoByDefaultSetsUserAgentAndCrossProtocolRedirects() {
+  public void remoteVideoSetsUserAgentAndCrossProtocolRedirects() {
+    final String userAgent = "A User Agent";
     VideoAsset asset =
         VideoAsset.fromRemoteUrl(
-            "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.UNKNOWN, new HashMap<>());
+            "https://flutter.dev/video.mp4",
+            VideoAsset.StreamingFormat.UNKNOWN,
+            new HashMap<>(),
+            userAgent);
 
     DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
 
@@ -73,29 +77,9 @@ public final class VideoAssetTest {
     ((HttpVideoAsset) asset)
         .getMediaSourceFactory(ApplicationProvider.getApplicationContext(), mockFactory);
 
-    verify(mockFactory).setUserAgent("ExoPlayer");
+    verify(mockFactory).setUserAgent(userAgent);
     verify(mockFactory).setAllowCrossProtocolRedirects(true);
     verify(mockFactory, never()).setDefaultRequestProperties(anyMap());
-  }
-
-  @Test
-  public void remoteVideoOverridesUserAgentIfProvided() {
-    Map<String, String> headers = new HashMap<>();
-    headers.put("User-Agent", "FantasticalVideoBot");
-
-    VideoAsset asset =
-        VideoAsset.fromRemoteUrl(
-            "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.UNKNOWN, headers);
-
-    DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
-
-    // Cast to HttpVideoAsset to call a testing-only method to intercept calls.
-    ((HttpVideoAsset) asset)
-        .getMediaSourceFactory(ApplicationProvider.getApplicationContext(), mockFactory);
-
-    verify(mockFactory).setUserAgent("FantasticalVideoBot");
-    verify(mockFactory).setAllowCrossProtocolRedirects(true);
-    verify(mockFactory).setDefaultRequestProperties(headers);
   }
 
   // This tests that without using the overrides we get a working, non-mocked object.
@@ -105,7 +89,10 @@ public final class VideoAssetTest {
   public void remoteVideoGetMediaSourceFactoryInProductionReturnsRealMediaSource() {
     VideoAsset asset =
         VideoAsset.fromRemoteUrl(
-            "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.UNKNOWN, new HashMap<>());
+            "https://flutter.dev/video.mp4",
+            VideoAsset.StreamingFormat.UNKNOWN,
+            new HashMap<>(),
+            null);
 
     MediaSource source =
         asset
@@ -123,7 +110,7 @@ public final class VideoAssetTest {
 
     VideoAsset asset =
         VideoAsset.fromRemoteUrl(
-            "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.UNKNOWN, headers);
+            "https://flutter.dev/video.mp4", VideoAsset.StreamingFormat.UNKNOWN, headers, null);
 
     DefaultHttpDataSource.Factory mockFactory = mockHttpFactory();
 
@@ -131,7 +118,6 @@ public final class VideoAssetTest {
     ((HttpVideoAsset) asset)
         .getMediaSourceFactory(ApplicationProvider.getApplicationContext(), mockFactory);
 
-    verify(mockFactory).setUserAgent("ExoPlayer");
     verify(mockFactory).setAllowCrossProtocolRedirects(true);
     verify(mockFactory).setDefaultRequestProperties(headers);
   }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacksTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerEventCallbacksTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -93,7 +91,7 @@ public final class VideoPlayerEventCallbacksTest {
   }
 
   @Test
-  public void onBufferingUpdateProvidesAListWithASingleRange() {
+  public void onBufferingUpdateProvidesPosition() {
     eventCallbacks.onBufferingUpdate(10L);
 
     verify(mockEventSink).success(eventCaptor.capture());
@@ -101,7 +99,7 @@ public final class VideoPlayerEventCallbacksTest {
     Map<String, Object> actual = eventCaptor.getValue();
     Map<String, Object> expected = new HashMap<>();
     expected.put("event", "bufferingUpdate");
-    expected.put("values", Collections.singletonList(Arrays.asList(0, 10L)));
+    expected.put("position", 10L);
     assertEquals(expected, actual);
   }
 

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -175,39 +175,36 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
       dynamic event,
     ) {
       final Map<dynamic, dynamic> map = event as Map<dynamic, dynamic>;
-      switch (map['event']) {
-        case 'initialized':
-          return VideoEvent(
-            eventType: VideoEventType.initialized,
-            duration: Duration(milliseconds: map['duration'] as int),
-            size: Size(
-              (map['width'] as num?)?.toDouble() ?? 0.0,
-              (map['height'] as num?)?.toDouble() ?? 0.0,
+      return switch (map['event']) {
+        'initialized' => VideoEvent(
+          eventType: VideoEventType.initialized,
+          duration: Duration(milliseconds: map['duration'] as int),
+          size: Size(
+            (map['width'] as num?)?.toDouble() ?? 0.0,
+            (map['height'] as num?)?.toDouble() ?? 0.0,
+          ),
+          rotationCorrection: map['rotationCorrection'] as int? ?? 0,
+        ),
+        'completed' => VideoEvent(eventType: VideoEventType.completed),
+        'bufferingUpdate' => VideoEvent(
+          eventType: VideoEventType.bufferingUpdate,
+          buffered: <DurationRange>[
+            DurationRange(
+              Duration.zero,
+              Duration(milliseconds: map['position'] as int),
             ),
-            rotationCorrection: map['rotationCorrection'] as int? ?? 0,
-          );
-        case 'completed':
-          return VideoEvent(eventType: VideoEventType.completed);
-        case 'bufferingUpdate':
-          final int position = map['position']! as int;
-          return VideoEvent(
-            eventType: VideoEventType.bufferingUpdate,
-            buffered: <DurationRange>[
-              DurationRange(Duration.zero, Duration(milliseconds: position)),
-            ],
-          );
-        case 'bufferingStart':
-          return VideoEvent(eventType: VideoEventType.bufferingStart);
-        case 'bufferingEnd':
-          return VideoEvent(eventType: VideoEventType.bufferingEnd);
-        case 'isPlayingStateUpdate':
-          return VideoEvent(
-            eventType: VideoEventType.isPlayingStateUpdate,
-            isPlaying: map['isPlaying'] as bool,
-          );
-        default:
-          return VideoEvent(eventType: VideoEventType.unknown);
-      }
+          ],
+        ),
+        'bufferingStart' => VideoEvent(
+          eventType: VideoEventType.bufferingStart,
+        ),
+        'bufferingEnd' => VideoEvent(eventType: VideoEventType.bufferingEnd),
+        'isPlayingStateUpdate' => VideoEvent(
+          eventType: VideoEventType.isPlayingStateUpdate,
+          isPlaying: map['isPlaying'] as bool,
+        ),
+        _ => VideoEvent(eventType: VideoEventType.unknown),
+      };
     });
   }
 

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -189,11 +189,12 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
         case 'completed':
           return VideoEvent(eventType: VideoEventType.completed);
         case 'bufferingUpdate':
-          final List<dynamic> values = map['values'] as List<dynamic>;
-
+          final int position = map['position']! as int;
           return VideoEvent(
-            buffered: values.map<DurationRange>(_toDurationRange).toList(),
             eventType: VideoEventType.bufferingUpdate,
+            buffered: <DurationRange>[
+              DurationRange(Duration.zero, Duration(milliseconds: position)),
+            ],
           );
         case 'bufferingStart':
           return VideoEvent(eventType: VideoEventType.bufferingStart);
@@ -258,14 +259,6 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
       // this code must handle the possibility of a new enum value.
       _ => null,
     };
-  }
-
-  DurationRange _toDurationRange(dynamic value) {
-    final List<dynamic> pair = value as List<dynamic>;
-    return DurationRange(
-      Duration(milliseconds: pair[0] as int),
-      Duration(milliseconds: pair[1] as int),
-    );
   }
 }
 

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -76,7 +76,7 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
     String? asset;
     String? packageName;
     String? uri;
-    String? formatHint;
+    PlatformVideoFormat? formatHint;
     Map<String, String> httpHeaders = <String, String>{};
     switch (dataSource.sourceType) {
       case DataSourceType.asset:
@@ -84,7 +84,7 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
         packageName = dataSource.package;
       case DataSourceType.network:
         uri = dataSource.uri;
-        formatHint = _videoFormatStringMap[dataSource.formatHint];
+        formatHint = _platformVideoFormatFromVideoFormat(dataSource.formatHint);
         httpHeaders = dataSource.httpHeaders;
       case DataSourceType.file:
         uri = dataSource.uri;
@@ -238,13 +238,19 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
     return player ?? (throw StateError('No active player with ID $id.'));
   }
 
-  static const Map<VideoFormat, String> _videoFormatStringMap =
-      <VideoFormat, String>{
-        VideoFormat.ss: 'ss',
-        VideoFormat.hls: 'hls',
-        VideoFormat.dash: 'dash',
-        VideoFormat.other: 'other',
-      };
+  PlatformVideoFormat? _platformVideoFormatFromVideoFormat(
+    VideoFormat? format,
+  ) {
+    return switch (format) {
+      VideoFormat.dash => PlatformVideoFormat.dash,
+      VideoFormat.hls => PlatformVideoFormat.hls,
+      VideoFormat.ss => PlatformVideoFormat.ss,
+      VideoFormat.other => null,
+      // Include a catch-all, since the enum comes from another package, so
+      // this code must handle the possibility of a new enum value.
+      _ => null,
+    };
+  }
 
   DurationRange _toDurationRange(dynamic value) {
     final List<dynamic> pair = value as List<dynamic>;

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -75,7 +75,8 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
 
     String? uri;
     PlatformVideoFormat? formatHint;
-    Map<String, String> httpHeaders = <String, String>{};
+    final Map<String, String> httpHeaders = dataSource.httpHeaders;
+    final String? userAgent = _userAgentFromHeaders(httpHeaders);
     switch (dataSource.sourceType) {
       case DataSourceType.asset:
         final String? asset = dataSource.asset;
@@ -92,10 +93,7 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
       case DataSourceType.network:
         uri = dataSource.uri;
         formatHint = _platformVideoFormatFromVideoFormat(dataSource.formatHint);
-        httpHeaders = dataSource.httpHeaders;
       case DataSourceType.file:
-        uri = dataSource.uri;
-        httpHeaders = dataSource.httpHeaders;
       case DataSourceType.contentUri:
         uri = dataSource.uri;
     }
@@ -105,6 +103,7 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
     final CreateMessage message = CreateMessage(
       uri: uri,
       httpHeaders: httpHeaders,
+      userAgent: userAgent,
       formatHint: formatHint,
       viewType: _platformVideoViewTypeFromVideoViewType(options.viewType),
     );
@@ -120,6 +119,19 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
     ensureApiInitialized(playerId);
 
     return playerId;
+  }
+
+  // Returns the user agent to use with ExoPlayer for the given headers.
+  String? _userAgentFromHeaders(Map<String, String> httpHeaders) {
+    // TODO(stuartmorgan): HTTP headers are case-insensitive, so this should be
+    //  adjusted to find any entry where the key has a case-insensitive match.
+    const String userAgentKey = 'User-Agent';
+    // TODO(stuartmorgan): Investigate removing this. The use of a hard-coded
+    //  default agent dates back to the original ExoPlayer implementation of the
+    //  plugin, but it's not clear why the default isn't null, which would let
+    //  ExoPlayer use its own default value.
+    const String defaultUserAgent = 'ExoPlayer';
+    return httpHeaders[userAgentKey] ?? defaultUserAgent;
   }
 
   /// Returns the API instance for [playerId], creating it if it doesn't already

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -81,19 +81,13 @@ class PlatformVideoViewCreationParams {
 
 class CreateMessage {
   CreateMessage({
-    this.asset,
-    this.uri,
-    this.packageName,
+    required this.uri,
     this.formatHint,
     required this.httpHeaders,
     this.viewType,
   });
 
-  String? asset;
-
-  String? uri;
-
-  String? packageName;
+  String uri;
 
   PlatformVideoFormat? formatHint;
 
@@ -102,14 +96,7 @@ class CreateMessage {
   PlatformVideoViewType? viewType;
 
   List<Object?> _toList() {
-    return <Object?>[
-      asset,
-      uri,
-      packageName,
-      formatHint,
-      httpHeaders,
-      viewType,
-    ];
+    return <Object?>[uri, formatHint, httpHeaders, viewType];
   }
 
   Object encode() {
@@ -119,13 +106,11 @@ class CreateMessage {
   static CreateMessage decode(Object result) {
     result as List<Object?>;
     return CreateMessage(
-      asset: result[0] as String?,
-      uri: result[1] as String?,
-      packageName: result[2] as String?,
-      formatHint: result[3] as PlatformVideoFormat?,
+      uri: result[0]! as String,
+      formatHint: result[1] as PlatformVideoFormat?,
       httpHeaders:
-          (result[4] as Map<Object?, Object?>?)!.cast<String, String>(),
-      viewType: result[5] as PlatformVideoViewType?,
+          (result[2] as Map<Object?, Object?>?)!.cast<String, String>(),
+      viewType: result[3] as PlatformVideoViewType?,
     );
   }
 
@@ -313,6 +298,38 @@ class AndroidVideoPlayerApi {
       );
     } else {
       return;
+    }
+  }
+
+  Future<String> getLookupKeyForAsset(String asset, String? packageName) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.getLookupKeyForAsset$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[asset, packageName],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as String?)!;
     }
   }
 }

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -84,6 +84,7 @@ class CreateMessage {
     required this.uri,
     this.formatHint,
     required this.httpHeaders,
+    this.userAgent,
     this.viewType,
   });
 
@@ -93,10 +94,12 @@ class CreateMessage {
 
   Map<String, String> httpHeaders;
 
+  String? userAgent;
+
   PlatformVideoViewType? viewType;
 
   List<Object?> _toList() {
-    return <Object?>[uri, formatHint, httpHeaders, viewType];
+    return <Object?>[uri, formatHint, httpHeaders, userAgent, viewType];
   }
 
   Object encode() {
@@ -110,7 +113,8 @@ class CreateMessage {
       formatHint: result[1] as PlatformVideoFormat?,
       httpHeaders:
           (result[2] as Map<Object?, Object?>?)!.cast<String, String>(),
-      viewType: result[3] as PlatformVideoViewType?,
+      userAgent: result[3] as String?,
+      viewType: result[4] as PlatformVideoViewType?,
     );
   }
 

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -18,20 +18,6 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse({
-  Object? result,
-  PlatformException? error,
-  bool empty = false,
-}) {
-  if (empty) {
-    return <Object?>[];
-  }
-  if (error == null) {
-    return <Object?>[result];
-  }
-  return <Object?>[error.code, error.message, error.details];
-}
-
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
     return a.length == b.length &&
@@ -52,6 +38,9 @@ bool _deepEquals(Object? a, Object? b) {
 
 /// Pigeon equivalent of VideoViewType.
 enum PlatformVideoViewType { textureView, platformView }
+
+/// Pigeon equivalent of video_platform_interface's VideoFormat.
+enum PlatformVideoFormat { dash, hls, ss }
 
 /// Information passed to the platform view creation.
 class PlatformVideoViewCreationParams {
@@ -106,7 +95,7 @@ class CreateMessage {
 
   String? packageName;
 
-  String? formatHint;
+  PlatformVideoFormat? formatHint;
 
   Map<String, String> httpHeaders;
 
@@ -133,7 +122,7 @@ class CreateMessage {
       asset: result[0] as String?,
       uri: result[1] as String?,
       packageName: result[2] as String?,
-      formatHint: result[3] as String?,
+      formatHint: result[3] as PlatformVideoFormat?,
       httpHeaders:
           (result[4] as Map<Object?, Object?>?)!.cast<String, String>(),
       viewType: result[5] as PlatformVideoViewType?,
@@ -167,11 +156,14 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PlatformVideoViewType) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    } else if (value is PlatformVideoViewCreationParams) {
+    } else if (value is PlatformVideoFormat) {
       buffer.putUint8(130);
+      writeValue(buffer, value.index);
+    } else if (value is PlatformVideoViewCreationParams) {
+      buffer.putUint8(131);
       writeValue(buffer, value.encode());
     } else if (value is CreateMessage) {
-      buffer.putUint8(131);
+      buffer.putUint8(132);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -185,8 +177,11 @@ class _PigeonCodec extends StandardMessageCodec {
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PlatformVideoViewType.values[value];
       case 130:
-        return PlatformVideoViewCreationParams.decode(readValue(buffer)!);
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : PlatformVideoFormat.values[value];
       case 131:
+        return PlatformVideoViewCreationParams.decode(readValue(buffer)!);
+      case 132:
         return CreateMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -27,10 +27,8 @@ class PlatformVideoViewCreationParams {
 }
 
 class CreateMessage {
-  CreateMessage({required this.httpHeaders});
-  String? asset;
-  String? uri;
-  String? packageName;
+  CreateMessage({required this.uri, required this.httpHeaders});
+  String uri;
   PlatformVideoFormat? formatHint;
   Map<String, String> httpHeaders;
   PlatformVideoViewType? viewType;
@@ -42,6 +40,7 @@ abstract class AndroidVideoPlayerApi {
   int create(CreateMessage msg);
   void dispose(int playerId);
   void setMixWithOthers(bool mixWithOthers);
+  String getLookupKeyForAsset(String asset, String? packageName);
 }
 
 @HostApi()

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -31,6 +31,7 @@ class CreateMessage {
   String uri;
   PlatformVideoFormat? formatHint;
   Map<String, String> httpHeaders;
+  String? userAgent;
   PlatformVideoViewType? viewType;
 }
 

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -16,6 +16,9 @@ import 'package:pigeon/pigeon.dart';
 /// Pigeon equivalent of VideoViewType.
 enum PlatformVideoViewType { textureView, platformView }
 
+/// Pigeon equivalent of video_platform_interface's VideoFormat.
+enum PlatformVideoFormat { dash, hls, ss }
+
 /// Information passed to the platform view creation.
 class PlatformVideoViewCreationParams {
   const PlatformVideoViewCreationParams({required this.playerId});
@@ -28,7 +31,7 @@ class CreateMessage {
   String? asset;
   String? uri;
   String? packageName;
-  String? formatHint;
+  PlatformVideoFormat? formatHint;
   Map<String, String> httpHeaders;
   PlatformVideoViewType? viewType;
 }

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.8.9
+version: 2.8.10
 
 environment:
   sdk: ^3.7.0

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -151,6 +151,52 @@ void main() {
       expect(createMessage.httpHeaders, headers);
     });
 
+    test('create with network sets a default user agent', () async {
+      final (
+        AndroidVideoPlayer player,
+        MockAndroidVideoPlayerApi api,
+        _,
+      ) = setUpMockPlayer(playerId: 1);
+      when(api.create(any)).thenAnswer((_) async => 2);
+
+      await player.create(
+        DataSource(
+          sourceType: DataSourceType.network,
+          uri: 'https://example.com',
+          httpHeaders: <String, String>{},
+        ),
+      );
+      final VerificationResult verification = verify(api.create(captureAny));
+      final CreateMessage createMessage =
+          verification.captured[0] as CreateMessage;
+      expect(createMessage.userAgent, 'ExoPlayer');
+    });
+
+    test('create with network uses user agent from headers', () async {
+      final (
+        AndroidVideoPlayer player,
+        MockAndroidVideoPlayerApi api,
+        _,
+      ) = setUpMockPlayer(playerId: 1);
+      when(api.create(any)).thenAnswer((_) async => 2);
+
+      const String userAgent = 'Test User Agent';
+      const Map<String, String> headers = <String, String>{
+        'User-Agent': userAgent,
+      };
+      await player.create(
+        DataSource(
+          sourceType: DataSourceType.network,
+          uri: 'https://example.com',
+          httpHeaders: headers,
+        ),
+      );
+      final VerificationResult verification = verify(api.create(captureAny));
+      final CreateMessage createMessage =
+          verification.captured[0] as CreateMessage;
+      expect(createMessage.userAgent, userAgent);
+    });
+
     test('create with file', () async {
       final (
         AndroidVideoPlayer player,

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -560,10 +560,7 @@ void main() {
                     const StandardMethodCodec().encodeSuccessEnvelope(
                       <String, dynamic>{
                         'event': 'bufferingUpdate',
-                        'values': <List<dynamic>>[
-                          <int>[0, 1234],
-                          <int>[1235, 4000],
-                        ],
+                        'position': 1234,
                       },
                     ),
                     (ByteData? data) {},
@@ -646,10 +643,6 @@ void main() {
             eventType: VideoEventType.bufferingUpdate,
             buffered: <DurationRange>[
               DurationRange(Duration.zero, const Duration(milliseconds: 1234)),
-              DurationRange(
-                const Duration(milliseconds: 1235),
-                const Duration(milliseconds: 4000),
-              ),
             ],
           ),
           VideoEvent(eventType: VideoEventType.bufferingStart),

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -72,6 +72,11 @@ void main() {
 
       const String asset = 'someAsset';
       const String package = 'somePackage';
+      const String assetKey = 'resultingAssetKey';
+      when(
+        api.getLookupKeyForAsset(asset, package),
+      ).thenAnswer((_) async => assetKey);
+
       final int? playerId = await player.create(
         DataSource(
           sourceType: DataSourceType.asset,
@@ -83,8 +88,7 @@ void main() {
       final VerificationResult verification = verify(api.create(captureAny));
       final CreateMessage createMessage =
           verification.captured[0] as CreateMessage;
-      expect(createMessage.asset, asset);
-      expect(createMessage.packageName, package);
+      expect(createMessage.uri, 'asset:///$assetKey');
       expect(playerId, newPlayerId);
       expect(
         player.buildViewWithOptions(VideoViewOptions(playerId: playerId!)),
@@ -113,10 +117,8 @@ void main() {
       final VerificationResult verification = verify(api.create(captureAny));
       final CreateMessage createMessage =
           verification.captured[0] as CreateMessage;
-      expect(createMessage.asset, null);
       expect(createMessage.uri, uri);
-      expect(createMessage.packageName, null);
-      expect(createMessage.formatHint, 'dash');
+      expect(createMessage.formatHint, PlatformVideoFormat.dash);
       expect(createMessage.httpHeaders, <String, String>{});
       expect(playerId, newPlayerId);
       expect(
@@ -207,6 +209,11 @@ void main() {
 
       const String asset = 'someAsset';
       const String package = 'somePackage';
+      const String assetKey = 'resultingAssetKey';
+      when(
+        api.getLookupKeyForAsset(asset, package),
+      ).thenAnswer((_) async => assetKey);
+
       final int? playerId = await player.createWithOptions(
         VideoCreationOptions(
           dataSource: DataSource(
@@ -221,8 +228,7 @@ void main() {
       final VerificationResult verification = verify(api.create(captureAny));
       final CreateMessage createMessage =
           verification.captured[0] as CreateMessage;
-      expect(createMessage.asset, asset);
-      expect(createMessage.packageName, package);
+      expect(createMessage.uri, 'asset:///$assetKey');
       expect(playerId, newPlayerId);
       expect(
         player.buildViewWithOptions(VideoViewOptions(playerId: playerId!)),
@@ -254,10 +260,8 @@ void main() {
       final VerificationResult verification = verify(api.create(captureAny));
       final CreateMessage createMessage =
           verification.captured[0] as CreateMessage;
-      expect(createMessage.asset, null);
       expect(createMessage.uri, uri);
-      expect(createMessage.packageName, null);
-      expect(createMessage.formatHint, 'dash');
+      expect(createMessage.formatHint, PlatformVideoFormat.dash);
       expect(createMessage.httpHeaders, <String, String>{});
       expect(playerId, newPlayerId);
       expect(

--- a/packages/video_player/video_player_android/test/android_video_player_test.mocks.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.mocks.dart
@@ -78,6 +78,25 @@ class MockAndroidVideoPlayerApi extends _i1.Mock
             returnValueForMissingStub: _i4.Future<void>.value(),
           )
           as _i4.Future<void>);
+
+  @override
+  _i4.Future<String> getLookupKeyForAsset(String? asset, String? packageName) =>
+      (super.noSuchMethod(
+            Invocation.method(#getLookupKeyForAsset, [asset, packageName]),
+            returnValue: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#getLookupKeyForAsset, [asset, packageName]),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#getLookupKeyForAsset, [asset, packageName]),
+              ),
+            ),
+          )
+          as _i4.Future<String>);
 }
 
 /// A class which mocks [VideoPlayerInstanceApi].


### PR DESCRIPTION
Moves some logic from native code to Dart:
- User-Agent header -> ExoPlayer user agent extraction logic (with TODOs for future improvements, based on implementation issues/questions I noticed while converting it).
- Asset -> URL lookup.
- Conversion of buffer position to the buffer range list required for the Dart event stream.

Also converts video format hint from strings to enums, which was missed in earlier Pigeon conversions. Using strings was the pre-Pigeon way of handling this kind of thing.

Part of https://github.com/flutter/flutter/issues/172763

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
