### PR TITLE
feat(interactive_media_ads): Add support for remaining AdsRequest met…

### DIFF
--- a/packages/interactive_media_ads/lib/src/ads_request.dart
+++ b/packages/interactive_media_ads/lib/src/ads_request.dart
@@ -2,36 +2,122 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
+
 import 'content_progress_provider.dart';
 import 'platform_interface/platform_interface.dart';
 
 /// An object containing the data used to request ads from the server.
+@immutable
 class AdsRequest {
   /// Creates an [AdsRequest].
   AdsRequest({
     required String adTagUrl,
     ContentProgressProvider? contentProgressProvider,
-  }) : this.fromPlatform(
-          PlatformAdsRequest(
+  }) : this.fromPlatformCreationParams(
+          PlatformAdsRequestCreationParams(
             adTagUrl: adTagUrl,
             contentProgressProvider: contentProgressProvider?.platform,
           ),
         );
 
+  /// Creates an [AdsRequest] with a VAST, VMAP, or ad rules response to be
+  /// used instead of making a request through an ad tag URL.
+  AdsRequest.fromAdsResponse({
+    required String adsResponse,
+    ContentProgressProvider? contentProgressProvider,
+  }) : this.fromPlatformCreationParams(
+          PlatformAdsRequestCreationParams(
+            adsResponse: adsResponse,
+            contentProgressProvider: contentProgressProvider?.platform,
+          ),
+        );
+
+  /// Constructs an [AdsRequest] from creation params for a specific platform.
+  AdsRequest.fromPlatformCreationParams(
+    PlatformAdsRequestCreationParams params,
+  ) : this.fromPlatform(PlatformAdsRequest(params));
+
   /// Constructs an [AdsRequest] from a specific platform implementation.
-  AdsRequest.fromPlatform(this.platform);
+  const AdsRequest.fromPlatform(this.platform);
 
   /// Implementation of [PlatformAdsRequest] for the current platform.
   final PlatformAdsRequest platform;
 
-  /// The URL from which ads will be requested.
-  String get adTagUrl => platform.adTagUrl;
+  /// Notifies the SDK whether the player intends to start the content and ad in
+  /// response to a user action or whether it will be automatically played.
+  ///
+  /// Not calling this function leaves the setting as unknown. Note: Changing
+  /// this setting will have no impact on ad playback.
+  Future<void> setAdWillAutoPlay(bool adWillAutoPlay) {
+    return platform.setAdWillAutoPlay(adWillAutoPlay);
+  }
 
-  /// A [ContentProgressProvider] instance to allow scheduling of ad breaks
-  /// based on content progress (cue points).
-  ContentProgressProvider? get contentProgressProvider => platform
-              .contentProgressProvider !=
-          null
-      ? ContentProgressProvider.fromPlatform(platform.contentProgressProvider!)
-      : null;
+  /// Notifies the SDK whether the player intends to start the content and ad
+  /// while muted.
+  ///
+  /// Not calling this function leaves the setting as unknown. Note: Changing
+  /// this setting will have no impact on ad playback.
+  Future<void> setAdWillPlayMuted(bool adWillPlayMuted) {
+    return platform.setAdWillPlayMuted(adWillPlayMuted);
+  }
+
+  /// Notifies the SDK whether the player intends to continuously play the
+  /// content videos one after another similar to TV broadcast.
+  ///
+  /// Not calling this function leaves the setting as unknown. Note: Changing
+  /// this setting will have no impact on ad playback.
+  Future<void> setContinuousPlayback(bool continuousPlayback) {
+    return platform.setContinuousPlayback(continuousPlayback);
+  }
+
+  /// Specifies the duration of the content in seconds to be shown.
+  ///
+  /// This optional parameter is used by AdX requests. It is recommended for AdX
+  /// users.
+  Future<void> setContentDuration(double contentDuration) {
+    return platform.setContentDuration(contentDuration);
+  }
+
+  /// Specifies the keywords used to describe the content to be shown.
+  ///
+  -/// This optional parameter is used by AdX requests and is recommended for AdX
+  /// users.
+  Future<void> setContentKeywords(List<String> contentKeywords) {
+    return platform.setContentKeywords(contentKeywords);
+  }
+
+  /// Specifies the title of the content to be shown.
+  ///
+  /// Used in AdX requests. This optional parameter is used by AdX requests and
+  /// is recommended for AdX users.
+  Future<void> setContentTitle(String contentTitle) {
+    return platform.setContentTitle(contentTitle);
+  }
+
+  /// Specifies the universal link to the content’s screen.
+  ///
+  /// If provided, this parameter is passed to the OM SDK. See
+  /// [Apple documentation](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content)
+  /// for more information.
+  Future<void> setContentUrl(String contentUrl) {
+    return platform.setContentUrl(contentUrl);
+  }
+
+  /// Specifies the maximum amount of time to wait in seconds, after calling
+  /// requestAds, before requesting the ad tag URL.
+  ///
+  /// This can be used to stagger requests during a live-stream event, in order
+  /// to mitigate spikes in the number of requests.
+  Future<void> setLiveStreamPrefetchSeconds(double liveStreamPrefetchSeconds) {
+    return platform.setLiveStreamPrefetchSeconds(liveStreamPrefetchSeconds);
+  }
+
+  /// Specifies the VAST load timeout in milliseconds for a single wrapper.
+  ///
+  /// This parameter is optional and will override the default timeout,
+  /// currently set to 5000ms.
+  Future<void> setVastLoadTimeout(double vastLoadTimeout) {
+    return platform.setVastLoadTimeout(vastLoadTimeout);
+  }
 }

