### PR TITLE
[in_app_purchase_storekit] Add support for quantity in consumable product purchases (#171570)

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/InAppPurchasePlugin+StoreKit2.swift
+++ b/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/InAppPurchasePlugin+StoreKit2.swift
@@ -60,6 +60,9 @@ extension InAppPurchasePlugin: InAppPurchase2API {
         {
           purchaseOptions.insert(.appAccountToken(accountTokenUUID))
         }
+        if let quantity = options?.quantity {
+          purchaseOptions.insert(.quantity(Int(quantity)))
+        }
 
         if #available(iOS 17.4, macOS 14.4, *) {
           if let promotionalOffer = options?.promotionalOffer {


### PR DESCRIPTION
This PR adds support for specifying a `quantity` when purchasing **consumable** products using StoreKit 2 in the `in_app_purchase_storekit` package.

#### ✅ What’s changing

* Introduces logic to read the `quantity` field from `PurchaseParam` and insert it into the native StoreKit 2 `.purchase(options:)` call.
* Ensures this logic is only applied to consumable products.
* Adds null checks and default behavior to maintain compatibility with purchases that don’t specify quantity.

#### 🧪 Testing

* Verified on a real device using StoreKit 2 with different `quantity` values.
* Ensures no change to StoreKit 1 flow or other product types.

#### 📌 Fixes

Fixes [[flutter/flutter#171570](https://github.com/flutter/flutter/issues/171570)](https://github.com/flutter/flutter/issues/171570)