### PR TITLE
Add review agent style guidelines to .gemini/styleguide.md

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -21,3 +21,13 @@ auto-formatter, for each language, as described in
 - PR descriptions should include the Pre-Review Checklist from
   [the PR template](https://github.com/flutter/packages/blob/main/.github/PULL_REQUEST_TEMPLATE.md),
   with all of the steps completed.
+
+## Review Agent Guidelines
+
+When providing a summary, the review agent must adhere to the following principles:
+- **Be Objective:** Focus on a neutral, descriptive summary of the changes. Avoid subjective value judgments
+  like "good," "bad," "positive," or "negative." The goal is to report what the code does, not to evaluate it.
+- **Use Code as the Source of Truth:** Base all summaries on the code diff. Do not trust or rephrase the PR
+  description, which may be outdated or inaccurate. A summary must reflect the actual changes in the code.
+- **Be Concise:** Generate summaries that are brief and to the point. Focus on the most significant changes,
+  and avoid unnecessary details or verbose explanations. This ensures the feedback is easy to scan and understand.


### PR DESCRIPTION
Initial attempt at adding guidance for GCAfGH to try cut down on the behavior observed so far that it:
- Almost always includes generic praise for the PR, which is unhelpful since the agent has no context for evaluating what PRs we actually want (see [this particularly problematic example](https://github.com/flutter/packages/pull/9795#pullrequestreview-3113026764))
- Appears to trust PR descriptions. E.g., recently praising a PR that was missing tests of most of the PR, but had a PR description saying it included extensive testing, as being extremely well tested.

This text is based on some iteration with Gemini, under the theory that the AI model has far more exposure to examples of good prompts than I do. 🤷🏻