### PR TITLE
[flutter_migrate] Remove ios-language argument

### DIFF
--- a/packages/flutter_migrate/CHANGELOG.md
+++ b/packages/flutter_migrate/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.1.1+1
 
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+* Add ios-language error handling for Flutter 3.35
 
 ## 0.0.1+4
 

--- a/packages/flutter_migrate/lib/src/compute.dart
+++ b/packages/flutter_migrate/lib/src/compute.dart
@@ -51,8 +51,8 @@ bool _skipped(
   if (canonicalizedSkippedFiles.contains(canonicalizedLocalPath)) {
     return true;
   }
-  final Iterable<String> canonicalizedSkippedDirectories = _skippedDirectories
-      .map<String>((String path) => canonicalize(path));
+  final Iterable<String> canonicalizedSkippedDirectories =
+      _skippedDirectories.map<String>((String path) => canonicalize(path));
   for (final String dir in canonicalizedSkippedDirectories) {
     if (canonicalizedLocalPath.startsWith('$dir${fileSystem.path.separator}')) {
       return true;
@@ -274,12 +274,12 @@ Future<MigrateResult?> computeMigration({
   // Generate the base templates
   final ReferenceProjects referenceProjects =
       await _generateBaseAndTargetReferenceProjects(
-        context: context,
-        result: result,
-        revisionConfig: revisionConfig,
-        platforms: platforms,
-        commandParameters: commandParameters,
-      );
+    context: context,
+    result: result,
+    revisionConfig: revisionConfig,
+    platforms: platforms,
+    commandParameters: commandParameters,
+  );
 
   // Generate diffs. These diffs are used to determine if a file is newly added, needs merging,
   // or deleted (rare). Only files with diffs between the base and target revisions need to be
@@ -393,10 +393,10 @@ Future<ReferenceProjects> _generateBaseAndTargetReferenceProjects({
   // Use user-provided projects if provided, if not, generate them internally.
   final bool customBaseProjectDir = commandParameters.baseAppPath != null;
   final bool customTargetProjectDir = commandParameters.targetAppPath != null;
-  Directory baseProjectDir = context.fileSystem.systemTempDirectory
-      .createTempSync('baseProject');
-  Directory targetProjectDir = context.fileSystem.systemTempDirectory
-      .createTempSync('targetProject');
+  Directory baseProjectDir =
+      context.fileSystem.systemTempDirectory.createTempSync('baseProject');
+  Directory targetProjectDir =
+      context.fileSystem.systemTempDirectory.createTempSync('targetProject');
   if (customBaseProjectDir) {
     baseProjectDir = context.fileSystem.directory(
       commandParameters.baseAppPath,
@@ -435,10 +435,6 @@ Future<ReferenceProjects> _generateBaseAndTargetReferenceProjects({
       context.environment['FlutterProject.android.isKotlin']! as bool
           ? 'kotlin'
           : 'java';
-  final String iosLanguage =
-      context.environment['FlutterProject.ios.isSwift']! as bool
-          ? 'swift'
-          : 'objc';
 
   final Directory targetFlutterDirectory = context.fileSystem.directory(
     context.environment.getString('Cache.flutterRoot'),
@@ -454,7 +450,6 @@ Future<ReferenceProjects> _generateBaseAndTargetReferenceProjects({
     directory: baseProjectDir,
     name: name,
     androidLanguage: androidLanguage,
-    iosLanguage: iosLanguage,
     platformWhitelist: platforms,
   );
   context.baseProject = baseProject;
@@ -482,7 +477,6 @@ Future<ReferenceProjects> _generateBaseAndTargetReferenceProjects({
     directory: targetProjectDir,
     name: name,
     androidLanguage: androidLanguage,
-    iosLanguage: iosLanguage,
     platformWhitelist: platforms,
   );
   context.targetProject = targetProject;
@@ -531,7 +525,6 @@ abstract class MigrateFlutterProject {
     required this.directory,
     required this.name,
     required this.androidLanguage,
-    required this.iosLanguage,
     this.platformWhitelist,
   });
 
@@ -539,7 +532,6 @@ abstract class MigrateFlutterProject {
   final Directory directory;
   final String name;
   final String androidLanguage;
-  final String iosLanguage;
   final List<SupportedPlatform>? platformWhitelist;
 
   /// Run git diff over each matching pair of files in the this project and the provided target project.
@@ -662,8 +654,8 @@ abstract class MigrateFlutterProject {
       MetadataCustomMerge(logger: context.migrateLogger.logger),
     ];
     // For each existing file in the project, we attempt to 3 way merge if it is changed by the user.
-    final List<FileSystemEntity> currentFiles = context.flutterProject.directory
-        .listSync(recursive: true);
+    final List<FileSystemEntity> currentFiles =
+        context.flutterProject.directory.listSync(recursive: true);
     final String projectRootPath =
         context.flutterProject.directory.absolute.path;
     final Set<String> missingAlwaysMigrateFiles = Set<String>.of(
@@ -855,8 +847,8 @@ abstract class MigrateFlutterProject {
 
     // Add files that are in the target, marked as always migrate, and missing in the current project.
     for (final String localPath in missingAlwaysMigrateFiles) {
-      final File targetTemplateFile = result.generatedTargetTemplateDirectory!
-          .childFile(localPath);
+      final File targetTemplateFile =
+          result.generatedTargetTemplateDirectory!.childFile(localPath);
       if (targetTemplateFile.existsSync() &&
           !_skipped(
             localPath,
@@ -881,7 +873,6 @@ class MigrateBaseFlutterProject extends MigrateFlutterProject {
     required super.directory,
     required super.name,
     required super.androidLanguage,
-    required super.iosLanguage,
     super.platformWhitelist,
   });
 
@@ -952,25 +943,22 @@ class MigrateBaseFlutterProject extends MigrateFlutterProject {
         context.migrateLogger.printStatus(
           'Creating base app for $platforms with revision $revision.',
         );
-        final String newDirectoryPath = await context.migrateUtils
-            .createFromTemplates(
-              sdkDir.childDirectory('bin').absolute.path,
-              name: name,
-              androidLanguage: androidLanguage,
-              iosLanguage: iosLanguage,
-              outputDirectory:
-                  result.generatedBaseTemplateDirectory!.absolute.path,
-              platforms: platforms,
-            );
+        final String newDirectoryPath =
+            await context.migrateUtils.createFromTemplates(
+          sdkDir.childDirectory('bin').absolute.path,
+          name: name,
+          androidLanguage: androidLanguage,
+          outputDirectory: result.generatedBaseTemplateDirectory!.absolute.path,
+          platforms: platforms,
+        );
         if (newDirectoryPath != result.generatedBaseTemplateDirectory?.path) {
           result.generatedBaseTemplateDirectory = context.fileSystem.directory(
             newDirectoryPath,
           );
         }
         // Determine merge type for each newly generated file.
-        final List<FileSystemEntity> generatedBaseFiles = result
-            .generatedBaseTemplateDirectory!
-            .listSync(recursive: true);
+        final List<FileSystemEntity> generatedBaseFiles =
+            result.generatedBaseTemplateDirectory!.listSync(recursive: true);
         for (final FileSystemEntity entity in generatedBaseFiles) {
           if (entity is! File) {
             continue;
@@ -983,10 +971,9 @@ class MigrateBaseFlutterProject extends MigrateFlutterProject {
           );
           if (!result.mergeTypeMap.containsKey(localPath)) {
             // Use two way merge when the base revision is the same as the target revision.
-            result.mergeTypeMap[localPath] =
-                revision == targetRevision
-                    ? MergeType.twoWay
-                    : MergeType.threeWay;
+            result.mergeTypeMap[localPath] = revision == targetRevision
+                ? MergeType.twoWay
+                : MergeType.threeWay;
           }
         }
         if (newDirectoryPath != result.generatedBaseTemplateDirectory?.path) {
@@ -1010,7 +997,6 @@ class MigrateTargetFlutterProject extends MigrateFlutterProject {
     required super.directory,
     required super.name,
     required super.androidLanguage,
-    required super.iosLanguage,
     super.platformWhitelist,
   });
 
@@ -1031,7 +1017,6 @@ class MigrateTargetFlutterProject extends MigrateFlutterProject {
         targetFlutterDirectory.childDirectory('bin').absolute.path,
         name: name,
         androidLanguage: androidLanguage,
-        iosLanguage: iosLanguage,
         outputDirectory: result.generatedTargetTemplateDirectory!.absolute.path,
       );
     }
@@ -1101,14 +1086,13 @@ class MigrateRevisions {
     if (baseRevision == null) {
       for (final MigratePlatformConfig platform
           in config.platformConfigs.values) {
-        final String effectiveRevision =
-            platform.baseRevision == null
-                ? metadataRevision ??
-                    _getFallbackBaseRevision(
-                      allowFallbackBaseRevision,
-                      context.migrateLogger,
-                    )
-                : platform.baseRevision!;
+        final String effectiveRevision = platform.baseRevision == null
+            ? metadataRevision ??
+                _getFallbackBaseRevision(
+                  allowFallbackBaseRevision,
+                  context.migrateLogger,
+                )
+            : platform.baseRevision!;
         if (!components.contains(platform.component)) {
           continue;
         }

--- a/packages/flutter_migrate/lib/src/utils.dart
+++ b/packages/flutter_migrate/lib/src/utils.dart
@@ -22,9 +22,9 @@ class MigrateUtils {
     required Logger logger,
     required FileSystem fileSystem,
     required ProcessManager processManager,
-  }) : _processManager = processManager,
-       _logger = logger,
-       _fileSystem = fileSystem;
+  })  : _processManager = processManager,
+        _logger = logger,
+        _fileSystem = fileSystem;
 
   final Logger _logger;
   final FileSystem _fileSystem;
@@ -104,7 +104,6 @@ class MigrateUtils {
     required String name,
     bool legacyNameParameter = false,
     required String androidLanguage,
-    required String iosLanguage,
     required String outputDirectory,
     String? createVersion,
     List<String> platforms = const <String>[],
@@ -123,7 +122,7 @@ class MigrateUtils {
       cmdArgs.add('--project-name=$name');
     }
     cmdArgs.add('--android-language=$androidLanguage');
-    cmdArgs.add('--ios-language=$iosLanguage');
+
     if (platforms.isNotEmpty) {
       String platformsArg = '--platforms=';
       for (int i = 0; i < platforms.length; i++) {
@@ -146,8 +145,6 @@ class MigrateUtils {
     );
     final String error = result.stderr as String;
 
-    // Catch errors due to parameters not existing.
-
     // Old versions of the tool does not include the platforms option.
     if (error.contains('Could not find an option named "platforms".')) {
       return createFromTemplates(
@@ -155,9 +152,8 @@ class MigrateUtils {
         name: name,
         legacyNameParameter: legacyNameParameter,
         androidLanguage: androidLanguage,
-        iosLanguage: iosLanguage,
         outputDirectory: outputDirectory,
-        iterationsAllowed: iterationsAllowed--,
+        iterationsAllowed: iterationsAllowed - 1,
       );
     }
     // Old versions of the tool does not include the project-name option.
@@ -169,10 +165,9 @@ class MigrateUtils {
         name: name,
         legacyNameParameter: true,
         androidLanguage: androidLanguage,
-        iosLanguage: iosLanguage,
         outputDirectory: outputDirectory,
         platforms: platforms,
-        iterationsAllowed: iterationsAllowed--,
+        iterationsAllowed: iterationsAllowed - 1,
       );
     }
     if (error.contains('Multiple output directories specified.')) {
@@ -182,9 +177,8 @@ class MigrateUtils {
           name: name,
           legacyNameParameter: legacyNameParameter,
           androidLanguage: androidLanguage,
-          iosLanguage: iosLanguage,
           outputDirectory: outputDirectory,
-          iterationsAllowed: iterationsAllowed--,
+          iterationsAllowed: iterationsAllowed - 1,
         );
       }
     }
@@ -365,8 +359,7 @@ class MigrateUtils {
 
   /// Returns true if the file does not contain any git conflit markers.
   bool conflictsResolved(String contents) {
-    final bool hasMarker =
-        contents.contains('>>>>>>>') ||
+    final bool hasMarker = contents.contains('>>>>>>>') ||
         contents.contains('=======') ||
         contents.contains('<<<<<<<');
     return !hasMarker;
@@ -421,12 +414,11 @@ void printCommandText(
   bool? standalone = true,
   bool newlineAfter = true,
 }) {
-  final String prefix =
-      standalone == null
-          ? ''
-          : (standalone
-              ? 'dart run <flutter_migrate_dir>${Platform.pathSeparator}bin${Platform.pathSeparator}flutter_migrate.dart '
-              : 'flutter migrate ');
+  final String prefix = standalone == null
+      ? ''
+      : (standalone
+          ? 'dart run <flutter_migrate_dir>${Platform.pathSeparator}bin${Platform.pathSeparator}flutter_migrate.dart '
+          : 'flutter migrate ');
   printCommand('$prefix$command', logger, newlineAfter: newlineAfter);
 }
 
@@ -437,10 +429,10 @@ enum DiffType { command, addition, deletion, ignored, none }
 /// file or deletion of an existing file.
 class DiffResult {
   DiffResult({required this.diffType, this.diff, this.exitCode})
-    : assert(
-        diffType == DiffType.command && exitCode != null ||
-            diffType != DiffType.command && exitCode == null,
-      );
+      : assert(
+          diffType == DiffType.command && exitCode != null ||
+              diffType != DiffType.command && exitCode == null,
+        );
 
   /// The diff string output by git.
   final String? diff;
@@ -457,8 +449,8 @@ class DiffResult {
 abstract class MergeResult {
   /// Initializes a MergeResult based off of a ProcessResult.
   MergeResult(ProcessResult result, this.localPath)
-    : hasConflict = result.exitCode != 0,
-      exitCode = result.exitCode;
+      : hasConflict = result.exitCode != 0,
+        exitCode = result.exitCode;
 
   /// Manually initializes a MergeResult with explicit values.
   MergeResult.explicit({
@@ -481,7 +473,7 @@ abstract class MergeResult {
 class StringMergeResult extends MergeResult {
   /// Initializes a BinaryMergeResult based off of a ProcessResult.
   StringMergeResult(super.result, super.localPath)
-    : mergedString = result.stdout as String;
+      : mergedString = result.stdout as String;
 
   /// Manually initializes a StringMergeResult with explicit values.
   StringMergeResult.explicit({
@@ -499,7 +491,7 @@ class StringMergeResult extends MergeResult {
 class BinaryMergeResult extends MergeResult {
   /// Initializes a BinaryMergeResult based off of a ProcessResult.
   BinaryMergeResult(super.result, super.localPath)
-    : mergedBytes = result.stdout as Uint8List;
+      : mergedBytes = result.stdout as Uint8List;
 
   /// Manually initializes a BinaryMergeResult with explicit values.
   BinaryMergeResult.explicit({

--- a/packages/flutter_migrate/pubspec.yaml
+++ b/packages/flutter_migrate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_migrate
 description: A tool to migrate legacy flutter projects to modern versions.
-version: 0.0.1+4
+version: 0.1.1+1
 repository: https://github.com/flutter/packages/tree/main/packages/flutter_migrate
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ap%3A%20flutter_migrate
 publish_to: none
@@ -12,15 +12,16 @@ dependencies:
   args: ^2.3.1
   convert: ^3.0.2
   file:  ">=6.0.0 <8.0.0"
-  intl: ">=0.17.0 <0.20.0"
+  intl: ">=0.17.0 <0.21.0"
   meta: ^1.8.0
   path: ^1.8.0
-  process: ^4.2.4
-  vm_service: ^9.3.0
+  process: ^5.0.5
+  vm_service: ^15.0.2
   yaml: ^3.1.1
 
 dev_dependencies:
+  build_runner: ^2.7.0
   collection: ^1.16.0
   file_testing: ^3.0.0
-  lints: ^2.0.0
+  lints: ^6.0.0
   test: ^1.16.0

--- a/packages/flutter_migrate/test/compute_test.dart
+++ b/packages/flutter_migrate/test/compute_test.dart
@@ -90,9 +90,9 @@ void main() {
 ''');
     environment =
         await FlutterToolsEnvironment.initializeFlutterToolsEnvironment(
-          envProcessManager,
-          logger,
-        );
+      envProcessManager,
+      logger,
+    );
     context = MigrateContext(
       flutterProject: flutterProject,
       skippedPrefixes: <String>{},
@@ -142,12 +142,11 @@ void main() {
           workingDir.createSync(recursive: true);
           final MigrateTargetFlutterProject targetProject =
               MigrateTargetFlutterProject(
-                path: null,
-                directory: targetDir,
-                name: 'base',
-                androidLanguage: 'java',
-                iosLanguage: 'objc',
-              );
+            path: null,
+            directory: targetDir,
+            name: 'base',
+            androidLanguage: 'java',
+          );
 
           await targetProject.createProject(
             context,
@@ -181,12 +180,11 @@ void main() {
           workingDir.createSync(recursive: true);
           final MigrateBaseFlutterProject baseProject =
               MigrateBaseFlutterProject(
-                path: null,
-                directory: baseDir,
-                name: 'base',
-                androidLanguage: 'java',
-                iosLanguage: 'objc',
-              );
+            path: null,
+            directory: baseDir,
+            name: 'base',
+            androidLanguage: 'java',
+          );
 
           await baseProject.createProject(
             context,
@@ -235,20 +233,18 @@ void main() {
 
           final MigrateBaseFlutterProject baseProject =
               MigrateBaseFlutterProject(
-                path: 'some_existing_base_path',
-                directory: baseDir,
-                name: 'base',
-                androidLanguage: 'java',
-                iosLanguage: 'objc',
-              );
+            path: 'some_existing_base_path',
+            directory: baseDir,
+            name: 'base',
+            androidLanguage: 'java',
+          );
           final MigrateTargetFlutterProject targetProject =
               MigrateTargetFlutterProject(
-                path: 'some_existing_target_path',
-                directory: targetDir,
-                name: 'base',
-                androidLanguage: 'java',
-                iosLanguage: 'objc',
-              );
+            path: 'some_existing_target_path',
+            directory: targetDir,
+            name: 'base',
+            androidLanguage: 'java',
+          );
 
           await baseProject.createProject(
             context,
@@ -511,101 +507,73 @@ migration:
         );
 
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.root]!
+          revisions.config.platformConfigs[FlutterProjectComponent.root]!
               .createRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.android]!
+          revisions.config.platformConfigs[FlutterProjectComponent.android]!
               .createRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.ios]!
+          revisions.config.platformConfigs[FlutterProjectComponent.ios]!
               .createRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.linux]!
+          revisions.config.platformConfigs[FlutterProjectComponent.linux]!
               .createRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.macos]!
+          revisions.config.platformConfigs[FlutterProjectComponent.macos]!
               .createRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.web]!
+          revisions.config.platformConfigs[FlutterProjectComponent.web]!
               .createRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.windows]!
+          revisions.config.platformConfigs[FlutterProjectComponent.windows]!
               .createRevision,
           '36427af29421f406ac95ff55ea31d1dc49a45b5f',
         );
 
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.root]!
+          revisions.config.platformConfigs[FlutterProjectComponent.root]!
               .baseRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.android]!
+          revisions.config.platformConfigs[FlutterProjectComponent.android]!
               .baseRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.ios]!
+          revisions.config.platformConfigs[FlutterProjectComponent.ios]!
               .baseRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.linux]!
+          revisions.config.platformConfigs[FlutterProjectComponent.linux]!
               .baseRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.macos]!
+          revisions.config.platformConfigs[FlutterProjectComponent.macos]!
               .baseRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.web]!
+          revisions.config.platformConfigs[FlutterProjectComponent.web]!
               .baseRevision,
           '9b2d32b605630f28625709ebd9d78ab3016b2bf6',
         );
         expect(
-          revisions
-              .config
-              .platformConfigs[FlutterProjectComponent.windows]!
+          revisions.config.platformConfigs[FlutterProjectComponent.windows]!
               .baseRevision,
           '36427af29421f406ac95ff55ea31d1dc49a45b5f',
         );
@@ -645,16 +613,14 @@ migration:
           directory: baseDir,
           name: 'base',
           androidLanguage: 'java',
-          iosLanguage: 'objc',
         );
         final MigrateTargetFlutterProject targetProject =
             MigrateTargetFlutterProject(
-              path: null,
-              directory: targetDir,
-              name: 'base',
-              androidLanguage: 'java',
-              iosLanguage: 'objc',
-            );
+          path: null,
+          directory: targetDir,
+          name: 'base',
+          androidLanguage: 'java',
+        );
 
         await baseProject.createProject(
           context,
@@ -815,8 +781,8 @@ migration:
         );
         expect(
           canonicalizedDiffResults[canonicalize(
-                'android/app/src/main/AndroidManifest.xml',
-              )]!
+            'android/app/src/main/AndroidManifest.xml',
+          )]!
               .diff,
           contains(r'''
 @@ -1,39 +1,34 @@
@@ -895,16 +861,14 @@ migration:
           directory: baseDir,
           name: 'base',
           androidLanguage: 'java',
-          iosLanguage: 'objc',
         );
         final MigrateTargetFlutterProject targetProject =
             MigrateTargetFlutterProject(
-              path: null,
-              directory: targetDir,
-              name: 'base',
-              androidLanguage: 'java',
-              iosLanguage: 'objc',
-            );
+          path: null,
+          directory: targetDir,
+          name: 'base',
+          androidLanguage: 'java',
+        );
 
         await baseProject.createProject(
           context,

--- a/packages/flutter_migrate/test/utils_test.dart
+++ b/packages/flutter_migrate/test/utils_test.dart
@@ -93,15 +93,21 @@ void main() {
         ..createSync()
         ..writeAsStringSync('ignored_file.dart', flush: true);
 
-      await Process.run('git', <String>[
-        'add',
-        '.',
-      ], workingDirectory: projectRootPath);
-      await Process.run('git', <String>[
-        'commit',
-        '-m',
-        'Initial commit',
-      ], workingDirectory: projectRootPath);
+      await Process.run(
+          'git',
+          <String>[
+            'add',
+            '.',
+          ],
+          workingDirectory: projectRootPath);
+      await Process.run(
+          'git',
+          <String>[
+            'commit',
+            '-m',
+            'Initial commit',
+          ],
+          workingDirectory: projectRootPath);
 
       expect(await utils.hasUncommittedChanges(projectRootPath), false);
     });
@@ -144,10 +150,9 @@ void main() {
       await utils.gitInit(projectRootPath);
       expect(projectRoot.childDirectory('.git').existsSync(), true);
 
-      final File file1 =
-          projectRoot.childFile('some_file.dart')
-            ..createSync()
-            ..writeAsStringSync('void main() {}\n', flush: true);
+      final File file1 = projectRoot.childFile('some_file.dart')
+        ..createSync()
+        ..writeAsStringSync('void main() {}\n', flush: true);
 
       final File file2 = projectRoot.childFile('some_other_file.dart');
 
@@ -210,14 +215,12 @@ void main() {
         flush: true,
       );
 
-      StringMergeResult result =
-          await utils.gitMergeFile(
-                base: file1.path,
-                current: file2.path,
-                target: file3.path,
-                localPath: 'some_file.dart',
-              )
-              as StringMergeResult;
+      StringMergeResult result = await utils.gitMergeFile(
+        base: file1.path,
+        current: file2.path,
+        target: file3.path,
+        localPath: 'some_file.dart',
+      ) as StringMergeResult;
 
       expect(
         result.mergedString,
@@ -231,14 +234,12 @@ void main() {
         flush: true,
       );
 
-      result =
-          await utils.gitMergeFile(
-                base: file1.path,
-                current: file2.path,
-                target: file3.path,
-                localPath: 'some_file.dart',
-              )
-              as StringMergeResult;
+      result = await utils.gitMergeFile(
+        base: file1.path,
+        current: file2.path,
+        target: file3.path,
+        localPath: 'some_file.dart',
+      ) as StringMergeResult;
 
       expect(
         result.mergedString,
@@ -248,14 +249,12 @@ void main() {
       expect(result.exitCode, 1);
 
       // Two way merge
-      result =
-          await utils.gitMergeFile(
-                base: file1.path,
-                current: file1.path,
-                target: file3.path,
-                localPath: 'some_file.dart',
-              )
-              as StringMergeResult;
+      result = await utils.gitMergeFile(
+        base: file1.path,
+        current: file1.path,
+        target: file3.path,
+        localPath: 'some_file.dart',
+      ) as StringMergeResult;
 
       expect(
         result.mergedString,
@@ -313,7 +312,6 @@ void main() {
           projectRoot.childDirectory('bin').path,
           name: 'testapp',
           androidLanguage: 'java',
-          iosLanguage: 'objc',
           outputDirectory: appDir.path,
         );
         expect(appDir.childFile('pubspec.yaml').existsSync(), true);


### PR DESCRIPTION
Since flutter 3.35, flutter_migrate throws an exception because ios-language is being passed as argument and is no longer supported.

https://github.com/flutter/flutter/issues/173845#issue-3325141978

On pub.dev, the published version is already 0.1.0 : https://pub.dev/packages/flutter_migrate

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.
