### PR TITLE
[video_player] Move more Obj-C logic to Dart

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.1
+
+* Restructures internal logic to move more code to Dart.
+
 ## 2.8.0
 
 * Adds platform view support for macOS.

--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
@@ -168,32 +168,6 @@
 
 @implementation VideoPlayerTests
 
-- (void)testCreateWithOptionsReturnsErrorForInvalidAssetPath {
-  NSObject<FlutterPluginRegistrar> *registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
-  OCMStub([registrar lookupKeyForAsset:[OCMArg any]]).andReturn(nil);
-  FVPVideoPlayerPlugin *videoPlayerPlugin =
-      [[FVPVideoPlayerPlugin alloc] initWithRegistrar:registrar];
-
-  FlutterError *initializationError;
-  [videoPlayerPlugin initialize:&initializationError];
-  XCTAssertNil(initializationError);
-
-  FVPCreationOptions *create =
-      [FVPCreationOptions makeWithAsset:@"invalid/path/to/asset"
-                                    uri:nil
-                            packageName:nil
-                             formatHint:nil
-                            httpHeaders:@{}
-                               viewType:FVPPlatformVideoViewTypeTextureView];
-
-  FlutterError *createError;
-  NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&createError];
-
-  XCTAssertNil(playerIdentifier);
-  XCTAssertNotNil(createError);
-  XCTAssertEqualObjects(createError.code, @"video_player");
-}
-
 - (void)testBlankVideoBugWithEncryptedVideoStreamAndInvertedAspectRatioBugForSomeVideoStream {
   // This is to fix 2 bugs: 1. blank video for encrypted video streams on iOS 16
   // (https://github.com/flutter/flutter/issues/111457) and 2. swapped width and height for some
@@ -218,12 +192,9 @@
   XCTAssertNil(error);
 
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypeTextureView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypeTextureView];
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(playerIdentifier);
@@ -253,12 +224,9 @@
   [videoPlayerPlugin initialize:&initalizationError];
   XCTAssertNil(initalizationError);
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypePlatformView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypePlatformView];
   FlutterError *createError;
   [videoPlayerPlugin createWithOptions:create error:&createError];
 
@@ -284,12 +252,9 @@
   [videoPlayerPlugin initialize:&initalizationError];
   XCTAssertNil(initalizationError);
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypeTextureView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypeTextureView];
   FlutterError *createError;
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&createError];
   FVPTextureBasedVideoPlayer *player =
@@ -344,12 +309,9 @@
   [videoPlayerPlugin initialize:&initalizationError];
   XCTAssertNil(initalizationError);
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypeTextureView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypeTextureView];
   FlutterError *createError;
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&createError];
 
@@ -393,12 +355,9 @@
   [videoPlayerPlugin initialize:&initalizationError];
   XCTAssertNil(initalizationError);
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypeTextureView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypeTextureView];
   FlutterError *createError;
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&createError];
   FVPTextureBasedVideoPlayer *player =
@@ -451,12 +410,9 @@
   [videoPlayerPlugin initialize:&initalizationError];
   XCTAssertNil(initalizationError);
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypeTextureView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypeTextureView];
   FlutterError *createError;
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&createError];
   FVPTextureBasedVideoPlayer *player =
@@ -481,12 +437,9 @@
   XCTAssertNil(error);
 
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypeTextureView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypeTextureView];
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(playerIdentifier);
@@ -513,12 +466,9 @@
   XCTAssertNil(error);
 
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypeTextureView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypeTextureView];
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(playerIdentifier);
@@ -709,12 +659,9 @@
     XCTAssertNil(error);
 
     FVPCreationOptions *create = [FVPCreationOptions
-        makeWithAsset:nil
-                  uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-          packageName:nil
-           formatHint:nil
-          httpHeaders:@{}
-             viewType:FVPPlatformVideoViewTypeTextureView];
+        makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
+        httpHeaders:@{}
+           viewType:FVPPlatformVideoViewTypeTextureView];
     NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&error];
     XCTAssertNil(error);
     XCTAssertNotNil(playerIdentifier);
@@ -763,12 +710,9 @@
     XCTAssertNil(error);
 
     FVPCreationOptions *create = [FVPCreationOptions
-        makeWithAsset:nil
-                  uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-          packageName:nil
-           formatHint:nil
-          httpHeaders:@{}
-             viewType:FVPPlatformVideoViewTypeTextureView];
+        makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
+        httpHeaders:@{}
+           viewType:FVPPlatformVideoViewTypeTextureView];
     NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&error];
     XCTAssertNil(error);
     XCTAssertNotNil(playerIdentifier);
@@ -830,13 +774,9 @@
 
   [videoPlayerPlugin initialize:&error];
 
-  FVPCreationOptions *create =
-      [FVPCreationOptions makeWithAsset:nil
-                                    uri:@""
-                            packageName:nil
-                             formatHint:nil
-                            httpHeaders:@{}
-                               viewType:FVPPlatformVideoViewTypeTextureView];
+  FVPCreationOptions *create = [FVPCreationOptions makeWithUri:@""
+                                                   httpHeaders:@{}
+                                                      viewType:FVPPlatformVideoViewTypeTextureView];
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&error];
   FVPVideoPlayer *player = videoPlayerPlugin.playersByIdentifier[playerIdentifier];
   XCTAssertNotNil(player);