--- a/packages/interactive_media_ads/lib/src/android/android_ads_request.dart
+++ b/packages/interactive_media_ads/lib/src/android/android_ads_request.dart
@@ -1,0 +1,83 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../platform_interface/platform_ads_request.dart';
+import 'interactive_media_ads.g.dart';
+
+/// Android implementation of [PlatformAdsRequest].
+@immutable
+final class AndroidAdsRequest extends PlatformAdsRequest {
+  /// Constructs an [AndroidAdsRequest].
+  AndroidAdsRequest(super.params) : super.implementation();
+
+  late final Future<AdsRequest> _request = _createRequest();
+
+  @override
+  Future<void> setAdWillAutoPlay(bool adWillAutoPlay) async {
+    (await _request).setAdWillAutoPlay(adWillAutoPlay);
+  }
+
+  @override
+  Future<void> setAdWillPlayMuted(bool adWillPlayMuted) async {
+    (await _request).setAdWillPlayMuted(adWillPlayMuted);
+  }
+
+  @override
+  Future<void> setContinuousPlayback(bool continuousPlayback) async {
+    (await _request).setContinuousPlayback(continuousPlayback);
+  }
+
+  @override
+  Future<void> setContentDuration(double contentDuration) async {
+    (await _request).setContentDuration(contentDuration);
+  }
+
+  @override
+  Future<void> setContentKeywords(List<String> contentKeywords) async {
+    (await _request).setContentKeywords(contentKeywords);
+  }
+
+  @override
+  Future<void> setContentTitle(String contentTitle) async {
+    (await _request).setContentTitle(contentTitle);
+  }
+
+  @override
+  Future<void> setContentUrl(String contentUrl) async {
+    (await _request).setContentUrl(contentUrl);
+  }
+
+  @override
+  Future<void> setLiveStreamPrefetchSeconds(
+    double liveStreamPrefetchSeconds,
+  ) async {
+    (await _request).setLiveStreamPrefetchSeconds(liveStreamPrefetchSeconds);
+  }
+
+  @override
+  Future<void> setVastLoadTimeout(double vastLoadTimeout) async {
+    (await _request).setVastLoadTimeout(vastLoadTimeout);
+  }
+
+  Future<AdsRequest> _createRequest() async {
+    final AdsRequest request = await ImaSdkFactory.instance.createAdsRequest();
+
+    final List<Future<void>> futures = <Future<void>>[];
+    if (params.adTagUrl case final String adTagUrl) {
+      futures.add(request.setAdTagUrl(adTagUrl));
+    } else if (params.adsResponse case final String adsResponse) {
+      futures.add(request.setAdsResponse(adsResponse));
+    }
+
+    // TODO(bparrishMines): Add contentProgressProvider when it's supported on
+    // Android.
+
+    await Future.wait(futures);
+    return request;
+  }
+}

