### PR TITLE
[camera_avfoundation] Implementation swift migration - part 11

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.21+1
+
+* Migrates `startImageStream` method to Swift.
+
 ## 0.9.21
 
 * Fixes crash when streaming is enabled during recording.

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.21+1
 
-* Migrates `startImageStream` method to Swift.
+* Migrates `startImageStream` and `setUpCaptureSessionForAudioIfNeeded` methods to Swift.
+* Removes Objective-C implementation of `reportErrorMessage` method.
 
 ## 0.9.21
 

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
@@ -343,7 +343,6 @@ final class DefaultCamera: FLTCam, Camera {
       newAudioWriterInput.expectsMediaDataInRealTime = true
       mediaSettingsAVWrapper.addInput(newAudioWriterInput, to: videoWriter)
       self.audioWriterInput = newAudioWriterInput
-      audioOutput.setSampleBufferDelegate(self, queue: captureSessionQueue)
     }
 
     if flashMode == .torch {

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/DefaultCamera.swift
@@ -92,6 +92,92 @@ final class DefaultCamera: FLTCam, Camera {
     return (captureVideoInput, captureVideoOutput, connection)
   }
 
+  func setUpCaptureSessionForAudioIfNeeded() {
+    // Don't setup audio twice or we will lose the audio.
+    guard !mediaSettings.enableAudio || !isAudioSetup else { return }
+
+    let audioDevice = audioCaptureDeviceFactory()
+    do {
+      // Create a device input with the device and add it to the session.
+      // Setup the audio input.
+      let audioInput = try captureDeviceInputFactory.deviceInput(with: audioDevice)
+
+      // Setup the audio output.
+      let audioOutput = AVCaptureAudioDataOutput()
+
+      let block = {
+        // Set up options implicit to AVAudioSessionCategoryPlayback to avoid conflicts with other
+        // plugins like video_player.
+        DefaultCamera.upgradeAudioSessionCategory(
+          requestedCategory: .playAndRecord,
+          options: [.defaultToSpeaker, .allowBluetoothA2DP, .allowAirPlay]
+        )
+      }
+
+      if !Thread.isMainThread {
+        DispatchQueue.main.sync(execute: block)
+      } else {
+        block()
+      }
+
+      if audioCaptureSession.canAddInput(audioInput) {
+        audioCaptureSession.addInput(audioInput)
+
+        if audioCaptureSession.canAddOutput(audioOutput) {
+          audioCaptureSession.addOutput(audioOutput)
+          audioOutput.setSampleBufferDelegate(self, queue: captureSessionQueue)
+          isAudioSetup = true
+        } else {
+          reportErrorMessage("Unable to add Audio input/output to session capture")
+          isAudioSetup = false
+        }
+      }
+    } catch let error as NSError {
+      reportErrorMessage(error.description)
+    }
+  }
+
+  // This function, although slightly modified, is also in video_player_avfoundation (in ObjC).
+  // Both need to do the same thing and run on the same thread (for example main thread).
+  // Configure application wide audio session manually to prevent overwriting flag
+  // MixWithOthers by capture session.
+  // Only change category if it is considered an upgrade which means it can only enable
+  // ability to play in silent mode or ability to record audio but never disables it,
+  // that could affect other plugins which depend on this global state. Only change
+  // category or options if there is change to prevent unnecessary lags and silence.
+  private static func upgradeAudioSessionCategory(
+    requestedCategory: AVAudioSession.Category,
+    options: AVAudioSession.CategoryOptions
+  ) {
+    let playCategories: Set<AVAudioSession.Category> = [.playback, .playAndRecord]
+    let recordCategories: Set<AVAudioSession.Category> = [.record, .playAndRecord]
+    let requiredCategories: Set<AVAudioSession.Category> = [
+      requestedCategory, AVAudioSession.sharedInstance().category,
+    ]
+
+    let requiresPlay = !requiredCategories.isDisjoint(with: playCategories)
+    let requiresRecord = !requiredCategories.isDisjoint(with: recordCategories)
+
+    var finalCategory = requestedCategory
+    if requiresPlay && requiresRecord {
+      finalCategory = .playAndRecord
+    } else if requiresPlay {
+      finalCategory = .playback
+    } else if requiresRecord {
+      finalCategory = .record
+    }
+
+    let finalOptions = AVAudioSession.sharedInstance().categoryOptions.union(options)
+
+    if finalCategory == AVAudioSession.sharedInstance().category
+      && finalOptions == AVAudioSession.sharedInstance().categoryOptions
+    {
+      return
+    }
+
+    try? AVAudioSession.sharedInstance().setCategory(finalCategory, options: finalOptions)
+  }
+
   func reportInitializationState() {
     // Get all the state on the current thread, not the main thread.
     let state = FCPPlatformCameraState.make(
@@ -1036,6 +1122,9 @@ final class DefaultCamera: FLTCam, Camera {
     }
   }
 
+  /// Reports the given error message to the Dart side of the plugin.
+  ///
+  /// Can be called from any thread.
   private func reportErrorMessage(_ errorMessage: String) {
     FLTEnsureToRunOnMainQueue { [weak self] in
       self?.dartAPI?.reportError(errorMessage) { _ in

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
@@ -64,7 +64,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(readonly, nonatomic) FLTCamMediaSettingsAVWrapper *mediaSettingsAVWrapper;
 @property(readonly, nonatomic) FCPPlatformMediaSettings *mediaSettings;
 @property(nonatomic, copy) InputPixelBufferAdaptorFactory inputPixelBufferAdaptorFactory;
-@property(strong, nonatomic) AVCaptureAudioDataOutput *audioOutput;
 @property(assign, nonatomic) BOOL isAudioSetup;
 /// A wrapper for AVCaptureDevice creation to allow for dependency injection in tests.
 @property(nonatomic, copy) AudioCaptureDeviceFactory audioCaptureDeviceFactory;

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
@@ -70,8 +70,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param error report to the caller if any error happened creating the camera.
 - (instancetype)initWithConfiguration:(FLTCamConfiguration *)configuration error:(NSError **)error;
 
-- (void)startImageStreamWithMessenger:(NSObject<FlutterBinaryMessenger> *)messenger
-                           completion:(nonnull void (^)(FlutterError *_Nullable))completion;
 - (void)setUpCaptureSessionForAudioIfNeeded;
 
 // Methods exposed for the Swift DefaultCamera subclass

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam.h
@@ -65,12 +65,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property(readonly, nonatomic) FCPPlatformMediaSettings *mediaSettings;
 @property(nonatomic, copy) InputPixelBufferAdaptorFactory inputPixelBufferAdaptorFactory;
 @property(strong, nonatomic) AVCaptureAudioDataOutput *audioOutput;
+@property(assign, nonatomic) BOOL isAudioSetup;
+/// A wrapper for AVCaptureDevice creation to allow for dependency injection in tests.
+@property(nonatomic, copy) AudioCaptureDeviceFactory audioCaptureDeviceFactory;
 
 /// Initializes an `FLTCam` instance with the given configuration.
 /// @param error report to the caller if any error happened creating the camera.
 - (instancetype)initWithConfiguration:(FLTCamConfiguration *)configuration error:(NSError **)error;
-
-- (void)setUpCaptureSessionForAudioIfNeeded;
 
 // Methods exposed for the Swift DefaultCamera subclass
 - (void)updateOrientation;

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam_Test.h
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/FLTCam_Test.h
@@ -31,9 +31,4 @@
 @property(readonly, nonatomic)
     NSMutableDictionary<NSNumber *, FLTSavePhotoDelegate *> *inProgressSavePhotoDelegates;
 
-/// Start streaming images.
-- (void)startImageStreamWithMessenger:(NSObject<FlutterBinaryMessenger> *)messenger
-                   imageStreamHandler:(FLTImageStreamHandler *)imageStreamHandler
-                           completion:(void (^)(FlutterError *))completion;
-
 @end

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.21
+version: 0.9.21+1
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Migrates camera implementation as part of https://github.com/flutter/flutter/issues/119109

Resolves https://github.com/flutter/flutter/issues/170439. This PR migrates the last one of the problematic methods (`startImageStream`) to Switft, which resolves the issue.

This PR migrates the 8th chunk of `FLTCam` class to Swift:
* `startImageStream`
* `setUpCaptureSessionForAudioIfNeeded`
* `reportErrorMessage` (ObjC implementation removal)

Some properties of the FLTCam have to be temporarily made public so that they are accessible in DefaultCamera.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