@@ -896,12 +836,9 @@
   [videoPlayerPlugin initialize:&error];
   XCTAssertNil(error);
   FVPCreationOptions *create = [FVPCreationOptions
-      makeWithAsset:nil
-                uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-        packageName:nil
-         formatHint:nil
-        httpHeaders:@{}
-           viewType:FVPPlatformVideoViewTypeTextureView];
+      makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
+      httpHeaders:@{}
+         viewType:FVPPlatformVideoViewTypeTextureView];
   NSNumber *playerIdentifier = [videoPlayerPlugin createWithOptions:create error:&error];
   FVPTextureBasedVideoPlayer *player =
       (FVPTextureBasedVideoPlayer *)videoPlayerPlugin.playersByIdentifier[playerIdentifier];

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPTextureBasedVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPTextureBasedVideoPlayer.m
@@ -31,18 +31,6 @@
 @end
 
 @implementation FVPTextureBasedVideoPlayer
-- (instancetype)initWithAsset:(NSString *)asset
-                 frameUpdater:(FVPFrameUpdater *)frameUpdater
-                  displayLink:(NSObject<FVPDisplayLink> *)displayLink
-                    avFactory:(id<FVPAVFactory>)avFactory
-                 viewProvider:(NSObject<FVPViewProvider> *)viewProvider {
-  return [self initWithURL:[NSURL fileURLWithPath:[FVPVideoPlayer absolutePathForAssetName:asset]]
-              frameUpdater:frameUpdater
-               displayLink:displayLink
-               httpHeaders:@{}
-                 avFactory:avFactory
-              viewProvider:viewProvider];
-}
 
 - (instancetype)initWithURL:(NSURL *)url
                frameUpdater:(FVPFrameUpdater *)frameUpdater

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayer.m
@@ -17,14 +17,6 @@ static void *playbackLikelyToKeepUpContext = &playbackLikelyToKeepUpContext;
 static void *rateContext = &rateContext;
 
 @implementation FVPVideoPlayer
-- (instancetype)initWithAsset:(NSString *)asset
-                    avFactory:(id<FVPAVFactory>)avFactory
-                 viewProvider:(NSObject<FVPViewProvider> *)viewProvider {
-  return [self initWithURL:[NSURL fileURLWithPath:[FVPVideoPlayer absolutePathForAssetName:asset]]
-               httpHeaders:@{}
-                 avFactory:avFactory
-              viewProvider:viewProvider];
-}
 
 - (instancetype)initWithURL:(NSURL *)url
                 httpHeaders:(nonnull NSDictionary<NSString *, NSString *> *)headers
@@ -120,19 +112,6 @@ static void *rateContext = &rateContext;
     _onDisposed();
   }
   [_eventChannel setStreamHandler:nil];
-}
-
-+ (NSString *)absolutePathForAssetName:(NSString *)assetName {
-  NSString *path = [[NSBundle mainBundle] pathForResource:assetName ofType:nil];
-#if TARGET_OS_OSX
-  // See https://github.com/flutter/flutter/issues/135302
-  // TODO(stuartmorgan): Remove this if the asset APIs are adjusted to work better for macOS.
-  if (!path) {
-    path = [NSURL URLWithString:assetName relativeToURL:NSBundle.mainBundle.bundleURL].path;
-  }
-#endif
-
-  return path;
 }
 
 - (void)addObserversForItem:(AVPlayerItem *)item player:(AVPlayer *)player {

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -259,7 +259,7 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
   // See https://github.com/flutter/flutter/issues/135302
   // TODO(stuartmorgan): Remove this if the asset APIs are adjusted to work better for macOS.
   if (!path) {
-    path = [NSURL URLWithString:assetName relativeToURL:NSBundle.mainBundle.bundleURL].path;
+    path = [NSURL URLWithString:resource relativeToURL:NSBundle.mainBundle.bundleURL].path;
   }
 #endif
 

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -192,12 +192,6 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
   @try {
     FVPVideoPlayer *player = textureBased ? [self texturePlayerWithOptions:options]
                                           : [self platformViewPlayerWithOptions:options];
-
-    if (player == nil) {
-      *error = [FlutterError errorWithCode:@"video_player" message:@"not implemented" details:nil];
-      return nil;
-    }
-
     return @([self onPlayerSetup:player]);
   } @catch (NSException *exception) {
     *error = [FlutterError errorWithCode:@"video_player" message:exception.reason details:nil];
@@ -205,7 +199,7 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
   }
 }
 
-- (nullable FVPTextureBasedVideoPlayer *)texturePlayerWithOptions:
+- (nonnull FVPTextureBasedVideoPlayer *)texturePlayerWithOptions:
     (nonnull FVPCreationOptions *)options {
   FVPFrameUpdater *frameUpdater =
       [[FVPFrameUpdater alloc] initWithRegistry:self.registrar.textures];
@@ -223,7 +217,7 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
                                             viewProvider:self.viewProvider];
 }
 
