### PR TITLE
[video_player] Move Android buffer updates to Dart

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.11
+
+* Moves buffer position update event generation to Dart.
+
 ## 2.8.10
 
 * Restructures internal logic to move more code to Dart.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -324,6 +324,100 @@ public class Messages {
     }
   }
 
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static final class PlaybackState {
+    /** The current playback position, in milliseconds. */
+    private @NonNull Long playPosition;
+
+    public @NonNull Long getPlayPosition() {
+      return playPosition;
+    }
+
+    public void setPlayPosition(@NonNull Long setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"playPosition\" is null.");
+      }
+      this.playPosition = setterArg;
+    }
+
+    /** The current buffer position, in milliseconds. */
+    private @NonNull Long bufferPosition;
+
+    public @NonNull Long getBufferPosition() {
+      return bufferPosition;
+    }
+
+    public void setBufferPosition(@NonNull Long setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"bufferPosition\" is null.");
+      }
+      this.bufferPosition = setterArg;
+    }
+
+    /** Constructor is non-public to enforce null safety; use Builder. */
+    PlaybackState() {}
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      PlaybackState that = (PlaybackState) o;
+      return playPosition.equals(that.playPosition) && bufferPosition.equals(that.bufferPosition);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(playPosition, bufferPosition);
+    }
+
+    public static final class Builder {
+
+      private @Nullable Long playPosition;
+
+      @CanIgnoreReturnValue
+      public @NonNull Builder setPlayPosition(@NonNull Long setterArg) {
+        this.playPosition = setterArg;
+        return this;
+      }
+
+      private @Nullable Long bufferPosition;
+
+      @CanIgnoreReturnValue
+      public @NonNull Builder setBufferPosition(@NonNull Long setterArg) {
+        this.bufferPosition = setterArg;
+        return this;
+      }
+
+      public @NonNull PlaybackState build() {
+        PlaybackState pigeonReturn = new PlaybackState();
+        pigeonReturn.setPlayPosition(playPosition);
+        pigeonReturn.setBufferPosition(bufferPosition);
+        return pigeonReturn;
+      }
+    }
+
+    @NonNull
+    ArrayList<Object> toList() {
+      ArrayList<Object> toListResult = new ArrayList<>(2);
+      toListResult.add(playPosition);
+      toListResult.add(bufferPosition);
+      return toListResult;
+    }
+
+    static @NonNull PlaybackState fromList(@NonNull ArrayList<Object> pigeonVar_list) {
+      PlaybackState pigeonResult = new PlaybackState();
+      Object playPosition = pigeonVar_list.get(0);
+      pigeonResult.setPlayPosition((Long) playPosition);
+      Object bufferPosition = pigeonVar_list.get(1);
+      pigeonResult.setBufferPosition((Long) bufferPosition);
+      return pigeonResult;
+    }
+  }
+
   private static class PigeonCodec extends StandardMessageCodec {
     public static final PigeonCodec INSTANCE = new PigeonCodec();
 
@@ -346,6 +440,8 @@ public class Messages {
           return PlatformVideoViewCreationParams.fromList((ArrayList<Object>) readValue(buffer));
         case (byte) 132:
           return CreateMessage.fromList((ArrayList<Object>) readValue(buffer));
+        case (byte) 133:
+          return PlaybackState.fromList((ArrayList<Object>) readValue(buffer));
         default:
           return super.readValueOfType(type, buffer);
       }
@@ -365,6 +461,9 @@ public class Messages {
       } else if (value instanceof CreateMessage) {
         stream.write(132);
         writeValue(stream, ((CreateMessage) value).toList());
+      } else if (value instanceof PlaybackState) {
+        stream.write(133);
+        writeValue(stream, ((PlaybackState) value).toList());
       } else {
         super.writeValue(stream, value);
       }
@@ -541,12 +640,17 @@ public class Messages {
 
     void play();
 
-    @NonNull
-    Long getPosition();
-
     void seekTo(@NonNull Long position);
 
     void pause();
+    /**
+     * Returns the current playback state.
+     *
+     * <p>This is combined into a single call to minimize platform channel calls for state that
+     * needs to be polled frequently.
+     */
+    @NonNull
+    PlaybackState getPlaybackState();
 
     /** The codec used by VideoPlayerInstanceApi. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -668,29 +772,6 @@ public class Messages {
         BasicMessageChannel<Object> channel =
             new BasicMessageChannel<>(
                 binaryMessenger,
-                "dev.flutter.pigeon.video_player_android.VideoPlayerInstanceApi.getPosition"
-                    + messageChannelSuffix,
-                getCodec());
-        if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                ArrayList<Object> wrapped = new ArrayList<>();
-                try {
-                  Long output = api.getPosition();
-                  wrapped.add(0, output);
-                } catch (Throwable exception) {
-                  wrapped = wrapError(exception);
-                }
-                reply.reply(wrapped);
-              });
-        } else {
-          channel.setMessageHandler(null);
-        }
-      }
-      {
-        BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
                 "dev.flutter.pigeon.video_player_android.VideoPlayerInstanceApi.seekTo"
                     + messageChannelSuffix,
                 getCodec());
@@ -726,6 +807,29 @@ public class Messages {
                 try {
                   api.pause();
                   wrapped.add(0, null);
+                } catch (Throwable exception) {
+                  wrapped = wrapError(exception);
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger,
+                "dev.flutter.pigeon.video_player_android.VideoPlayerInstanceApi.getPlaybackState"
+                    + messageChannelSuffix,
+                getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<>();
+                try {
+                  PlaybackState output = api.getPlaybackState();
+                  wrapped.add(0, output);
                 } catch (Throwable exception) {
                   wrapped = wrapError(exception);
                 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -107,12 +107,11 @@ public abstract class VideoPlayer implements Messages.VideoPlayerInstanceApi {
   }
 
   @Override
-  public @NonNull Long getPosition() {
-    long position = exoPlayer.getCurrentPosition();
-    // TODO(stuartmorgan): Move this; this is relying on the fact that getPosition is called
-    //  frequently to drive buffering updates, which is a fragile hack.
-    sendBufferingUpdate();
-    return position;
+  public @NonNull Messages.PlaybackState getPlaybackState() {
+    return new Messages.PlaybackState.Builder()
+        .setPlayPosition(exoPlayer.getCurrentPosition())
+        .setBufferPosition(exoPlayer.getBufferedPosition())
+        .build();
   }
 
   @Override

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -66,10 +66,6 @@ public abstract class VideoPlayer implements Messages.VideoPlayerInstanceApi {
   protected abstract ExoPlayerEventListener createExoPlayerEventListener(
       @NonNull ExoPlayer exoPlayer, @Nullable SurfaceProducer surfaceProducer);
 
-  void sendBufferingUpdate() {
-    videoPlayerEvents.onBufferingUpdate(exoPlayer.getBufferedPosition());
-  }
-
   private static void setAudioAttributes(ExoPlayer exoPlayer, boolean isMixMode) {
     exoPlayer.setAudioAttributes(
         new AudioAttributes.Builder().setContentType(C.AUDIO_CONTENT_TYPE_MOVIE).build(),

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -127,17 +127,6 @@ public final class VideoPlayerTest {
   }
 
   @Test
-  public void sendsBufferingUpdatesOnDemand() {
-    VideoPlayer videoPlayer = createVideoPlayer();
-
-    when(mockExoPlayer.getBufferedPosition()).thenReturn(10L);
-    videoPlayer.sendBufferingUpdate();
-    verify(mockEvents).onBufferingUpdate(10L);
-
-    videoPlayer.dispose();
-  }
-
-  @Test
   public void togglesLoopingEnablesAndDisablesRepeatMode() {
     VideoPlayer videoPlayer = createVideoPlayer();
 
@@ -177,14 +166,29 @@ public final class VideoPlayerTest {
   }
 
   @Test
-  public void seekAndGetPosition() {
+  public void seekTo() {
     VideoPlayer videoPlayer = createVideoPlayer();
 
     videoPlayer.seekTo(10L);
     verify(mockExoPlayer).seekTo(10);
 
-    when(mockExoPlayer.getCurrentPosition()).thenReturn(20L);
-    assertEquals(20L, videoPlayer.getPosition().longValue());
+    videoPlayer.dispose();
+  }
+
+  @Test
+  public void GetPlaybackState() {
+    VideoPlayer videoPlayer = createVideoPlayer();
+
+    final long playbackPosition = 20L;
+    final long bufferedPosition = 10L;
+    when(mockExoPlayer.getCurrentPosition()).thenReturn(playbackPosition);
+    when(mockExoPlayer.getBufferedPosition()).thenReturn(bufferedPosition);
+
+    final Messages.PlaybackState state = videoPlayer.getPlaybackState();
+    assertEquals(playbackPosition, state.getPlayPosition().longValue());
+    assertEquals(bufferedPosition, state.getBufferPosition().longValue());
+
+    videoPlayer.dispose();
   }
 
   @Test

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -135,6 +135,48 @@ class CreateMessage {
   int get hashCode => Object.hashAll(_toList());
 }
 
+class PlaybackState {
+  PlaybackState({required this.playPosition, required this.bufferPosition});
+
+  /// The current playback position, in milliseconds.
+  int playPosition;
+
+  /// The current buffer position, in milliseconds.
+  int bufferPosition;
+
+  List<Object?> _toList() {
+    return <Object?>[playPosition, bufferPosition];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static PlaybackState decode(Object result) {
+    result as List<Object?>;
+    return PlaybackState(
+      playPosition: result[0]! as int,
+      bufferPosition: result[1]! as int,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! PlaybackState || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -154,6 +196,9 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is CreateMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
+    } else if (value is PlaybackState) {
+      buffer.putUint8(133);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -172,6 +217,8 @@ class _PigeonCodec extends StandardMessageCodec {
         return PlatformVideoViewCreationParams.decode(readValue(buffer)!);
       case 132:
         return CreateMessage.decode(readValue(buffer)!);
+      case 133:
+        return PlaybackState.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -460,36 +507,6 @@ class VideoPlayerInstanceApi {
     }
   }
 
-  Future<int> getPosition() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_android.VideoPlayerInstanceApi.getPosition$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_sendFuture as List<Object?>?;
-    if (pigeonVar_replyList == null) {
-      throw _createConnectionError(pigeonVar_channelName);
-    } else if (pigeonVar_replyList.length > 1) {
-      throw PlatformException(
-        code: pigeonVar_replyList[0]! as String,
-        message: pigeonVar_replyList[1] as String?,
-        details: pigeonVar_replyList[2],
-      );
-    } else if (pigeonVar_replyList[0] == null) {
-      throw PlatformException(
-        code: 'null-error',
-        message: 'Host platform returned null value for non-null return value.',
-      );
-    } else {
-      return (pigeonVar_replyList[0] as int?)!;
-    }
-  }
-
   Future<void> seekTo(int position) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.video_player_android.VideoPlayerInstanceApi.seekTo$pigeonVar_messageChannelSuffix';
@@ -539,6 +556,40 @@ class VideoPlayerInstanceApi {
       );
     } else {
       return;
+    }
+  }
+
+  /// Returns the current playback state.
+  ///
+  /// This is combined into a single call to minimize platform channel calls for
+  /// state that needs to be polled frequently.
+  Future<PlaybackState> getPlaybackState() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_android.VideoPlayerInstanceApi.getPlaybackState$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as PlaybackState?)!;
     }
   }
 }

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -35,6 +35,16 @@ class CreateMessage {
   PlatformVideoViewType? viewType;
 }
 
+class PlaybackState {
+  PlaybackState({required this.playPosition, required this.bufferPosition});
+
+  /// The current playback position, in milliseconds.
+  final int playPosition;
+
+  /// The current buffer position, in milliseconds.
+  final int bufferPosition;
+}
+
 @HostApi()
 abstract class AndroidVideoPlayerApi {
   void initialize();
@@ -50,7 +60,12 @@ abstract class VideoPlayerInstanceApi {
   void setVolume(double volume);
   void setPlaybackSpeed(double speed);
   void play();
-  int getPosition();
   void seekTo(int position);
   void pause();
+
+  /// Returns the current playback state.
+  ///
+  /// This is combined into a single call to minimize platform channel calls for
+  /// state that needs to be polled frequently.
+  PlaybackState getPlaybackState();
 }

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.8.10
+version: 2.8.11
 
 environment:
   sdk: ^3.7.0

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -529,16 +529,19 @@ void main() {
       verify(playerApi.seekTo(positionMilliseconds));
     });
 
-    test('getPosition', () async {
+    test('getPlaybackState', () async {
       final (
         AndroidVideoPlayer player,
         _,
         MockVideoPlayerInstanceApi playerApi,
       ) = setUpMockPlayer(playerId: 1);
       const int positionMilliseconds = 12345;
-      when(
-        playerApi.getPosition(),
-      ).thenAnswer((_) async => positionMilliseconds);
+      when(playerApi.getPlaybackState()).thenAnswer(
+        (_) async => PlaybackState(
+          playPosition: positionMilliseconds,
+          bufferPosition: 0,
+        ),
+      );
 
       final Duration position = await player.getPosition(1);
       expect(position, const Duration(milliseconds: positionMilliseconds));

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -545,12 +545,8 @@ void main() {
     });
 
     test('videoEventsFor', () async {
-      final (
-        AndroidVideoPlayer player,
-        MockAndroidVideoPlayerApi api,
-        _,
-      ) = setUpMockPlayer(playerId: 1);
-      const String mockChannel = 'flutter.io/videoPlayer/videoEvents123';
+      const int playerId = 1;
+      const String mockChannel = 'flutter.io/videoPlayer/videoEvents$playerId';
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMessageHandler(mockChannel, (ByteData? message) async {
             final MethodCall methodCall = const StandardMethodCodec()
@@ -669,8 +665,17 @@ void main() {
               fail('Expected listen or cancel');
             }
           });
+
+      // Creating the player triggers the stream listener, so that must be done
+      // after setting up the mock native handler above.
+      final (
+        AndroidVideoPlayer player,
+        MockAndroidVideoPlayerApi api,
+        _,
+      ) = setUpMockPlayer(playerId: playerId);
+
       expect(
-        player.videoEventsFor(123),
+        player.videoEventsFor(playerId),
         emitsInOrder(<dynamic>[
           VideoEvent(
             eventType: VideoEventType.initialized,

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -29,7 +29,7 @@ void main() {
       pluginApi: pluginApi,
       playerProvider: (_) => instanceApi,
     );
-    player.ensureApiInitialized(playerId);
+    player.ensureApiInitialized(playerId, VideoViewType.platformView);
     return (player, pluginApi, instanceApi);
   }
 

--- a/packages/video_player/video_player_android/test/android_video_player_test.mocks.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.mocks.dart
@@ -23,6 +23,11 @@ import 'package:video_player_android/src/messages.g.dart' as _i2;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
+class _FakePlaybackState_0 extends _i1.SmartFake implements _i2.PlaybackState {
+  _FakePlaybackState_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [AndroidVideoPlayerApi].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -156,15 +161,6 @@ class MockVideoPlayerInstanceApi extends _i1.Mock
           as _i4.Future<void>);
 
   @override
-  _i4.Future<int> getPosition() =>
-      (super.noSuchMethod(
-            Invocation.method(#getPosition, []),
-            returnValue: _i4.Future<int>.value(0),
-            returnValueForMissingStub: _i4.Future<int>.value(0),
-          )
-          as _i4.Future<int>);
-
-  @override
   _i4.Future<void> seekTo(int? position) =>
       (super.noSuchMethod(
             Invocation.method(#seekTo, [position]),
@@ -181,4 +177,23 @@ class MockVideoPlayerInstanceApi extends _i1.Mock
             returnValueForMissingStub: _i4.Future<void>.value(),
           )
           as _i4.Future<void>);
+
+  @override
+  _i4.Future<_i2.PlaybackState> getPlaybackState() =>
+      (super.noSuchMethod(
+            Invocation.method(#getPlaybackState, []),
+            returnValue: _i4.Future<_i2.PlaybackState>.value(
+              _FakePlaybackState_0(
+                this,
+                Invocation.method(#getPlaybackState, []),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<_i2.PlaybackState>.value(
+              _FakePlaybackState_0(
+                this,
+                Invocation.method(#getPlaybackState, []),
+              ),
+            ),
+          )
+          as _i4.Future<_i2.PlaybackState>);
 }


### PR DESCRIPTION
Since ExoPlayer does not generate events for changes to the buffer position, the `video_player_android` synthesizes them via polling. This moves the logic to generate these events from Java to Dart, to reduce the amount of logic on the Java side.

This does not attempt to fix the structural problem that the workaround was piggy-backed on the fact that the app-facing package polls frequently for the playback position, generating buffer update events when that polling happens rather than via any independent internal polling system. This approach is not only fragile, as it depends on logic defined in another package, but already doesn't work in the case of a paused video. However, this refactoring will make it possible to change this behavior in Dart code in a follow-up focused on that behavioral change. This change should be behavior-neutral, except that it adds the simple improvement of not creating events if the buffer position hasn't changed, so that clients aren't getting a stream of useless buffer position events during playback.

This version will also be more efficient from a platform channel standpoint, since instead of sending a separate message with the buffer position, it's returned in the same call as the playback position.

To support synthesizing events on the Dart side, this adds a custom stream controller in Dart, instead of creating it directly from the EventChannel stream; this change will make future changes to a non-method-channel approach (e.g., FFI callbacks) straightforward. As this adds non-trivial additional per-player-instance state on the Dart side, this adds a Dart player instance class, and consolidates existing state into that class, including passthrough methods for the API calls, making it clearer which state is plugin level vs player level.

Part of https://github.com/flutter/flutter/issues/172763

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
