### PR TITLE
[video_player] Separate event stream from player on iOS

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.2
+
+* Restructure internals of Dart notification of video player events.
+
 ## 2.8.1
 
 * Restructures internal logic to move more code to Dart.

--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
@@ -8,6 +8,7 @@
 
 #import <OCMock/OCMock.h>
 #import <video_player_avfoundation/AVAssetTrackUtils.h>
+#import <video_player_avfoundation/FVPEventBridge.h>
 #import <video_player_avfoundation/FVPNativeVideoViewFactory.h>
 #import <video_player_avfoundation/FVPTextureBasedVideoPlayer_Test.h>
 #import <video_player_avfoundation/FVPVideoPlayerPlugin_Test.h>
@@ -160,6 +161,55 @@
                                               callback:(void (^)(void))callback {
   self.fireDisplayLink = callback;
   return self.displayLink;
+}
+
+@end
+
+#pragma mark -
+
+@interface StubEventListener : NSObject <FVPVideoEventListener>
+
+@property(nonatomic) XCTestExpectation *initializationExpectation;
+@property(nonatomic) int64_t initializationDuration;
+@property(nonatomic) CGSize initialiaztionSize;
+
+- (instancetype)initWithInitalizationExpectation:(XCTestExpectation *)expectation;
+
+@end
+
+@implementation StubEventListener
+
+- (instancetype)initWithInitalizationExpectation:(XCTestExpectation *)expectation {
+  self = [super init];
+  _initializationExpectation = expectation;
+  return self;
+}
+
+- (void)videoPlayerDidComplete {
+}
+
+- (void)videoPlayerDidEndBuffering {
+}
+
+- (void)videoPlayerDidErrorWithMessage:(NSString *)errorMessage {
+}
+
+- (void)videoPlayerDidInitializeWithDuration:(int64_t)duration size:(CGSize)size {
+  [self.initializationExpectation fulfill];
+  self.initializationDuration = duration;
+  self.initialiaztionSize = size;
+}
+
+- (void)videoPlayerDidSetPlaying:(BOOL)playing {
+}
+
+- (void)videoPlayerDidStartBuffering {
+}
+
+- (void)videoPlayerDidUpdateBufferRegions:(NSArray<NSArray<NSValue *> *> *)regions {
+}
+
+- (void)videoPlayerWasDisposed {
 }
 
 @end
@@ -477,16 +527,19 @@
   AVPlayer *avPlayer = player.player;
   [avPlayer play];
 
-  [player onListenWithArguments:nil
-                      eventSink:^(NSDictionary<NSString *, id> *event) {
-                        if ([event[@"event"] isEqualToString:@"bufferingEnd"]) {
-                          XCTAssertTrue(avPlayer.currentItem.isPlaybackLikelyToKeepUp);
-                        }
+  // TODO(stuartmorgan): Update this test to instead use a mock listener, and add separate unit
+  // tests of FVPEventBridge.
+  [(NSObject<FlutterStreamHandler> *)player.eventListener
+      onListenWithArguments:nil
+                  eventSink:^(NSDictionary<NSString *, id> *event) {
+                    if ([event[@"event"] isEqualToString:@"bufferingEnd"]) {
+                      XCTAssertTrue(avPlayer.currentItem.isPlaybackLikelyToKeepUp);
+                    }
 
-                        if ([event[@"event"] isEqualToString:@"bufferingStart"]) {
-                          XCTAssertFalse(avPlayer.currentItem.isPlaybackLikelyToKeepUp);
-                        }
-                      }];
+                    if ([event[@"event"] isEqualToString:@"bufferingStart"]) {
+                      XCTAssertFalse(avPlayer.currentItem.isPlaybackLikelyToKeepUp);
+                    }
+                  }];
   XCTestExpectation *bufferingStateExpectation =
       [self expectationWithDescription:@"bufferingState"];
   NSTimeInterval timeout = 10;