--- a/packages/interactive_media_ads/lib/src/android/android_interactive_media_ads.dart
+++ b/packages/interactive_media_ads/lib/src/android/android_interactive_media_ads.dart
@@ -9,11 +9,19 @@ import '../platform_interface/platform_ads_manager_delegate.dart';
 import '../platform_interface/platform_ads_rendering_settings.dart';
 import '../platform_interface/platform_companion_ad_slot.dart';
 import '../platform_interface/platform_content_progress_provider.dart';
+import '../platform_interface/platform_ad_display_container.dart';
+import '../platform_interface/platform_ads_loader.dart';
+import '../platform_interface/platform_ads_manager_delegate.dart';
+import '../platform_interface/platform_ads_rendering_settings.dart';
+import '../platform_interface/platform_ads_request.dart';
+import '../platform_interface/platform_companion_ad_slot.dart';
+import '../platform_interface/platform_content_progress_provider.dart';
 import '../platform_interface/platform_ima_settings.dart';
 import 'android_ad_display_container.dart';
 import 'android_ads_loader.dart';
 import 'android_ads_manager_delegate.dart';
 import 'android_ads_rendering_settings.dart';
+import 'android_ads_request.dart';
 import 'android_companion_ad_slot.dart';
 import 'android_content_progress_provider.dart';
 import 'android_ima_settings.dart';
@@ -72,5 +80,12 @@ final class AndroidInteractiveMediaAds extends InteractiveMediaAdsPlatform {
     PlatformImaSettingsCreationParams params,
   ) {
     return AndroidImaSettings(params);
+  }
+
+  @override
+  AndroidAdsRequest createPlatformAdsRequest(
+    PlatformAdsRequestCreationParams params,
+  ) {
+    return AndroidAdsRequest(params);
   }
 }

--- a/packages/interactive_media_ads/lib/src/ios/ios_ads_request.dart
+++ b/packages/interactive_media_ads/lib/src/ios/ios_ads_request.dart
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import '../platform_interface/platform_ads_request.dart';
+import 'interactive_media_ads.g.dart';
+
+/// iOS implementation of [PlatformAdsRequest].
+@immutable
+final class IOSAdsRequest extends PlatformAdsRequest {
+  /// Constructs an [IOSAdsRequest].
+  IOSAdsRequest(super.params) : super.implementation();
+
+  /// Returns the native object to be passed to the pigeon API.
+  late final IMAAdsRequest nativeRequest = _createRequest();
+
+  @override
+  Future<void> setAdWillAutoPlay(bool adWillAutoPlay) {
+    return nativeRequest.setAdWillAutoPlay(adWillAutoPlay);
+  }
+
+  @override
+  Future<void> setAdWillPlayMuted(bool adWillPlayMuted) {
+    return nativeRequest.setAdWillPlayMuted(adWillPlayMuted);
+  }
+
+  @override
+  Future<void> setContinuousPlayback(bool continuousPlayback) {
+    return nativeRequest.setContinuousPlayback(continuousPlayback);
+  }
+
+  @override
+  Future<void> setContentDuration(double contentDuration) {
+    return nativeRequest.setContentDuration(contentDuration);
+  }
+
+  @override
+  Future<void> setContentKeywords(List<String> contentKeywords) {
+    return nativeRequest.setContentKeywords(contentKeywords);
+  }
+
+  @override
+  Future<void> setContentTitle(String contentTitle) {
+    return nativeRequest.setContentTitle(contentTitle);
+  }
+
+  @override
+  Future<void> setContentUrl(String contentUrl) {
+    return nativeRequest.setContentURL(contentUrl);
+  }
+
+  @override
+  Future<void> setLiveStreamPrefetchSeconds(double liveStreamPrefetchSeconds) {
+    return nativeRequest.setLiveStreamPrefetchSeconds(liveStreamPrefetchSeconds);
+  }
+
+  @override
+  Future<void> setVastLoadTimeout(double vastLoadTimeout) {
+    return nativeRequest.setVastLoadTimeout(vastLoadTimeout);
+  }
+
+  IMAAdsRequest _createRequest() {
+    final IMAContentPlayhead? contentPlayhead;
+    if (params.contentProgressProvider != null) {
+      // TODO(bparrishMines): Finish content progress provider.
+      contentPlayhead = IMAContentPlayhead();
+    } else {
+      contentPlayhead = null;
+    }
+
+    if (params.adTagUrl case final String adTagUrl) {
+      return IMAAdsRequest(
+        adTagUrl,
+        // The ad display container is mainly used for rendering ads and isn't
+        // needed until the ads are loaded.
+        IMAAdDisplayContainer(null),
+        contentPlayhead,
+      );
+    } else {
+      return IMAAdsRequest.withAdsResponse(
+        params.adsResponse!,
+        // The ad display container is mainly used for rendering ads and isn't
+        // needed until the ads are loaded.
+        IMAAdDisplayContainer(null),
+        contentPlayhead,
+      );
+    }
+  }
+}

