### PR TITLE
[in_app_purchase] Update in_app_purchase_storekit version in in_app_purchase

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
+## 3.2.4
+* Updates minimum `in_app_purchase_storekit` version to 0.4.4.
+
 ## 3.2.3
 * Updates minimum `in_app_purchase_storekit` version to 0.4.0.
 

--- a/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
   in_app_purchase_android: ^0.4.0
-  in_app_purchase_storekit: ^0.4.0
+  in_app_purchase_storekit: ^0.4.4
   shared_preferences: ^2.0.0
 
 dev_dependencies:

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.2.3
+version: 3.2.4
 
 environment:
   sdk: ^3.6.0
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   in_app_purchase_android: ^0.4.0
   in_app_purchase_platform_interface: ^1.4.0
-  in_app_purchase_storekit: ^0.4.0
+  in_app_purchase_storekit: ^0.4.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**Description:**
This PR updates the `in_app_purchase_storekit` dependency to `0.4.4` in the `in_app_purchase` package and its example app.
This keeps the StoreKit implementation in sync with the latest release, ensuring compatibility with recent changes and improvements.

---

**Pre-Review Checklist** ✅

* [x] I read the \[Contributor Guide] and followed the process outlined there for submitting PRs.
* [x] I read the \[Tree Hygiene] page, which explains my responsibilities.
* [x] I read and followed the \[relevant style guides] and ran \[the auto-formatter].
* [x] I signed the \[CLA].
* [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`.
* [x] I updated `pubspec.yaml` with an appropriate new version according to the \[pub versioning philosophy].
* [x] I updated `CHANGELOG.md` to add a description of the change, \[following repository CHANGELOG style].
* [x] I marked this PR as test-exempt since it is a dependency roll.