@@ -498,39 +551,39 @@
 }
 
 - (void)testVideoControls {
-  NSDictionary<NSString *, id> *videoInitialization =
+  StubEventListener *eventListener =
       [self sanityTestURI:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"];
-  XCTAssertEqualObjects(videoInitialization[@"height"], @720);
-  XCTAssertEqualObjects(videoInitialization[@"width"], @1280);
-  XCTAssertEqualWithAccuracy([videoInitialization[@"duration"] intValue], 4000, 200);
+  XCTAssertEqual(eventListener.initialiaztionSize.height, 720);
+  XCTAssertEqual(eventListener.initialiaztionSize.width, 1280);
+  XCTAssertEqualWithAccuracy(eventListener.initializationDuration, 4000, 200);
 }
 
 - (void)testAudioControls {
-  NSDictionary<NSString *, id> *audioInitialization = [self
+  StubEventListener *eventListener = [self
       sanityTestURI:@"https://flutter.github.io/assets-for-api-docs/assets/audio/rooster.mp3"];
-  XCTAssertEqualObjects(audioInitialization[@"height"], @0);
-  XCTAssertEqualObjects(audioInitialization[@"width"], @0);
+  XCTAssertEqual(eventListener.initialiaztionSize.height, 0);
+  XCTAssertEqual(eventListener.initialiaztionSize.width, 0);
   // Perfect precision not guaranteed.
-  XCTAssertEqualWithAccuracy([audioInitialization[@"duration"] intValue], 5400, 200);
+  XCTAssertEqualWithAccuracy(eventListener.initializationDuration, 5400, 200);
 }
 
 - (void)testHLSControls {
-  NSDictionary<NSString *, id> *videoInitialization = [self
+  StubEventListener *eventListener = [self
       sanityTestURI:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"];
-  XCTAssertEqualObjects(videoInitialization[@"height"], @720);
-  XCTAssertEqualObjects(videoInitialization[@"width"], @1280);
-  XCTAssertEqualWithAccuracy([videoInitialization[@"duration"] intValue], 4000, 200);
+  XCTAssertEqual(eventListener.initialiaztionSize.height, 720);
+  XCTAssertEqual(eventListener.initialiaztionSize.width, 1280);
+  XCTAssertEqualWithAccuracy(eventListener.initializationDuration, 4000, 200);
 }
 
 - (void)testAudioOnlyHLSControls {
   XCTSkip(@"Flaky; see https://github.com/flutter/flutter/issues/164381");
 
-  NSDictionary<NSString *, id> *videoInitialization =
+  StubEventListener *eventListener =
       [self sanityTestURI:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/"
                           @"bee_audio_only.m3u8"];
-  XCTAssertEqualObjects(videoInitialization[@"height"], @0);
-  XCTAssertEqualObjects(videoInitialization[@"width"], @0);
-  XCTAssertEqualWithAccuracy([videoInitialization[@"duration"] intValue], 4000, 200);
+  XCTAssertEqual(eventListener.initialiaztionSize.height, 0);
+  XCTAssertEqual(eventListener.initialiaztionSize.width, 0);
+  XCTAssertEqualWithAccuracy(eventListener.initializationDuration, 4000, 200);
 }
 
 #if TARGET_OS_IOS
@@ -555,6 +608,8 @@
                               httpHeaders:@{}
                                 avFactory:stubAVFactory
                              viewProvider:[[StubViewProvider alloc] initWithView:nil]];
+  NSObject<FVPVideoEventListener> *listener = OCMProtocolMock(@protocol(FVPVideoEventListener));
+  player.eventListener = listener;
 
   XCTestExpectation *seekExpectation =
       [self expectationWithDescription:@"seekTo has zero tolerance when seeking not to end"];
@@ -577,6 +632,8 @@
                               httpHeaders:@{}
                                 avFactory:stubAVFactory
                              viewProvider:[[StubViewProvider alloc] initWithView:nil]];
+  NSObject<FVPVideoEventListener> *listener = OCMProtocolMock(@protocol(FVPVideoEventListener));
+  player.eventListener = listener;
 
   XCTestExpectation *seekExpectation =
       [self expectationWithDescription:@"seekTo has non-zero tolerance when seeking to end"];
@@ -592,7 +649,9 @@
 
 /// Sanity checks a video player playing the given URL with the actual AVPlayer. This is essentially
 /// a mini integration test of the player component.
-- (NSDictionary<NSString *, id> *)sanityTestURI:(NSString *)testURI {
+///
+/// Returns the stub event listener to allow tests to inspect the call state.
+- (StubEventListener *)sanityTestURI:(NSString *)testURI {
   NSURL *testURL = [NSURL URLWithString:testURI];
   XCTAssertNotNil(testURL);
   FVPVideoPlayer *player =
@@ -603,15 +662,9 @@
   XCTAssertNotNil(player);
 
   XCTestExpectation *initializedExpectation = [self expectationWithDescription:@"initialized"];
-  __block NSDictionary<NSString *, id> *initializationEvent;
-  [player onListenWithArguments:nil
-                      eventSink:^(NSDictionary<NSString *, id> *event) {
-                        if ([event[@"event"] isEqualToString:@"initialized"]) {
-                          initializationEvent = event;
-                          XCTAssertEqual(event.count, 4);
-                          [initializedExpectation fulfill];
-                        }
-                      }];
+  StubEventListener *listener =
+      [[StubEventListener alloc] initWithInitalizationExpectation:initializedExpectation];
+  player.eventListener = listener;
   [self waitForExpectationsWithTimeout:30.0 handler:nil];
 
   // Starts paused.
@@ -634,9 +687,7 @@
   XCTAssertNil(error);
   XCTAssertEqual(avPlayer.volume, 0.1f);
 
-  [player onCancelWithArguments:nil];
-
-  return initializationEvent;
+  return listener;
 }
 
 // Checks whether [AVPlayer rate] KVO observations are correctly detached.
@@ -787,12 +838,15 @@
   [self waitForExpectationsWithTimeout:10.0 handler:nil];
 
   XCTestExpectation *failedExpectation = [self expectationWithDescription:@"failed"];
-  [player onListenWithArguments:nil
-                      eventSink:^(FlutterError *event) {
-                        if ([event isKindOfClass:FlutterError.class]) {
-                          [failedExpectation fulfill];
-                        }
-                      }];
+  // TODO(stuartmorgan): Update this test to instead use a mock listener, and add separate unit
+  // tests of FVPEventBridge.
+  [(NSObject<FlutterStreamHandler> *)player.eventListener
+      onListenWithArguments:nil
+                  eventSink:^(FlutterError *event) {
+                    if ([event isKindOfClass:FlutterError.class]) {
+                      [failedExpectation fulfill];
+                    }
+                  }];
   [self waitForExpectationsWithTimeout:10.0 handler:nil];
 }
 
@@ -804,12 +858,9 @@
                              viewProvider:[[StubViewProvider alloc] initWithView:nil]];
 
   XCTestExpectation *initializedExpectation = [self expectationWithDescription:@"initialized"];
-  [player onListenWithArguments:nil
-                      eventSink:^(NSDictionary<NSString *, id> *event) {
-                        if ([event[@"event"] isEqualToString:@"initialized"]) {
-                          [initializedExpectation fulfill];
-                        }
-                      }];
+  StubEventListener *listener =
+      [[StubEventListener alloc] initWithInitalizationExpectation:initializedExpectation];
+  player.eventListener = listener;
   [self waitForExpectationsWithTimeout:10 handler:nil];
 
   FlutterError *error;

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPEventBridge.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPEventBridge.m
@@ -1,0 +1,122 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "./include/video_player_avfoundation/FVPEventBridge.h"
+
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_OSX
+#import <FlutterMacOS/FlutterMacOS.h>
+#else
+#import <Flutter/Flutter.h>
+#endif
+
+@interface FVPEventBridge () <FlutterStreamHandler>
+
+/// The event channel to dispatch notifications to.
+// TODO(stuartmorgan): Convert this to Pigeon event channels once the plugin is using Swift
+// Pigeon generation.
+@property(nonatomic) FlutterEventChannel *eventChannel;
+
+/// The event sink associated with eventChannel.
+///
+/// Will be nil both before the channel listener is ready on the Dart side, and after it has been
+/// closed on the Dart side.
+@property(nonatomic, nullable) FlutterEventSink eventSink;
+
+/// A queue of events received before eventSink is ready, to dispatch once the channel is fully
+/// set up.
+@property(nonatomic, copy) NSMutableArray<NSObject *> *queuedEvents;
+
+@end
+
+@implementation FVPEventBridge
+
+- (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger> *)messenger
+                      channelName:(NSString *)channelName {
+  self = [super init];
+  if (self) {
+    _queuedEvents = [[NSMutableArray alloc] init];
+    _eventChannel = [FlutterEventChannel eventChannelWithName:channelName
+                                              binaryMessenger:messenger];
+    // This retain loop is broken in videoPlayerWasDisposed.
+    [_eventChannel setStreamHandler:self];
+  }
+  return self;
+}
+
+#pragma mark FlutterStreamHandler
+
+- (FlutterError *_Nullable)onListenWithArguments:(id _Nullable)arguments
+                                       eventSink:(nonnull FlutterEventSink)events {
+  self.eventSink = events;
+
+  // Send any events that came in before the sink was ready.
+  for (id event in self.queuedEvents) {
+    self.eventSink(event);
+  }
+  [self.queuedEvents removeAllObjects];
+
+  return nil;
+}
+
+- (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {
+  self.eventSink = nil;
+  // No need to queue events coming in after this point; nil the queue so they will be discarded.
+  self.queuedEvents = nil;
+  return nil;
+}
+
+#pragma mark FVPVideoPlayerDelegate
+
+- (void)videoPlayerDidInitializeWithDuration:(int64_t)duration size:(CGSize)size {
+  [self sendOrQueue:@{
+    @"event" : @"initialized",
+    @"duration" : @(duration),
+    @"width" : @(size.width),
+    @"height" : @(size.height)
+  }];
+}
+
+- (void)videoPlayerDidErrorWithMessage:(NSString *)errorMessage {
+  [self sendOrQueue:[FlutterError errorWithCode:@"VideoError" message:errorMessage details:nil]];
+}
+
+- (void)videoPlayerDidComplete {
+  [self sendOrQueue:@{@"event" : @"completed"}];
+}
+
+- (void)videoPlayerDidStartBuffering {
+  [self sendOrQueue:@{@"event" : @"bufferingStart"}];
+}
+
+- (void)videoPlayerDidEndBuffering {
+  [self sendOrQueue:@{@"event" : @"bufferingEnd"}];
+}
+
+- (void)videoPlayerDidUpdateBufferRegions:(NSArray<NSArray<NSValue *> *> *)regions {
+  [self sendOrQueue:@{@"event" : @"bufferingUpdate", @"values" : regions}];
+}
+
+- (void)videoPlayerDidSetPlaying:(BOOL)playing {
+  [self sendOrQueue:@{@"event" : @"isPlayingStateUpdate", @"isPlaying" : @(playing)}];
+}
+
+- (void)videoPlayerWasDisposed {
+  [self.eventChannel setStreamHandler:nil];
+}
+
+#pragma mark Private methods
+
+/// Sends the given event to the event sink if it is ready to receive events, or enqueues it to send
+/// later if not.
+- (void)sendOrQueue:(id)event {
+  if (self.eventSink) {
+    self.eventSink(event);
+  } else {
+    [self.queuedEvents addObject:event];
+  }
+}
+
+@end

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPTextureBasedVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPTextureBasedVideoPlayer.m
@@ -118,7 +118,7 @@
       }];
 }
 