--- a/packages/interactive_media_ads/lib/src/ios/ios_interactive_media_ads.dart
+++ b/packages/interactive_media_ads/lib/src/ios/ios_interactive_media_ads.dart
@@ -9,11 +9,19 @@ import '../platform_interface/platform_ads_manager_delegate.dart';
 import '../platform_interface/platform_ads_rendering_settings.dart';
 import '../platform_interface/platform_companion_ad_slot.dart';
 import '../platform_interface/platform_content_progress_provider.dart';
+import '../platform_interface/platform_ad_display_container.dart';
+import '../platform_interface/platform_ads_loader.dart';
+import '../platform_interface/platform_ads_manager_delegate.dart';
+import '../platform_interface/platform_ads_rendering_settings.dart';
+import '../platform_interface/platform_ads_request.dart';
+import '../platform_interface/platform_companion_ad_slot.dart';
+import '../platform_interface/platform_content_progress_provider.dart';
 import '../platform_interface/platform_ima_settings.dart';
 import 'ios_ad_display_container.dart';
 import 'ios_ads_loader.dart';
 import 'ios_ads_manager_delegate.dart';
 import 'ios_ads_rendering_settings.dart';
+import 'ios_ads_request.dart';
 import 'ios_companion_ad_slot.dart';
 import 'ios_content_progress_provider.dart';
 import 'ios_ima_settings.dart';
@@ -70,5 +78,12 @@ final class IOSInteractiveMediaAds extends InteractiveMediaAdsPlatform {
     PlatformImaSettingsCreationParams params,
   ) {
     return IOSImaSettings(params);
+  }
+
+  @override
+  IOSAdsRequest createPlatformAdsRequest(
+    PlatformAdsRequestCreationParams params,
+  ) {
+    return IOSAdsRequest(params);
   }
 }

--- a/packages/interactive_media_ads/lib/src/platform_interface/interactive_media_ads_platform.dart
+++ b/packages/interactive_media_ads/lib/src/platform_interface/interactive_media_ads_platform.dart
@@ -6,6 +6,7 @@ import 'platform_ad_display_container.dart';
 import 'platform_ads_loader.dart';
 import 'platform_ads_manager_delegate.dart';
 import 'platform_ads_rendering_settings.dart';
+import 'platform_ads_request.dart';
 import 'platform_companion_ad_slot.dart';
 import 'platform_content_progress_provider.dart';
 import 'platform_ima_settings.dart';
@@ -39,7 +40,7 @@ abstract base class InteractiveMediaAdsPlatform {
     PlatformContentProgressProviderCreationParams params,
   );
 
-  /// Creates a new [PlatformContentProgressProvider].
+  /// Creates a new [PlatformAdsRenderingSettings].
   PlatformAdsRenderingSettings createPlatformAdsRenderingSettings(
     PlatformAdsRenderingSettingsCreationParams params,
   );
@@ -52,5 +53,10 @@ abstract base class InteractiveMediaAdsPlatform {
   /// Creates a new [PlatformImaSettings].
   PlatformImaSettings createPlatformImaSettings(
     PlatformImaSettingsCreationParams params,
+  );
+
+  /// Creates a new [PlatformAdsRequest].
+  PlatformAdsRequest createPlatformAdsRequest(
+    PlatformAdsRequestCreationParams params,
   );
 }