-- (nullable FVPVideoPlayer *)platformViewPlayerWithOptions:(nonnull FVPCreationOptions *)options {
+- (nonnull FVPVideoPlayer *)platformViewPlayerWithOptions:(nonnull FVPCreationOptions *)options {
   // FVPVideoPlayer contains all required logic for platform views.
   return [[FVPVideoPlayer alloc] initWithURL:[NSURL URLWithString:options.uri]
                                  httpHeaders:options.httpHeaders

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -218,12 +218,7 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
                                                  [frameUpdater displayLinkFired];
                                                }];
 
-  NSString *stringURI =
-      options.asset != nil ? [self assetURLFromCreationOptions:options] : options.uri;
-  if (!stringURI) {
-    return nil;
-  }
-  return [[FVPTextureBasedVideoPlayer alloc] initWithURL:[NSURL URLWithString:stringURI]
+  return [[FVPTextureBasedVideoPlayer alloc] initWithURL:[NSURL URLWithString:options.uri]
                                             frameUpdater:frameUpdater
                                              displayLink:displayLink
                                              httpHeaders:options.httpHeaders
@@ -233,11 +228,6 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
 
 - (nullable FVPVideoPlayer *)platformViewPlayerWithOptions:(nonnull FVPCreationOptions *)options {
   // FVPVideoPlayer contains all required logic for platform views.
-  NSString *stringURI =
-      options.asset != nil ? [self assetURLFromCreationOptions:options] : options.uri;
-  if (!stringURI) {
-    return nil;
-  }
   return [[FVPVideoPlayer alloc] initWithURL:[NSURL URLWithString:options.uri]
                                  httpHeaders:options.httpHeaders
                                    avFactory:self.avFactory
@@ -283,11 +273,6 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
 #endif
 
   return [NSURL fileURLWithPath:path].absoluteString;
-}
-
-- (NSString *)assetURLFromCreationOptions:(nonnull FVPCreationOptions *)options {
-  FlutterError *error;
-  return [self fileURLForAssetWithName:options.asset package:options.packageName error:&error];
 }
 
 @end

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -269,6 +269,9 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
   }
 #endif
 
+  if (!path) {
+    return nil;
+  }
   return [NSURL fileURLWithPath:path].absoluteString;
 }
 

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPTextureBasedVideoPlayer.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPTextureBasedVideoPlayer.h
@@ -23,14 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
                   avFactory:(id<FVPAVFactory>)avFactory
                viewProvider:(NSObject<FVPViewProvider> *)viewProvider;
 
-/// Initializes a new instance of FVPTextureBasedVideoPlayer with the given asset, frame updater,
-/// display link, AV factory, and registrar.
-- (instancetype)initWithAsset:(NSString *)asset
-                 frameUpdater:(FVPFrameUpdater *)frameUpdater
-                  displayLink:(NSObject<FVPDisplayLink> *)displayLink
-                    avFactory:(id<FVPAVFactory>)avFactory
-                 viewProvider:(NSObject<FVPViewProvider> *)viewProvider;
-
 /// Sets the texture Identifier for the frame updater. This method should be called once the texture
 /// identifier is obtained from the texture registry.
 - (void)setTextureIdentifier:(int64_t)textureIdentifier;

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer.h
@@ -35,12 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// A block that will be called when dispose is called.
 @property(nonatomic, nullable, copy) void (^onDisposed)(void);
 
-/// Initializes a new instance of FVPVideoPlayer with the given asset, AV factory, and view
-/// provider.
-- (instancetype)initWithAsset:(NSString *)asset
-                    avFactory:(id<FVPAVFactory>)avFactory
-                 viewProvider:(NSObject<FVPViewProvider> *)viewProvider;
-
 /// Initializes a new instance of FVPVideoPlayer with the given URL, HTTP headers, AV factory, and
 /// view provider.
 - (instancetype)initWithURL:(NSURL *)url

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer_Internal.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer_Internal.h
@@ -40,10 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Updates the playing state of the video player.
 - (void)updatePlayingState;
-
-/// Returns the absolute file path for a given asset name.
-/// This method attempts to locate the specified asset within the app bundle.
-+ (NSString *)absolutePathForAssetName:(NSString *)assetName;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
@@ -57,7 +57,6 @@ NSObject<FlutterMessageCodec> *FVPGetMessagesCodec(void);
                                    error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)disposePlayer:(NSInteger)playerId error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)setMixWithOthers:(BOOL)mixWithOthers error:(FlutterError *_Nullable *_Nonnull)error;
-/// @return `nil` only when `error != nil`.
 - (nullable NSString *)fileURLForAssetWithName:(NSString *)asset
                                        package:(nullable NSString *)package
                                          error:(FlutterError *_Nullable *_Nonnull)error;

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
@@ -63,6 +63,10 @@ NSObject<FlutterMessageCodec> *FVPGetMessagesCodec(void);
                                    error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)disposePlayer:(NSInteger)playerId error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)setMixWithOthers:(BOOL)mixWithOthers error:(FlutterError *_Nullable *_Nonnull)error;