-- (void)disposeSansEventChannel {
+- (void)dispose {
   // This check prevents the crash caused by removing the KVO observers twice.
   // When performing a Hot Restart, the leftover players are disposed once directly
   // by [FVPVideoPlayerPlugin initialize:] method and then disposed again by
@@ -127,7 +127,7 @@
     return;
   }
 
-  [super disposeSansEventChannel];
+  [super dispose];
 
   [self.playerLayer removeFromSuperlayer];
 

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayer.m
@@ -95,23 +95,17 @@ static void *rateContext = &rateContext;
   }
 }
 
-/// This method allows you to dispose without touching the event channel. This
-/// is useful for the case where the Engine is in the process of deconstruction
-/// so the channel is going to die or is already dead.
-- (void)disposeSansEventChannel {
+- (void)dispose {
   _disposed = YES;
   [self removeKeyValueObservers];
 
   [self.player replaceCurrentItemWithPlayerItem:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
 
-- (void)dispose {
-  [self disposeSansEventChannel];
   if (_onDisposed) {
     _onDisposed();
   }
-  [_eventChannel setStreamHandler:nil];
+  [self.eventListener videoPlayerWasDisposed];
 }
 
 - (void)addObserversForItem:(AVPlayerItem *)item player:(AVPlayer *)player {
@@ -155,9 +149,7 @@ static void *rateContext = &rateContext;
     AVPlayerItem *p = [notification object];
     [p seekToTime:kCMTimeZero completionHandler:nil];
   } else {
-    if (_eventSink) {
-      _eventSink(@{@"event" : @"completed"});
-    }
+    [self.eventListener videoPlayerDidComplete];
   }
 }
 
@@ -225,16 +217,14 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
                         change:(NSDictionary *)change
                        context:(void *)context {
   if (context == timeRangeContext) {
-    if (_eventSink != nil) {
-      NSMutableArray<NSArray<NSNumber *> *> *values = [[NSMutableArray alloc] init];
-      for (NSValue *rangeValue in [object loadedTimeRanges]) {
-        CMTimeRange range = [rangeValue CMTimeRangeValue];
-        [values addObject:@[
-          @(FVPCMTimeToMillis(range.start)),
-          @(FVPCMTimeToMillis(range.duration)),
-        ]];
-      }
-      _eventSink(@{@"event" : @"bufferingUpdate", @"values" : values});
+    NSMutableArray<NSArray<NSNumber *> *> *values = [[NSMutableArray alloc] init];
+    for (NSValue *rangeValue in [object loadedTimeRanges]) {
+      CMTimeRange range = [rangeValue CMTimeRangeValue];
+      [values addObject:@[
+        @(FVPCMTimeToMillis(range.start)),
+        @(FVPCMTimeToMillis(range.duration)),
+      ]];
+      [self.eventListener videoPlayerDidUpdateBufferRegions:values];
     }
   } else if (context == statusContext) {
     AVPlayerItem *item = (AVPlayerItem *)object;
@@ -246,7 +236,7 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
         break;
       case AVPlayerItemStatusReadyToPlay:
         [item addOutput:_videoOutput];
-        [self setupEventSinkIfReadyToPlay];
+        [self reportInitializedIfReadyToPlay];
         break;
     }
   } else if (context == presentationSizeContext || context == durationContext) {
@@ -255,27 +245,20 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
       // Due to an apparent bug, when the player item is ready, it still may not have determined
       // its presentation size or duration. When these properties are finally set, re-check if
       // all required properties and instantiate the event sink if it is not already set up.
-      [self setupEventSinkIfReadyToPlay];
+      [self reportInitializedIfReadyToPlay];
     }
   } else if (context == playbackLikelyToKeepUpContext) {
     [self updatePlayingState];
     if ([[_player currentItem] isPlaybackLikelyToKeepUp]) {
-      if (_eventSink != nil) {
-        _eventSink(@{@"event" : @"bufferingEnd"});
-      }
+      [self.eventListener videoPlayerDidEndBuffering];
     } else {
-      if (_eventSink != nil) {
-        _eventSink(@{@"event" : @"bufferingStart"});
-      }
+      [self.eventListener videoPlayerDidStartBuffering];
     }
   } else if (context == rateContext) {
     // Important: Make sure to cast the object to AVPlayer when observing the rate property,
     // as it is not available in AVPlayerItem.
     AVPlayer *player = (AVPlayer *)object;
-    if (_eventSink != nil) {
-      _eventSink(
-          @{@"event" : @"isPlayingStateUpdate", @"isPlaying" : player.rate > 0 ? @YES : @NO});
-    }
+    [self.eventListener videoPlayerDidSetPlaying:(player.rate > 0)];
   }
 }
 
@@ -325,9 +308,6 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void)sendFailedToLoadVideoEvent {
-  if (_eventSink == nil) {
-    return;
-  }
   // Prefer more detailed error information from tracks loading.
   NSError *error;
   if ([self.player.currentItem.asset statusOfValueForKey:@"tracks"
@@ -347,11 +327,11 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   add(underlyingError.localizedDescription);
   add(underlyingError.localizedFailureReason);
   NSString *message = [details.array componentsJoinedByString:@": "];
-  _eventSink([FlutterError errorWithCode:@"VideoError" message:message details:nil]);
+  [self.eventListener videoPlayerDidErrorWithMessage:message];
 }
 
-- (void)setupEventSinkIfReadyToPlay {
-  if (_eventSink && !_isInitialized) {
+- (void)reportInitializedIfReadyToPlay {
+  if (!_isInitialized) {
     AVPlayerItem *currentItem = self.player.currentItem;
     CGSize size = currentItem.presentationSize;
     CGFloat width = size.width;
@@ -395,12 +375,7 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
     _isInitialized = YES;
     [self updatePlayingState];
 
-    _eventSink(@{
-      @"event" : @"initialized",
-      @"duration" : @(duration),
-      @"width" : @(width),
-      @"height" : @(height)
-    });
+    [self.eventListener videoPlayerDidInitializeWithDuration:duration size:size];
   }
 }
 
@@ -450,32 +425,6 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
 - (void)setPlaybackSpeed:(double)speed error:(FlutterError *_Nullable *_Nonnull)error {
   _targetPlaybackSpeed = @(speed);
   [self updatePlayingState];
-}
-
-#pragma mark - FlutterStreamHandler
-
-- (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {
-  _eventSink = nil;
-  return nil;
-}
-
-- (FlutterError *_Nullable)onListenWithArguments:(id _Nullable)arguments
-                                       eventSink:(nonnull FlutterEventSink)events {
-  _eventSink = events;
-  // TODO(@recastrodiaz): remove the line below when the race condition is resolved:
-  // https://github.com/flutter/flutter/issues/21483
-  // This line ensures the 'initialized' event is sent when the event
-  // 'AVPlayerItemStatusReadyToPlay' fires before _eventSink is set (this function
-  // onListenWithArguments is called)
-  // and also send error in similar case with 'AVPlayerItemStatusFailed'
-  // https://github.com/flutter/flutter/issues/151475
-  // https://github.com/flutter/flutter/issues/147707
-  if (self.player.currentItem.status == AVPlayerItemStatusFailed) {
-    [self sendFailedToLoadVideoEvent];
-    return nil;
-  }
-  [self setupEventSinkIfReadyToPlay];
-  return nil;
 }
 
 #pragma mark - Private

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPEventBridge.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPEventBridge.h
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+
+#import "FVPVideoEventListener.h"
+
+#if TARGET_OS_OSX
+#import <FlutterMacOS/FlutterMacOS.h>
+#else
+#import <Flutter/Flutter.h>
+#endif
+
+/// An implementation of FVPVideoEventListener that forwards messages to Dart via an event channel.
+@interface FVPEventBridge : NSObject <FVPVideoEventListener>
+
+/// Initializes the the bridge to use an event channel with the given name.
+- (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger> *)messenger
+                      channelName:(NSString *)channelName;
+
+@end

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoEventListener.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoEventListener.h
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+
+/// Handles event/status callbacks from FVPVideoPlayer.
+///
+/// This is an abstraction around the event channel to avoid coupling FVPVideoPlayer directly to
+/// implementation details specific to the plugin communication method.
+@protocol FVPVideoEventListener <NSObject>
+@required
+// Called when the video player has initialized.
+- (void)videoPlayerDidInitializeWithDuration:(int64_t)duration size:(CGSize)size;
+// Called if there is an error in video load or playback.
+- (void)videoPlayerDidErrorWithMessage:(NSString *)errorMessage;
+/// Called when the video player plays to the end and then stops (i.e., looping is not enabled).
+- (void)videoPlayerDidComplete;
+/// Called when the video player needs to buffer more in order to play witohut stopping.
+- (void)videoPlayerDidStartBuffering;
+/// Called when the video player has buffered enough to likely be able to play witohut stopping.
+- (void)videoPlayerDidEndBuffering;
+/// Called when the buffered regions change.
+///
+/// The array elements are two-element arrays, each containing the start and duration, in
+/// milliseconds, of a buffered region.
+- (void)videoPlayerDidUpdateBufferRegions:(NSArray<NSArray<NSValue *> *> *)regions;
+/// Called when the player starts or stops playing.
+- (void)videoPlayerDidSetPlaying:(BOOL)playing;
+/// Called when the video player has been disposed on the Dart side.
+- (void)videoPlayerWasDisposed;
+@end

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer.h
@@ -6,6 +6,7 @@
 
 #import "./messages.g.h"
 #import "FVPAVFactory.h"
+#import "FVPVideoEventListener.h"
 #import "FVPViewProvider.h"
 
 #if TARGET_OS_OSX
@@ -21,9 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// This class contains all functionalities needed to manage video playback in platform views and is
 /// typically used alongside FVPNativeVideoViewFactory. If you need to display a video using a
 /// texture, use FVPTextureBasedVideoPlayer instead.
-@interface FVPVideoPlayer : NSObject <FlutterStreamHandler, FVPVideoPlayerInstanceApi>
-/// The Flutter event channel used to communicate with the Flutter engine.
-@property(nonatomic) FlutterEventChannel *eventChannel;
+@interface FVPVideoPlayer : NSObject <FVPVideoPlayerInstanceApi>
 /// The AVPlayer instance used for video playback.
 @property(nonatomic, readonly) AVPlayer *player;
 /// Indicates whether the video player has been disposed.
@@ -32,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) BOOL isLooping;
 /// The current playback position of the video, in milliseconds.
 @property(nonatomic, readonly) int64_t position;
+/// The event listener to report video events to.
+@property(nonatomic, nullable) NSObject<FVPVideoEventListener> *eventListener;
 /// A block that will be called when dispose is called.
 @property(nonatomic, nullable, copy) void (^onDisposed)(void);
 
@@ -44,11 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Disposes the video player and releases any resources it holds.
 - (void)dispose;
-
-/// Disposes the video player without touching the event channel. This
-/// is useful for the case where the Engine is in the process of deconstruction
-/// so the channel is going to die or is already dead.
-- (void)disposeSansEventChannel;
 
 @end
 

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer_Internal.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer_Internal.h
@@ -4,14 +4,9 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import "FVPAVFactory.h"
+#import "FVPVideoEventListener.h"
 #import "FVPVideoPlayer.h"
 #import "FVPViewProvider.h"
-
-#if TARGET_OS_OSX
-#import <FlutterMacOS/FlutterMacOS.h>
-#else
-#import <Flutter/Flutter.h>
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,8 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) AVPlayerItemVideoOutput *videoOutput;
 /// The view provider, to obtain view information from.
 @property(nonatomic, readonly, nullable) NSObject<FVPViewProvider> *viewProvider;
-/// The Flutter event sink used to send events to the Flutter engine.
-@property(nonatomic) FlutterEventSink eventSink;
 /// The preferred transform for the video. It can be used to handle the rotation of the video.
 @property(nonatomic) CGAffineTransform preferredTransform;
 /// The target playback speed requested by the plugin client.

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.8.1
+version: 2.8.2
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Abstracts the details of the native->Dart communication system from the player instance by adding a listener protocol, and moving the event channel into an implementation of that protocol.

Also simplifies the logic to avoid messaging races during channel setup by adding a generic queue to the listener implementation instead of requiring the player to track whether or not it's allowed to send messages, and hard-coding specific messages to re-send later.

Part of https://github.com/flutter/flutter/issues/172763

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
