### PR TITLE
[url_launcher_ios] Fix test button text to work on iOS 26

### DIFF
--- a/packages/url_launcher/url_launcher_ios/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_ios/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+* Fixes test button text to work on iOS 26.
+
 ## 6.3.4
 
 * Updates to Pigeon 25.5.0.

--- a/packages/url_launcher/url_launcher_ios/example/ios/RunnerUITests/URLLauncherUITests.swift
+++ b/packages/url_launcher/url_launcher_ios/example/ios/RunnerUITests/URLLauncherUITests.swift
@@ -28,10 +28,11 @@ class URLLauncherUITests: XCTestCase {
       button.tap()
       let webView = app.webViews.firstMatch
       XCTAssertTrue(webView.waitForExistence(timeout: 30.0))
-      XCTAssertTrue(app.buttons["ForwardButton"].waitForExistence(timeout: 30.0))
-      XCTAssertTrue(app.buttons["Share"].exists)
-      XCTAssertTrue(app.buttons["OpenInSafariButton"].exists)
-      let doneButton = app.buttons["Done"]
+      XCTAssertTrue(app.buttons["OpenInSafariButton"].waitForExistence(timeout: 30.0))
+
+      // iOS 18 is "Done". iOS 26 is "Close".
+      let doneButtonPredicate = NSPredicate(format: "label = 'Close' OR label = 'Done'")
+      let doneButton = app.buttons.element(matching: doneButtonPredicate).firstMatch
       XCTAssertTrue(doneButton.waitForExistence(timeout: 30.0))
       // This should just be doneButton.tap, but for some reason that stopped working in Xcode 15;
       // tapping via coordinate works, however.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/173100

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