+/// @return `nil` only when `error != nil`.
+- (nullable NSString *)fileURLForAssetWithName:(NSString *)asset
+                                       package:(nullable NSString *)package
+                                         error:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
 extern void SetUpFVPAVFoundationVideoPlayerApi(

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
@@ -40,11 +40,9 @@ typedef NS_ENUM(NSUInteger, FVPPlatformVideoViewType) {
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)makeWithUri:(NSString *)uri
-                 formatHint:(nullable NSString *)formatHint
                 httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
                    viewType:(FVPPlatformVideoViewType)viewType;
 @property(nonatomic, copy) NSString *uri;
-@property(nonatomic, copy, nullable) NSString *formatHint;
 @property(nonatomic, copy) NSDictionary<NSString *, NSString *> *httpHeaders;
 @property(nonatomic, assign) FVPPlatformVideoViewType viewType;
 @end

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
@@ -39,15 +39,11 @@ typedef NS_ENUM(NSUInteger, FVPPlatformVideoViewType) {
 @interface FVPCreationOptions : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)makeWithAsset:(nullable NSString *)asset
-                          uri:(nullable NSString *)uri
-                  packageName:(nullable NSString *)packageName
-                   formatHint:(nullable NSString *)formatHint
-                  httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
-                     viewType:(FVPPlatformVideoViewType)viewType;
-@property(nonatomic, copy, nullable) NSString *asset;
-@property(nonatomic, copy, nullable) NSString *uri;
-@property(nonatomic, copy, nullable) NSString *packageName;
++ (instancetype)makeWithUri:(NSString *)uri
+                 formatHint:(nullable NSString *)formatHint
+                httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
+                   viewType:(FVPPlatformVideoViewType)viewType;
+@property(nonatomic, copy) NSString *uri;
 @property(nonatomic, copy, nullable) NSString *formatHint;
 @property(nonatomic, copy) NSDictionary<NSString *, NSString *> *httpHeaders;
 @property(nonatomic, assign) FVPPlatformVideoViewType viewType;

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
@@ -78,12 +78,10 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 
 @implementation FVPCreationOptions
 + (instancetype)makeWithUri:(NSString *)uri
-                 formatHint:(nullable NSString *)formatHint
                 httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
                    viewType:(FVPPlatformVideoViewType)viewType {
   FVPCreationOptions *pigeonResult = [[FVPCreationOptions alloc] init];
   pigeonResult.uri = uri;
-  pigeonResult.formatHint = formatHint;
   pigeonResult.httpHeaders = httpHeaders;
   pigeonResult.viewType = viewType;
   return pigeonResult;
@@ -91,9 +89,8 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 + (FVPCreationOptions *)fromList:(NSArray<id> *)list {
   FVPCreationOptions *pigeonResult = [[FVPCreationOptions alloc] init];
   pigeonResult.uri = GetNullableObjectAtIndex(list, 0);
-  pigeonResult.formatHint = GetNullableObjectAtIndex(list, 1);
-  pigeonResult.httpHeaders = GetNullableObjectAtIndex(list, 2);
-  FVPPlatformVideoViewTypeBox *boxedFVPPlatformVideoViewType = GetNullableObjectAtIndex(list, 3);
+  pigeonResult.httpHeaders = GetNullableObjectAtIndex(list, 1);
+  FVPPlatformVideoViewTypeBox *boxedFVPPlatformVideoViewType = GetNullableObjectAtIndex(list, 2);
   pigeonResult.viewType = boxedFVPPlatformVideoViewType.value;
   return pigeonResult;
 }
@@ -103,7 +100,6 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 - (NSArray<id> *)toList {
   return @[
     self.uri ?: [NSNull null],
-    self.formatHint ?: [NSNull null],
     self.httpHeaders ?: [NSNull null],
     [[FVPPlatformVideoViewTypeBox alloc] initWithValue:self.viewType],
   ];

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
@@ -77,16 +77,12 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 @end
 
 @implementation FVPCreationOptions
-+ (instancetype)makeWithAsset:(nullable NSString *)asset
-                          uri:(nullable NSString *)uri
-                  packageName:(nullable NSString *)packageName
-                   formatHint:(nullable NSString *)formatHint
-                  httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
-                     viewType:(FVPPlatformVideoViewType)viewType {
++ (instancetype)makeWithUri:(NSString *)uri
+                 formatHint:(nullable NSString *)formatHint
+                httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
+                   viewType:(FVPPlatformVideoViewType)viewType {
   FVPCreationOptions *pigeonResult = [[FVPCreationOptions alloc] init];
-  pigeonResult.asset = asset;
   pigeonResult.uri = uri;
-  pigeonResult.packageName = packageName;
   pigeonResult.formatHint = formatHint;
   pigeonResult.httpHeaders = httpHeaders;
   pigeonResult.viewType = viewType;
@@ -94,12 +90,10 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 }
 + (FVPCreationOptions *)fromList:(NSArray<id> *)list {
   FVPCreationOptions *pigeonResult = [[FVPCreationOptions alloc] init];
-  pigeonResult.asset = GetNullableObjectAtIndex(list, 0);
-  pigeonResult.uri = GetNullableObjectAtIndex(list, 1);
-  pigeonResult.packageName = GetNullableObjectAtIndex(list, 2);
-  pigeonResult.formatHint = GetNullableObjectAtIndex(list, 3);
-  pigeonResult.httpHeaders = GetNullableObjectAtIndex(list, 4);
-  FVPPlatformVideoViewTypeBox *boxedFVPPlatformVideoViewType = GetNullableObjectAtIndex(list, 5);
+  pigeonResult.uri = GetNullableObjectAtIndex(list, 0);
+  pigeonResult.formatHint = GetNullableObjectAtIndex(list, 1);
+  pigeonResult.httpHeaders = GetNullableObjectAtIndex(list, 2);
+  FVPPlatformVideoViewTypeBox *boxedFVPPlatformVideoViewType = GetNullableObjectAtIndex(list, 3);
   pigeonResult.viewType = boxedFVPPlatformVideoViewType.value;
   return pigeonResult;
 }
@@ -108,9 +102,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 }
 - (NSArray<id> *)toList {
   return @[
-    self.asset ?: [NSNull null],
     self.uri ?: [NSNull null],
-    self.packageName ?: [NSNull null],
     self.formatHint ?: [NSNull null],
     self.httpHeaders ?: [NSNull null],
     [[FVPPlatformVideoViewTypeBox alloc] initWithValue:self.viewType],

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
@@ -284,6 +284,31 @@ void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> bin
       [channel setMessageHandler:nil];
     }
   }
+  {
+    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
+           initWithName:[NSString stringWithFormat:@"%@%@",
+                                                   @"dev.flutter.pigeon.video_player_avfoundation."
+                                                   @"AVFoundationVideoPlayerApi.getAssetUrl",
+                                                   messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+                  codec:FVPGetMessagesCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(fileURLForAssetWithName:package:error:)],
+                @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to "
+                @"@selector(fileURLForAssetWithName:package:error:)",
+                api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray<id> *args = message;
+        NSString *arg_asset = GetNullableObjectAtIndex(args, 0);
+        NSString *arg_package = GetNullableObjectAtIndex(args, 1);
+        FlutterError *error;
+        NSString *output = [api fileURLForAssetWithName:arg_asset package:arg_package error:&error];
+        callback(wrapResult(output, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
 }
 void SetUpFVPVideoPlayerInstanceApi(id<FlutterBinaryMessenger> binaryMessenger,
                                     NSObject<FVPVideoPlayerInstanceApi> *api) {

--- a/packages/video_player/video_player_avfoundation/example/lib/main.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/main.dart
@@ -269,9 +269,9 @@ class _BumbleBeeEncryptedLiveStreamState
     _controller.addListener(() {
       setState(() {});
     });
-    _controller.initialize();
-
-    _controller.play();
+    _controller.initialize().then((_) {
+      _controller.play();
+    });
   }
 
   @override

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -88,9 +88,7 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
           dataSource.package,
         );
       case DataSourceType.network:
-        uri = dataSource.uri;
       case DataSourceType.file:
-        uri = dataSource.uri;
       case DataSourceType.contentUri:
         uri = dataSource.uri;
     }
@@ -168,37 +166,33 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
         .receiveBroadcastStream()
         .map((dynamic event) {
       final Map<dynamic, dynamic> map = event as Map<dynamic, dynamic>;
-      switch (map['event']) {
-        case 'initialized':
-          return VideoEvent(
+      return switch (map['event']) {
+        'initialized' => VideoEvent(
             eventType: VideoEventType.initialized,
             duration: Duration(milliseconds: map['duration'] as int),
-            size: Size((map['width'] as num?)?.toDouble() ?? 0.0,
-                (map['height'] as num?)?.toDouble() ?? 0.0),
-          );
-        case 'completed':
-          return VideoEvent(
+            size: Size(
+              (map['width'] as num?)?.toDouble() ?? 0.0,
+              (map['height'] as num?)?.toDouble() ?? 0.0,
+            ),
+          ),
+        'completed' => VideoEvent(
             eventType: VideoEventType.completed,
-          );
-        case 'bufferingUpdate':
-          final List<dynamic> values = map['values'] as List<dynamic>;
-
-          return VideoEvent(
-            buffered: values.map<DurationRange>(_toDurationRange).toList(),
+          ),
+        'bufferingUpdate' => VideoEvent(
+            buffered: (map['values'] as List<dynamic>)
+                .map<DurationRange>(_toDurationRange)
+                .toList(),
             eventType: VideoEventType.bufferingUpdate,
-          );
-        case 'bufferingStart':
-          return VideoEvent(eventType: VideoEventType.bufferingStart);
-        case 'bufferingEnd':
-          return VideoEvent(eventType: VideoEventType.bufferingEnd);
-        case 'isPlayingStateUpdate':
-          return VideoEvent(
+          ),
+        'bufferingStart' =>
+          VideoEvent(eventType: VideoEventType.bufferingStart),
+        'bufferingEnd' => VideoEvent(eventType: VideoEventType.bufferingEnd),
+        'isPlayingStateUpdate' => VideoEvent(
             eventType: VideoEventType.isPlayingStateUpdate,
             isPlaying: map['isPlaying'] as bool,
-          );
-        default:
-          return VideoEvent(eventType: VideoEventType.unknown);
-      }
+          ),
+        _ => VideoEvent(eventType: VideoEventType.unknown),
+      };
     });
   }
 

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -74,29 +74,34 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     final DataSource dataSource = options.dataSource;
     final VideoViewType viewType = options.viewType;
 
-    String? asset;
-    String? packageName;
     String? uri;
     String? formatHint;
-    Map<String, String> httpHeaders = <String, String>{};
     switch (dataSource.sourceType) {
       case DataSourceType.asset:
-        asset = dataSource.asset;
-        packageName = dataSource.package;
+        final String? asset = dataSource.asset;
+        if (asset == null) {
+          throw ArgumentError(
+            '"asset" must be non-null for an asset data source',
+          );
+        }
+        uri = await _api.getAssetUrl(
+          asset,
+          dataSource.package,
+        );
       case DataSourceType.network:
         uri = dataSource.uri;
         formatHint = _videoFormatStringMap[dataSource.formatHint];
-        httpHeaders = dataSource.httpHeaders;
       case DataSourceType.file:
         uri = dataSource.uri;
       case DataSourceType.contentUri:
         uri = dataSource.uri;
     }
+    if (uri == null) {
+      throw ArgumentError('Unable to construct a video asset from $options');
+    }
     final CreationOptions pigeonCreationOptions = CreationOptions(
-      asset: asset,
-      packageName: packageName,
       uri: uri,
-      httpHeaders: httpHeaders,
+      httpHeaders: dataSource.httpHeaders,
       formatHint: formatHint,
       viewType: _platformVideoViewTypeFromVideoViewType(viewType),
     );

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -87,6 +87,14 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
           asset,
           dataSource.package,
         );
+        if (uri == null) {
+          // Throw a platform exception for compatibility with the previous
+          // implementation, which threw on the native side.
+          throw PlatformException(
+              code: 'video_player',
+              message:
+                  'Asset $asset not found in package ${dataSource.package}.');
+        }
       case DataSourceType.network:
       case DataSourceType.file:
       case DataSourceType.contentUri:

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -75,7 +75,6 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     final VideoViewType viewType = options.viewType;
 
     String? uri;
-    String? formatHint;
     switch (dataSource.sourceType) {
       case DataSourceType.asset:
         final String? asset = dataSource.asset;
@@ -90,7 +89,6 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
         );
       case DataSourceType.network:
         uri = dataSource.uri;
-        formatHint = _videoFormatStringMap[dataSource.formatHint];
       case DataSourceType.file:
         uri = dataSource.uri;
       case DataSourceType.contentUri:
@@ -102,7 +100,6 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     final CreationOptions pigeonCreationOptions = CreationOptions(
       uri: uri,
       httpHeaders: dataSource.httpHeaders,
-      formatHint: formatHint,
       viewType: _platformVideoViewTypeFromVideoViewType(viewType),
     );
 
@@ -254,14 +251,6 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     final VideoPlayerInstanceApi? player = _players[id];
     return player ?? (throw StateError('No active player with ID $id.'));
   }