--- a/packages/interactive_media_ads/lib/src/platform_interface/platform_ads_request.dart
+++ b/packages/interactive_media_ads/lib/src/platform_interface/platform_ads_request.dart
@@ -2,20 +2,113 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
+
+import 'interactive_media_ads_platform.dart';
 import 'platform_content_progress_provider.dart';
 
-/// An object containing the data used to request ads from the server.
-class PlatformAdsRequest {
-  /// Creates an [PlatformAdsRequest].
-  PlatformAdsRequest({
-    required this.adTagUrl,
+/// Creation parameters for a [PlatformAdsRequest].
+@immutable
+base class PlatformAdsRequestCreationParams {
+  /// Creates a [PlatformAdsRequestCreationParams].
+  const PlatformAdsRequestCreationParams({
+    this.adTagUrl,
+    this.adsResponse,
     this.contentProgressProvider,
-  });
+  }) : assert(
+          (adTagUrl != null && adsResponse == null) ||
+              (adTagUrl == null && adsResponse != null),
+          'Exactly one of `adTagUrl` or `adsResponse` must be provided.',
+        );
 
   /// The URL from which ads will be requested.
-  final String adTagUrl;
+  final String? adTagUrl;
+
+  /// Specifies a VAST, VMAP, or ad rules response to be used instead of making
+  /// a request through an ad tag URL.
+  final String? adsResponse;
 
   /// A [PlatformContentProgressProvider] instance to allow scheduling of ad
   /// breaks based on content progress (cue points).
   final PlatformContentProgressProvider? contentProgressProvider;
+}
+
+/// An object containing the data used to request ads from the server.
+abstract base class PlatformAdsRequest {
+  /// Creates a new [PlatformAdsRequest].
+  factory PlatformAdsRequest(PlatformAdsRequestCreationParams params) {
+    assert(InteractiveMediaAdsPlatform.instance != null);
+    final PlatformAdsRequest implementation =
+        InteractiveMediaAdsPlatform.instance!.createPlatformAdsRequest(params);
+    return implementation;
+  }
+
+  /// Used by the platform implementation to create a new [PlatformAdsRequest].
+  ///
+  /// Should only be used by platform implementations because they can't extend
+  /// a class that only contains a factory constructor.
+  @protected
+  PlatformAdsRequest.implementation(this.params);
+
+  /// The parameters used to initialize the [PlatformAdsRequest].
+  final PlatformAdsRequestCreationParams params;
+
+  /// Notifies the SDK whether the player intends to start the content and ad in
+  /// response to a user action or whether it will be automatically played.
+  ///
+  /// Not calling this function leaves the setting as unknown. Note: Changing
+  /// this setting will have no impact on ad playback.
+  Future<void> setAdWillAutoPlay(bool adWillAutoPlay);
+
+  /// Notifies the SDK whether the player intends to start the content and ad
+  /// while muted.
+  ///
+  /// Not calling this function leaves the setting as unknown. Note: Changing
+  /// this setting will have no impact on ad playback.
+  Future<void> setAdWillPlayMuted(bool adWillPlayMuted);
+
+  /// Notifies the SDK whether the player intends to continuously play the
+  /// content videos one after another similar to TV broadcast.
+  ///
+  /// Not calling this function leaves the setting as unknown. Note: Changing
+  /// this setting will have no impact on ad playback.
+  Future<void> setContinuousPlayback(bool continuousPlayback);
+
+  /// Specifies the duration of the content in seconds to be shown.
+  ///
+  /// This optional parameter is used by AdX requests. It is recommended for AdX
+  /// users.
+  Future<void> setContentDuration(double contentDuration);
+
+  /// Specifies the keywords used to describe the content to be shown.
+  ///
+  -/// This optional parameter is used by AdX requests and is recommended for AdX
+  /// users.
+  Future<void> setContentKeywords(List<String> contentKeywords);
+
+  /// Specifies the title of the content to be shown.
+  ///
+  /// Used in AdX requests. This optional parameter is used by AdX requests and
+  /// is recommended for AdX users.
+  Future<void> setContentTitle(String contentTitle);
+
+  /// Specifies the universal link to the content’s screen.
+  ///
+  /// If provided, this parameter is passed to the OM SDK. See
+  /// [Apple documentation](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content)
+  /// for more information.
+  Future<void> setContentUrl(String contentUrl);
+
+  /// Specifies the maximum amount of time to wait in seconds, after calling
+  /// requestAds, before requesting the ad tag URL.
+  ///
+  /// This can be used to stagger requests during a live-stream event, in order
+  /// to mitigate spikes in the number of requests.
+  Future<void> setLiveStreamPrefetchSeconds(double liveStreamPrefetchSeconds);
+
+  /// Specifies the VAST load timeout in milliseconds for a single wrapper.
+  ///
+  /// This parameter is optional and will override the default timeout,
+  /// currently set to 5000ms.
+  Future<void> setVastLoadTimeout(double vastLoadTimeout);
 }

--- a/packages/interactive_media_ads/test/ads_request_test.dart
+++ b/packages/interactive_media_ads/test/ads_request_test.dart
@@ -1,0 +1,94 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interactive_media_ads/interactive_media_ads.dart';
+import 'package:interactive_media_ads/src/platform_interface/platform_interface.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'ads_request_test.mocks.dart';
+import 'test_stubs.dart';
+
+@GenerateMocks(<Type>[
+  PlatformAdsRequest,
+  TestInteractiveMediaAdsPlatform,
+])
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AdsRequest', () {
+    late MockTestInteractiveMediaAdsPlatform platform;
+
+    setUp(() {
+      platform = MockTestInteractiveMediaAdsPlatform();
+      InteractiveMediaAdsPlatform.instance = platform;
+    });
+
+    test('fromAdsResponse uses ads response in creation params', () {
+      final AdsRequest request = AdsRequest.fromAdsResponse(
+        adsResponse: 'adsResponse',
+      );
+
+      final PlatformAdsRequestCreationParams params =
+          request.platform.params as PlatformAdsRequestCreationParams;
+      expect(params.adsResponse, 'adsResponse');
+      expect(params.adTagUrl, isNull);
+    });
+
+    test('setAdWillAutoPlay calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setAdWillAutoPlay(true);
+      verify(request.platform.setAdWillAutoPlay(true));
+    });
+
+    test('setAdWillPlayMuted calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setAdWillPlayMuted(true);
+      verify(request.platform.setAdWillPlayMuted(true));
+    });
+
+    test('setContinuousPlayback calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setContinuousPlayback(true);
+      verify(request.platform.setContinuousPlayback(true));
+    });
+
+    test('setContentDuration calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setContentDuration(1.0);
+      verify(request.platform.setContentDuration(1.0));
+    });
+
+    test('setContentKeywords calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setContentKeywords(<String>['keyword']);
+      verify(request.platform.setContentKeywords(<String>['keyword']));
+    });
+
+    test('setContentTitle calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setContentTitle('title');
+      verify(request.platform.setContentTitle('title'));
+    });
+
+    test('setContentUrl calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setContentUrl('url');
+      verify(request.platform.setContentUrl('url'));
+    });
+
+    test('setLiveStreamPrefetchSeconds calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setLiveStreamPrefetchSeconds(1.0);
+      verify(request.platform.setLiveStreamPrefetchSeconds(1.0));
+    });
+
+    test('setVastLoadTimeout calls through to platform', () {
+      const AdsRequest request = AdsRequest(adTagUrl: 'adTagUrl');
+      request.setVastLoadTimeout(1.0);
+      verify(request.platform.setVastLoadTimeout(1.0));
+    });
+  });
+}


### PR DESCRIPTION
…hods

This change adds support for the remaining methods of `AdsRequest`. The following methods have been added:
- `setAdWillAutoPlay`
- `setAdWillPlayMuted`
- `setAdsResponse`
- `setContentDuration`
- `setContentKeywords`
- `setContentTitle`
- `setContinuousPlayback`
- `setContentUrl`
- `setLiveStreamPrefetchSeconds`
- `setVastLoadTimeout`

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