-
-  static const Map<VideoFormat, String> _videoFormatStringMap =
-      <VideoFormat, String>{
-    VideoFormat.ss: 'ss',
-    VideoFormat.hls: 'hls',
-    VideoFormat.dash: 'dash',
-    VideoFormat.other: 'other',
-  };
 
   DurationRange _toDurationRange(dynamic value) {
     final List<dynamic> pair = value as List<dynamic>;

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -294,7 +294,7 @@ class AVFoundationVideoPlayerApi {
     }
   }
 
-  Future<String> getAssetUrl(String asset, String? package) async {
+  Future<String?> getAssetUrl(String asset, String? package) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.getAssetUrl$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
@@ -315,13 +315,8 @@ class AVFoundationVideoPlayerApi {
         message: pigeonVar_replyList[1] as String?,
         details: pigeonVar_replyList[2],
       );
-    } else if (pigeonVar_replyList[0] == null) {
-      throw PlatformException(
-        code: 'null-error',
-        message: 'Host platform returned null value for non-null return value.',
-      );
     } else {
-      return (pigeonVar_replyList[0] as String?)!;
+      return (pigeonVar_replyList[0] as String?);
     }
   }
 }

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -308,6 +308,37 @@ class AVFoundationVideoPlayerApi {
       return;
     }
   }
+
+  Future<String> getAssetUrl(String asset, String? package) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.getAssetUrl$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[asset, package]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as String?)!;
+    }
+  }
 }
 
 class VideoPlayerInstanceApi {

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -84,19 +84,13 @@ class PlatformVideoViewCreationParams {
 
 class CreationOptions {
   CreationOptions({
-    this.asset,
-    this.uri,
-    this.packageName,
+    required this.uri,
     this.formatHint,
     required this.httpHeaders,
     required this.viewType,
   });
 
-  String? asset;
-
-  String? uri;
-
-  String? packageName;
+  String uri;
 
   String? formatHint;
 
@@ -106,9 +100,7 @@ class CreationOptions {
 
   List<Object?> _toList() {
     return <Object?>[
-      asset,
       uri,
-      packageName,
       formatHint,
       httpHeaders,
       viewType,
@@ -122,13 +114,11 @@ class CreationOptions {
   static CreationOptions decode(Object result) {
     result as List<Object?>;
     return CreationOptions(
-      asset: result[0] as String?,
-      uri: result[1] as String?,
-      packageName: result[2] as String?,
-      formatHint: result[3] as String?,
+      uri: result[0]! as String,
+      formatHint: result[1] as String?,
       httpHeaders:
-          (result[4] as Map<Object?, Object?>?)!.cast<String, String>(),
-      viewType: result[5]! as PlatformVideoViewType,
+          (result[2] as Map<Object?, Object?>?)!.cast<String, String>(),
+      viewType: result[3]! as PlatformVideoViewType,
     );
   }
 

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -85,14 +85,11 @@ class PlatformVideoViewCreationParams {
 class CreationOptions {
   CreationOptions({
     required this.uri,
-    this.formatHint,
     required this.httpHeaders,
     required this.viewType,
   });
 
   String uri;
-
-  String? formatHint;
 
   Map<String, String> httpHeaders;
 
@@ -101,7 +98,6 @@ class CreationOptions {
   List<Object?> _toList() {
     return <Object?>[
       uri,
-      formatHint,
       httpHeaders,
       viewType,
     ];
@@ -115,10 +111,9 @@ class CreationOptions {
     result as List<Object?>;
     return CreationOptions(
       uri: result[0]! as String,
-      formatHint: result[1] as String?,
       httpHeaders:
-          (result[2] as Map<Object?, Object?>?)!.cast<String, String>(),
-      viewType: result[3]! as PlatformVideoViewType,
+          (result[1] as Map<Object?, Object?>?)!.cast<String, String>(),
+      viewType: result[2]! as PlatformVideoViewType,
     );
   }
 

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -40,7 +40,6 @@ class CreationOptions {
   });
 
   String uri;
-  String? formatHint;
   Map<String, String> httpHeaders;
   PlatformVideoViewType viewType;
 }

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -34,13 +34,12 @@ class PlatformVideoViewCreationParams {
 
 class CreationOptions {
   CreationOptions({
+    required this.uri,
     required this.httpHeaders,
     required this.viewType,
   });
 
-  String? asset;
-  String? uri;
-  String? packageName;
+  String uri;
   String? formatHint;
   Map<String, String> httpHeaders;
   PlatformVideoViewType viewType;

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -57,6 +57,8 @@ abstract class AVFoundationVideoPlayerApi {
   void dispose(int playerId);
   @ObjCSelector('setMixWithOthers:')
   void setMixWithOthers(bool mixWithOthers);
+  @ObjCSelector('fileURLForAssetWithName:package:')
+  String getAssetUrl(String asset, String? package);
 }
 
 @HostApi()

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -56,7 +56,7 @@ abstract class AVFoundationVideoPlayerApi {
   @ObjCSelector('setMixWithOthers:')
   void setMixWithOthers(bool mixWithOthers);
   @ObjCSelector('fileURLForAssetWithName:package:')
-  String getAssetUrl(String asset, String? package);
+  String? getAssetUrl(String asset, String? package);
 }
 
 @HostApi()

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.8.0
+version: 2.8.1
 
 environment:
   sdk: ^3.6.0

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -75,6 +75,11 @@ void main() {
 
       const String asset = 'someAsset';
       const String package = 'somePackage';
+      const String assetUrl = 'file:///some/asset/path';
+      when(
+        api.getAssetUrl(asset, package),
+      ).thenAnswer((_) async => assetUrl);
+
       final int? playerId = await player.create(
         DataSource(
           sourceType: DataSourceType.asset,
@@ -86,8 +91,7 @@ void main() {
       final VerificationResult verification = verify(api.create(captureAny));
       final CreationOptions creationOptions =
           verification.captured[0] as CreationOptions;
-      expect(creationOptions.asset, asset);
-      expect(creationOptions.packageName, package);
+      expect(creationOptions.uri, assetUrl);
       expect(playerId, newPlayerId);
       expect(player.playerViewStates[newPlayerId],
           const VideoPlayerTextureViewState(textureId: newPlayerId));
@@ -114,9 +118,7 @@ void main() {
       final VerificationResult verification = verify(api.create(captureAny));
       final CreationOptions creationOptions =
           verification.captured[0] as CreationOptions;
-      expect(creationOptions.asset, null);
       expect(creationOptions.uri, uri);
-      expect(creationOptions.packageName, null);
       expect(creationOptions.formatHint, 'dash');
       expect(creationOptions.httpHeaders, <String, String>{});
       expect(playerId, newPlayerId);
@@ -181,6 +183,10 @@ void main() {
 
       const String asset = 'someAsset';
       const String package = 'somePackage';
+      const String assetUrl = 'file:///some/asset/path';
+      when(
+        api.getAssetUrl(asset, package),
+      ).thenAnswer((_) async => assetUrl);
       final int? playerId = await player.createWithOptions(
         VideoCreationOptions(
           dataSource: DataSource(
@@ -195,8 +201,7 @@ void main() {
       final VerificationResult verification = verify(api.create(captureAny));
       final CreationOptions creationOptions =
           verification.captured[0] as CreationOptions;
-      expect(creationOptions.asset, asset);
-      expect(creationOptions.packageName, package);
+      expect(creationOptions.uri, assetUrl);
       expect(playerId, newPlayerId);
       expect(player.playerViewStates[newPlayerId],
           const VideoPlayerTextureViewState(textureId: newPlayerId));
@@ -226,9 +231,7 @@ void main() {
       final VerificationResult verification = verify(api.create(captureAny));
       final CreationOptions creationOptions =
           verification.captured[0] as CreationOptions;
-      expect(creationOptions.asset, null);
       expect(creationOptions.uri, uri);
-      expect(creationOptions.packageName, null);
       expect(creationOptions.formatHint, 'dash');
       expect(creationOptions.httpHeaders, <String, String>{});
       expect(playerId, newPlayerId);

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -119,7 +119,6 @@ void main() {
       final CreationOptions creationOptions =
           verification.captured[0] as CreationOptions;
       expect(creationOptions.uri, uri);
-      expect(creationOptions.formatHint, 'dash');
       expect(creationOptions.httpHeaders, <String, String>{});
       expect(playerId, newPlayerId);
       expect(player.playerViewStates[newPlayerId],
@@ -232,7 +231,6 @@ void main() {
       final CreationOptions creationOptions =
           verification.captured[0] as CreationOptions;
       expect(creationOptions.uri, uri);
-      expect(creationOptions.formatHint, 'dash');
       expect(creationOptions.httpHeaders, <String, String>{});
       expect(playerId, newPlayerId);
       expect(player.playerViewStates[newPlayerId],

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -97,6 +97,31 @@ void main() {
           const VideoPlayerTextureViewState(textureId: newPlayerId));
     });
 
+    test('create with asset throws PlatformException for missing asset',
+        () async {
+      final (
+        AVFoundationVideoPlayer player,
+        MockAVFoundationVideoPlayerApi api,
+        _,
+      ) = setUpMockPlayer(playerId: 1);
+
+      const String asset = 'someAsset';
+      const String package = 'somePackage';
+      when(
+        api.getAssetUrl(asset, package),
+      ).thenAnswer((_) async => null);
+
+      expect(
+          player.create(
+            DataSource(
+              sourceType: DataSourceType.asset,
+              asset: asset,
+              package: package,
+            ),
+          ),
+          throwsA(isA<PlatformException>()));
+    });
+
     test('create with network', () async {
       final (
         AVFoundationVideoPlayer player,

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.mocks.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.mocks.dart
@@ -81,6 +81,42 @@ class MockAVFoundationVideoPlayerApi extends _i1.Mock
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<String> getAssetUrl(
+    String? asset,
+    String? package,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getAssetUrl,
+          [
+            asset,
+            package,
+          ],
+        ),
+        returnValue: _i4.Future<String>.value(_i3.dummyValue<String>(
+          this,
+          Invocation.method(
+            #getAssetUrl,
+            [
+              asset,
+              package,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i4.Future<String>.value(_i3.dummyValue<String>(
+          this,
+          Invocation.method(
+            #getAssetUrl,
+            [
+              asset,
+              package,
+            ],
+          ),
+        )),
+      ) as _i4.Future<String>);
 }
 
 /// A class which mocks [VideoPlayerInstanceApi].

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.mocks.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.mocks.dart
@@ -83,7 +83,7 @@ class MockAVFoundationVideoPlayerApi extends _i1.Mock
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<String> getAssetUrl(
+  _i4.Future<String?> getAssetUrl(
     String? asset,
     String? package,
   ) =>
@@ -95,28 +95,9 @@ class MockAVFoundationVideoPlayerApi extends _i1.Mock
             package,
           ],
         ),
-        returnValue: _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #getAssetUrl,
-            [
-              asset,
-              package,
-            ],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #getAssetUrl,
-            [
-              asset,
-              package,
-            ],
-          ),
-        )),
-      ) as _i4.Future<String>);
+        returnValue: _i4.Future<String?>.value(),
+        returnValueForMissingStub: _i4.Future<String?>.value(),
+      ) as _i4.Future<String?>);
 }
 
 /// A class which mocks [VideoPlayerInstanceApi].


### PR DESCRIPTION
Moves some logic from native code to Dart:
- Asset -> URL lookup.

Also does some minor native cleanup:
- Removes unnecessary state from `FVPVideoPlayerPlugin`; several registrar-vended objects were being stored, and later changes required storing the registrar itself, so now we can just get those from the registrar on demand.
- Removes nil player handling; the player can never return nil now.
- Removes `formatHint` from the Pigeon interface; it was only ever used on Android, so doesn't need to be sent across the language boundary.

Part of https://github.com/flutter/flutter/issues/172763

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
