### PR TITLE
[camera] Updates min SDK to 3.29

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+
 ## 0.11.2
 
 * Fixes overflowed toggles in the camera example.

--- a/packages/camera/camera/README.md
+++ b/packages/camera/camera/README.md
@@ -131,23 +131,26 @@ class _CameraAppState extends State<CameraApp> {
   void initState() {
     super.initState();
     controller = CameraController(_cameras[0], ResolutionPreset.max);
-    controller.initialize().then((_) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {});
-    }).catchError((Object e) {
-      if (e is CameraException) {
-        switch (e.code) {
-          case 'CameraAccessDenied':
-            // Handle access errors here.
-            break;
-          default:
-            // Handle other errors here.
-            break;
-        }
-      }
-    });
+    controller
+        .initialize()
+        .then((_) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {});
+        })
+        .catchError((Object e) {
+          if (e is CameraException) {
+            switch (e.code) {
+              case 'CameraAccessDenied':
+                // Handle access errors here.
+                break;
+              default:
+                // Handle other errors here.
+                break;
+            }
+          }
+        });
   }
 
   @override
@@ -161,11 +164,10 @@ class _CameraAppState extends State<CameraApp> {
     if (!controller.value.isInitialized) {
       return Container();
     }
-    return MaterialApp(
-      home: CameraPreview(controller),
-    );
+    return MaterialApp(home: CameraPreview(controller));
   }
 }
+
 ```
 
 For a more elaborate usage example see [here](https://github.com/flutter/packages/tree/main/packages/camera/camera/example).

--- a/packages/camera/camera/example/integration_test/camera_test.dart
+++ b/packages/camera/camera/example/integration_test/camera_test.dart
@@ -33,15 +33,15 @@ void main() {
 
   final Map<ResolutionPreset, Size> presetExpectedSizes =
       <ResolutionPreset, Size>{
-    ResolutionPreset.low:
-        Platform.isAndroid ? const Size(240, 320) : const Size(288, 352),
-    ResolutionPreset.medium:
-        Platform.isAndroid ? const Size(480, 720) : const Size(480, 640),
-    ResolutionPreset.high: const Size(720, 1280),
-    ResolutionPreset.veryHigh: const Size(1080, 1920),
-    ResolutionPreset.ultraHigh: const Size(2160, 3840),
-    // Don't bother checking for max here since it could be anything.
-  };
+        ResolutionPreset.low:
+            Platform.isAndroid ? const Size(240, 320) : const Size(288, 352),
+        ResolutionPreset.medium:
+            Platform.isAndroid ? const Size(480, 720) : const Size(480, 640),
+        ResolutionPreset.high: const Size(720, 1280),
+        ResolutionPreset.veryHigh: const Size(1080, 1920),
+        ResolutionPreset.ultraHigh: const Size(2160, 3840),
+        // Don't bother checking for max here since it could be anything.
+      };
 
   /// Verify that [actual] has dimensions that are at least as large as
   /// [expectedSize]. Allows for a mismatch in portrait vs landscape. Returns
@@ -57,7 +57,9 @@ void main() {
   // automatic code to fall back to smaller sizes when we need to. Returns
   // whether the image is exactly the desired resolution.
   Future<bool> testCaptureVideoResolution(
-      CameraController controller, ResolutionPreset preset) async {
+    CameraController controller,
+    ResolutionPreset preset,
+  ) async {
     final Size expectedSize = presetExpectedSizes[preset]!;
 
     // Take Video
@@ -67,15 +69,18 @@ void main() {
 
     // Load video metadata
     final File videoFile = File(file.path);
-    final VideoPlayerController videoController =
-        VideoPlayerController.file(videoFile);
+    final VideoPlayerController videoController = VideoPlayerController.file(
+      videoFile,
+    );
     await videoController.initialize();
     final Size video = videoController.value.size;
 
     // Verify image dimensions are as expected
     expect(video, isNotNull);
     return assertExpectedDimensions(
-        expectedSize, Size(video.height, video.width));
+      expectedSize,
+      Size(video.height, video.width),
+    );
   }
 
   testWidgets(
@@ -89,14 +94,20 @@ void main() {
         bool previousPresetExactlySupported = true;
         for (final MapEntry<ResolutionPreset, Size> preset
             in presetExpectedSizes.entries) {
-          final CameraController controller =
-              CameraController(cameraDescription, preset.key);
+          final CameraController controller = CameraController(
+            cameraDescription,
+            preset.key,
+          );
           await controller.initialize();
           await controller.prepareForVideoRecording();
-          final bool presetExactlySupported =
-              await testCaptureVideoResolution(controller, preset.key);
-          assert(!(!previousPresetExactlySupported && presetExactlySupported),
-              'The camera took higher resolution pictures at a lower resolution.');
+          final bool presetExactlySupported = await testCaptureVideoResolution(
+            controller,
+            preset.key,
+          );
+          assert(
+            !(!previousPresetExactlySupported && presetExactlySupported),
+            'The camera took higher resolution pictures at a lower resolution.',
+          );
           previousPresetExactlySupported = presetExactlySupported;
           await controller.dispose();
         }
@@ -188,46 +199,44 @@ void main() {
     expect(duration, lessThan(recordingTime - timePaused));
   }, skip: !Platform.isAndroid || skipFor157181);
 
-  testWidgets(
-    'Android image streaming',
-    (WidgetTester tester) async {
-      final List<CameraDescription> cameras = await availableCameras();
-      if (cameras.isEmpty) {
+  testWidgets('Android image streaming', (WidgetTester tester) async {
+    final List<CameraDescription> cameras = await availableCameras();
+    if (cameras.isEmpty) {
+      return;
+    }
+
+    final CameraController controller = CameraController(
+      cameras[0],
+      ResolutionPreset.low,
+      enableAudio: false,
+    );
+
+    await controller.initialize();
+    bool isDetecting = false;
+
+    await controller.startImageStream((CameraImage image) {
+      if (isDetecting) {
         return;
       }
 
-      final CameraController controller = CameraController(
-        cameras[0],
-        ResolutionPreset.low,
-        enableAudio: false,
-      );
+      isDetecting = true;
 
-      await controller.initialize();
-      bool isDetecting = false;
+      expectLater(image, isNotNull).whenComplete(() => isDetecting = false);
+    });
 
-      await controller.startImageStream((CameraImage image) {
-        if (isDetecting) {
-          return;
-        }
+    expect(controller.value.isStreamingImages, true);
 
-        isDetecting = true;
+    sleep(const Duration(milliseconds: 500));
 
-        expectLater(image, isNotNull).whenComplete(() => isDetecting = false);
-      });
-
-      expect(controller.value.isStreamingImages, true);
-
-      sleep(const Duration(milliseconds: 500));
-
-      await controller.stopImageStream();
-      await controller.dispose();
-    },
-    skip: !Platform.isAndroid,
-  );
+    await controller.stopImageStream();
+    await controller.dispose();
+  }, skip: !Platform.isAndroid);
 
   /// Start streaming with specifying the ImageFormatGroup.
-  Future<CameraImage> startStreaming(List<CameraDescription> cameras,
-      ImageFormatGroup? imageFormatGroup) async {
+  Future<CameraImage> startStreaming(
+    List<CameraDescription> cameras,
+    ImageFormatGroup? imageFormatGroup,
+  ) async {
     final CameraController controller = CameraController(
       cameras.first,
       ResolutionPreset.low,
@@ -290,29 +299,27 @@ void main() {
     expect(controller.description, cameras[1]);
   });
 
-  testWidgets(
-    'iOS image streaming with imageFormatGroup',
-    (WidgetTester tester) async {
-      final List<CameraDescription> cameras = await availableCameras();
-      if (cameras.isEmpty) {
-        return;
-      }
+  testWidgets('iOS image streaming with imageFormatGroup', (
+    WidgetTester tester,
+  ) async {
+    final List<CameraDescription> cameras = await availableCameras();
+    if (cameras.isEmpty) {
+      return;
+    }
 
-      CameraImage image = await startStreaming(cameras, null);
-      expect(image, isNotNull);
-      expect(image.format.group, ImageFormatGroup.bgra8888);
-      expect(image.planes.length, 1);
+    CameraImage image = await startStreaming(cameras, null);
+    expect(image, isNotNull);
+    expect(image.format.group, ImageFormatGroup.bgra8888);
+    expect(image.planes.length, 1);
 
-      image = await startStreaming(cameras, ImageFormatGroup.yuv420);
-      expect(image, isNotNull);
-      expect(image.format.group, ImageFormatGroup.yuv420);
-      expect(image.planes.length, 2);
+    image = await startStreaming(cameras, ImageFormatGroup.yuv420);
+    expect(image, isNotNull);
+    expect(image.format.group, ImageFormatGroup.yuv420);
+    expect(image.planes.length, 2);
 
-      image = await startStreaming(cameras, ImageFormatGroup.bgra8888);
-      expect(image, isNotNull);
-      expect(image.format.group, ImageFormatGroup.bgra8888);
-      expect(image.planes.length, 1);
-    },
-    skip: !Platform.isIOS,
-  );
+    image = await startStreaming(cameras, ImageFormatGroup.bgra8888);
+    expect(image, isNotNull);
+    expect(image.format.group, ImageFormatGroup.bgra8888);
+    expect(image.planes.length, 1);
+  }, skip: !Platform.isIOS);
 }

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -132,9 +132,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Camera example'),
-      ),
+      appBar: AppBar(title: const Text('Camera example')),
       body: Column(
         children: <Widget>[
           Expanded(
@@ -151,9 +149,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               child: Padding(
                 padding: const EdgeInsets.all(1.0),
-                child: Center(
-                  child: _cameraPreviewWidget(),
-                ),
+                child: Center(child: _cameraPreviewWidget()),
               ),
             ),
           ),
@@ -162,10 +158,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           Padding(
             padding: const EdgeInsets.all(5.0),
             child: Row(
-              children: <Widget>[
-                _cameraTogglesRowWidget(),
-                _thumbnailWidget(),
-              ],
+              children: <Widget>[_cameraTogglesRowWidget(), _thumbnailWidget()],
             ),
           ),
         ],
@@ -193,15 +186,17 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         child: CameraPreview(
           controller!,
           child: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-            return GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onScaleStart: _handleScaleStart,
-              onScaleUpdate: _handleScaleUpdate,
-              onTapDown: (TapDownDetails details) =>
-                  onViewFinderTap(details, constraints),
-            );
-          }),
+            builder: (BuildContext context, BoxConstraints constraints) {
+              return GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onScaleStart: _handleScaleStart,
+                onScaleUpdate: _handleScaleUpdate,
+                onTapDown:
+                    (TapDownDetails details) =>
+                        onViewFinderTap(details, constraints),
+              );
+            },
+          ),
         ),
       );
     }
@@ -217,8 +212,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       return;
     }
 
-    _currentScale = (_baseScale * details.scale)
-        .clamp(_minAvailableZoom, _maxAvailableZoom);
+    _currentScale = (_baseScale * details.scale).clamp(
+      _minAvailableZoom,
+      _maxAvailableZoom,
+    );
 
     await controller!.setZoomLevel(_currentScale);
   }
@@ -270,20 +267,19 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
             // The exposure and focus mode are currently not supported on the web.
             ...!kIsWeb
                 ? <Widget>[
-                    IconButton(
-                      icon: const Icon(Icons.exposure),
-                      color: Colors.blue,
-                      onPressed: controller != null
-                          ? onExposureModeButtonPressed
-                          : null,
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.filter_center_focus),
-                      color: Colors.blue,
-                      onPressed:
-                          controller != null ? onFocusModeButtonPressed : null,
-                    )
-                  ]
+                  IconButton(
+                    icon: const Icon(Icons.exposure),
+                    color: Colors.blue,
+                    onPressed:
+                        controller != null ? onExposureModeButtonPressed : null,
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.filter_center_focus),
+                    color: Colors.blue,
+                    onPressed:
+                        controller != null ? onFocusModeButtonPressed : null,
+                  ),
+                ]
                 : <Widget>[],
             IconButton(
               icon: Icon(enableAudio ? Icons.volume_up : Icons.volume_mute),
@@ -291,13 +287,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               onPressed: controller != null ? onAudioModeButtonPressed : null,
             ),
             IconButton(
-              icon: Icon(controller?.value.isCaptureOrientationLocked ?? false
-                  ? Icons.screen_lock_rotation
-                  : Icons.screen_rotation),
+              icon: Icon(
+                controller?.value.isCaptureOrientationLocked ?? false
+                    ? Icons.screen_lock_rotation
+                    : Icons.screen_rotation,
+              ),
               color: Colors.blue,
-              onPressed: controller != null
-                  ? onCaptureOrientationLockButtonPressed
-                  : null,
+              onPressed:
+                  controller != null
+                      ? onCaptureOrientationLockButtonPressed
+                      : null,
             ),
           ],
         ),
@@ -317,39 +316,47 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_off),
-              color: controller?.value.flashMode == FlashMode.off
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.off)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.off
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.off)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.flash_auto),
-              color: controller?.value.flashMode == FlashMode.auto
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.auto)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.auto
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.auto)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.flash_on),
-              color: controller?.value.flashMode == FlashMode.always
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.always)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.always
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.always)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.highlight),
-              color: controller?.value.flashMode == FlashMode.torch
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.torch)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.torch
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.torch)
+                      : null,
             ),
           ],
         ),
@@ -359,14 +366,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _exposureModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
-      foregroundColor: controller?.value.exposureMode == ExposureMode.auto
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.exposureMode == ExposureMode.auto
+              ? Colors.orange
+              : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
-      foregroundColor: controller?.value.exposureMode == ExposureMode.locked
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.exposureMode == ExposureMode.locked
+              ? Colors.orange
+              : Colors.blue,
     );
 
     return SizeTransition(
@@ -376,18 +385,18 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           color: Colors.grey.shade50,
           child: Column(
             children: <Widget>[
-              const Center(
-                child: Text('Exposure Mode'),
-              ),
+              const Center(child: Text('Exposure Mode')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
-                    onPressed: controller != null
-                        ? () =>
-                            onSetExposureModeButtonPressed(ExposureMode.auto)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetExposureModeButtonPressed(
+                              ExposureMode.auto,
+                            )
+                            : null,
                     onLongPress: () {
                       if (controller != null) {
                         controller!.setExposurePoint(null);
@@ -398,24 +407,25 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () =>
-                            onSetExposureModeButtonPressed(ExposureMode.locked)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetExposureModeButtonPressed(
+                              ExposureMode.locked,
+                            )
+                            : null,
                     child: const Text('LOCKED'),
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () => controller!.setExposureOffset(0.0)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => controller!.setExposureOffset(0.0)
+                            : null,
                     child: const Text('RESET OFFSET'),
                   ),
                 ],
               ),
-              const Center(
-                child: Text('Exposure Offset'),
-              ),
+              const Center(child: Text('Exposure Offset')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
@@ -425,10 +435,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                     min: _minAvailableExposureOffset,
                     max: _maxAvailableExposureOffset,
                     label: _currentExposureOffset.toString(),
-                    onChanged: _minAvailableExposureOffset ==
-                            _maxAvailableExposureOffset
-                        ? null
-                        : setExposureOffset,
+                    onChanged:
+                        _minAvailableExposureOffset ==
+                                _maxAvailableExposureOffset
+                            ? null
+                            : setExposureOffset,
                   ),
                   Text(_maxAvailableExposureOffset.toString()),
                 ],
@@ -442,14 +453,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _focusModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
-      foregroundColor: controller?.value.focusMode == FocusMode.auto
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.focusMode == FocusMode.auto
+              ? Colors.orange
+              : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
-      foregroundColor: controller?.value.focusMode == FocusMode.locked
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.focusMode == FocusMode.locked
+              ? Colors.orange
+              : Colors.blue,
     );
 
     return SizeTransition(
@@ -459,17 +472,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           color: Colors.grey.shade50,
           child: Column(
             children: <Widget>[
-              const Center(
-                child: Text('Focus Mode'),
-              ),
+              const Center(child: Text('Focus Mode')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
-                    onPressed: controller != null
-                        ? () => onSetFocusModeButtonPressed(FocusMode.auto)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetFocusModeButtonPressed(FocusMode.auto)
+                            : null,
                     onLongPress: () {
                       if (controller != null) {
                         controller!.setFocusPoint(null);
@@ -480,9 +492,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () => onSetFocusModeButtonPressed(FocusMode.locked)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () =>
+                                onSetFocusModeButtonPressed(FocusMode.locked)
+                            : null,
                     child: const Text('LOCKED'),
                   ),
                 ],
@@ -504,43 +518,48 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         IconButton(
           icon: const Icon(Icons.camera_alt),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  !cameraController.value.isRecordingVideo
-              ? onTakePictureButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      !cameraController.value.isRecordingVideo
+                  ? onTakePictureButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.videocam),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  !cameraController.value.isRecordingVideo
-              ? onVideoRecordButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      !cameraController.value.isRecordingVideo
+                  ? onVideoRecordButtonPressed
+                  : null,
         ),
         IconButton(
-          icon: cameraController != null &&
-                  cameraController.value.isRecordingPaused
-              ? const Icon(Icons.play_arrow)
-              : const Icon(Icons.pause),
+          icon:
+              cameraController != null &&
+                      cameraController.value.isRecordingPaused
+                  ? const Icon(Icons.play_arrow)
+                  : const Icon(Icons.pause),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  cameraController.value.isRecordingVideo
-              ? cameraController.value.isRecordingPaused
-                  ? onResumeButtonPressed
-                  : onPauseButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      cameraController.value.isRecordingVideo
+                  ? cameraController.value.isRecordingPaused
+                      ? onResumeButtonPressed
+                      : onPauseButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.stop),
           color: Colors.red,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  cameraController.value.isRecordingVideo
-              ? onStopButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      cameraController.value.isRecordingVideo
+                  ? onStopButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.pause_presentation),
@@ -599,8 +618,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   String timestamp() => DateTime.now().millisecondsSinceEpoch.toString();
 
   void showInSnackBar(String message) {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   void onViewFinderTap(TapDownDetails details, BoxConstraints constraints) {
@@ -627,7 +647,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   }
 
   Future<void> _initializeCameraController(
-      CameraDescription cameraDescription) async {
+    CameraDescription cameraDescription,
+  ) async {
     final CameraController cameraController = CameraController(
       cameraDescription,
       kIsWeb ? ResolutionPreset.max : ResolutionPreset.medium,
@@ -644,7 +665,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       }
       if (cameraController.value.hasError) {
         showInSnackBar(
-            'Camera error ${cameraController.value.errorDescription}');
+          'Camera error ${cameraController.value.errorDescription}',
+        );
       }
     });
 
@@ -654,19 +676,20 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         // The exposure mode is currently not supported on the web.
         ...!kIsWeb
             ? <Future<Object?>>[
-                cameraController.getMinExposureOffset().then(
-                    (double value) => _minAvailableExposureOffset = value),
-                cameraController
-                    .getMaxExposureOffset()
-                    .then((double value) => _maxAvailableExposureOffset = value)
-              ]
+              cameraController.getMinExposureOffset().then(
+                (double value) => _minAvailableExposureOffset = value,
+              ),
+              cameraController.getMaxExposureOffset().then(
+                (double value) => _maxAvailableExposureOffset = value,
+              ),
+            ]
             : <Future<Object?>>[],
-        cameraController
-            .getMaxZoomLevel()
-            .then((double value) => _maxAvailableZoom = value),
-        cameraController
-            .getMinZoomLevel()
-            .then((double value) => _minAvailableZoom = value),
+        cameraController.getMaxZoomLevel().then(
+          (double value) => _maxAvailableZoom = value,
+        ),
+        cameraController.getMinZoomLevel().then(
+          (double value) => _minAvailableZoom = value,
+        ),
       ]);
     } on CameraException catch (e) {
       switch (e.code) {
@@ -758,7 +781,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         } else {
           await cameraController.lockCaptureOrientation();
           showInSnackBar(
-              'Capture orientation locked to ${cameraController.value.lockedCaptureOrientation.toString().split('.').last}');
+            'Capture orientation locked to ${cameraController.value.lockedCaptureOrientation.toString().split('.').last}',
+          );
         }
       }
     } on CameraException catch (e) {
@@ -977,9 +1001,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       return;
     }
 
-    final VideoPlayerController vController = kIsWeb
-        ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
-        : VideoPlayerController.file(File(videoFile!.path));
+    final VideoPlayerController vController =
+        kIsWeb
+            ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
+            : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {
       if (videoController != null) {
@@ -1037,9 +1062,7 @@ class CameraApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: CameraExampleHome(),
-    );
+    return const MaterialApp(home: CameraExampleHome());
   }
 }
 

--- a/packages/camera/camera/example/lib/readme_full_example.dart
+++ b/packages/camera/camera/example/lib/readme_full_example.dart
@@ -31,23 +31,26 @@ class _CameraAppState extends State<CameraApp> {
   void initState() {
     super.initState();
     controller = CameraController(_cameras[0], ResolutionPreset.max);
-    controller.initialize().then((_) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {});
-    }).catchError((Object e) {
-      if (e is CameraException) {
-        switch (e.code) {
-          case 'CameraAccessDenied':
-            // Handle access errors here.
-            break;
-          default:
-            // Handle other errors here.
-            break;
-        }
-      }
-    });
+    controller
+        .initialize()
+        .then((_) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {});
+        })
+        .catchError((Object e) {
+          if (e is CameraException) {
+            switch (e.code) {
+              case 'CameraAccessDenied':
+                // Handle access errors here.
+                break;
+              default:
+                // Handle other errors here.
+                break;
+            }
+          }
+        });
   }
 
   @override
@@ -61,9 +64,8 @@ class _CameraAppState extends State<CameraApp> {
     if (!controller.value.isInitialized) {
       return Container();
     }
-    return MaterialApp(
-      home: CameraPreview(controller),
-    );
+    return MaterialApp(home: CameraPreview(controller));
   }
 }
+
 // #enddocregion FullAppExample

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the camera plugin.
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   camera:

--- a/packages/camera/camera/example/test/main_test.dart
+++ b/packages/camera/camera/example/test/main_test.dart
@@ -15,22 +15,21 @@ void main() {
     expect(find.byType(SnackBar), findsOneWidget);
   });
 
-  testWidgets(
-    'CameraDescription toggles will not overflow',
-    (WidgetTester tester) async {
-      WidgetsFlutterBinding.ensureInitialized();
-      // Adds 10 fake camera descriptions.
-      for (int i = 0; i < 10; i++) {
-        cameras.add(
-          CameraDescription(
-            name: 'camera_$i',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90,
-          ),
-        );
-      }
-      await tester.pumpWidget(const CameraApp());
-      await tester.pumpAndSettle();
-    },
-  );
+  testWidgets('CameraDescription toggles will not overflow', (
+    WidgetTester tester,
+  ) async {
+    WidgetsFlutterBinding.ensureInitialized();
+    // Adds 10 fake camera descriptions.
+    for (int i = 0; i < 10; i++) {
+      cameras.add(
+        CameraDescription(
+          name: 'camera_$i',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+      );
+    }
+    await tester.pumpWidget(const CameraApp());
+    await tester.pumpAndSettle();
+  });
 }

--- a/packages/camera/camera/example/test_driver/integration_test.dart
+++ b/packages/camera/camera/example/test_driver/integration_test.dart
@@ -29,14 +29,14 @@ Future<void> main() async {
     'pm',
     'grant',
     _examplePackage,
-    'android.permission.CAMERA'
+    'android.permission.CAMERA',
   ]);
   Process.runSync('adb', <String>[
     'shell',
     'pm',
     'grant',
     _examplePackage,
-    'android.permission.RECORD_AUDIO'
+    'android.permission.RECORD_AUDIO',
   ]);
   print('Starting test.');
   final FlutterDriver driver = await FlutterDriver.connect();
@@ -51,14 +51,14 @@ Future<void> main() async {
     'pm',
     'revoke',
     _examplePackage,
-    'android.permission.CAMERA'
+    'android.permission.CAMERA',
   ]);
   Process.runSync('adb', <String>[
     'shell',
     'pm',
     'revoke',
     _examplePackage,
-    'android.permission.RECORD_AUDIO'
+    'android.permission.RECORD_AUDIO',
   ]);
 
   final Map<String, dynamic> result = jsonDecode(data) as Map<String, dynamic>;

--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -58,21 +58,21 @@ class CameraValue {
 
   /// Creates a new camera controller state for an uninitialized controller.
   const CameraValue.uninitialized(CameraDescription description)
-      : this(
-          isInitialized: false,
-          isRecordingVideo: false,
-          isTakingPicture: false,
-          isStreamingImages: false,
-          isRecordingPaused: false,
-          flashMode: FlashMode.auto,
-          exposureMode: ExposureMode.auto,
-          exposurePointSupported: false,
-          focusMode: FocusMode.auto,
-          focusPointSupported: false,
-          deviceOrientation: DeviceOrientation.portraitUp,
-          isPreviewPaused: false,
-          description: description,
-        );
+    : this(
+        isInitialized: false,
+        isRecordingVideo: false,
+        isTakingPicture: false,
+        isStreamingImages: false,
+        isRecordingPaused: false,
+        flashMode: FlashMode.auto,
+        exposureMode: ExposureMode.auto,
+        exposurePointSupported: false,
+        focusMode: FocusMode.auto,
+        focusPointSupported: false,
+        deviceOrientation: DeviceOrientation.portraitUp,
+        isPreviewPaused: false,
+        description: description,
+      );
 
   /// True after [CameraController.initialize] has completed successfully.
   final bool isInitialized;
@@ -187,17 +187,20 @@ class CameraValue {
           exposurePointSupported ?? this.exposurePointSupported,
       focusPointSupported: focusPointSupported ?? this.focusPointSupported,
       deviceOrientation: deviceOrientation ?? this.deviceOrientation,
-      lockedCaptureOrientation: lockedCaptureOrientation == null
-          ? this.lockedCaptureOrientation
-          : lockedCaptureOrientation.orNull,
-      recordingOrientation: recordingOrientation == null
-          ? this.recordingOrientation
-          : recordingOrientation.orNull,
+      lockedCaptureOrientation:
+          lockedCaptureOrientation == null
+              ? this.lockedCaptureOrientation
+              : lockedCaptureOrientation.orNull,
+      recordingOrientation:
+          recordingOrientation == null
+              ? this.recordingOrientation
+              : recordingOrientation.orNull,
       isPreviewPaused: isPreviewPaused ?? this.isPreviewPaused,
       description: description ?? this.description,
-      previewPauseOrientation: previewPauseOrientation == null
-          ? this.previewPauseOrientation
-          : previewPauseOrientation.orNull,
+      previewPauseOrientation:
+          previewPauseOrientation == null
+              ? this.previewPauseOrientation
+              : previewPauseOrientation.orNull,
     );
   }
 
@@ -249,13 +252,14 @@ class CameraController extends ValueNotifier<CameraValue> {
     int? videoBitrate,
     int? audioBitrate,
     this.imageFormatGroup,
-  })  : mediaSettings = MediaSettings(
-            resolutionPreset: resolutionPreset,
-            enableAudio: enableAudio,
-            fps: fps,
-            videoBitrate: videoBitrate,
-            audioBitrate: audioBitrate),
-        super(CameraValue.uninitialized(description));
+  }) : mediaSettings = MediaSettings(
+         resolutionPreset: resolutionPreset,
+         enableAudio: enableAudio,
+         fps: fps,
+         videoBitrate: videoBitrate,
+         audioBitrate: audioBitrate,
+       ),
+       super(CameraValue.uninitialized(description));
 
   /// The properties of the camera device controlled by this controller.
   CameraDescription get description => value.description;
@@ -298,7 +302,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   // this value is null.
   Future<void>? _initializeFuture;
   StreamSubscription<DeviceOrientationChangedEvent>?
-      _deviceOrientationSubscription;
+  _deviceOrientationSubscription;
 
   /// Checks whether [CameraController.dispose] has completed successfully.
   ///
@@ -336,22 +340,21 @@ class CameraController extends ValueNotifier<CameraValue> {
       _deviceOrientationSubscription ??= CameraPlatform.instance
           .onDeviceOrientationChanged()
           .listen((DeviceOrientationChangedEvent event) {
-        value = value.copyWith(
-          deviceOrientation: event.orientation,
-        );
-      });
+            value = value.copyWith(deviceOrientation: event.orientation);
+          });
 
       _cameraId = await CameraPlatform.instance.createCameraWithSettings(
         description,
         mediaSettings,
       );
 
-      _unawaited(CameraPlatform.instance
-          .onCameraInitialized(_cameraId)
-          .first
-          .then((CameraInitializedEvent event) {
-        initializeCompleter.complete(event);
-      }));
+      _unawaited(
+        CameraPlatform.instance.onCameraInitialized(_cameraId).first.then((
+          CameraInitializedEvent event,
+        ) {
+          initializeCompleter.complete(event);
+        }),
+      );
 
       await CameraPlatform.instance.initializeCamera(
         _cameraId,
@@ -361,19 +364,22 @@ class CameraController extends ValueNotifier<CameraValue> {
       value = value.copyWith(
         isInitialized: true,
         description: description,
-        previewSize: await initializeCompleter.future
-            .then((CameraInitializedEvent event) => Size(
-                  event.previewWidth,
-                  event.previewHeight,
-                )),
-        exposureMode: await initializeCompleter.future
-            .then((CameraInitializedEvent event) => event.exposureMode),
-        focusMode: await initializeCompleter.future
-            .then((CameraInitializedEvent event) => event.focusMode),
+        previewSize: await initializeCompleter.future.then(
+          (CameraInitializedEvent event) =>
+              Size(event.previewWidth, event.previewHeight),
+        ),
+        exposureMode: await initializeCompleter.future.then(
+          (CameraInitializedEvent event) => event.exposureMode,
+        ),
+        focusMode: await initializeCompleter.future.then(
+          (CameraInitializedEvent event) => event.focusMode,
+        ),
         exposurePointSupported: await initializeCompleter.future.then(
-            (CameraInitializedEvent event) => event.exposurePointSupported),
-        focusPointSupported: await initializeCompleter.future
-            .then((CameraInitializedEvent event) => event.focusPointSupported),
+          (CameraInitializedEvent event) => event.exposurePointSupported,
+        ),
+        focusPointSupported: await initializeCompleter.future.then(
+          (CameraInitializedEvent event) => event.focusPointSupported,
+        ),
       );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
@@ -405,9 +411,11 @@ class CameraController extends ValueNotifier<CameraValue> {
     try {
       await CameraPlatform.instance.pausePreview(_cameraId);
       value = value.copyWith(
-          isPreviewPaused: true,
-          previewPauseOrientation: Optional<DeviceOrientation>.of(
-              value.lockedCaptureOrientation ?? value.deviceOrientation));
+        isPreviewPaused: true,
+        previewPauseOrientation: Optional<DeviceOrientation>.of(
+          value.lockedCaptureOrientation ?? value.deviceOrientation,
+        ),
+      );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -421,8 +429,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     try {
       await CameraPlatform.instance.resumePreview(_cameraId);
       value = value.copyWith(
-          isPreviewPaused: false,
-          previewPauseOrientation: const Optional<DeviceOrientation>.absent());
+        isPreviewPaused: false,
+        previewPauseOrientation: const Optional<DeviceOrientation>.absent(),
+      );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -504,8 +513,8 @@ class CameraController extends ValueNotifier<CameraValue> {
       _imageStreamSubscription = CameraPlatform.instance
           .onStreamedFrameAvailable(_cameraId)
           .listen((CameraImageData imageData) {
-        onAvailable(CameraImage.fromPlatformInterface(imageData));
-      });
+            onAvailable(CameraImage.fromPlatformInterface(imageData));
+          });
       value = value.copyWith(isStreamingImages: true);
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
@@ -545,8 +554,9 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
   /// Throws a [CameraException] if the capture fails.
-  Future<void> startVideoRecording(
-      {onLatestImageAvailable? onAvailable}) async {
+  Future<void> startVideoRecording({
+    onLatestImageAvailable? onAvailable,
+  }) async {
     _throwIfNotInitialized('startVideoRecording');
     if (value.isRecordingVideo) {
       throw CameraException(
@@ -564,13 +574,16 @@ class CameraController extends ValueNotifier<CameraValue> {
 
     try {
       await CameraPlatform.instance.startVideoCapturing(
-          VideoCaptureOptions(_cameraId, streamCallback: streamCallback));
+        VideoCaptureOptions(_cameraId, streamCallback: streamCallback),
+      );
       value = value.copyWith(
-          isRecordingVideo: true,
-          isRecordingPaused: false,
-          recordingOrientation: Optional<DeviceOrientation>.of(
-              value.lockedCaptureOrientation ?? value.deviceOrientation),
-          isStreamingImages: onAvailable != null);
+        isRecordingVideo: true,
+        isRecordingPaused: false,
+        recordingOrientation: Optional<DeviceOrientation>.of(
+          value.lockedCaptureOrientation ?? value.deviceOrientation,
+        ),
+        isStreamingImages: onAvailable != null,
+      );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -593,8 +606,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
 
     try {
-      final XFile file =
-          await CameraPlatform.instance.stopVideoRecording(_cameraId);
+      final XFile file = await CameraPlatform.instance.stopVideoRecording(
+        _cameraId,
+      );
       value = value.copyWith(
         isRecordingVideo: false,
         recordingOrientation: const Optional<DeviceOrientation>.absent(),
@@ -715,18 +729,14 @@ class CameraController extends ValueNotifier<CameraValue> {
     if (point != null &&
         (point.dx < 0 || point.dx > 1 || point.dy < 0 || point.dy > 1)) {
       throw ArgumentError(
-          'The values of point should be anywhere between (0,0) and (1,1).');
+        'The values of point should be anywhere between (0,0) and (1,1).',
+      );
     }
 
     try {
       await CameraPlatform.instance.setExposurePoint(
         _cameraId,
-        point == null
-            ? null
-            : Point<double>(
-                point.dx,
-                point.dy,
-              ),
+        point == null ? null : Point<double>(point.dx, point.dy),
       );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
@@ -779,8 +789,10 @@ class CameraController extends ValueNotifier<CameraValue> {
   Future<double> setExposureOffset(double offset) async {
     _throwIfNotInitialized('setExposureOffset');
     // Check if offset is in range
-    final List<double> range = await Future.wait(
-        <Future<double>>[getMinExposureOffset(), getMaxExposureOffset()]);
+    final List<double> range = await Future.wait(<Future<double>>[
+      getMinExposureOffset(),
+      getMaxExposureOffset(),
+    ]);
     if (offset < range[0] || offset > range[1]) {
       throw CameraException(
         'exposureOffsetOutOfBounds',
@@ -814,10 +826,14 @@ class CameraController extends ValueNotifier<CameraValue> {
   Future<void> lockCaptureOrientation([DeviceOrientation? orientation]) async {
     try {
       await CameraPlatform.instance.lockCaptureOrientation(
-          _cameraId, orientation ?? value.deviceOrientation);
+        _cameraId,
+        orientation ?? value.deviceOrientation,
+      );
       value = value.copyWith(
-          lockedCaptureOrientation: Optional<DeviceOrientation>.of(
-              orientation ?? value.deviceOrientation));
+        lockedCaptureOrientation: Optional<DeviceOrientation>.of(
+          orientation ?? value.deviceOrientation,
+        ),
+      );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -838,7 +854,8 @@ class CameraController extends ValueNotifier<CameraValue> {
     try {
       await CameraPlatform.instance.unlockCaptureOrientation(_cameraId);
       value = value.copyWith(
-          lockedCaptureOrientation: const Optional<DeviceOrientation>.absent());
+        lockedCaptureOrientation: const Optional<DeviceOrientation>.absent(),
+      );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -852,17 +869,13 @@ class CameraController extends ValueNotifier<CameraValue> {
     if (point != null &&
         (point.dx < 0 || point.dx > 1 || point.dy < 0 || point.dy > 1)) {
       throw ArgumentError(
-          'The values of point should be anywhere between (0,0) and (1,1).');
+        'The values of point should be anywhere between (0,0) and (1,1).',
+      );
     }
     try {
       await CameraPlatform.instance.setFocusPoint(
         _cameraId,
-        point == null
-            ? null
-            : Point<double>(
-                point.dx,
-                point.dy,
-              ),
+        point == null ? null : Point<double>(point.dx, point.dy),
       );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);

--- a/packages/camera/camera/lib/src/camera_image.dart
+++ b/packages/camera/camera/lib/src/camera_image.dart
@@ -15,20 +15,20 @@ import 'package:flutter/foundation.dart';
 /// format of the Image.
 class Plane {
   Plane._fromPlatformInterface(CameraImagePlane plane)
-      : bytes = plane.bytes,
-        bytesPerPixel = plane.bytesPerPixel,
-        bytesPerRow = plane.bytesPerRow,
-        height = plane.height,
-        width = plane.width;
+    : bytes = plane.bytes,
+      bytesPerPixel = plane.bytesPerPixel,
+      bytesPerRow = plane.bytesPerRow,
+      height = plane.height,
+      width = plane.width;
 
   // Only used by the deprecated codepath that's kept to avoid breaking changes.
   // Never called by the plugin itself.
   Plane._fromPlatformData(Map<dynamic, dynamic> data)
-      : bytes = data['bytes'] as Uint8List,
-        bytesPerPixel = data['bytesPerPixel'] as int?,
-        bytesPerRow = data['bytesPerRow'] as int,
-        height = data['height'] as int?,
-        width = data['width'] as int?;
+    : bytes = data['bytes'] as Uint8List,
+      bytesPerPixel = data['bytesPerPixel'] as int?,
+      bytesPerRow = data['bytesPerRow'] as int,
+      height = data['height'] as int?,
+      width = data['width'] as int?;
 
   /// Bytes representing this plane.
   final Uint8List bytes;
@@ -55,8 +55,8 @@ class Plane {
 /// Describes how pixels are represented in an image.
 class ImageFormat {
   ImageFormat._fromPlatformInterface(CameraImageFormat format)
-      : group = format.group,
-        raw = format.raw;
+    : group = format.group,
+      raw = format.raw;
 
   // Only used by the deprecated codepath that's kept to avoid breaking changes.
   // Never called by the plugin itself.
@@ -118,27 +118,33 @@ ImageFormatGroup _asImageFormatGroup(dynamic rawFormat) {
 class CameraImage {
   /// Creates a [CameraImage] from the platform interface version.
   CameraImage.fromPlatformInterface(CameraImageData data)
-      : format = ImageFormat._fromPlatformInterface(data.format),
-        height = data.height,
-        width = data.width,
-        planes = List<Plane>.unmodifiable(data.planes.map<Plane>(
-            (CameraImagePlane plane) => Plane._fromPlatformInterface(plane))),
-        lensAperture = data.lensAperture,
-        sensorExposureTime = data.sensorExposureTime,
-        sensorSensitivity = data.sensorSensitivity;
+    : format = ImageFormat._fromPlatformInterface(data.format),
+      height = data.height,
+      width = data.width,
+      planes = List<Plane>.unmodifiable(
+        data.planes.map<Plane>(
+          (CameraImagePlane plane) => Plane._fromPlatformInterface(plane),
+        ),
+      ),
+      lensAperture = data.lensAperture,
+      sensorExposureTime = data.sensorExposureTime,
+      sensorSensitivity = data.sensorSensitivity;
 
   /// Creates a [CameraImage] from method channel data.
   @Deprecated('Use fromPlatformInterface instead')
   CameraImage.fromPlatformData(Map<dynamic, dynamic> data)
-      : format = ImageFormat._fromPlatformData(data['format']),
-        height = data['height'] as int,
-        width = data['width'] as int,
-        lensAperture = data['lensAperture'] as double?,
-        sensorExposureTime = data['sensorExposureTime'] as int?,
-        sensorSensitivity = data['sensorSensitivity'] as double?,
-        planes = List<Plane>.unmodifiable((data['planes'] as List<dynamic>)
-            .map<Plane>((dynamic planeData) =>
-                Plane._fromPlatformData(planeData as Map<dynamic, dynamic>)));
+    : format = ImageFormat._fromPlatformData(data['format']),
+      height = data['height'] as int,
+      width = data['width'] as int,
+      lensAperture = data['lensAperture'] as double?,
+      sensorExposureTime = data['sensorExposureTime'] as int?,
+      sensorSensitivity = data['sensorSensitivity'] as double?,
+      planes = List<Plane>.unmodifiable(
+        (data['planes'] as List<dynamic>).map<Plane>(
+          (dynamic planeData) =>
+              Plane._fromPlatformData(planeData as Map<dynamic, dynamic>),
+        ),
+      );
 
   /// Format of the image provided.
   ///

--- a/packages/camera/camera/lib/src/camera_preview.dart
+++ b/packages/camera/camera/lib/src/camera_preview.dart
@@ -23,23 +23,24 @@ class CameraPreview extends StatelessWidget {
   Widget build(BuildContext context) {
     return controller.value.isInitialized
         ? ValueListenableBuilder<CameraValue>(
-            valueListenable: controller,
-            builder: (BuildContext context, Object? value, Widget? child) {
-              return AspectRatio(
-                aspectRatio: _isLandscape()
-                    ? controller.value.aspectRatio
-                    : (1 / controller.value.aspectRatio),
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: <Widget>[
-                    _wrapInRotatedBox(child: controller.buildPreview()),
-                    child ?? Container(),
-                  ],
-                ),
-              );
-            },
-            child: child,
-          )
+          valueListenable: controller,
+          builder: (BuildContext context, Object? value, Widget? child) {
+            return AspectRatio(
+              aspectRatio:
+                  _isLandscape()
+                      ? controller.value.aspectRatio
+                      : (1 / controller.value.aspectRatio),
+              child: Stack(
+                fit: StackFit.expand,
+                children: <Widget>[
+                  _wrapInRotatedBox(child: controller.buildPreview()),
+                  child ?? Container(),
+                ],
+              ),
+            );
+          },
+          child: child,
+        )
         : Container();
   }
 
@@ -48,16 +49,13 @@ class CameraPreview extends StatelessWidget {
       return child;
     }
 
-    return RotatedBox(
-      quarterTurns: _getQuarterTurns(),
-      child: child,
-    );
+    return RotatedBox(quarterTurns: _getQuarterTurns(), child: child);
   }
 
   bool _isLandscape() {
     return <DeviceOrientation>[
       DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight
+      DeviceOrientation.landscapeRight,
     ].contains(_getApplicableOrientation());
   }
 

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.11.2
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera/test/camera_export_test.dart
+++ b/packages/camera/camera/test/camera_export_test.dart
@@ -9,20 +9,17 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('camera', () {
-    test(
-      'ensure camera.dart exports classes from platform interface',
-      () {
-        main_file.CameraDescription;
-        main_file.CameraException;
-        main_file.CameraLensDirection;
-        main_file.CameraLensType;
-        main_file.ExposureMode;
-        main_file.FlashMode;
-        main_file.FocusMode;
-        main_file.ImageFormatGroup;
-        main_file.ResolutionPreset;
-        main_file.XFile;
-      },
-    );
+    test('ensure camera.dart exports classes from platform interface', () {
+      main_file.CameraDescription;
+      main_file.CameraException;
+      main_file.CameraLensDirection;
+      main_file.CameraLensType;
+      main_file.ExposureMode;
+      main_file.FlashMode;
+      main_file.FocusMode;
+      main_file.ImageFormatGroup;
+      main_file.ResolutionPreset;
+      main_file.XFile;
+    });
   });
 }

--- a/packages/camera/camera/test/camera_image_stream_test.dart
+++ b/packages/camera/camera/test/camera_image_stream_test.dart
@@ -21,11 +21,13 @@ void main() {
 
   test('startImageStream() throws $CameraException when uninitialized', () {
     final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
+      const CameraDescription(
+        name: 'cam',
+        lensDirection: CameraLensDirection.back,
+        sensorOrientation: 90,
+      ),
+      ResolutionPreset.max,
+    );
 
     expect(
       () => cameraController.startImageStream((CameraImage image) {}),
@@ -45,57 +47,74 @@ void main() {
     );
   });
 
-  test('startImageStream() throws $CameraException when recording videos',
-      () async {
-    final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
-
-    await cameraController.initialize();
-
-    cameraController.value =
-        cameraController.value.copyWith(isRecordingVideo: true);
-
-    expect(
-        () => cameraController.startImageStream((CameraImage image) {}),
-        throwsA(isA<CameraException>().having(
-          (CameraException error) => error.description,
-          'A video recording is already started.',
-          'startImageStream was called while a video is being recorded.',
-        )));
-  });
   test(
-      'startImageStream() throws $CameraException when already streaming images',
-      () async {
-    final CameraController cameraController = CameraController(
+    'startImageStream() throws $CameraException when recording videos',
+    () async {
+      final CameraController cameraController = CameraController(
         const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
-    await cameraController.initialize();
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
 
-    cameraController.value =
-        cameraController.value.copyWith(isStreamingImages: true);
-    expect(
+      await cameraController.initialize();
+
+      cameraController.value = cameraController.value.copyWith(
+        isRecordingVideo: true,
+      );
+
+      expect(
         () => cameraController.startImageStream((CameraImage image) {}),
-        throwsA(isA<CameraException>().having(
-          (CameraException error) => error.description,
-          'A camera has started streaming images.',
-          'startImageStream was called while a camera was streaming images.',
-        )));
-  });
+        throwsA(
+          isA<CameraException>().having(
+            (CameraException error) => error.description,
+            'A video recording is already started.',
+            'startImageStream was called while a video is being recorded.',
+          ),
+        ),
+      );
+    },
+  );
+  test(
+    'startImageStream() throws $CameraException when already streaming images',
+    () async {
+      final CameraController cameraController = CameraController(
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
+      await cameraController.initialize();
+
+      cameraController.value = cameraController.value.copyWith(
+        isStreamingImages: true,
+      );
+      expect(
+        () => cameraController.startImageStream((CameraImage image) {}),
+        throwsA(
+          isA<CameraException>().having(
+            (CameraException error) => error.description,
+            'A camera has started streaming images.',
+            'startImageStream was called while a camera was streaming images.',
+          ),
+        ),
+      );
+    },
+  );
 
   test('startImageStream() calls CameraPlatform', () async {
     final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
+      const CameraDescription(
+        name: 'cam',
+        lensDirection: CameraLensDirection.back,
+        sensorOrientation: 90,
+      ),
+      ResolutionPreset.max,
+    );
     await cameraController.initialize();
 
     await cameraController.startImageStream((CameraImage image) {});
@@ -103,17 +122,19 @@ void main() {
     expect(mockPlatform.streamCallLog, <String>[
       'supportsImageStreaming',
       'onStreamedFrameAvailable',
-      'listen'
+      'listen',
     ]);
   });
 
   test('stopImageStream() throws $CameraException when uninitialized', () {
     final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
+      const CameraDescription(
+        name: 'cam',
+        lensDirection: CameraLensDirection.back,
+        sensorOrientation: 90,
+      ),
+      ResolutionPreset.max,
+    );
 
     expect(
       cameraController.stopImageStream,
@@ -133,32 +154,41 @@ void main() {
     );
   });
 
-  test('stopImageStream() throws $CameraException when not streaming images',
-      () async {
-    final CameraController cameraController = CameraController(
+  test(
+    'stopImageStream() throws $CameraException when not streaming images',
+    () async {
+      final CameraController cameraController = CameraController(
         const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
-    await cameraController.initialize();
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
+      await cameraController.initialize();
 
-    expect(
+      expect(
         cameraController.stopImageStream,
-        throwsA(isA<CameraException>().having(
-          (CameraException error) => error.description,
-          'No camera is streaming images',
-          'stopImageStream was called when no camera is streaming images.',
-        )));
-  });
+        throwsA(
+          isA<CameraException>().having(
+            (CameraException error) => error.description,
+            'No camera is streaming images',
+            'stopImageStream was called when no camera is streaming images.',
+          ),
+        ),
+      );
+    },
+  );
 
   test('stopImageStream() intended behaviour', () async {
     final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
+      const CameraDescription(
+        name: 'cam',
+        lensDirection: CameraLensDirection.back,
+        sensorOrientation: 90,
+      ),
+      ResolutionPreset.max,
+    );
     await cameraController.initialize();
     await cameraController.startImageStream((CameraImage image) {});
     await cameraController.stopImageStream();
@@ -168,35 +198,41 @@ void main() {
       'onStreamedFrameAvailable',
       'listen',
       'supportsImageStreaming',
-      'cancel'
+      'cancel',
     ]);
   });
 
   test('startVideoRecording() can stream images', () async {
     final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
+      const CameraDescription(
+        name: 'cam',
+        lensDirection: CameraLensDirection.back,
+        sensorOrientation: 90,
+      ),
+      ResolutionPreset.max,
+    );
 
     await cameraController.initialize();
 
     await cameraController.startVideoRecording(
-        onAvailable: (CameraImage image) {});
+      onAvailable: (CameraImage image) {},
+    );
 
     expect(
-        mockPlatform.streamCallLog.contains('startVideoCapturing with stream'),
-        isTrue);
+      mockPlatform.streamCallLog.contains('startVideoCapturing with stream'),
+      isTrue,
+    );
   });
 
   test('startVideoRecording() by default does not stream', () async {
     final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
+      const CameraDescription(
+        name: 'cam',
+        lensDirection: CameraLensDirection.back,
+        sensorOrientation: 90,
+      ),
+      ResolutionPreset.max,
+    );
 
     await cameraController.initialize();
 
@@ -212,8 +248,10 @@ class MockStreamingCameraPlatform extends MockCameraPlatform {
   StreamController<CameraImageData>? _streamController;
 
   @override
-  Stream<CameraImageData> onStreamedFrameAvailable(int cameraId,
-      {CameraImageStreamOptions? options}) {
+  Stream<CameraImageData> onStreamedFrameAvailable(
+    int cameraId, {
+    CameraImageStreamOptions? options,
+  }) {
     streamCallLog.add('onStreamedFrameAvailable');
     _streamController = StreamController<CameraImageData>(
       onListen: _onFrameStreamListen,

--- a/packages/camera/camera/test/camera_image_test.dart
+++ b/packages/camera/camera/test/camera_image_test.dart
@@ -48,12 +48,16 @@ void main() {
     expect(image.planes.length, originalImage.planes.length);
     for (int i = 0; i < image.planes.length; i++) {
       expect(
-          image.planes[i].bytes.length, originalImage.planes[i].bytes.length);
+        image.planes[i].bytes.length,
+        originalImage.planes[i].bytes.length,
+      );
       for (int j = 0; j < image.planes[i].bytes.length; j++) {
         expect(image.planes[i].bytes[j], originalImage.planes[i].bytes[j]);
       }
       expect(
-          image.planes[i].bytesPerPixel, originalImage.planes[i].bytesPerPixel);
+        image.planes[i].bytesPerPixel,
+        originalImage.planes[i].bytesPerPixel,
+      );
       expect(image.planes[i].bytesPerRow, originalImage.planes[i].bytesPerRow);
       expect(image.planes[i].width, originalImage.planes[i].width);
       expect(image.planes[i].height, originalImage.planes[i].height);
@@ -63,24 +67,25 @@ void main() {
   group('legacy constructors', () {
     test('$CameraImage can be created', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      final CameraImage cameraImage =
-          CameraImage.fromPlatformData(<dynamic, dynamic>{
-        'format': 35,
-        'height': 1,
-        'width': 4,
-        'lensAperture': 1.8,
-        'sensorExposureTime': 9991324,
-        'sensorSensitivity': 92.0,
-        'planes': <dynamic>[
-          <dynamic, dynamic>{
-            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-            'bytesPerPixel': 1,
-            'bytesPerRow': 4,
-            'height': 1,
-            'width': 4
-          }
-        ]
-      });
+      final CameraImage cameraImage = CameraImage.fromPlatformData(
+        <dynamic, dynamic>{
+          'format': 35,
+          'height': 1,
+          'width': 4,
+          'lensAperture': 1.8,
+          'sensorExposureTime': 9991324,
+          'sensorSensitivity': 92.0,
+          'planes': <dynamic>[
+            <dynamic, dynamic>{
+              'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+              'bytesPerPixel': 1,
+              'bytesPerRow': 4,
+              'height': 1,
+              'width': 4,
+            },
+          ],
+        },
+      );
       expect(cameraImage.height, 1);
       expect(cameraImage.width, 4);
       expect(cameraImage.format.group, ImageFormatGroup.yuv420);
@@ -90,118 +95,123 @@ void main() {
     test('$CameraImage has ImageFormatGroup.yuv420 for iOS', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
-      final CameraImage cameraImage =
-          CameraImage.fromPlatformData(<dynamic, dynamic>{
-        'format': 875704438,
-        'height': 1,
-        'width': 4,
-        'lensAperture': 1.8,
-        'sensorExposureTime': 9991324,
-        'sensorSensitivity': 92.0,
-        'planes': <dynamic>[
-          <dynamic, dynamic>{
-            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-            'bytesPerPixel': 1,
-            'bytesPerRow': 4,
-            'height': 1,
-            'width': 4
-          }
-        ]
-      });
+      final CameraImage cameraImage = CameraImage.fromPlatformData(
+        <dynamic, dynamic>{
+          'format': 875704438,
+          'height': 1,
+          'width': 4,
+          'lensAperture': 1.8,
+          'sensorExposureTime': 9991324,
+          'sensorSensitivity': 92.0,
+          'planes': <dynamic>[
+            <dynamic, dynamic>{
+              'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+              'bytesPerPixel': 1,
+              'bytesPerRow': 4,
+              'height': 1,
+              'width': 4,
+            },
+          ],
+        },
+      );
       expect(cameraImage.format.group, ImageFormatGroup.yuv420);
     });
 
     test('$CameraImage has ImageFormatGroup.yuv420 for Android', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final CameraImage cameraImage =
-          CameraImage.fromPlatformData(<dynamic, dynamic>{
-        'format': 35,
-        'height': 1,
-        'width': 4,
-        'lensAperture': 1.8,
-        'sensorExposureTime': 9991324,
-        'sensorSensitivity': 92.0,
-        'planes': <dynamic>[
-          <dynamic, dynamic>{
-            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-            'bytesPerPixel': 1,
-            'bytesPerRow': 4,
-            'height': 1,
-            'width': 4
-          }
-        ]
-      });
+      final CameraImage cameraImage = CameraImage.fromPlatformData(
+        <dynamic, dynamic>{
+          'format': 35,
+          'height': 1,
+          'width': 4,
+          'lensAperture': 1.8,
+          'sensorExposureTime': 9991324,
+          'sensorSensitivity': 92.0,
+          'planes': <dynamic>[
+            <dynamic, dynamic>{
+              'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+              'bytesPerPixel': 1,
+              'bytesPerRow': 4,
+              'height': 1,
+              'width': 4,
+            },
+          ],
+        },
+      );
       expect(cameraImage.format.group, ImageFormatGroup.yuv420);
     });
 
     test('$CameraImage has ImageFormatGroup.nv21 for android', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final CameraImage cameraImage =
-          CameraImage.fromPlatformData(<dynamic, dynamic>{
-        'format': 17,
-        'height': 1,
-        'width': 4,
-        'lensAperture': 1.8,
-        'sensorExposureTime': 9991324,
-        'sensorSensitivity': 92.0,
-        'planes': <dynamic>[
-          <dynamic, dynamic>{
-            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-            'bytesPerPixel': 1,
-            'bytesPerRow': 4,
-            'height': 1,
-            'width': 4
-          }
-        ]
-      });
+      final CameraImage cameraImage = CameraImage.fromPlatformData(
+        <dynamic, dynamic>{
+          'format': 17,
+          'height': 1,
+          'width': 4,
+          'lensAperture': 1.8,
+          'sensorExposureTime': 9991324,
+          'sensorSensitivity': 92.0,
+          'planes': <dynamic>[
+            <dynamic, dynamic>{
+              'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+              'bytesPerPixel': 1,
+              'bytesPerRow': 4,
+              'height': 1,
+              'width': 4,
+            },
+          ],
+        },
+      );
       expect(cameraImage.format.group, ImageFormatGroup.nv21);
     });
 
     test('$CameraImage has ImageFormatGroup.bgra8888 for iOS', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
-      final CameraImage cameraImage =
-          CameraImage.fromPlatformData(<dynamic, dynamic>{
-        'format': 1111970369,
-        'height': 1,
-        'width': 4,
-        'lensAperture': 1.8,
-        'sensorExposureTime': 9991324,
-        'sensorSensitivity': 92.0,
-        'planes': <dynamic>[
-          <dynamic, dynamic>{
-            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-            'bytesPerPixel': 1,
-            'bytesPerRow': 4,
-            'height': 1,
-            'width': 4
-          }
-        ]
-      });
+      final CameraImage cameraImage = CameraImage.fromPlatformData(
+        <dynamic, dynamic>{
+          'format': 1111970369,
+          'height': 1,
+          'width': 4,
+          'lensAperture': 1.8,
+          'sensorExposureTime': 9991324,
+          'sensorSensitivity': 92.0,
+          'planes': <dynamic>[
+            <dynamic, dynamic>{
+              'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+              'bytesPerPixel': 1,
+              'bytesPerRow': 4,
+              'height': 1,
+              'width': 4,
+            },
+          ],
+        },
+      );
       expect(cameraImage.format.group, ImageFormatGroup.bgra8888);
     });
 
     test('$CameraImage has ImageFormatGroup.unknown', () {
-      final CameraImage cameraImage =
-          CameraImage.fromPlatformData(<dynamic, dynamic>{
-        'format': null,
-        'height': 1,
-        'width': 4,
-        'lensAperture': 1.8,
-        'sensorExposureTime': 9991324,
-        'sensorSensitivity': 92.0,
-        'planes': <dynamic>[
-          <dynamic, dynamic>{
-            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-            'bytesPerPixel': 1,
-            'bytesPerRow': 4,
-            'height': 1,
-            'width': 4
-          }
-        ]
-      });
+      final CameraImage cameraImage = CameraImage.fromPlatformData(
+        <dynamic, dynamic>{
+          'format': null,
+          'height': 1,
+          'width': 4,
+          'lensAperture': 1.8,
+          'sensorExposureTime': 9991324,
+          'sensorSensitivity': 92.0,
+          'planes': <dynamic>[
+            <dynamic, dynamic>{
+              'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+              'bytesPerPixel': 1,
+              'bytesPerRow': 4,
+              'height': 1,
+              'width': 4,
+            },
+          ],
+        },
+      );
       expect(cameraImage.format.group, ImageFormatGroup.unknown);
     });
   });

--- a/packages/camera/camera/test/camera_preview_test.dart
+++ b/packages/camera/camera/test/camera_preview_test.dart
@@ -15,7 +15,10 @@ class FakeController extends ValueNotifier<CameraValue>
   FakeController() : super(const CameraValue.uninitialized(fakeDescription));
 
   static const CameraDescription fakeDescription = CameraDescription(
-      name: '', lensDirection: CameraLensDirection.back, sensorOrientation: 0);
+    name: '',
+    lensDirection: CameraLensDirection.back,
+    sensorOrientation: 0,
+  );
 
   @override
   Future<void> dispose() async {
@@ -71,12 +74,12 @@ class FakeController extends ValueNotifier<CameraValue>
 
   @override
   MediaSettings get mediaSettings => const MediaSettings(
-        resolutionPreset: ResolutionPreset.low,
-        fps: 15,
-        videoBitrate: 200000,
-        audioBitrate: 32000,
-        enableAudio: true,
-      );
+    resolutionPreset: ResolutionPreset.low,
+    fps: 15,
+    videoBitrate: 200000,
+    audioBitrate: 32000,
+    enableAudio: true,
+  );
 
   @override
   Future<void> resumeVideoRecording() async {}
@@ -106,8 +109,9 @@ class FakeController extends ValueNotifier<CameraValue>
   Future<void> startImageStream(onLatestImageAvailable onAvailable) async {}
 
   @override
-  Future<void> startVideoRecording(
-      {onLatestImageAvailable? onAvailable}) async {}
+  Future<void> startVideoRecording({
+    onLatestImageAvailable? onAvailable,
+  }) async {}
 
   @override
   Future<void> stopImageStream() async {}
@@ -140,439 +144,460 @@ class FakeController extends ValueNotifier<CameraValue>
 void main() {
   group('RotatedBox (Android only)', () {
     testWidgets(
-        'when recording in DeviceOrientaiton.portraitUp, rotatedBox should not be rotated',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when recording in DeviceOrientaiton.portraitUp, rotatedBox should not be rotated',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           isRecordingVideo: true,
           deviceOrientation: DeviceOrientation.portraitDown,
           lockedCaptureOrientation:
               const Optional<DeviceOrientation>.fromNullable(
-                  DeviceOrientation.landscapeRight),
+                DeviceOrientation.landscapeRight,
+              ),
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.portraitUp),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.portraitUp,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 0);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 0);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when recording in DeviceOrientaiton.landscapeRight, rotatedBox should be rotated by one clockwise quarter turn',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when recording in DeviceOrientaiton.landscapeRight, rotatedBox should be rotated by one clockwise quarter turn',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           isRecordingVideo: true,
           deviceOrientation: DeviceOrientation.portraitUp,
           lockedCaptureOrientation:
               const Optional<DeviceOrientation>.fromNullable(
-                  DeviceOrientation.landscapeLeft),
+                DeviceOrientation.landscapeLeft,
+              ),
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeRight),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeRight,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 1);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 1);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when recording in DeviceOrientaiton.portraitDown, rotatedBox should be rotated by two clockwise quarter turns',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when recording in DeviceOrientaiton.portraitDown, rotatedBox should be rotated by two clockwise quarter turns',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           isRecordingVideo: true,
           deviceOrientation: DeviceOrientation.portraitUp,
           lockedCaptureOrientation:
               const Optional<DeviceOrientation>.fromNullable(
-                  DeviceOrientation.landscapeRight),
+                DeviceOrientation.landscapeRight,
+              ),
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.portraitDown),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.portraitDown,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 2);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 2);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when recording in DeviceOrientaiton.landscapeLeft, rotatedBox should be rotated by three clockwise quarter turns',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when recording in DeviceOrientaiton.landscapeLeft, rotatedBox should be rotated by three clockwise quarter turns',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           isRecordingVideo: true,
           deviceOrientation: DeviceOrientation.portraitUp,
           lockedCaptureOrientation:
               const Optional<DeviceOrientation>.fromNullable(
-                  DeviceOrientation.landscapeRight),
+                DeviceOrientation.landscapeRight,
+              ),
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeLeft),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeLeft,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 3);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 3);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when orientation locked in DeviceOrientaiton.portaitUp, rotatedBox should not be rotated',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when orientation locked in DeviceOrientaiton.portaitUp, rotatedBox should not be rotated',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           deviceOrientation: DeviceOrientation.portraitDown,
           lockedCaptureOrientation:
               const Optional<DeviceOrientation>.fromNullable(
-                  DeviceOrientation.portraitUp),
+                DeviceOrientation.portraitUp,
+              ),
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeLeft),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeLeft,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 0);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 0);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when orientation locked in DeviceOrientaiton.landscapeRight, rotatedBox should be rotated by one clockwise quarter turn',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when orientation locked in DeviceOrientaiton.landscapeRight, rotatedBox should be rotated by one clockwise quarter turn',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           deviceOrientation: DeviceOrientation.portraitDown,
           lockedCaptureOrientation:
               const Optional<DeviceOrientation>.fromNullable(
-                  DeviceOrientation.landscapeRight),
+                DeviceOrientation.landscapeRight,
+              ),
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeLeft),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeLeft,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 1);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 1);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when orientation locked in DeviceOrientaiton.portraitDown, rotatedBox should be rotated by two clockwise quarter turns',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when orientation locked in DeviceOrientaiton.portraitDown, rotatedBox should be rotated by two clockwise quarter turns',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           deviceOrientation: DeviceOrientation.portraitUp,
           lockedCaptureOrientation:
               const Optional<DeviceOrientation>.fromNullable(
-                  DeviceOrientation.portraitDown),
+                DeviceOrientation.portraitDown,
+              ),
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeLeft),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeLeft,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 2);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 2);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when orientation locked in DeviceOrientaiton.landscapeRight, rotatedBox should be rotated by three clockwise quarter turns',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when orientation locked in DeviceOrientaiton.landscapeRight, rotatedBox should be rotated by three clockwise quarter turns',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           deviceOrientation: DeviceOrientation.portraitUp,
           lockedCaptureOrientation:
               const Optional<DeviceOrientation>.fromNullable(
-                  DeviceOrientation.landscapeRight),
+                DeviceOrientation.landscapeRight,
+              ),
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeLeft),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeLeft,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 1);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 1);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when orientation not locked, not recording, and device orientation is portrait up, rotatedBox should not be rotated',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when orientation not locked, not recording, and device orientation is portrait up, rotatedBox should not be rotated',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           deviceOrientation: DeviceOrientation.portraitUp,
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeLeft),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeLeft,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 0);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 0);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when orientation not locked, not recording, and device orientation is landscape right, rotatedBox should be rotated by one clockwise quarter turn',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when orientation not locked, not recording, and device orientation is landscape right, rotatedBox should be rotated by one clockwise quarter turn',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           deviceOrientation: DeviceOrientation.landscapeRight,
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeLeft),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeLeft,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 1);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 1);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when orientation not locked, not recording, and device orientation is portrait down, rotatedBox should be rotated by two clockwise quarter turns',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when orientation not locked, not recording, and device orientation is portrait down, rotatedBox should be rotated by two clockwise quarter turns',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           deviceOrientation: DeviceOrientation.portraitDown,
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.landscapeLeft),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.landscapeLeft,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 2);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 2);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
 
     testWidgets(
-        'when orientation not locked, not recording, and device orientation is landscape left, rotatedBox should be rotated by three clockwise quarter turns',
-        (
-      WidgetTester tester,
-    ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      'when orientation not locked, not recording, and device orientation is landscape left, rotatedBox should be rotated by three clockwise quarter turns',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      final FakeController controller = FakeController();
-      addTearDown(controller.dispose);
+        final FakeController controller = FakeController();
+        addTearDown(controller.dispose);
 
-      controller.value = controller.value.copyWith(
+        controller.value = controller.value.copyWith(
           isInitialized: true,
           deviceOrientation: DeviceOrientation.landscapeLeft,
           recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
-              DeviceOrientation.portraitDown),
-          previewSize: const Size(480, 640) // preview size irrelevant to test
-          );
+            DeviceOrientation.portraitDown,
+          ),
+          previewSize: const Size(480, 640), // preview size irrelevant to test
+        );
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: CameraPreview(controller),
-        ),
-      );
-      expect(find.byType(RotatedBox), findsOneWidget);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: CameraPreview(controller),
+          ),
+        );
+        expect(find.byType(RotatedBox), findsOneWidget);
 
-      final RotatedBox rotatedBox =
-          tester.widget<RotatedBox>(find.byType(RotatedBox));
-      expect(rotatedBox.quarterTurns, 3);
+        final RotatedBox rotatedBox = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(rotatedBox.quarterTurns, 3);
 
-      debugDefaultTargetPlatformOverride = null;
-    });
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
   }, skip: kIsWeb);
 
-  testWidgets('when not on Android there should not be a rotated box',
-      (WidgetTester tester) async {
+  testWidgets('when not on Android there should not be a rotated box', (
+    WidgetTester tester,
+  ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     final FakeController controller = FakeController();
     addTearDown(controller.dispose);
     controller.value = controller.value.copyWith(
-        isInitialized: true,
-        previewSize: const Size(480, 640) // preview size irrelevant to test
-        );
+      isInitialized: true,
+      previewSize: const Size(480, 640), // preview size irrelevant to test
+    );
 
     await tester.pumpWidget(
       Directionality(

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -15,15 +15,17 @@ import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 List<CameraDescription> get mockAvailableCameras => <CameraDescription>[
-      const CameraDescription(
-          name: 'camBack',
-          lensDirection: CameraLensDirection.back,
-          sensorOrientation: 90),
-      const CameraDescription(
-          name: 'camFront',
-          lensDirection: CameraLensDirection.front,
-          sensorOrientation: 180),
-    ];
+  const CameraDescription(
+    name: 'camBack',
+    lensDirection: CameraLensDirection.back,
+    sensorOrientation: 90,
+  ),
+  const CameraDescription(
+    name: 'camFront',
+    lensDirection: CameraLensDirection.front,
+    sensorOrientation: 180,
+  ),
+];
 
 int get mockInitializeCamera => 13;
 
@@ -56,32 +58,33 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
 
   group('camera', () {
-    test('debugCheckIsDisposed should not throw assertion error when disposed',
-        () {
-      const MockCameraDescription description = MockCameraDescription();
-      final CameraController controller = CameraController(
-        description,
-        ResolutionPreset.low,
-      );
+    test(
+      'debugCheckIsDisposed should not throw assertion error when disposed',
+      () {
+        const MockCameraDescription description = MockCameraDescription();
+        final CameraController controller = CameraController(
+          description,
+          ResolutionPreset.low,
+        );
 
-      controller.dispose();
+        controller.dispose();
 
-      expect(controller.debugCheckIsDisposed, returnsNormally);
-    });
+        expect(controller.debugCheckIsDisposed, returnsNormally);
+      },
+    );
 
-    test('debugCheckIsDisposed should throw assertion error when not disposed',
-        () {
-      const MockCameraDescription description = MockCameraDescription();
-      final CameraController controller = CameraController(
-        description,
-        ResolutionPreset.low,
-      );
+    test(
+      'debugCheckIsDisposed should throw assertion error when not disposed',
+      () {
+        const MockCameraDescription description = MockCameraDescription();
+        final CameraController controller = CameraController(
+          description,
+          ResolutionPreset.low,
+        );
 
-      expect(
-        () => controller.debugCheckIsDisposed(),
-        throwsAssertionError,
-      );
-    });
+        expect(() => controller.debugCheckIsDisposed(), throwsAssertionError);
+      },
+    );
 
     test('availableCameras() has camera', () async {
       CameraPlatform.instance = MockCameraPlatform();
@@ -99,11 +102,13 @@ void main() {
 
     test('Can be initialized', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       expect(cameraController.value.aspectRatio, 1);
@@ -114,9 +119,10 @@ void main() {
     test('can be initialized with media settings', () async {
       final CameraController cameraController = CameraController(
         const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
         ResolutionPreset.low,
         fps: 15,
         videoBitrate: 200000,
@@ -137,11 +143,13 @@ void main() {
 
     test('default constructor initializes media settings', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       expect(cameraController.resolutionPreset, ResolutionPreset.max);
@@ -153,11 +161,13 @@ void main() {
 
     test('can be disposed', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       expect(cameraController.value.aspectRatio, 1);
@@ -171,11 +181,13 @@ void main() {
 
     test('initialize() throws CameraException when disposed', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       expect(cameraController.value.aspectRatio, 1);
@@ -187,53 +199,47 @@ void main() {
       verify(CameraPlatform.instance.dispose(13)).called(1);
 
       expect(
-          cameraController.initialize,
-          throwsA(isA<CameraException>().having(
+        cameraController.initialize,
+        throwsA(
+          isA<CameraException>().having(
             (CameraException error) => error.description,
             'Error description',
             'initialize was called on a disposed CameraController',
-          )));
+          ),
+        ),
+      );
     });
 
-    test('initialize() throws $CameraException on $PlatformException ',
-        () async {
-      final CameraController cameraController = CameraController(
+    test(
+      'initialize() throws $CameraException on $PlatformException ',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
 
-      mockPlatformException = true;
+        mockPlatformException = true;
 
-      expect(
+        expect(
           cameraController.initialize,
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'foo',
-            'bar',
-          )));
-      mockPlatformException = false;
-    });
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'foo',
+              'bar',
+            ),
+          ),
+        );
+        mockPlatformException = false;
+      },
+    );
 
     test('initialize() sets imageFormat', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max,
-        imageFormatGroup: ImageFormatGroup.yuv420,
-      );
-      await cameraController.initialize();
-      verify(CameraPlatform.instance
-              .initializeCamera(13, imageFormatGroup: ImageFormatGroup.yuv420))
-          .called(1);
-    });
-
-    test('setDescription waits for initialize before calling dispose',
-        () async {
       final CameraController cameraController = CameraController(
         const CameraDescription(
           name: 'cam',
@@ -241,40 +247,66 @@ void main() {
           sensorOrientation: 90,
         ),
         ResolutionPreset.max,
-        imageFormatGroup: ImageFormatGroup.bgra8888,
+        imageFormatGroup: ImageFormatGroup.yuv420,
       );
-
-      final Completer<void> initializeCompleter = Completer<void>();
-      when(CameraPlatform.instance.initializeCamera(
-        mockInitializeCamera,
-        imageFormatGroup: ImageFormatGroup.bgra8888,
-      )).thenAnswer(
-        (_) => initializeCompleter.future,
-      );
-
-      unawaited(cameraController.initialize());
-
-      final Future<void> setDescriptionFuture = cameraController.setDescription(
-        const CameraDescription(
-            name: 'cam2',
-            lensDirection: CameraLensDirection.front,
-            sensorOrientation: 90),
-      );
-      verifyNever(CameraPlatform.instance.dispose(mockInitializeCamera));
-
-      initializeCompleter.complete();
-
-      await setDescriptionFuture;
-      verify(CameraPlatform.instance.dispose(mockInitializeCamera));
+      await cameraController.initialize();
+      verify(
+        CameraPlatform.instance.initializeCamera(
+          13,
+          imageFormatGroup: ImageFormatGroup.yuv420,
+        ),
+      ).called(1);
     });
+
+    test(
+      'setDescription waits for initialize before calling dispose',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+          imageFormatGroup: ImageFormatGroup.bgra8888,
+        );
+
+        final Completer<void> initializeCompleter = Completer<void>();
+        when(
+          CameraPlatform.instance.initializeCamera(
+            mockInitializeCamera,
+            imageFormatGroup: ImageFormatGroup.bgra8888,
+          ),
+        ).thenAnswer((_) => initializeCompleter.future);
+
+        unawaited(cameraController.initialize());
+
+        final Future<void> setDescriptionFuture = cameraController
+            .setDescription(
+              const CameraDescription(
+                name: 'cam2',
+                lensDirection: CameraLensDirection.front,
+                sensorOrientation: 90,
+              ),
+            );
+        verifyNever(CameraPlatform.instance.dispose(mockInitializeCamera));
+
+        initializeCompleter.complete();
+
+        await setDescriptionFuture;
+        verify(CameraPlatform.instance.dispose(mockInitializeCamera));
+      },
+    );
 
     test('prepareForVideoRecording() calls $CameraPlatform ', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       await cameraController.prepareForVideoRecording();
@@ -284,11 +316,13 @@ void main() {
 
     test('takePicture() throws $CameraException when uninitialized ', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       expect(
         cameraController.takePicture(),
         throwsA(
@@ -307,144 +341,179 @@ void main() {
       );
     });
 
-    test('takePicture() throws $CameraException when takePicture is true',
-        () async {
-      final CameraController cameraController = CameraController(
+    test(
+      'takePicture() throws $CameraException when takePicture is true',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
 
-      cameraController.value =
-          cameraController.value.copyWith(isTakingPicture: true);
-      expect(
+        cameraController.value = cameraController.value.copyWith(
+          isTakingPicture: true,
+        );
+        expect(
           cameraController.takePicture(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'Previous capture has not returned yet.',
-            'takePicture was called before the previous capture returned.',
-          )));
-    });
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'Previous capture has not returned yet.',
+              'takePicture was called before the previous capture returned.',
+            ),
+          ),
+        );
+      },
+    );
 
     test('takePicture() returns $XFile', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
       final XFile xFile = await cameraController.takePicture();
 
       expect(xFile.path, mockTakePicture.path);
     });
 
-    test('takePicture() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
+    test(
+      'takePicture() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
 
-      mockPlatformException = true;
-      expect(
+        mockPlatformException = true;
+        expect(
           cameraController.takePicture(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'foo',
-            'bar',
-          )));
-      mockPlatformException = false;
-    });
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'foo',
+              'bar',
+            ),
+          ),
+        );
+        mockPlatformException = false;
+      },
+    );
 
-    test('startVideoRecording() throws $CameraException when uninitialized',
-        () async {
-      final CameraController cameraController = CameraController(
+    test(
+      'startVideoRecording() throws $CameraException when uninitialized',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
 
-      expect(
-        cameraController.startVideoRecording(),
-        throwsA(
-          isA<CameraException>()
-              .having(
-                (CameraException error) => error.code,
-                'code',
-                'Uninitialized CameraController',
-              )
-              .having(
-                (CameraException error) => error.description,
-                'description',
-                'startVideoRecording() was called on an uninitialized CameraController.',
-              ),
-        ),
-      );
-    });
-    test('startVideoRecording() throws $CameraException when recording videos',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-
-      await cameraController.initialize();
-
-      cameraController.value =
-          cameraController.value.copyWith(isRecordingVideo: true);
-
-      expect(
+        expect(
           cameraController.startVideoRecording(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'A video recording is already started.',
-            'startVideoRecording was called when a recording is already started.',
-          )));
-    });
-
-    test('getMaxZoomLevel() throws $CameraException when uninitialized',
-        () async {
-      final CameraController cameraController = CameraController(
+          throwsA(
+            isA<CameraException>()
+                .having(
+                  (CameraException error) => error.code,
+                  'code',
+                  'Uninitialized CameraController',
+                )
+                .having(
+                  (CameraException error) => error.description,
+                  'description',
+                  'startVideoRecording() was called on an uninitialized CameraController.',
+                ),
+          ),
+        );
+      },
+    );
+    test(
+      'startVideoRecording() throws $CameraException when recording videos',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
 
-      expect(
-        cameraController.getMaxZoomLevel,
-        throwsA(
-          isA<CameraException>()
-              .having(
-                (CameraException error) => error.code,
-                'code',
-                'Uninitialized CameraController',
-              )
-              .having(
-                (CameraException error) => error.description,
-                'description',
-                'getMaxZoomLevel() was called on an uninitialized CameraController.',
-              ),
-        ),
-      );
-    });
+        await cameraController.initialize();
+
+        cameraController.value = cameraController.value.copyWith(
+          isRecordingVideo: true,
+        );
+
+        expect(
+          cameraController.startVideoRecording(),
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'A video recording is already started.',
+              'startVideoRecording was called when a recording is already started.',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'getMaxZoomLevel() throws $CameraException when uninitialized',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+
+        expect(
+          cameraController.getMaxZoomLevel,
+          throwsA(
+            isA<CameraException>()
+                .having(
+                  (CameraException error) => error.code,
+                  'code',
+                  'Uninitialized CameraController',
+                )
+                .having(
+                  (CameraException error) => error.description,
+                  'description',
+                  'getMaxZoomLevel() was called on an uninitialized CameraController.',
+                ),
+          ),
+        );
+      },
+    );
 
     test('getMaxZoomLevel() throws $CameraException when disposed', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
 
       await cameraController.initialize();
       await cameraController.dispose();
@@ -468,84 +537,102 @@ void main() {
     });
 
     test(
-        'getMaxZoomLevel() throws $CameraException when a platform exception occured.',
-        () async {
-      final CameraController cameraController = CameraController(
+      'getMaxZoomLevel() throws $CameraException when a platform exception occured.',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
 
-      await cameraController.initialize();
-      when(CameraPlatform.instance.getMaxZoomLevel(mockInitializeCamera))
-          .thenThrow(CameraException(
-        'TEST_ERROR',
-        'This is a test error messge',
-      ));
+        await cameraController.initialize();
+        when(
+          CameraPlatform.instance.getMaxZoomLevel(mockInitializeCamera),
+        ).thenThrow(
+          CameraException('TEST_ERROR', 'This is a test error messge'),
+        );
 
-      expect(
+        expect(
           cameraController.getMaxZoomLevel,
-          throwsA(isA<CameraException>()
-              .having(
-                  (CameraException error) => error.code, 'code', 'TEST_ERROR')
-              .having(
-                (CameraException error) => error.description,
-                'description',
-                'This is a test error messge',
-              )));
-    });
+          throwsA(
+            isA<CameraException>()
+                .having(
+                  (CameraException error) => error.code,
+                  'code',
+                  'TEST_ERROR',
+                )
+                .having(
+                  (CameraException error) => error.description,
+                  'description',
+                  'This is a test error messge',
+                ),
+          ),
+        );
+      },
+    );
 
     test('getMaxZoomLevel() returns max zoom level.', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
 
       await cameraController.initialize();
-      when(CameraPlatform.instance.getMaxZoomLevel(mockInitializeCamera))
-          .thenAnswer((_) => Future<double>.value(42.0));
+      when(
+        CameraPlatform.instance.getMaxZoomLevel(mockInitializeCamera),
+      ).thenAnswer((_) => Future<double>.value(42.0));
 
       final double maxZoomLevel = await cameraController.getMaxZoomLevel();
       expect(maxZoomLevel, 42.0);
     });
 
-    test('getMinZoomLevel() throws $CameraException when uninitialized',
-        () async {
-      final CameraController cameraController = CameraController(
+    test(
+      'getMinZoomLevel() throws $CameraException when uninitialized',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
 
-      expect(
-        cameraController.getMinZoomLevel,
-        throwsA(
-          isA<CameraException>()
-              .having(
-                (CameraException error) => error.code,
-                'code',
-                'Uninitialized CameraController',
-              )
-              .having(
-                (CameraException error) => error.description,
-                'description',
-                'getMinZoomLevel() was called on an uninitialized CameraController.',
-              ),
-        ),
-      );
-    });
+        expect(
+          cameraController.getMinZoomLevel,
+          throwsA(
+            isA<CameraException>()
+                .having(
+                  (CameraException error) => error.code,
+                  'code',
+                  'Uninitialized CameraController',
+                )
+                .having(
+                  (CameraException error) => error.description,
+                  'description',
+                  'getMinZoomLevel() was called on an uninitialized CameraController.',
+                ),
+          ),
+        );
+      },
+    );
 
     test('getMinZoomLevel() throws $CameraException when disposed', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
 
       await cameraController.initialize();
       await cameraController.dispose();
@@ -569,45 +656,57 @@ void main() {
     });
 
     test(
-        'getMinZoomLevel() throws $CameraException when a platform exception occured.',
-        () async {
-      final CameraController cameraController = CameraController(
+      'getMinZoomLevel() throws $CameraException when a platform exception occured.',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
 
-      await cameraController.initialize();
-      when(CameraPlatform.instance.getMinZoomLevel(mockInitializeCamera))
-          .thenThrow(CameraException(
-        'TEST_ERROR',
-        'This is a test error messge',
-      ));
+        await cameraController.initialize();
+        when(
+          CameraPlatform.instance.getMinZoomLevel(mockInitializeCamera),
+        ).thenThrow(
+          CameraException('TEST_ERROR', 'This is a test error messge'),
+        );
 
-      expect(
+        expect(
           cameraController.getMinZoomLevel,
-          throwsA(isA<CameraException>()
-              .having(
-                  (CameraException error) => error.code, 'code', 'TEST_ERROR')
-              .having(
-                (CameraException error) => error.description,
-                'description',
-                'This is a test error messge',
-              )));
-    });
+          throwsA(
+            isA<CameraException>()
+                .having(
+                  (CameraException error) => error.code,
+                  'code',
+                  'TEST_ERROR',
+                )
+                .having(
+                  (CameraException error) => error.description,
+                  'description',
+                  'This is a test error messge',
+                ),
+          ),
+        );
+      },
+    );
 
     test('getMinZoomLevel() returns max zoom level.', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
 
       await cameraController.initialize();
-      when(CameraPlatform.instance.getMinZoomLevel(mockInitializeCamera))
-          .thenAnswer((_) => Future<double>.value(42.0));
+      when(
+        CameraPlatform.instance.getMinZoomLevel(mockInitializeCamera),
+      ).thenAnswer((_) => Future<double>.value(42.0));
 
       final double maxZoomLevel = await cameraController.getMinZoomLevel();
       expect(maxZoomLevel, 42.0);
@@ -615,11 +714,13 @@ void main() {
 
     test('setZoomLevel() throws $CameraException when uninitialized', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
 
       expect(
         () => cameraController.setZoomLevel(42.0),
@@ -641,11 +742,13 @@ void main() {
 
     test('setZoomLevel() throws $CameraException when disposed', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
 
       await cameraController.initialize();
       await cameraController.dispose();
@@ -669,492 +772,658 @@ void main() {
     });
 
     test(
-        'setZoomLevel() throws $CameraException when a platform exception occured.',
-        () async {
-      final CameraController cameraController = CameraController(
+      'setZoomLevel() throws $CameraException when a platform exception occured.',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
 
-      await cameraController.initialize();
-      when(CameraPlatform.instance.setZoomLevel(mockInitializeCamera, 42.0))
-          .thenThrow(CameraException(
-        'TEST_ERROR',
-        'This is a test error messge',
-      ));
+        await cameraController.initialize();
+        when(
+          CameraPlatform.instance.setZoomLevel(mockInitializeCamera, 42.0),
+        ).thenThrow(
+          CameraException('TEST_ERROR', 'This is a test error messge'),
+        );
 
-      expect(
+        expect(
           () => cameraController.setZoomLevel(42),
-          throwsA(isA<CameraException>()
-              .having(
-                  (CameraException error) => error.code, 'code', 'TEST_ERROR')
-              .having(
-                (CameraException error) => error.description,
-                'description',
-                'This is a test error messge',
-              )));
+          throwsA(
+            isA<CameraException>()
+                .having(
+                  (CameraException error) => error.code,
+                  'code',
+                  'TEST_ERROR',
+                )
+                .having(
+                  (CameraException error) => error.description,
+                  'description',
+                  'This is a test error messge',
+                ),
+          ),
+        );
 
-      reset(CameraPlatform.instance);
-    });
+        reset(CameraPlatform.instance);
+      },
+    );
 
     test(
-        'setZoomLevel() completes and calls method channel with correct value.',
-        () async {
-      final CameraController cameraController = CameraController(
+      'setZoomLevel() completes and calls method channel with correct value.',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
 
-      await cameraController.initialize();
-      await cameraController.setZoomLevel(42.0);
+        await cameraController.initialize();
+        await cameraController.setZoomLevel(42.0);
 
-      verify(CameraPlatform.instance.setZoomLevel(mockInitializeCamera, 42.0))
-          .called(1);
-    });
+        verify(
+          CameraPlatform.instance.setZoomLevel(mockInitializeCamera, 42.0),
+        ).called(1);
+      },
+    );
 
     test('setFlashMode() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       await cameraController.setFlashMode(FlashMode.always);
 
-      verify(CameraPlatform.instance
-              .setFlashMode(cameraController.cameraId, FlashMode.always))
-          .called(1);
-    });
-
-    test('setFlashMode() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-
-      when(CameraPlatform.instance
-              .setFlashMode(cameraController.cameraId, FlashMode.always))
-          .thenThrow(
-        PlatformException(
-          code: 'TEST_ERROR',
-          message: 'This is a test error message',
+      verify(
+        CameraPlatform.instance.setFlashMode(
+          cameraController.cameraId,
+          FlashMode.always,
         ),
-      );
-
-      expect(
-          cameraController.setFlashMode(FlashMode.always),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
+      ).called(1);
     });
+
+    test(
+      'setFlashMode() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+
+        when(
+          CameraPlatform.instance.setFlashMode(
+            cameraController.cameraId,
+            FlashMode.always,
+          ),
+        ).thenThrow(
+          PlatformException(
+            code: 'TEST_ERROR',
+            message: 'This is a test error message',
+          ),
+        );
+
+        expect(
+          cameraController.setFlashMode(FlashMode.always),
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
 
     test('setExposureMode() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       await cameraController.setExposureMode(ExposureMode.auto);
 
-      verify(CameraPlatform.instance
-              .setExposureMode(cameraController.cameraId, ExposureMode.auto))
-          .called(1);
-    });
-
-    test('setExposureMode() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-
-      when(CameraPlatform.instance
-              .setExposureMode(cameraController.cameraId, ExposureMode.auto))
-          .thenThrow(
-        PlatformException(
-          code: 'TEST_ERROR',
-          message: 'This is a test error message',
+      verify(
+        CameraPlatform.instance.setExposureMode(
+          cameraController.cameraId,
+          ExposureMode.auto,
         ),
-      );
-
-      expect(
-          cameraController.setExposureMode(ExposureMode.auto),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
+      ).called(1);
     });
+
+    test(
+      'setExposureMode() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+
+        when(
+          CameraPlatform.instance.setExposureMode(
+            cameraController.cameraId,
+            ExposureMode.auto,
+          ),
+        ).thenThrow(
+          PlatformException(
+            code: 'TEST_ERROR',
+            message: 'This is a test error message',
+          ),
+        );
+
+        expect(
+          cameraController.setExposureMode(ExposureMode.auto),
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
 
     test('setExposurePoint() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       await cameraController.setExposurePoint(const Offset(0.5, 0.5));
 
-      verify(CameraPlatform.instance.setExposurePoint(
-              cameraController.cameraId, const Point<double>(0.5, 0.5)))
-          .called(1);
-    });
-
-    test('setExposurePoint() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-
-      when(CameraPlatform.instance.setExposurePoint(
-              cameraController.cameraId, const Point<double>(0.5, 0.5)))
-          .thenThrow(
-        PlatformException(
-          code: 'TEST_ERROR',
-          message: 'This is a test error message',
+      verify(
+        CameraPlatform.instance.setExposurePoint(
+          cameraController.cameraId,
+          const Point<double>(0.5, 0.5),
         ),
-      );
-
-      expect(
-          cameraController.setExposurePoint(const Offset(0.5, 0.5)),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
+      ).called(1);
     });
+
+    test(
+      'setExposurePoint() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+
+        when(
+          CameraPlatform.instance.setExposurePoint(
+            cameraController.cameraId,
+            const Point<double>(0.5, 0.5),
+          ),
+        ).thenThrow(
+          PlatformException(
+            code: 'TEST_ERROR',
+            message: 'This is a test error message',
+          ),
+        );
+
+        expect(
+          cameraController.setExposurePoint(const Offset(0.5, 0.5)),
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
 
     test('getMinExposureOffset() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
-      when(CameraPlatform.instance
-              .getMinExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) => Future<double>.value(0.0));
+      when(
+        CameraPlatform.instance.getMinExposureOffset(cameraController.cameraId),
+      ).thenAnswer((_) => Future<double>.value(0.0));
 
       await cameraController.getMinExposureOffset();
 
-      verify(CameraPlatform.instance
-              .getMinExposureOffset(cameraController.cameraId))
-          .called(1);
+      verify(
+        CameraPlatform.instance.getMinExposureOffset(cameraController.cameraId),
+      ).called(1);
     });
 
-    test('getMinExposureOffset() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
+    test(
+      'getMinExposureOffset() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
 
-      when(CameraPlatform.instance
-              .getMinExposureOffset(cameraController.cameraId))
-          .thenThrow(
-        CameraException(
-          'TEST_ERROR',
-          'This is a test error message',
-        ),
-      );
+        when(
+          CameraPlatform.instance.getMinExposureOffset(
+            cameraController.cameraId,
+          ),
+        ).thenThrow(
+          CameraException('TEST_ERROR', 'This is a test error message'),
+        );
 
-      expect(
+        expect(
           cameraController.getMinExposureOffset(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
-    });
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
 
     test('getMaxExposureOffset() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
-      when(CameraPlatform.instance
-              .getMaxExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) => Future<double>.value(1.0));
+      when(
+        CameraPlatform.instance.getMaxExposureOffset(cameraController.cameraId),
+      ).thenAnswer((_) => Future<double>.value(1.0));
 
       await cameraController.getMaxExposureOffset();
 
-      verify(CameraPlatform.instance
-              .getMaxExposureOffset(cameraController.cameraId))
-          .called(1);
+      verify(
+        CameraPlatform.instance.getMaxExposureOffset(cameraController.cameraId),
+      ).called(1);
     });
 
-    test('getMaxExposureOffset() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
+    test(
+      'getMaxExposureOffset() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
 
-      when(CameraPlatform.instance
-              .getMaxExposureOffset(cameraController.cameraId))
-          .thenThrow(
-        CameraException(
-          'TEST_ERROR',
-          'This is a test error message',
-        ),
-      );
+        when(
+          CameraPlatform.instance.getMaxExposureOffset(
+            cameraController.cameraId,
+          ),
+        ).thenThrow(
+          CameraException('TEST_ERROR', 'This is a test error message'),
+        );
 
-      expect(
+        expect(
           cameraController.getMaxExposureOffset(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
-    });
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
 
     test('getExposureOffsetStepSize() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
-      when(CameraPlatform.instance
-              .getExposureOffsetStepSize(cameraController.cameraId))
-          .thenAnswer((_) => Future<double>.value(0.0));
+      when(
+        CameraPlatform.instance.getExposureOffsetStepSize(
+          cameraController.cameraId,
+        ),
+      ).thenAnswer((_) => Future<double>.value(0.0));
 
       await cameraController.getExposureOffsetStepSize();
 
-      verify(CameraPlatform.instance
-              .getExposureOffsetStepSize(cameraController.cameraId))
-          .called(1);
+      verify(
+        CameraPlatform.instance.getExposureOffsetStepSize(
+          cameraController.cameraId,
+        ),
+      ).called(1);
     });
 
     test(
-        'getExposureOffsetStepSize() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
+      'getExposureOffsetStepSize() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
 
-      when(CameraPlatform.instance
-              .getExposureOffsetStepSize(cameraController.cameraId))
-          .thenThrow(
-        CameraException(
-          'TEST_ERROR',
-          'This is a test error message',
-        ),
-      );
+        when(
+          CameraPlatform.instance.getExposureOffsetStepSize(
+            cameraController.cameraId,
+          ),
+        ).thenThrow(
+          CameraException('TEST_ERROR', 'This is a test error message'),
+        );
 
-      expect(
+        expect(
           cameraController.getExposureOffsetStepSize(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
-    });
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
 
     test('setExposureOffset() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
-      when(CameraPlatform.instance
-              .getMinExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) async => -1.0);
-      when(CameraPlatform.instance
-              .getMaxExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) async => 2.0);
-      when(CameraPlatform.instance
-              .getExposureOffsetStepSize(cameraController.cameraId))
-          .thenAnswer((_) async => 1.0);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 1.0))
-          .thenAnswer((_) async => 1.0);
+      when(
+        CameraPlatform.instance.getMinExposureOffset(cameraController.cameraId),
+      ).thenAnswer((_) async => -1.0);
+      when(
+        CameraPlatform.instance.getMaxExposureOffset(cameraController.cameraId),
+      ).thenAnswer((_) async => 2.0);
+      when(
+        CameraPlatform.instance.getExposureOffsetStepSize(
+          cameraController.cameraId,
+        ),
+      ).thenAnswer((_) async => 1.0);
+      when(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          1.0,
+        ),
+      ).thenAnswer((_) async => 1.0);
 
       await cameraController.setExposureOffset(1.0);
 
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 1.0))
-          .called(1);
-    });
-
-    test('setExposureOffset() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      when(CameraPlatform.instance
-              .getMinExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) async => -1.0);
-      when(CameraPlatform.instance
-              .getMaxExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) async => 2.0);
-      when(CameraPlatform.instance
-              .getExposureOffsetStepSize(cameraController.cameraId))
-          .thenAnswer((_) async => 1.0);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 1.0))
-          .thenThrow(
-        CameraException(
-          'TEST_ERROR',
-          'This is a test error message',
+      verify(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          1.0,
         ),
-      );
-
-      expect(
-          cameraController.setExposureOffset(1.0),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
+      ).called(1);
     });
 
     test(
-        'setExposureOffset() throws $CameraException when offset is out of bounds',
-        () async {
-      final CameraController cameraController = CameraController(
+      'setExposureOffset() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      when(CameraPlatform.instance
-              .getMinExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) async => -1.0);
-      when(CameraPlatform.instance
-              .getMaxExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) async => 2.0);
-      when(CameraPlatform.instance
-              .getExposureOffsetStepSize(cameraController.cameraId))
-          .thenAnswer((_) async => 1.0);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 0.0))
-          .thenAnswer((_) async => 0.0);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, -1.0))
-          .thenAnswer((_) async => 0.0);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 2.0))
-          .thenAnswer((_) async => 0.0);
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        when(
+          CameraPlatform.instance.getMinExposureOffset(
+            cameraController.cameraId,
+          ),
+        ).thenAnswer((_) async => -1.0);
+        when(
+          CameraPlatform.instance.getMaxExposureOffset(
+            cameraController.cameraId,
+          ),
+        ).thenAnswer((_) async => 2.0);
+        when(
+          CameraPlatform.instance.getExposureOffsetStepSize(
+            cameraController.cameraId,
+          ),
+        ).thenAnswer((_) async => 1.0);
+        when(
+          CameraPlatform.instance.setExposureOffset(
+            cameraController.cameraId,
+            1.0,
+          ),
+        ).thenThrow(
+          CameraException('TEST_ERROR', 'This is a test error message'),
+        );
 
-      expect(
+        expect(
+          cameraController.setExposureOffset(1.0),
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'setExposureOffset() throws $CameraException when offset is out of bounds',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        when(
+          CameraPlatform.instance.getMinExposureOffset(
+            cameraController.cameraId,
+          ),
+        ).thenAnswer((_) async => -1.0);
+        when(
+          CameraPlatform.instance.getMaxExposureOffset(
+            cameraController.cameraId,
+          ),
+        ).thenAnswer((_) async => 2.0);
+        when(
+          CameraPlatform.instance.getExposureOffsetStepSize(
+            cameraController.cameraId,
+          ),
+        ).thenAnswer((_) async => 1.0);
+        when(
+          CameraPlatform.instance.setExposureOffset(
+            cameraController.cameraId,
+            0.0,
+          ),
+        ).thenAnswer((_) async => 0.0);
+        when(
+          CameraPlatform.instance.setExposureOffset(
+            cameraController.cameraId,
+            -1.0,
+          ),
+        ).thenAnswer((_) async => 0.0);
+        when(
+          CameraPlatform.instance.setExposureOffset(
+            cameraController.cameraId,
+            2.0,
+          ),
+        ).thenAnswer((_) async => 0.0);
+
+        expect(
           cameraController.setExposureOffset(3.0),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'exposureOffsetOutOfBounds',
-            'The provided exposure offset was outside the supported range for this device.',
-          )));
-      expect(
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'exposureOffsetOutOfBounds',
+              'The provided exposure offset was outside the supported range for this device.',
+            ),
+          ),
+        );
+        expect(
           cameraController.setExposureOffset(-2.0),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'exposureOffsetOutOfBounds',
-            'The provided exposure offset was outside the supported range for this device.',
-          )));
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'exposureOffsetOutOfBounds',
+              'The provided exposure offset was outside the supported range for this device.',
+            ),
+          ),
+        );
 
-      await cameraController.setExposureOffset(0.0);
-      await cameraController.setExposureOffset(-1.0);
-      await cameraController.setExposureOffset(2.0);
+        await cameraController.setExposureOffset(0.0);
+        await cameraController.setExposureOffset(-1.0);
+        await cameraController.setExposureOffset(2.0);
 
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 0.0))
-          .called(1);
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, -1.0))
-          .called(1);
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 2.0))
-          .called(1);
-    });
+        verify(
+          CameraPlatform.instance.setExposureOffset(
+            cameraController.cameraId,
+            0.0,
+          ),
+        ).called(1);
+        verify(
+          CameraPlatform.instance.setExposureOffset(
+            cameraController.cameraId,
+            -1.0,
+          ),
+        ).called(1);
+        verify(
+          CameraPlatform.instance.setExposureOffset(
+            cameraController.cameraId,
+            2.0,
+          ),
+        ).called(1);
+      },
+    );
 
     test('setExposureOffset() rounds offset to nearest step', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
-      when(CameraPlatform.instance
-              .getMinExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) async => -1.2);
-      when(CameraPlatform.instance
-              .getMaxExposureOffset(cameraController.cameraId))
-          .thenAnswer((_) async => 1.2);
-      when(CameraPlatform.instance
-              .getExposureOffsetStepSize(cameraController.cameraId))
-          .thenAnswer((_) async => 0.4);
+      when(
+        CameraPlatform.instance.getMinExposureOffset(cameraController.cameraId),
+      ).thenAnswer((_) async => -1.2);
+      when(
+        CameraPlatform.instance.getMaxExposureOffset(cameraController.cameraId),
+      ).thenAnswer((_) async => 1.2);
+      when(
+        CameraPlatform.instance.getExposureOffsetStepSize(
+          cameraController.cameraId,
+        ),
+      ).thenAnswer((_) async => 0.4);
 
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, -1.2))
-          .thenAnswer((_) async => -1.2);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, -0.8))
-          .thenAnswer((_) async => -0.8);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, -0.4))
-          .thenAnswer((_) async => -0.4);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 0.0))
-          .thenAnswer((_) async => 0.0);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 0.4))
-          .thenAnswer((_) async => 0.4);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 0.8))
-          .thenAnswer((_) async => 0.8);
-      when(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 1.2))
-          .thenAnswer((_) async => 1.2);
+      when(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          -1.2,
+        ),
+      ).thenAnswer((_) async => -1.2);
+      when(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          -0.8,
+        ),
+      ).thenAnswer((_) async => -0.8);
+      when(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          -0.4,
+        ),
+      ).thenAnswer((_) async => -0.4);
+      when(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          0.0,
+        ),
+      ).thenAnswer((_) async => 0.0);
+      when(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          0.4,
+        ),
+      ).thenAnswer((_) async => 0.4);
+      when(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          0.8,
+        ),
+      ).thenAnswer((_) async => 0.8);
+      when(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          1.2,
+        ),
+      ).thenAnswer((_) async => 1.2);
 
       await cameraController.setExposureOffset(1.2);
       await cameraController.setExposureOffset(-1.2);
@@ -1173,274 +1442,371 @@ void main() {
       await cameraController.setExposureOffset(-0.6);
       await cameraController.setExposureOffset(-0.7);
 
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 0.8))
-          .called(2);
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, -0.8))
-          .called(2);
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 0.0))
-          .called(2);
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, 0.4))
-          .called(4);
-      verify(CameraPlatform.instance
-              .setExposureOffset(cameraController.cameraId, -0.4))
-          .called(4);
+      verify(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          0.8,
+        ),
+      ).called(2);
+      verify(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          -0.8,
+        ),
+      ).called(2);
+      verify(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          0.0,
+        ),
+      ).called(2);
+      verify(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          0.4,
+        ),
+      ).called(4);
+      verify(
+        CameraPlatform.instance.setExposureOffset(
+          cameraController.cameraId,
+          -0.4,
+        ),
+      ).called(4);
     });
 
     test('pausePreview() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
-      cameraController.value = cameraController.value
-          .copyWith(deviceOrientation: DeviceOrientation.portraitUp);
+      cameraController.value = cameraController.value.copyWith(
+        deviceOrientation: DeviceOrientation.portraitUp,
+      );
 
       await cameraController.pausePreview();
 
-      verify(CameraPlatform.instance.pausePreview(cameraController.cameraId))
-          .called(1);
+      verify(
+        CameraPlatform.instance.pausePreview(cameraController.cameraId),
+      ).called(1);
       expect(cameraController.value.isPreviewPaused, equals(true));
-      expect(cameraController.value.previewPauseOrientation,
-          DeviceOrientation.portraitUp);
-    });
-
-    test('pausePreview() does not call $CameraPlatform when already paused',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      cameraController.value =
-          cameraController.value.copyWith(isPreviewPaused: true);
-
-      await cameraController.pausePreview();
-
-      verifyNever(
-          CameraPlatform.instance.pausePreview(cameraController.cameraId));
-      expect(cameraController.value.isPreviewPaused, equals(true));
+      expect(
+        cameraController.value.previewPauseOrientation,
+        DeviceOrientation.portraitUp,
+      );
     });
 
     test(
-        'pausePreview() sets previewPauseOrientation according to locked orientation',
-        () async {
-      final CameraController cameraController = CameraController(
+      'pausePreview() does not call $CameraPlatform when already paused',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      cameraController.value = cameraController.value.copyWith(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        cameraController.value = cameraController.value.copyWith(
+          isPreviewPaused: true,
+        );
+
+        await cameraController.pausePreview();
+
+        verifyNever(
+          CameraPlatform.instance.pausePreview(cameraController.cameraId),
+        );
+        expect(cameraController.value.isPreviewPaused, equals(true));
+      },
+    );
+
+    test(
+      'pausePreview() sets previewPauseOrientation according to locked orientation',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        cameraController.value = cameraController.value.copyWith(
           isPreviewPaused: false,
           deviceOrientation: DeviceOrientation.portraitUp,
-          lockedCaptureOrientation:
-              Optional<DeviceOrientation>.of(DeviceOrientation.landscapeRight));
+          lockedCaptureOrientation: Optional<DeviceOrientation>.of(
+            DeviceOrientation.landscapeRight,
+          ),
+        );
 
-      await cameraController.pausePreview();
+        await cameraController.pausePreview();
 
-      expect(cameraController.value.deviceOrientation,
-          equals(DeviceOrientation.portraitUp));
-      expect(cameraController.value.previewPauseOrientation,
-          equals(DeviceOrientation.landscapeRight));
-    });
+        expect(
+          cameraController.value.deviceOrientation,
+          equals(DeviceOrientation.portraitUp),
+        );
+        expect(
+          cameraController.value.previewPauseOrientation,
+          equals(DeviceOrientation.landscapeRight),
+        );
+      },
+    );
 
-    test('pausePreview() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
+    test(
+      'pausePreview() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      when(CameraPlatform.instance.pausePreview(cameraController.cameraId))
-          .thenThrow(
-        PlatformException(
-          code: 'TEST_ERROR',
-          message: 'This is a test error message',
-        ),
-      );
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        when(
+          CameraPlatform.instance.pausePreview(cameraController.cameraId),
+        ).thenThrow(
+          PlatformException(
+            code: 'TEST_ERROR',
+            message: 'This is a test error message',
+          ),
+        );
 
-      expect(
+        expect(
           cameraController.pausePreview(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
-    });
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
 
     test('resumePreview() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      cameraController.value =
-          cameraController.value.copyWith(isPreviewPaused: true);
-
-      await cameraController.resumePreview();
-
-      verify(CameraPlatform.instance.resumePreview(cameraController.cameraId))
-          .called(1);
-      expect(cameraController.value.isPreviewPaused, equals(false));
-    });
-
-    test('resumePreview() does not call $CameraPlatform when not paused',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      cameraController.value =
-          cameraController.value.copyWith(isPreviewPaused: false);
-
-      await cameraController.resumePreview();
-
-      verifyNever(
-          CameraPlatform.instance.resumePreview(cameraController.cameraId));
-      expect(cameraController.value.isPreviewPaused, equals(false));
-    });
-
-    test('resumePreview() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      cameraController.value =
-          cameraController.value.copyWith(isPreviewPaused: true);
-      when(CameraPlatform.instance.resumePreview(cameraController.cameraId))
-          .thenThrow(
-        PlatformException(
-          code: 'TEST_ERROR',
-          message: 'This is a test error message',
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
         ),
+        ResolutionPreset.max,
+      );
+      await cameraController.initialize();
+      cameraController.value = cameraController.value.copyWith(
+        isPreviewPaused: true,
       );
 
-      expect(
-          cameraController.resumePreview(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
-    });
+      await cameraController.resumePreview();
 
-    test('lockCaptureOrientation() calls $CameraPlatform', () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-
-      await cameraController.lockCaptureOrientation();
-      expect(cameraController.value.lockedCaptureOrientation,
-          equals(DeviceOrientation.portraitUp));
-      await cameraController
-          .lockCaptureOrientation(DeviceOrientation.landscapeRight);
-      expect(cameraController.value.lockedCaptureOrientation,
-          equals(DeviceOrientation.landscapeRight));
-
-      verify(CameraPlatform.instance.lockCaptureOrientation(
-              cameraController.cameraId, DeviceOrientation.portraitUp))
-          .called(1);
-      verify(CameraPlatform.instance.lockCaptureOrientation(
-              cameraController.cameraId, DeviceOrientation.landscapeRight))
-          .called(1);
+      verify(
+        CameraPlatform.instance.resumePreview(cameraController.cameraId),
+      ).called(1);
+      expect(cameraController.value.isPreviewPaused, equals(false));
     });
 
     test(
-        'lockCaptureOrientation() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
+      'resumePreview() does not call $CameraPlatform when not paused',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      when(CameraPlatform.instance.lockCaptureOrientation(
-              cameraController.cameraId, DeviceOrientation.portraitUp))
-          .thenThrow(
-        PlatformException(
-          code: 'TEST_ERROR',
-          message: 'This is a test error message',
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        cameraController.value = cameraController.value.copyWith(
+          isPreviewPaused: false,
+        );
+
+        await cameraController.resumePreview();
+
+        verifyNever(
+          CameraPlatform.instance.resumePreview(cameraController.cameraId),
+        );
+        expect(cameraController.value.isPreviewPaused, equals(false));
+      },
+    );
+
+    test(
+      'resumePreview() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        cameraController.value = cameraController.value.copyWith(
+          isPreviewPaused: true,
+        );
+        when(
+          CameraPlatform.instance.resumePreview(cameraController.cameraId),
+        ).thenThrow(
+          PlatformException(
+            code: 'TEST_ERROR',
+            message: 'This is a test error message',
+          ),
+        );
+
+        expect(
+          cameraController.resumePreview(),
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
+
+    test('lockCaptureOrientation() calls $CameraPlatform', () async {
+      final CameraController cameraController = CameraController(
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
         ),
+        ResolutionPreset.max,
+      );
+      await cameraController.initialize();
+
+      await cameraController.lockCaptureOrientation();
+      expect(
+        cameraController.value.lockedCaptureOrientation,
+        equals(DeviceOrientation.portraitUp),
+      );
+      await cameraController.lockCaptureOrientation(
+        DeviceOrientation.landscapeRight,
+      );
+      expect(
+        cameraController.value.lockedCaptureOrientation,
+        equals(DeviceOrientation.landscapeRight),
       );
 
-      expect(
-          cameraController.lockCaptureOrientation(DeviceOrientation.portraitUp),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
+      verify(
+        CameraPlatform.instance.lockCaptureOrientation(
+          cameraController.cameraId,
+          DeviceOrientation.portraitUp,
+        ),
+      ).called(1);
+      verify(
+        CameraPlatform.instance.lockCaptureOrientation(
+          cameraController.cameraId,
+          DeviceOrientation.landscapeRight,
+        ),
+      ).called(1);
     });
+
+    test(
+      'lockCaptureOrientation() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
+          const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        when(
+          CameraPlatform.instance.lockCaptureOrientation(
+            cameraController.cameraId,
+            DeviceOrientation.portraitUp,
+          ),
+        ).thenThrow(
+          PlatformException(
+            code: 'TEST_ERROR',
+            message: 'This is a test error message',
+          ),
+        );
+
+        expect(
+          cameraController.lockCaptureOrientation(DeviceOrientation.portraitUp),
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
 
     test('unlockCaptureOrientation() calls $CameraPlatform', () async {
       final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
       await cameraController.initialize();
 
       await cameraController.unlockCaptureOrientation();
       expect(cameraController.value.lockedCaptureOrientation, equals(null));
 
-      verify(CameraPlatform.instance
-              .unlockCaptureOrientation(cameraController.cameraId))
-          .called(1);
+      verify(
+        CameraPlatform.instance.unlockCaptureOrientation(
+          cameraController.cameraId,
+        ),
+      ).called(1);
     });
 
     test(
-        'unlockCaptureOrientation() throws $CameraException on $PlatformException',
-        () async {
-      final CameraController cameraController = CameraController(
+      'unlockCaptureOrientation() throws $CameraException on $PlatformException',
+      () async {
+        final CameraController cameraController = CameraController(
           const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-      await cameraController.initialize();
-      when(CameraPlatform.instance
-              .unlockCaptureOrientation(cameraController.cameraId))
-          .thenThrow(
-        PlatformException(
-          code: 'TEST_ERROR',
-          message: 'This is a test error message',
-        ),
-      );
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90,
+          ),
+          ResolutionPreset.max,
+        );
+        await cameraController.initialize();
+        when(
+          CameraPlatform.instance.unlockCaptureOrientation(
+            cameraController.cameraId,
+          ),
+        ).thenThrow(
+          PlatformException(
+            code: 'TEST_ERROR',
+            message: 'This is a test error message',
+          ),
+        );
 
-      expect(
+        expect(
           cameraController.unlockCaptureOrientation(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'TEST_ERROR',
-            'This is a test error message',
-          )));
-    });
+          throwsA(
+            isA<CameraException>().having(
+              (CameraException error) => error.description,
+              'TEST_ERROR',
+              'This is a test error message',
+            ),
+          ),
+        );
+      },
+    );
   });
 }
 
@@ -1451,14 +1817,13 @@ class MockCameraPlatform extends Mock
   Future<void> initializeCamera(
     int? cameraId, {
     ImageFormatGroup? imageFormatGroup = ImageFormatGroup.unknown,
-  }) async =>
-      super.noSuchMethod(Invocation.method(
-        #initializeCamera,
-        <Object?>[cameraId],
-        <Symbol, dynamic>{
-          #imageFormatGroup: imageFormatGroup,
-        },
-      ));
+  }) async => super.noSuchMethod(
+    Invocation.method(
+      #initializeCamera,
+      <Object?>[cameraId],
+      <Symbol, dynamic>{#imageFormatGroup: imageFormatGroup},
+    ),
+  );
 
   @override
   Future<void> dispose(int? cameraId) async {
@@ -1471,7 +1836,9 @@ class MockCameraPlatform extends Mock
 
   @override
   Future<int> createCameraWithSettings(
-          CameraDescription cameraDescription, MediaSettings? mediaSettings) =>
+    CameraDescription cameraDescription,
+    MediaSettings? mediaSettings,
+  ) =>
       mockPlatformException
           ? throw PlatformException(code: 'foo', message: 'bar')
           : Future<int>.value(mockInitializeCamera);
@@ -1481,8 +1848,7 @@ class MockCameraPlatform extends Mock
     CameraDescription description,
     ResolutionPreset? resolutionPreset, {
     bool enableAudio = false,
-  }) =>
-      createCameraWithSettings(description, null);
+  }) => createCameraWithSettings(description, null);
 
   @override
   Stream<CameraInitializedEvent> onCameraInitialized(int cameraId) =>
@@ -1499,12 +1865,14 @@ class MockCameraPlatform extends Mock
   @override
   Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() =>
       Stream<DeviceOrientationChangedEvent>.value(
-          mockOnDeviceOrientationChangedEvent);
+        mockOnDeviceOrientationChangedEvent,
+      );
 
   @override
-  Future<XFile> takePicture(int cameraId) => mockPlatformException
-      ? throw PlatformException(code: 'foo', message: 'bar')
-      : Future<XFile>.value(mockTakePicture);
+  Future<XFile> takePicture(int cameraId) =>
+      mockPlatformException
+          ? throw PlatformException(code: 'foo', message: 'bar')
+          : Future<XFile>.value(mockTakePicture);
 
   @override
   Future<void> prepareForVideoRecording() async =>
@@ -1526,92 +1894,111 @@ class MockCameraPlatform extends Mock
 
   @override
   Future<void> lockCaptureOrientation(
-          int? cameraId, DeviceOrientation? orientation) async =>
-      super.noSuchMethod(Invocation.method(
-          #lockCaptureOrientation, <Object?>[cameraId, orientation]));
+    int? cameraId,
+    DeviceOrientation? orientation,
+  ) async => super.noSuchMethod(
+    Invocation.method(#lockCaptureOrientation, <Object?>[
+      cameraId,
+      orientation,
+    ]),
+  );
 
   @override
   Future<void> unlockCaptureOrientation(int? cameraId) async =>
       super.noSuchMethod(
-          Invocation.method(#unlockCaptureOrientation, <Object?>[cameraId]));
+        Invocation.method(#unlockCaptureOrientation, <Object?>[cameraId]),
+      );
 
   @override
   Future<void> pausePreview(int? cameraId) async =>
       super.noSuchMethod(Invocation.method(#pausePreview, <Object?>[cameraId]));
 
   @override
-  Future<void> resumePreview(int? cameraId) async => super
-      .noSuchMethod(Invocation.method(#resumePreview, <Object?>[cameraId]));
+  Future<void> resumePreview(int? cameraId) async => super.noSuchMethod(
+    Invocation.method(#resumePreview, <Object?>[cameraId]),
+  );
 
   @override
-  Future<double> getMaxZoomLevel(int? cameraId) async => super.noSuchMethod(
-        Invocation.method(#getMaxZoomLevel, <Object?>[cameraId]),
-        returnValue: Future<double>.value(1.0),
-      ) as Future<double>;
+  Future<double> getMaxZoomLevel(int? cameraId) async =>
+      super.noSuchMethod(
+            Invocation.method(#getMaxZoomLevel, <Object?>[cameraId]),
+            returnValue: Future<double>.value(1.0),
+          )
+          as Future<double>;
 
   @override
-  Future<double> getMinZoomLevel(int? cameraId) async => super.noSuchMethod(
-        Invocation.method(#getMinZoomLevel, <Object?>[cameraId]),
-        returnValue: Future<double>.value(0.0),
-      ) as Future<double>;
+  Future<double> getMinZoomLevel(int? cameraId) async =>
+      super.noSuchMethod(
+            Invocation.method(#getMinZoomLevel, <Object?>[cameraId]),
+            returnValue: Future<double>.value(0.0),
+          )
+          as Future<double>;
 
   @override
   Future<void> setZoomLevel(int? cameraId, double? zoom) async =>
       super.noSuchMethod(
-          Invocation.method(#setZoomLevel, <Object?>[cameraId, zoom]));
+        Invocation.method(#setZoomLevel, <Object?>[cameraId, zoom]),
+      );
 
   @override
   Future<void> setFlashMode(int? cameraId, FlashMode? mode) async =>
       super.noSuchMethod(
-          Invocation.method(#setFlashMode, <Object?>[cameraId, mode]));
+        Invocation.method(#setFlashMode, <Object?>[cameraId, mode]),
+      );
 
   @override
   Future<void> setExposureMode(int? cameraId, ExposureMode? mode) async =>
       super.noSuchMethod(
-          Invocation.method(#setExposureMode, <Object?>[cameraId, mode]));
+        Invocation.method(#setExposureMode, <Object?>[cameraId, mode]),
+      );
 
   @override
   Future<void> setExposurePoint(int? cameraId, Point<double>? point) async =>
       super.noSuchMethod(
-          Invocation.method(#setExposurePoint, <Object?>[cameraId, point]));
+        Invocation.method(#setExposurePoint, <Object?>[cameraId, point]),
+      );
 
   @override
   Future<double> getMinExposureOffset(int? cameraId) async =>
       super.noSuchMethod(
-        Invocation.method(#getMinExposureOffset, <Object?>[cameraId]),
-        returnValue: Future<double>.value(0.0),
-      ) as Future<double>;
+            Invocation.method(#getMinExposureOffset, <Object?>[cameraId]),
+            returnValue: Future<double>.value(0.0),
+          )
+          as Future<double>;
 
   @override
   Future<double> getMaxExposureOffset(int? cameraId) async =>
       super.noSuchMethod(
-        Invocation.method(#getMaxExposureOffset, <Object?>[cameraId]),
-        returnValue: Future<double>.value(1.0),
-      ) as Future<double>;
+            Invocation.method(#getMaxExposureOffset, <Object?>[cameraId]),
+            returnValue: Future<double>.value(1.0),
+          )
+          as Future<double>;
 
   @override
   Future<double> getExposureOffsetStepSize(int? cameraId) async =>
       super.noSuchMethod(
-        Invocation.method(#getExposureOffsetStepSize, <Object?>[cameraId]),
-        returnValue: Future<double>.value(1.0),
-      ) as Future<double>;
+            Invocation.method(#getExposureOffsetStepSize, <Object?>[cameraId]),
+            returnValue: Future<double>.value(1.0),
+          )
+          as Future<double>;
 
   @override
   Future<double> setExposureOffset(int? cameraId, double? offset) async =>
       super.noSuchMethod(
-        Invocation.method(#setExposureOffset, <Object?>[cameraId, offset]),
-        returnValue: Future<double>.value(1.0),
-      ) as Future<double>;
+            Invocation.method(#setExposureOffset, <Object?>[cameraId, offset]),
+            returnValue: Future<double>.value(1.0),
+          )
+          as Future<double>;
 }
 
 class MockCameraDescription extends CameraDescription {
   /// Creates a new camera description with the given properties.
   const MockCameraDescription()
-      : super(
-          name: 'Test',
-          lensDirection: CameraLensDirection.back,
-          sensorOrientation: 0,
-        );
+    : super(
+        name: 'Test',
+        lensDirection: CameraLensDirection.back,
+        sensorOrientation: 0,
+      );
 
   @override
   CameraLensDirection get lensDirection => CameraLensDirection.back;

--- a/packages/camera/camera/test/camera_value_test.dart
+++ b/packages/camera/camera/test/camera_value_test.dart
@@ -43,15 +43,18 @@ void main() {
       expect(cameraValue.exposurePointSupported, true);
       expect(cameraValue.deviceOrientation, DeviceOrientation.portraitUp);
       expect(
-          cameraValue.lockedCaptureOrientation, DeviceOrientation.portraitUp);
+        cameraValue.lockedCaptureOrientation,
+        DeviceOrientation.portraitUp,
+      );
       expect(cameraValue.recordingOrientation, DeviceOrientation.portraitUp);
       expect(cameraValue.isPreviewPaused, false);
       expect(cameraValue.previewPauseOrientation, DeviceOrientation.portraitUp);
     });
 
     test('Can be created as uninitialized', () {
-      const CameraValue cameraValue =
-          CameraValue.uninitialized(FakeController.fakeDescription);
+      const CameraValue cameraValue = CameraValue.uninitialized(
+        FakeController.fakeDescription,
+      );
 
       expect(cameraValue, isA<CameraValue>());
       expect(cameraValue.isInitialized, isFalse);
@@ -73,8 +76,9 @@ void main() {
     });
 
     test('Can be copied with isInitialized', () {
-      const CameraValue cv =
-          CameraValue.uninitialized(FakeController.fakeDescription);
+      const CameraValue cv = CameraValue.uninitialized(
+        FakeController.fakeDescription,
+      );
       final CameraValue cameraValue = cv.copyWith(isInitialized: true);
 
       expect(cameraValue, isA<CameraValue>());
@@ -97,17 +101,21 @@ void main() {
     });
 
     test('Has aspectRatio after setting size', () {
-      const CameraValue cv =
-          CameraValue.uninitialized(FakeController.fakeDescription);
-      final CameraValue cameraValue =
-          cv.copyWith(isInitialized: true, previewSize: const Size(20, 10));
+      const CameraValue cv = CameraValue.uninitialized(
+        FakeController.fakeDescription,
+      );
+      final CameraValue cameraValue = cv.copyWith(
+        isInitialized: true,
+        previewSize: const Size(20, 10),
+      );
 
       expect(cameraValue.aspectRatio, 2.0);
     });
 
     test('hasError is true after setting errorDescription', () {
-      const CameraValue cv =
-          CameraValue.uninitialized(FakeController.fakeDescription);
+      const CameraValue cv = CameraValue.uninitialized(
+        FakeController.fakeDescription,
+      );
       final CameraValue cameraValue = cv.copyWith(errorDescription: 'error');
 
       expect(cameraValue.hasError, isTrue);
@@ -115,12 +123,14 @@ void main() {
     });
 
     test('Recording paused is false when not recording', () {
-      const CameraValue cv =
-          CameraValue.uninitialized(FakeController.fakeDescription);
+      const CameraValue cv = CameraValue.uninitialized(
+        FakeController.fakeDescription,
+      );
       final CameraValue cameraValue = cv.copyWith(
-          isInitialized: true,
-          isRecordingVideo: false,
-          isRecordingPaused: true);
+        isInitialized: true,
+        isRecordingVideo: false,
+        isRecordingPaused: true,
+      );
 
       expect(cameraValue.isRecordingPaused, isFalse);
     });
@@ -147,21 +157,22 @@ void main() {
       );
 
       expect(
-          cameraValue.toString(),
-          'CameraValue(isRecordingVideo: false, isInitialized: false, '
-          'errorDescription: null, previewSize: Size(10.0, 10.0), '
-          'isStreamingImages: false, flashMode: FlashMode.auto, '
-          'exposureMode: ExposureMode.auto, focusMode: FocusMode.auto, '
-          'exposurePointSupported: true, focusPointSupported: true, '
-          'deviceOrientation: DeviceOrientation.portraitUp, '
-          'lockedCaptureOrientation: DeviceOrientation.portraitUp, '
-          'recordingOrientation: DeviceOrientation.portraitUp, '
-          'isPreviewPaused: true, '
-          'previewPausedOrientation: DeviceOrientation.portraitUp, '
-          // CameraDescription.toString is defined in the platform interface
-          // package, so don't assert a specific value for it, only that
-          // whatever it returns is inserted as expected.
-          'description: ${FakeController.fakeDescription})');
+        cameraValue.toString(),
+        'CameraValue(isRecordingVideo: false, isInitialized: false, '
+        'errorDescription: null, previewSize: Size(10.0, 10.0), '
+        'isStreamingImages: false, flashMode: FlashMode.auto, '
+        'exposureMode: ExposureMode.auto, focusMode: FocusMode.auto, '
+        'exposurePointSupported: true, focusPointSupported: true, '
+        'deviceOrientation: DeviceOrientation.portraitUp, '
+        'lockedCaptureOrientation: DeviceOrientation.portraitUp, '
+        'recordingOrientation: DeviceOrientation.portraitUp, '
+        'isPreviewPaused: true, '
+        'previewPausedOrientation: DeviceOrientation.portraitUp, '
+        // CameraDescription.toString is defined in the platform interface
+        // package, so don't assert a specific value for it, only that
+        // whatever it returns is inserted as expected.
+        'description: ${FakeController.fakeDescription})',
+      );
     });
   });
 }

--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+
 ## 0.10.10+5
 
 * Updates kotlin version to 2.2.0 to enable gradle 8.11 support.

--- a/packages/camera/camera_android/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_android/example/integration_test/camera_test.dart
@@ -30,13 +30,13 @@ void main() {
 
   final Map<ResolutionPreset, Size> presetExpectedSizes =
       <ResolutionPreset, Size>{
-    ResolutionPreset.low: const Size(240, 320),
-    ResolutionPreset.medium: const Size(480, 720),
-    ResolutionPreset.high: const Size(720, 1280),
-    ResolutionPreset.veryHigh: const Size(1080, 1920),
-    ResolutionPreset.ultraHigh: const Size(2160, 3840),
-    // Don't bother checking for max here since it could be anything.
-  };
+        ResolutionPreset.low: const Size(240, 320),
+        ResolutionPreset.medium: const Size(480, 720),
+        ResolutionPreset.high: const Size(720, 1280),
+        ResolutionPreset.veryHigh: const Size(1080, 1920),
+        ResolutionPreset.ultraHigh: const Size(2160, 3840),
+        // Don't bother checking for max here since it could be anything.
+      };
 
   /// Verify that [actual] has dimensions that are at least as large as
   /// [expectedSize]. Allows for a mismatch in portrait vs landscape. Returns
@@ -52,7 +52,9 @@ void main() {
   // automatic code to fall back to smaller sizes when we need to. Returns
   // whether the image is exactly the desired resolution.
   Future<bool> testCaptureVideoResolution(
-      CameraController controller, ResolutionPreset preset) async {
+    CameraController controller,
+    ResolutionPreset preset,
+  ) async {
     final Size expectedSize = presetExpectedSizes[preset]!;
 
     // Take Video
@@ -62,15 +64,18 @@ void main() {
 
     // Load video metadata
     final File videoFile = File(file.path);
-    final VideoPlayerController videoController =
-        VideoPlayerController.file(videoFile);
+    final VideoPlayerController videoController = VideoPlayerController.file(
+      videoFile,
+    );
     await videoController.initialize();
     final Size video = videoController.value.size;
 
     // Verify image dimensions are as expected
     expect(video, isNotNull);
     return assertExpectedDimensions(
-        expectedSize, Size(video.height, video.width));
+      expectedSize,
+      Size(video.height, video.width),
+    );
   }
 
   testWidgets(
@@ -86,14 +91,19 @@ void main() {
         for (final MapEntry<ResolutionPreset, Size> preset
             in presetExpectedSizes.entries) {
           final CameraController controller = CameraController(
-              cameraDescription,
-              mediaSettings: MediaSettings(resolutionPreset: preset.key));
+            cameraDescription,
+            mediaSettings: MediaSettings(resolutionPreset: preset.key),
+          );
           await controller.initialize();
           await controller.prepareForVideoRecording();
-          final bool presetExactlySupported =
-              await testCaptureVideoResolution(controller, preset.key);
-          assert(!(!previousPresetExactlySupported && presetExactlySupported),
-              'The camera took higher resolution pictures at a lower resolution.');
+          final bool presetExactlySupported = await testCaptureVideoResolution(
+            controller,
+            preset.key,
+          );
+          assert(
+            !(!previousPresetExactlySupported && presetExactlySupported),
+            'The camera took higher resolution pictures at a lower resolution.',
+          );
           previousPresetExactlySupported = presetExactlySupported;
           await controller.dispose();
         }
@@ -175,9 +185,9 @@ void main() {
     } catch (err) {
       expect(err, isA<PlatformException>());
       expect(
-          (err as PlatformException).message,
-          equals(
-              'Device does not support switching the camera while recording'));
+        (err as PlatformException).message,
+        equals('Device does not support switching the camera while recording'),
+      );
       failed = true;
     }
 
@@ -205,55 +215,50 @@ void main() {
     expect(controller.description, cameras[1]);
   });
 
-  testWidgets(
-    'image streaming',
-    (WidgetTester tester) async {
-      final List<CameraDescription> cameras =
-          await CameraPlatform.instance.availableCameras();
-      if (cameras.isEmpty) {
+  testWidgets('image streaming', (WidgetTester tester) async {
+    final List<CameraDescription> cameras =
+        await CameraPlatform.instance.availableCameras();
+    if (cameras.isEmpty) {
+      return;
+    }
+
+    final CameraController controller = CameraController(cameras[0]);
+
+    await controller.initialize();
+    bool isDetecting = false;
+
+    await controller.startImageStream((CameraImageData image) {
+      if (isDetecting) {
         return;
       }
 
-      final CameraController controller = CameraController(cameras[0]);
+      isDetecting = true;
 
-      await controller.initialize();
-      bool isDetecting = false;
+      expectLater(image, isNotNull).whenComplete(() => isDetecting = false);
+    });
 
-      await controller.startImageStream((CameraImageData image) {
-        if (isDetecting) {
-          return;
-        }
+    expect(controller.value.isStreamingImages, true);
 
-        isDetecting = true;
+    sleep(const Duration(milliseconds: 500));
 
-        expectLater(image, isNotNull).whenComplete(() => isDetecting = false);
-      });
+    await controller.stopImageStream();
+    await controller.dispose();
+  });
 
-      expect(controller.value.isStreamingImages, true);
+  testWidgets('recording with image stream', (WidgetTester tester) async {
+    final List<CameraDescription> cameras =
+        await CameraPlatform.instance.availableCameras();
+    if (cameras.isEmpty) {
+      return;
+    }
 
-      sleep(const Duration(milliseconds: 500));
+    final CameraController controller = CameraController(cameras[0]);
 
-      await controller.stopImageStream();
-      await controller.dispose();
-    },
-  );
+    await controller.initialize();
+    bool isDetecting = false;
 
-  testWidgets(
-    'recording with image stream',
-    (WidgetTester tester) async {
-      final List<CameraDescription> cameras =
-          await CameraPlatform.instance.availableCameras();
-      if (cameras.isEmpty) {
-        return;
-      }
-
-      final CameraController controller = CameraController(cameras[0]);
-
-      await controller.initialize();
-      bool isDetecting = false;
-
-      await controller.startVideoRecording(
-          streamCallback: (CameraImageData image) {
+    await controller.startVideoRecording(
+      streamCallback: (CameraImageData image) {
         if (isDetecting) {
           return;
         }
@@ -261,21 +266,21 @@ void main() {
         isDetecting = true;
 
         expectLater(image, isNotNull);
-      });
+      },
+    );
 
-      expect(controller.value.isStreamingImages, true);
+    expect(controller.value.isStreamingImages, true);
 
-      // Stopping recording before anything is recorded will throw, per
-      // https://developer.android.com/reference/android/media/MediaRecorder.html#stop()
-      // so delay long enough to ensure that some data is recorded.
-      await Future<void>.delayed(const Duration(seconds: 2));
+    // Stopping recording before anything is recorded will throw, per
+    // https://developer.android.com/reference/android/media/MediaRecorder.html#stop()
+    // so delay long enough to ensure that some data is recorded.
+    await Future<void>.delayed(const Duration(seconds: 2));
 
-      await controller.stopVideoRecording();
-      await controller.dispose();
+    await controller.stopVideoRecording();
+    await controller.dispose();
 
-      expect(controller.value.isStreamingImages, false);
-    },
-  );
+    expect(controller.value.isStreamingImages, false);
+  });
 
   group('Camera settings', () {
     Future<CameraDescription> getCamera() async {
@@ -316,7 +321,9 @@ void main() {
         final CameraController controller = CameraController(
           cameraDescription,
           mediaSettings: MediaSettings(
-              resolutionPreset: ResolutionPreset.medium, fps: fps),
+            resolutionPreset: ResolutionPreset.medium,
+            fps: fps,
+          ),
         );
 
         await startRecording(controller);
@@ -347,8 +354,9 @@ void main() {
         final CameraController controller = CameraController(
           cameraDescription,
           mediaSettings: MediaSettings(
-              resolutionPreset: ResolutionPreset.medium,
-              videoBitrate: videoBitrate),
+            resolutionPreset: ResolutionPreset.medium,
+            videoBitrate: videoBitrate,
+          ),
         );
 
         await startRecording(controller);

--- a/packages/camera/camera_android/example/lib/camera_controller.dart
+++ b/packages/camera/camera_android/example/lib/camera_controller.dart
@@ -33,19 +33,19 @@ class CameraValue {
 
   /// Creates a new camera controller state for an uninitialized controller.
   const CameraValue.uninitialized(CameraDescription description)
-      : this(
-          isInitialized: false,
-          isRecordingVideo: false,
-          isTakingPicture: false,
-          isStreamingImages: false,
-          isRecordingPaused: false,
-          flashMode: FlashMode.auto,
-          exposureMode: ExposureMode.auto,
-          focusMode: FocusMode.auto,
-          deviceOrientation: DeviceOrientation.portraitUp,
-          isPreviewPaused: false,
-          description: description,
-        );
+    : this(
+        isInitialized: false,
+        isRecordingVideo: false,
+        isTakingPicture: false,
+        isStreamingImages: false,
+        isRecordingPaused: false,
+        flashMode: FlashMode.auto,
+        exposureMode: ExposureMode.auto,
+        focusMode: FocusMode.auto,
+        deviceOrientation: DeviceOrientation.portraitUp,
+        isPreviewPaused: false,
+        description: description,
+      );
 
   /// True after [CameraController.initialize] has completed successfully.
   final bool isInitialized;
@@ -131,17 +131,20 @@ class CameraValue {
       exposureMode: exposureMode ?? this.exposureMode,
       focusMode: focusMode ?? this.focusMode,
       deviceOrientation: deviceOrientation ?? this.deviceOrientation,
-      lockedCaptureOrientation: lockedCaptureOrientation == null
-          ? this.lockedCaptureOrientation
-          : lockedCaptureOrientation.orNull,
-      recordingOrientation: recordingOrientation == null
-          ? this.recordingOrientation
-          : recordingOrientation.orNull,
+      lockedCaptureOrientation:
+          lockedCaptureOrientation == null
+              ? this.lockedCaptureOrientation
+              : lockedCaptureOrientation.orNull,
+      recordingOrientation:
+          recordingOrientation == null
+              ? this.recordingOrientation
+              : recordingOrientation.orNull,
       isPreviewPaused: isPreviewPaused ?? this.isPreviewPaused,
       description: description ?? this.description,
-      previewPauseOrientation: previewPauseOrientation == null
-          ? this.previewPauseOrientation
-          : previewPauseOrientation.orNull,
+      previewPauseOrientation:
+          previewPauseOrientation == null
+              ? this.previewPauseOrientation
+              : previewPauseOrientation.orNull,
     );
   }
 
@@ -173,11 +176,12 @@ class CameraController extends ValueNotifier<CameraValue> {
   /// Creates a new camera controller in an uninitialized state.
   CameraController(
     CameraDescription cameraDescription, {
-    MediaSettings mediaSettings =
-        const MediaSettings(resolutionPreset: ResolutionPreset.medium),
+    MediaSettings mediaSettings = const MediaSettings(
+      resolutionPreset: ResolutionPreset.medium,
+    ),
     this.imageFormatGroup,
-  })  : _mediaSettings = mediaSettings,
-        super(CameraValue.uninitialized(cameraDescription));
+  }) : _mediaSettings = mediaSettings,
+       super(CameraValue.uninitialized(cameraDescription));
 
   ///
   final MediaSettings _mediaSettings;
@@ -196,7 +200,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   StreamSubscription<CameraImageData>? _imageStreamSubscription;
   FutureOr<bool>? _initCalled;
   StreamSubscription<DeviceOrientationChangedEvent>?
-      _deviceOrientationSubscription;
+  _deviceOrientationSubscription;
 
   /// The camera identifier with which the controller is associated.
   int get cameraId => _cameraId;
@@ -211,22 +215,21 @@ class CameraController extends ValueNotifier<CameraValue> {
     _deviceOrientationSubscription = CameraPlatform.instance
         .onDeviceOrientationChanged()
         .listen((DeviceOrientationChangedEvent event) {
-      value = value.copyWith(
-        deviceOrientation: event.orientation,
-      );
-    });
+          value = value.copyWith(deviceOrientation: event.orientation);
+        });
 
     _cameraId = await CameraPlatform.instance.createCameraWithSettings(
       description,
       _mediaSettings,
     );
 
-    unawaited(CameraPlatform.instance
-        .onCameraInitialized(_cameraId)
-        .first
-        .then((CameraInitializedEvent event) {
-      initializeCompleter.complete(event);
-    }));
+    unawaited(
+      CameraPlatform.instance.onCameraInitialized(_cameraId).first.then((
+        CameraInitializedEvent event,
+      ) {
+        initializeCompleter.complete(event);
+      }),
+    );
 
     await CameraPlatform.instance.initializeCamera(
       _cameraId,
@@ -236,19 +239,22 @@ class CameraController extends ValueNotifier<CameraValue> {
     value = value.copyWith(
       isInitialized: true,
       description: description,
-      previewSize: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => Size(
-                event.previewWidth,
-                event.previewHeight,
-              )),
-      exposureMode: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => event.exposureMode),
-      focusMode: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => event.focusMode),
-      exposurePointSupported: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => event.exposurePointSupported),
-      focusPointSupported: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => event.focusPointSupported),
+      previewSize: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) =>
+            Size(event.previewWidth, event.previewHeight),
+      ),
+      exposureMode: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) => event.exposureMode,
+      ),
+      focusMode: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) => event.focusMode,
+      ),
+      exposurePointSupported: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) => event.exposurePointSupported,
+      ),
+      focusPointSupported: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) => event.focusPointSupported,
+      ),
     );
 
     _initCalled = true;
@@ -263,17 +269,20 @@ class CameraController extends ValueNotifier<CameraValue> {
   Future<void> pausePreview() async {
     await CameraPlatform.instance.pausePreview(_cameraId);
     value = value.copyWith(
-        isPreviewPaused: true,
-        previewPauseOrientation: Optional<DeviceOrientation>.of(
-            value.lockedCaptureOrientation ?? value.deviceOrientation));
+      isPreviewPaused: true,
+      previewPauseOrientation: Optional<DeviceOrientation>.of(
+        value.lockedCaptureOrientation ?? value.deviceOrientation,
+      ),
+    );
   }
 
   /// Resumes the current camera preview
   Future<void> resumePreview() async {
     await CameraPlatform.instance.resumePreview(_cameraId);
     value = value.copyWith(
-        isPreviewPaused: false,
-        previewPauseOrientation: const Optional<DeviceOrientation>.absent());
+      isPreviewPaused: false,
+      previewPauseOrientation: const Optional<DeviceOrientation>.absent(),
+    );
   }
 
   /// Sets the description of the camera.
@@ -298,12 +307,13 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Start streaming images from platform camera.
   Future<void> startImageStream(
-      void Function(CameraImageData image) onAvailable) async {
+    void Function(CameraImageData image) onAvailable,
+  ) async {
     _imageStreamSubscription = CameraPlatform.instance
         .onStreamedFrameAvailable(_cameraId)
         .listen((CameraImageData imageData) {
-      onAvailable(imageData);
-    });
+          onAvailable(imageData);
+        });
     value = value.copyWith(isStreamingImages: true);
   }
 
@@ -318,16 +328,20 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
   /// Throws a [CameraException] if the capture fails.
-  Future<void> startVideoRecording(
-      {void Function(CameraImageData image)? streamCallback}) async {
+  Future<void> startVideoRecording({
+    void Function(CameraImageData image)? streamCallback,
+  }) async {
     await CameraPlatform.instance.startVideoCapturing(
-        VideoCaptureOptions(_cameraId, streamCallback: streamCallback));
+      VideoCaptureOptions(_cameraId, streamCallback: streamCallback),
+    );
     value = value.copyWith(
-        isRecordingVideo: true,
-        isRecordingPaused: false,
-        isStreamingImages: streamCallback != null,
-        recordingOrientation: Optional<DeviceOrientation>.of(
-            value.lockedCaptureOrientation ?? value.deviceOrientation));
+      isRecordingVideo: true,
+      isRecordingPaused: false,
+      isStreamingImages: streamCallback != null,
+      recordingOrientation: Optional<DeviceOrientation>.of(
+        value.lockedCaptureOrientation ?? value.deviceOrientation,
+      ),
+    );
   }
 
   /// Stops the video recording and returns the file where it was saved.
@@ -338,8 +352,9 @@ class CameraController extends ValueNotifier<CameraValue> {
       await stopImageStream();
     }
 
-    final XFile file =
-        await CameraPlatform.instance.stopVideoRecording(_cameraId);
+    final XFile file = await CameraPlatform.instance.stopVideoRecording(
+      _cameraId,
+    );
     value = value.copyWith(
       isRecordingVideo: false,
       isRecordingPaused: false,
@@ -386,12 +401,12 @@ class CameraController extends ValueNotifier<CameraValue> {
     // Check if offset is in range
     final List<double> range = await Future.wait(<Future<double>>[
       CameraPlatform.instance.getMinExposureOffset(_cameraId),
-      CameraPlatform.instance.getMaxExposureOffset(_cameraId)
+      CameraPlatform.instance.getMaxExposureOffset(_cameraId),
     ]);
 
     // Round to the closest step if needed
-    final double stepSize =
-        await CameraPlatform.instance.getExposureOffsetStepSize(_cameraId);
+    final double stepSize = await CameraPlatform.instance
+        .getExposureOffsetStepSize(_cameraId);
     if (stepSize > 0) {
       final double inv = 1.0 / stepSize;
       double roundedOffset = (offset * inv).roundToDouble() / inv;
@@ -410,18 +425,23 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// If [orientation] is omitted, the current device orientation is used.
   Future<void> lockCaptureOrientation() async {
-    await CameraPlatform.instance
-        .lockCaptureOrientation(_cameraId, value.deviceOrientation);
+    await CameraPlatform.instance.lockCaptureOrientation(
+      _cameraId,
+      value.deviceOrientation,
+    );
     value = value.copyWith(
-        lockedCaptureOrientation:
-            Optional<DeviceOrientation>.of(value.deviceOrientation));
+      lockedCaptureOrientation: Optional<DeviceOrientation>.of(
+        value.deviceOrientation,
+      ),
+    );
   }
 
   /// Unlocks the capture orientation.
   Future<void> unlockCaptureOrientation() async {
     await CameraPlatform.instance.unlockCaptureOrientation(_cameraId);
     value = value.copyWith(
-        lockedCaptureOrientation: const Optional<DeviceOrientation>.absent());
+      lockedCaptureOrientation: const Optional<DeviceOrientation>.absent(),
+    );
   }
 
   /// Sets the focus mode for taking pictures.

--- a/packages/camera/camera_android/example/lib/camera_preview.dart
+++ b/packages/camera/camera_android/example/lib/camera_preview.dart
@@ -23,26 +23,25 @@ class CameraPreview extends StatelessWidget {
   Widget build(BuildContext context) {
     return controller.value.isInitialized
         ? ValueListenableBuilder<CameraValue>(
-            valueListenable: controller,
-            builder: (BuildContext context, Object? value, Widget? child) {
-              final double cameraAspectRatio =
-                  controller.value.previewSize!.width /
-                      controller.value.previewSize!.height;
-              return AspectRatio(
-                aspectRatio: _isLandscape()
-                    ? cameraAspectRatio
-                    : (1 / cameraAspectRatio),
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: <Widget>[
-                    _wrapInRotatedBox(child: controller.buildPreview()),
-                    child ?? Container(),
-                  ],
-                ),
-              );
-            },
-            child: child,
-          )
+          valueListenable: controller,
+          builder: (BuildContext context, Object? value, Widget? child) {
+            final double cameraAspectRatio =
+                controller.value.previewSize!.width /
+                controller.value.previewSize!.height;
+            return AspectRatio(
+              aspectRatio:
+                  _isLandscape() ? cameraAspectRatio : (1 / cameraAspectRatio),
+              child: Stack(
+                fit: StackFit.expand,
+                children: <Widget>[
+                  _wrapInRotatedBox(child: controller.buildPreview()),
+                  child ?? Container(),
+                ],
+              ),
+            );
+          },
+          child: child,
+        )
         : Container();
   }
 
@@ -51,16 +50,13 @@ class CameraPreview extends StatelessWidget {
       return child;
     }
 
-    return RotatedBox(
-      quarterTurns: _getQuarterTurns(),
-      child: child,
-    );
+    return RotatedBox(quarterTurns: _getQuarterTurns(), child: child);
   }
 
   bool _isLandscape() {
     return <DeviceOrientation>[
       DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight
+      DeviceOrientation.landscapeRight,
     ].contains(_getApplicableOrientation());
   }
 

--- a/packages/camera/camera_android/example/lib/main.dart
+++ b/packages/camera/camera_android/example/lib/main.dart
@@ -130,9 +130,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Camera example'),
-      ),
+      appBar: AppBar(title: const Text('Camera example')),
       body: Column(
         children: <Widget>[
           Expanded(
@@ -149,9 +147,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               child: Padding(
                 padding: const EdgeInsets.all(1.0),
-                child: Center(
-                  child: _cameraPreviewWidget(),
-                ),
+                child: Center(child: _cameraPreviewWidget()),
               ),
             ),
           ),
@@ -160,10 +156,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           Padding(
             padding: const EdgeInsets.all(5.0),
             child: Row(
-              children: <Widget>[
-                _cameraTogglesRowWidget(),
-                _thumbnailWidget(),
-              ],
+              children: <Widget>[_cameraTogglesRowWidget(), _thumbnailWidget()],
             ),
           ),
         ],
@@ -191,15 +184,17 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         child: CameraPreview(
           controller!,
           child: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-            return GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onScaleStart: _handleScaleStart,
-              onScaleUpdate: _handleScaleUpdate,
-              onTapDown: (TapDownDetails details) =>
-                  onViewFinderTap(details, constraints),
-            );
-          }),
+            builder: (BuildContext context, BoxConstraints constraints) {
+              return GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onScaleStart: _handleScaleStart,
+                onScaleUpdate: _handleScaleUpdate,
+                onTapDown:
+                    (TapDownDetails details) =>
+                        onViewFinderTap(details, constraints),
+              );
+            },
+          ),
         ),
       );
     }
@@ -215,11 +210,15 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       return;
     }
 
-    _currentScale = (_baseScale * details.scale)
-        .clamp(_minAvailableZoom, _maxAvailableZoom);
+    _currentScale = (_baseScale * details.scale).clamp(
+      _minAvailableZoom,
+      _maxAvailableZoom,
+    );
 
-    await CameraPlatform.instance
-        .setZoomLevel(controller!.cameraId, _currentScale);
+    await CameraPlatform.instance.setZoomLevel(
+      controller!.cameraId,
+      _currentScale,
+    );
   }
 
   /// Display the thumbnail of the captured image or video.
@@ -238,8 +237,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               SizedBox(
                 width: 64.0,
                 height: 64.0,
-                child: (localVideoController == null)
-                    ? (
+                child:
+                    (localVideoController == null)
+                        ? (
                         // The captured image on the web contains a network-accessible URL
                         // pointing to a location within the browser. It may be displayed
                         // either with Image.network or Image.memory after loading the image
@@ -247,16 +247,18 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                         kIsWeb
                             ? Image.network(imageFile!.path)
                             : Image.file(File(imageFile!.path)))
-                    : Container(
-                        decoration: BoxDecoration(
-                            border: Border.all(color: Colors.pink)),
-                        child: Center(
-                          child: AspectRatio(
+                        : Container(
+                          decoration: BoxDecoration(
+                            border: Border.all(color: Colors.pink),
+                          ),
+                          child: Center(
+                            child: AspectRatio(
                               aspectRatio:
                                   localVideoController.value.aspectRatio,
-                              child: VideoPlayer(localVideoController)),
+                              child: VideoPlayer(localVideoController),
+                            ),
+                          ),
                         ),
-                      ),
               ),
           ],
         ),
@@ -279,20 +281,19 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
             // The exposure and focus mode are currently not supported on the web.
             ...!kIsWeb
                 ? <Widget>[
-                    IconButton(
-                      icon: const Icon(Icons.exposure),
-                      color: Colors.blue,
-                      onPressed: controller != null
-                          ? onExposureModeButtonPressed
-                          : null,
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.filter_center_focus),
-                      color: Colors.blue,
-                      onPressed:
-                          controller != null ? onFocusModeButtonPressed : null,
-                    )
-                  ]
+                  IconButton(
+                    icon: const Icon(Icons.exposure),
+                    color: Colors.blue,
+                    onPressed:
+                        controller != null ? onExposureModeButtonPressed : null,
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.filter_center_focus),
+                    color: Colors.blue,
+                    onPressed:
+                        controller != null ? onFocusModeButtonPressed : null,
+                  ),
+                ]
                 : <Widget>[],
             IconButton(
               icon: Icon(enableAudio ? Icons.volume_up : Icons.volume_mute),
@@ -300,13 +301,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               onPressed: controller != null ? onAudioModeButtonPressed : null,
             ),
             IconButton(
-              icon: Icon(controller?.value.isCaptureOrientationLocked ?? false
-                  ? Icons.screen_lock_rotation
-                  : Icons.screen_rotation),
+              icon: Icon(
+                controller?.value.isCaptureOrientationLocked ?? false
+                    ? Icons.screen_lock_rotation
+                    : Icons.screen_rotation,
+              ),
               color: Colors.blue,
-              onPressed: controller != null
-                  ? onCaptureOrientationLockButtonPressed
-                  : null,
+              onPressed:
+                  controller != null
+                      ? onCaptureOrientationLockButtonPressed
+                      : null,
             ),
           ],
         ),
@@ -326,39 +330,47 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_off),
-              color: controller?.value.flashMode == FlashMode.off
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.off)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.off
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.off)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.flash_auto),
-              color: controller?.value.flashMode == FlashMode.auto
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.auto)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.auto
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.auto)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.flash_on),
-              color: controller?.value.flashMode == FlashMode.always
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.always)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.always
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.always)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.highlight),
-              color: controller?.value.flashMode == FlashMode.torch
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.torch)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.torch
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.torch)
+                      : null,
             ),
           ],
         ),
@@ -368,14 +380,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _exposureModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
-      foregroundColor: controller?.value.exposureMode == ExposureMode.auto
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.exposureMode == ExposureMode.auto
+              ? Colors.orange
+              : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
-      foregroundColor: controller?.value.exposureMode == ExposureMode.locked
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.exposureMode == ExposureMode.locked
+              ? Colors.orange
+              : Colors.blue,
     );
 
     return SizeTransition(
@@ -385,22 +399,24 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           color: Colors.grey.shade50,
           child: Column(
             children: <Widget>[
-              const Center(
-                child: Text('Exposure Mode'),
-              ),
+              const Center(child: Text('Exposure Mode')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
-                    onPressed: controller != null
-                        ? () =>
-                            onSetExposureModeButtonPressed(ExposureMode.auto)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetExposureModeButtonPressed(
+                              ExposureMode.auto,
+                            )
+                            : null,
                     onLongPress: () {
                       if (controller != null) {
-                        CameraPlatform.instance
-                            .setExposurePoint(controller!.cameraId, null);
+                        CameraPlatform.instance.setExposurePoint(
+                          controller!.cameraId,
+                          null,
+                        );
                         showInSnackBar('Resetting exposure point');
                       }
                     },
@@ -408,24 +424,25 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () =>
-                            onSetExposureModeButtonPressed(ExposureMode.locked)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetExposureModeButtonPressed(
+                              ExposureMode.locked,
+                            )
+                            : null,
                     child: const Text('LOCKED'),
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () => controller!.setExposureOffset(0.0)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => controller!.setExposureOffset(0.0)
+                            : null,
                     child: const Text('RESET OFFSET'),
                   ),
                 ],
               ),
-              const Center(
-                child: Text('Exposure Offset'),
-              ),
+              const Center(child: Text('Exposure Offset')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
@@ -435,10 +452,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                     min: _minAvailableExposureOffset,
                     max: _maxAvailableExposureOffset,
                     label: _currentExposureOffset.toString(),
-                    onChanged: _minAvailableExposureOffset ==
-                            _maxAvailableExposureOffset
-                        ? null
-                        : setExposureOffset,
+                    onChanged:
+                        _minAvailableExposureOffset ==
+                                _maxAvailableExposureOffset
+                            ? null
+                            : setExposureOffset,
                   ),
                   Text(_maxAvailableExposureOffset.toString()),
                 ],
@@ -452,14 +470,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _focusModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
-      foregroundColor: controller?.value.focusMode == FocusMode.auto
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.focusMode == FocusMode.auto
+              ? Colors.orange
+              : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
-      foregroundColor: controller?.value.focusMode == FocusMode.locked
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.focusMode == FocusMode.locked
+              ? Colors.orange
+              : Colors.blue,
     );
 
     return SizeTransition(
@@ -469,21 +489,22 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           color: Colors.grey.shade50,
           child: Column(
             children: <Widget>[
-              const Center(
-                child: Text('Focus Mode'),
-              ),
+              const Center(child: Text('Focus Mode')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
-                    onPressed: controller != null
-                        ? () => onSetFocusModeButtonPressed(FocusMode.auto)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetFocusModeButtonPressed(FocusMode.auto)
+                            : null,
                     onLongPress: () {
                       if (controller != null) {
-                        CameraPlatform.instance
-                            .setFocusPoint(controller!.cameraId, null);
+                        CameraPlatform.instance.setFocusPoint(
+                          controller!.cameraId,
+                          null,
+                        );
                       }
                       showInSnackBar('Resetting focus point');
                     },
@@ -491,9 +512,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () => onSetFocusModeButtonPressed(FocusMode.locked)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () =>
+                                onSetFocusModeButtonPressed(FocusMode.locked)
+                            : null,
                     child: const Text('LOCKED'),
                   ),
                 ],
@@ -515,44 +538,49 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         IconButton(
           icon: const Icon(Icons.camera_alt),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  !cameraController.value.isRecordingVideo
-              ? onTakePictureButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      !cameraController.value.isRecordingVideo
+                  ? onTakePictureButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.videocam),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  !cameraController.value.isRecordingVideo
-              ? onVideoRecordButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      !cameraController.value.isRecordingVideo
+                  ? onVideoRecordButtonPressed
+                  : null,
         ),
         IconButton(
-          icon: cameraController != null &&
-                  (!cameraController.value.isRecordingVideo ||
-                      cameraController.value.isRecordingPaused)
-              ? const Icon(Icons.play_arrow)
-              : const Icon(Icons.pause),
+          icon:
+              cameraController != null &&
+                      (!cameraController.value.isRecordingVideo ||
+                          cameraController.value.isRecordingPaused)
+                  ? const Icon(Icons.play_arrow)
+                  : const Icon(Icons.pause),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  cameraController.value.isRecordingVideo
-              ? cameraController.value.isRecordingPaused
-                  ? onResumeButtonPressed
-                  : onPauseButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      cameraController.value.isRecordingVideo
+                  ? cameraController.value.isRecordingPaused
+                      ? onResumeButtonPressed
+                      : onPauseButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.stop),
           color: Colors.red,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  cameraController.value.isRecordingVideo
-              ? onStopButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      cameraController.value.isRecordingVideo
+                  ? onStopButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.pause_presentation),
@@ -606,8 +634,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   String timestamp() => DateTime.now().millisecondsSinceEpoch.toString();
 
   void showInSnackBar(String message) {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   void onViewFinderTap(TapDownDetails details, BoxConstraints constraints) {
@@ -634,7 +663,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   }
 
   Future<void> _initializeCameraController(
-      CameraDescription cameraDescription) async {
+    CameraDescription cameraDescription,
+  ) async {
     final CameraController cameraController = CameraController(
       cameraDescription,
       mediaSettings: MediaSettings(
@@ -660,14 +690,13 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         // The exposure mode is currently not supported on the web.
         ...!kIsWeb
             ? <Future<Object?>>[
-                CameraPlatform.instance
-                    .getMinExposureOffset(cameraController.cameraId)
-                    .then(
-                        (double value) => _minAvailableExposureOffset = value),
-                CameraPlatform.instance
-                    .getMaxExposureOffset(cameraController.cameraId)
-                    .then((double value) => _maxAvailableExposureOffset = value)
-              ]
+              CameraPlatform.instance
+                  .getMinExposureOffset(cameraController.cameraId)
+                  .then((double value) => _minAvailableExposureOffset = value),
+              CameraPlatform.instance
+                  .getMaxExposureOffset(cameraController.cameraId)
+                  .then((double value) => _maxAvailableExposureOffset = value),
+            ]
             : <Future<Object?>>[],
         CameraPlatform.instance
             .getMaxZoomLevel(cameraController.cameraId)
@@ -769,7 +798,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         } else {
           await cameraController.lockCaptureOrientation();
           showInSnackBar(
-              'Capture orientation locked to ${cameraController.value.lockedCaptureOrientation.toString().split('.').last}');
+            'Capture orientation locked to ${cameraController.value.lockedCaptureOrientation.toString().split('.').last}',
+          );
         }
       }
     } on CameraException catch (e) {
@@ -988,9 +1018,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       return;
     }
 
-    final VideoPlayerController vController = kIsWeb
-        ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
-        : VideoPlayerController.file(File(videoFile!.path));
+    final VideoPlayerController vController =
+        kIsWeb
+            ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
+            : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {
       if (videoController != null) {
@@ -1048,9 +1079,7 @@ class CameraApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: CameraExampleHome(),
-    );
+    return const MaterialApp(home: CameraExampleHome());
   }
 }
 

--- a/packages/camera/camera_android/example/pubspec.yaml
+++ b/packages/camera/camera_android/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the camera plugin.
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   camera_android:

--- a/packages/camera/camera_android/example/test_driver/integration_test.dart
+++ b/packages/camera/camera_android/example/test_driver/integration_test.dart
@@ -29,14 +29,14 @@ Future<void> main() async {
     'pm',
     'grant',
     _examplePackage,
-    'android.permission.CAMERA'
+    'android.permission.CAMERA',
   ]);
   Process.runSync('adb', <String>[
     'shell',
     'pm',
     'grant',
     _examplePackage,
-    'android.permission.RECORD_AUDIO'
+    'android.permission.RECORD_AUDIO',
   ]);
   print('Starting test.');
   final FlutterDriver driver = await FlutterDriver.connect();
@@ -51,14 +51,14 @@ Future<void> main() async {
     'pm',
     'revoke',
     _examplePackage,
-    'android.permission.CAMERA'
+    'android.permission.CAMERA',
   ]);
   Process.runSync('adb', <String>[
     'shell',
     'pm',
     'revoke',
     _examplePackage,
-    'android.permission.RECORD_AUDIO'
+    'android.permission.RECORD_AUDIO',
   ]);
 
   final Map<String, dynamic> result = jsonDecode(data) as Map<String, dynamic>;

--- a/packages/camera/camera_android/lib/src/android_camera.dart
+++ b/packages/camera/camera_android/lib/src/android_camera.dart
@@ -18,7 +18,7 @@ import 'utils.dart';
 class AndroidCamera extends CameraPlatform {
   /// Creates a new [CameraPlatform] instance.
   AndroidCamera({@visibleForTesting CameraApi? hostApi})
-      : _hostApi = hostApi ?? CameraApi();
+    : _hostApi = hostApi ?? CameraApi();
 
   /// Registers this class as the default instance of [CameraPlatform].
   static void registerWith() {
@@ -60,22 +60,25 @@ class AndroidCamera extends CameraPlatform {
   // The stream for vending frames to platform interface clients.
   StreamController<CameraImageData>? _frameStreamController;
 
-  Stream<CameraEvent> _cameraEvents(int cameraId) =>
-      cameraEventStreamController.stream
-          .where((CameraEvent event) => event.cameraId == cameraId);
+  Stream<CameraEvent> _cameraEvents(int cameraId) => cameraEventStreamController
+      .stream
+      .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
   Future<List<CameraDescription>> availableCameras() async {
     try {
       final List<PlatformCameraDescription> cameraDescriptions =
           await _hostApi.getAvailableCameras();
-      return cameraDescriptions
-          .map((PlatformCameraDescription cameraDescription) {
+      return cameraDescriptions.map((
+        PlatformCameraDescription cameraDescription,
+      ) {
         return CameraDescription(
-            name: cameraDescription.name,
-            lensDirection: cameraLensDirectionFromPlatform(
-                cameraDescription.lensDirection),
-            sensorOrientation: cameraDescription.sensorOrientation);
+          name: cameraDescription.name,
+          lensDirection: cameraLensDirectionFromPlatform(
+            cameraDescription.lensDirection,
+          ),
+          sensorOrientation: cameraDescription.sensorOrientation,
+        );
       }).toList();
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
@@ -87,13 +90,10 @@ class AndroidCamera extends CameraPlatform {
     CameraDescription cameraDescription,
     ResolutionPreset? resolutionPreset, {
     bool enableAudio = false,
-  }) =>
-      createCameraWithSettings(
-          cameraDescription,
-          MediaSettings(
-            resolutionPreset: resolutionPreset,
-            enableAudio: enableAudio,
-          ));
+  }) => createCameraWithSettings(
+    cameraDescription,
+    MediaSettings(resolutionPreset: resolutionPreset, enableAudio: enableAudio),
+  );
 
   @override
   Future<int> createCameraWithSettings(
@@ -102,7 +102,9 @@ class AndroidCamera extends CameraPlatform {
   ) async {
     try {
       return await _hostApi.create(
-          cameraDescription.name, mediaSettingsToPlatform(mediaSettings));
+        cameraDescription.name,
+        mediaSettingsToPlatform(mediaSettings),
+      );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -113,16 +115,18 @@ class AndroidCamera extends CameraPlatform {
     int cameraId, {
     ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,
   }) async {
-    hostCameraHandlers.putIfAbsent(cameraId,
-        () => HostCameraMessageHandler(cameraId, cameraEventStreamController));
+    hostCameraHandlers.putIfAbsent(
+      cameraId,
+      () => HostCameraMessageHandler(cameraId, cameraEventStreamController),
+    );
 
     final Completer<void> completer = Completer<void>();
 
-    unawaited(onCameraInitialized(cameraId)
-        .first
-        .then((CameraInitializedEvent value) {
-      completer.complete();
-    }));
+    unawaited(
+      onCameraInitialized(cameraId).first.then((CameraInitializedEvent value) {
+        completer.complete();
+      }),
+    );
 
     try {
       await _hostApi.initialize(imageFormatGroupToPlatform(imageFormatGroup));
@@ -135,8 +139,9 @@ class AndroidCamera extends CameraPlatform {
 
   @override
   Future<void> dispose(int cameraId) async {
-    final HostCameraMessageHandler? handler =
-        hostCameraHandlers.remove(cameraId);
+    final HostCameraMessageHandler? handler = hostCameraHandlers.remove(
+      cameraId,
+    );
     handler?.dispose();
 
     await _hostApi.dispose();
@@ -178,8 +183,9 @@ class AndroidCamera extends CameraPlatform {
     int cameraId,
     DeviceOrientation orientation,
   ) async {
-    await _hostApi
-        .lockCaptureOrientation(deviceOrientationToPlatform(orientation));
+    await _hostApi.lockCaptureOrientation(
+      deviceOrientationToPlatform(orientation),
+    );
   }
 
   @override
@@ -198,8 +204,10 @@ class AndroidCamera extends CameraPlatform {
   Future<void> prepareForVideoRecording() async {}
 
   @override
-  Future<void> startVideoRecording(int cameraId,
-      {Duration? maxVideoDuration}) async {
+  Future<void> startVideoRecording(
+    int cameraId, {
+    Duration? maxVideoDuration,
+  }) async {
     // Ignore maxVideoDuration, as it is unimplemented and deprecated.
     return startVideoCapturing(VideoCaptureOptions(cameraId));
   }
@@ -232,14 +240,17 @@ class AndroidCamera extends CameraPlatform {
   bool supportsImageStreaming() => true;
 
   @override
-  Stream<CameraImageData> onStreamedFrameAvailable(int cameraId,
-      {CameraImageStreamOptions? options}) {
+  Stream<CameraImageData> onStreamedFrameAvailable(
+    int cameraId, {
+    CameraImageStreamOptions? options,
+  }) {
     _installStreamController(onListen: _onFrameStreamListen);
     return _frameStreamController!.stream;
   }
 
-  StreamController<CameraImageData> _installStreamController(
-      {void Function()? onListen}) {
+  StreamController<CameraImageData> _installStreamController({
+    void Function()? onListen,
+  }) {
     _frameStreamController = StreamController<CameraImageData>(
       onListen: onListen ?? () {},
       onPause: _onFrameStreamPauseResume,
@@ -259,13 +270,16 @@ class AndroidCamera extends CameraPlatform {
   }
 
   void _startStreamListener() {
-    const EventChannel cameraEventChannel =
-        EventChannel('plugins.flutter.io/camera_android/imageStream');
-    _platformImageStreamSubscription =
-        cameraEventChannel.receiveBroadcastStream().listen((dynamic imageData) {
-      _frameStreamController!
-          .add(cameraImageFromPlatformData(imageData as Map<dynamic, dynamic>));
-    });
+    const EventChannel cameraEventChannel = EventChannel(
+      'plugins.flutter.io/camera_android/imageStream',
+    );
+    _platformImageStreamSubscription = cameraEventChannel
+        .receiveBroadcastStream()
+        .listen((dynamic imageData) {
+          _frameStreamController!.add(
+            cameraImageFromPlatformData(imageData as Map<dynamic, dynamic>),
+          );
+        });
   }
 
   FutureOr<void> _onFrameStreamCancel() async {
@@ -276,8 +290,10 @@ class AndroidCamera extends CameraPlatform {
   }
 
   void _onFrameStreamPauseResume() {
-    throw CameraException('InvalidCall',
-        'Pause and resume are not supported for onStreamedFrameAvailable');
+    throw CameraException(
+      'InvalidCall',
+      'Pause and resume are not supported for onStreamedFrameAvailable',
+    );
   }
 
   @override
@@ -359,7 +375,8 @@ class AndroidCamera extends CameraPlatform {
 
   @override
   Future<void> setDescriptionWhileRecording(
-      CameraDescription description) async {
+    CameraDescription description,
+  ) async {
     await _hostApi.setDescriptionWhileRecording(description.name);
   }
 
@@ -382,8 +399,9 @@ class HostDeviceMessageHandler implements CameraGlobalEventApi {
       StreamController<DeviceEvent>.broadcast();
   @override
   void deviceOrientationChanged(PlatformDeviceOrientation orientation) {
-    deviceEventStreamController.add(DeviceOrientationChangedEvent(
-        deviceOrientationFromPlatform(orientation)));
+    deviceEventStreamController.add(
+      DeviceOrientationChangedEvent(deviceOrientationFromPlatform(orientation)),
+    );
   }
 }
 
@@ -412,14 +430,17 @@ class HostCameraMessageHandler implements CameraEventApi {
 
   @override
   void initialized(PlatformCameraState initialState) {
-    cameraEventStreamController.add(CameraInitializedEvent(
+    cameraEventStreamController.add(
+      CameraInitializedEvent(
         cameraId,
         initialState.previewSize.width,
         initialState.previewSize.height,
         exposureModeFromPlatform(initialState.exposureMode),
         initialState.exposurePointSupported,
         focusModeFromPlatform(initialState.focusMode),
-        initialState.focusPointSupported));
+        initialState.focusPointSupported,
+      ),
+    );
   }
 
   @override

--- a/packages/camera/camera_android/lib/src/messages.g.dart
+++ b/packages/camera/camera_android/lib/src/messages.g.dart
@@ -18,8 +18,11 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({
+  Object? result,
+  PlatformException? error,
+  bool empty = false,
+}) {
   if (empty) {
     return <Object?>[];
   }
@@ -30,11 +33,7 @@ List<Object?> wrapResponse(
 }
 
 /// Pigeon equivalent of [CameraLensDirection].
-enum PlatformCameraLensDirection {
-  front,
-  back,
-  external,
-}
+enum PlatformCameraLensDirection { front, back, external }
 
 /// Pigeon equivalent of [DeviceOrientation].
 enum PlatformDeviceOrientation {
@@ -45,26 +44,13 @@ enum PlatformDeviceOrientation {
 }
 
 /// Pigeon equivalent of [ExposureMode].
-enum PlatformExposureMode {
-  auto,
-  locked,
-}
+enum PlatformExposureMode { auto, locked }
 
 /// Pigeon equivalent of [FocusMode].
-enum PlatformFocusMode {
-  auto,
-  locked,
-}
+enum PlatformFocusMode { auto, locked }
 
 /// Pigeon equivalent of [ResolutionPreset].
-enum PlatformResolutionPreset {
-  low,
-  medium,
-  high,
-  veryHigh,
-  ultraHigh,
-  max,
-}
+enum PlatformResolutionPreset { low, medium, high, veryHigh, ultraHigh, max }
 
 /// Pigeon equivalent of [ImageFormatGroup].
 enum PlatformImageFormatGroup {
@@ -75,12 +61,7 @@ enum PlatformImageFormatGroup {
 }
 
 /// Pigeon equivalent of [FlashMode].
-enum PlatformFlashMode {
-  off,
-  auto,
-  always,
-  torch,
-}
+enum PlatformFlashMode { off, auto, always, torch }
 
 /// Pigeon equivalent of [CameraDescription].
 class PlatformCameraDescription {
@@ -97,11 +78,7 @@ class PlatformCameraDescription {
   int sensorOrientation;
 
   Object encode() {
-    return <Object?>[
-      name,
-      lensDirection,
-      sensorOrientation,
-    ];
+    return <Object?>[name, lensDirection, sensorOrientation];
   }
 
   static PlatformCameraDescription decode(Object result) {
@@ -158,20 +135,14 @@ class PlatformCameraState {
 
 /// Pigeon equivalent of [Size].
 class PlatformSize {
-  PlatformSize({
-    required this.width,
-    required this.height,
-  });
+  PlatformSize({required this.width, required this.height});
 
   double width;
 
   double height;
 
   Object encode() {
-    return <Object?>[
-      width,
-      height,
-    ];
+    return <Object?>[width, height];
   }
 
   static PlatformSize decode(Object result) {
@@ -185,28 +156,19 @@ class PlatformSize {
 
 /// Pigeon equivalent of [Point].
 class PlatformPoint {
-  PlatformPoint({
-    required this.x,
-    required this.y,
-  });
+  PlatformPoint({required this.x, required this.y});
 
   double x;
 
   double y;
 
   Object encode() {
-    return <Object?>[
-      x,
-      y,
-    ];
+    return <Object?>[x, y];
   }
 
   static PlatformPoint decode(Object result) {
     result as List<Object?>;
-    return PlatformPoint(
-      x: result[0]! as double,
-      y: result[1]! as double,
-    );
+    return PlatformPoint(x: result[0]! as double, y: result[1]! as double);
   }
 }
 
@@ -345,11 +307,12 @@ class CameraApi {
   /// Constructor for [CameraApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  CameraApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  CameraApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix =
+           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -362,10 +325,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.getAvailableCameras$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -389,17 +352,20 @@ class CameraApi {
 
   /// Creates a new camera with the given name and settings and returns its ID.
   Future<int> create(
-      String cameraName, PlatformMediaSettings mediaSettings) async {
+    String cameraName,
+    PlatformMediaSettings mediaSettings,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.camera_android.CameraApi.create$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[cameraName, mediaSettings]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[cameraName, mediaSettings])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -424,10 +390,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.initialize$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[imageFormat]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -449,10 +415,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.dispose$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -470,15 +436,16 @@ class CameraApi {
 
   /// Locks the camera with the given ID to the given orientation.
   Future<void> lockCaptureOrientation(
-      PlatformDeviceOrientation orientation) async {
+    PlatformDeviceOrientation orientation,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.camera_android.CameraApi.lockCaptureOrientation$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[orientation]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -500,10 +467,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.unlockCaptureOrientation$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -526,10 +493,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.takePicture$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -556,10 +523,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.startVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[enableStream]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -582,10 +549,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.stopVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -612,10 +579,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.pauseVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -637,10 +604,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.resumeVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -662,10 +629,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.startImageStream$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -687,10 +654,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.stopImageStream$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -712,10 +679,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.setFlashMode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[flashMode]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -737,10 +704,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.setExposureMode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[exposureMode]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -764,10 +731,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.setExposurePoint$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[point]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -789,10 +756,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.getMinExposureOffset$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -819,10 +786,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.getMaxExposureOffset$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -849,10 +816,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.getExposureOffsetStepSize$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -880,10 +847,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.setExposureOffset$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[offset]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -910,10 +877,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.setFocusMode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[focusMode]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -937,10 +904,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.setFocusPoint$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[point]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -962,10 +929,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.getMaxZoomLevel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -992,10 +959,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.getMinZoomLevel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1022,10 +989,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.setZoomLevel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[zoom]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1047,10 +1014,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.pausePreview$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1072,10 +1039,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.resumePreview$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1099,10 +1066,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_android.CameraApi.setDescriptionWhileRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[description]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1134,23 +1101,27 @@ abstract class CameraGlobalEventApi {
     messageChannelSuffix =
         messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_android.CameraGlobalEventApi.deviceOrientationChanged$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_android.CameraGlobalEventApi.deviceOrientationChanged$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.camera_android.CameraGlobalEventApi.deviceOrientationChanged was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.camera_android.CameraGlobalEventApi.deviceOrientationChanged was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final PlatformDeviceOrientation? arg_orientation =
               (args[0] as PlatformDeviceOrientation?);
-          assert(arg_orientation != null,
-              'Argument for dev.flutter.pigeon.camera_android.CameraGlobalEventApi.deviceOrientationChanged was null, expected non-null PlatformDeviceOrientation.');
+          assert(
+            arg_orientation != null,
+            'Argument for dev.flutter.pigeon.camera_android.CameraGlobalEventApi.deviceOrientationChanged was null, expected non-null PlatformDeviceOrientation.',
+          );
           try {
             api.deviceOrientationChanged(arg_orientation!);
             return wrapResponse(empty: true);
@@ -1158,7 +1129,8 @@ abstract class CameraGlobalEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1187,23 +1159,27 @@ abstract class CameraEventApi {
     messageChannelSuffix =
         messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_android.CameraEventApi.initialized$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_android.CameraEventApi.initialized$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.camera_android.CameraEventApi.initialized was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.camera_android.CameraEventApi.initialized was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final PlatformCameraState? arg_initialState =
               (args[0] as PlatformCameraState?);
-          assert(arg_initialState != null,
-              'Argument for dev.flutter.pigeon.camera_android.CameraEventApi.initialized was null, expected non-null PlatformCameraState.');
+          assert(
+            arg_initialState != null,
+            'Argument for dev.flutter.pigeon.camera_android.CameraEventApi.initialized was null, expected non-null PlatformCameraState.',
+          );
           try {
             api.initialized(arg_initialState!);
             return wrapResponse(empty: true);
@@ -1211,28 +1187,33 @@ abstract class CameraEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_android.CameraEventApi.error$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_android.CameraEventApi.error$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.camera_android.CameraEventApi.error was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.camera_android.CameraEventApi.error was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_message = (args[0] as String?);
-          assert(arg_message != null,
-              'Argument for dev.flutter.pigeon.camera_android.CameraEventApi.error was null, expected non-null String.');
+          assert(
+            arg_message != null,
+            'Argument for dev.flutter.pigeon.camera_android.CameraEventApi.error was null, expected non-null String.',
+          );
           try {
             api.error(arg_message!);
             return wrapResponse(empty: true);
@@ -1240,18 +1221,19 @@ abstract class CameraEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_android.CameraEventApi.closed$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_android.CameraEventApi.closed$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1263,7 +1245,8 @@ abstract class CameraEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }

--- a/packages/camera/camera_android/lib/src/type_conversion.dart
+++ b/packages/camera/camera_android/lib/src/type_conversion.dart
@@ -10,16 +10,20 @@ import 'package:camera_platform_interface/camera_platform_interface.dart';
 /// [CameraImageData].
 CameraImageData cameraImageFromPlatformData(Map<dynamic, dynamic> data) {
   return CameraImageData(
-      format: _cameraImageFormatFromPlatformData(data['format']),
-      height: data['height'] as int,
-      width: data['width'] as int,
-      lensAperture: data['lensAperture'] as double?,
-      sensorExposureTime: data['sensorExposureTime'] as int?,
-      sensorSensitivity: data['sensorSensitivity'] as double?,
-      planes: List<CameraImagePlane>.unmodifiable(
-          (data['planes'] as List<dynamic>).map<CameraImagePlane>(
-              (dynamic planeData) => _cameraImagePlaneFromPlatformData(
-                  planeData as Map<dynamic, dynamic>))));
+    format: _cameraImageFormatFromPlatformData(data['format']),
+    height: data['height'] as int,
+    width: data['width'] as int,
+    lensAperture: data['lensAperture'] as double?,
+    sensorExposureTime: data['sensorExposureTime'] as int?,
+    sensorSensitivity: data['sensorSensitivity'] as double?,
+    planes: List<CameraImagePlane>.unmodifiable(
+      (data['planes'] as List<dynamic>).map<CameraImagePlane>(
+        (dynamic planeData) => _cameraImagePlaneFromPlatformData(
+          planeData as Map<dynamic, dynamic>,
+        ),
+      ),
+    ),
+  );
 }
 
 CameraImageFormat _cameraImageFormatFromPlatformData(dynamic data) {
@@ -41,9 +45,10 @@ ImageFormatGroup _imageFormatGroupFromPlatformData(dynamic data) {
 
 CameraImagePlane _cameraImagePlaneFromPlatformData(Map<dynamic, dynamic> data) {
   return CameraImagePlane(
-      bytes: data['bytes'] as Uint8List,
-      bytesPerPixel: data['bytesPerPixel'] as int?,
-      bytesPerRow: data['bytesPerRow'] as int,
-      height: data['height'] as int?,
-      width: data['width'] as int?);
+    bytes: data['bytes'] as Uint8List,
+    bytesPerPixel: data['bytesPerPixel'] as int?,
+    bytesPerRow: data['bytesPerRow'] as int,
+    height: data['height'] as int?,
+    width: data['width'] as int?,
+  );
 }

--- a/packages/camera/camera_android/lib/src/utils.dart
+++ b/packages/camera/camera_android/lib/src/utils.dart
@@ -11,28 +11,27 @@ import 'messages.g.dart';
 
 /// Converts a [PlatformCameraLensDirection] to [CameraLensDirection].
 CameraLensDirection cameraLensDirectionFromPlatform(
-        PlatformCameraLensDirection direction) =>
-    switch (direction) {
-      PlatformCameraLensDirection.front => CameraLensDirection.front,
-      PlatformCameraLensDirection.back => CameraLensDirection.back,
-      PlatformCameraLensDirection.external => CameraLensDirection.external,
-    };
+  PlatformCameraLensDirection direction,
+) => switch (direction) {
+  PlatformCameraLensDirection.front => CameraLensDirection.front,
+  PlatformCameraLensDirection.back => CameraLensDirection.back,
+  PlatformCameraLensDirection.external => CameraLensDirection.external,
+};
 
 /// Converts a [PlatformDeviceOrientation] to [DeviceOrientation].
 DeviceOrientation deviceOrientationFromPlatform(
-        PlatformDeviceOrientation orientation) =>
-    switch (orientation) {
-      PlatformDeviceOrientation.portraitUp => DeviceOrientation.portraitUp,
-      PlatformDeviceOrientation.portraitDown => DeviceOrientation.portraitDown,
-      PlatformDeviceOrientation.landscapeLeft =>
-        DeviceOrientation.landscapeLeft,
-      PlatformDeviceOrientation.landscapeRight =>
-        DeviceOrientation.landscapeRight,
-    };
+  PlatformDeviceOrientation orientation,
+) => switch (orientation) {
+  PlatformDeviceOrientation.portraitUp => DeviceOrientation.portraitUp,
+  PlatformDeviceOrientation.portraitDown => DeviceOrientation.portraitDown,
+  PlatformDeviceOrientation.landscapeLeft => DeviceOrientation.landscapeLeft,
+  PlatformDeviceOrientation.landscapeRight => DeviceOrientation.landscapeRight,
+};
 
 /// Converts a [DeviceOrientation] to [PlatformDeviceOrientation].
 PlatformDeviceOrientation deviceOrientationToPlatform(
-    DeviceOrientation orientation) {
+  DeviceOrientation orientation,
+) {
   switch (orientation) {
     case DeviceOrientation.portraitUp:
       return PlatformDeviceOrientation.portraitUp;
@@ -106,12 +105,12 @@ PlatformResolutionPreset resolutionPresetToPlatform(ResolutionPreset? preset) =>
 /// Converts a [MediaSettings] to [PlatformMediaSettings].
 PlatformMediaSettings mediaSettingsToPlatform(MediaSettings? settings) =>
     PlatformMediaSettings(
-        resolutionPreset:
-            resolutionPresetToPlatform(settings?.resolutionPreset),
-        enableAudio: settings?.enableAudio ?? false,
-        videoBitrate: settings?.videoBitrate,
-        audioBitrate: settings?.audioBitrate,
-        fps: settings?.fps);
+      resolutionPreset: resolutionPresetToPlatform(settings?.resolutionPreset),
+      enableAudio: settings?.enableAudio ?? false,
+      videoBitrate: settings?.videoBitrate,
+      audioBitrate: settings?.audioBitrate,
+      fps: settings?.fps,
+    );
 
 /// Converts an [ImageFormatGroup] to [PlatformImageFormatGroup].
 ///

--- a/packages/camera/camera_android/pigeons/messages.dart
+++ b/packages/camera/camera_android/pigeons/messages.dart
@@ -3,26 +3,24 @@
 // found in the LICENSE file.
 import 'package:pigeon/pigeon.dart';
 
-@ConfigurePigeon(PigeonOptions(
-  dartOut: 'lib/src/messages.g.dart',
-  javaOptions: JavaOptions(package: 'io.flutter.plugins.camera'),
-  javaOut: 'android/src/main/java/io/flutter/plugins/camera/Messages.java',
-  copyrightHeader: 'pigeons/copyright.txt',
-))
-
+@ConfigurePigeon(
+  PigeonOptions(
+    dartOut: 'lib/src/messages.g.dart',
+    javaOptions: JavaOptions(package: 'io.flutter.plugins.camera'),
+    javaOut: 'android/src/main/java/io/flutter/plugins/camera/Messages.java',
+    copyrightHeader: 'pigeons/copyright.txt',
+  ),
+)
 /// Pigeon equivalent of [CameraLensDirection].
-enum PlatformCameraLensDirection {
-  front,
-  back,
-  external,
-}
+enum PlatformCameraLensDirection { front, back, external }
 
 /// Pigeon equivalent of [CameraDescription].
 class PlatformCameraDescription {
-  PlatformCameraDescription(
-      {required this.name,
-      required this.lensDirection,
-      required this.sensorOrientation});
+  PlatformCameraDescription({
+    required this.name,
+    required this.lensDirection,
+    required this.sensorOrientation,
+  });
 
   final String name;
   final PlatformCameraLensDirection lensDirection;
@@ -38,25 +36,20 @@ enum PlatformDeviceOrientation {
 }
 
 /// Pigeon equivalent of [ExposureMode].
-enum PlatformExposureMode {
-  auto,
-  locked,
-}
+enum PlatformExposureMode { auto, locked }
 
 /// Pigeon equivalent of [FocusMode].
-enum PlatformFocusMode {
-  auto,
-  locked,
-}
+enum PlatformFocusMode { auto, locked }
 
 /// Data needed for [CameraInitializedEvent].
 class PlatformCameraState {
-  PlatformCameraState(
-      {required this.previewSize,
-      required this.exposureMode,
-      required this.focusMode,
-      required this.exposurePointSupported,
-      required this.focusPointSupported});
+  PlatformCameraState({
+    required this.previewSize,
+    required this.exposureMode,
+    required this.focusMode,
+    required this.exposurePointSupported,
+    required this.focusPointSupported,
+  });
 
   final PlatformSize previewSize;
   final PlatformExposureMode exposureMode;
@@ -82,23 +75,17 @@ class PlatformPoint {
 }
 
 /// Pigeon equivalent of [ResolutionPreset].
-enum PlatformResolutionPreset {
-  low,
-  medium,
-  high,
-  veryHigh,
-  ultraHigh,
-  max,
-}
+enum PlatformResolutionPreset { low, medium, high, veryHigh, ultraHigh, max }
 
 /// Pigeon equivalent of [MediaSettings].
 class PlatformMediaSettings {
-  PlatformMediaSettings(
-      {required this.resolutionPreset,
-      required this.enableAudio,
-      this.fps,
-      this.videoBitrate,
-      this.audioBitrate});
+  PlatformMediaSettings({
+    required this.resolutionPreset,
+    required this.enableAudio,
+    this.fps,
+    this.videoBitrate,
+    this.audioBitrate,
+  });
   final PlatformResolutionPreset resolutionPreset;
   final int? fps;
   final int? videoBitrate;
@@ -115,12 +102,7 @@ enum PlatformImageFormatGroup {
 }
 
 /// Pigeon equivalent of [FlashMode].
-enum PlatformFlashMode {
-  off,
-  auto,
-  always,
-  torch,
-}
+enum PlatformFlashMode { off, auto, always, torch }
 
 /// Handles calls from Dart to the native side.
 @HostApi()

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -6,8 +6,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.10.10+5
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera_android/test/android_camera_test.dart
+++ b/packages/camera/camera_android/test/android_camera_test.dart
@@ -35,13 +35,17 @@ void main() {
     // have been initialized. While registerWith could initialize them, that
     // could slow down startup, so instead the handler should be set up lazily.
     final ByteData? response = await TestDefaultBinaryMessengerBinding
-        .instance.defaultBinaryMessenger
+        .instance
+        .defaultBinaryMessenger
         .handlePlatformMessage(
-            AndroidCamera.deviceEventChannelName,
-            const StandardMethodCodec().encodeMethodCall(const MethodCall(
-                'orientation_changed',
-                <String, Object>{'orientation': 'portraitDown'})),
-            (ByteData? data) {});
+          AndroidCamera.deviceEventChannelName,
+          const StandardMethodCodec().encodeMethodCall(
+            const MethodCall('orientation_changed', <String, Object>{
+              'orientation': 'portraitDown',
+            }),
+          ),
+          (ByteData? data) {},
+        );
     expect(response, null);
   });
 
@@ -54,18 +58,26 @@ void main() {
     test('Should send creation data and receive back a camera id', () async {
       // Arrange
       final AndroidCamera camera = AndroidCamera(hostApi: mockCameraApi);
-      when(mockCameraApi.create(
+      when(
+        mockCameraApi.create(
           'Test',
-          argThat(predicate((PlatformMediaSettings settings) =>
-              settings.resolutionPreset == PlatformResolutionPreset.high &&
-              !settings.enableAudio)))).thenAnswer((_) async => 1);
+          argThat(
+            predicate(
+              (PlatformMediaSettings settings) =>
+                  settings.resolutionPreset == PlatformResolutionPreset.high &&
+                  !settings.enableAudio,
+            ),
+          ),
+        ),
+      ).thenAnswer((_) async => 1);
 
       // Act
       final int cameraId = await camera.createCamera(
         const CameraDescription(
-            name: 'Test',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0),
+          name: 'Test',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 0,
+        ),
         ResolutionPreset.high,
       );
 
@@ -74,76 +86,110 @@ void main() {
     });
 
     test(
-        'Should send creation data and receive back a camera id using createCameraWithSettings',
-        () async {
-      // Arrange
-      final AndroidCamera camera = AndroidCamera(hostApi: mockCameraApi);
-      when(mockCameraApi.create(
-          'Test',
-          argThat(predicate((PlatformMediaSettings settings) =>
-              settings.resolutionPreset == PlatformResolutionPreset.low &&
-              !settings.enableAudio &&
-              settings.fps == 15 &&
-              settings.videoBitrate == 200000 &&
-              settings.audioBitrate == 32000)))).thenAnswer((_) async => 1);
+      'Should send creation data and receive back a camera id using createCameraWithSettings',
+      () async {
+        // Arrange
+        final AndroidCamera camera = AndroidCamera(hostApi: mockCameraApi);
+        when(
+          mockCameraApi.create(
+            'Test',
+            argThat(
+              predicate(
+                (PlatformMediaSettings settings) =>
+                    settings.resolutionPreset == PlatformResolutionPreset.low &&
+                    !settings.enableAudio &&
+                    settings.fps == 15 &&
+                    settings.videoBitrate == 200000 &&
+                    settings.audioBitrate == 32000,
+              ),
+            ),
+          ),
+        ).thenAnswer((_) async => 1);
 
-      // Act
-      final int cameraId = await camera.createCameraWithSettings(
-        const CameraDescription(
-            name: 'Test',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0),
-        const MediaSettings(
-          resolutionPreset: ResolutionPreset.low,
-          fps: 15,
-          videoBitrate: 200000,
-          audioBitrate: 32000,
-        ),
-      );
-
-      // Assert
-      expect(cameraId, 1);
-    });
-
-    test('Should throw CameraException when create throws a PlatformException',
-        () {
-      // Arrange
-      final AndroidCamera camera = AndroidCamera(hostApi: mockCameraApi);
-      when(mockCameraApi.create(
-          'Test',
-          argThat(predicate((PlatformMediaSettings settings) =>
-              settings.resolutionPreset == PlatformResolutionPreset.high &&
-              !settings.enableAudio)))).thenThrow(CameraException(
-          'TESTING_ERROR_CODE', 'Mock error message used during testing.'));
-
-      // Act
-      expect(
-        () => camera.createCamera(
+        // Act
+        final int cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
             name: 'Test',
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          ResolutionPreset.high,
-        ),
-        throwsA(
-          isA<CameraException>()
-              .having(
-                  (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
-              .having((CameraException e) => e.description, 'description',
-                  'Mock error message used during testing.'),
-        ),
-      );
-    });
+          const MediaSettings(
+            resolutionPreset: ResolutionPreset.low,
+            fps: 15,
+            videoBitrate: 200000,
+            audioBitrate: 32000,
+          ),
+        );
+
+        // Assert
+        expect(cameraId, 1);
+      },
+    );
+
+    test(
+      'Should throw CameraException when create throws a PlatformException',
+      () {
+        // Arrange
+        final AndroidCamera camera = AndroidCamera(hostApi: mockCameraApi);
+        when(
+          mockCameraApi.create(
+            'Test',
+            argThat(
+              predicate(
+                (PlatformMediaSettings settings) =>
+                    settings.resolutionPreset ==
+                        PlatformResolutionPreset.high &&
+                    !settings.enableAudio,
+              ),
+            ),
+          ),
+        ).thenThrow(
+          CameraException(
+            'TESTING_ERROR_CODE',
+            'Mock error message used during testing.',
+          ),
+        );
+
+        // Act
+        expect(
+          () => camera.createCamera(
+            const CameraDescription(
+              name: 'Test',
+              lensDirection: CameraLensDirection.back,
+              sensorOrientation: 0,
+            ),
+            ResolutionPreset.high,
+          ),
+          throwsA(
+            isA<CameraException>()
+                .having(
+                  (CameraException e) => e.code,
+                  'code',
+                  'TESTING_ERROR_CODE',
+                )
+                .having(
+                  (CameraException e) => e.description,
+                  'description',
+                  'Mock error message used during testing.',
+                ),
+          ),
+        );
+      },
+    );
 
     test(
       'Should throw CameraException when initialize throws a PlatformException',
       () {
         // Arrange
         final AndroidCamera camera = AndroidCamera(hostApi: mockCameraApi);
-        when(mockCameraApi.initialize(PlatformImageFormatGroup.yuv420))
-            .thenThrow(CameraException('TESTING_ERROR_CODE',
-                'Mock error message used during testing.'));
+        when(
+          mockCameraApi.initialize(PlatformImageFormatGroup.yuv420),
+        ).thenThrow(
+          CameraException(
+            'TESTING_ERROR_CODE',
+            'Mock error message used during testing.',
+          ),
+        );
 
         // Act
         expect(
@@ -151,7 +197,10 @@ void main() {
           throwsA(
             isA<CameraException>()
                 .having(
-                    (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
+                  (CameraException e) => e.code,
+                  'code',
+                  'TESTING_ERROR_CODE',
+                )
                 .having(
                   (CameraException e) => e.description,
                   'description',
@@ -165,11 +214,18 @@ void main() {
     test('Should send initialization data', () async {
       // Arrange
       final AndroidCamera camera = AndroidCamera(hostApi: mockCameraApi);
-      when(mockCameraApi.create(
+      when(
+        mockCameraApi.create(
           'Test',
-          argThat(predicate((PlatformMediaSettings settings) =>
-              settings.resolutionPreset == PlatformResolutionPreset.high &&
-              !settings.enableAudio)))).thenAnswer((_) async => 1);
+          argThat(
+            predicate(
+              (PlatformMediaSettings settings) =>
+                  settings.resolutionPreset == PlatformResolutionPreset.high &&
+                  !settings.enableAudio,
+            ),
+          ),
+        ),
+      ).thenAnswer((_) async => 1);
 
       final int cameraId = await camera.createCamera(
         const CameraDescription(
@@ -182,31 +238,41 @@ void main() {
 
       // Act
       final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-      camera.cameraEventStreamController.add(CameraInitializedEvent(
-        cameraId,
-        1920,
-        1080,
-        ExposureMode.auto,
-        true,
-        FocusMode.auto,
-        true,
-      ));
+      camera.cameraEventStreamController.add(
+        CameraInitializedEvent(
+          cameraId,
+          1920,
+          1080,
+          ExposureMode.auto,
+          true,
+          FocusMode.auto,
+          true,
+        ),
+      );
       await initializeFuture;
 
       // Assert
       expect(cameraId, 1);
-      verify(mockCameraApi.initialize(PlatformImageFormatGroup.yuv420))
-          .called(1);
+      verify(
+        mockCameraApi.initialize(PlatformImageFormatGroup.yuv420),
+      ).called(1);
     });
 
     test('Should send a disposal call on dispose', () async {
       // Arrange
       final AndroidCamera camera = AndroidCamera(hostApi: mockCameraApi);
-      when(mockCameraApi.create(
+      when(
+        mockCameraApi.create(
           'Test',
-          argThat(predicate((PlatformMediaSettings settings) =>
-              settings.resolutionPreset == PlatformResolutionPreset.high &&
-              !settings.enableAudio)))).thenAnswer((_) async => 1);
+          argThat(
+            predicate(
+              (PlatformMediaSettings settings) =>
+                  settings.resolutionPreset == PlatformResolutionPreset.high &&
+                  !settings.enableAudio,
+            ),
+          ),
+        ),
+      ).thenAnswer((_) async => 1);
       final int cameraId = await camera.createCamera(
         const CameraDescription(
           name: 'Test',
@@ -216,15 +282,17 @@ void main() {
         ResolutionPreset.high,
       );
       final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-      camera.cameraEventStreamController.add(CameraInitializedEvent(
-        cameraId,
-        1920,
-        1080,
-        ExposureMode.auto,
-        true,
-        FocusMode.auto,
-        true,
-      ));
+      camera.cameraEventStreamController.add(
+        CameraInitializedEvent(
+          cameraId,
+          1920,
+          1080,
+          ExposureMode.auto,
+          true,
+          FocusMode.auto,
+          true,
+        ),
+      );
       await initializeFuture;
 
       // Act
@@ -252,22 +320,24 @@ void main() {
         ResolutionPreset.high,
       );
       final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-      camera.cameraEventStreamController.add(CameraInitializedEvent(
-        cameraId,
-        1920,
-        1080,
-        ExposureMode.auto,
-        true,
-        FocusMode.auto,
-        true,
-      ));
+      camera.cameraEventStreamController.add(
+        CameraInitializedEvent(
+          cameraId,
+          1920,
+          1080,
+          ExposureMode.auto,
+          true,
+          FocusMode.auto,
+          true,
+        ),
+      );
       await initializeFuture;
     });
 
     test('Should receive initialized event', () async {
       // Act
-      final Stream<CameraInitializedEvent> eventStream =
-          camera.onCameraInitialized(cameraId);
+      final Stream<CameraInitializedEvent> eventStream = camera
+          .onCameraInitialized(cameraId);
       final StreamQueue<CameraInitializedEvent> streamQueue =
           StreamQueue<CameraInitializedEvent>(eventStream);
 
@@ -282,12 +352,15 @@ void main() {
         FocusMode.auto,
         true,
       );
-      camera.hostCameraHandlers[cameraId]!.initialized(PlatformCameraState(
+      camera.hostCameraHandlers[cameraId]!.initialized(
+        PlatformCameraState(
           previewSize: previewSize,
           exposureMode: PlatformExposureMode.auto,
           focusMode: PlatformFocusMode.auto,
           exposurePointSupported: true,
-          focusPointSupported: true));
+          focusPointSupported: true,
+        ),
+      );
 
       // Assert
       expect(await streamQueue.next, event);
@@ -298,8 +371,9 @@ void main() {
 
     test('Should receive camera closing events', () async {
       // Act
-      final Stream<CameraClosingEvent> eventStream =
-          camera.onCameraClosing(cameraId);
+      final Stream<CameraClosingEvent> eventStream = camera.onCameraClosing(
+        cameraId,
+      );
       final StreamQueue<CameraClosingEvent> streamQueue =
           StreamQueue<CameraClosingEvent>(eventStream);
 
@@ -320,14 +394,17 @@ void main() {
 
     test('Should receive camera error events', () async {
       // Act
-      final Stream<CameraErrorEvent> errorStream =
-          camera.onCameraError(cameraId);
+      final Stream<CameraErrorEvent> errorStream = camera.onCameraError(
+        cameraId,
+      );
       final StreamQueue<CameraErrorEvent> streamQueue =
           StreamQueue<CameraErrorEvent>(errorStream);
 
       // Emit test events
-      final CameraErrorEvent event =
-          CameraErrorEvent(cameraId, 'Error Description');
+      final CameraErrorEvent event = CameraErrorEvent(
+        cameraId,
+        'Error Description',
+      );
       for (int i = 0; i < 3; i++) {
         camera.hostCameraHandlers[cameraId]!.error('Error Description');
       }
@@ -349,11 +426,13 @@ void main() {
           StreamQueue<DeviceOrientationChangedEvent>(eventStream);
 
       // Emit test events
-      const DeviceOrientationChangedEvent event =
-          DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
+      const DeviceOrientationChangedEvent event = DeviceOrientationChangedEvent(
+        DeviceOrientation.portraitUp,
+      );
       for (int i = 0; i < 3; i++) {
-        camera.hostHandler
-            .deviceOrientationChanged(PlatformDeviceOrientation.portraitUp);
+        camera.hostHandler.deviceOrientationChanged(
+          PlatformDeviceOrientation.portraitUp,
+        );
       }
 
       // Assert
@@ -397,65 +476,83 @@ void main() {
       await initializeFuture;
     });
 
-    test('Should fetch CameraDescription instances for available cameras',
-        () async {
-      // Arrange
-      final List<PlatformCameraDescription> returnData =
-          <PlatformCameraDescription>[
-        PlatformCameraDescription(
-            name: 'Test 1',
-            lensDirection: PlatformCameraLensDirection.front,
-            sensorOrientation: 1),
-        PlatformCameraDescription(
-            name: 'Test 2',
-            lensDirection: PlatformCameraLensDirection.back,
-            sensorOrientation: 2),
-      ];
-      when(mockCameraApi.getAvailableCameras())
-          .thenAnswer((_) async => returnData);
+    test(
+      'Should fetch CameraDescription instances for available cameras',
+      () async {
+        // Arrange
+        final List<PlatformCameraDescription> returnData =
+            <PlatformCameraDescription>[
+              PlatformCameraDescription(
+                name: 'Test 1',
+                lensDirection: PlatformCameraLensDirection.front,
+                sensorOrientation: 1,
+              ),
+              PlatformCameraDescription(
+                name: 'Test 2',
+                lensDirection: PlatformCameraLensDirection.back,
+                sensorOrientation: 2,
+              ),
+            ];
+        when(
+          mockCameraApi.getAvailableCameras(),
+        ).thenAnswer((_) async => returnData);
 
-      // Act
-      final List<CameraDescription> cameras = await camera.availableCameras();
+        // Act
+        final List<CameraDescription> cameras = await camera.availableCameras();
 
-      // Assert
-      expect(cameras.length, returnData.length);
-      for (int i = 0; i < returnData.length; i++) {
-        final PlatformCameraDescription platformCameraDescription =
-            returnData[i];
-        final CameraDescription cameraDescription = CameraDescription(
+        // Assert
+        expect(cameras.length, returnData.length);
+        for (int i = 0; i < returnData.length; i++) {
+          final PlatformCameraDescription platformCameraDescription =
+              returnData[i];
+          final CameraDescription cameraDescription = CameraDescription(
             name: platformCameraDescription.name,
             lensDirection: cameraLensDirectionFromPlatform(
-                platformCameraDescription.lensDirection),
-            sensorOrientation: platformCameraDescription.sensorOrientation);
-        expect(cameras[i], cameraDescription);
-      }
-    });
+              platformCameraDescription.lensDirection,
+            ),
+            sensorOrientation: platformCameraDescription.sensorOrientation,
+          );
+          expect(cameras[i], cameraDescription);
+        }
+      },
+    );
 
     test(
-        'Should throw CameraException when availableCameras throws a PlatformException',
-        () {
-      // Arrange
-      when(mockCameraApi.getAvailableCameras()).thenThrow(PlatformException(
-          code: 'TESTING_ERROR_CODE',
-          message: 'Mock error message used during testing.'));
+      'Should throw CameraException when availableCameras throws a PlatformException',
+      () {
+        // Arrange
+        when(mockCameraApi.getAvailableCameras()).thenThrow(
+          PlatformException(
+            code: 'TESTING_ERROR_CODE',
+            message: 'Mock error message used during testing.',
+          ),
+        );
 
-      // Act
-      expect(
-        camera.availableCameras,
-        throwsA(
-          isA<CameraException>()
-              .having(
-                  (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
-              .having((CameraException e) => e.description, 'description',
-                  'Mock error message used during testing.'),
-        ),
-      );
-    });
+        // Act
+        expect(
+          camera.availableCameras,
+          throwsA(
+            isA<CameraException>()
+                .having(
+                  (CameraException e) => e.code,
+                  'code',
+                  'TESTING_ERROR_CODE',
+                )
+                .having(
+                  (CameraException e) => e.description,
+                  'description',
+                  'Mock error message used during testing.',
+                ),
+          ),
+        );
+      },
+    );
 
     test('Should take a picture and return an XFile instance', () async {
       // Arrange
-      when(mockCameraApi.takePicture())
-          .thenAnswer((_) async => '/test/path.jpg');
+      when(
+        mockCameraApi.takePicture(),
+      ).thenAnswer((_) async => '/test/path.jpg');
 
       // Act
       final XFile file = await camera.takePicture(cameraId);
@@ -474,23 +571,27 @@ void main() {
     });
 
     test(
-        'Should pass enableStream if callback is passed when starting recording a video',
-        () async {
-      // Arrange
-      // Act
-      await camera.startVideoCapturing(
-        VideoCaptureOptions(cameraId,
-            streamCallback: (CameraImageData imageData) {}),
-      );
+      'Should pass enableStream if callback is passed when starting recording a video',
+      () async {
+        // Arrange
+        // Act
+        await camera.startVideoCapturing(
+          VideoCaptureOptions(
+            cameraId,
+            streamCallback: (CameraImageData imageData) {},
+          ),
+        );
 
-      // Assert
-      verify(mockCameraApi.startVideoRecording(true)).called(1);
-    });
+        // Assert
+        verify(mockCameraApi.startVideoRecording(true)).called(1);
+      },
+    );
 
     test('Should stop a video recording and return the file', () async {
       // Arrange
-      when(mockCameraApi.stopVideoRecording())
-          .thenAnswer((_) async => '/test/path.mp4');
+      when(
+        mockCameraApi.stopVideoRecording(),
+      ).thenAnswer((_) async => '/test/path.mp4');
 
       // Act
       final XFile file = await camera.stopVideoRecording(cameraId);
@@ -520,17 +621,18 @@ void main() {
     test('Should set the description while recording', () async {
       // Arrange
       const CameraDescription camera2Description = CameraDescription(
-          name: 'Test2',
-          lensDirection: CameraLensDirection.front,
-          sensorOrientation: 0);
+        name: 'Test2',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 0,
+      );
 
       // Act
       await camera.setDescriptionWhileRecording(camera2Description);
 
       // Assert
-      verify(mockCameraApi
-              .setDescriptionWhileRecording(camera2Description.name))
-          .called(1);
+      verify(
+        mockCameraApi.setDescriptionWhileRecording(camera2Description.name),
+      ).called(1);
     });
 
     test('Should set the flash mode', () async {
@@ -555,10 +657,12 @@ void main() {
       await camera.setExposureMode(cameraId, ExposureMode.locked);
 
       // Assert
-      verify(mockCameraApi.setExposureMode(PlatformExposureMode.auto))
-          .called(1);
-      verify(mockCameraApi.setExposureMode(PlatformExposureMode.locked))
-          .called(1);
+      verify(
+        mockCameraApi.setExposureMode(PlatformExposureMode.auto),
+      ).called(1);
+      verify(
+        mockCameraApi.setExposureMode(PlatformExposureMode.locked),
+      ).called(1);
     });
 
     test('Should set the exposure point', () async {
@@ -568,9 +672,15 @@ void main() {
       await camera.setExposurePoint(cameraId, null);
 
       // Assert
-      verify(mockCameraApi.setExposurePoint(argThat(predicate(
-              (PlatformPoint point) => point.x == 0.4 && point.y == 0.5))))
-          .called(1);
+      verify(
+        mockCameraApi.setExposurePoint(
+          argThat(
+            predicate(
+              (PlatformPoint point) => point.x == 0.4 && point.y == 0.5,
+            ),
+          ),
+        ),
+      ).called(1);
       verify(mockCameraApi.setExposurePoint(null)).called(1);
     });
 
@@ -579,8 +689,9 @@ void main() {
       when(mockCameraApi.getMinExposureOffset()).thenAnswer((_) async => 2.0);
 
       // Act
-      final double minExposureOffset =
-          await camera.getMinExposureOffset(cameraId);
+      final double minExposureOffset = await camera.getMinExposureOffset(
+        cameraId,
+      );
 
       // Assert
       expect(minExposureOffset, 2.0);
@@ -591,8 +702,9 @@ void main() {
       when(mockCameraApi.getMaxExposureOffset()).thenAnswer((_) async => 2.0);
 
       // Act
-      final double maxExposureOffset =
-          await camera.getMaxExposureOffset(cameraId);
+      final double maxExposureOffset = await camera.getMaxExposureOffset(
+        cameraId,
+      );
 
       // Assert
       expect(maxExposureOffset, 2.0);
@@ -600,8 +712,9 @@ void main() {
 
     test('Should get the exposure offset step size', () async {
       // Arrange
-      when(mockCameraApi.getExposureOffsetStepSize())
-          .thenAnswer((_) async => 0.25);
+      when(
+        mockCameraApi.getExposureOffsetStepSize(),
+      ).thenAnswer((_) async => 0.25);
 
       // Act
       final double stepSize = await camera.getExposureOffsetStepSize(cameraId);
@@ -672,31 +785,44 @@ void main() {
       verify(mockCameraApi.setZoomLevel(2.0)).called(1);
     });
 
-    test('Should throw CameraException when illegal zoom level is supplied',
-        () async {
-      // Arrange
-      when(mockCameraApi.setZoomLevel(-1.0)).thenThrow(
-          PlatformException(code: 'ZOOM_ERROR', message: 'Illegal zoom error'));
+    test(
+      'Should throw CameraException when illegal zoom level is supplied',
+      () async {
+        // Arrange
+        when(mockCameraApi.setZoomLevel(-1.0)).thenThrow(
+          PlatformException(code: 'ZOOM_ERROR', message: 'Illegal zoom error'),
+        );
 
-      // Act & assert
-      expect(
+        // Act & assert
+        expect(
           () => camera.setZoomLevel(cameraId, -1.0),
-          throwsA(isA<CameraException>()
-              .having((CameraException e) => e.code, 'code', 'ZOOM_ERROR')
-              .having((CameraException e) => e.description, 'description',
-                  'Illegal zoom error')));
-    });
+          throwsA(
+            isA<CameraException>()
+                .having((CameraException e) => e.code, 'code', 'ZOOM_ERROR')
+                .having(
+                  (CameraException e) => e.description,
+                  'description',
+                  'Illegal zoom error',
+                ),
+          ),
+        );
+      },
+    );
 
     test('Should lock the capture orientation', () async {
       // Arrange
       // Act
       await camera.lockCaptureOrientation(
-          cameraId, DeviceOrientation.portraitUp);
+        cameraId,
+        DeviceOrientation.portraitUp,
+      );
 
       // Assert
-      verify(mockCameraApi
-              .lockCaptureOrientation(PlatformDeviceOrientation.portraitUp))
-          .called(1);
+      verify(
+        mockCameraApi.lockCaptureOrientation(
+          PlatformDeviceOrientation.portraitUp,
+        ),
+      ).called(1);
     });
 
     test('Should unlock the capture orientation', () async {

--- a/packages/camera/camera_android/test/android_camera_test.mocks.dart
+++ b/packages/camera/camera_android/test/android_camera_test.mocks.dart
@@ -27,31 +27,33 @@ import 'package:mockito/src/dummies.dart' as _i3;
 /// See the documentation for Mockito's code generation for more information.
 class MockCameraApi extends _i1.Mock implements _i2.CameraApi {
   @override
-  String get pigeonVar_messageChannelSuffix => (super.noSuchMethod(
-        Invocation.getter(#pigeonVar_messageChannelSuffix),
-        returnValue: _i3.dummyValue<String>(
-          this,
-          Invocation.getter(#pigeonVar_messageChannelSuffix),
-        ),
-        returnValueForMissingStub: _i3.dummyValue<String>(
-          this,
-          Invocation.getter(#pigeonVar_messageChannelSuffix),
-        ),
-      ) as String);
+  String get pigeonVar_messageChannelSuffix =>
+      (super.noSuchMethod(
+            Invocation.getter(#pigeonVar_messageChannelSuffix),
+            returnValue: _i3.dummyValue<String>(
+              this,
+              Invocation.getter(#pigeonVar_messageChannelSuffix),
+            ),
+            returnValueForMissingStub: _i3.dummyValue<String>(
+              this,
+              Invocation.getter(#pigeonVar_messageChannelSuffix),
+            ),
+          )
+          as String);
 
   @override
   _i4.Future<List<_i2.PlatformCameraDescription>> getAvailableCameras() =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getAvailableCameras,
-          [],
-        ),
-        returnValue: _i4.Future<List<_i2.PlatformCameraDescription>>.value(
-            <_i2.PlatformCameraDescription>[]),
-        returnValueForMissingStub:
-            _i4.Future<List<_i2.PlatformCameraDescription>>.value(
-                <_i2.PlatformCameraDescription>[]),
-      ) as _i4.Future<List<_i2.PlatformCameraDescription>>);
+            Invocation.method(#getAvailableCameras, []),
+            returnValue: _i4.Future<List<_i2.PlatformCameraDescription>>.value(
+              <_i2.PlatformCameraDescription>[],
+            ),
+            returnValueForMissingStub:
+                _i4.Future<List<_i2.PlatformCameraDescription>>.value(
+                  <_i2.PlatformCameraDescription>[],
+                ),
+          )
+          as _i4.Future<List<_i2.PlatformCameraDescription>>);
 
   @override
   _i4.Future<int> create(
@@ -59,310 +61,259 @@ class MockCameraApi extends _i1.Mock implements _i2.CameraApi {
     _i2.PlatformMediaSettings? mediaSettings,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #create,
-          [
-            cameraName,
-            mediaSettings,
-          ],
-        ),
-        returnValue: _i4.Future<int>.value(0),
-        returnValueForMissingStub: _i4.Future<int>.value(0),
-      ) as _i4.Future<int>);
+            Invocation.method(#create, [cameraName, mediaSettings]),
+            returnValue: _i4.Future<int>.value(0),
+            returnValueForMissingStub: _i4.Future<int>.value(0),
+          )
+          as _i4.Future<int>);
 
   @override
   _i4.Future<void> initialize(_i2.PlatformImageFormatGroup? imageFormat) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #initialize,
-          [imageFormat],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#initialize, [imageFormat]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> dispose() => (super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> dispose() =>
+      (super.noSuchMethod(
+            Invocation.method(#dispose, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> lockCaptureOrientation(
-          _i2.PlatformDeviceOrientation? orientation) =>
+    _i2.PlatformDeviceOrientation? orientation,
+  ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #lockCaptureOrientation,
-          [orientation],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#lockCaptureOrientation, [orientation]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> unlockCaptureOrientation() => (super.noSuchMethod(
-        Invocation.method(
-          #unlockCaptureOrientation,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> unlockCaptureOrientation() =>
+      (super.noSuchMethod(
+            Invocation.method(#unlockCaptureOrientation, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<String> takePicture() => (super.noSuchMethod(
-        Invocation.method(
-          #takePicture,
-          [],
-        ),
-        returnValue: _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #takePicture,
-            [],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #takePicture,
-            [],
-          ),
-        )),
-      ) as _i4.Future<String>);
+  _i4.Future<String> takePicture() =>
+      (super.noSuchMethod(
+            Invocation.method(#takePicture, []),
+            returnValue: _i4.Future<String>.value(
+              _i3.dummyValue<String>(this, Invocation.method(#takePicture, [])),
+            ),
+            returnValueForMissingStub: _i4.Future<String>.value(
+              _i3.dummyValue<String>(this, Invocation.method(#takePicture, [])),
+            ),
+          )
+          as _i4.Future<String>);
 
   @override
   _i4.Future<void> startVideoRecording(bool? enableStream) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #startVideoRecording,
-          [enableStream],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#startVideoRecording, [enableStream]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<String> stopVideoRecording() => (super.noSuchMethod(
-        Invocation.method(
-          #stopVideoRecording,
-          [],
-        ),
-        returnValue: _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #stopVideoRecording,
-            [],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #stopVideoRecording,
-            [],
-          ),
-        )),
-      ) as _i4.Future<String>);
+  _i4.Future<String> stopVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#stopVideoRecording, []),
+            returnValue: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#stopVideoRecording, []),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#stopVideoRecording, []),
+              ),
+            ),
+          )
+          as _i4.Future<String>);
 
   @override
-  _i4.Future<void> pauseVideoRecording() => (super.noSuchMethod(
-        Invocation.method(
-          #pauseVideoRecording,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> pauseVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#pauseVideoRecording, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> resumeVideoRecording() => (super.noSuchMethod(
-        Invocation.method(
-          #resumeVideoRecording,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> resumeVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#resumeVideoRecording, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> startImageStream() => (super.noSuchMethod(
-        Invocation.method(
-          #startImageStream,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> startImageStream() =>
+      (super.noSuchMethod(
+            Invocation.method(#startImageStream, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> stopImageStream() => (super.noSuchMethod(
-        Invocation.method(
-          #stopImageStream,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> stopImageStream() =>
+      (super.noSuchMethod(
+            Invocation.method(#stopImageStream, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setFlashMode(_i2.PlatformFlashMode? flashMode) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setFlashMode,
-          [flashMode],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setFlashMode, [flashMode]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setExposureMode(_i2.PlatformExposureMode? exposureMode) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setExposureMode,
-          [exposureMode],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setExposureMode, [exposureMode]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setExposurePoint(_i2.PlatformPoint? point) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setExposurePoint,
-          [point],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setExposurePoint, [point]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<double> getMinExposureOffset() => (super.noSuchMethod(
-        Invocation.method(
-          #getMinExposureOffset,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getMinExposureOffset() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMinExposureOffset, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<double> getMaxExposureOffset() => (super.noSuchMethod(
-        Invocation.method(
-          #getMaxExposureOffset,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getMaxExposureOffset() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMaxExposureOffset, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<double> getExposureOffsetStepSize() => (super.noSuchMethod(
-        Invocation.method(
-          #getExposureOffsetStepSize,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getExposureOffsetStepSize() =>
+      (super.noSuchMethod(
+            Invocation.method(#getExposureOffsetStepSize, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<double> setExposureOffset(double? offset) => (super.noSuchMethod(
-        Invocation.method(
-          #setExposureOffset,
-          [offset],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> setExposureOffset(double? offset) =>
+      (super.noSuchMethod(
+            Invocation.method(#setExposureOffset, [offset]),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
   _i4.Future<void> setFocusMode(_i2.PlatformFocusMode? focusMode) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setFocusMode,
-          [focusMode],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setFocusMode, [focusMode]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setFocusPoint(_i2.PlatformPoint? point) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setFocusPoint,
-          [point],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setFocusPoint, [point]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<double> getMaxZoomLevel() => (super.noSuchMethod(
-        Invocation.method(
-          #getMaxZoomLevel,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getMaxZoomLevel() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMaxZoomLevel, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<double> getMinZoomLevel() => (super.noSuchMethod(
-        Invocation.method(
-          #getMinZoomLevel,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getMinZoomLevel() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMinZoomLevel, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<void> setZoomLevel(double? zoom) => (super.noSuchMethod(
-        Invocation.method(
-          #setZoomLevel,
-          [zoom],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> setZoomLevel(double? zoom) =>
+      (super.noSuchMethod(
+            Invocation.method(#setZoomLevel, [zoom]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> pausePreview() => (super.noSuchMethod(
-        Invocation.method(
-          #pausePreview,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> pausePreview() =>
+      (super.noSuchMethod(
+            Invocation.method(#pausePreview, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> resumePreview() => (super.noSuchMethod(
-        Invocation.method(
-          #resumePreview,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> resumePreview() =>
+      (super.noSuchMethod(
+            Invocation.method(#resumePreview, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setDescriptionWhileRecording(String? description) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setDescriptionWhileRecording,
-          [description],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setDescriptionWhileRecording, [description]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 }

--- a/packages/camera/camera_android/test/method_channel_mock.dart
+++ b/packages/camera/camera_android/test/method_channel_mock.dart
@@ -24,8 +24,10 @@ class MethodChannelMock {
     log.add(methodCall);
 
     if (!methods.containsKey(methodCall.method)) {
-      throw MissingPluginException('No implementation found for method '
-          '${methodCall.method} on channel ${methodChannel.name}');
+      throw MissingPluginException(
+        'No implementation found for method '
+        '${methodCall.method} on channel ${methodChannel.name}',
+      );
     }
 
     return Future<dynamic>.delayed(delay ?? Duration.zero, () {

--- a/packages/camera/camera_android/test/type_conversion_test.dart
+++ b/packages/camera/camera_android/test/type_conversion_test.dart
@@ -10,24 +10,25 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('CameraImageData can be created', () {
-    final CameraImageData cameraImage =
-        cameraImageFromPlatformData(<dynamic, dynamic>{
-      'format': 1,
-      'height': 1,
-      'width': 4,
-      'lensAperture': 1.8,
-      'sensorExposureTime': 9991324,
-      'sensorSensitivity': 92.0,
-      'planes': <dynamic>[
-        <dynamic, dynamic>{
-          'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-          'bytesPerPixel': 1,
-          'bytesPerRow': 4,
-          'height': 1,
-          'width': 4
-        }
-      ]
-    });
+    final CameraImageData cameraImage = cameraImageFromPlatformData(
+      <dynamic, dynamic>{
+        'format': 1,
+        'height': 1,
+        'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
+        'planes': <dynamic>[
+          <dynamic, dynamic>{
+            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+            'bytesPerPixel': 1,
+            'bytesPerRow': 4,
+            'height': 1,
+            'width': 4,
+          },
+        ],
+      },
+    );
     expect(cameraImage.height, 1);
     expect(cameraImage.width, 4);
     expect(cameraImage.format.group, ImageFormatGroup.unknown);
@@ -35,46 +36,48 @@ void main() {
   });
 
   test('CameraImageData has ImageFormatGroup.yuv420', () {
-    final CameraImageData cameraImage =
-        cameraImageFromPlatformData(<dynamic, dynamic>{
-      'format': 35,
-      'height': 1,
-      'width': 4,
-      'lensAperture': 1.8,
-      'sensorExposureTime': 9991324,
-      'sensorSensitivity': 92.0,
-      'planes': <dynamic>[
-        <dynamic, dynamic>{
-          'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-          'bytesPerPixel': 1,
-          'bytesPerRow': 4,
-          'height': 1,
-          'width': 4
-        }
-      ]
-    });
+    final CameraImageData cameraImage = cameraImageFromPlatformData(
+      <dynamic, dynamic>{
+        'format': 35,
+        'height': 1,
+        'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
+        'planes': <dynamic>[
+          <dynamic, dynamic>{
+            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+            'bytesPerPixel': 1,
+            'bytesPerRow': 4,
+            'height': 1,
+            'width': 4,
+          },
+        ],
+      },
+    );
     expect(cameraImage.format.group, ImageFormatGroup.yuv420);
   });
 
   test('CameraImageData has ImageFormatGroup.nv21', () {
-    final CameraImageData cameraImage =
-        cameraImageFromPlatformData(<dynamic, dynamic>{
-      'format': 17,
-      'height': 1,
-      'width': 4,
-      'lensAperture': 1.8,
-      'sensorExposureTime': 9991324,
-      'sensorSensitivity': 92.0,
-      'planes': <dynamic>[
-        <dynamic, dynamic>{
-          'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-          'bytesPerPixel': 1,
-          'bytesPerRow': 4,
-          'height': 1,
-          'width': 4
-        }
-      ]
-    });
+    final CameraImageData cameraImage = cameraImageFromPlatformData(
+      <dynamic, dynamic>{
+        'format': 17,
+        'height': 1,
+        'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
+        'planes': <dynamic>[
+          <dynamic, dynamic>{
+            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+            'bytesPerPixel': 1,
+            'bytesPerRow': 4,
+            'height': 1,
+            'width': 4,
+          },
+        ],
+      },
+    );
     expect(cameraImage.format.group, ImageFormatGroup.nv21);
   });
 }

--- a/packages/camera/camera_android/test/utils_test.dart
+++ b/packages/camera/camera_android/test/utils_test.dart
@@ -11,44 +11,51 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Utility methods', () {
     test(
-        'Should return CameraLensDirection when valid value is supplied when parsing camera lens direction',
-        () {
-      expect(
-        cameraLensDirectionFromPlatform(PlatformCameraLensDirection.back),
-        CameraLensDirection.back,
-      );
-      expect(
-        cameraLensDirectionFromPlatform(PlatformCameraLensDirection.front),
-        CameraLensDirection.front,
-      );
-      expect(
-        cameraLensDirectionFromPlatform(PlatformCameraLensDirection.external),
-        CameraLensDirection.external,
-      );
-    });
+      'Should return CameraLensDirection when valid value is supplied when parsing camera lens direction',
+      () {
+        expect(
+          cameraLensDirectionFromPlatform(PlatformCameraLensDirection.back),
+          CameraLensDirection.back,
+        );
+        expect(
+          cameraLensDirectionFromPlatform(PlatformCameraLensDirection.front),
+          CameraLensDirection.front,
+        );
+        expect(
+          cameraLensDirectionFromPlatform(PlatformCameraLensDirection.external),
+          CameraLensDirection.external,
+        );
+      },
+    );
 
     test('deviceOrientationFromPlatform() should convert correctly', () {
       expect(
-          deviceOrientationFromPlatform(PlatformDeviceOrientation.portraitUp),
-          DeviceOrientation.portraitUp);
+        deviceOrientationFromPlatform(PlatformDeviceOrientation.portraitUp),
+        DeviceOrientation.portraitUp,
+      );
       expect(
-          deviceOrientationFromPlatform(PlatformDeviceOrientation.portraitDown),
-          DeviceOrientation.portraitDown);
+        deviceOrientationFromPlatform(PlatformDeviceOrientation.portraitDown),
+        DeviceOrientation.portraitDown,
+      );
       expect(
-          deviceOrientationFromPlatform(
-              PlatformDeviceOrientation.landscapeRight),
-          DeviceOrientation.landscapeRight);
+        deviceOrientationFromPlatform(PlatformDeviceOrientation.landscapeRight),
+        DeviceOrientation.landscapeRight,
+      );
       expect(
-          deviceOrientationFromPlatform(
-              PlatformDeviceOrientation.landscapeLeft),
-          DeviceOrientation.landscapeLeft);
+        deviceOrientationFromPlatform(PlatformDeviceOrientation.landscapeLeft),
+        DeviceOrientation.landscapeLeft,
+      );
     });
 
     test('exposureModeFromPlatform() should convert correctly', () {
-      expect(exposureModeFromPlatform(PlatformExposureMode.auto),
-          ExposureMode.auto);
-      expect(exposureModeFromPlatform(PlatformExposureMode.locked),
-          ExposureMode.locked);
+      expect(
+        exposureModeFromPlatform(PlatformExposureMode.auto),
+        ExposureMode.auto,
+      );
+      expect(
+        exposureModeFromPlatform(PlatformExposureMode.locked),
+        ExposureMode.locked,
+      );
     });
 
     test('focusModeFromPlatform() should convert correctly', () {

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+
 ## 0.6.20+1
 
 * Updates kotlin version to 2.2.0 to enable gradle 8.11 support.

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+
 ## 0.9.21+1
 
 * Migrates `startImageStream` and `setUpCaptureSessionForAudioIfNeeded` methods to Swift.

--- a/packages/camera/camera_avfoundation/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_avfoundation/example/integration_test/camera_test.dart
@@ -32,13 +32,13 @@ void main() {
 
   final Map<ResolutionPreset, Size> presetExpectedSizes =
       <ResolutionPreset, Size>{
-    ResolutionPreset.low: const Size(288, 352),
-    ResolutionPreset.medium: const Size(480, 640),
-    ResolutionPreset.high: const Size(720, 1280),
-    ResolutionPreset.veryHigh: const Size(1080, 1920),
-    ResolutionPreset.ultraHigh: const Size(2160, 3840),
-    // Don't bother checking for max here since it could be anything.
-  };
+        ResolutionPreset.low: const Size(288, 352),
+        ResolutionPreset.medium: const Size(480, 640),
+        ResolutionPreset.high: const Size(720, 1280),
+        ResolutionPreset.veryHigh: const Size(1080, 1920),
+        ResolutionPreset.ultraHigh: const Size(2160, 3840),
+        // Don't bother checking for max here since it could be anything.
+      };
 
   /// Verify that [actual] has dimensions that are at least as large as
   /// [expectedSize]. Allows for a mismatch in portrait vs landscape. Returns
@@ -54,7 +54,9 @@ void main() {
   // automatic code to fall back to smaller sizes when we need to. Returns
   // whether the image is exactly the desired resolution.
   Future<bool> testCaptureImageResolution(
-      CameraController controller, ResolutionPreset preset) async {
+    CameraController controller,
+    ResolutionPreset preset,
+  ) async {
     final Size expectedSize = presetExpectedSizes[preset]!;
 
     // Take Picture
@@ -67,11 +69,14 @@ void main() {
     // Verify image dimensions are as expected
     expect(image, isNotNull);
     return assertExpectedDimensions(
-        expectedSize, Size(image.height.toDouble(), image.width.toDouble()));
+      expectedSize,
+      Size(image.height.toDouble(), image.width.toDouble()),
+    );
   }
 
-  testWidgets('Capture specific image resolutions',
-      (WidgetTester tester) async {
+  testWidgets('Capture specific image resolutions', (
+    WidgetTester tester,
+  ) async {
     final List<CameraDescription> cameras =
         await CameraPlatform.instance.availableCameras();
     if (cameras.isEmpty) {
@@ -81,13 +86,19 @@ void main() {
       bool previousPresetExactlySupported = true;
       for (final MapEntry<ResolutionPreset, Size> preset
           in presetExpectedSizes.entries) {
-        final CameraController controller =
-            CameraController(cameraDescription, preset.key);
+        final CameraController controller = CameraController(
+          cameraDescription,
+          preset.key,
+        );
         await controller.initialize();
-        final bool presetExactlySupported =
-            await testCaptureImageResolution(controller, preset.key);
-        assert(!(!previousPresetExactlySupported && presetExactlySupported),
-            'The camera took higher resolution pictures at a lower resolution.');
+        final bool presetExactlySupported = await testCaptureImageResolution(
+          controller,
+          preset.key,
+        );
+        assert(
+          !(!previousPresetExactlySupported && presetExactlySupported),
+          'The camera took higher resolution pictures at a lower resolution.',
+        );
         previousPresetExactlySupported = presetExactlySupported;
         await controller.dispose();
       }
@@ -98,7 +109,9 @@ void main() {
   // automatic code to fall back to smaller sizes when we need to. Returns
   // whether the image is exactly the desired resolution.
   Future<bool> testCaptureVideoResolution(
-      CameraController controller, ResolutionPreset preset) async {
+    CameraController controller,
+    ResolutionPreset preset,
+  ) async {
     final Size expectedSize = presetExpectedSizes[preset]!;
 
     // Take Video
@@ -108,19 +121,23 @@ void main() {
 
     // Load video metadata
     final File videoFile = File(file.path);
-    final VideoPlayerController videoController =
-        VideoPlayerController.file(videoFile);
+    final VideoPlayerController videoController = VideoPlayerController.file(
+      videoFile,
+    );
     await videoController.initialize();
     final Size video = videoController.value.size;
 
     // Verify image dimensions are as expected
     expect(video, isNotNull);
     return assertExpectedDimensions(
-        expectedSize, Size(video.height, video.width));
+      expectedSize,
+      Size(video.height, video.width),
+    );
   }
 
-  testWidgets('Capture specific video resolutions',
-      (WidgetTester tester) async {
+  testWidgets('Capture specific video resolutions', (
+    WidgetTester tester,
+  ) async {
     final List<CameraDescription> cameras =
         await CameraPlatform.instance.availableCameras();
     if (cameras.isEmpty) {
@@ -130,14 +147,20 @@ void main() {
       bool previousPresetExactlySupported = true;
       for (final MapEntry<ResolutionPreset, Size> preset
           in presetExpectedSizes.entries) {
-        final CameraController controller =
-            CameraController(cameraDescription, preset.key);
+        final CameraController controller = CameraController(
+          cameraDescription,
+          preset.key,
+        );
         await controller.initialize();
         await controller.prepareForVideoRecording();
-        final bool presetExactlySupported =
-            await testCaptureVideoResolution(controller, preset.key);
-        assert(!(!previousPresetExactlySupported && presetExactlySupported),
-            'The camera took higher resolution pictures at a lower resolution.');
+        final bool presetExactlySupported = await testCaptureVideoResolution(
+          controller,
+          preset.key,
+        );
+        assert(
+          !(!previousPresetExactlySupported && presetExactlySupported),
+          'The camera took higher resolution pictures at a lower resolution.',
+        );
         previousPresetExactlySupported = presetExactlySupported;
         await controller.dispose();
       }
@@ -240,8 +263,10 @@ void main() {
   });
 
   /// Start streaming with specifying the ImageFormatGroup.
-  Future<CameraImageData> startStreaming(List<CameraDescription> cameras,
-      ImageFormatGroup? imageFormatGroup) async {
+  Future<CameraImageData> startStreaming(
+    List<CameraDescription> cameras,
+    ImageFormatGroup? imageFormatGroup,
+  ) async {
     final CameraController controller = CameraController(
       cameras.first,
       ResolutionPreset.low,
@@ -265,31 +290,30 @@ void main() {
     return completer.future;
   }
 
-  testWidgets(
-    'image streaming with imageFormatGroup',
-    (WidgetTester tester) async {
-      final List<CameraDescription> cameras =
-          await CameraPlatform.instance.availableCameras();
-      if (cameras.isEmpty) {
-        return;
-      }
+  testWidgets('image streaming with imageFormatGroup', (
+    WidgetTester tester,
+  ) async {
+    final List<CameraDescription> cameras =
+        await CameraPlatform.instance.availableCameras();
+    if (cameras.isEmpty) {
+      return;
+    }
 
-      CameraImageData image = await startStreaming(cameras, null);
-      expect(image, isNotNull);
-      expect(image.format.group, ImageFormatGroup.bgra8888);
-      expect(image.planes.length, 1);
+    CameraImageData image = await startStreaming(cameras, null);
+    expect(image, isNotNull);
+    expect(image.format.group, ImageFormatGroup.bgra8888);
+    expect(image.planes.length, 1);
 
-      image = await startStreaming(cameras, ImageFormatGroup.yuv420);
-      expect(image, isNotNull);
-      expect(image.format.group, ImageFormatGroup.yuv420);
-      expect(image.planes.length, 2);
+    image = await startStreaming(cameras, ImageFormatGroup.yuv420);
+    expect(image, isNotNull);
+    expect(image.format.group, ImageFormatGroup.yuv420);
+    expect(image.planes.length, 2);
 
-      image = await startStreaming(cameras, ImageFormatGroup.bgra8888);
-      expect(image, isNotNull);
-      expect(image.format.group, ImageFormatGroup.bgra8888);
-      expect(image.planes.length, 1);
-    },
-  );
+    image = await startStreaming(cameras, ImageFormatGroup.bgra8888);
+    expect(image, isNotNull);
+    expect(image.format.group, ImageFormatGroup.bgra8888);
+    expect(image.planes.length, 1);
+  });
 
   testWidgets('Recording with video streaming', (WidgetTester tester) async {
     final List<CameraDescription> cameras =
@@ -308,11 +332,12 @@ void main() {
     await controller.prepareForVideoRecording();
     final Completer<CameraImageData> completer = Completer<CameraImageData>();
     await controller.startVideoRecording(
-        streamCallback: (CameraImageData image) {
-      if (!completer.isCompleted) {
-        completer.complete(image);
-      }
-    });
+      streamCallback: (CameraImageData image) {
+        if (!completer.isCompleted) {
+          completer.complete(image);
+        }
+      },
+    );
     sleep(const Duration(milliseconds: 500));
     await controller.stopVideoRecording();
     await controller.dispose();
@@ -321,8 +346,9 @@ void main() {
   });
 
   // Test fileFormat is respected when taking a picture.
-  testWidgets('Capture specific image output formats',
-      (WidgetTester tester) async {
+  testWidgets('Capture specific image output formats', (
+    WidgetTester tester,
+  ) async {
     final List<CameraDescription> cameras =
         await CameraPlatform.instance.availableCameras();
     if (cameras.isEmpty) {
@@ -330,8 +356,10 @@ void main() {
     }
     for (final CameraDescription cameraDescription in cameras) {
       for (final ImageFileFormat fileFormat in ImageFileFormat.values) {
-        final CameraController controller =
-            CameraController(cameraDescription, ResolutionPreset.low);
+        final CameraController controller = CameraController(
+          cameraDescription,
+          ResolutionPreset.low,
+        );
         await controller.initialize();
         await controller.setImageFileFormat(fileFormat);
         final XFile file = await controller.takePicture();
@@ -375,8 +403,11 @@ void main() {
       }
 
       for (int n = 0; n < lengths.length - 1; n++) {
-        expect(lengths[n], lessThan(lengths[n + 1]),
-            reason: 'incrementing fps should increment file size');
+        expect(
+          lengths[n],
+          lessThan(lengths[n + 1]),
+          reason: 'incrementing fps should increment file size',
+        );
       }
     });
 
@@ -414,8 +445,11 @@ void main() {
       }
 
       for (int n = 0; n < lengths.length - 1; n++) {
-        expect(lengths[n], lessThan(lengths[n + 1]),
-            reason: 'incrementing video bitrate should increment file size');
+        expect(
+          lengths[n],
+          lessThan(lengths[n + 1]),
+          reason: 'incrementing video bitrate should increment file size',
+        );
       }
     });
 
@@ -433,11 +467,12 @@ void main() {
         final CameraController controller = CameraController.withSettings(
           cameras.first,
           mediaSettings: MediaSettings(
-              resolutionPreset: ResolutionPreset.low,
-              fps: 5,
-              videoBitrate: 32000,
-              audioBitrate: audioBitrate,
-              enableAudio: true),
+            resolutionPreset: ResolutionPreset.low,
+            fps: 5,
+            videoBitrate: 32000,
+            audioBitrate: audioBitrate,
+            enableAudio: true,
+          ),
         );
         await controller.initialize();
         await controller.prepareForVideoRecording();
@@ -458,8 +493,11 @@ void main() {
       }
 
       for (int n = 0; n < lengths.length - 1; n++) {
-        expect(lengths[n], lessThan(lengths[n + 1]),
-            reason: 'incrementing audio bitrate should increment file size');
+        expect(
+          lengths[n],
+          lessThan(lengths[n + 1]),
+          reason: 'incrementing audio bitrate should increment file size',
+        );
       }
     });
   });

--- a/packages/camera/camera_avfoundation/example/lib/camera_controller.dart
+++ b/packages/camera/camera_avfoundation/example/lib/camera_controller.dart
@@ -33,19 +33,19 @@ class CameraValue {
 
   /// Creates a new camera controller state for an uninitialized controller.
   const CameraValue.uninitialized(CameraDescription description)
-      : this(
-          isInitialized: false,
-          isRecordingVideo: false,
-          isTakingPicture: false,
-          isStreamingImages: false,
-          isRecordingPaused: false,
-          flashMode: FlashMode.auto,
-          exposureMode: ExposureMode.auto,
-          focusMode: FocusMode.auto,
-          deviceOrientation: DeviceOrientation.portraitUp,
-          isPreviewPaused: false,
-          description: description,
-        );
+    : this(
+        isInitialized: false,
+        isRecordingVideo: false,
+        isTakingPicture: false,
+        isStreamingImages: false,
+        isRecordingPaused: false,
+        flashMode: FlashMode.auto,
+        exposureMode: ExposureMode.auto,
+        focusMode: FocusMode.auto,
+        deviceOrientation: DeviceOrientation.portraitUp,
+        isPreviewPaused: false,
+        description: description,
+      );
 
   /// True after [CameraController.initialize] has completed successfully.
   final bool isInitialized;
@@ -131,17 +131,20 @@ class CameraValue {
       exposureMode: exposureMode ?? this.exposureMode,
       focusMode: focusMode ?? this.focusMode,
       deviceOrientation: deviceOrientation ?? this.deviceOrientation,
-      lockedCaptureOrientation: lockedCaptureOrientation == null
-          ? this.lockedCaptureOrientation
-          : lockedCaptureOrientation.orNull,
-      recordingOrientation: recordingOrientation == null
-          ? this.recordingOrientation
-          : recordingOrientation.orNull,
+      lockedCaptureOrientation:
+          lockedCaptureOrientation == null
+              ? this.lockedCaptureOrientation
+              : lockedCaptureOrientation.orNull,
+      recordingOrientation:
+          recordingOrientation == null
+              ? this.recordingOrientation
+              : recordingOrientation.orNull,
       isPreviewPaused: isPreviewPaused ?? this.isPreviewPaused,
       description: description ?? this.description,
-      previewPauseOrientation: previewPauseOrientation == null
-          ? this.previewPauseOrientation
-          : previewPauseOrientation.orNull,
+      previewPauseOrientation:
+          previewPauseOrientation == null
+              ? this.previewPauseOrientation
+              : previewPauseOrientation.orNull,
     );
   }
 
@@ -176,24 +179,25 @@ class CameraController extends ValueNotifier<CameraValue> {
     ResolutionPreset resolutionPreset, {
     bool enableAudio = true,
     ImageFormatGroup? imageFormatGroup,
-  }) =>
-      CameraController.withSettings(
-        cameraDescription,
-        mediaSettings: MediaSettings(
-          resolutionPreset: resolutionPreset,
-          enableAudio: enableAudio,
-        ),
-        imageFormatGroup: imageFormatGroup,
-      );
+  }) => CameraController.withSettings(
+    cameraDescription,
+    mediaSettings: MediaSettings(
+      resolutionPreset: resolutionPreset,
+      enableAudio: enableAudio,
+    ),
+    imageFormatGroup: imageFormatGroup,
+  );
 
   /// Creates a new camera controller in an uninitialized state, using specified media settings like FPS and bitrate.
   CameraController.withSettings(
     CameraDescription cameraDescription, {
     required this.mediaSettings,
     this.imageFormatGroup,
-  })  : assert(mediaSettings.resolutionPreset != null,
-            'resolutionPreset should be provided in CameraController.withSettings'),
-        super(CameraValue.uninitialized(cameraDescription));
+  }) : assert(
+         mediaSettings.resolutionPreset != null,
+         'resolutionPreset should be provided in CameraController.withSettings',
+       ),
+       super(CameraValue.uninitialized(cameraDescription));
 
   /// The properties of the camera device controlled by this controller.
   CameraDescription get description => value.description;
@@ -212,7 +216,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   StreamSubscription<CameraImageData>? _imageStreamSubscription;
   FutureOr<bool>? _initCalled;
   StreamSubscription<DeviceOrientationChangedEvent>?
-      _deviceOrientationSubscription;
+  _deviceOrientationSubscription;
 
   /// The camera identifier with which the controller is associated.
   int get cameraId => _cameraId;
@@ -227,22 +231,21 @@ class CameraController extends ValueNotifier<CameraValue> {
     _deviceOrientationSubscription = CameraPlatform.instance
         .onDeviceOrientationChanged()
         .listen((DeviceOrientationChangedEvent event) {
-      value = value.copyWith(
-        deviceOrientation: event.orientation,
-      );
-    });
+          value = value.copyWith(deviceOrientation: event.orientation);
+        });
 
     _cameraId = await CameraPlatform.instance.createCameraWithSettings(
       description,
       mediaSettings,
     );
 
-    unawaited(CameraPlatform.instance
-        .onCameraInitialized(_cameraId)
-        .first
-        .then((CameraInitializedEvent event) {
-      initializeCompleter.complete(event);
-    }));
+    unawaited(
+      CameraPlatform.instance.onCameraInitialized(_cameraId).first.then((
+        CameraInitializedEvent event,
+      ) {
+        initializeCompleter.complete(event);
+      }),
+    );
 
     await CameraPlatform.instance.initializeCamera(
       _cameraId,
@@ -252,19 +255,22 @@ class CameraController extends ValueNotifier<CameraValue> {
     value = value.copyWith(
       isInitialized: true,
       description: description,
-      previewSize: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => Size(
-                event.previewWidth,
-                event.previewHeight,
-              )),
-      exposureMode: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => event.exposureMode),
-      focusMode: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => event.focusMode),
-      exposurePointSupported: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => event.exposurePointSupported),
-      focusPointSupported: await initializeCompleter.future
-          .then((CameraInitializedEvent event) => event.focusPointSupported),
+      previewSize: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) =>
+            Size(event.previewWidth, event.previewHeight),
+      ),
+      exposureMode: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) => event.exposureMode,
+      ),
+      focusMode: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) => event.focusMode,
+      ),
+      exposurePointSupported: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) => event.exposurePointSupported,
+      ),
+      focusPointSupported: await initializeCompleter.future.then(
+        (CameraInitializedEvent event) => event.focusPointSupported,
+      ),
     );
 
     _initCalled = true;
@@ -279,17 +285,20 @@ class CameraController extends ValueNotifier<CameraValue> {
   Future<void> pausePreview() async {
     await CameraPlatform.instance.pausePreview(_cameraId);
     value = value.copyWith(
-        isPreviewPaused: true,
-        previewPauseOrientation: Optional<DeviceOrientation>.of(
-            value.lockedCaptureOrientation ?? value.deviceOrientation));
+      isPreviewPaused: true,
+      previewPauseOrientation: Optional<DeviceOrientation>.of(
+        value.lockedCaptureOrientation ?? value.deviceOrientation,
+      ),
+    );
   }
 
   /// Resumes the current camera preview
   Future<void> resumePreview() async {
     await CameraPlatform.instance.resumePreview(_cameraId);
     value = value.copyWith(
-        isPreviewPaused: false,
-        previewPauseOrientation: const Optional<DeviceOrientation>.absent());
+      isPreviewPaused: false,
+      previewPauseOrientation: const Optional<DeviceOrientation>.absent(),
+    );
   }
 
   /// Sets the description of the camera
@@ -314,12 +323,13 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Start streaming images from platform camera.
   Future<void> startImageStream(
-      void Function(CameraImageData image) onAvailable) async {
+    void Function(CameraImageData image) onAvailable,
+  ) async {
     _imageStreamSubscription = CameraPlatform.instance
         .onStreamedFrameAvailable(_cameraId)
         .listen((CameraImageData imageData) {
-      onAvailable(imageData);
-    });
+          onAvailable(imageData);
+        });
     value = value.copyWith(isStreamingImages: true);
   }
 
@@ -334,16 +344,20 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
   /// Throws a [CameraException] if the capture fails.
-  Future<void> startVideoRecording(
-      {void Function(CameraImageData image)? streamCallback}) async {
+  Future<void> startVideoRecording({
+    void Function(CameraImageData image)? streamCallback,
+  }) async {
     await CameraPlatform.instance.startVideoCapturing(
-        VideoCaptureOptions(_cameraId, streamCallback: streamCallback));
+      VideoCaptureOptions(_cameraId, streamCallback: streamCallback),
+    );
     value = value.copyWith(
-        isRecordingVideo: true,
-        isRecordingPaused: false,
-        isStreamingImages: streamCallback != null,
-        recordingOrientation: Optional<DeviceOrientation>.of(
-            value.lockedCaptureOrientation ?? value.deviceOrientation));
+      isRecordingVideo: true,
+      isRecordingPaused: false,
+      isStreamingImages: streamCallback != null,
+      recordingOrientation: Optional<DeviceOrientation>.of(
+        value.lockedCaptureOrientation ?? value.deviceOrientation,
+      ),
+    );
   }
 
   /// Stops the video recording and returns the file where it was saved.
@@ -354,8 +368,9 @@ class CameraController extends ValueNotifier<CameraValue> {
       await stopImageStream();
     }
 
-    final XFile file =
-        await CameraPlatform.instance.stopVideoRecording(_cameraId);
+    final XFile file = await CameraPlatform.instance.stopVideoRecording(
+      _cameraId,
+    );
     value = value.copyWith(
       isRecordingVideo: false,
       recordingOrientation: const Optional<DeviceOrientation>.absent(),
@@ -401,12 +416,12 @@ class CameraController extends ValueNotifier<CameraValue> {
     // Check if offset is in range
     final List<double> range = await Future.wait(<Future<double>>[
       CameraPlatform.instance.getMinExposureOffset(_cameraId),
-      CameraPlatform.instance.getMaxExposureOffset(_cameraId)
+      CameraPlatform.instance.getMaxExposureOffset(_cameraId),
     ]);
 
     // Round to the closest step if needed
-    final double stepSize =
-        await CameraPlatform.instance.getExposureOffsetStepSize(_cameraId);
+    final double stepSize = await CameraPlatform.instance
+        .getExposureOffsetStepSize(_cameraId);
     if (stepSize > 0) {
       final double inv = 1.0 / stepSize;
       double roundedOffset = (offset * inv).roundToDouble() / inv;
@@ -425,18 +440,23 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// If [orientation] is omitted, the current device orientation is used.
   Future<void> lockCaptureOrientation() async {
-    await CameraPlatform.instance
-        .lockCaptureOrientation(_cameraId, value.deviceOrientation);
+    await CameraPlatform.instance.lockCaptureOrientation(
+      _cameraId,
+      value.deviceOrientation,
+    );
     value = value.copyWith(
-        lockedCaptureOrientation:
-            Optional<DeviceOrientation>.of(value.deviceOrientation));
+      lockedCaptureOrientation: Optional<DeviceOrientation>.of(
+        value.deviceOrientation,
+      ),
+    );
   }
 
   /// Unlocks the capture orientation.
   Future<void> unlockCaptureOrientation() async {
     await CameraPlatform.instance.unlockCaptureOrientation(_cameraId);
     value = value.copyWith(
-        lockedCaptureOrientation: const Optional<DeviceOrientation>.absent());
+      lockedCaptureOrientation: const Optional<DeviceOrientation>.absent(),
+    );
   }
 
   /// Sets the focus mode for taking pictures.

--- a/packages/camera/camera_avfoundation/example/lib/camera_preview.dart
+++ b/packages/camera/camera_avfoundation/example/lib/camera_preview.dart
@@ -23,26 +23,25 @@ class CameraPreview extends StatelessWidget {
   Widget build(BuildContext context) {
     return controller.value.isInitialized
         ? ValueListenableBuilder<CameraValue>(
-            valueListenable: controller,
-            builder: (BuildContext context, Object? value, Widget? child) {
-              final double cameraAspectRatio =
-                  controller.value.previewSize!.width /
-                      controller.value.previewSize!.height;
-              return AspectRatio(
-                aspectRatio: _isLandscape()
-                    ? cameraAspectRatio
-                    : (1 / cameraAspectRatio),
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: <Widget>[
-                    _wrapInRotatedBox(child: controller.buildPreview()),
-                    child ?? Container(),
-                  ],
-                ),
-              );
-            },
-            child: child,
-          )
+          valueListenable: controller,
+          builder: (BuildContext context, Object? value, Widget? child) {
+            final double cameraAspectRatio =
+                controller.value.previewSize!.width /
+                controller.value.previewSize!.height;
+            return AspectRatio(
+              aspectRatio:
+                  _isLandscape() ? cameraAspectRatio : (1 / cameraAspectRatio),
+              child: Stack(
+                fit: StackFit.expand,
+                children: <Widget>[
+                  _wrapInRotatedBox(child: controller.buildPreview()),
+                  child ?? Container(),
+                ],
+              ),
+            );
+          },
+          child: child,
+        )
         : Container();
   }
 
@@ -51,16 +50,13 @@ class CameraPreview extends StatelessWidget {
       return child;
     }
 
-    return RotatedBox(
-      quarterTurns: _getQuarterTurns(),
-      child: child,
-    );
+    return RotatedBox(quarterTurns: _getQuarterTurns(), child: child);
   }
 
   bool _isLandscape() {
     return <DeviceOrientation>[
       DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight
+      DeviceOrientation.landscapeRight,
     ].contains(_getApplicableOrientation());
   }
 

--- a/packages/camera/camera_avfoundation/example/lib/main.dart
+++ b/packages/camera/camera_avfoundation/example/lib/main.dart
@@ -130,9 +130,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Camera example'),
-      ),
+      appBar: AppBar(title: const Text('Camera example')),
       body: Column(
         children: <Widget>[
           Expanded(
@@ -149,9 +147,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               child: Padding(
                 padding: const EdgeInsets.all(1.0),
-                child: Center(
-                  child: _cameraPreviewWidget(),
-                ),
+                child: Center(child: _cameraPreviewWidget()),
               ),
             ),
           ),
@@ -160,10 +156,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           Padding(
             padding: const EdgeInsets.all(5.0),
             child: Row(
-              children: <Widget>[
-                _cameraTogglesRowWidget(),
-                _thumbnailWidget(),
-              ],
+              children: <Widget>[_cameraTogglesRowWidget(), _thumbnailWidget()],
             ),
           ),
         ],
@@ -191,15 +184,17 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         child: CameraPreview(
           controller!,
           child: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-            return GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onScaleStart: _handleScaleStart,
-              onScaleUpdate: _handleScaleUpdate,
-              onTapDown: (TapDownDetails details) =>
-                  onViewFinderTap(details, constraints),
-            );
-          }),
+            builder: (BuildContext context, BoxConstraints constraints) {
+              return GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onScaleStart: _handleScaleStart,
+                onScaleUpdate: _handleScaleUpdate,
+                onTapDown:
+                    (TapDownDetails details) =>
+                        onViewFinderTap(details, constraints),
+              );
+            },
+          ),
         ),
       );
     }
@@ -215,11 +210,15 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       return;
     }
 
-    _currentScale = (_baseScale * details.scale)
-        .clamp(_minAvailableZoom, _maxAvailableZoom);
+    _currentScale = (_baseScale * details.scale).clamp(
+      _minAvailableZoom,
+      _maxAvailableZoom,
+    );
 
-    await CameraPlatform.instance
-        .setZoomLevel(controller!.cameraId, _currentScale);
+    await CameraPlatform.instance.setZoomLevel(
+      controller!.cameraId,
+      _currentScale,
+    );
   }
 
   /// Display the thumbnail of the captured image or video.
@@ -238,8 +237,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               SizedBox(
                 width: 64.0,
                 height: 64.0,
-                child: (localVideoController == null)
-                    ? (
+                child:
+                    (localVideoController == null)
+                        ? (
                         // The captured image on the web contains a network-accessible URL
                         // pointing to a location within the browser. It may be displayed
                         // either with Image.network or Image.memory after loading the image
@@ -247,16 +247,18 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                         kIsWeb
                             ? Image.network(imageFile!.path)
                             : Image.file(File(imageFile!.path)))
-                    : Container(
-                        decoration: BoxDecoration(
-                            border: Border.all(color: Colors.pink)),
-                        child: Center(
-                          child: AspectRatio(
+                        : Container(
+                          decoration: BoxDecoration(
+                            border: Border.all(color: Colors.pink),
+                          ),
+                          child: Center(
+                            child: AspectRatio(
                               aspectRatio:
                                   localVideoController.value.aspectRatio,
-                              child: VideoPlayer(localVideoController)),
+                              child: VideoPlayer(localVideoController),
+                            ),
+                          ),
                         ),
-                      ),
               ),
           ],
         ),
@@ -279,20 +281,19 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
             // The exposure and focus mode are currently not supported on the web.
             ...!kIsWeb
                 ? <Widget>[
-                    IconButton(
-                      icon: const Icon(Icons.exposure),
-                      color: Colors.blue,
-                      onPressed: controller != null
-                          ? onExposureModeButtonPressed
-                          : null,
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.filter_center_focus),
-                      color: Colors.blue,
-                      onPressed:
-                          controller != null ? onFocusModeButtonPressed : null,
-                    )
-                  ]
+                  IconButton(
+                    icon: const Icon(Icons.exposure),
+                    color: Colors.blue,
+                    onPressed:
+                        controller != null ? onExposureModeButtonPressed : null,
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.filter_center_focus),
+                    color: Colors.blue,
+                    onPressed:
+                        controller != null ? onFocusModeButtonPressed : null,
+                  ),
+                ]
                 : <Widget>[],
             IconButton(
               icon: Icon(enableAudio ? Icons.volume_up : Icons.volume_mute),
@@ -300,13 +301,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               onPressed: controller != null ? onAudioModeButtonPressed : null,
             ),
             IconButton(
-              icon: Icon(controller?.value.isCaptureOrientationLocked ?? false
-                  ? Icons.screen_lock_rotation
-                  : Icons.screen_rotation),
+              icon: Icon(
+                controller?.value.isCaptureOrientationLocked ?? false
+                    ? Icons.screen_lock_rotation
+                    : Icons.screen_rotation,
+              ),
               color: Colors.blue,
-              onPressed: controller != null
-                  ? onCaptureOrientationLockButtonPressed
-                  : null,
+              onPressed:
+                  controller != null
+                      ? onCaptureOrientationLockButtonPressed
+                      : null,
             ),
           ],
         ),
@@ -326,39 +330,47 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_off),
-              color: controller?.value.flashMode == FlashMode.off
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.off)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.off
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.off)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.flash_auto),
-              color: controller?.value.flashMode == FlashMode.auto
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.auto)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.auto
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.auto)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.flash_on),
-              color: controller?.value.flashMode == FlashMode.always
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.always)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.always
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.always)
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.highlight),
-              color: controller?.value.flashMode == FlashMode.torch
-                  ? Colors.orange
-                  : Colors.blue,
-              onPressed: controller != null
-                  ? () => onSetFlashModeButtonPressed(FlashMode.torch)
-                  : null,
+              color:
+                  controller?.value.flashMode == FlashMode.torch
+                      ? Colors.orange
+                      : Colors.blue,
+              onPressed:
+                  controller != null
+                      ? () => onSetFlashModeButtonPressed(FlashMode.torch)
+                      : null,
             ),
           ],
         ),
@@ -368,14 +380,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _exposureModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
-      foregroundColor: controller?.value.exposureMode == ExposureMode.auto
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.exposureMode == ExposureMode.auto
+              ? Colors.orange
+              : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
-      foregroundColor: controller?.value.exposureMode == ExposureMode.locked
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.exposureMode == ExposureMode.locked
+              ? Colors.orange
+              : Colors.blue,
     );
 
     return SizeTransition(
@@ -385,22 +399,24 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           color: Colors.grey.shade50,
           child: Column(
             children: <Widget>[
-              const Center(
-                child: Text('Exposure Mode'),
-              ),
+              const Center(child: Text('Exposure Mode')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
-                    onPressed: controller != null
-                        ? () =>
-                            onSetExposureModeButtonPressed(ExposureMode.auto)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetExposureModeButtonPressed(
+                              ExposureMode.auto,
+                            )
+                            : null,
                     onLongPress: () {
                       if (controller != null) {
-                        CameraPlatform.instance
-                            .setExposurePoint(controller!.cameraId, null);
+                        CameraPlatform.instance.setExposurePoint(
+                          controller!.cameraId,
+                          null,
+                        );
                         showInSnackBar('Resetting exposure point');
                       }
                     },
@@ -408,24 +424,25 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () =>
-                            onSetExposureModeButtonPressed(ExposureMode.locked)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetExposureModeButtonPressed(
+                              ExposureMode.locked,
+                            )
+                            : null,
                     child: const Text('LOCKED'),
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () => controller!.setExposureOffset(0.0)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => controller!.setExposureOffset(0.0)
+                            : null,
                     child: const Text('RESET OFFSET'),
                   ),
                 ],
               ),
-              const Center(
-                child: Text('Exposure Offset'),
-              ),
+              const Center(child: Text('Exposure Offset')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
@@ -435,10 +452,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                     min: _minAvailableExposureOffset,
                     max: _maxAvailableExposureOffset,
                     label: _currentExposureOffset.toString(),
-                    onChanged: _minAvailableExposureOffset ==
-                            _maxAvailableExposureOffset
-                        ? null
-                        : setExposureOffset,
+                    onChanged:
+                        _minAvailableExposureOffset ==
+                                _maxAvailableExposureOffset
+                            ? null
+                            : setExposureOffset,
                   ),
                   Text(_maxAvailableExposureOffset.toString()),
                 ],
@@ -452,14 +470,16 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _focusModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
-      foregroundColor: controller?.value.focusMode == FocusMode.auto
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.focusMode == FocusMode.auto
+              ? Colors.orange
+              : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
-      foregroundColor: controller?.value.focusMode == FocusMode.locked
-          ? Colors.orange
-          : Colors.blue,
+      foregroundColor:
+          controller?.value.focusMode == FocusMode.locked
+              ? Colors.orange
+              : Colors.blue,
     );
 
     return SizeTransition(
@@ -469,21 +489,22 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           color: Colors.grey.shade50,
           child: Column(
             children: <Widget>[
-              const Center(
-                child: Text('Focus Mode'),
-              ),
+              const Center(child: Text('Focus Mode')),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
-                    onPressed: controller != null
-                        ? () => onSetFocusModeButtonPressed(FocusMode.auto)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () => onSetFocusModeButtonPressed(FocusMode.auto)
+                            : null,
                     onLongPress: () {
                       if (controller != null) {
-                        CameraPlatform.instance
-                            .setFocusPoint(controller!.cameraId, null);
+                        CameraPlatform.instance.setFocusPoint(
+                          controller!.cameraId,
+                          null,
+                        );
                       }
                       showInSnackBar('Resetting focus point');
                     },
@@ -491,9 +512,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed: controller != null
-                        ? () => onSetFocusModeButtonPressed(FocusMode.locked)
-                        : null,
+                    onPressed:
+                        controller != null
+                            ? () =>
+                                onSetFocusModeButtonPressed(FocusMode.locked)
+                            : null,
                     child: const Text('LOCKED'),
                   ),
                 ],
@@ -515,44 +538,49 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         IconButton(
           icon: const Icon(Icons.camera_alt),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  !cameraController.value.isRecordingVideo
-              ? onTakePictureButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      !cameraController.value.isRecordingVideo
+                  ? onTakePictureButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.videocam),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  !cameraController.value.isRecordingVideo
-              ? onVideoRecordButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      !cameraController.value.isRecordingVideo
+                  ? onVideoRecordButtonPressed
+                  : null,
         ),
         IconButton(
-          icon: cameraController != null &&
-                  (!cameraController.value.isRecordingVideo ||
-                      cameraController.value.isRecordingPaused)
-              ? const Icon(Icons.play_arrow)
-              : const Icon(Icons.pause),
+          icon:
+              cameraController != null &&
+                      (!cameraController.value.isRecordingVideo ||
+                          cameraController.value.isRecordingPaused)
+                  ? const Icon(Icons.play_arrow)
+                  : const Icon(Icons.pause),
           color: Colors.blue,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  cameraController.value.isRecordingVideo
-              ? cameraController.value.isRecordingPaused
-                  ? onResumeButtonPressed
-                  : onPauseButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      cameraController.value.isRecordingVideo
+                  ? cameraController.value.isRecordingPaused
+                      ? onResumeButtonPressed
+                      : onPauseButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.stop),
           color: Colors.red,
-          onPressed: cameraController != null &&
-                  cameraController.value.isInitialized &&
-                  cameraController.value.isRecordingVideo
-              ? onStopButtonPressed
-              : null,
+          onPressed:
+              cameraController != null &&
+                      cameraController.value.isInitialized &&
+                      cameraController.value.isRecordingVideo
+                  ? onStopButtonPressed
+                  : null,
         ),
         IconButton(
           icon: const Icon(Icons.pause_presentation),
@@ -593,9 +621,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               title: Icon(getCameraLensIcon(cameraDescription.lensDirection)),
               groupValue: controller?.description,
               value: cameraDescription,
-              onChanged: (controller?.value.isRecordingVideo ?? false)
-                  ? null
-                  : onChanged,
+              onChanged:
+                  (controller?.value.isRecordingVideo ?? false)
+                      ? null
+                      : onChanged,
             ),
           ),
         );
@@ -608,8 +637,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   String timestamp() => DateTime.now().millisecondsSinceEpoch.toString();
 
   void showInSnackBar(String message) {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   void onViewFinderTap(TapDownDetails details, BoxConstraints constraints) {
@@ -636,7 +666,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   }
 
   Future<void> _initializeCameraController(
-      CameraDescription cameraDescription) async {
+    CameraDescription cameraDescription,
+  ) async {
     final CameraController cameraController = CameraController(
       cameraDescription,
       kIsWeb ? ResolutionPreset.max : ResolutionPreset.medium,
@@ -659,14 +690,13 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         // The exposure mode is currently not supported on the web.
         ...!kIsWeb
             ? <Future<Object?>>[
-                CameraPlatform.instance
-                    .getMinExposureOffset(cameraController.cameraId)
-                    .then(
-                        (double value) => _minAvailableExposureOffset = value),
-                CameraPlatform.instance
-                    .getMaxExposureOffset(cameraController.cameraId)
-                    .then((double value) => _maxAvailableExposureOffset = value)
-              ]
+              CameraPlatform.instance
+                  .getMinExposureOffset(cameraController.cameraId)
+                  .then((double value) => _minAvailableExposureOffset = value),
+              CameraPlatform.instance
+                  .getMaxExposureOffset(cameraController.cameraId)
+                  .then((double value) => _maxAvailableExposureOffset = value),
+            ]
             : <Future<Object?>>[],
         CameraPlatform.instance
             .getMaxZoomLevel(cameraController.cameraId)
@@ -768,7 +798,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         } else {
           await cameraController.lockCaptureOrientation();
           showInSnackBar(
-              'Capture orientation locked to ${cameraController.value.lockedCaptureOrientation.toString().split('.').last}');
+            'Capture orientation locked to ${cameraController.value.lockedCaptureOrientation.toString().split('.').last}',
+          );
         }
       }
     } on CameraException catch (e) {
@@ -987,9 +1018,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       return;
     }
 
-    final VideoPlayerController vController = kIsWeb
-        ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
-        : VideoPlayerController.file(File(videoFile!.path));
+    final VideoPlayerController vController =
+        kIsWeb
+            ? VideoPlayerController.networkUrl(Uri.parse(videoFile!.path))
+            : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {
       if (videoController != null) {
@@ -1047,9 +1079,7 @@ class CameraApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: CameraExampleHome(),
-    );
+    return const MaterialApp(home: CameraExampleHome());
   }
 }
 

--- a/packages/camera/camera_avfoundation/example/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the camera plugin.
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   camera_avfoundation:

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -19,7 +19,7 @@ import 'utils.dart';
 class AVFoundationCamera extends CameraPlatform {
   /// Creates a new AVFoundation-based [CameraPlatform] implementation instance.
   AVFoundationCamera({@visibleForTesting CameraApi? api})
-      : _hostApi = api ?? CameraApi();
+    : _hostApi = api ?? CameraApi();
 
   /// Registers this class as the default instance of [CameraPlatform].
   static void registerWith() {
@@ -60,9 +60,9 @@ class AVFoundationCamera extends CameraPlatform {
   // The stream for vending frames to platform interface clients.
   StreamController<CameraImageData>? _frameStreamController;
 
-  Stream<CameraEvent> _cameraEvents(int cameraId) =>
-      cameraEventStreamController.stream
-          .where((CameraEvent event) => event.cameraId == cameraId);
+  Stream<CameraEvent> _cameraEvents(int cameraId) => cameraEventStreamController
+      .stream
+      .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
   Future<List<CameraDescription>> availableCameras() async {
@@ -80,13 +80,10 @@ class AVFoundationCamera extends CameraPlatform {
     CameraDescription cameraDescription,
     ResolutionPreset? resolutionPreset, {
     bool enableAudio = false,
-  }) =>
-      createCameraWithSettings(
-          cameraDescription,
-          MediaSettings(
-            resolutionPreset: resolutionPreset,
-            enableAudio: enableAudio,
-          ));
+  }) => createCameraWithSettings(
+    cameraDescription,
+    MediaSettings(resolutionPreset: resolutionPreset, enableAudio: enableAudio),
+  );
 
   @override
   Future<int> createCameraWithSettings(
@@ -95,15 +92,17 @@ class AVFoundationCamera extends CameraPlatform {
   ) async {
     try {
       return await _hostApi.create(
-          cameraDescription.name,
-          PlatformMediaSettings(
-            resolutionPreset:
-                _pigeonResolutionPreset(mediaSettings?.resolutionPreset),
-            framesPerSecond: mediaSettings?.fps,
-            videoBitrate: mediaSettings?.videoBitrate,
-            audioBitrate: mediaSettings?.audioBitrate,
-            enableAudio: mediaSettings?.enableAudio ?? true,
-          ));
+        cameraDescription.name,
+        PlatformMediaSettings(
+          resolutionPreset: _pigeonResolutionPreset(
+            mediaSettings?.resolutionPreset,
+          ),
+          framesPerSecond: mediaSettings?.fps,
+          videoBitrate: mediaSettings?.videoBitrate,
+          audioBitrate: mediaSettings?.audioBitrate,
+          enableAudio: mediaSettings?.enableAudio ?? true,
+        ),
+      );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -114,24 +113,23 @@ class AVFoundationCamera extends CameraPlatform {
     int cameraId, {
     ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,
   }) async {
-    hostCameraHandlers.putIfAbsent(cameraId,
-        () => HostCameraMessageHandler(cameraId, cameraEventStreamController));
+    hostCameraHandlers.putIfAbsent(
+      cameraId,
+      () => HostCameraMessageHandler(cameraId, cameraEventStreamController),
+    );
 
     final Completer<void> completer = Completer<void>();
 
-    unawaited(onCameraInitialized(cameraId)
-        .first
-        .then((CameraInitializedEvent value) {
-      completer.complete();
-    }));
+    unawaited(
+      onCameraInitialized(cameraId).first.then((CameraInitializedEvent value) {
+        completer.complete();
+      }),
+    );
 
     try {
       await _hostApi.initialize(cameraId, _pigeonImageFormat(imageFormatGroup));
     } on PlatformException catch (e, s) {
-      completer.completeError(
-        CameraException(e.code, e.message),
-        s,
-      );
+      completer.completeError(CameraException(e.code, e.message), s);
     }
 
     return completer.future;
@@ -139,8 +137,9 @@ class AVFoundationCamera extends CameraPlatform {
 
   @override
   Future<void> dispose(int cameraId) async {
-    final HostCameraMessageHandler? handler =
-        hostCameraHandlers.remove(cameraId);
+    final HostCameraMessageHandler? handler = hostCameraHandlers.remove(
+      cameraId,
+    );
     handler?.dispose();
 
     await _hostApi.dispose(cameraId);
@@ -182,8 +181,9 @@ class AVFoundationCamera extends CameraPlatform {
     int cameraId,
     DeviceOrientation orientation,
   ) async {
-    await _hostApi
-        .lockCaptureOrientation(serializeDeviceOrientation(orientation));
+    await _hostApi.lockCaptureOrientation(
+      serializeDeviceOrientation(orientation),
+    );
   }
 
   @override
@@ -203,8 +203,10 @@ class AVFoundationCamera extends CameraPlatform {
   }
 
   @override
-  Future<void> startVideoRecording(int cameraId,
-      {Duration? maxVideoDuration}) async {
+  Future<void> startVideoRecording(
+    int cameraId, {
+    Duration? maxVideoDuration,
+  }) async {
     // Ignore maxVideoDuration, as it is unimplemented and deprecated.
     return startVideoCapturing(VideoCaptureOptions(cameraId));
   }
@@ -241,15 +243,19 @@ class AVFoundationCamera extends CameraPlatform {
   bool supportsImageStreaming() => true;
 
   @override
-  Stream<CameraImageData> onStreamedFrameAvailable(int cameraId,
-      {CameraImageStreamOptions? options}) {
-    _frameStreamController =
-        _createStreamController(onListen: _onFrameStreamListen);
+  Stream<CameraImageData> onStreamedFrameAvailable(
+    int cameraId, {
+    CameraImageStreamOptions? options,
+  }) {
+    _frameStreamController = _createStreamController(
+      onListen: _onFrameStreamListen,
+    );
     return _frameStreamController!.stream;
   }
 
-  StreamController<CameraImageData> _createStreamController(
-      {void Function()? onListen}) {
+  StreamController<CameraImageData> _createStreamController({
+    void Function()? onListen,
+  }) {
     return StreamController<CameraImageData>(
       onListen: onListen ?? () {},
       onPause: _onFrameStreamPauseResume,
@@ -268,18 +274,21 @@ class AVFoundationCamera extends CameraPlatform {
   }
 
   void _startStreamListener() {
-    const EventChannel cameraEventChannel =
-        EventChannel('plugins.flutter.io/camera_avfoundation/imageStream');
-    _platformImageStreamSubscription =
-        cameraEventChannel.receiveBroadcastStream().listen((dynamic imageData) {
-      try {
-        _hostApi.receivedImageStreamData();
-      } on PlatformException catch (e) {
-        throw CameraException(e.code, e.message);
-      }
-      _frameStreamController!
-          .add(cameraImageFromPlatformData(imageData as Map<dynamic, dynamic>));
-    });
+    const EventChannel cameraEventChannel = EventChannel(
+      'plugins.flutter.io/camera_avfoundation/imageStream',
+    );
+    _platformImageStreamSubscription = cameraEventChannel
+        .receiveBroadcastStream()
+        .listen((dynamic imageData) {
+          try {
+            _hostApi.receivedImageStreamData();
+          } on PlatformException catch (e) {
+            throw CameraException(e.code, e.message);
+          }
+          _frameStreamController!.add(
+            cameraImageFromPlatformData(imageData as Map<dynamic, dynamic>),
+          );
+        });
   }
 
   FutureOr<void> _onFrameStreamCancel() async {
@@ -290,8 +299,10 @@ class AVFoundationCamera extends CameraPlatform {
   }
 
   void _onFrameStreamPauseResume() {
-    throw CameraException('InvalidCall',
-        'Pause and resume are not supported for onStreamedFrameAvailable');
+    throw CameraException(
+      'InvalidCall',
+      'Pause and resume are not supported for onStreamedFrameAvailable',
+    );
   }
 
   @override
@@ -381,7 +392,8 @@ class AVFoundationCamera extends CameraPlatform {
 
   @override
   Future<void> setDescriptionWhileRecording(
-      CameraDescription description) async {
+    CameraDescription description,
+  ) async {
     await _hostApi.updateDescriptionWhileRecording(description.name);
   }
 
@@ -452,7 +464,8 @@ class AVFoundationCamera extends CameraPlatform {
 
   /// Returns a [ResolutionPreset]'s Pigeon representation.
   PlatformResolutionPreset _pigeonResolutionPreset(
-      ResolutionPreset? resolutionPreset) {
+    ResolutionPreset? resolutionPreset,
+  ) {
     if (resolutionPreset == null) {
       // Provide a default if one isn't provided, since the native side needs
       // to set something.
@@ -552,8 +565,9 @@ class HostDeviceMessageHandler implements CameraGlobalEventApi {
 
   @override
   void deviceOrientationChanged(PlatformDeviceOrientation orientation) {
-    deviceEventStreamController.add(DeviceOrientationChangedEvent(
-        deviceOrientationFromPlatform(orientation)));
+    deviceEventStreamController.add(
+      DeviceOrientationChangedEvent(deviceOrientationFromPlatform(orientation)),
+    );
   }
 }
 
@@ -585,14 +599,16 @@ class HostCameraMessageHandler implements CameraEventApi {
 
   @override
   void initialized(PlatformCameraState initialState) {
-    streamController.add(CameraInitializedEvent(
-      cameraId,
-      initialState.previewSize.width,
-      initialState.previewSize.height,
-      exposureModeFromPlatform(initialState.exposureMode),
-      initialState.exposurePointSupported,
-      focusModeFromPlatform(initialState.focusMode),
-      initialState.focusPointSupported,
-    ));
+    streamController.add(
+      CameraInitializedEvent(
+        cameraId,
+        initialState.previewSize.width,
+        initialState.previewSize.height,
+        exposureModeFromPlatform(initialState.exposureMode),
+        initialState.exposurePointSupported,
+        focusModeFromPlatform(initialState.focusMode),
+        initialState.focusPointSupported,
+      ),
+    );
   }
 }

--- a/packages/camera/camera_avfoundation/lib/src/messages.g.dart
+++ b/packages/camera/camera_avfoundation/lib/src/messages.g.dart
@@ -18,8 +18,11 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({
+  Object? result,
+  PlatformException? error,
+  bool empty = false,
+}) {
   if (empty) {
     return <Object?>[];
   }
@@ -47,48 +50,21 @@ enum PlatformDeviceOrientation {
   landscapeRight,
 }
 
-enum PlatformExposureMode {
-  auto,
-  locked,
-}
+enum PlatformExposureMode { auto, locked }
 
-enum PlatformFlashMode {
-  off,
-  auto,
-  always,
-  torch,
-}
+enum PlatformFlashMode { off, auto, always, torch }
 
-enum PlatformFocusMode {
-  auto,
-  locked,
-}
+enum PlatformFocusMode { auto, locked }
 
 /// Pigeon version of ImageFileFormat.
-enum PlatformImageFileFormat {
-  jpeg,
-  heif,
-}
+enum PlatformImageFileFormat { jpeg, heif }
 
-enum PlatformImageFormatGroup {
-  bgra8888,
-  yuv420,
-}
+enum PlatformImageFormatGroup { bgra8888, yuv420 }
 
-enum PlatformResolutionPreset {
-  low,
-  medium,
-  high,
-  veryHigh,
-  ultraHigh,
-  max,
-}
+enum PlatformResolutionPreset { low, medium, high, veryHigh, ultraHigh, max }
 
 class PlatformCameraDescription {
-  PlatformCameraDescription({
-    required this.name,
-    required this.lensDirection,
-  });
+  PlatformCameraDescription({required this.name, required this.lensDirection});
 
   /// The name of the camera device.
   String name;
@@ -97,10 +73,7 @@ class PlatformCameraDescription {
   PlatformCameraLensDirection lensDirection;
 
   Object encode() {
-    return <Object?>[
-      name,
-      lensDirection,
-    ];
+    return <Object?>[name, lensDirection];
   }
 
   static PlatformCameraDescription decode(Object result) {
@@ -200,46 +173,31 @@ class PlatformMediaSettings {
 }
 
 class PlatformPoint {
-  PlatformPoint({
-    required this.x,
-    required this.y,
-  });
+  PlatformPoint({required this.x, required this.y});
 
   double x;
 
   double y;
 
   Object encode() {
-    return <Object?>[
-      x,
-      y,
-    ];
+    return <Object?>[x, y];
   }
 
   static PlatformPoint decode(Object result) {
     result as List<Object?>;
-    return PlatformPoint(
-      x: result[0]! as double,
-      y: result[1]! as double,
-    );
+    return PlatformPoint(x: result[0]! as double, y: result[1]! as double);
   }
 }
 
 class PlatformSize {
-  PlatformSize({
-    required this.width,
-    required this.height,
-  });
+  PlatformSize({required this.width, required this.height});
 
   double width;
 
   double height;
 
   Object encode() {
-    return <Object?>[
-      width,
-      height,
-    ];
+    return <Object?>[width, height];
   }
 
   static PlatformSize decode(Object result) {
@@ -349,11 +307,12 @@ class CameraApi {
   /// Constructor for [CameraApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  CameraApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  CameraApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix =
+           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -366,10 +325,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.getAvailableCameras$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -397,12 +356,13 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.create$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[cameraName, settings]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[cameraName, settings])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -423,17 +383,20 @@ class CameraApi {
 
   /// Initializes the camera with the given ID.
   Future<void> initialize(
-      int cameraId, PlatformImageFormatGroup imageFormat) async {
+    int cameraId,
+    PlatformImageFormatGroup imageFormat,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.initialize$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[cameraId, imageFormat]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[cameraId, imageFormat])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -453,10 +416,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.startImageStream$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -478,10 +441,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.stopImageStream$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -506,10 +469,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.receivedImageStreamData$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -532,10 +495,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.dispose$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraId]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -553,15 +516,16 @@ class CameraApi {
 
   /// Locks the camera capture to the current device orientation.
   Future<void> lockCaptureOrientation(
-      PlatformDeviceOrientation orientation) async {
+    PlatformDeviceOrientation orientation,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.lockCaptureOrientation$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[orientation]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -584,10 +548,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.unlockCaptureOrientation$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -610,10 +574,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.takePicture$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -640,10 +604,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.prepareForVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -666,10 +630,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.startVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[enableStream]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -691,10 +655,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.stopVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -721,10 +685,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.pauseVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -746,10 +710,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.resumeVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -771,10 +735,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.setFlashMode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[mode]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -796,10 +760,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.setExposureMode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[mode]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -823,10 +787,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.setExposurePoint$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[point]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -848,10 +812,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.getMinExposureOffset$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -878,10 +842,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.getMaxExposureOffset$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -908,10 +872,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.setExposureOffset$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[offset]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -933,10 +897,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.setFocusMode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[mode]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -960,10 +924,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.setFocusPoint$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[point]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -985,10 +949,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.getMinZoomLevel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1015,10 +979,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.getMaxZoomLevel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1045,10 +1009,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.setZoomLevel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[zoom]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1070,10 +1034,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.pausePreview$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1095,10 +1059,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.resumePreview$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1122,10 +1086,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.updateDescriptionWhileRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraName]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1147,10 +1111,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_avfoundation.CameraApi.setImageFileFormat$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[format]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -1182,23 +1146,27 @@ abstract class CameraGlobalEventApi {
     messageChannelSuffix =
         messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_avfoundation.CameraGlobalEventApi.deviceOrientationChanged$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_avfoundation.CameraGlobalEventApi.deviceOrientationChanged$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.camera_avfoundation.CameraGlobalEventApi.deviceOrientationChanged was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.camera_avfoundation.CameraGlobalEventApi.deviceOrientationChanged was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final PlatformDeviceOrientation? arg_orientation =
               (args[0] as PlatformDeviceOrientation?);
-          assert(arg_orientation != null,
-              'Argument for dev.flutter.pigeon.camera_avfoundation.CameraGlobalEventApi.deviceOrientationChanged was null, expected non-null PlatformDeviceOrientation.');
+          assert(
+            arg_orientation != null,
+            'Argument for dev.flutter.pigeon.camera_avfoundation.CameraGlobalEventApi.deviceOrientationChanged was null, expected non-null PlatformDeviceOrientation.',
+          );
           try {
             api.deviceOrientationChanged(arg_orientation!);
             return wrapResponse(empty: true);
@@ -1206,7 +1174,8 @@ abstract class CameraGlobalEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1237,23 +1206,27 @@ abstract class CameraEventApi {
     messageChannelSuffix =
         messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_avfoundation.CameraEventApi.initialized$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_avfoundation.CameraEventApi.initialized$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.camera_avfoundation.CameraEventApi.initialized was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.camera_avfoundation.CameraEventApi.initialized was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final PlatformCameraState? arg_initialState =
               (args[0] as PlatformCameraState?);
-          assert(arg_initialState != null,
-              'Argument for dev.flutter.pigeon.camera_avfoundation.CameraEventApi.initialized was null, expected non-null PlatformCameraState.');
+          assert(
+            arg_initialState != null,
+            'Argument for dev.flutter.pigeon.camera_avfoundation.CameraEventApi.initialized was null, expected non-null PlatformCameraState.',
+          );
           try {
             api.initialized(arg_initialState!);
             return wrapResponse(empty: true);
@@ -1261,28 +1234,33 @@ abstract class CameraEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_avfoundation.CameraEventApi.error$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_avfoundation.CameraEventApi.error$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.camera_avfoundation.CameraEventApi.error was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.camera_avfoundation.CameraEventApi.error was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_message = (args[0] as String?);
-          assert(arg_message != null,
-              'Argument for dev.flutter.pigeon.camera_avfoundation.CameraEventApi.error was null, expected non-null String.');
+          assert(
+            arg_message != null,
+            'Argument for dev.flutter.pigeon.camera_avfoundation.CameraEventApi.error was null, expected non-null String.',
+          );
           try {
             api.error(arg_message!);
             return wrapResponse(empty: true);
@@ -1290,7 +1268,8 @@ abstract class CameraEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }

--- a/packages/camera/camera_avfoundation/lib/src/type_conversion.dart
+++ b/packages/camera/camera_avfoundation/lib/src/type_conversion.dart
@@ -10,16 +10,20 @@ import 'package:camera_platform_interface/camera_platform_interface.dart';
 /// [CameraImageData].
 CameraImageData cameraImageFromPlatformData(Map<dynamic, dynamic> data) {
   return CameraImageData(
-      format: _cameraImageFormatFromPlatformData(data['format']),
-      height: data['height'] as int,
-      width: data['width'] as int,
-      lensAperture: data['lensAperture'] as double?,
-      sensorExposureTime: data['sensorExposureTime'] as int?,
-      sensorSensitivity: data['sensorSensitivity'] as double?,
-      planes: List<CameraImagePlane>.unmodifiable(
-          (data['planes'] as List<dynamic>).map<CameraImagePlane>(
-              (dynamic planeData) => _cameraImagePlaneFromPlatformData(
-                  planeData as Map<dynamic, dynamic>))));
+    format: _cameraImageFormatFromPlatformData(data['format']),
+    height: data['height'] as int,
+    width: data['width'] as int,
+    lensAperture: data['lensAperture'] as double?,
+    sensorExposureTime: data['sensorExposureTime'] as int?,
+    sensorSensitivity: data['sensorSensitivity'] as double?,
+    planes: List<CameraImagePlane>.unmodifiable(
+      (data['planes'] as List<dynamic>).map<CameraImagePlane>(
+        (dynamic planeData) => _cameraImagePlaneFromPlatformData(
+          planeData as Map<dynamic, dynamic>,
+        ),
+      ),
+    ),
+  );
 }
 
 CameraImageFormat _cameraImageFormatFromPlatformData(dynamic data) {
@@ -40,9 +44,10 @@ ImageFormatGroup _imageFormatGroupFromPlatformData(dynamic data) {
 
 CameraImagePlane _cameraImagePlaneFromPlatformData(Map<dynamic, dynamic> data) {
   return CameraImagePlane(
-      bytes: data['bytes'] as Uint8List,
-      bytesPerPixel: data['bytesPerPixel'] as int?,
-      bytesPerRow: data['bytesPerRow'] as int,
-      height: data['height'] as int?,
-      width: data['width'] as int?);
+    bytes: data['bytes'] as Uint8List,
+    bytesPerPixel: data['bytesPerPixel'] as int?,
+    bytesPerRow: data['bytesPerRow'] as int,
+    height: data['height'] as int?,
+    width: data['width'] as int?,
+  );
 }

--- a/packages/camera/camera_avfoundation/lib/src/utils.dart
+++ b/packages/camera/camera_avfoundation/lib/src/utils.dart
@@ -9,16 +9,19 @@ import 'messages.g.dart';
 
 /// Creates a [CameraDescription] from a Pigeon [PlatformCameraDescription].
 CameraDescription cameraDescriptionFromPlatform(
-    PlatformCameraDescription camera) {
+  PlatformCameraDescription camera,
+) {
   return CameraDescription(
-      name: camera.name,
-      lensDirection: cameraLensDirectionFromPlatform(camera.lensDirection),
-      sensorOrientation: 90);
+    name: camera.name,
+    lensDirection: cameraLensDirectionFromPlatform(camera.lensDirection),
+    sensorOrientation: 90,
+  );
 }
 
 /// Converts a Pigeon [PlatformCameraLensDirection] to a [CameraLensDirection].
 CameraLensDirection cameraLensDirectionFromPlatform(
-    PlatformCameraLensDirection direction) {
+  PlatformCameraLensDirection direction,
+) {
   return switch (direction) {
     PlatformCameraLensDirection.front => CameraLensDirection.front,
     PlatformCameraLensDirection.back => CameraLensDirection.back,
@@ -28,7 +31,8 @@ CameraLensDirection cameraLensDirectionFromPlatform(
 
 /// Convents the given device orientation to Pigeon.
 PlatformDeviceOrientation serializeDeviceOrientation(
-    DeviceOrientation orientation) {
+  DeviceOrientation orientation,
+) {
   switch (orientation) {
     case DeviceOrientation.portraitUp:
       return PlatformDeviceOrientation.portraitUp;
@@ -50,7 +54,8 @@ PlatformDeviceOrientation serializeDeviceOrientation(
 
 /// Converts a Pigeon [PlatformDeviceOrientation] to a [DeviceOrientation].
 DeviceOrientation deviceOrientationFromPlatform(
-    PlatformDeviceOrientation orientation) {
+  PlatformDeviceOrientation orientation,
+) {
   return switch (orientation) {
     PlatformDeviceOrientation.portraitUp => DeviceOrientation.portraitUp,
     PlatformDeviceOrientation.portraitDown => DeviceOrientation.portraitDown,

--- a/packages/camera/camera_avfoundation/pigeons/messages.dart
+++ b/packages/camera/camera_avfoundation/pigeons/messages.dart
@@ -4,19 +4,20 @@
 
 import 'package:pigeon/pigeon.dart';
 
-@ConfigurePigeon(PigeonOptions(
-  dartOut: 'lib/src/messages.g.dart',
-  objcHeaderOut:
-      'ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/messages.g.h',
-  objcSourceOut:
-      'ios/camera_avfoundation/Sources/camera_avfoundation_objc/messages.g.m',
-  objcOptions: ObjcOptions(
-    prefix: 'FCP',
-    headerIncludePath: './include/camera_avfoundation/messages.g.h',
+@ConfigurePigeon(
+  PigeonOptions(
+    dartOut: 'lib/src/messages.g.dart',
+    objcHeaderOut:
+        'ios/camera_avfoundation/Sources/camera_avfoundation_objc/include/camera_avfoundation/messages.g.h',
+    objcSourceOut:
+        'ios/camera_avfoundation/Sources/camera_avfoundation_objc/messages.g.m',
+    objcOptions: ObjcOptions(
+      prefix: 'FCP',
+      headerIncludePath: './include/camera_avfoundation/messages.g.h',
+    ),
+    copyrightHeader: 'pigeons/copyright.txt',
   ),
-  copyrightHeader: 'pigeons/copyright.txt',
-))
-
+)
 // Pigeon version of CameraLensDirection.
 enum PlatformCameraLensDirection {
   /// Front facing camera (a user looking at the screen is seen by the camera).
@@ -38,53 +39,26 @@ enum PlatformDeviceOrientation {
 }
 
 // Pigeon version of ExposureMode.
-enum PlatformExposureMode {
-  auto,
-  locked,
-}
+enum PlatformExposureMode { auto, locked }
 
 // Pigeon version of FlashMode.
-enum PlatformFlashMode {
-  off,
-  auto,
-  always,
-  torch,
-}
+enum PlatformFlashMode { off, auto, always, torch }
 
 // Pigeon version of FocusMode.
-enum PlatformFocusMode {
-  auto,
-  locked,
-}
+enum PlatformFocusMode { auto, locked }
 
 /// Pigeon version of ImageFileFormat.
-enum PlatformImageFileFormat {
-  jpeg,
-  heif,
-}
+enum PlatformImageFileFormat { jpeg, heif }
 
 // Pigeon version of the subset of ImageFormatGroup supported on iOS.
-enum PlatformImageFormatGroup {
-  bgra8888,
-  yuv420,
-}
+enum PlatformImageFormatGroup { bgra8888, yuv420 }
 
 // Pigeon version of ResolutionPreset.
-enum PlatformResolutionPreset {
-  low,
-  medium,
-  high,
-  veryHigh,
-  ultraHigh,
-  max,
-}
+enum PlatformResolutionPreset { low, medium, high, veryHigh, ultraHigh, max }
 
 // Pigeon version of CameraDescription.
 class PlatformCameraDescription {
-  PlatformCameraDescription({
-    required this.name,
-    required this.lensDirection,
-  });
+  PlatformCameraDescription({required this.name, required this.lensDirection});
 
   /// The name of the camera device.
   final String name;

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.9.21+1
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -38,15 +38,17 @@ void main() {
       // Act
       final int cameraId = await camera.createCamera(
         const CameraDescription(
-            name: cameraName,
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0),
+          name: cameraName,
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 0,
+        ),
         ResolutionPreset.high,
       );
 
       // Assert
-      final VerificationResult verification =
-          verify(mockApi.create(captureAny, captureAny));
+      final VerificationResult verification = verify(
+        mockApi.create(captureAny, captureAny),
+      );
       expect(verification.captured[0], cameraName);
       final PlatformMediaSettings? settings =
           verification.captured[1] as PlatformMediaSettings?;
@@ -56,76 +58,88 @@ void main() {
     });
 
     test(
-        'Should send creation data and receive back a camera id using createCameraWithSettings',
-        () async {
-      // Arrange
-      final MockCameraApi mockApi = MockCameraApi();
-      when(mockApi.create(any, any)).thenAnswer((_) async => 1);
-      final AVFoundationCamera camera = AVFoundationCamera(api: mockApi);
-      const String cameraName = 'Test';
-      const int fps = 15;
-      const int videoBitrate = 200000;
-      const int audioBitrate = 32000;
+      'Should send creation data and receive back a camera id using createCameraWithSettings',
+      () async {
+        // Arrange
+        final MockCameraApi mockApi = MockCameraApi();
+        when(mockApi.create(any, any)).thenAnswer((_) async => 1);
+        final AVFoundationCamera camera = AVFoundationCamera(api: mockApi);
+        const String cameraName = 'Test';
+        const int fps = 15;
+        const int videoBitrate = 200000;
+        const int audioBitrate = 32000;
 
-      // Act
-      final int cameraId = await camera.createCameraWithSettings(
-        const CameraDescription(
-            name: cameraName,
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0),
-        const MediaSettings(
-          resolutionPreset: ResolutionPreset.low,
-          fps: fps,
-          videoBitrate: videoBitrate,
-          audioBitrate: audioBitrate,
-          enableAudio: true,
-        ),
-      );
-
-      // Assert
-      final VerificationResult verification =
-          verify(mockApi.create(captureAny, captureAny));
-      expect(verification.captured[0], cameraName);
-      final PlatformMediaSettings? settings =
-          verification.captured[1] as PlatformMediaSettings?;
-      expect(settings, isNotNull);
-      expect(settings?.resolutionPreset, PlatformResolutionPreset.low);
-      expect(settings?.framesPerSecond, fps);
-      expect(settings?.videoBitrate, videoBitrate);
-      expect(settings?.audioBitrate, audioBitrate);
-      expect(settings?.enableAudio, true);
-      expect(cameraId, 1);
-    });
-
-    test('Should throw CameraException when create throws a PlatformException',
-        () {
-      // Arrange
-      const String exceptionCode = 'TESTING_ERROR_CODE';
-      const String exceptionMessage = 'Mock error message used during testing.';
-      final MockCameraApi mockApi = MockCameraApi();
-      when(mockApi.create(any, any)).thenAnswer((_) async {
-        throw PlatformException(code: exceptionCode, message: exceptionMessage);
-      });
-      final AVFoundationCamera camera = AVFoundationCamera(api: mockApi);
-
-      // Act
-      expect(
-        () => camera.createCamera(
+        // Act
+        final int cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
-            name: 'Test',
+            name: cameraName,
             lensDirection: CameraLensDirection.back,
             sensorOrientation: 0,
           ),
-          ResolutionPreset.high,
-        ),
-        throwsA(
-          isA<CameraException>()
-              .having((CameraException e) => e.code, 'code', exceptionCode)
-              .having((CameraException e) => e.description, 'description',
-                  exceptionMessage),
-        ),
-      );
-    });
+          const MediaSettings(
+            resolutionPreset: ResolutionPreset.low,
+            fps: fps,
+            videoBitrate: videoBitrate,
+            audioBitrate: audioBitrate,
+            enableAudio: true,
+          ),
+        );
+
+        // Assert
+        final VerificationResult verification = verify(
+          mockApi.create(captureAny, captureAny),
+        );
+        expect(verification.captured[0], cameraName);
+        final PlatformMediaSettings? settings =
+            verification.captured[1] as PlatformMediaSettings?;
+        expect(settings, isNotNull);
+        expect(settings?.resolutionPreset, PlatformResolutionPreset.low);
+        expect(settings?.framesPerSecond, fps);
+        expect(settings?.videoBitrate, videoBitrate);
+        expect(settings?.audioBitrate, audioBitrate);
+        expect(settings?.enableAudio, true);
+        expect(cameraId, 1);
+      },
+    );
+
+    test(
+      'Should throw CameraException when create throws a PlatformException',
+      () {
+        // Arrange
+        const String exceptionCode = 'TESTING_ERROR_CODE';
+        const String exceptionMessage =
+            'Mock error message used during testing.';
+        final MockCameraApi mockApi = MockCameraApi();
+        when(mockApi.create(any, any)).thenAnswer((_) async {
+          throw PlatformException(
+            code: exceptionCode,
+            message: exceptionMessage,
+          );
+        });
+        final AVFoundationCamera camera = AVFoundationCamera(api: mockApi);
+
+        // Act
+        expect(
+          () => camera.createCamera(
+            const CameraDescription(
+              name: 'Test',
+              lensDirection: CameraLensDirection.back,
+              sensorOrientation: 0,
+            ),
+            ResolutionPreset.high,
+          ),
+          throwsA(
+            isA<CameraException>()
+                .having((CameraException e) => e.code, 'code', exceptionCode)
+                .having(
+                  (CameraException e) => e.description,
+                  'description',
+                  exceptionMessage,
+                ),
+          ),
+        );
+      },
+    );
 
     test(
       'Should throw CameraException when initialize throws a PlatformException',
@@ -137,7 +151,9 @@ void main() {
         final MockCameraApi mockApi = MockCameraApi();
         when(mockApi.initialize(any, any)).thenAnswer((_) async {
           throw PlatformException(
-              code: exceptionCode, message: exceptionMessage);
+            code: exceptionCode,
+            message: exceptionMessage,
+          );
         });
         final AVFoundationCamera camera = AVFoundationCamera(api: mockApi);
 
@@ -147,7 +163,10 @@ void main() {
           throwsA(
             isA<CameraException>()
                 .having(
-                    (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
+                  (CameraException e) => e.code,
+                  'code',
+                  'TESTING_ERROR_CODE',
+                )
                 .having(
                   (CameraException e) => e.description,
                   'description',
@@ -173,20 +192,23 @@ void main() {
 
       // Act
       final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-      camera.cameraEventStreamController.add(CameraInitializedEvent(
-        cameraId,
-        1920,
-        1080,
-        ExposureMode.auto,
-        true,
-        FocusMode.auto,
-        true,
-      ));
+      camera.cameraEventStreamController.add(
+        CameraInitializedEvent(
+          cameraId,
+          1920,
+          1080,
+          ExposureMode.auto,
+          true,
+          FocusMode.auto,
+          true,
+        ),
+      );
       await initializeFuture;
 
       // Assert
-      final VerificationResult verification =
-          verify(mockApi.initialize(captureAny, captureAny));
+      final VerificationResult verification = verify(
+        mockApi.initialize(captureAny, captureAny),
+      );
       expect(verification.captured[0], cameraId);
       // The default when unspecified should be bgra8888.
       expect(verification.captured[1], PlatformImageFormatGroup.bgra8888);
@@ -205,23 +227,26 @@ void main() {
         ResolutionPreset.high,
       );
       final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-      camera.cameraEventStreamController.add(CameraInitializedEvent(
-        cameraId,
-        1920,
-        1080,
-        ExposureMode.auto,
-        true,
-        FocusMode.auto,
-        true,
-      ));
+      camera.cameraEventStreamController.add(
+        CameraInitializedEvent(
+          cameraId,
+          1920,
+          1080,
+          ExposureMode.auto,
+          true,
+          FocusMode.auto,
+          true,
+        ),
+      );
       await initializeFuture;
 
       // Act
       await camera.dispose(cameraId);
 
       // Assert
-      final VerificationResult verification =
-          verify(mockApi.dispose(captureAny));
+      final VerificationResult verification = verify(
+        mockApi.dispose(captureAny),
+      );
       expect(verification.captured[0], cameraId);
     });
   });
@@ -242,22 +267,24 @@ void main() {
         ResolutionPreset.high,
       );
       final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-      camera.cameraEventStreamController.add(CameraInitializedEvent(
-        cameraId,
-        1920,
-        1080,
-        ExposureMode.auto,
-        true,
-        FocusMode.auto,
-        true,
-      ));
+      camera.cameraEventStreamController.add(
+        CameraInitializedEvent(
+          cameraId,
+          1920,
+          1080,
+          ExposureMode.auto,
+          true,
+          FocusMode.auto,
+          true,
+        ),
+      );
       await initializeFuture;
     });
 
     test('Should receive initialized event', () async {
       // Act
-      final Stream<CameraInitializedEvent> eventStream =
-          camera.onCameraInitialized(cameraId);
+      final Stream<CameraInitializedEvent> eventStream = camera
+          .onCameraInitialized(cameraId);
       final StreamQueue<CameraInitializedEvent> streamQueue =
           StreamQueue<CameraInitializedEvent>(eventStream);
 
@@ -272,13 +299,15 @@ void main() {
         FocusMode.auto,
         true,
       );
-      camera.hostCameraHandlers[cameraId]!.initialized(PlatformCameraState(
-        previewSize: previewSize,
-        exposureMode: PlatformExposureMode.auto,
-        focusMode: PlatformFocusMode.auto,
-        exposurePointSupported: true,
-        focusPointSupported: true,
-      ));
+      camera.hostCameraHandlers[cameraId]!.initialized(
+        PlatformCameraState(
+          previewSize: previewSize,
+          exposureMode: PlatformExposureMode.auto,
+          focusMode: PlatformFocusMode.auto,
+          exposurePointSupported: true,
+          focusPointSupported: true,
+        ),
+      );
 
       // Assert
       expect(await streamQueue.next, event);
@@ -289,8 +318,9 @@ void main() {
 
     test('Should receive camera error events', () async {
       // Act
-      final Stream<CameraErrorEvent> errorStream =
-          camera.onCameraError(cameraId);
+      final Stream<CameraErrorEvent> errorStream = camera.onCameraError(
+        cameraId,
+      );
       final StreamQueue<CameraErrorEvent> streamQueue =
           StreamQueue<CameraErrorEvent>(errorStream);
 
@@ -318,11 +348,13 @@ void main() {
           StreamQueue<DeviceOrientationChangedEvent>(eventStream);
 
       // Emit test events
-      const DeviceOrientationChangedEvent event =
-          DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
+      const DeviceOrientationChangedEvent event = DeviceOrientationChangedEvent(
+        DeviceOrientation.portraitUp,
+      );
       for (int i = 0; i < 3; i++) {
-        camera.hostHandler
-            .deviceOrientationChanged(PlatformDeviceOrientation.portraitUp);
+        camera.hostHandler.deviceOrientationChanged(
+          PlatformDeviceOrientation.portraitUp,
+        );
       }
 
       // Assert
@@ -367,47 +399,60 @@ void main() {
       await initializeFuture;
     });
 
-    test('Should fetch CameraDescription instances for available cameras',
-        () async {
-      final List<PlatformCameraDescription> returnData =
-          <PlatformCameraDescription>[
-        PlatformCameraDescription(
-            name: 'Test 1', lensDirection: PlatformCameraLensDirection.front),
-        PlatformCameraDescription(
-            name: 'Test 2', lensDirection: PlatformCameraLensDirection.back),
-      ];
-      when(mockApi.getAvailableCameras()).thenAnswer((_) async => returnData);
+    test(
+      'Should fetch CameraDescription instances for available cameras',
+      () async {
+        final List<PlatformCameraDescription> returnData =
+            <PlatformCameraDescription>[
+              PlatformCameraDescription(
+                name: 'Test 1',
+                lensDirection: PlatformCameraLensDirection.front,
+              ),
+              PlatformCameraDescription(
+                name: 'Test 2',
+                lensDirection: PlatformCameraLensDirection.back,
+              ),
+            ];
+        when(mockApi.getAvailableCameras()).thenAnswer((_) async => returnData);
 
-      final List<CameraDescription> cameras = await camera.availableCameras();
+        final List<CameraDescription> cameras = await camera.availableCameras();
 
-      expect(cameras.length, returnData.length);
-      for (int i = 0; i < returnData.length; i++) {
-        expect(cameras[i].name, returnData[i].name);
-        expect(cameras[i].lensDirection,
-            cameraLensDirectionFromPlatform(returnData[i].lensDirection));
-        // This value isn't provided by the platform, so is hard-coded to 90.
-        expect(cameras[i].sensorOrientation, 90);
-      }
-    });
+        expect(cameras.length, returnData.length);
+        for (int i = 0; i < returnData.length; i++) {
+          expect(cameras[i].name, returnData[i].name);
+          expect(
+            cameras[i].lensDirection,
+            cameraLensDirectionFromPlatform(returnData[i].lensDirection),
+          );
+          // This value isn't provided by the platform, so is hard-coded to 90.
+          expect(cameras[i].sensorOrientation, 90);
+        }
+      },
+    );
 
     test(
-        'Should throw CameraException when availableCameras throws a PlatformException',
-        () {
-      const String code = 'TESTING_ERROR_CODE';
-      const String message = 'Mock error message used during testing.';
-      when(mockApi.getAvailableCameras()).thenAnswer(
-          (_) async => throw PlatformException(code: code, message: message));
+      'Should throw CameraException when availableCameras throws a PlatformException',
+      () {
+        const String code = 'TESTING_ERROR_CODE';
+        const String message = 'Mock error message used during testing.';
+        when(mockApi.getAvailableCameras()).thenAnswer(
+          (_) async => throw PlatformException(code: code, message: message),
+        );
 
-      expect(
-        camera.availableCameras,
-        throwsA(
-          isA<CameraException>()
-              .having((CameraException e) => e.code, 'code', code)
-              .having(
-                  (CameraException e) => e.description, 'description', message),
-        ),
-      );
-    });
+        expect(
+          camera.availableCameras,
+          throwsA(
+            isA<CameraException>()
+                .having((CameraException e) => e.code, 'code', code)
+                .having(
+                  (CameraException e) => e.description,
+                  'description',
+                  message,
+                ),
+          ),
+        );
+      },
+    );
 
     test('Should take a picture and return an XFile instance', () async {
       const String stubPath = '/test/path.jpg';
@@ -431,13 +476,18 @@ void main() {
     });
 
     test(
-        'Should pass enableStream if callback is passed when starting recording a video',
-        () async {
-      await camera.startVideoCapturing(VideoCaptureOptions(cameraId,
-          streamCallback: (CameraImageData imageData) {}));
+      'Should pass enableStream if callback is passed when starting recording a video',
+      () async {
+        await camera.startVideoCapturing(
+          VideoCaptureOptions(
+            cameraId,
+            streamCallback: (CameraImageData imageData) {},
+          ),
+        );
 
-      verify(mockApi.startVideoRecording(true));
-    });
+        verify(mockApi.startVideoRecording(true));
+      },
+    );
 
     test('Should stop a video recording and return the file', () async {
       const String stubPath = '/test/path.mp4';
@@ -462,9 +512,10 @@ void main() {
 
     test('Should set the description while recording', () async {
       const CameraDescription camera2Description = CameraDescription(
-          name: 'Test2',
-          lensDirection: CameraLensDirection.front,
-          sensorOrientation: 0);
+        name: 'Test2',
+        lensDirection: CameraLensDirection.front,
+        sensorOrientation: 0,
+      );
 
       await camera.setDescriptionWhileRecording(camera2Description);
 
@@ -511,8 +562,9 @@ void main() {
       const Point<double> point = Point<double>(0.4, 0.6);
       await camera.setExposurePoint(cameraId, point);
 
-      final VerificationResult verification =
-          verify(mockApi.setExposurePoint(captureAny));
+      final VerificationResult verification = verify(
+        mockApi.setExposurePoint(captureAny),
+      );
       final PlatformPoint? passedPoint =
           verification.captured[0] as PlatformPoint?;
       expect(passedPoint?.x, point.x);
@@ -522,8 +574,9 @@ void main() {
     test('Should set the exposure point to null for reset', () async {
       await camera.setExposurePoint(cameraId, null);
 
-      final VerificationResult verification =
-          verify(mockApi.setExposurePoint(captureAny));
+      final VerificationResult verification = verify(
+        mockApi.setExposurePoint(captureAny),
+      );
       final PlatformPoint? passedPoint =
           verification.captured[0] as PlatformPoint?;
       expect(passedPoint, null);
@@ -531,22 +584,26 @@ void main() {
 
     test('Should get the min exposure offset', () async {
       const double stubMinOffset = 2.0;
-      when(mockApi.getMinExposureOffset())
-          .thenAnswer((_) async => stubMinOffset);
+      when(
+        mockApi.getMinExposureOffset(),
+      ).thenAnswer((_) async => stubMinOffset);
 
-      final double minExposureOffset =
-          await camera.getMinExposureOffset(cameraId);
+      final double minExposureOffset = await camera.getMinExposureOffset(
+        cameraId,
+      );
 
       expect(minExposureOffset, stubMinOffset);
     });
 
     test('Should get the max exposure offset', () async {
       const double stubMaxOffset = 2.0;
-      when(mockApi.getMaxExposureOffset())
-          .thenAnswer((_) async => stubMaxOffset);
+      when(
+        mockApi.getMaxExposureOffset(),
+      ).thenAnswer((_) async => stubMaxOffset);
 
-      final double maxExposureOffset =
-          await camera.getMaxExposureOffset(cameraId);
+      final double maxExposureOffset = await camera.getMaxExposureOffset(
+        cameraId,
+      );
 
       expect(maxExposureOffset, stubMaxOffset);
     });
@@ -582,8 +639,9 @@ void main() {
       const Point<double> point = Point<double>(0.4, 0.6);
       await camera.setFocusPoint(cameraId, point);
 
-      final VerificationResult verification =
-          verify(mockApi.setFocusPoint(captureAny));
+      final VerificationResult verification = verify(
+        mockApi.setFocusPoint(captureAny),
+      );
       final PlatformPoint? passedPoint =
           verification.captured[0] as PlatformPoint?;
       expect(passedPoint?.x, point.x);
@@ -593,8 +651,9 @@ void main() {
     test('Should set the focus point to null for reset', () async {
       await camera.setFocusPoint(cameraId, null);
 
-      final VerificationResult verification =
-          verify(mockApi.setFocusPoint(captureAny));
+      final VerificationResult verification = verify(
+        mockApi.setFocusPoint(captureAny),
+      );
       final PlatformPoint? passedPoint =
           verification.captured[0] as PlatformPoint?;
       expect(passedPoint, null);
@@ -633,27 +692,39 @@ void main() {
       verify(mockApi.setZoomLevel(zoom));
     });
 
-    test('Should throw CameraException when illegal zoom level is supplied',
-        () async {
-      const String code = 'ZOOM_ERROR';
-      const String message = 'Illegal zoom error';
-      when(mockApi.setZoomLevel(any)).thenAnswer(
-          (_) async => throw PlatformException(code: code, message: message));
+    test(
+      'Should throw CameraException when illegal zoom level is supplied',
+      () async {
+        const String code = 'ZOOM_ERROR';
+        const String message = 'Illegal zoom error';
+        when(mockApi.setZoomLevel(any)).thenAnswer(
+          (_) async => throw PlatformException(code: code, message: message),
+        );
 
-      expect(
+        expect(
           () => camera.setZoomLevel(cameraId, -1.0),
-          throwsA(isA<CameraException>()
-              .having((CameraException e) => e.code, 'code', code)
-              .having((CameraException e) => e.description, 'description',
-                  message)));
-    });
+          throwsA(
+            isA<CameraException>()
+                .having((CameraException e) => e.code, 'code', code)
+                .having(
+                  (CameraException e) => e.description,
+                  'description',
+                  message,
+                ),
+          ),
+        );
+      },
+    );
 
     test('Should lock the capture orientation', () async {
       await camera.lockCaptureOrientation(
-          cameraId, DeviceOrientation.portraitUp);
+        cameraId,
+        DeviceOrientation.portraitUp,
+      );
 
       verify(
-          mockApi.lockCaptureOrientation(PlatformDeviceOrientation.portraitUp));
+        mockApi.lockCaptureOrientation(PlatformDeviceOrientation.portraitUp),
+      );
     });
 
     test('Should unlock the capture orientation', () async {

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.mocks.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.mocks.dart
@@ -27,31 +27,33 @@ import 'package:mockito/src/dummies.dart' as _i3;
 /// See the documentation for Mockito's code generation for more information.
 class MockCameraApi extends _i1.Mock implements _i2.CameraApi {
   @override
-  String get pigeonVar_messageChannelSuffix => (super.noSuchMethod(
-        Invocation.getter(#pigeonVar_messageChannelSuffix),
-        returnValue: _i3.dummyValue<String>(
-          this,
-          Invocation.getter(#pigeonVar_messageChannelSuffix),
-        ),
-        returnValueForMissingStub: _i3.dummyValue<String>(
-          this,
-          Invocation.getter(#pigeonVar_messageChannelSuffix),
-        ),
-      ) as String);
+  String get pigeonVar_messageChannelSuffix =>
+      (super.noSuchMethod(
+            Invocation.getter(#pigeonVar_messageChannelSuffix),
+            returnValue: _i3.dummyValue<String>(
+              this,
+              Invocation.getter(#pigeonVar_messageChannelSuffix),
+            ),
+            returnValueForMissingStub: _i3.dummyValue<String>(
+              this,
+              Invocation.getter(#pigeonVar_messageChannelSuffix),
+            ),
+          )
+          as String);
 
   @override
   _i4.Future<List<_i2.PlatformCameraDescription>> getAvailableCameras() =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getAvailableCameras,
-          [],
-        ),
-        returnValue: _i4.Future<List<_i2.PlatformCameraDescription>>.value(
-            <_i2.PlatformCameraDescription>[]),
-        returnValueForMissingStub:
-            _i4.Future<List<_i2.PlatformCameraDescription>>.value(
-                <_i2.PlatformCameraDescription>[]),
-      ) as _i4.Future<List<_i2.PlatformCameraDescription>>);
+            Invocation.method(#getAvailableCameras, []),
+            returnValue: _i4.Future<List<_i2.PlatformCameraDescription>>.value(
+              <_i2.PlatformCameraDescription>[],
+            ),
+            returnValueForMissingStub:
+                _i4.Future<List<_i2.PlatformCameraDescription>>.value(
+                  <_i2.PlatformCameraDescription>[],
+                ),
+          )
+          as _i4.Future<List<_i2.PlatformCameraDescription>>);
 
   @override
   _i4.Future<int> create(
@@ -59,16 +61,11 @@ class MockCameraApi extends _i1.Mock implements _i2.CameraApi {
     _i2.PlatformMediaSettings? settings,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #create,
-          [
-            cameraName,
-            settings,
-          ],
-        ),
-        returnValue: _i4.Future<int>.value(0),
-        returnValueForMissingStub: _i4.Future<int>.value(0),
-      ) as _i4.Future<int>);
+            Invocation.method(#create, [cameraName, settings]),
+            returnValue: _i4.Future<int>.value(0),
+            returnValueForMissingStub: _i4.Future<int>.value(0),
+          )
+          as _i4.Future<int>);
 
   @override
   _i4.Future<void> initialize(
@@ -76,320 +73,268 @@ class MockCameraApi extends _i1.Mock implements _i2.CameraApi {
     _i2.PlatformImageFormatGroup? imageFormat,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #initialize,
-          [
-            cameraId,
-            imageFormat,
-          ],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#initialize, [cameraId, imageFormat]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> startImageStream() => (super.noSuchMethod(
-        Invocation.method(
-          #startImageStream,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> startImageStream() =>
+      (super.noSuchMethod(
+            Invocation.method(#startImageStream, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> stopImageStream() => (super.noSuchMethod(
-        Invocation.method(
-          #stopImageStream,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> stopImageStream() =>
+      (super.noSuchMethod(
+            Invocation.method(#stopImageStream, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> receivedImageStreamData() => (super.noSuchMethod(
-        Invocation.method(
-          #receivedImageStreamData,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> receivedImageStreamData() =>
+      (super.noSuchMethod(
+            Invocation.method(#receivedImageStreamData, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> dispose(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> dispose(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#dispose, [cameraId]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> lockCaptureOrientation(
-          _i2.PlatformDeviceOrientation? orientation) =>
+    _i2.PlatformDeviceOrientation? orientation,
+  ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #lockCaptureOrientation,
-          [orientation],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#lockCaptureOrientation, [orientation]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> unlockCaptureOrientation() => (super.noSuchMethod(
-        Invocation.method(
-          #unlockCaptureOrientation,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> unlockCaptureOrientation() =>
+      (super.noSuchMethod(
+            Invocation.method(#unlockCaptureOrientation, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<String> takePicture() => (super.noSuchMethod(
-        Invocation.method(
-          #takePicture,
-          [],
-        ),
-        returnValue: _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #takePicture,
-            [],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #takePicture,
-            [],
-          ),
-        )),
-      ) as _i4.Future<String>);
+  _i4.Future<String> takePicture() =>
+      (super.noSuchMethod(
+            Invocation.method(#takePicture, []),
+            returnValue: _i4.Future<String>.value(
+              _i3.dummyValue<String>(this, Invocation.method(#takePicture, [])),
+            ),
+            returnValueForMissingStub: _i4.Future<String>.value(
+              _i3.dummyValue<String>(this, Invocation.method(#takePicture, [])),
+            ),
+          )
+          as _i4.Future<String>);
 
   @override
-  _i4.Future<void> prepareForVideoRecording() => (super.noSuchMethod(
-        Invocation.method(
-          #prepareForVideoRecording,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> prepareForVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#prepareForVideoRecording, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> startVideoRecording(bool? enableStream) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #startVideoRecording,
-          [enableStream],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#startVideoRecording, [enableStream]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<String> stopVideoRecording() => (super.noSuchMethod(
-        Invocation.method(
-          #stopVideoRecording,
-          [],
-        ),
-        returnValue: _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #stopVideoRecording,
-            [],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #stopVideoRecording,
-            [],
-          ),
-        )),
-      ) as _i4.Future<String>);
+  _i4.Future<String> stopVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#stopVideoRecording, []),
+            returnValue: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#stopVideoRecording, []),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#stopVideoRecording, []),
+              ),
+            ),
+          )
+          as _i4.Future<String>);
 
   @override
-  _i4.Future<void> pauseVideoRecording() => (super.noSuchMethod(
-        Invocation.method(
-          #pauseVideoRecording,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> pauseVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#pauseVideoRecording, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> resumeVideoRecording() => (super.noSuchMethod(
-        Invocation.method(
-          #resumeVideoRecording,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> resumeVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#resumeVideoRecording, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setFlashMode(_i2.PlatformFlashMode? mode) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setFlashMode,
-          [mode],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setFlashMode, [mode]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setExposureMode(_i2.PlatformExposureMode? mode) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setExposureMode,
-          [mode],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setExposureMode, [mode]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setExposurePoint(_i2.PlatformPoint? point) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setExposurePoint,
-          [point],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setExposurePoint, [point]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<double> getMinExposureOffset() => (super.noSuchMethod(
-        Invocation.method(
-          #getMinExposureOffset,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getMinExposureOffset() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMinExposureOffset, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<double> getMaxExposureOffset() => (super.noSuchMethod(
-        Invocation.method(
-          #getMaxExposureOffset,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getMaxExposureOffset() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMaxExposureOffset, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<void> setExposureOffset(double? offset) => (super.noSuchMethod(
-        Invocation.method(
-          #setExposureOffset,
-          [offset],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> setExposureOffset(double? offset) =>
+      (super.noSuchMethod(
+            Invocation.method(#setExposureOffset, [offset]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setFocusMode(_i2.PlatformFocusMode? mode) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setFocusMode,
-          [mode],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setFocusMode, [mode]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setFocusPoint(_i2.PlatformPoint? point) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setFocusPoint,
-          [point],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setFocusPoint, [point]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<double> getMinZoomLevel() => (super.noSuchMethod(
-        Invocation.method(
-          #getMinZoomLevel,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getMinZoomLevel() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMinZoomLevel, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<double> getMaxZoomLevel() => (super.noSuchMethod(
-        Invocation.method(
-          #getMaxZoomLevel,
-          [],
-        ),
-        returnValue: _i4.Future<double>.value(0.0),
-        returnValueForMissingStub: _i4.Future<double>.value(0.0),
-      ) as _i4.Future<double>);
+  _i4.Future<double> getMaxZoomLevel() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMaxZoomLevel, []),
+            returnValue: _i4.Future<double>.value(0.0),
+            returnValueForMissingStub: _i4.Future<double>.value(0.0),
+          )
+          as _i4.Future<double>);
 
   @override
-  _i4.Future<void> setZoomLevel(double? zoom) => (super.noSuchMethod(
-        Invocation.method(
-          #setZoomLevel,
-          [zoom],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> setZoomLevel(double? zoom) =>
+      (super.noSuchMethod(
+            Invocation.method(#setZoomLevel, [zoom]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> pausePreview() => (super.noSuchMethod(
-        Invocation.method(
-          #pausePreview,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> pausePreview() =>
+      (super.noSuchMethod(
+            Invocation.method(#pausePreview, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> resumePreview() => (super.noSuchMethod(
-        Invocation.method(
-          #resumePreview,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> resumePreview() =>
+      (super.noSuchMethod(
+            Invocation.method(#resumePreview, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> updateDescriptionWhileRecording(String? cameraName) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #updateDescriptionWhileRecording,
-          [cameraName],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#updateDescriptionWhileRecording, [cameraName]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setImageFileFormat(_i2.PlatformImageFileFormat? format) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setImageFileFormat,
-          [format],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#setImageFileFormat, [format]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 }

--- a/packages/camera/camera_avfoundation/test/type_conversion_test.dart
+++ b/packages/camera/camera_avfoundation/test/type_conversion_test.dart
@@ -10,24 +10,25 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('CameraImageData can be created', () {
-    final CameraImageData cameraImage =
-        cameraImageFromPlatformData(<dynamic, dynamic>{
-      'format': 1,
-      'height': 1,
-      'width': 4,
-      'lensAperture': 1.8,
-      'sensorExposureTime': 9991324,
-      'sensorSensitivity': 92.0,
-      'planes': <dynamic>[
-        <dynamic, dynamic>{
-          'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-          'bytesPerPixel': 1,
-          'bytesPerRow': 4,
-          'height': 1,
-          'width': 4
-        }
-      ]
-    });
+    final CameraImageData cameraImage = cameraImageFromPlatformData(
+      <dynamic, dynamic>{
+        'format': 1,
+        'height': 1,
+        'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
+        'planes': <dynamic>[
+          <dynamic, dynamic>{
+            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+            'bytesPerPixel': 1,
+            'bytesPerRow': 4,
+            'height': 1,
+            'width': 4,
+          },
+        ],
+      },
+    );
     expect(cameraImage.height, 1);
     expect(cameraImage.width, 4);
     expect(cameraImage.format.group, ImageFormatGroup.unknown);
@@ -35,24 +36,25 @@ void main() {
   });
 
   test('CameraImageData has ImageFormatGroup.yuv420', () {
-    final CameraImageData cameraImage =
-        cameraImageFromPlatformData(<dynamic, dynamic>{
-      'format': 875704438,
-      'height': 1,
-      'width': 4,
-      'lensAperture': 1.8,
-      'sensorExposureTime': 9991324,
-      'sensorSensitivity': 92.0,
-      'planes': <dynamic>[
-        <dynamic, dynamic>{
-          'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-          'bytesPerPixel': 1,
-          'bytesPerRow': 4,
-          'height': 1,
-          'width': 4
-        }
-      ]
-    });
+    final CameraImageData cameraImage = cameraImageFromPlatformData(
+      <dynamic, dynamic>{
+        'format': 875704438,
+        'height': 1,
+        'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
+        'planes': <dynamic>[
+          <dynamic, dynamic>{
+            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+            'bytesPerPixel': 1,
+            'bytesPerRow': 4,
+            'height': 1,
+            'width': 4,
+          },
+        ],
+      },
+    );
     expect(cameraImage.format.group, ImageFormatGroup.yuv420);
   });
 }

--- a/packages/camera/camera_avfoundation/test/utils_test.dart
+++ b/packages/camera/camera_avfoundation/test/utils_test.dart
@@ -26,31 +26,41 @@ void main() {
     });
 
     test('serializeDeviceOrientation() should serialize correctly', () {
-      expect(serializeDeviceOrientation(DeviceOrientation.portraitUp),
-          PlatformDeviceOrientation.portraitUp);
-      expect(serializeDeviceOrientation(DeviceOrientation.portraitDown),
-          PlatformDeviceOrientation.portraitDown);
-      expect(serializeDeviceOrientation(DeviceOrientation.landscapeRight),
-          PlatformDeviceOrientation.landscapeRight);
-      expect(serializeDeviceOrientation(DeviceOrientation.landscapeLeft),
-          PlatformDeviceOrientation.landscapeLeft);
+      expect(
+        serializeDeviceOrientation(DeviceOrientation.portraitUp),
+        PlatformDeviceOrientation.portraitUp,
+      );
+      expect(
+        serializeDeviceOrientation(DeviceOrientation.portraitDown),
+        PlatformDeviceOrientation.portraitDown,
+      );
+      expect(
+        serializeDeviceOrientation(DeviceOrientation.landscapeRight),
+        PlatformDeviceOrientation.landscapeRight,
+      );
+      expect(
+        serializeDeviceOrientation(DeviceOrientation.landscapeLeft),
+        PlatformDeviceOrientation.landscapeLeft,
+      );
     });
 
     test('deviceOrientationFromPlatform() should convert correctly', () {
       expect(
-          deviceOrientationFromPlatform(PlatformDeviceOrientation.portraitUp),
-          DeviceOrientation.portraitUp);
+        deviceOrientationFromPlatform(PlatformDeviceOrientation.portraitUp),
+        DeviceOrientation.portraitUp,
+      );
       expect(
-          deviceOrientationFromPlatform(PlatformDeviceOrientation.portraitDown),
-          DeviceOrientation.portraitDown);
+        deviceOrientationFromPlatform(PlatformDeviceOrientation.portraitDown),
+        DeviceOrientation.portraitDown,
+      );
       expect(
-          deviceOrientationFromPlatform(
-              PlatformDeviceOrientation.landscapeRight),
-          DeviceOrientation.landscapeRight);
+        deviceOrientationFromPlatform(PlatformDeviceOrientation.landscapeRight),
+        DeviceOrientation.landscapeRight,
+      );
       expect(
-          deviceOrientationFromPlatform(
-              PlatformDeviceOrientation.landscapeLeft),
-          DeviceOrientation.landscapeLeft);
+        deviceOrientationFromPlatform(PlatformDeviceOrientation.landscapeLeft),
+        DeviceOrientation.landscapeLeft,
+      );
     });
   });
 }

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 2.10.0

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 2.10.0
 

--- a/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
+++ b/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
@@ -63,14 +63,14 @@ class CameraInitializedEvent extends CameraEvent {
   /// Converts the supplied [Map] to an instance of the [CameraInitializedEvent]
   /// class.
   CameraInitializedEvent.fromJson(Map<String, dynamic> json)
-      : previewWidth = json['previewWidth']! as double,
-        previewHeight = json['previewHeight']! as double,
-        exposureMode = deserializeExposureMode(json['exposureMode']! as String),
-        exposurePointSupported =
-            (json['exposurePointSupported'] as bool?) ?? false,
-        focusMode = deserializeFocusMode(json['focusMode']! as String),
-        focusPointSupported = (json['focusPointSupported'] as bool?) ?? false,
-        super(json['cameraId']! as int);
+    : previewWidth = json['previewWidth']! as double,
+      previewHeight = json['previewHeight']! as double,
+      exposureMode = deserializeExposureMode(json['exposureMode']! as String),
+      exposurePointSupported =
+          (json['exposurePointSupported'] as bool?) ?? false,
+      focusMode = deserializeFocusMode(json['focusMode']! as String),
+      focusPointSupported = (json['focusPointSupported'] as bool?) ?? false,
+      super(json['cameraId']! as int);
 
   /// The width of the preview in pixels.
   final double previewWidth;
@@ -93,14 +93,14 @@ class CameraInitializedEvent extends CameraEvent {
   /// Converts the [CameraInitializedEvent] instance into a [Map] instance that
   /// can be serialized to JSON.
   Map<String, dynamic> toJson() => <String, Object>{
-        'cameraId': cameraId,
-        'previewWidth': previewWidth,
-        'previewHeight': previewHeight,
-        'exposureMode': serializeExposureMode(exposureMode),
-        'exposurePointSupported': exposurePointSupported,
-        'focusMode': serializeFocusMode(focusMode),
-        'focusPointSupported': focusPointSupported,
-      };
+    'cameraId': cameraId,
+    'previewWidth': previewWidth,
+    'previewHeight': previewHeight,
+    'exposureMode': serializeExposureMode(exposureMode),
+    'exposurePointSupported': exposurePointSupported,
+    'focusMode': serializeFocusMode(focusMode),
+    'focusPointSupported': focusPointSupported,
+  };
 
   @override
   bool operator ==(Object other) =>
@@ -117,14 +117,14 @@ class CameraInitializedEvent extends CameraEvent {
 
   @override
   int get hashCode => Object.hash(
-        super.hashCode,
-        previewWidth,
-        previewHeight,
-        exposureMode,
-        exposurePointSupported,
-        focusMode,
-        focusPointSupported,
-      );
+    super.hashCode,
+    previewWidth,
+    previewHeight,
+    exposureMode,
+    exposurePointSupported,
+    focusMode,
+    focusPointSupported,
+  );
 }
 
 /// An event fired when the resolution preset of the camera has changed.
@@ -143,9 +143,9 @@ class CameraResolutionChangedEvent extends CameraEvent {
   /// Converts the supplied [Map] to an instance of the
   /// [CameraResolutionChangedEvent] class.
   CameraResolutionChangedEvent.fromJson(Map<String, dynamic> json)
-      : captureWidth = json['captureWidth']! as double,
-        captureHeight = json['captureHeight']! as double,
-        super(json['cameraId']! as int);
+    : captureWidth = json['captureWidth']! as double,
+      captureHeight = json['captureHeight']! as double,
+      super(json['cameraId']! as int);
 
   /// The capture width in pixels.
   final double captureWidth;
@@ -156,10 +156,10 @@ class CameraResolutionChangedEvent extends CameraEvent {
   /// Converts the [CameraResolutionChangedEvent] instance into a [Map] instance
   /// that can be serialized to JSON.
   Map<String, dynamic> toJson() => <String, Object>{
-        'cameraId': cameraId,
-        'captureWidth': captureWidth,
-        'captureHeight': captureHeight,
-      };
+    'cameraId': cameraId,
+    'captureWidth': captureWidth,
+    'captureHeight': captureHeight,
+  };
 
   @override
   bool operator ==(Object other) =>
@@ -183,13 +183,11 @@ class CameraClosingEvent extends CameraEvent {
   /// Converts the supplied [Map] to an instance of the [CameraClosingEvent]
   /// class.
   CameraClosingEvent.fromJson(Map<String, dynamic> json)
-      : super(json['cameraId']! as int);
+    : super(json['cameraId']! as int);
 
   /// Converts the [CameraClosingEvent] instance into a [Map] instance that can
   /// be serialized to JSON.
-  Map<String, dynamic> toJson() => <String, Object>{
-        'cameraId': cameraId,
-      };
+  Map<String, dynamic> toJson() => <String, Object>{'cameraId': cameraId};
 
   @override
   bool operator ==(Object other) =>
@@ -216,8 +214,8 @@ class CameraErrorEvent extends CameraEvent {
   /// Converts the supplied [Map] to an instance of the [CameraErrorEvent]
   /// class.
   CameraErrorEvent.fromJson(Map<String, dynamic> json)
-      : description = json['description']! as String,
-        super(json['cameraId']! as int);
+    : description = json['description']! as String,
+      super(json['cameraId']! as int);
 
   /// Description of the error.
   final String description;
@@ -225,9 +223,9 @@ class CameraErrorEvent extends CameraEvent {
   /// Converts the [CameraErrorEvent] instance into a [Map] instance that can be
   /// serialized to JSON.
   Map<String, dynamic> toJson() => <String, Object>{
-        'cameraId': cameraId,
-        'description': description,
-      };
+    'cameraId': cameraId,
+    'description': description,
+  };
 
   @override
   bool operator ==(Object other) =>
@@ -253,11 +251,12 @@ class VideoRecordedEvent extends CameraEvent {
   /// Converts the supplied [Map] to an instance of the [VideoRecordedEvent]
   /// class.
   VideoRecordedEvent.fromJson(Map<String, dynamic> json)
-      : file = XFile(json['path']! as String),
-        maxVideoDuration = json['maxVideoDuration'] != null
-            ? Duration(milliseconds: json['maxVideoDuration'] as int)
-            : null,
-        super(json['cameraId']! as int);
+    : file = XFile(json['path']! as String),
+      maxVideoDuration =
+          json['maxVideoDuration'] != null
+              ? Duration(milliseconds: json['maxVideoDuration'] as int)
+              : null,
+      super(json['cameraId']! as int);
 
   /// XFile of the recorded video.
   final XFile file;
@@ -268,10 +267,10 @@ class VideoRecordedEvent extends CameraEvent {
   /// Converts the [VideoRecordedEvent] instance into a [Map] instance that can be
   /// serialized to JSON.
   Map<String, dynamic> toJson() => <String, Object?>{
-        'cameraId': cameraId,
-        'path': file.path,
-        'maxVideoDuration': maxVideoDuration?.inMilliseconds
-      };
+    'cameraId': cameraId,
+    'path': file.path,
+    'maxVideoDuration': maxVideoDuration?.inMilliseconds,
+  };
 
   @override
   bool operator ==(Object other) =>

--- a/packages/camera/camera_platform_interface/lib/src/events/device_event.dart
+++ b/packages/camera/camera_platform_interface/lib/src/events/device_event.dart
@@ -34,8 +34,9 @@ class DeviceOrientationChangedEvent extends DeviceEvent {
   /// Converts the supplied [Map] to an instance of the [DeviceOrientationChangedEvent]
   /// class.
   DeviceOrientationChangedEvent.fromJson(Map<String, dynamic> json)
-      : orientation =
-            deserializeDeviceOrientation(json['orientation']! as String);
+    : orientation = deserializeDeviceOrientation(
+        json['orientation']! as String,
+      );
 
   /// The new orientation of the device
   final DeviceOrientation orientation;
@@ -43,8 +44,8 @@ class DeviceOrientationChangedEvent extends DeviceEvent {
   /// Converts the [DeviceOrientationChangedEvent] instance into a [Map] instance that
   /// can be serialized to JSON.
   Map<String, dynamic> toJson() => <String, Object>{
-        'orientation': serializeDeviceOrientation(orientation),
-      };
+    'orientation': serializeDeviceOrientation(orientation),
+  };
 
   @override
   bool operator ==(Object other) =>

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -20,10 +20,12 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/camera');
 class MethodChannelCamera extends CameraPlatform {
   /// Construct a new method channel camera instance.
   MethodChannelCamera() {
-    const MethodChannel channel =
-        MethodChannel('flutter.io/cameraPlugin/device');
+    const MethodChannel channel = MethodChannel(
+      'flutter.io/cameraPlugin/device',
+    );
     channel.setMethodCallHandler(
-        (MethodCall call) => handleDeviceMethodCall(call));
+      (MethodCall call) => handleDeviceMethodCall(call),
+    );
   }
 
   final Map<int, MethodChannel> _channels = <int, MethodChannel>{};
@@ -56,9 +58,9 @@ class MethodChannelCamera extends CameraPlatform {
   // The stream for vending frames to platform interface clients.
   StreamController<CameraImageData>? _frameStreamController;
 
-  Stream<CameraEvent> _cameraEvents(int cameraId) =>
-      cameraEventStreamController.stream
-          .where((CameraEvent event) => event.cameraId == cameraId);
+  Stream<CameraEvent> _cameraEvents(int cameraId) => cameraEventStreamController
+      .stream
+      .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
   Future<List<CameraDescription>> availableCameras() async {
@@ -73,8 +75,9 @@ class MethodChannelCamera extends CameraPlatform {
       return cameras.map((Map<dynamic, dynamic> camera) {
         return CameraDescription(
           name: camera['name']! as String,
-          lensDirection:
-              parseCameraLensDirection(camera['lensFacing']! as String),
+          lensDirection: parseCameraLensDirection(
+            camera['lensFacing']! as String,
+          ),
           sensorOrientation: camera['sensorOrientation']! as int,
         );
       }).toList();
@@ -88,11 +91,10 @@ class MethodChannelCamera extends CameraPlatform {
     CameraDescription cameraDescription,
     ResolutionPreset? resolutionPreset, {
     bool enableAudio = false,
-  }) async =>
-      createCameraWithSettings(
-          cameraDescription,
-          MediaSettings(
-              resolutionPreset: resolutionPreset, enableAudio: enableAudio));
+  }) async => createCameraWithSettings(
+    cameraDescription,
+    MediaSettings(resolutionPreset: resolutionPreset, enableAudio: enableAudio),
+  );
 
   @override
   Future<int> createCameraWithSettings(
@@ -103,15 +105,18 @@ class MethodChannelCamera extends CameraPlatform {
       final ResolutionPreset? resolutionPreset = mediaSettings.resolutionPreset;
       final Map<String, dynamic>? reply = await _channel
           .invokeMapMethod<String, dynamic>('create', <String, dynamic>{
-        'cameraName': cameraDescription.name,
-        'resolutionPreset': resolutionPreset != null
-            ? _serializeResolutionPreset(mediaSettings.resolutionPreset!)
-            : null,
-        'fps': mediaSettings.fps,
-        'videoBitrate': mediaSettings.videoBitrate,
-        'audioBitrate': mediaSettings.audioBitrate,
-        'enableAudio': mediaSettings.enableAudio,
-      });
+            'cameraName': cameraDescription.name,
+            'resolutionPreset':
+                resolutionPreset != null
+                    ? _serializeResolutionPreset(
+                      mediaSettings.resolutionPreset!,
+                    )
+                    : null,
+            'fps': mediaSettings.fps,
+            'videoBitrate': mediaSettings.videoBitrate,
+            'audioBitrate': mediaSettings.audioBitrate,
+            'enableAudio': mediaSettings.enableAudio,
+          });
 
       return reply!['cameraId']! as int;
     } on PlatformException catch (e) {
@@ -125,10 +130,12 @@ class MethodChannelCamera extends CameraPlatform {
     ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,
   }) {
     _channels.putIfAbsent(cameraId, () {
-      final MethodChannel channel =
-          MethodChannel('flutter.io/cameraPlugin/camera$cameraId');
+      final MethodChannel channel = MethodChannel(
+        'flutter.io/cameraPlugin/camera$cameraId',
+      );
       channel.setMethodCallHandler(
-          (MethodCall call) => handleCameraMethodCall(call, cameraId));
+        (MethodCall call) => handleCameraMethodCall(call, cameraId),
+      );
       return channel;
     });
 
@@ -138,28 +145,27 @@ class MethodChannelCamera extends CameraPlatform {
       completer.complete();
     });
 
-    _channel.invokeMapMethod<String, dynamic>(
-      'initialize',
-      <String, dynamic>{
-        'cameraId': cameraId,
-        'imageFormatGroup': imageFormatGroup.name(),
-      },
-    ).catchError(
-      // TODO(srawlins): This should return a value of the future's type. This
-      // will fail upcoming analysis checks with
-      // https://github.com/flutter/flutter/issues/105750.
-      // ignore: body_might_complete_normally_catch_error
-      (Object error, StackTrace stackTrace) {
-        if (error is! PlatformException) {
-          // ignore: only_throw_errors
-          throw error;
-        }
-        completer.completeError(
-          CameraException(error.code, error.message),
-          stackTrace,
+    _channel
+        .invokeMapMethod<String, dynamic>('initialize', <String, dynamic>{
+          'cameraId': cameraId,
+          'imageFormatGroup': imageFormatGroup.name(),
+        })
+        .catchError(
+          // TODO(srawlins): This should return a value of the future's type. This
+          // will fail upcoming analysis checks with
+          // https://github.com/flutter/flutter/issues/105750.
+          // ignore: body_might_complete_normally_catch_error
+          (Object error, StackTrace stackTrace) {
+            if (error is! PlatformException) {
+              // ignore: only_throw_errors
+              throw error;
+            }
+            completer.completeError(
+              CameraException(error.code, error.message),
+              stackTrace,
+            );
+          },
         );
-      },
-    );
 
     return completer.future;
   }
@@ -172,10 +178,9 @@ class MethodChannelCamera extends CameraPlatform {
       _channels.remove(cameraId);
     }
 
-    await _channel.invokeMethod<void>(
-      'dispose',
-      <String, dynamic>{'cameraId': cameraId},
-    );
+    await _channel.invokeMethod<void>('dispose', <String, dynamic>{
+      'cameraId': cameraId,
+    });
   }
 
   @override
@@ -218,7 +223,7 @@ class MethodChannelCamera extends CameraPlatform {
       'lockCaptureOrientation',
       <String, dynamic>{
         'cameraId': cameraId,
-        'orientation': serializeDeviceOrientation(orientation)
+        'orientation': serializeDeviceOrientation(orientation),
       },
     );
   }
@@ -253,22 +258,22 @@ class MethodChannelCamera extends CameraPlatform {
       _channel.invokeMethod<void>('prepareForVideoRecording');
 
   @override
-  Future<void> startVideoRecording(int cameraId,
-      {Duration? maxVideoDuration}) async {
+  Future<void> startVideoRecording(
+    int cameraId, {
+    Duration? maxVideoDuration,
+  }) async {
     return startVideoCapturing(
-        VideoCaptureOptions(cameraId, maxDuration: maxVideoDuration));
+      VideoCaptureOptions(cameraId, maxDuration: maxVideoDuration),
+    );
   }
 
   @override
   Future<void> startVideoCapturing(VideoCaptureOptions options) async {
-    await _channel.invokeMethod<void>(
-      'startVideoRecording',
-      <String, dynamic>{
-        'cameraId': options.cameraId,
-        'maxVideoDuration': options.maxDuration?.inMilliseconds,
-        'enableStream': options.streamCallback != null,
-      },
-    );
+    await _channel.invokeMethod<void>('startVideoRecording', <String, dynamic>{
+      'cameraId': options.cameraId,
+      'maxVideoDuration': options.maxDuration?.inMilliseconds,
+      'enableStream': options.streamCallback != null,
+    });
 
     if (options.streamCallback != null) {
       _installStreamController().stream.listen(options.streamCallback);
@@ -295,26 +300,28 @@ class MethodChannelCamera extends CameraPlatform {
 
   @override
   Future<void> pauseVideoRecording(int cameraId) => _channel.invokeMethod<void>(
-        'pauseVideoRecording',
-        <String, dynamic>{'cameraId': cameraId},
-      );
+    'pauseVideoRecording',
+    <String, dynamic>{'cameraId': cameraId},
+  );
 
   @override
   Future<void> resumeVideoRecording(int cameraId) =>
-      _channel.invokeMethod<void>(
-        'resumeVideoRecording',
-        <String, dynamic>{'cameraId': cameraId},
-      );
+      _channel.invokeMethod<void>('resumeVideoRecording', <String, dynamic>{
+        'cameraId': cameraId,
+      });
 
   @override
-  Stream<CameraImageData> onStreamedFrameAvailable(int cameraId,
-      {CameraImageStreamOptions? options}) {
+  Stream<CameraImageData> onStreamedFrameAvailable(
+    int cameraId, {
+    CameraImageStreamOptions? options,
+  }) {
     _installStreamController(onListen: _onFrameStreamListen);
     return _frameStreamController!.stream;
   }
 
-  StreamController<CameraImageData> _installStreamController(
-      {void Function()? onListen}) {
+  StreamController<CameraImageData> _installStreamController({
+    void Function()? onListen,
+  }) {
     _frameStreamController = StreamController<CameraImageData>(
       onListen: onListen ?? () {},
       onPause: _onFrameStreamPauseResume,
@@ -334,20 +341,23 @@ class MethodChannelCamera extends CameraPlatform {
   }
 
   void _startStreamListener() {
-    const EventChannel cameraEventChannel =
-        EventChannel('plugins.flutter.io/camera/imageStream');
-    _platformImageStreamSubscription =
-        cameraEventChannel.receiveBroadcastStream().listen((dynamic imageData) {
-      if (defaultTargetPlatform == TargetPlatform.iOS) {
-        try {
-          _channel.invokeMethod<void>('receivedImageStreamData');
-        } on PlatformException catch (e) {
-          throw CameraException(e.code, e.message);
-        }
-      }
-      _frameStreamController!
-          .add(cameraImageFromPlatformData(imageData as Map<dynamic, dynamic>));
-    });
+    const EventChannel cameraEventChannel = EventChannel(
+      'plugins.flutter.io/camera/imageStream',
+    );
+    _platformImageStreamSubscription = cameraEventChannel
+        .receiveBroadcastStream()
+        .listen((dynamic imageData) {
+          if (defaultTargetPlatform == TargetPlatform.iOS) {
+            try {
+              _channel.invokeMethod<void>('receivedImageStreamData');
+            } on PlatformException catch (e) {
+              throw CameraException(e.code, e.message);
+            }
+          }
+          _frameStreamController!.add(
+            cameraImageFromPlatformData(imageData as Map<dynamic, dynamic>),
+          );
+        });
   }
 
   FutureOr<void> _onFrameStreamCancel() async {
@@ -358,44 +368,37 @@ class MethodChannelCamera extends CameraPlatform {
   }
 
   void _onFrameStreamPauseResume() {
-    throw CameraException('InvalidCall',
-        'Pause and resume are not supported for onStreamedFrameAvailable');
+    throw CameraException(
+      'InvalidCall',
+      'Pause and resume are not supported for onStreamedFrameAvailable',
+    );
   }
 
   @override
   Future<void> setFlashMode(int cameraId, FlashMode mode) =>
-      _channel.invokeMethod<void>(
-        'setFlashMode',
-        <String, dynamic>{
-          'cameraId': cameraId,
-          'mode': _serializeFlashMode(mode),
-        },
-      );
+      _channel.invokeMethod<void>('setFlashMode', <String, dynamic>{
+        'cameraId': cameraId,
+        'mode': _serializeFlashMode(mode),
+      });
 
   @override
   Future<void> setExposureMode(int cameraId, ExposureMode mode) =>
-      _channel.invokeMethod<void>(
-        'setExposureMode',
-        <String, dynamic>{
-          'cameraId': cameraId,
-          'mode': serializeExposureMode(mode),
-        },
-      );
+      _channel.invokeMethod<void>('setExposureMode', <String, dynamic>{
+        'cameraId': cameraId,
+        'mode': serializeExposureMode(mode),
+      });
 
   @override
   Future<void> setExposurePoint(int cameraId, Point<double>? point) {
     assert(point == null || point.x >= 0 && point.x <= 1);
     assert(point == null || point.y >= 0 && point.y <= 1);
 
-    return _channel.invokeMethod<void>(
-      'setExposurePoint',
-      <String, dynamic>{
-        'cameraId': cameraId,
-        'reset': point == null,
-        'x': point?.x,
-        'y': point?.y,
-      },
-    );
+    return _channel.invokeMethod<void>('setExposurePoint', <String, dynamic>{
+      'cameraId': cameraId,
+      'reset': point == null,
+      'x': point?.x,
+      'y': point?.y,
+    });
   }
 
   @override
@@ -432,10 +435,7 @@ class MethodChannelCamera extends CameraPlatform {
   Future<double> setExposureOffset(int cameraId, double offset) async {
     final double? appliedOffset = await _channel.invokeMethod<double>(
       'setExposureOffset',
-      <String, dynamic>{
-        'cameraId': cameraId,
-        'offset': offset,
-      },
+      <String, dynamic>{'cameraId': cameraId, 'offset': offset},
     );
 
     return appliedOffset!;
@@ -443,28 +443,22 @@ class MethodChannelCamera extends CameraPlatform {
 
   @override
   Future<void> setFocusMode(int cameraId, FocusMode mode) =>
-      _channel.invokeMethod<void>(
-        'setFocusMode',
-        <String, dynamic>{
-          'cameraId': cameraId,
-          'mode': serializeFocusMode(mode),
-        },
-      );
+      _channel.invokeMethod<void>('setFocusMode', <String, dynamic>{
+        'cameraId': cameraId,
+        'mode': serializeFocusMode(mode),
+      });
 
   @override
   Future<void> setFocusPoint(int cameraId, Point<double>? point) {
     assert(point == null || point.x >= 0 && point.x <= 1);
     assert(point == null || point.y >= 0 && point.y <= 1);
 
-    return _channel.invokeMethod<void>(
-      'setFocusPoint',
-      <String, dynamic>{
-        'cameraId': cameraId,
-        'reset': point == null,
-        'x': point?.x,
-        'y': point?.y,
-      },
-    );
+    return _channel.invokeMethod<void>('setFocusPoint', <String, dynamic>{
+      'cameraId': cameraId,
+      'reset': point == null,
+      'x': point?.x,
+      'y': point?.y,
+    });
   }
 
   @override
@@ -490,13 +484,10 @@ class MethodChannelCamera extends CameraPlatform {
   @override
   Future<void> setZoomLevel(int cameraId, double zoom) async {
     try {
-      await _channel.invokeMethod<double>(
-        'setZoomLevel',
-        <String, dynamic>{
-          'cameraId': cameraId,
-          'zoom': zoom,
-        },
-      );
+      await _channel.invokeMethod<double>('setZoomLevel', <String, dynamic>{
+        'cameraId': cameraId,
+        'zoom': zoom,
+      });
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -504,40 +495,34 @@ class MethodChannelCamera extends CameraPlatform {
 
   @override
   Future<void> pausePreview(int cameraId) async {
-    await _channel.invokeMethod<double>(
-      'pausePreview',
-      <String, dynamic>{'cameraId': cameraId},
-    );
+    await _channel.invokeMethod<double>('pausePreview', <String, dynamic>{
+      'cameraId': cameraId,
+    });
   }
 
   @override
   Future<void> resumePreview(int cameraId) async {
-    await _channel.invokeMethod<double>(
-      'resumePreview',
-      <String, dynamic>{'cameraId': cameraId},
-    );
+    await _channel.invokeMethod<double>('resumePreview', <String, dynamic>{
+      'cameraId': cameraId,
+    });
   }
 
   @override
   Future<void> setDescriptionWhileRecording(
-      CameraDescription description) async {
+    CameraDescription description,
+  ) async {
     await _channel.invokeMethod<double>(
       'setDescriptionWhileRecording',
-      <String, dynamic>{
-        'cameraName': description.name,
-      },
+      <String, dynamic>{'cameraName': description.name},
     );
   }
 
   @override
   Future<void> setImageFileFormat(int cameraId, ImageFileFormat format) {
-    return _channel.invokeMethod<void>(
-      'setImageFileFormat',
-      <String, dynamic>{
-        'cameraId': cameraId,
-        'fileFormat': format.name,
-      },
-    );
+    return _channel.invokeMethod<void>('setImageFileFormat', <String, dynamic>{
+      'cameraId': cameraId,
+      'fileFormat': format.name,
+    });
   }
 
   @override
@@ -585,8 +570,11 @@ class MethodChannelCamera extends CameraPlatform {
     switch (call.method) {
       case 'orientation_changed':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
-        deviceEventStreamController.add(DeviceOrientationChangedEvent(
-            deserializeDeviceOrientation(arguments['orientation']! as String)));
+        deviceEventStreamController.add(
+          DeviceOrientationChangedEvent(
+            deserializeDeviceOrientation(arguments['orientation']! as String),
+          ),
+        );
       default:
         throw MissingPluginException();
     }
@@ -601,41 +589,44 @@ class MethodChannelCamera extends CameraPlatform {
     switch (call.method) {
       case 'initialized':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
-        cameraEventStreamController.add(CameraInitializedEvent(
-          cameraId,
-          arguments['previewWidth']! as double,
-          arguments['previewHeight']! as double,
-          deserializeExposureMode(arguments['exposureMode']! as String),
-          arguments['exposurePointSupported']! as bool,
-          deserializeFocusMode(arguments['focusMode']! as String),
-          arguments['focusPointSupported']! as bool,
-        ));
+        cameraEventStreamController.add(
+          CameraInitializedEvent(
+            cameraId,
+            arguments['previewWidth']! as double,
+            arguments['previewHeight']! as double,
+            deserializeExposureMode(arguments['exposureMode']! as String),
+            arguments['exposurePointSupported']! as bool,
+            deserializeFocusMode(arguments['focusMode']! as String),
+            arguments['focusPointSupported']! as bool,
+          ),
+        );
       case 'resolution_changed':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
-        cameraEventStreamController.add(CameraResolutionChangedEvent(
-          cameraId,
-          arguments['captureWidth']! as double,
-          arguments['captureHeight']! as double,
-        ));
+        cameraEventStreamController.add(
+          CameraResolutionChangedEvent(
+            cameraId,
+            arguments['captureWidth']! as double,
+            arguments['captureHeight']! as double,
+          ),
+        );
       case 'camera_closing':
-        cameraEventStreamController.add(CameraClosingEvent(
-          cameraId,
-        ));
+        cameraEventStreamController.add(CameraClosingEvent(cameraId));
       case 'video_recorded':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
-        cameraEventStreamController.add(VideoRecordedEvent(
-          cameraId,
-          XFile(arguments['path']! as String),
-          arguments['maxVideoDuration'] != null
-              ? Duration(milliseconds: arguments['maxVideoDuration']! as int)
-              : null,
-        ));
+        cameraEventStreamController.add(
+          VideoRecordedEvent(
+            cameraId,
+            XFile(arguments['path']! as String),
+            arguments['maxVideoDuration'] != null
+                ? Duration(milliseconds: arguments['maxVideoDuration']! as int)
+                : null,
+          ),
+        );
       case 'error':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
-        cameraEventStreamController.add(CameraErrorEvent(
-          cameraId,
-          arguments['description']! as String,
-        ));
+        cameraEventStreamController.add(
+          CameraErrorEvent(cameraId, arguments['description']! as String),
+        );
       default:
         throw MissingPluginException();
     }

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/type_conversion.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/type_conversion.dart
@@ -10,16 +10,20 @@ import '../types/types.dart';
 /// [CameraImageData].
 CameraImageData cameraImageFromPlatformData(Map<dynamic, dynamic> data) {
   return CameraImageData(
-      format: _cameraImageFormatFromPlatformData(data['format']),
-      height: data['height'] as int,
-      width: data['width'] as int,
-      lensAperture: data['lensAperture'] as double?,
-      sensorExposureTime: data['sensorExposureTime'] as int?,
-      sensorSensitivity: data['sensorSensitivity'] as double?,
-      planes: List<CameraImagePlane>.unmodifiable(
-          (data['planes'] as List<dynamic>).map<CameraImagePlane>(
-              (dynamic planeData) => _cameraImagePlaneFromPlatformData(
-                  planeData as Map<dynamic, dynamic>))));
+    format: _cameraImageFormatFromPlatformData(data['format']),
+    height: data['height'] as int,
+    width: data['width'] as int,
+    lensAperture: data['lensAperture'] as double?,
+    sensorExposureTime: data['sensorExposureTime'] as int?,
+    sensorSensitivity: data['sensorSensitivity'] as double?,
+    planes: List<CameraImagePlane>.unmodifiable(
+      (data['planes'] as List<dynamic>).map<CameraImagePlane>(
+        (dynamic planeData) => _cameraImagePlaneFromPlatformData(
+          planeData as Map<dynamic, dynamic>,
+        ),
+      ),
+    ),
+  );
 }
 
 CameraImageFormat _cameraImageFormatFromPlatformData(dynamic data) {
@@ -51,9 +55,10 @@ ImageFormatGroup _imageFormatGroupFromPlatformData(dynamic data) {
 
 CameraImagePlane _cameraImagePlaneFromPlatformData(Map<dynamic, dynamic> data) {
   return CameraImagePlane(
-      bytes: data['bytes'] as Uint8List,
-      bytesPerPixel: data['bytesPerPixel'] as int?,
-      bytesPerRow: data['bytesPerRow'] as int,
-      height: data['height'] as int?,
-      width: data['width'] as int?);
+    bytes: data['bytes'] as Uint8List,
+    bytesPerPixel: data['bytesPerPixel'] as int?,
+    bytesPerRow: data['bytesPerRow'] as int,
+    height: data['height'] as int?,
+    width: data['width'] as int?,
+  );
 }

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -114,12 +114,15 @@ abstract class CameraPlatform extends PlatformInterface {
   /// - Should support all 4 orientations.
   Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() {
     throw UnimplementedError(
-        'onDeviceOrientationChanged() is not implemented.');
+      'onDeviceOrientationChanged() is not implemented.',
+    );
   }
 
   /// Locks the capture orientation.
   Future<void> lockCaptureOrientation(
-      int cameraId, DeviceOrientation orientation) {
+    int cameraId,
+    DeviceOrientation orientation,
+  ) {
     throw UnimplementedError('lockCaptureOrientation() is not implemented.');
   }
 
@@ -144,7 +147,8 @@ abstract class CameraPlatform extends PlatformInterface {
   Future<void> startVideoRecording(
     int cameraId, {
     @Deprecated(
-        'This parameter is unused, and will be ignored on all platforms')
+      'This parameter is unused, and will be ignored on all platforms',
+    )
     Duration? maxVideoDuration,
   }) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
@@ -186,8 +190,10 @@ abstract class CameraPlatform extends PlatformInterface {
   ///
   // TODO(bmparr): Add options to control streaming settings (e.g.,
   // resolution and FPS).
-  Stream<CameraImageData> onStreamedFrameAvailable(int cameraId,
-      {CameraImageStreamOptions? options}) {
+  Stream<CameraImageData> onStreamedFrameAvailable(
+    int cameraId, {
+    CameraImageStreamOptions? options,
+  }) {
     throw UnimplementedError('onStreamedFrameAvailable() is not implemented.');
   }
 
@@ -288,7 +294,8 @@ abstract class CameraPlatform extends PlatformInterface {
   /// Sets the active camera while recording.
   Future<void> setDescriptionWhileRecording(CameraDescription description) {
     throw UnimplementedError(
-        'setDescriptionWhileRecording() is not implemented.');
+      'setDescriptionWhileRecording() is not implemented.',
+    );
   }
 
   /// Returns a widget showing a live camera preview.

--- a/packages/camera/camera_platform_interface/lib/src/types/media_settings.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/media_settings.dart
@@ -19,11 +19,15 @@ class MediaSettings {
     this.videoBitrate,
     this.audioBitrate,
     this.enableAudio = false,
-  })  : assert(fps == null || fps > 0, 'fps must be null or greater than zero'),
-        assert(videoBitrate == null || videoBitrate > 0,
-            'videoBitrate must be null or greater than zero'),
-        assert(audioBitrate == null || audioBitrate > 0,
-            'audioBitrate must be null or greater than zero');
+  }) : assert(fps == null || fps > 0, 'fps must be null or greater than zero'),
+       assert(
+         videoBitrate == null || videoBitrate > 0,
+         'videoBitrate must be null or greater than zero',
+       ),
+       assert(
+         audioBitrate == null || audioBitrate > 0,
+         'audioBitrate must be null or greater than zero',
+       );
 
   /// [ResolutionPreset] affect the quality of video recording and image capture.
   final ResolutionPreset? resolutionPreset;
@@ -58,12 +62,12 @@ class MediaSettings {
 
   @override
   int get hashCode => Object.hash(
-        resolutionPreset,
-        fps,
-        videoBitrate,
-        audioBitrate,
-        enableAudio,
-      );
+    resolutionPreset,
+    fps,
+    videoBitrate,
+    audioBitrate,
+    enableAudio,
+  );
 
   @override
   String toString() {

--- a/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
@@ -13,14 +13,15 @@ class VideoCaptureOptions {
   const VideoCaptureOptions(
     this.cameraId, {
     @Deprecated(
-        'This parameter is unused, and will be ignored on all platforms')
+      'This parameter is unused, and will be ignored on all platforms',
+    )
     this.maxDuration,
     this.streamCallback,
     this.streamOptions,
   }) : assert(
-          streamOptions == null || streamCallback != null,
-          'Must specify streamCallback if providing streamOptions.',
-        );
+         streamOptions == null || streamCallback != null,
+         'Must specify streamCallback if providing streamOptions.',
+       );
 
   /// The ID of the camera to use for capturing.
   final int cameraId;

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.10.0
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   cross_file: ^0.3.1

--- a/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
+++ b/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
@@ -33,490 +33,513 @@ void main() {
     });
 
     test(
-        'Default implementation of availableCameras() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of availableCameras() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.availableCameras(),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of onCameraInitialized() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.onCameraInitialized(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.availableCameras(),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of onResolutionChanged() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of onCameraInitialized() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.onCameraResolutionChanged(1),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of onCameraClosing() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.onCameraClosing(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.onCameraInitialized(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of onCameraError() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of onResolutionChanged() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.onCameraError(1),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of onDeviceOrientationChanged() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.onDeviceOrientationChanged(),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.onCameraResolutionChanged(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of lockCaptureOrientation() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of onCameraClosing() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.lockCaptureOrientation(
-            1, DeviceOrientation.portraitUp),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of unlockCaptureOrientation() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.unlockCaptureOrientation(1),
-        throwsUnimplementedError,
-      );
-    });
-
-    test('Default implementation of dispose() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.dispose(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.onCameraClosing(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of createCamera() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of onCameraError() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.createCamera(
-          const CameraDescription(
-            name: 'back',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0,
+        // Act & Assert
+        expect(() => cameraPlatform.onCameraError(1), throwsUnimplementedError);
+      },
+    );
+
+    test(
+      'Default implementation of onDeviceOrientationChanged() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.onDeviceOrientationChanged(),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of lockCaptureOrientation() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.lockCaptureOrientation(
+            1,
+            DeviceOrientation.portraitUp,
           ),
-          ResolutionPreset.low,
-        ),
-        throwsUnimplementedError,
-      );
-    });
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of createCameraWithSettings() should call createCamera() passing parameters',
-        () {
-      // Arrange
-      const CameraDescription cameraDescription = CameraDescription(
-        name: 'back',
-        lensDirection: CameraLensDirection.back,
-        sensorOrientation: 0,
-      );
+      'Default implementation of unlockCaptureOrientation() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      const MediaSettings mediaSettings = MediaSettings(
-        resolutionPreset: ResolutionPreset.low,
-        fps: 15,
-        videoBitrate: 200000,
-        audioBitrate: 32000,
-        enableAudio: true,
-      );
-
-      bool createCameraCalled = false;
-
-      final OverriddenCameraPlatform cameraPlatform = OverriddenCameraPlatform((
-        CameraDescription cameraDescriptionArg,
-        ResolutionPreset? resolutionPresetArg,
-        bool enableAudioArg,
-      ) {
+        // Act & Assert
         expect(
-          cameraDescriptionArg,
+          () => cameraPlatform.unlockCaptureOrientation(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of dispose() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(() => cameraPlatform.dispose(1), throwsUnimplementedError);
+      },
+    );
+
+    test(
+      'Default implementation of createCamera() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.createCamera(
+            const CameraDescription(
+              name: 'back',
+              lensDirection: CameraLensDirection.back,
+              sensorOrientation: 0,
+            ),
+            ResolutionPreset.low,
+          ),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of createCameraWithSettings() should call createCamera() passing parameters',
+      () {
+        // Arrange
+        const CameraDescription cameraDescription = CameraDescription(
+          name: 'back',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 0,
+        );
+
+        const MediaSettings mediaSettings = MediaSettings(
+          resolutionPreset: ResolutionPreset.low,
+          fps: 15,
+          videoBitrate: 200000,
+          audioBitrate: 32000,
+          enableAudio: true,
+        );
+
+        bool createCameraCalled = false;
+
+        final OverriddenCameraPlatform cameraPlatform =
+            OverriddenCameraPlatform((
+              CameraDescription cameraDescriptionArg,
+              ResolutionPreset? resolutionPresetArg,
+              bool enableAudioArg,
+            ) {
+              expect(
+                cameraDescriptionArg,
+                cameraDescription,
+                reason: 'should pass camera description',
+              );
+              expect(
+                resolutionPresetArg,
+                mediaSettings.resolutionPreset,
+                reason: 'should pass resolution preset',
+              );
+              expect(
+                enableAudioArg,
+                mediaSettings.enableAudio,
+                reason: 'should pass enableAudio',
+              );
+
+              createCameraCalled = true;
+            });
+
+        // Act & Assert
+        cameraPlatform.createCameraWithSettings(
           cameraDescription,
-          reason: 'should pass camera description',
+          mediaSettings,
         );
+
         expect(
-          resolutionPresetArg,
-          mediaSettings.resolutionPreset,
-          reason: 'should pass resolution preset',
-        );
-        expect(
-          enableAudioArg,
-          mediaSettings.enableAudio,
-          reason: 'should pass enableAudio',
-        );
-
-        createCameraCalled = true;
-      });
-
-      // Act & Assert
-      cameraPlatform.createCameraWithSettings(
-        cameraDescription,
-        mediaSettings,
-      );
-
-      expect(createCameraCalled, isTrue,
+          createCameraCalled,
+          isTrue,
           reason:
-              'default implementation of createCameraWithSettings should call createCamera passing parameters');
-    });
+              'default implementation of createCameraWithSettings should call createCamera passing parameters',
+        );
+      },
+    );
 
     test(
-        'Default implementation of initializeCamera() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of initializeCamera() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.initializeCamera(1),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of pauseVideoRecording() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.pauseVideoRecording(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.initializeCamera(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of prepareForVideoRecording() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of pauseVideoRecording() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.prepareForVideoRecording(),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of resumeVideoRecording() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.resumeVideoRecording(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.pauseVideoRecording(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of setFlashMode() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of prepareForVideoRecording() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.setFlashMode(1, FlashMode.auto),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of setExposureMode() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.setExposureMode(1, ExposureMode.auto),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.prepareForVideoRecording(),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of setExposurePoint() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of resumeVideoRecording() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.setExposurePoint(1, null),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of getMinExposureOffset() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.getMinExposureOffset(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.resumeVideoRecording(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of getMaxExposureOffset() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of setFlashMode() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.getMaxExposureOffset(1),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of getExposureOffsetStepSize() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.getExposureOffsetStepSize(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.setFlashMode(1, FlashMode.auto),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of setExposureOffset() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of setExposureMode() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.setExposureOffset(1, 2.0),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of setFocusMode() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.setFocusMode(1, FocusMode.auto),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.setExposureMode(1, ExposureMode.auto),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of setFocusPoint() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of setExposurePoint() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.setFocusPoint(1, null),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of startVideoRecording() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.startVideoRecording(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.setExposurePoint(1, null),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of stopVideoRecording() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of getMinExposureOffset() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.stopVideoRecording(1),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of takePicture() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.takePicture(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.getMinExposureOffset(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of getMaxZoomLevel() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of getMaxExposureOffset() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.getMaxZoomLevel(1),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of getMinZoomLevel() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.getMinZoomLevel(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.getMaxExposureOffset(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of setZoomLevel() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of getExposureOffsetStepSize() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.setZoomLevel(1, 1.0),
-        throwsUnimplementedError,
-      );
-    });
-
-    test(
-        'Default implementation of pausePreview() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
-
-      // Act & Assert
-      expect(
-        () => cameraPlatform.pausePreview(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.getExposureOffsetStepSize(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of resumePreview() should throw unimplemented error',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of setExposureOffset() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        () => cameraPlatform.resumePreview(1),
-        throwsUnimplementedError,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.setExposureOffset(1, 2.0),
+          throwsUnimplementedError,
+        );
+      },
+    );
 
     test(
-        'Default implementation of supportsImageStreaming() should return false',
-        () {
-      // Arrange
-      final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+      'Default implementation of setFocusMode() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
 
-      // Act & Assert
-      expect(
-        cameraPlatform.supportsImageStreaming(),
-        false,
-      );
-    });
+        // Act & Assert
+        expect(
+          () => cameraPlatform.setFocusMode(1, FocusMode.auto),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of setFocusPoint() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.setFocusPoint(1, null),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of startVideoRecording() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.startVideoRecording(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of stopVideoRecording() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.stopVideoRecording(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of takePicture() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(() => cameraPlatform.takePicture(1), throwsUnimplementedError);
+      },
+    );
+
+    test(
+      'Default implementation of getMaxZoomLevel() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.getMaxZoomLevel(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of getMinZoomLevel() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.getMinZoomLevel(1),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of setZoomLevel() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(
+          () => cameraPlatform.setZoomLevel(1, 1.0),
+          throwsUnimplementedError,
+        );
+      },
+    );
+
+    test(
+      'Default implementation of pausePreview() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(() => cameraPlatform.pausePreview(1), throwsUnimplementedError);
+      },
+    );
+
+    test(
+      'Default implementation of resumePreview() should throw unimplemented error',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(() => cameraPlatform.resumePreview(1), throwsUnimplementedError);
+      },
+    );
+
+    test(
+      'Default implementation of supportsImageStreaming() should return false',
+      () {
+        // Arrange
+        final ExtendsCameraPlatform cameraPlatform = ExtendsCameraPlatform();
+
+        // Act & Assert
+        expect(cameraPlatform.supportsImageStreaming(), false);
+      },
+    );
   });
 
   group('exports', () {
     test('CameraDescription is exported', () {
       const CameraDescription(
-          name: 'abc-123',
-          sensorOrientation: 1,
-          lensDirection: CameraLensDirection.external);
+        name: 'abc-123',
+        sensorOrientation: 1,
+        lensDirection: CameraLensDirection.external,
+      );
     });
 
     test('CameraException is exported', () {
@@ -572,12 +595,15 @@ class OverriddenCameraPlatform extends CameraPlatform {
     CameraDescription cameraDescription,
     ResolutionPreset? resolutionPreset,
     bool enableAudio,
-  ) _onCreateCameraCalled;
+  )
+  _onCreateCameraCalled;
 
   @override
   Future<int> createCamera(
-      CameraDescription cameraDescription, ResolutionPreset? resolutionPreset,
-      {bool enableAudio = false}) {
+    CameraDescription cameraDescription,
+    ResolutionPreset? resolutionPreset, {
+    bool enableAudio = false,
+  }) {
     _onCreateCameraCalled(cameraDescription, resolutionPreset, enableAudio);
     return Future<int>.value(0);
   }

--- a/packages/camera/camera_platform_interface/test/events/camera_event_test.dart
+++ b/packages/camera/camera_platform_interface/test/events/camera_event_test.dart
@@ -11,7 +11,14 @@ void main() {
   group('CameraInitializedEvent tests', () {
     test('Constructor should initialize all properties', () {
       const CameraInitializedEvent event = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
 
       expect(event.cameraId, 1);
       expect(event.previewWidth, 1024);
@@ -25,14 +32,14 @@ void main() {
     test('fromJson should initialize all properties', () {
       final CameraInitializedEvent event =
           CameraInitializedEvent.fromJson(const <String, dynamic>{
-        'cameraId': 1,
-        'previewWidth': 1024.0,
-        'previewHeight': 640.0,
-        'exposureMode': 'auto',
-        'exposurePointSupported': true,
-        'focusMode': 'auto',
-        'focusPointSupported': true,
-      });
+            'cameraId': 1,
+            'previewWidth': 1024.0,
+            'previewHeight': 640.0,
+            'exposureMode': 'auto',
+            'exposurePointSupported': true,
+            'focusMode': 'auto',
+            'focusPointSupported': true,
+          });
 
       expect(event.cameraId, 1);
       expect(event.previewWidth, 1024);
@@ -45,7 +52,14 @@ void main() {
 
     test('toJson should return a map with all fields', () {
       const CameraInitializedEvent event = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
 
       final Map<String, dynamic> jsonMap = event.toJson();
 
@@ -61,88 +75,210 @@ void main() {
 
     test('equals should return true if objects are the same', () {
       const CameraInitializedEvent firstEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
       const CameraInitializedEvent secondEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
 
       expect(firstEvent == secondEvent, true);
     });
 
     test('equals should return false if cameraId is different', () {
       const CameraInitializedEvent firstEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
       const CameraInitializedEvent secondEvent = CameraInitializedEvent(
-          2, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        2,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
 
       expect(firstEvent == secondEvent, false);
     });
 
     test('equals should return false if previewWidth is different', () {
       const CameraInitializedEvent firstEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
       const CameraInitializedEvent secondEvent = CameraInitializedEvent(
-          1, 2048, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        2048,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
 
       expect(firstEvent == secondEvent, false);
     });
 
     test('equals should return false if previewHeight is different', () {
       const CameraInitializedEvent firstEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
       const CameraInitializedEvent secondEvent = CameraInitializedEvent(
-          1, 1024, 980, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        980,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
 
       expect(firstEvent == secondEvent, false);
     });
 
     test('equals should return false if exposureMode is different', () {
       const CameraInitializedEvent firstEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
       const CameraInitializedEvent secondEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.locked, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.locked,
+        true,
+        FocusMode.auto,
+        true,
+      );
 
       expect(firstEvent == secondEvent, false);
     });
 
-    test('equals should return false if exposurePointSupported is different',
-        () {
-      const CameraInitializedEvent firstEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
-      const CameraInitializedEvent secondEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, false, FocusMode.auto, true);
+    test(
+      'equals should return false if exposurePointSupported is different',
+      () {
+        const CameraInitializedEvent firstEvent = CameraInitializedEvent(
+          1,
+          1024,
+          640,
+          ExposureMode.auto,
+          true,
+          FocusMode.auto,
+          true,
+        );
+        const CameraInitializedEvent secondEvent = CameraInitializedEvent(
+          1,
+          1024,
+          640,
+          ExposureMode.auto,
+          false,
+          FocusMode.auto,
+          true,
+        );
 
-      expect(firstEvent == secondEvent, false);
-    });
+        expect(firstEvent == secondEvent, false);
+      },
+    );
 
     test('equals should return false if focusMode is different', () {
       const CameraInitializedEvent firstEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
       const CameraInitializedEvent secondEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.locked, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.locked,
+        true,
+      );
 
       expect(firstEvent == secondEvent, false);
     });
 
     test('equals should return false if focusPointSupported is different', () {
       const CameraInitializedEvent firstEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
       const CameraInitializedEvent secondEvent = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, false);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        false,
+      );
 
       expect(firstEvent == secondEvent, false);
     });
 
     test('hashCode should match hashCode of all properties', () {
       const CameraInitializedEvent event = CameraInitializedEvent(
-          1, 1024, 640, ExposureMode.auto, true, FocusMode.auto, true);
+        1,
+        1024,
+        640,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      );
       final int expectedHashCode = Object.hash(
-          event.cameraId.hashCode,
-          event.previewWidth,
-          event.previewHeight,
-          event.exposureMode,
-          event.exposurePointSupported,
-          event.focusMode,
-          event.focusPointSupported);
+        event.cameraId.hashCode,
+        event.previewWidth,
+        event.previewHeight,
+        event.exposureMode,
+        event.exposurePointSupported,
+        event.focusMode,
+        event.focusPointSupported,
+      );
 
       expect(event.hashCode, expectedHashCode);
     });
@@ -150,8 +286,11 @@ void main() {
 
   group('CameraResolutionChangesEvent tests', () {
     test('Constructor should initialize all properties', () {
-      const CameraResolutionChangedEvent event =
-          CameraResolutionChangedEvent(1, 1024, 640);
+      const CameraResolutionChangedEvent event = CameraResolutionChangedEvent(
+        1,
+        1024,
+        640,
+      );
 
       expect(event.cameraId, 1);
       expect(event.captureWidth, 1024);
@@ -161,10 +300,10 @@ void main() {
     test('fromJson should initialize all properties', () {
       final CameraResolutionChangedEvent event =
           CameraResolutionChangedEvent.fromJson(const <String, dynamic>{
-        'cameraId': 1,
-        'captureWidth': 1024.0,
-        'captureHeight': 640.0,
-      });
+            'cameraId': 1,
+            'captureWidth': 1024.0,
+            'captureHeight': 640.0,
+          });
 
       expect(event.cameraId, 1);
       expect(event.captureWidth, 1024);
@@ -172,8 +311,11 @@ void main() {
     });
 
     test('toJson should return a map with all fields', () {
-      const CameraResolutionChangedEvent event =
-          CameraResolutionChangedEvent(1, 1024, 640);
+      const CameraResolutionChangedEvent event = CameraResolutionChangedEvent(
+        1,
+        1024,
+        640,
+      );
 
       final Map<String, dynamic> jsonMap = event.toJson();
 
@@ -220,8 +362,11 @@ void main() {
     });
 
     test('hashCode should match hashCode of all properties', () {
-      const CameraResolutionChangedEvent event =
-          CameraResolutionChangedEvent(1, 1024, 640);
+      const CameraResolutionChangedEvent event = CameraResolutionChangedEvent(
+        1,
+        1024,
+        640,
+      );
       final int expectedHashCode = Object.hash(
         event.cameraId.hashCode,
         event.captureWidth,
@@ -240,10 +385,9 @@ void main() {
     });
 
     test('fromJson should initialize all properties', () {
-      final CameraClosingEvent event =
-          CameraClosingEvent.fromJson(const <String, dynamic>{
-        'cameraId': 1,
-      });
+      final CameraClosingEvent event = CameraClosingEvent.fromJson(
+        const <String, dynamic>{'cameraId': 1},
+      );
 
       expect(event.cameraId, 1);
     });
@@ -289,7 +433,8 @@ void main() {
 
     test('fromJson should initialize all properties', () {
       final CameraErrorEvent event = CameraErrorEvent.fromJson(
-          const <String, dynamic>{'cameraId': 1, 'description': 'Error'});
+        const <String, dynamic>{'cameraId': 1, 'description': 'Error'},
+      );
 
       expect(event.cameraId, 1);
       expect(event.description, 'Error');
@@ -328,8 +473,10 @@ void main() {
 
     test('hashCode should match hashCode of all properties', () {
       const CameraErrorEvent event = CameraErrorEvent(1, 'Error');
-      final int expectedHashCode =
-          Object.hash(event.cameraId.hashCode, event.description);
+      final int expectedHashCode = Object.hash(
+        event.cameraId.hashCode,
+        event.description,
+      );
 
       expect(event.hashCode, expectedHashCode);
     });

--- a/packages/camera/camera_platform_interface/test/events/device_event_test.dart
+++ b/packages/camera/camera_platform_interface/test/events/device_event_test.dart
@@ -11,8 +11,9 @@ void main() {
 
   group('DeviceOrientationChangedEvent tests', () {
     test('Constructor should initialize all properties', () {
-      const DeviceOrientationChangedEvent event =
-          DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
+      const DeviceOrientationChangedEvent event = DeviceOrientationChangedEvent(
+        DeviceOrientation.portraitUp,
+      );
 
       expect(event.orientation, DeviceOrientation.portraitUp);
     });
@@ -20,15 +21,16 @@ void main() {
     test('fromJson should initialize all properties', () {
       final DeviceOrientationChangedEvent event =
           DeviceOrientationChangedEvent.fromJson(const <String, dynamic>{
-        'orientation': 'portraitUp',
-      });
+            'orientation': 'portraitUp',
+          });
 
       expect(event.orientation, DeviceOrientation.portraitUp);
     });
 
     test('toJson should return a map with all fields', () {
-      const DeviceOrientationChangedEvent event =
-          DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
+      const DeviceOrientationChangedEvent event = DeviceOrientationChangedEvent(
+        DeviceOrientation.portraitUp,
+      );
 
       final Map<String, dynamic> jsonMap = event.toJson();
 
@@ -55,8 +57,9 @@ void main() {
     });
 
     test('hashCode should match hashCode of all properties', () {
-      const DeviceOrientationChangedEvent event =
-          DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
+      const DeviceOrientationChangedEvent event = DeviceOrientationChangedEvent(
+        DeviceOrientation.portraitUp,
+      );
       final int expectedHashCode = event.orientation.hashCode;
 
       expect(event.hashCode, expectedHashCode);

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -23,21 +23,23 @@ void main() {
       test('Should send creation data and receive back a camera id', () async {
         // Arrange
         final MethodChannelMock cameraMockChannel = MethodChannelMock(
-            channelName: 'plugins.flutter.io/camera',
-            methods: <String, dynamic>{
-              'create': <String, dynamic>{
-                'cameraId': 1,
-                'imageFormatGroup': 'unknown',
-              }
-            });
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{
+            'create': <String, dynamic>{
+              'cameraId': 1,
+              'imageFormatGroup': 'unknown',
+            },
+          },
+        );
         final MethodChannelCamera camera = MethodChannelCamera();
 
         // Act
         final int cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
-              name: 'Test',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 0),
+            name: 'Test',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 0,
+          ),
           const MediaSettings(
             resolutionPreset: ResolutionPreset.low,
             fps: 15,
@@ -56,7 +58,7 @@ void main() {
               'fps': 15,
               'videoBitrate': 200000,
               'audioBitrate': 32000,
-              'enableAudio': false
+              'enableAudio': false,
             },
           ),
         ]);
@@ -64,84 +66,100 @@ void main() {
       });
 
       test(
-          'Should throw CameraException when create throws a PlatformException',
-          () {
-        // Arrange
-        MethodChannelMock(
+        'Should throw CameraException when create throws a PlatformException',
+        () {
+          // Arrange
+          MethodChannelMock(
             channelName: 'plugins.flutter.io/camera',
             methods: <String, dynamic>{
               'create': PlatformException(
                 code: 'TESTING_ERROR_CODE',
                 message: 'Mock error message used during testing.',
-              )
-            });
-        final MethodChannelCamera camera = MethodChannelCamera();
+              ),
+            },
+          );
+          final MethodChannelCamera camera = MethodChannelCamera();
 
-        // Act
-        expect(
-          () => camera.createCameraWithSettings(
-            const CameraDescription(
-              name: 'Test',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 0,
+          // Act
+          expect(
+            () => camera.createCameraWithSettings(
+              const CameraDescription(
+                name: 'Test',
+                lensDirection: CameraLensDirection.back,
+                sensorOrientation: 0,
+              ),
+              const MediaSettings(
+                resolutionPreset: ResolutionPreset.low,
+                fps: 15,
+                videoBitrate: 200000,
+                audioBitrate: 32000,
+                enableAudio: true,
+              ),
             ),
-            const MediaSettings(
-              resolutionPreset: ResolutionPreset.low,
-              fps: 15,
-              videoBitrate: 200000,
-              audioBitrate: 32000,
-              enableAudio: true,
+            throwsA(
+              isA<CameraException>()
+                  .having(
+                    (CameraException e) => e.code,
+                    'code',
+                    'TESTING_ERROR_CODE',
+                  )
+                  .having(
+                    (CameraException e) => e.description,
+                    'description',
+                    'Mock error message used during testing.',
+                  ),
             ),
-          ),
-          throwsA(
-            isA<CameraException>()
-                .having(
-                    (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
-                .having((CameraException e) => e.description, 'description',
-                    'Mock error message used during testing.'),
-          ),
-        );
-      });
+          );
+        },
+      );
 
       test(
-          'Should throw CameraException when create throws a PlatformException',
-          () {
-        // Arrange
-        MethodChannelMock(
+        'Should throw CameraException when create throws a PlatformException',
+        () {
+          // Arrange
+          MethodChannelMock(
             channelName: 'plugins.flutter.io/camera',
             methods: <String, dynamic>{
               'create': PlatformException(
                 code: 'TESTING_ERROR_CODE',
                 message: 'Mock error message used during testing.',
-              )
-            });
-        final MethodChannelCamera camera = MethodChannelCamera();
+              ),
+            },
+          );
+          final MethodChannelCamera camera = MethodChannelCamera();
 
-        // Act
-        expect(
-          () => camera.createCameraWithSettings(
-            const CameraDescription(
-              name: 'Test',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 0,
+          // Act
+          expect(
+            () => camera.createCameraWithSettings(
+              const CameraDescription(
+                name: 'Test',
+                lensDirection: CameraLensDirection.back,
+                sensorOrientation: 0,
+              ),
+              const MediaSettings(
+                resolutionPreset: ResolutionPreset.low,
+                fps: 15,
+                videoBitrate: 200000,
+                audioBitrate: 32000,
+                enableAudio: true,
+              ),
             ),
-            const MediaSettings(
-              resolutionPreset: ResolutionPreset.low,
-              fps: 15,
-              videoBitrate: 200000,
-              audioBitrate: 32000,
-              enableAudio: true,
+            throwsA(
+              isA<CameraException>()
+                  .having(
+                    (CameraException e) => e.code,
+                    'code',
+                    'TESTING_ERROR_CODE',
+                  )
+                  .having(
+                    (CameraException e) => e.description,
+                    'description',
+                    'Mock error message used during testing.',
+                  ),
             ),
-          ),
-          throwsA(
-            isA<CameraException>()
-                .having(
-                    (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
-                .having((CameraException e) => e.description, 'description',
-                    'Mock error message used during testing.'),
-          ),
-        );
-      });
+          );
+        },
+      );
 
       test(
         'Should throw CameraException when initialize throws a PlatformException',
@@ -153,7 +171,7 @@ void main() {
               'initialize': PlatformException(
                 code: 'TESTING_ERROR_CODE',
                 message: 'Mock error message used during testing.',
-              )
+              ),
             },
           );
           final MethodChannelCamera camera = MethodChannelCamera();
@@ -163,8 +181,11 @@ void main() {
             () => camera.initializeCamera(0),
             throwsA(
               isA<CameraException>()
-                  .having((CameraException e) => e.code, 'code',
-                      'TESTING_ERROR_CODE')
+                  .having(
+                    (CameraException e) => e.code,
+                    'code',
+                    'TESTING_ERROR_CODE',
+                  )
                   .having(
                     (CameraException e) => e.description,
                     'description',
@@ -178,14 +199,15 @@ void main() {
       test('Should send initialization data', () async {
         // Arrange
         final MethodChannelMock cameraMockChannel = MethodChannelMock(
-            channelName: 'plugins.flutter.io/camera',
-            methods: <String, dynamic>{
-              'create': <String, dynamic>{
-                'cameraId': 1,
-                'imageFormatGroup': 'unknown',
-              },
-              'initialize': null
-            });
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{
+            'create': <String, dynamic>{
+              'cameraId': 1,
+              'imageFormatGroup': 'unknown',
+            },
+            'initialize': null,
+          },
+        );
         final MethodChannelCamera camera = MethodChannelCamera();
         final int cameraId = await camera.createCameraWithSettings(
           const CameraDescription(
@@ -204,15 +226,17 @@ void main() {
 
         // Act
         final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-        camera.cameraEventStreamController.add(CameraInitializedEvent(
-          cameraId,
-          1920,
-          1080,
-          ExposureMode.auto,
-          true,
-          FocusMode.auto,
-          true,
-        ));
+        camera.cameraEventStreamController.add(
+          CameraInitializedEvent(
+            cameraId,
+            1920,
+            1080,
+            ExposureMode.auto,
+            true,
+            FocusMode.auto,
+            true,
+          ),
+        );
         await initializeFuture;
 
         // Assert
@@ -232,12 +256,13 @@ void main() {
       test('Should send a disposal call on dispose', () async {
         // Arrange
         final MethodChannelMock cameraMockChannel = MethodChannelMock(
-            channelName: 'plugins.flutter.io/camera',
-            methods: <String, dynamic>{
-              'create': <String, dynamic>{'cameraId': 1},
-              'initialize': null,
-              'dispose': <String, dynamic>{'cameraId': 1}
-            });
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{
+            'create': <String, dynamic>{'cameraId': 1},
+            'initialize': null,
+            'dispose': <String, dynamic>{'cameraId': 1},
+          },
+        );
 
         final MethodChannelCamera camera = MethodChannelCamera();
         final int cameraId = await camera.createCameraWithSettings(
@@ -255,15 +280,17 @@ void main() {
           ),
         );
         final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-        camera.cameraEventStreamController.add(CameraInitializedEvent(
-          cameraId,
-          1920,
-          1080,
-          ExposureMode.auto,
-          true,
-          FocusMode.auto,
-          true,
-        ));
+        camera.cameraEventStreamController.add(
+          CameraInitializedEvent(
+            cameraId,
+            1920,
+            1080,
+            ExposureMode.auto,
+            true,
+            FocusMode.auto,
+            true,
+          ),
+        );
         await initializeFuture;
 
         // Act
@@ -274,10 +301,7 @@ void main() {
         expect(cameraMockChannel.log, <Matcher>[
           anything,
           anything,
-          isMethodCall(
-            'dispose',
-            arguments: <String, Object?>{'cameraId': 1},
-          ),
+          isMethodCall('dispose', arguments: <String, Object?>{'cameraId': 1}),
         ]);
       });
     });
@@ -290,183 +314,7 @@ void main() {
           channelName: 'plugins.flutter.io/camera',
           methods: <String, dynamic>{
             'create': <String, dynamic>{'cameraId': 1},
-            'initialize': null
-          },
-        );
-        camera = MethodChannelCamera();
-        cameraId = await camera.createCameraWithSettings(
-          const CameraDescription(
-            name: 'Test',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0,
-          ),
-          const MediaSettings(
-            resolutionPreset: ResolutionPreset.low,
-            fps: 15,
-            videoBitrate: 200000,
-            audioBitrate: 32000,
-            enableAudio: true,
-          ),
-        );
-        final Future<void> initializeFuture = camera.initializeCamera(cameraId);
-        camera.cameraEventStreamController.add(CameraInitializedEvent(
-          cameraId,
-          1920,
-          1080,
-          ExposureMode.auto,
-          true,
-          FocusMode.auto,
-          true,
-        ));
-        await initializeFuture;
-      });
-
-      test('Should receive initialized event', () async {
-        // Act
-        final Stream<CameraInitializedEvent> eventStream =
-            camera.onCameraInitialized(cameraId);
-        final StreamQueue<CameraInitializedEvent> streamQueue =
-            StreamQueue<CameraInitializedEvent>(eventStream);
-
-        // Emit test events
-        final CameraInitializedEvent event = CameraInitializedEvent(
-          cameraId,
-          3840,
-          2160,
-          ExposureMode.auto,
-          true,
-          FocusMode.auto,
-          true,
-        );
-        await camera.handleCameraMethodCall(
-            MethodCall('initialized', event.toJson()), cameraId);
-
-        // Assert
-        expect(await streamQueue.next, event);
-
-        // Clean up
-        await streamQueue.cancel();
-      });
-
-      test('Should receive resolution changes', () async {
-        // Act
-        final Stream<CameraResolutionChangedEvent> resolutionStream =
-            camera.onCameraResolutionChanged(cameraId);
-        final StreamQueue<CameraResolutionChangedEvent> streamQueue =
-            StreamQueue<CameraResolutionChangedEvent>(resolutionStream);
-
-        // Emit test events
-        final CameraResolutionChangedEvent fhdEvent =
-            CameraResolutionChangedEvent(cameraId, 1920, 1080);
-        final CameraResolutionChangedEvent uhdEvent =
-            CameraResolutionChangedEvent(cameraId, 3840, 2160);
-        await camera.handleCameraMethodCall(
-            MethodCall('resolution_changed', fhdEvent.toJson()), cameraId);
-        await camera.handleCameraMethodCall(
-            MethodCall('resolution_changed', uhdEvent.toJson()), cameraId);
-        await camera.handleCameraMethodCall(
-            MethodCall('resolution_changed', fhdEvent.toJson()), cameraId);
-        await camera.handleCameraMethodCall(
-            MethodCall('resolution_changed', uhdEvent.toJson()), cameraId);
-
-        // Assert
-        expect(await streamQueue.next, fhdEvent);
-        expect(await streamQueue.next, uhdEvent);
-        expect(await streamQueue.next, fhdEvent);
-        expect(await streamQueue.next, uhdEvent);
-
-        // Clean up
-        await streamQueue.cancel();
-      });
-
-      test('Should receive camera closing events', () async {
-        // Act
-        final Stream<CameraClosingEvent> eventStream =
-            camera.onCameraClosing(cameraId);
-        final StreamQueue<CameraClosingEvent> streamQueue =
-            StreamQueue<CameraClosingEvent>(eventStream);
-
-        // Emit test events
-        final CameraClosingEvent event = CameraClosingEvent(cameraId);
-        await camera.handleCameraMethodCall(
-            MethodCall('camera_closing', event.toJson()), cameraId);
-        await camera.handleCameraMethodCall(
-            MethodCall('camera_closing', event.toJson()), cameraId);
-        await camera.handleCameraMethodCall(
-            MethodCall('camera_closing', event.toJson()), cameraId);
-
-        // Assert
-        expect(await streamQueue.next, event);
-        expect(await streamQueue.next, event);
-        expect(await streamQueue.next, event);
-
-        // Clean up
-        await streamQueue.cancel();
-      });
-
-      test('Should receive camera error events', () async {
-        // Act
-        final Stream<CameraErrorEvent> errorStream =
-            camera.onCameraError(cameraId);
-        final StreamQueue<CameraErrorEvent> streamQueue =
-            StreamQueue<CameraErrorEvent>(errorStream);
-
-        // Emit test events
-        final CameraErrorEvent event =
-            CameraErrorEvent(cameraId, 'Error Description');
-        await camera.handleCameraMethodCall(
-            MethodCall('error', event.toJson()), cameraId);
-        await camera.handleCameraMethodCall(
-            MethodCall('error', event.toJson()), cameraId);
-        await camera.handleCameraMethodCall(
-            MethodCall('error', event.toJson()), cameraId);
-
-        // Assert
-        expect(await streamQueue.next, event);
-        expect(await streamQueue.next, event);
-        expect(await streamQueue.next, event);
-
-        // Clean up
-        await streamQueue.cancel();
-      });
-
-      test('Should receive device orientation change events', () async {
-        // Act
-        final Stream<DeviceOrientationChangedEvent> eventStream =
-            camera.onDeviceOrientationChanged();
-        final StreamQueue<DeviceOrientationChangedEvent> streamQueue =
-            StreamQueue<DeviceOrientationChangedEvent>(eventStream);
-
-        // Emit test events
-        const DeviceOrientationChangedEvent event =
-            DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
-        await camera.handleDeviceMethodCall(
-            MethodCall('orientation_changed', event.toJson()));
-        await camera.handleDeviceMethodCall(
-            MethodCall('orientation_changed', event.toJson()));
-        await camera.handleDeviceMethodCall(
-            MethodCall('orientation_changed', event.toJson()));
-
-        // Assert
-        expect(await streamQueue.next, event);
-        expect(await streamQueue.next, event);
-        expect(await streamQueue.next, event);
-
-        // Clean up
-        await streamQueue.cancel();
-      });
-    });
-
-    group('Function Tests', () {
-      late MethodChannelCamera camera;
-      late int cameraId;
-
-      setUp(() async {
-        MethodChannelMock(
-          channelName: 'plugins.flutter.io/camera',
-          methods: <String, dynamic>{
-            'create': <String, dynamic>{'cameraId': 1},
-            'initialize': null
+            'initialize': null,
           },
         );
         camera = MethodChannelCamera();
@@ -499,87 +347,309 @@ void main() {
         await initializeFuture;
       });
 
-      test('Should fetch CameraDescription instances for available cameras',
-          () async {
-        // Arrange
-        final List<dynamic> returnData = <dynamic>[
-          <String, dynamic>{
-            'name': 'Test 1',
-            'lensFacing': 'front',
-            'sensorOrientation': 1
-          },
-          <String, dynamic>{
-            'name': 'Test 2',
-            'lensFacing': 'back',
-            'sensorOrientation': 2
-          }
-        ];
-        final MethodChannelMock channel = MethodChannelMock(
-          channelName: 'plugins.flutter.io/camera',
-          methods: <String, dynamic>{'availableCameras': returnData},
+      test('Should receive initialized event', () async {
+        // Act
+        final Stream<CameraInitializedEvent> eventStream = camera
+            .onCameraInitialized(cameraId);
+        final StreamQueue<CameraInitializedEvent> streamQueue =
+            StreamQueue<CameraInitializedEvent>(eventStream);
+
+        // Emit test events
+        final CameraInitializedEvent event = CameraInitializedEvent(
+          cameraId,
+          3840,
+          2160,
+          ExposureMode.auto,
+          true,
+          FocusMode.auto,
+          true,
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('initialized', event.toJson()),
+          cameraId,
         );
 
+        // Assert
+        expect(await streamQueue.next, event);
+
+        // Clean up
+        await streamQueue.cancel();
+      });
+
+      test('Should receive resolution changes', () async {
         // Act
-        final List<CameraDescription> cameras = await camera.availableCameras();
+        final Stream<CameraResolutionChangedEvent> resolutionStream = camera
+            .onCameraResolutionChanged(cameraId);
+        final StreamQueue<CameraResolutionChangedEvent> streamQueue =
+            StreamQueue<CameraResolutionChangedEvent>(resolutionStream);
+
+        // Emit test events
+        final CameraResolutionChangedEvent fhdEvent =
+            CameraResolutionChangedEvent(cameraId, 1920, 1080);
+        final CameraResolutionChangedEvent uhdEvent =
+            CameraResolutionChangedEvent(cameraId, 3840, 2160);
+        await camera.handleCameraMethodCall(
+          MethodCall('resolution_changed', fhdEvent.toJson()),
+          cameraId,
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('resolution_changed', uhdEvent.toJson()),
+          cameraId,
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('resolution_changed', fhdEvent.toJson()),
+          cameraId,
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('resolution_changed', uhdEvent.toJson()),
+          cameraId,
+        );
 
         // Assert
-        expect(channel.log, <Matcher>[
-          isMethodCall('availableCameras', arguments: null),
-        ]);
-        expect(cameras.length, returnData.length);
-        for (int i = 0; i < returnData.length; i++) {
-          final Map<String, Object?> typedData =
-              (returnData[i] as Map<dynamic, dynamic>).cast<String, Object?>();
-          final CameraDescription cameraDescription = CameraDescription(
-            name: typedData['name']! as String,
-            lensDirection:
-                parseCameraLensDirection(typedData['lensFacing']! as String),
-            sensorOrientation: typedData['sensorOrientation']! as int,
-          );
-          expect(cameras[i], cameraDescription);
-        }
+        expect(await streamQueue.next, fhdEvent);
+        expect(await streamQueue.next, uhdEvent);
+        expect(await streamQueue.next, fhdEvent);
+        expect(await streamQueue.next, uhdEvent);
+
+        // Clean up
+        await streamQueue.cancel();
+      });
+
+      test('Should receive camera closing events', () async {
+        // Act
+        final Stream<CameraClosingEvent> eventStream = camera.onCameraClosing(
+          cameraId,
+        );
+        final StreamQueue<CameraClosingEvent> streamQueue =
+            StreamQueue<CameraClosingEvent>(eventStream);
+
+        // Emit test events
+        final CameraClosingEvent event = CameraClosingEvent(cameraId);
+        await camera.handleCameraMethodCall(
+          MethodCall('camera_closing', event.toJson()),
+          cameraId,
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('camera_closing', event.toJson()),
+          cameraId,
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('camera_closing', event.toJson()),
+          cameraId,
+        );
+
+        // Assert
+        expect(await streamQueue.next, event);
+        expect(await streamQueue.next, event);
+        expect(await streamQueue.next, event);
+
+        // Clean up
+        await streamQueue.cancel();
+      });
+
+      test('Should receive camera error events', () async {
+        // Act
+        final Stream<CameraErrorEvent> errorStream = camera.onCameraError(
+          cameraId,
+        );
+        final StreamQueue<CameraErrorEvent> streamQueue =
+            StreamQueue<CameraErrorEvent>(errorStream);
+
+        // Emit test events
+        final CameraErrorEvent event = CameraErrorEvent(
+          cameraId,
+          'Error Description',
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('error', event.toJson()),
+          cameraId,
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('error', event.toJson()),
+          cameraId,
+        );
+        await camera.handleCameraMethodCall(
+          MethodCall('error', event.toJson()),
+          cameraId,
+        );
+
+        // Assert
+        expect(await streamQueue.next, event);
+        expect(await streamQueue.next, event);
+        expect(await streamQueue.next, event);
+
+        // Clean up
+        await streamQueue.cancel();
+      });
+
+      test('Should receive device orientation change events', () async {
+        // Act
+        final Stream<DeviceOrientationChangedEvent> eventStream =
+            camera.onDeviceOrientationChanged();
+        final StreamQueue<DeviceOrientationChangedEvent> streamQueue =
+            StreamQueue<DeviceOrientationChangedEvent>(eventStream);
+
+        // Emit test events
+        const DeviceOrientationChangedEvent event =
+            DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
+        await camera.handleDeviceMethodCall(
+          MethodCall('orientation_changed', event.toJson()),
+        );
+        await camera.handleDeviceMethodCall(
+          MethodCall('orientation_changed', event.toJson()),
+        );
+        await camera.handleDeviceMethodCall(
+          MethodCall('orientation_changed', event.toJson()),
+        );
+
+        // Assert
+        expect(await streamQueue.next, event);
+        expect(await streamQueue.next, event);
+        expect(await streamQueue.next, event);
+
+        // Clean up
+        await streamQueue.cancel();
+      });
+    });
+
+    group('Function Tests', () {
+      late MethodChannelCamera camera;
+      late int cameraId;
+
+      setUp(() async {
+        MethodChannelMock(
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{
+            'create': <String, dynamic>{'cameraId': 1},
+            'initialize': null,
+          },
+        );
+        camera = MethodChannelCamera();
+        cameraId = await camera.createCameraWithSettings(
+          const CameraDescription(
+            name: 'Test',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 0,
+          ),
+          const MediaSettings(
+            resolutionPreset: ResolutionPreset.low,
+            fps: 15,
+            videoBitrate: 200000,
+            audioBitrate: 32000,
+            enableAudio: true,
+          ),
+        );
+        final Future<void> initializeFuture = camera.initializeCamera(cameraId);
+        camera.cameraEventStreamController.add(
+          CameraInitializedEvent(
+            cameraId,
+            1920,
+            1080,
+            ExposureMode.auto,
+            true,
+            FocusMode.auto,
+            true,
+          ),
+        );
+        await initializeFuture;
       });
 
       test(
-          'Should throw CameraException when availableCameras throws a PlatformException',
-          () {
-        // Arrange
-        MethodChannelMock(
+        'Should fetch CameraDescription instances for available cameras',
+        () async {
+          // Arrange
+          final List<dynamic> returnData = <dynamic>[
+            <String, dynamic>{
+              'name': 'Test 1',
+              'lensFacing': 'front',
+              'sensorOrientation': 1,
+            },
+            <String, dynamic>{
+              'name': 'Test 2',
+              'lensFacing': 'back',
+              'sensorOrientation': 2,
+            },
+          ];
+          final MethodChannelMock channel = MethodChannelMock(
+            channelName: 'plugins.flutter.io/camera',
+            methods: <String, dynamic>{'availableCameras': returnData},
+          );
+
+          // Act
+          final List<CameraDescription> cameras =
+              await camera.availableCameras();
+
+          // Assert
+          expect(channel.log, <Matcher>[
+            isMethodCall('availableCameras', arguments: null),
+          ]);
+          expect(cameras.length, returnData.length);
+          for (int i = 0; i < returnData.length; i++) {
+            final Map<String, Object?> typedData =
+                (returnData[i] as Map<dynamic, dynamic>)
+                    .cast<String, Object?>();
+            final CameraDescription cameraDescription = CameraDescription(
+              name: typedData['name']! as String,
+              lensDirection: parseCameraLensDirection(
+                typedData['lensFacing']! as String,
+              ),
+              sensorOrientation: typedData['sensorOrientation']! as int,
+            );
+            expect(cameras[i], cameraDescription);
+          }
+        },
+      );
+
+      test(
+        'Should throw CameraException when availableCameras throws a PlatformException',
+        () {
+          // Arrange
+          MethodChannelMock(
             channelName: 'plugins.flutter.io/camera',
             methods: <String, dynamic>{
               'availableCameras': PlatformException(
                 code: 'TESTING_ERROR_CODE',
                 message: 'Mock error message used during testing.',
-              )
-            });
+              ),
+            },
+          );
 
-        // Act
-        expect(
-          camera.availableCameras,
-          throwsA(
-            isA<CameraException>()
-                .having(
-                    (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
-                .having((CameraException e) => e.description, 'description',
-                    'Mock error message used during testing.'),
-          ),
-        );
-      });
+          // Act
+          expect(
+            camera.availableCameras,
+            throwsA(
+              isA<CameraException>()
+                  .having(
+                    (CameraException e) => e.code,
+                    'code',
+                    'TESTING_ERROR_CODE',
+                  )
+                  .having(
+                    (CameraException e) => e.description,
+                    'description',
+                    'Mock error message used during testing.',
+                  ),
+            ),
+          );
+        },
+      );
 
       test('Should take a picture and return an XFile instance', () async {
         // Arrange
         final MethodChannelMock channel = MethodChannelMock(
-            channelName: 'plugins.flutter.io/camera',
-            methods: <String, dynamic>{'takePicture': '/test/path.jpg'});
+          channelName: 'plugins.flutter.io/camera',
+          methods: <String, dynamic>{'takePicture': '/test/path.jpg'},
+        );
 
         // Act
         final XFile file = await camera.takePicture(cameraId);
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('takePicture', arguments: <String, Object?>{
-            'cameraId': cameraId,
-          }),
+          isMethodCall(
+            'takePicture',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
         expect(file.path, '/test/path.jpg');
       });
@@ -612,11 +682,14 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('startVideoRecording', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'maxVideoDuration': null,
-            'enableStream': false,
-          }),
+          isMethodCall(
+            'startVideoRecording',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'maxVideoDuration': null,
+              'enableStream': false,
+            },
+          ),
         ]);
       });
 
@@ -629,17 +702,18 @@ void main() {
 
         // Act
         const CameraDescription cameraDescription = CameraDescription(
-            name: 'Test',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 0);
+          name: 'Test',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 0,
+        );
         await camera.setDescriptionWhileRecording(cameraDescription);
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setDescriptionWhileRecording',
-              arguments: <String, Object?>{
-                'cameraName': cameraDescription.name
-              }),
+          isMethodCall(
+            'setDescriptionWhileRecording',
+            arguments: <String, Object?>{'cameraName': cameraDescription.name},
+          ),
         ]);
       });
 
@@ -655,9 +729,10 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('stopVideoRecording', arguments: <String, Object?>{
-            'cameraId': cameraId,
-          }),
+          isMethodCall(
+            'stopVideoRecording',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
         expect(file.path, '/test/path.mp4');
       });
@@ -674,9 +749,10 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('pauseVideoRecording', arguments: <String, Object?>{
-            'cameraId': cameraId,
-          }),
+          isMethodCall(
+            'pauseVideoRecording',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -692,9 +768,10 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('resumeVideoRecording', arguments: <String, Object?>{
-            'cameraId': cameraId,
-          }),
+          isMethodCall(
+            'resumeVideoRecording',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -713,22 +790,25 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setFlashMode', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'mode': 'torch'
-          }),
-          isMethodCall('setFlashMode', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'mode': 'always'
-          }),
-          isMethodCall('setFlashMode', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'mode': 'auto'
-          }),
-          isMethodCall('setFlashMode', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'mode': 'off'
-          }),
+          isMethodCall(
+            'setFlashMode',
+            arguments: <String, Object?>{'cameraId': cameraId, 'mode': 'torch'},
+          ),
+          isMethodCall(
+            'setFlashMode',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'mode': 'always',
+            },
+          ),
+          isMethodCall(
+            'setFlashMode',
+            arguments: <String, Object?>{'cameraId': cameraId, 'mode': 'auto'},
+          ),
+          isMethodCall(
+            'setFlashMode',
+            arguments: <String, Object?>{'cameraId': cameraId, 'mode': 'off'},
+          ),
         ]);
       });
 
@@ -745,14 +825,17 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setExposureMode', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'mode': 'auto'
-          }),
-          isMethodCall('setExposureMode', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'mode': 'locked'
-          }),
+          isMethodCall(
+            'setExposureMode',
+            arguments: <String, Object?>{'cameraId': cameraId, 'mode': 'auto'},
+          ),
+          isMethodCall(
+            'setExposureMode',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'mode': 'locked',
+            },
+          ),
         ]);
       });
 
@@ -769,18 +852,24 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setExposurePoint', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'x': 0.5,
-            'y': 0.5,
-            'reset': false
-          }),
-          isMethodCall('setExposurePoint', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'x': null,
-            'y': null,
-            'reset': true
-          }),
+          isMethodCall(
+            'setExposurePoint',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'x': 0.5,
+              'y': 0.5,
+              'reset': false,
+            },
+          ),
+          isMethodCall(
+            'setExposurePoint',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'x': null,
+              'y': null,
+              'reset': true,
+            },
+          ),
         ]);
       });
 
@@ -792,15 +881,17 @@ void main() {
         );
 
         // Act
-        final double minExposureOffset =
-            await camera.getMinExposureOffset(cameraId);
+        final double minExposureOffset = await camera.getMinExposureOffset(
+          cameraId,
+        );
 
         // Assert
         expect(minExposureOffset, 2.0);
         expect(channel.log, <Matcher>[
-          isMethodCall('getMinExposureOffset', arguments: <String, Object?>{
-            'cameraId': cameraId,
-          }),
+          isMethodCall(
+            'getMinExposureOffset',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -812,15 +903,17 @@ void main() {
         );
 
         // Act
-        final double maxExposureOffset =
-            await camera.getMaxExposureOffset(cameraId);
+        final double maxExposureOffset = await camera.getMaxExposureOffset(
+          cameraId,
+        );
 
         // Assert
         expect(maxExposureOffset, 2.0);
         expect(channel.log, <Matcher>[
-          isMethodCall('getMaxExposureOffset', arguments: <String, Object?>{
-            'cameraId': cameraId,
-          }),
+          isMethodCall(
+            'getMaxExposureOffset',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -832,16 +925,17 @@ void main() {
         );
 
         // Act
-        final double stepSize =
-            await camera.getExposureOffsetStepSize(cameraId);
+        final double stepSize = await camera.getExposureOffsetStepSize(
+          cameraId,
+        );
 
         // Assert
         expect(stepSize, 0.25);
         expect(channel.log, <Matcher>[
-          isMethodCall('getExposureOffsetStepSize',
-              arguments: <String, Object?>{
-                'cameraId': cameraId,
-              }),
+          isMethodCall(
+            'getExposureOffsetStepSize',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -853,16 +947,18 @@ void main() {
         );
 
         // Act
-        final double actualOffset =
-            await camera.setExposureOffset(cameraId, 0.5);
+        final double actualOffset = await camera.setExposureOffset(
+          cameraId,
+          0.5,
+        );
 
         // Assert
         expect(actualOffset, 0.6);
         expect(channel.log, <Matcher>[
-          isMethodCall('setExposureOffset', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'offset': 0.5,
-          }),
+          isMethodCall(
+            'setExposureOffset',
+            arguments: <String, Object?>{'cameraId': cameraId, 'offset': 0.5},
+          ),
         ]);
       });
 
@@ -879,14 +975,17 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setFocusMode', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'mode': 'auto'
-          }),
-          isMethodCall('setFocusMode', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'mode': 'locked'
-          }),
+          isMethodCall(
+            'setFocusMode',
+            arguments: <String, Object?>{'cameraId': cameraId, 'mode': 'auto'},
+          ),
+          isMethodCall(
+            'setFocusMode',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'mode': 'locked',
+            },
+          ),
         ]);
       });
 
@@ -903,18 +1002,24 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setFocusPoint', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'x': 0.5,
-            'y': 0.5,
-            'reset': false
-          }),
-          isMethodCall('setFocusPoint', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'x': null,
-            'y': null,
-            'reset': true
-          }),
+          isMethodCall(
+            'setFocusPoint',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'x': 0.5,
+              'y': 0.5,
+              'reset': false,
+            },
+          ),
+          isMethodCall(
+            'setFocusPoint',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'x': null,
+              'y': null,
+              'reset': true,
+            },
+          ),
         ]);
       });
 
@@ -927,15 +1032,20 @@ void main() {
         expect((widget as Texture).textureId, cameraId);
       });
 
-      test('Should throw MissingPluginException when handling unknown method',
-          () {
-        final MethodChannelCamera camera = MethodChannelCamera();
+      test(
+        'Should throw MissingPluginException when handling unknown method',
+        () {
+          final MethodChannelCamera camera = MethodChannelCamera();
 
-        expect(
+          expect(
             () => camera.handleCameraMethodCall(
-                const MethodCall('unknown_method'), 1),
-            throwsA(isA<MissingPluginException>()));
-      });
+              const MethodCall('unknown_method'),
+              1,
+            ),
+            throwsA(isA<MissingPluginException>()),
+          );
+        },
+      );
 
       test('Should get the max zoom level', () async {
         // Arrange
@@ -950,9 +1060,10 @@ void main() {
         // Assert
         expect(maxZoomLevel, 10.0);
         expect(channel.log, <Matcher>[
-          isMethodCall('getMaxZoomLevel', arguments: <String, Object?>{
-            'cameraId': cameraId,
-          }),
+          isMethodCall(
+            'getMaxZoomLevel',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -969,9 +1080,10 @@ void main() {
         // Assert
         expect(maxZoomLevel, 1.0);
         expect(channel.log, <Matcher>[
-          isMethodCall('getMinZoomLevel', arguments: <String, Object?>{
-            'cameraId': cameraId,
-          }),
+          isMethodCall(
+            'getMinZoomLevel',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -987,32 +1099,42 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setZoomLevel',
-              arguments: <String, Object?>{'cameraId': cameraId, 'zoom': 2.0}),
+          isMethodCall(
+            'setZoomLevel',
+            arguments: <String, Object?>{'cameraId': cameraId, 'zoom': 2.0},
+          ),
         ]);
       });
 
-      test('Should throw CameraException when illegal zoom level is supplied',
-          () async {
-        // Arrange
-        MethodChannelMock(
-          channelName: 'plugins.flutter.io/camera',
-          methods: <String, dynamic>{
-            'setZoomLevel': PlatformException(
-              code: 'ZOOM_ERROR',
-              message: 'Illegal zoom error',
-            )
-          },
-        );
+      test(
+        'Should throw CameraException when illegal zoom level is supplied',
+        () async {
+          // Arrange
+          MethodChannelMock(
+            channelName: 'plugins.flutter.io/camera',
+            methods: <String, dynamic>{
+              'setZoomLevel': PlatformException(
+                code: 'ZOOM_ERROR',
+                message: 'Illegal zoom error',
+              ),
+            },
+          );
 
-        // Act & assert
-        expect(
+          // Act & assert
+          expect(
             () => camera.setZoomLevel(cameraId, -1.0),
-            throwsA(isA<CameraException>()
-                .having((CameraException e) => e.code, 'code', 'ZOOM_ERROR')
-                .having((CameraException e) => e.description, 'description',
-                    'Illegal zoom error')));
-      });
+            throwsA(
+              isA<CameraException>()
+                  .having((CameraException e) => e.code, 'code', 'ZOOM_ERROR')
+                  .having(
+                    (CameraException e) => e.description,
+                    'description',
+                    'Illegal zoom error',
+                  ),
+            ),
+          );
+        },
+      );
 
       test('Should lock the capture orientation', () async {
         // Arrange
@@ -1023,14 +1145,19 @@ void main() {
 
         // Act
         await camera.lockCaptureOrientation(
-            cameraId, DeviceOrientation.portraitUp);
+          cameraId,
+          DeviceOrientation.portraitUp,
+        );
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('lockCaptureOrientation', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'orientation': 'portraitUp'
-          }),
+          isMethodCall(
+            'lockCaptureOrientation',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'orientation': 'portraitUp',
+            },
+          ),
         ]);
       });
 
@@ -1046,8 +1173,10 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('unlockCaptureOrientation',
-              arguments: <String, Object?>{'cameraId': cameraId}),
+          isMethodCall(
+            'unlockCaptureOrientation',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -1063,8 +1192,10 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('pausePreview',
-              arguments: <String, Object?>{'cameraId': cameraId}),
+          isMethodCall(
+            'pausePreview',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -1080,8 +1211,10 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('resumePreview',
-              arguments: <String, Object?>{'cameraId': cameraId}),
+          isMethodCall(
+            'resumePreview',
+            arguments: <String, Object?>{'cameraId': cameraId},
+          ),
         ]);
       });
 
@@ -1143,10 +1276,13 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setImageFileFormat', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'fileFormat': 'heif',
-          }),
+          isMethodCall(
+            'setImageFileFormat',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'fileFormat': 'heif',
+            },
+          ),
         ]);
       });
 
@@ -1154,9 +1290,7 @@ void main() {
         // Arrange
         final MethodChannelMock channel = MethodChannelMock(
           channelName: 'plugins.flutter.io/camera',
-          methods: <String, dynamic>{
-            'setImageFileFormat': 'jpeg',
-          },
+          methods: <String, dynamic>{'setImageFileFormat': 'jpeg'},
         );
 
         // Act
@@ -1164,10 +1298,13 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('setImageFileFormat', arguments: <String, Object?>{
-            'cameraId': cameraId,
-            'fileFormat': 'jpeg',
-          }),
+          isMethodCall(
+            'setImageFileFormat',
+            arguments: <String, Object?>{
+              'cameraId': cameraId,
+              'fileFormat': 'jpeg',
+            },
+          ),
         ]);
       });
     });

--- a/packages/camera/camera_platform_interface/test/method_channel/type_conversion_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/type_conversion_test.dart
@@ -9,24 +9,25 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('CameraImageData can be created', () {
-    final CameraImageData cameraImage =
-        cameraImageFromPlatformData(<dynamic, dynamic>{
-      'format': 35,
-      'height': 1,
-      'width': 4,
-      'lensAperture': 1.8,
-      'sensorExposureTime': 9991324,
-      'sensorSensitivity': 92.0,
-      'planes': <dynamic>[
-        <dynamic, dynamic>{
-          'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-          'bytesPerPixel': 1,
-          'bytesPerRow': 4,
-          'height': 1,
-          'width': 4
-        }
-      ]
-    });
+    final CameraImageData cameraImage = cameraImageFromPlatformData(
+      <dynamic, dynamic>{
+        'format': 35,
+        'height': 1,
+        'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
+        'planes': <dynamic>[
+          <dynamic, dynamic>{
+            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+            'bytesPerPixel': 1,
+            'bytesPerRow': 4,
+            'height': 1,
+            'width': 4,
+          },
+        ],
+      },
+    );
     expect(cameraImage.height, 1);
     expect(cameraImage.width, 4);
     expect(cameraImage.format.group, ImageFormatGroup.yuv420);
@@ -36,48 +37,50 @@ void main() {
   test('CameraImageData has ImageFormatGroup.yuv420 for iOS', () {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
-    final CameraImageData cameraImage =
-        cameraImageFromPlatformData(<dynamic, dynamic>{
-      'format': 875704438,
-      'height': 1,
-      'width': 4,
-      'lensAperture': 1.8,
-      'sensorExposureTime': 9991324,
-      'sensorSensitivity': 92.0,
-      'planes': <dynamic>[
-        <dynamic, dynamic>{
-          'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-          'bytesPerPixel': 1,
-          'bytesPerRow': 4,
-          'height': 1,
-          'width': 4
-        }
-      ]
-    });
+    final CameraImageData cameraImage = cameraImageFromPlatformData(
+      <dynamic, dynamic>{
+        'format': 875704438,
+        'height': 1,
+        'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
+        'planes': <dynamic>[
+          <dynamic, dynamic>{
+            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+            'bytesPerPixel': 1,
+            'bytesPerRow': 4,
+            'height': 1,
+            'width': 4,
+          },
+        ],
+      },
+    );
     expect(cameraImage.format.group, ImageFormatGroup.yuv420);
   });
 
   test('CameraImageData has ImageFormatGroup.yuv420 for Android', () {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-    final CameraImageData cameraImage =
-        cameraImageFromPlatformData(<dynamic, dynamic>{
-      'format': 35,
-      'height': 1,
-      'width': 4,
-      'lensAperture': 1.8,
-      'sensorExposureTime': 9991324,
-      'sensorSensitivity': 92.0,
-      'planes': <dynamic>[
-        <dynamic, dynamic>{
-          'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
-          'bytesPerPixel': 1,
-          'bytesPerRow': 4,
-          'height': 1,
-          'width': 4
-        }
-      ]
-    });
+    final CameraImageData cameraImage = cameraImageFromPlatformData(
+      <dynamic, dynamic>{
+        'format': 35,
+        'height': 1,
+        'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
+        'planes': <dynamic>[
+          <dynamic, dynamic>{
+            'bytes': Uint8List.fromList(<int>[1, 2, 3, 4]),
+            'bytesPerPixel': 1,
+            'bytesPerRow': 4,
+            'height': 1,
+            'width': 4,
+          },
+        ],
+      },
+    );
     expect(cameraImage.format.group, ImageFormatGroup.yuv420);
   });
 }

--- a/packages/camera/camera_platform_interface/test/types/camera_description_test.dart
+++ b/packages/camera/camera_platform_interface/test/types/camera_description_test.dart
@@ -107,19 +107,24 @@ void main() {
       expect(firstDescription == secondDescription, true);
     });
 
-    test('hashCode should match hashCode of all equality-tested properties',
-        () {
-      const CameraDescription description = CameraDescription(
-        name: 'Test',
-        lensDirection: CameraLensDirection.front,
-        sensorOrientation: 0,
-        lensType: CameraLensType.ultraWide,
-      );
-      final int expectedHashCode = Object.hash(
-          description.name, description.lensDirection, description.lensType);
+    test(
+      'hashCode should match hashCode of all equality-tested properties',
+      () {
+        const CameraDescription description = CameraDescription(
+          name: 'Test',
+          lensDirection: CameraLensDirection.front,
+          sensorOrientation: 0,
+          lensType: CameraLensType.ultraWide,
+        );
+        final int expectedHashCode = Object.hash(
+          description.name,
+          description.lensDirection,
+          description.lensType,
+        );
 
-      expect(description.hashCode, expectedHashCode);
-    });
+        expect(description.hashCode, expectedHashCode);
+      },
+    );
 
     test('toString should return correct string representation', () {
       const CameraDescription description = CameraDescription(

--- a/packages/camera/camera_platform_interface/test/types/camera_image_data_test.dart
+++ b/packages/camera/camera_platform_interface/test/types/camera_image_data_test.dart
@@ -18,11 +18,12 @@ void main() {
       sensorSensitivity: 92.0,
       planes: <CameraImagePlane>[
         CameraImagePlane(
-            bytes: Uint8List.fromList(<int>[1, 2, 3, 4]),
-            bytesPerRow: 4,
-            bytesPerPixel: 2,
-            height: 100,
-            width: 200)
+          bytes: Uint8List.fromList(<int>[1, 2, 3, 4]),
+          bytesPerRow: 4,
+          bytesPerPixel: 2,
+          height: 100,
+          width: 200,
+        ),
       ],
     );
     expect(cameraImage.format.group, ImageFormatGroup.jpeg);

--- a/packages/camera/camera_platform_interface/test/types/media_settings_test.dart
+++ b/packages/camera/camera_platform_interface/test/types/media_settings_test.dart
@@ -9,41 +9,45 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test(
-      'MediaSettings non-parametrized constructor should have correct initial values',
-      () {
-    const MediaSettings settingsWithNoParameters = MediaSettings();
+    'MediaSettings non-parametrized constructor should have correct initial values',
+    () {
+      const MediaSettings settingsWithNoParameters = MediaSettings();
 
-    expect(
-      settingsWithNoParameters.resolutionPreset,
-      isNull,
-      reason:
-          'MediaSettings constructor should have null default resolutionPreset',
-    );
+      expect(
+        settingsWithNoParameters.resolutionPreset,
+        isNull,
+        reason:
+            'MediaSettings constructor should have null default resolutionPreset',
+      );
 
-    expect(
-      settingsWithNoParameters.fps,
-      isNull,
-      reason: 'MediaSettings constructor should have null default fps',
-    );
+      expect(
+        settingsWithNoParameters.fps,
+        isNull,
+        reason: 'MediaSettings constructor should have null default fps',
+      );
 
-    expect(
-      settingsWithNoParameters.videoBitrate,
-      isNull,
-      reason: 'MediaSettings constructor should have null default videoBitrate',
-    );
+      expect(
+        settingsWithNoParameters.videoBitrate,
+        isNull,
+        reason:
+            'MediaSettings constructor should have null default videoBitrate',
+      );
 
-    expect(
-      settingsWithNoParameters.audioBitrate,
-      isNull,
-      reason: 'MediaSettings constructor should have null default audioBitrate',
-    );
+      expect(
+        settingsWithNoParameters.audioBitrate,
+        isNull,
+        reason:
+            'MediaSettings constructor should have null default audioBitrate',
+      );
 
-    expect(
-      settingsWithNoParameters.enableAudio,
-      isFalse,
-      reason: 'MediaSettings constructor should have false default enableAudio',
-    );
-  });
+      expect(
+        settingsWithNoParameters.enableAudio,
+        isFalse,
+        reason:
+            'MediaSettings constructor should have false default enableAudio',
+      );
+    },
+  );
 
   test('MediaSettings fps should hold parameters', () {
     const MediaSettings settings = MediaSettings(
@@ -194,10 +198,7 @@ void main() {
         enableAudio: enableAudio1,
       );
 
-      expect(
-        settings1 == sameSettings,
-        isTrue,
-      );
+      expect(settings1 == sameSettings, isTrue);
     });
 
     test('Identical objects should be equal', () {

--- a/packages/camera/camera_platform_interface/test/utils/method_channel_mock.dart
+++ b/packages/camera/camera_platform_interface/test/utils/method_channel_mock.dart
@@ -24,8 +24,10 @@ class MethodChannelMock {
     log.add(methodCall);
 
     if (!methods.containsKey(methodCall.method)) {
-      throw MissingPluginException('No implementation found for method '
-          '${methodCall.method} on channel ${methodChannel.name}');
+      throw MissingPluginException(
+        'No implementation found for method '
+        '${methodCall.method} on channel ${methodChannel.name}',
+      );
     }
 
     return Future<dynamic>.delayed(delay ?? Duration.zero, () {

--- a/packages/camera/camera_platform_interface/test/utils/utils_test.dart
+++ b/packages/camera/camera_platform_interface/test/utils/utils_test.dart
@@ -10,51 +10,63 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Utility methods', () {
     test(
-        'Should return CameraLensDirection when valid value is supplied when parsing camera lens direction',
-        () {
-      expect(
-        parseCameraLensDirection('back'),
-        CameraLensDirection.back,
-      );
-      expect(
-        parseCameraLensDirection('front'),
-        CameraLensDirection.front,
-      );
-      expect(
-        parseCameraLensDirection('external'),
-        CameraLensDirection.external,
-      );
-    });
+      'Should return CameraLensDirection when valid value is supplied when parsing camera lens direction',
+      () {
+        expect(parseCameraLensDirection('back'), CameraLensDirection.back);
+        expect(parseCameraLensDirection('front'), CameraLensDirection.front);
+        expect(
+          parseCameraLensDirection('external'),
+          CameraLensDirection.external,
+        );
+      },
+    );
 
     test(
-        'Should throw ArgumentException when invalid value is supplied when parsing camera lens direction',
-        () {
-      expect(
-        () => parseCameraLensDirection('test'),
-        throwsA(isArgumentError),
-      );
-    });
+      'Should throw ArgumentException when invalid value is supplied when parsing camera lens direction',
+      () {
+        expect(
+          () => parseCameraLensDirection('test'),
+          throwsA(isArgumentError),
+        );
+      },
+    );
 
     test('serializeDeviceOrientation() should serialize correctly', () {
-      expect(serializeDeviceOrientation(DeviceOrientation.portraitUp),
-          'portraitUp');
-      expect(serializeDeviceOrientation(DeviceOrientation.portraitDown),
-          'portraitDown');
-      expect(serializeDeviceOrientation(DeviceOrientation.landscapeRight),
-          'landscapeRight');
-      expect(serializeDeviceOrientation(DeviceOrientation.landscapeLeft),
-          'landscapeLeft');
+      expect(
+        serializeDeviceOrientation(DeviceOrientation.portraitUp),
+        'portraitUp',
+      );
+      expect(
+        serializeDeviceOrientation(DeviceOrientation.portraitDown),
+        'portraitDown',
+      );
+      expect(
+        serializeDeviceOrientation(DeviceOrientation.landscapeRight),
+        'landscapeRight',
+      );
+      expect(
+        serializeDeviceOrientation(DeviceOrientation.landscapeLeft),
+        'landscapeLeft',
+      );
     });
 
     test('deserializeDeviceOrientation() should deserialize correctly', () {
-      expect(deserializeDeviceOrientation('portraitUp'),
-          DeviceOrientation.portraitUp);
-      expect(deserializeDeviceOrientation('portraitDown'),
-          DeviceOrientation.portraitDown);
-      expect(deserializeDeviceOrientation('landscapeRight'),
-          DeviceOrientation.landscapeRight);
-      expect(deserializeDeviceOrientation('landscapeLeft'),
-          DeviceOrientation.landscapeLeft);
+      expect(
+        deserializeDeviceOrientation('portraitUp'),
+        DeviceOrientation.portraitUp,
+      );
+      expect(
+        deserializeDeviceOrientation('portraitDown'),
+        DeviceOrientation.portraitDown,
+      );
+      expect(
+        deserializeDeviceOrientation('landscapeRight'),
+        DeviceOrientation.landscapeRight,
+      );
+      expect(
+        deserializeDeviceOrientation('landscapeLeft'),
+        DeviceOrientation.landscapeLeft,
+      );
     });
   });
 }

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 0.3.5
 

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 0.3.5

--- a/packages/camera/camera_web/example/integration_test/camera_bitrate_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_bitrate_test.dart
@@ -45,8 +45,9 @@ void main() {
     }
   }
 
-  testWidgets('Camera allows to control video bitrate',
-      (WidgetTester tester) async {
+  testWidgets('Camera allows to control video bitrate', (
+    WidgetTester tester,
+  ) async {
     //const String supportedVideoType = 'video/webm';
     const String supportedVideoType = 'video/webm;codecs="vp9,opus"';
     bool isVideoTypeSupported(String type) => type == supportedVideoType;
@@ -65,49 +66,39 @@ void main() {
       mockWindow.navigator = navigator;
       mockNavigator.mediaDevices = mediaDevices;
 
-      final HTMLCanvasElement canvasElement = HTMLCanvasElement()
-        ..width = videoSize.width.toInt()
-        ..height = videoSize.height.toInt()
-        ..context2D.clearRect(0, 0, videoSize.width, videoSize.height);
+      final HTMLCanvasElement canvasElement =
+          HTMLCanvasElement()
+            ..width = videoSize.width.toInt()
+            ..height = videoSize.height.toInt()
+            ..context2D.clearRect(0, 0, videoSize.width, videoSize.height);
 
       final HTMLVideoElement videoElement = HTMLVideoElement();
 
       final MockCameraService cameraService = MockCameraService();
 
-      CameraPlatform.instance = CameraPlugin(
-        cameraService: cameraService,
-      )..window = window;
+      CameraPlatform.instance = CameraPlugin(cameraService: cameraService)
+        ..window = window;
 
       final CameraOptions options = CameraOptions(
         audio: const AudioConstraints(),
         video: VideoConstraints(
-          width: VideoSizeConstraint(
-            ideal: videoSize.width.toInt(),
-          ),
-          height: VideoSizeConstraint(
-            ideal: videoSize.height.toInt(),
-          ),
+          width: VideoSizeConstraint(ideal: videoSize.width.toInt()),
+          height: VideoSizeConstraint(ideal: videoSize.height.toInt()),
         ),
       );
 
       final int cameraId = videoBitrate;
 
       when(
-        cameraService.getMediaStreamForOptions(
-          options,
-          cameraId: cameraId,
-        ),
+        cameraService.getMediaStreamForOptions(options, cameraId: cameraId),
       ).thenAnswer((_) async => canvasElement.captureStream());
 
       final Camera camera = Camera(
-          textureId: cameraId,
-          cameraService: cameraService,
-          options: options,
-          recorderOptions: (
-            audioBitrate: null,
-            videoBitrate: videoBitrate,
-          ))
-        ..isVideoTypeSupported = isVideoTypeSupported;
+        textureId: cameraId,
+        cameraService: cameraService,
+        options: options,
+        recorderOptions: (audioBitrate: null, videoBitrate: videoBitrate),
+      )..isVideoTypeSupported = isVideoTypeSupported;
 
       await camera.initialize();
       await camera.play();

--- a/packages/camera/camera_web/example/integration_test/camera_error_code_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_error_code_test.dart
@@ -25,10 +25,7 @@ void main() {
       });
 
       testWidgets('notFound', (WidgetTester tester) async {
-        expect(
-          CameraErrorCode.notFound.toString(),
-          equals('cameraNotFound'),
-        );
+        expect(CameraErrorCode.notFound.toString(), equals('cameraNotFound'));
       });
 
       testWidgets('notReadable', (WidgetTester tester) async {
@@ -53,24 +50,15 @@ void main() {
       });
 
       testWidgets('type', (WidgetTester tester) async {
-        expect(
-          CameraErrorCode.type.toString(),
-          equals('cameraType'),
-        );
+        expect(CameraErrorCode.type.toString(), equals('cameraType'));
       });
 
       testWidgets('abort', (WidgetTester tester) async {
-        expect(
-          CameraErrorCode.abort.toString(),
-          equals('cameraAbort'),
-        );
+        expect(CameraErrorCode.abort.toString(), equals('cameraAbort'));
       });
 
       testWidgets('security', (WidgetTester tester) async {
-        expect(
-          CameraErrorCode.security.toString(),
-          equals('cameraSecurity'),
-        );
+        expect(CameraErrorCode.security.toString(), equals('cameraSecurity'));
       });
 
       testWidgets('missingMetadata', (WidgetTester tester) async {
@@ -123,10 +111,7 @@ void main() {
       });
 
       testWidgets('unknown', (WidgetTester tester) async {
-        expect(
-          CameraErrorCode.unknown.toString(),
-          equals('cameraUnknown'),
-        );
+        expect(CameraErrorCode.unknown.toString(), equals('cameraUnknown'));
       });
 
       group('fromMediaError', () {
@@ -134,7 +119,9 @@ void main() {
           expect(
             CameraErrorCode.fromMediaError(
               createJSInteropWrapper(
-                  FakeMediaError(MediaError.MEDIA_ERR_ABORTED)) as MediaError,
+                    FakeMediaError(MediaError.MEDIA_ERR_ABORTED),
+                  )
+                  as MediaError,
             ).toString(),
             equals('mediaErrorAborted'),
           );
@@ -144,7 +131,9 @@ void main() {
           expect(
             CameraErrorCode.fromMediaError(
               createJSInteropWrapper(
-                  FakeMediaError(MediaError.MEDIA_ERR_NETWORK)) as MediaError,
+                    FakeMediaError(MediaError.MEDIA_ERR_NETWORK),
+                  )
+                  as MediaError,
             ).toString(),
             equals('mediaErrorNetwork'),
           );
@@ -154,18 +143,22 @@ void main() {
           expect(
             CameraErrorCode.fromMediaError(
               createJSInteropWrapper(
-                  FakeMediaError(MediaError.MEDIA_ERR_DECODE)) as MediaError,
+                    FakeMediaError(MediaError.MEDIA_ERR_DECODE),
+                  )
+                  as MediaError,
             ).toString(),
             equals('mediaErrorDecode'),
           );
         });
 
-        testWidgets('with source not supported error code',
-            (WidgetTester tester) async {
+        testWidgets('with source not supported error code', (
+          WidgetTester tester,
+        ) async {
           expect(
             CameraErrorCode.fromMediaError(
               createJSInteropWrapper(
-                      FakeMediaError(MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED))
+                    FakeMediaError(MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED),
+                  )
                   as MediaError,
             ).toString(),
             equals('mediaErrorSourceNotSupported'),

--- a/packages/camera/camera_web/example/integration_test/camera_metadata_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_metadata_test.dart
@@ -13,15 +13,9 @@ void main() {
   group('CameraMetadata', () {
     testWidgets('supports value equality', (WidgetTester tester) async {
       expect(
-        const CameraMetadata(
-          deviceId: 'deviceId',
-          facingMode: 'environment',
-        ),
+        const CameraMetadata(deviceId: 'deviceId', facingMode: 'environment'),
         equals(
-          const CameraMetadata(
-            deviceId: 'deviceId',
-            facingMode: 'environment',
-          ),
+          const CameraMetadata(deviceId: 'deviceId', facingMode: 'environment'),
         ),
       );
     });

--- a/packages/camera/camera_web/example/integration_test/camera_options_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_options_test.dart
@@ -36,10 +36,16 @@ void main() {
           audio: const AudioConstraints(),
           video: VideoConstraints(
             facingMode: FacingModeConstraint(CameraType.environment),
-            width:
-                const VideoSizeConstraint(minimum: 10, ideal: 15, maximum: 20),
-            height:
-                const VideoSizeConstraint(minimum: 15, ideal: 20, maximum: 25),
+            width: const VideoSizeConstraint(
+              minimum: 10,
+              ideal: 15,
+              maximum: 20,
+            ),
+            height: const VideoSizeConstraint(
+              minimum: 15,
+              ideal: 20,
+              maximum: 25,
+            ),
             deviceId: 'deviceId',
           ),
         ),
@@ -49,9 +55,15 @@ void main() {
             video: VideoConstraints(
               facingMode: FacingModeConstraint(CameraType.environment),
               width: const VideoSizeConstraint(
-                  minimum: 10, ideal: 15, maximum: 20),
+                minimum: 10,
+                ideal: 15,
+                maximum: 20,
+              ),
               height: const VideoSizeConstraint(
-                  minimum: 15, ideal: 20, maximum: 25),
+                minimum: 15,
+                ideal: 20,
+                maximum: 25,
+              ),
               deviceId: 'deviceId',
             ),
           ),
@@ -91,9 +103,7 @@ void main() {
           'facingMode': videoConstraints.facingMode!.toJson(),
           'width': videoConstraints.width!.toJson(),
           'height': videoConstraints.height!.toJson(),
-          'deviceId': <String, Object>{
-            'exact': 'deviceId',
-          }
+          'deviceId': <String, Object>{'exact': 'deviceId'},
         }),
       );
     });
@@ -102,19 +112,31 @@ void main() {
       expect(
         VideoConstraints(
           facingMode: FacingModeConstraint.exact(CameraType.environment),
-          width:
-              const VideoSizeConstraint(minimum: 90, ideal: 100, maximum: 100),
-          height:
-              const VideoSizeConstraint(minimum: 40, ideal: 50, maximum: 50),
+          width: const VideoSizeConstraint(
+            minimum: 90,
+            ideal: 100,
+            maximum: 100,
+          ),
+          height: const VideoSizeConstraint(
+            minimum: 40,
+            ideal: 50,
+            maximum: 50,
+          ),
           deviceId: 'deviceId',
         ),
         equals(
           VideoConstraints(
             facingMode: FacingModeConstraint.exact(CameraType.environment),
             width: const VideoSizeConstraint(
-                minimum: 90, ideal: 100, maximum: 100),
-            height:
-                const VideoSizeConstraint(minimum: 40, ideal: 50, maximum: 50),
+              minimum: 90,
+              ideal: 100,
+              maximum: 100,
+            ),
+            height: const VideoSizeConstraint(
+              minimum: 40,
+              ideal: 50,
+              maximum: 50,
+            ),
             deviceId: 'deviceId',
           ),
         ),
@@ -124,8 +146,7 @@ void main() {
 
   group('FacingModeConstraint', () {
     group('ideal', () {
-      testWidgets(
-          'serializes correctly '
+      testWidgets('serializes correctly '
           'for environment camera type', (WidgetTester tester) async {
         expect(
           FacingModeConstraint(CameraType.environment).toJson(),
@@ -133,8 +154,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'serializes correctly '
+      testWidgets('serializes correctly '
           'for user camera type', (WidgetTester tester) async {
         expect(
           FacingModeConstraint(CameraType.user).toJson(),
@@ -151,8 +171,7 @@ void main() {
     });
 
     group('exact', () {
-      testWidgets(
-          'serializes correctly '
+      testWidgets('serializes correctly '
           'for environment camera type', (WidgetTester tester) async {
         expect(
           FacingModeConstraint.exact(CameraType.environment).toJson(),
@@ -160,8 +179,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'serializes correctly '
+      testWidgets('serializes correctly '
           'for user camera type', (WidgetTester tester) async {
         expect(
           FacingModeConstraint.exact(CameraType.user).toJson(),
@@ -186,27 +204,15 @@ void main() {
           ideal: 400,
           maximum: 400,
         ).toJson(),
-        equals(<String, Object>{
-          'min': 200,
-          'ideal': 400,
-          'max': 400,
-        }),
+        equals(<String, Object>{'min': 200, 'ideal': 400, 'max': 400}),
       );
     });
 
     testWidgets('supports value equality', (WidgetTester tester) async {
       expect(
-        const VideoSizeConstraint(
-          minimum: 100,
-          ideal: 200,
-          maximum: 300,
-        ),
+        const VideoSizeConstraint(minimum: 100, ideal: 200, maximum: 300),
         equals(
-          const VideoSizeConstraint(
-            minimum: 100,
-            ideal: 200,
-            maximum: 300,
-          ),
+          const VideoSizeConstraint(minimum: 100, ideal: 200, maximum: 300),
         ),
       );
     });

--- a/packages/camera/camera_web/example/integration_test/camera_service_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_service_test.dart
@@ -55,26 +55,28 @@ void main() {
       // Mock JsUtil to return the real getProperty from dart:js_util.
       when(jsUtil.getProperty(any, any)).thenAnswer(
         (Invocation invocation) =>
-            (invocation.positionalArguments[0] as JSObject)
-                .getProperty(invocation.positionalArguments[1] as JSAny),
+            (invocation.positionalArguments[0] as JSObject).getProperty(
+              invocation.positionalArguments[1] as JSAny,
+            ),
       );
 
       cameraService = CameraService()..window = window;
     });
 
     group('getMediaStreamForOptions', () {
-      testWidgets(
-          'calls MediaDevices.getUserMedia '
+      testWidgets('calls MediaDevices.getUserMedia '
           'with provided options', (WidgetTester tester) async {
         late final web.MediaStreamConstraints? capturedConstraints;
         mockMediaDevices.getUserMedia =
             ([web.MediaStreamConstraints? constraints]) {
-          capturedConstraints = constraints;
-          final web.MediaStream stream =
-              createJSInteropWrapper(FakeMediaStream(<web.MediaStreamTrack>[]))
-                  as web.MediaStream;
-          return Future<web.MediaStream>.value(stream).toJS;
-        }.toJS;
+              capturedConstraints = constraints;
+              final web.MediaStream stream =
+                  createJSInteropWrapper(
+                        FakeMediaStream(<web.MediaStreamTrack>[]),
+                      )
+                      as web.MediaStream;
+              return Future<web.MediaStream>.value(stream).toJS;
+            }.toJS;
 
         final CameraOptions options = CameraOptions(
           video: VideoConstraints(
@@ -96,15 +98,15 @@ void main() {
       });
 
       group('throws CameraWebException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'when MediaDevices.getUserMedia throws DomException '
             'with NotFoundError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'NotFoundError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'NotFoundError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -113,23 +115,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.notFound),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.notFound,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'when MediaDevices.getUserMedia throws DomException '
             'with DevicesNotFoundError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'DevicesNotFoundError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'DevicesNotFoundError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -138,23 +146,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.notFound),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.notFound,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with notReadable error '
+        testWidgets('with notReadable error '
             'when MediaDevices.getUserMedia throws DomException '
             'with NotReadableError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'NotReadableError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'NotReadableError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
@@ -162,23 +176,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.notReadable),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.notReadable,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with notReadable error '
+        testWidgets('with notReadable error '
             'when MediaDevices.getUserMedia throws DomException '
             'with TrackStartError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'TrackStartError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'TrackStartError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -187,23 +207,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.notReadable),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.notReadable,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with overconstrained error '
+        testWidgets('with overconstrained error '
             'when MediaDevices.getUserMedia throws DomException '
             'with OverconstrainedError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'OverconstrainedError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'OverconstrainedError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -212,23 +238,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.overconstrained),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.overconstrained,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with overconstrained error '
+        testWidgets('with overconstrained error '
             'when MediaDevices.getUserMedia throws DomException '
             'with ConstraintNotSatisfiedError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'ConstraintNotSatisfiedError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'ConstraintNotSatisfiedError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -237,23 +269,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.overconstrained),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.overconstrained,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with permissionDenied error '
+        testWidgets('with permissionDenied error '
             'when MediaDevices.getUserMedia throws DomException '
             'with NotAllowedError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'NotAllowedError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'NotAllowedError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -262,23 +300,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.permissionDenied),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.permissionDenied,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with permissionDenied error '
+        testWidgets('with permissionDenied error '
             'when MediaDevices.getUserMedia throws DomException '
             'with PermissionDeniedError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'PermissionDeniedError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'PermissionDeniedError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -287,23 +331,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.permissionDenied),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.permissionDenied,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with type error '
+        testWidgets('with type error '
             'when MediaDevices.getUserMedia throws DomException '
             'with TypeError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'TypeError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'TypeError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -312,23 +362,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.type),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.type,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with abort error '
+        testWidgets('with abort error '
             'when MediaDevices.getUserMedia throws DomException '
             'with AbortError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'AbortError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'AbortError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -337,23 +393,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.abort),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.abort,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with security error '
+        testWidgets('with security error '
             'when MediaDevices.getUserMedia throws DomException '
             'with SecurityError', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'SecurityError');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'SecurityError');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -362,23 +424,29 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.security),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.security,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with unknown error '
+        testWidgets('with unknown error '
             'when MediaDevices.getUserMedia throws DomException '
             'with an unknown error', (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw web.DOMException('', 'Unknown');
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw web.DOMException('', 'Unknown');
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -387,23 +455,30 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.unknown),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.unknown,
+                  ),
             ),
           );
         });
 
-        testWidgets(
-            'with unknown error '
-            'when MediaDevices.getUserMedia throws an unknown exception',
-            (WidgetTester tester) async {
-          mockMediaDevices.getUserMedia = ([web.MediaStreamConstraints? _]) {
-            throw Exception();
-            // ignore: dead_code
-            return Future<web.MediaStream>.value(web.MediaStream()).toJS;
-          }.toJS;
+        testWidgets('with unknown error '
+            'when MediaDevices.getUserMedia throws an unknown exception', (
+          WidgetTester tester,
+        ) async {
+          mockMediaDevices.getUserMedia =
+              ([web.MediaStreamConstraints? _]) {
+                throw Exception();
+                // ignore: dead_code
+                return Future<web.MediaStream>.value(web.MediaStream()).toJS;
+              }.toJS;
 
           expect(
             () => cameraService.getMediaStreamForOptions(
@@ -412,10 +487,16 @@ void main() {
             ),
             throwsA(
               isA<CameraWebException>()
-                  .having((CameraWebException e) => e.cameraId, 'cameraId',
-                      cameraId)
-                  .having((CameraWebException e) => e.code, 'code',
-                      CameraErrorCode.unknown),
+                  .having(
+                    (CameraWebException e) => e.cameraId,
+                    'cameraId',
+                    cameraId,
+                  )
+                  .having(
+                    (CameraWebException e) => e.code,
+                    'code',
+                    CameraErrorCode.unknown,
+                  ),
             ),
           );
         });
@@ -445,21 +526,22 @@ void main() {
         cameraService.jsUtil = jsUtil;
       });
 
-      testWidgets(
-          'returns the zoom level capability '
+      testWidgets('returns the zoom level capability '
           'based on the first video track', (WidgetTester tester) async {
-        mockMediaDevices.getSupportedConstraints = () {
-          return web.MediaTrackSupportedConstraints(zoom: true);
-        }.toJS;
+        mockMediaDevices.getSupportedConstraints =
+            () {
+              return web.MediaTrackSupportedConstraints(zoom: true);
+            }.toJS;
 
-        mockVideoTrack.getCapabilities = () {
-          return web.MediaTrackCapabilities(
-            zoom: web.MediaSettingsRange(min: 100, max: 400, step: 2),
-          );
-        }.toJS;
+        mockVideoTrack.getCapabilities =
+            () {
+              return web.MediaTrackCapabilities(
+                zoom: web.MediaSettingsRange(min: 100, max: 400, step: 2),
+              );
+            }.toJS;
 
-        final ZoomLevelCapability zoomLevelCapability =
-            cameraService.getZoomLevelCapabilityForCamera(camera);
+        final ZoomLevelCapability zoomLevelCapability = cameraService
+            .getZoomLevelCapabilityForCamera(camera);
 
         expect(zoomLevelCapability.minimum, equals(100.0));
         expect(zoomLevelCapability.maximum, equals(400.0));
@@ -467,19 +549,20 @@ void main() {
       });
 
       group('throws CameraWebException', () {
-        testWidgets(
-            'with zoomLevelNotSupported error '
+        testWidgets('with zoomLevelNotSupported error '
             'when the zoom level is not supported '
             'in the browser', (WidgetTester tester) async {
-          mockMediaDevices.getSupportedConstraints = () {
-            return web.MediaTrackSupportedConstraints(zoom: false);
-          }.toJS;
+          mockMediaDevices.getSupportedConstraints =
+              () {
+                return web.MediaTrackSupportedConstraints(zoom: false);
+              }.toJS;
 
-          mockVideoTrack.getCapabilities = () {
-            return web.MediaTrackCapabilities(
-              zoom: web.MediaSettingsRange(min: 100, max: 400, step: 2),
-            );
-          }.toJS;
+          mockVideoTrack.getCapabilities =
+              () {
+                return web.MediaTrackCapabilities(
+                  zoom: web.MediaSettingsRange(min: 100, max: 400, step: 2),
+                );
+              }.toJS;
 
           expect(
             () => cameraService.getZoomLevelCapabilityForCamera(camera),
@@ -499,13 +582,14 @@ void main() {
           );
         });
 
-        testWidgets(
-            'with notStarted error '
-            'when the camera stream has not been initialized',
-            (WidgetTester tester) async {
-          mockMediaDevices.getSupportedConstraints = () {
-            return web.MediaTrackSupportedConstraints(zoom: true);
-          }.toJS;
+        testWidgets('with notStarted error '
+            'when the camera stream has not been initialized', (
+          WidgetTester tester,
+        ) async {
+          mockMediaDevices.getSupportedConstraints =
+              () {
+                return web.MediaTrackSupportedConstraints(zoom: true);
+              }.toJS;
 
           // Create a camera stream with no video tracks.
           when(camera.stream).thenReturn(
@@ -538,12 +622,12 @@ void main() {
         cameraService.jsUtil = jsUtil;
       });
 
-      testWidgets(
-          'returns null '
+      testWidgets('returns null '
           'when the facing mode is not supported', (WidgetTester tester) async {
-        mockMediaDevices.getSupportedConstraints = () {
-          return web.MediaTrackSupportedConstraints(facingMode: false);
-        }.toJS;
+        mockMediaDevices.getSupportedConstraints =
+            () {
+              return web.MediaTrackSupportedConstraints(facingMode: false);
+            }.toJS;
 
         final String? facingMode = cameraService.getFacingModeForVideoTrack(
           createJSInteropWrapper(MockMediaStreamTrack())
@@ -562,81 +646,95 @@ void main() {
           videoTrack =
               createJSInteropWrapper(mockVideoTrack) as web.MediaStreamTrack;
 
-          when(jsUtil.hasProperty(videoTrack, 'getCapabilities'.toJS))
-              .thenReturn(true);
+          when(
+            jsUtil.hasProperty(videoTrack, 'getCapabilities'.toJS),
+          ).thenReturn(true);
 
-          mockMediaDevices.getSupportedConstraints = () {
-            return web.MediaTrackSupportedConstraints(facingMode: true);
-          }.toJS;
+          mockMediaDevices.getSupportedConstraints =
+              () {
+                return web.MediaTrackSupportedConstraints(facingMode: true);
+              }.toJS;
         });
 
-        testWidgets(
-            'returns an appropriate facing mode '
+        testWidgets('returns an appropriate facing mode '
             'based on the video track settings', (WidgetTester tester) async {
-          mockVideoTrack.getSettings = () {
-            return web.MediaTrackSettings(facingMode: 'user');
-          }.toJS;
+          mockVideoTrack.getSettings =
+              () {
+                return web.MediaTrackSettings(facingMode: 'user');
+              }.toJS;
 
-          final String? facingMode =
-              cameraService.getFacingModeForVideoTrack(videoTrack);
+          final String? facingMode = cameraService.getFacingModeForVideoTrack(
+            videoTrack,
+          );
 
           expect(facingMode, equals('user'));
         });
 
-        testWidgets(
-            'returns an appropriate facing mode '
+        testWidgets('returns an appropriate facing mode '
             'based on the video track capabilities '
-            'when the facing mode setting is empty',
-            (WidgetTester tester) async {
-          mockVideoTrack.getSettings = () {
-            return web.MediaTrackSettings(facingMode: '');
-          }.toJS;
-          mockVideoTrack.getCapabilities = () {
-            return web.MediaTrackCapabilities(
-              facingMode: <JSString>['environment'.toJS, 'left'.toJS].toJS,
-            );
-          }.toJS;
+            'when the facing mode setting is empty', (
+          WidgetTester tester,
+        ) async {
+          mockVideoTrack.getSettings =
+              () {
+                return web.MediaTrackSettings(facingMode: '');
+              }.toJS;
+          mockVideoTrack.getCapabilities =
+              () {
+                return web.MediaTrackCapabilities(
+                  facingMode: <JSString>['environment'.toJS, 'left'.toJS].toJS,
+                );
+              }.toJS;
 
-          when(jsUtil.hasProperty(videoTrack, 'getCapabilities'.toJS))
-              .thenReturn(true);
+          when(
+            jsUtil.hasProperty(videoTrack, 'getCapabilities'.toJS),
+          ).thenReturn(true);
 
-          final String? facingMode =
-              cameraService.getFacingModeForVideoTrack(videoTrack);
+          final String? facingMode = cameraService.getFacingModeForVideoTrack(
+            videoTrack,
+          );
 
           expect(facingMode, equals('environment'));
         });
 
-        testWidgets(
-            'returns null '
+        testWidgets('returns null '
             'when the facing mode setting '
             'and capabilities are empty', (WidgetTester tester) async {
-          mockVideoTrack.getSettings = () {
-            return web.MediaTrackSettings(facingMode: '');
-          }.toJS;
-          mockVideoTrack.getCapabilities = () {
-            return web.MediaTrackCapabilities(facingMode: <JSString>[].toJS);
-          }.toJS;
+          mockVideoTrack.getSettings =
+              () {
+                return web.MediaTrackSettings(facingMode: '');
+              }.toJS;
+          mockVideoTrack.getCapabilities =
+              () {
+                return web.MediaTrackCapabilities(
+                  facingMode: <JSString>[].toJS,
+                );
+              }.toJS;
 
-          final String? facingMode =
-              cameraService.getFacingModeForVideoTrack(videoTrack);
+          final String? facingMode = cameraService.getFacingModeForVideoTrack(
+            videoTrack,
+          );
 
           expect(facingMode, isNull);
         });
 
-        testWidgets(
-            'returns null '
+        testWidgets('returns null '
             'when the facing mode setting is empty and '
-            'the video track capabilities are not supported',
-            (WidgetTester tester) async {
-          mockVideoTrack.getSettings = () {
-            return web.MediaTrackSettings(facingMode: '');
-          }.toJS;
+            'the video track capabilities are not supported', (
+          WidgetTester tester,
+        ) async {
+          mockVideoTrack.getSettings =
+              () {
+                return web.MediaTrackSettings(facingMode: '');
+              }.toJS;
 
-          when(jsUtil.hasProperty(videoTrack, 'getCapabilities'.toJS))
-              .thenReturn(false);
+          when(
+            jsUtil.hasProperty(videoTrack, 'getCapabilities'.toJS),
+          ).thenReturn(false);
 
-          final String? facingMode =
-              cameraService.getFacingModeForVideoTrack(videoTrack);
+          final String? facingMode = cameraService.getFacingModeForVideoTrack(
+            videoTrack,
+          );
 
           expect(facingMode, isNull);
         });
@@ -644,8 +742,7 @@ void main() {
     });
 
     group('mapFacingModeToLensDirection', () {
-      testWidgets(
-          'returns front '
+      testWidgets('returns front '
           'when the facing mode is user', (WidgetTester tester) async {
         expect(
           cameraService.mapFacingModeToLensDirection('user'),
@@ -653,8 +750,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns back '
+      testWidgets('returns back '
           'when the facing mode is environment', (WidgetTester tester) async {
         expect(
           cameraService.mapFacingModeToLensDirection('environment'),
@@ -662,8 +758,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns external '
+      testWidgets('returns external '
           'when the facing mode is left', (WidgetTester tester) async {
         expect(
           cameraService.mapFacingModeToLensDirection('left'),
@@ -671,8 +766,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns external '
+      testWidgets('returns external '
           'when the facing mode is right', (WidgetTester tester) async {
         expect(
           cameraService.mapFacingModeToLensDirection('right'),
@@ -682,8 +776,7 @@ void main() {
     });
 
     group('mapFacingModeToCameraType', () {
-      testWidgets(
-          'returns user '
+      testWidgets('returns user '
           'when the facing mode is user', (WidgetTester tester) async {
         expect(
           cameraService.mapFacingModeToCameraType('user'),
@@ -691,8 +784,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns environment '
+      testWidgets('returns environment '
           'when the facing mode is environment', (WidgetTester tester) async {
         expect(
           cameraService.mapFacingModeToCameraType('environment'),
@@ -700,8 +792,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns user '
+      testWidgets('returns user '
           'when the facing mode is left', (WidgetTester tester) async {
         expect(
           cameraService.mapFacingModeToCameraType('left'),
@@ -709,8 +800,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns user '
+      testWidgets('returns user '
           'when the facing mode is right', (WidgetTester tester) async {
         expect(
           cameraService.mapFacingModeToCameraType('right'),
@@ -720,8 +810,7 @@ void main() {
     });
 
     group('mapResolutionPresetToSize', () {
-      testWidgets(
-          'returns 4096x2160 '
+      testWidgets('returns 4096x2160 '
           'when the resolution preset is max', (WidgetTester tester) async {
         expect(
           cameraService.mapResolutionPresetToSize(ResolutionPreset.max),
@@ -729,28 +818,27 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns 4096x2160 '
-          'when the resolution preset is ultraHigh',
-          (WidgetTester tester) async {
+      testWidgets('returns 4096x2160 '
+          'when the resolution preset is ultraHigh', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
           equals(const Size(4096, 2160)),
         );
       });
 
-      testWidgets(
-          'returns 1920x1080 '
-          'when the resolution preset is veryHigh',
-          (WidgetTester tester) async {
+      testWidgets('returns 1920x1080 '
+          'when the resolution preset is veryHigh', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapResolutionPresetToSize(ResolutionPreset.veryHigh),
           equals(const Size(1920, 1080)),
         );
       });
 
-      testWidgets(
-          'returns 1280x720 '
+      testWidgets('returns 1280x720 '
           'when the resolution preset is high', (WidgetTester tester) async {
         expect(
           cameraService.mapResolutionPresetToSize(ResolutionPreset.high),
@@ -758,8 +846,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns 720x480 '
+      testWidgets('returns 720x480 '
           'when the resolution preset is medium', (WidgetTester tester) async {
         expect(
           cameraService.mapResolutionPresetToSize(ResolutionPreset.medium),
@@ -767,8 +854,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns 320x240 '
+      testWidgets('returns 320x240 '
           'when the resolution preset is low', (WidgetTester tester) async {
         expect(
           cameraService.mapResolutionPresetToSize(ResolutionPreset.low),
@@ -778,10 +864,10 @@ void main() {
     });
 
     group('mapDeviceOrientationToOrientationType', () {
-      testWidgets(
-          'returns portraitPrimary '
-          'when the device orientation is portraitUp',
-          (WidgetTester tester) async {
+      testWidgets('returns portraitPrimary '
+          'when the device orientation is portraitUp', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapDeviceOrientationToOrientationType(
             DeviceOrientation.portraitUp,
@@ -790,10 +876,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns landscapePrimary '
-          'when the device orientation is landscapeLeft',
-          (WidgetTester tester) async {
+      testWidgets('returns landscapePrimary '
+          'when the device orientation is landscapeLeft', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapDeviceOrientationToOrientationType(
             DeviceOrientation.landscapeLeft,
@@ -802,10 +888,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns portraitSecondary '
-          'when the device orientation is portraitDown',
-          (WidgetTester tester) async {
+      testWidgets('returns portraitSecondary '
+          'when the device orientation is portraitDown', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapDeviceOrientationToOrientationType(
             DeviceOrientation.portraitDown,
@@ -814,10 +900,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns landscapeSecondary '
-          'when the device orientation is landscapeRight',
-          (WidgetTester tester) async {
+      testWidgets('returns landscapeSecondary '
+          'when the device orientation is landscapeRight', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapDeviceOrientationToOrientationType(
             DeviceOrientation.landscapeRight,
@@ -828,10 +914,10 @@ void main() {
     });
 
     group('mapOrientationTypeToDeviceOrientation', () {
-      testWidgets(
-          'returns portraitUp '
-          'when the orientation type is portraitPrimary',
-          (WidgetTester tester) async {
+      testWidgets('returns portraitUp '
+          'when the orientation type is portraitPrimary', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitPrimary,
@@ -840,10 +926,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns landscapeLeft '
-          'when the orientation type is landscapePrimary',
-          (WidgetTester tester) async {
+      testWidgets('returns landscapeLeft '
+          'when the orientation type is landscapePrimary', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapOrientationTypeToDeviceOrientation(
             OrientationType.landscapePrimary,
@@ -852,10 +938,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns portraitDown '
-          'when the orientation type is portraitSecondary',
-          (WidgetTester tester) async {
+      testWidgets('returns portraitDown '
+          'when the orientation type is portraitSecondary', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitSecondary,
@@ -864,10 +950,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns portraitDown '
-          'when the orientation type is portraitSecondary',
-          (WidgetTester tester) async {
+      testWidgets('returns portraitDown '
+          'when the orientation type is portraitSecondary', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapOrientationTypeToDeviceOrientation(
             OrientationType.portraitSecondary,
@@ -876,10 +962,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns landscapeRight '
-          'when the orientation type is landscapeSecondary',
-          (WidgetTester tester) async {
+      testWidgets('returns landscapeRight '
+          'when the orientation type is landscapeSecondary', (
+        WidgetTester tester,
+      ) async {
         expect(
           cameraService.mapOrientationTypeToDeviceOrientation(
             OrientationType.landscapeSecondary,
@@ -888,13 +974,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'returns portraitUp '
+      testWidgets('returns portraitUp '
           'for an unknown orientation type', (WidgetTester tester) async {
         expect(
-          cameraService.mapOrientationTypeToDeviceOrientation(
-            'unknown',
-          ),
+          cameraService.mapOrientationTypeToDeviceOrientation('unknown'),
           equals(DeviceOrientation.portraitUp),
         );
       });

--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -50,8 +50,9 @@ void main() {
 
       cameraService = MockCameraService();
 
-      final HTMLVideoElement videoElement =
-          getVideoElementWithBlankStream(const Size(10, 10));
+      final HTMLVideoElement videoElement = getVideoElementWithBlankStream(
+        const Size(10, 10),
+      );
       mediaStream = videoElement.captureStream();
 
       when(
@@ -63,8 +64,7 @@ void main() {
     });
 
     group('initialize', () {
-      testWidgets(
-          'calls CameraService.getMediaStreamForOptions '
+      testWidgets('calls CameraService.getMediaStreamForOptions '
           'with provided options', (WidgetTester tester) async {
         final CameraOptions options = CameraOptions(
           video: VideoConstraints(
@@ -82,22 +82,17 @@ void main() {
         await camera.initialize();
 
         verify(
-          cameraService.getMediaStreamForOptions(
-            options,
-            cameraId: textureId,
-          ),
+          cameraService.getMediaStreamForOptions(options, cameraId: textureId),
         ).called(1);
       });
 
-      testWidgets(
-          'creates a video element '
+      testWidgets('creates a video element '
           'with correct properties', (WidgetTester tester) async {
-        const AudioConstraints audioConstraints =
-            AudioConstraints(enabled: true);
+        const AudioConstraints audioConstraints = AudioConstraints(
+          enabled: true,
+        );
         final VideoConstraints videoConstraints = VideoConstraints(
-          facingMode: FacingModeConstraint(
-            CameraType.user,
-          ),
+          facingMode: FacingModeConstraint(CameraType.user),
         );
 
         final Camera camera = Camera(
@@ -115,31 +110,30 @@ void main() {
         expect(camera.videoElement.autoplay, isFalse);
         expect(camera.videoElement.muted, isTrue);
         expect(camera.videoElement.srcObject, mediaStream);
-        expect(camera.videoElement.attributes.getNamedItem('playsinline'),
-            isNotNull);
+        expect(
+          camera.videoElement.attributes.getNamedItem('playsinline'),
+          isNotNull,
+        );
 
         expect(
-            camera.videoElement.style.transformOrigin, equals('center center'));
+          camera.videoElement.style.transformOrigin,
+          equals('center center'),
+        );
         expect(camera.videoElement.style.pointerEvents, equals('none'));
         expect(camera.videoElement.style.width, equals('100%'));
         expect(camera.videoElement.style.height, equals('100%'));
         expect(camera.videoElement.style.objectFit, equals('cover'));
       });
 
-      testWidgets(
-          'flips the video element horizontally '
+      testWidgets('flips the video element horizontally '
           'for a back camera', (WidgetTester tester) async {
         final VideoConstraints videoConstraints = VideoConstraints(
-          facingMode: FacingModeConstraint(
-            CameraType.environment,
-          ),
+          facingMode: FacingModeConstraint(CameraType.environment),
         );
 
         final Camera camera = Camera(
           textureId: textureId,
-          options: CameraOptions(
-            video: videoConstraints,
-          ),
+          options: CameraOptions(video: videoConstraints),
           cameraService: cameraService,
         );
 
@@ -148,8 +142,7 @@ void main() {
         expect(camera.videoElement.style.transform, equals('scaleX(-1)'));
       });
 
-      testWidgets(
-          'creates a wrapping div element '
+      testWidgets('creates a wrapping div element '
           'with correct properties', (WidgetTester tester) async {
         final Camera camera = Camera(
           textureId: textureId,
@@ -160,9 +153,12 @@ void main() {
 
         expect(camera.divElement, isNotNull);
         expect(camera.divElement.style.objectFit, equals('cover'));
-        final JSArray<Element>? array = (globalContext['Array']! as JSObject)
-                .callMethod('from'.toJS, camera.divElement.children)
-            as JSArray<Element>?;
+        final JSArray<Element>? array =
+            (globalContext['Array']! as JSObject).callMethod(
+                  'from'.toJS,
+                  camera.divElement.children,
+                )
+                as JSArray<Element>?;
         expect(array?.toDart, contains(camera.videoElement));
       });
 
@@ -177,12 +173,13 @@ void main() {
         expect(camera.stream, mediaStream);
       });
 
-      testWidgets(
-          'throws an exception '
-          'when CameraService.getMediaStreamForOptions throws',
-          (WidgetTester tester) async {
-        final Exception exception =
-            Exception('A media stream exception occured.');
+      testWidgets('throws an exception '
+          'when CameraService.getMediaStreamForOptions throws', (
+        WidgetTester tester,
+      ) async {
+        final Exception exception = Exception(
+          'A media stream exception occured.',
+        );
 
         when(
           cameraService.getMediaStreamForOptions(
@@ -196,16 +193,14 @@ void main() {
           cameraService: cameraService,
         );
 
-        expect(
-          camera.initialize,
-          throwsA(exception),
-        );
+        expect(camera.initialize, throwsA(exception));
       });
     });
 
     group('play', () {
-      testWidgets('starts playing the video element',
-          (WidgetTester tester) async {
+      testWidgets('starts playing the video element', (
+        WidgetTester tester,
+      ) async {
         bool startedPlaying = false;
 
         final Camera camera = Camera(
@@ -216,7 +211,8 @@ void main() {
         await camera.initialize();
 
         final StreamSubscription<Event> cameraPlaySubscription = camera
-            .videoElement.onPlay
+            .videoElement
+            .onPlay
             .listen((Event event) => startedPlaying = true);
 
         await camera.play();
@@ -226,14 +222,11 @@ void main() {
         await cameraPlaySubscription.cancel();
       });
 
-      testWidgets(
-          'initializes the camera stream '
+      testWidgets('initializes the camera stream '
           'from CameraService.getMediaStreamForOptions '
           'if it does not exist', (WidgetTester tester) async {
         const CameraOptions options = CameraOptions(
-          video: VideoConstraints(
-            width: VideoSizeConstraint(ideal: 100),
-          ),
+          video: VideoConstraints(width: VideoSizeConstraint(ideal: 100)),
         );
 
         final Camera camera = Camera(
@@ -252,10 +245,7 @@ void main() {
 
         // Should be called twice: for initialize and play.
         verify(
-          cameraService.getMediaStreamForOptions(
-            options,
-            cameraId: textureId,
-          ),
+          cameraService.getMediaStreamForOptions(options, cameraId: textureId),
         ).called(2);
 
         expect(camera.videoElement.srcObject, mediaStream);
@@ -313,8 +303,7 @@ void main() {
         expect(pictureFile, isNotNull);
       });
 
-      group(
-          'enables the torch mode '
+      group('enables the torch mode '
           'when taking a picture', () {
         late MockMediaStreamTrack mockVideoTrack;
         late List<MediaStreamTrack> videoTracks;
@@ -327,39 +316,40 @@ void main() {
             createJSInteropWrapper(mockVideoTrack) as MediaStreamTrack,
             createJSInteropWrapper(MockMediaStreamTrack()) as MediaStreamTrack,
           ];
-          videoStream = createJSInteropWrapper(FakeMediaStream(videoTracks))
-              as MediaStream;
+          videoStream =
+              createJSInteropWrapper(FakeMediaStream(videoTracks))
+                  as MediaStream;
 
           videoElement = getVideoElementWithBlankStream(const Size(100, 100))
             ..muted = true;
 
-          mockVideoTrack.getCapabilities = () {
-            return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
-          }.toJS;
+          mockVideoTrack.getCapabilities =
+              () {
+                return MediaTrackCapabilities(
+                  torch: <JSBoolean>[true.toJS].toJS,
+                );
+              }.toJS;
         });
 
         testWidgets('if the flash mode is auto', (WidgetTester tester) async {
-          final Camera camera = Camera(
-            textureId: textureId,
-            cameraService: cameraService,
-          )
-            ..window = window
-            ..stream = videoStream
-            ..videoElement = videoElement
-            ..flashMode = FlashMode.auto;
+          final Camera camera =
+              Camera(textureId: textureId, cameraService: cameraService)
+                ..window = window
+                ..stream = videoStream
+                ..videoElement = videoElement
+                ..flashMode = FlashMode.auto;
 
           await camera.play();
 
           final List<MediaTrackConstraints> capturedConstraints =
               <MediaTrackConstraints>[];
-          mockVideoTrack.applyConstraints = ([
-            MediaTrackConstraints? constraints,
-          ]) {
-            if (constraints != null) {
-              capturedConstraints.add(constraints);
-            }
-            return Future<JSAny?>.value().toJS;
-          }.toJS;
+          mockVideoTrack.applyConstraints =
+              ([MediaTrackConstraints? constraints]) {
+                if (constraints != null) {
+                  capturedConstraints.add(constraints);
+                }
+                return Future<JSAny?>.value().toJS;
+              }.toJS;
 
           final XFile _ = await camera.takePicture();
 
@@ -369,27 +359,24 @@ void main() {
         });
 
         testWidgets('if the flash mode is always', (WidgetTester tester) async {
-          final Camera camera = Camera(
-            textureId: textureId,
-            cameraService: cameraService,
-          )
-            ..window = window
-            ..stream = videoStream
-            ..videoElement = videoElement
-            ..flashMode = FlashMode.always;
+          final Camera camera =
+              Camera(textureId: textureId, cameraService: cameraService)
+                ..window = window
+                ..stream = videoStream
+                ..videoElement = videoElement
+                ..flashMode = FlashMode.always;
 
           await camera.play();
 
           final List<MediaTrackConstraints> capturedConstraints =
               <MediaTrackConstraints>[];
-          mockVideoTrack.applyConstraints = ([
-            MediaTrackConstraints? constraints,
-          ]) {
-            if (constraints != null) {
-              capturedConstraints.add(constraints);
-            }
-            return Future<JSAny?>.value().toJS;
-          }.toJS;
+          mockVideoTrack.applyConstraints =
+              ([MediaTrackConstraints? constraints]) {
+                if (constraints != null) {
+                  capturedConstraints.add(constraints);
+                }
+                return Future<JSAny?>.value().toJS;
+              }.toJS;
 
           final XFile _ = await camera.takePicture();
 
@@ -401,14 +388,15 @@ void main() {
     });
 
     group('getVideoSize', () {
-      testWidgets(
-          'returns a size '
-          'based on the first video track settings',
-          (WidgetTester tester) async {
+      testWidgets('returns a size '
+          'based on the first video track settings', (
+        WidgetTester tester,
+      ) async {
         const Size videoSize = Size(1280, 720);
 
-        final HTMLVideoElement videoElement =
-            getVideoElementWithBlankStream(videoSize);
+        final HTMLVideoElement videoElement = getVideoElementWithBlankStream(
+          videoSize,
+        );
         mediaStream = videoElement.captureStream();
 
         final Camera camera = Camera(
@@ -418,14 +406,10 @@ void main() {
 
         await camera.initialize();
 
-        expect(
-          camera.getVideoSize(),
-          equals(videoSize),
-        );
+        expect(camera.getVideoSize(), equals(videoSize));
       });
 
-      testWidgets(
-          'returns Size.zero '
+      testWidgets('returns Size.zero '
           'if the camera is missing video tracks', (WidgetTester tester) async {
         // Create a video stream with no video tracks.
         final HTMLVideoElement videoElement = HTMLVideoElement();
@@ -438,10 +422,7 @@ void main() {
 
         await camera.initialize();
 
-        expect(
-          camera.getVideoSize(),
-          equals(Size.zero),
-        );
+        expect(camera.getVideoSize(), equals(Size.zero));
       });
     });
 
@@ -459,71 +440,66 @@ void main() {
         videoStream =
             createJSInteropWrapper(FakeMediaStream(videoTracks)) as MediaStream;
 
-        mockVideoTrack.applyConstraints = ([
-          MediaTrackConstraints? constraints,
-        ]) {
-          return Future<JSAny?>.value().toJS;
-        }.toJS;
+        mockVideoTrack.applyConstraints =
+            ([MediaTrackConstraints? constraints]) {
+              return Future<JSAny?>.value().toJS;
+            }.toJS;
 
-        mockVideoTrack.getCapabilities = () {
-          return MediaTrackCapabilities();
-        }.toJS;
+        mockVideoTrack.getCapabilities =
+            () {
+              return MediaTrackCapabilities();
+            }.toJS;
       });
 
       testWidgets('sets the camera flash mode', (WidgetTester tester) async {
-        mockMediaDevices.getSupportedConstraints = () {
-          return MediaTrackSupportedConstraints(torch: true);
-        }.toJS;
+        mockMediaDevices.getSupportedConstraints =
+            () {
+              return MediaTrackSupportedConstraints(torch: true);
+            }.toJS;
 
-        mockVideoTrack.getCapabilities = () {
-          return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
-        }.toJS;
+        mockVideoTrack.getCapabilities =
+            () {
+              return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
+            }.toJS;
 
-        final Camera camera = Camera(
-          textureId: textureId,
-          cameraService: cameraService,
-        )
-          ..window = window
-          ..stream = videoStream;
+        final Camera camera =
+            Camera(textureId: textureId, cameraService: cameraService)
+              ..window = window
+              ..stream = videoStream;
 
         const FlashMode flashMode = FlashMode.always;
 
         camera.setFlashMode(flashMode);
 
-        expect(
-          camera.flashMode,
-          equals(flashMode),
-        );
+        expect(camera.flashMode, equals(flashMode));
       });
 
-      testWidgets(
-          'enables the torch mode '
+      testWidgets('enables the torch mode '
           'if the flash mode is torch', (WidgetTester tester) async {
-        mockMediaDevices.getSupportedConstraints = () {
-          return MediaTrackSupportedConstraints(torch: true);
-        }.toJS;
+        mockMediaDevices.getSupportedConstraints =
+            () {
+              return MediaTrackSupportedConstraints(torch: true);
+            }.toJS;
 
-        mockVideoTrack.getCapabilities = () {
-          return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
-        }.toJS;
+        mockVideoTrack.getCapabilities =
+            () {
+              return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
+            }.toJS;
 
-        final Camera camera = Camera(
-          textureId: textureId,
-          cameraService: cameraService,
-        )
-          ..window = window
-          ..stream = videoStream;
+        final Camera camera =
+            Camera(textureId: textureId, cameraService: cameraService)
+              ..window = window
+              ..stream = videoStream;
 
         final List<MediaTrackConstraints> capturedConstraints =
             <MediaTrackConstraints>[];
-        mockVideoTrack.applyConstraints = ([
-          MediaTrackConstraints? constraints,
-        ]) {
-          if (constraints != null) {
-            capturedConstraints.add(constraints);
-          }
-          return Future<JSAny?>.value().toJS;
-        }.toJS;
+        mockVideoTrack.applyConstraints =
+            ([MediaTrackConstraints? constraints]) {
+              if (constraints != null) {
+                capturedConstraints.add(constraints);
+              }
+              return Future<JSAny?>.value().toJS;
+            }.toJS;
 
         camera.setFlashMode(FlashMode.torch);
 
@@ -531,34 +507,32 @@ void main() {
         expect(capturedConstraints[0].torch.dartify(), true);
       });
 
-      testWidgets(
-          'disables the torch mode '
+      testWidgets('disables the torch mode '
           'if the flash mode is not torch', (WidgetTester tester) async {
-        mockMediaDevices.getSupportedConstraints = () {
-          return MediaTrackSupportedConstraints(torch: true);
-        }.toJS;
+        mockMediaDevices.getSupportedConstraints =
+            () {
+              return MediaTrackSupportedConstraints(torch: true);
+            }.toJS;
 
-        mockVideoTrack.getCapabilities = () {
-          return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
-        }.toJS;
+        mockVideoTrack.getCapabilities =
+            () {
+              return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
+            }.toJS;
 
-        final Camera camera = Camera(
-          textureId: textureId,
-          cameraService: cameraService,
-        )
-          ..window = window
-          ..stream = videoStream;
+        final Camera camera =
+            Camera(textureId: textureId, cameraService: cameraService)
+              ..window = window
+              ..stream = videoStream;
 
         final List<MediaTrackConstraints> capturedConstraints =
             <MediaTrackConstraints>[];
-        mockVideoTrack.applyConstraints = ([
-          MediaTrackConstraints? constraints,
-        ]) {
-          if (constraints != null) {
-            capturedConstraints.add(constraints);
-          }
-          return Future<JSAny?>.value().toJS;
-        }.toJS;
+        mockVideoTrack.applyConstraints =
+            ([MediaTrackConstraints? constraints]) {
+              if (constraints != null) {
+                capturedConstraints.add(constraints);
+              }
+              return Future<JSAny?>.value().toJS;
+            }.toJS;
 
         camera.setFlashMode(FlashMode.auto);
 
@@ -567,24 +541,25 @@ void main() {
       });
 
       group('throws a CameraWebException', () {
-        testWidgets(
-            'with torchModeNotSupported error '
+        testWidgets('with torchModeNotSupported error '
             'when the torch mode is not supported '
             'in the browser', (WidgetTester tester) async {
-          mockMediaDevices.getSupportedConstraints = () {
-            return MediaTrackSupportedConstraints(torch: false);
-          }.toJS;
+          mockMediaDevices.getSupportedConstraints =
+              () {
+                return MediaTrackSupportedConstraints(torch: false);
+              }.toJS;
 
-          mockVideoTrack.getCapabilities = () {
-            return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
-          }.toJS;
+          mockVideoTrack.getCapabilities =
+              () {
+                return MediaTrackCapabilities(
+                  torch: <JSBoolean>[true.toJS].toJS,
+                );
+              }.toJS;
 
-          final Camera camera = Camera(
-            textureId: textureId,
-            cameraService: cameraService,
-          )
-            ..window = window
-            ..stream = videoStream;
+          final Camera camera =
+              Camera(textureId: textureId, cameraService: cameraService)
+                ..window = window
+                ..stream = videoStream;
 
           expect(
             () => camera.setFlashMode(FlashMode.always),
@@ -604,24 +579,25 @@ void main() {
           );
         });
 
-        testWidgets(
-            'with torchModeNotSupported error '
+        testWidgets('with torchModeNotSupported error '
             'when the torch mode is not supported '
             'by the camera', (WidgetTester tester) async {
-          mockMediaDevices.getSupportedConstraints = () {
-            return MediaTrackSupportedConstraints(torch: true);
-          }.toJS;
+          mockMediaDevices.getSupportedConstraints =
+              () {
+                return MediaTrackSupportedConstraints(torch: true);
+              }.toJS;
 
-          mockVideoTrack.getCapabilities = () {
-            return MediaTrackCapabilities(torch: <JSBoolean>[false.toJS].toJS);
-          }.toJS;
+          mockVideoTrack.getCapabilities =
+              () {
+                return MediaTrackCapabilities(
+                  torch: <JSBoolean>[false.toJS].toJS,
+                );
+              }.toJS;
 
-          final Camera camera = Camera(
-            textureId: textureId,
-            cameraService: cameraService,
-          )
-            ..window = window
-            ..stream = videoStream;
+          final Camera camera =
+              Camera(textureId: textureId, cameraService: cameraService)
+                ..window = window
+                ..stream = videoStream;
 
           expect(
             () => camera.setFlashMode(FlashMode.always),
@@ -641,17 +617,21 @@ void main() {
           );
         });
 
-        testWidgets(
-            'with notStarted error '
-            'when the camera stream has not been initialized',
-            (WidgetTester tester) async {
-          mockMediaDevices.getSupportedConstraints = () {
-            return MediaTrackSupportedConstraints(torch: true);
-          }.toJS;
+        testWidgets('with notStarted error '
+            'when the camera stream has not been initialized', (
+          WidgetTester tester,
+        ) async {
+          mockMediaDevices.getSupportedConstraints =
+              () {
+                return MediaTrackSupportedConstraints(torch: true);
+              }.toJS;
 
-          mockVideoTrack.getCapabilities = () {
-            return MediaTrackCapabilities(torch: <JSBoolean>[true.toJS].toJS);
-          }.toJS;
+          mockVideoTrack.getCapabilities =
+              () {
+                return MediaTrackCapabilities(
+                  torch: <JSBoolean>[true.toJS].toJS,
+                );
+              }.toJS;
 
           final Camera camera = Camera(
             textureId: textureId,
@@ -680,10 +660,10 @@ void main() {
 
     group('zoomLevel', () {
       group('getMaxZoomLevel', () {
-        testWidgets(
-            'returns maximum '
-            'from CameraService.getZoomLevelCapabilityForCamera',
-            (WidgetTester tester) async {
+        testWidgets('returns maximum '
+            'from CameraService.getZoomLevelCapabilityForCamera', (
+          WidgetTester tester,
+        ) async {
           final Camera camera = Camera(
             textureId: textureId,
             cameraService: cameraService,
@@ -692,30 +672,30 @@ void main() {
           final ZoomLevelCapability zoomLevelCapability = ZoomLevelCapability(
             minimum: 50.0,
             maximum: 100.0,
-            videoTrack: createJSInteropWrapper(MockMediaStreamTrack())
-                as MediaStreamTrack,
+            videoTrack:
+                createJSInteropWrapper(MockMediaStreamTrack())
+                    as MediaStreamTrack,
           );
 
-          when(cameraService.getZoomLevelCapabilityForCamera(camera))
-              .thenReturn(zoomLevelCapability);
+          when(
+            cameraService.getZoomLevelCapabilityForCamera(camera),
+          ).thenReturn(zoomLevelCapability);
 
           final double maximumZoomLevel = camera.getMaxZoomLevel();
 
-          verify(cameraService.getZoomLevelCapabilityForCamera(camera))
-              .called(1);
+          verify(
+            cameraService.getZoomLevelCapabilityForCamera(camera),
+          ).called(1);
 
-          expect(
-            maximumZoomLevel,
-            equals(zoomLevelCapability.maximum),
-          );
+          expect(maximumZoomLevel, equals(zoomLevelCapability.maximum));
         });
       });
 
       group('getMinZoomLevel', () {
-        testWidgets(
-            'returns minimum '
-            'from CameraService.getZoomLevelCapabilityForCamera',
-            (WidgetTester tester) async {
+        testWidgets('returns minimum '
+            'from CameraService.getZoomLevelCapabilityForCamera', (
+          WidgetTester tester,
+        ) async {
           final Camera camera = Camera(
             textureId: textureId,
             cameraService: cameraService,
@@ -724,30 +704,30 @@ void main() {
           final ZoomLevelCapability zoomLevelCapability = ZoomLevelCapability(
             minimum: 50.0,
             maximum: 100.0,
-            videoTrack: createJSInteropWrapper(MockMediaStreamTrack())
-                as MediaStreamTrack,
+            videoTrack:
+                createJSInteropWrapper(MockMediaStreamTrack())
+                    as MediaStreamTrack,
           );
 
-          when(cameraService.getZoomLevelCapabilityForCamera(camera))
-              .thenReturn(zoomLevelCapability);
+          when(
+            cameraService.getZoomLevelCapabilityForCamera(camera),
+          ).thenReturn(zoomLevelCapability);
 
           final double minimumZoomLevel = camera.getMinZoomLevel();
 
-          verify(cameraService.getZoomLevelCapabilityForCamera(camera))
-              .called(1);
+          verify(
+            cameraService.getZoomLevelCapabilityForCamera(camera),
+          ).called(1);
 
-          expect(
-            minimumZoomLevel,
-            equals(zoomLevelCapability.minimum),
-          );
+          expect(minimumZoomLevel, equals(zoomLevelCapability.minimum));
         });
       });
 
       group('setZoomLevel', () {
-        testWidgets(
-            'applies zoom on the video track '
-            'from CameraService.getZoomLevelCapabilityForCamera',
-            (WidgetTester tester) async {
+        testWidgets('applies zoom on the video track '
+            'from CameraService.getZoomLevelCapabilityForCamera', (
+          WidgetTester tester,
+        ) async {
           final Camera camera = Camera(
             textureId: textureId,
             cameraService: cameraService,
@@ -765,17 +745,17 @@ void main() {
 
           final List<MediaTrackConstraints> capturedConstraints =
               <MediaTrackConstraints>[];
-          mockVideoTrack.applyConstraints = ([
-            MediaTrackConstraints? constraints,
-          ]) {
-            if (constraints != null) {
-              capturedConstraints.add(constraints);
-            }
-            return Future<JSAny?>.value().toJS;
-          }.toJS;
+          mockVideoTrack.applyConstraints =
+              ([MediaTrackConstraints? constraints]) {
+                if (constraints != null) {
+                  capturedConstraints.add(constraints);
+                }
+                return Future<JSAny?>.value().toJS;
+              }.toJS;
 
-          when(cameraService.getZoomLevelCapabilityForCamera(camera))
-              .thenReturn(zoomLevelCapability);
+          when(
+            cameraService.getZoomLevelCapabilityForCamera(camera),
+          ).thenReturn(zoomLevelCapability);
 
           const double zoom = 75.0;
 
@@ -786,10 +766,10 @@ void main() {
         });
 
         group('throws a CameraWebException', () {
-          testWidgets(
-              'with zoomLevelInvalid error '
-              'when the provided zoom level is below minimum',
-              (WidgetTester tester) async {
+          testWidgets('with zoomLevelInvalid error '
+              'when the provided zoom level is below minimum', (
+            WidgetTester tester,
+          ) async {
             final Camera camera = Camera(
               textureId: textureId,
               cameraService: cameraService,
@@ -798,34 +778,37 @@ void main() {
             final ZoomLevelCapability zoomLevelCapability = ZoomLevelCapability(
               minimum: 50.0,
               maximum: 100.0,
-              videoTrack: createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
+              videoTrack:
+                  createJSInteropWrapper(MockMediaStreamTrack())
+                      as MediaStreamTrack,
             );
 
-            when(cameraService.getZoomLevelCapabilityForCamera(camera))
-                .thenReturn(zoomLevelCapability);
+            when(
+              cameraService.getZoomLevelCapabilityForCamera(camera),
+            ).thenReturn(zoomLevelCapability);
 
             expect(
-                () => camera.setZoomLevel(45.0),
-                throwsA(
-                  isA<CameraWebException>()
-                      .having(
-                        (CameraWebException e) => e.cameraId,
-                        'cameraId',
-                        textureId,
-                      )
-                      .having(
-                        (CameraWebException e) => e.code,
-                        'code',
-                        CameraErrorCode.zoomLevelInvalid,
-                      ),
-                ));
+              () => camera.setZoomLevel(45.0),
+              throwsA(
+                isA<CameraWebException>()
+                    .having(
+                      (CameraWebException e) => e.cameraId,
+                      'cameraId',
+                      textureId,
+                    )
+                    .having(
+                      (CameraWebException e) => e.code,
+                      'code',
+                      CameraErrorCode.zoomLevelInvalid,
+                    ),
+              ),
+            );
           });
 
-          testWidgets(
-              'with zoomLevelInvalid error '
-              'when the provided zoom level is below minimum',
-              (WidgetTester tester) async {
+          testWidgets('with zoomLevelInvalid error '
+              'when the provided zoom level is below minimum', (
+            WidgetTester tester,
+          ) async {
             final Camera camera = Camera(
               textureId: textureId,
               cameraService: cameraService,
@@ -834,12 +817,14 @@ void main() {
             final ZoomLevelCapability zoomLevelCapability = ZoomLevelCapability(
               minimum: 50.0,
               maximum: 100.0,
-              videoTrack: createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
+              videoTrack:
+                  createJSInteropWrapper(MockMediaStreamTrack())
+                      as MediaStreamTrack,
             );
 
-            when(cameraService.getZoomLevelCapabilityForCamera(camera))
-                .thenReturn(zoomLevelCapability);
+            when(
+              cameraService.getZoomLevelCapabilityForCamera(camera),
+            ).thenReturn(zoomLevelCapability);
 
             expect(
               () => camera.setZoomLevel(105.0),
@@ -863,10 +848,10 @@ void main() {
     });
 
     group('getLensDirection', () {
-      testWidgets(
-          'returns a lens direction '
-          'based on the first video track settings',
-          (WidgetTester tester) async {
+      testWidgets('returns a lens direction '
+          'based on the first video track settings', (
+        WidgetTester tester,
+      ) async {
         final MockVideoElement mockVideoElement = MockVideoElement();
         final HTMLVideoElement videoElement =
             createJSInteropWrapper(mockVideoElement) as HTMLVideoElement;
@@ -878,33 +863,32 @@ void main() {
 
         final MockMediaStreamTrack firstVideoTrack = MockMediaStreamTrack();
 
-        mockVideoElement.srcObject = createJSInteropWrapper(
-          FakeMediaStream(
-            <MediaStreamTrack>[
-              createJSInteropWrapper(firstVideoTrack) as MediaStreamTrack,
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-            ],
-          ),
-        ) as MediaStream;
+        mockVideoElement.srcObject =
+            createJSInteropWrapper(
+                  FakeMediaStream(<MediaStreamTrack>[
+                    createJSInteropWrapper(firstVideoTrack) as MediaStreamTrack,
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                  ]),
+                )
+                as MediaStream;
 
-        firstVideoTrack.getSettings = () {
-          return MediaTrackSettings(facingMode: 'environment');
-        }.toJS;
+        firstVideoTrack.getSettings =
+            () {
+              return MediaTrackSettings(facingMode: 'environment');
+            }.toJS;
 
-        when(cameraService.mapFacingModeToLensDirection('environment'))
-            .thenReturn(CameraLensDirection.external);
+        when(
+          cameraService.mapFacingModeToLensDirection('environment'),
+        ).thenReturn(CameraLensDirection.external);
 
-        expect(
-          camera.getLensDirection(),
-          equals(CameraLensDirection.external),
-        );
+        expect(camera.getLensDirection(), equals(CameraLensDirection.external));
       });
 
-      testWidgets(
-          'returns null '
-          'if the first video track is missing the facing mode',
-          (WidgetTester tester) async {
+      testWidgets('returns null '
+          'if the first video track is missing the facing mode', (
+        WidgetTester tester,
+      ) async {
         final MockVideoElement mockVideoElement = MockVideoElement();
         final HTMLVideoElement videoElement =
             createJSInteropWrapper(mockVideoElement) as HTMLVideoElement;
@@ -916,28 +900,25 @@ void main() {
 
         final MockMediaStreamTrack firstVideoTrack = MockMediaStreamTrack();
 
-        videoElement.srcObject = createJSInteropWrapper(
-          FakeMediaStream(
-            <MediaStreamTrack>[
-              createJSInteropWrapper(firstVideoTrack) as MediaStreamTrack,
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-            ],
-          ),
-        ) as MediaStream;
+        videoElement.srcObject =
+            createJSInteropWrapper(
+                  FakeMediaStream(<MediaStreamTrack>[
+                    createJSInteropWrapper(firstVideoTrack) as MediaStreamTrack,
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                  ]),
+                )
+                as MediaStream;
 
-        firstVideoTrack.getSettings = () {
-          return MediaTrackSettings();
-        }.toJS;
+        firstVideoTrack.getSettings =
+            () {
+              return MediaTrackSettings();
+            }.toJS;
 
-        expect(
-          camera.getLensDirection(),
-          isNull,
-        );
+        expect(camera.getLensDirection(), isNull);
       });
 
-      testWidgets(
-          'returns null '
+      testWidgets('returns null '
           'if the camera is missing video tracks', (WidgetTester tester) async {
         // Create a video stream with no video tracks.
         final HTMLVideoElement videoElement = HTMLVideoElement();
@@ -950,10 +931,7 @@ void main() {
 
         await camera.initialize();
 
-        expect(
-          camera.getLensDirection(),
-          isNull,
-        );
+        expect(camera.getLensDirection(), isNull);
       });
     });
 
@@ -988,8 +966,7 @@ void main() {
       });
 
       group('startVideoRecording', () {
-        testWidgets(
-            'creates a media recorder '
+        testWidgets('creates a media recorder '
             'with appropriate options', (WidgetTester tester) async {
           final Camera camera = Camera(
             textureId: 1,
@@ -1001,42 +978,29 @@ void main() {
 
           await camera.startVideoRecording();
 
-          expect(
-            camera.mediaRecorder!.stream,
-            equals(camera.stream),
-          );
+          expect(camera.mediaRecorder!.stream, equals(camera.stream));
 
-          expect(
-            camera.mediaRecorder!.mimeType,
-            equals(supportedVideoType),
-          );
+          expect(camera.mediaRecorder!.mimeType, equals(supportedVideoType));
 
-          expect(
-            camera.mediaRecorder!.state,
-            equals('recording'),
-          );
+          expect(camera.mediaRecorder!.state, equals('recording'));
         });
 
-        testWidgets('listens to the media recorder data events',
-            (WidgetTester tester) async {
-          final Camera camera = Camera(
-            textureId: 1,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..isVideoTypeSupported = isVideoTypeSupported;
+        testWidgets('listens to the media recorder data events', (
+          WidgetTester tester,
+        ) async {
+          final Camera camera =
+              Camera(textureId: 1, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..isVideoTypeSupported = isVideoTypeSupported;
 
           await camera.initialize();
           await camera.play();
 
           final List<String> capturedEvents = <String>[];
-          mockMediaRecorder.addEventListener = (
-            String type,
-            EventListener? callback, [
-            JSAny? options,
-          ]) {
-            capturedEvents.add(type);
-          }.toJS;
+          mockMediaRecorder.addEventListener =
+              (String type, EventListener? callback, [JSAny? options]) {
+                capturedEvents.add(type);
+              }.toJS;
 
           await camera.startVideoRecording();
 
@@ -1046,50 +1010,42 @@ void main() {
           );
         });
 
-        testWidgets('listens to the media recorder stop events',
-            (WidgetTester tester) async {
-          final Camera camera = Camera(
-            textureId: 1,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..isVideoTypeSupported = isVideoTypeSupported;
+        testWidgets('listens to the media recorder stop events', (
+          WidgetTester tester,
+        ) async {
+          final Camera camera =
+              Camera(textureId: 1, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..isVideoTypeSupported = isVideoTypeSupported;
 
           await camera.initialize();
           await camera.play();
 
           final List<String> capturedEvents = <String>[];
-          mockMediaRecorder.addEventListener = (
-            String type,
-            EventListener? callback, [
-            JSAny? options,
-          ]) {
-            capturedEvents.add(type);
-          }.toJS;
+          mockMediaRecorder.addEventListener =
+              (String type, EventListener? callback, [JSAny? options]) {
+                capturedEvents.add(type);
+              }.toJS;
 
           await camera.startVideoRecording();
 
-          expect(
-            capturedEvents.where((String e) => e == 'stop').length,
-            1,
-          );
+          expect(capturedEvents.where((String e) => e == 'stop').length, 1);
         });
 
         testWidgets('starts a video recording', (WidgetTester tester) async {
-          final Camera camera = Camera(
-            textureId: 1,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..isVideoTypeSupported = isVideoTypeSupported;
+          final Camera camera =
+              Camera(textureId: 1, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..isVideoTypeSupported = isVideoTypeSupported;
 
           await camera.initialize();
           await camera.play();
 
           final List<int?> capturedStarts = <int?>[];
-          mockMediaRecorder.start = ([int? timeslice]) {
-            capturedStarts.add(timeslice);
-          }.toJS;
+          mockMediaRecorder.start =
+              ([int? timeslice]) {
+                capturedStarts.add(timeslice);
+              }.toJS;
 
           await camera.startVideoRecording();
 
@@ -1097,8 +1053,7 @@ void main() {
         });
 
         group('throws a CameraWebException', () {
-          testWidgets(
-              'with notSupported error '
+          testWidgets('with notSupported error '
               'when no video types are supported', (WidgetTester tester) async {
             final Camera camera = Camera(
               textureId: 1,
@@ -1136,20 +1091,21 @@ void main() {
           )..mediaRecorder = mediaRecorder;
 
           int pauses = 0;
-          mockMediaRecorder.pause = () {
-            pauses++;
-          }.toJS;
+          mockMediaRecorder.pause =
+              () {
+                pauses++;
+              }.toJS;
 
           await camera.pauseVideoRecording();
 
           expect(pauses, 1);
         });
 
-        testWidgets(
-            'throws a CameraWebException '
+        testWidgets('throws a CameraWebException '
             'with videoRecordingNotStarted error '
-            'if the video recording was not started',
-            (WidgetTester tester) async {
+            'if the video recording was not started', (
+          WidgetTester tester,
+        ) async {
           final Camera camera = Camera(
             textureId: 1,
             cameraService: cameraService,
@@ -1182,20 +1138,21 @@ void main() {
           )..mediaRecorder = mediaRecorder;
 
           int resumes = 0;
-          mockMediaRecorder.resume = () {
-            resumes++;
-          }.toJS;
+          mockMediaRecorder.resume =
+              () {
+                resumes++;
+              }.toJS;
 
           await camera.resumeVideoRecording();
 
           expect(resumes, 1);
         });
 
-        testWidgets(
-            'throws a CameraWebException '
+        testWidgets('throws a CameraWebException '
             'with videoRecordingNotStarted error '
-            'if the video recording was not started',
-            (WidgetTester tester) async {
+            'if the video recording was not started', (
+          WidgetTester tester,
+        ) async {
           final Camera camera = Camera(
             textureId: 1,
             cameraService: cameraService,
@@ -1221,16 +1178,13 @@ void main() {
       });
 
       group('stopVideoRecording', () {
-        testWidgets(
-            'stops a video recording and '
+        testWidgets('stops a video recording and '
             'returns the captured file '
             'based on all video data parts', (WidgetTester tester) async {
-          final Camera camera = Camera(
-            textureId: 1,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..isVideoTypeSupported = isVideoTypeSupported;
+          final Camera camera =
+              Camera(textureId: 1, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..isVideoTypeSupported = isVideoTypeSupported;
 
           await camera.initialize();
           await camera.play();
@@ -1238,17 +1192,14 @@ void main() {
           late EventListener videoDataAvailableListener;
           late EventListener videoRecordingStoppedListener;
 
-          mockMediaRecorder.addEventListener = (
-            String type,
-            EventListener? callback, [
-            JSAny? options,
-          ]) {
-            if (type == 'dataavailable') {
-              videoDataAvailableListener = callback!;
-            } else if (type == 'stop') {
-              videoRecordingStoppedListener = callback!;
-            }
-          }.toJS;
+          mockMediaRecorder.addEventListener =
+              (String type, EventListener? callback, [JSAny? options]) {
+                if (type == 'dataavailable') {
+                  videoDataAvailableListener = callback!;
+                } else if (type == 'stop') {
+                  videoRecordingStoppedListener = callback!;
+                }
+              }.toJS;
 
           Blob? finalVideo;
           List<Blob>? videoParts;
@@ -1261,9 +1212,10 @@ void main() {
           await camera.startVideoRecording();
 
           int stops = 0;
-          mockMediaRecorder.stop = () {
-            stops++;
-          }.toJS;
+          mockMediaRecorder.stop =
+              () {
+                stops++;
+              }.toJS;
 
           final Future<XFile> videoFileFuture = camera.stopVideoRecording();
 
@@ -1292,32 +1244,20 @@ void main() {
 
           expect(stops, 1);
 
-          expect(
-            videoFile,
-            isNotNull,
-          );
+          expect(videoFile, isNotNull);
 
-          expect(
-            videoFile.mimeType,
-            equals(supportedVideoType),
-          );
+          expect(videoFile.mimeType, equals(supportedVideoType));
 
-          expect(
-            videoFile.name,
-            equals(finalVideo.hashCode.toString()),
-          );
+          expect(videoFile.name, equals(finalVideo.hashCode.toString()));
 
-          expect(
-            videoParts,
-            equals(capturedVideoParts),
-          );
+          expect(videoParts, equals(capturedVideoParts));
         });
 
-        testWidgets(
-            'throws a CameraWebException '
+        testWidgets('throws a CameraWebException '
             'with videoRecordingNotStarted error '
-            'if the video recording was not started',
-            (WidgetTester tester) async {
+            'if the video recording was not started', (
+          WidgetTester tester,
+        ) async {
           final Camera camera = Camera(
             textureId: 1,
             cameraService: cameraService,
@@ -1346,25 +1286,21 @@ void main() {
         late EventListener videoRecordingStoppedListener;
 
         setUp(() {
-          mockMediaRecorder.addEventListener = (
-            String type,
-            EventListener? callback, [
-            JSAny? options,
-          ]) {
-            if (type == 'stop') {
-              videoRecordingStoppedListener = callback!;
-            }
-          }.toJS;
+          mockMediaRecorder.addEventListener =
+              (String type, EventListener? callback, [JSAny? options]) {
+                if (type == 'stop') {
+                  videoRecordingStoppedListener = callback!;
+                }
+              }.toJS;
         });
 
-        testWidgets('stops listening to the media recorder data events',
-            (WidgetTester tester) async {
-          final Camera camera = Camera(
-            textureId: 1,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..isVideoTypeSupported = isVideoTypeSupported;
+        testWidgets('stops listening to the media recorder data events', (
+          WidgetTester tester,
+        ) async {
+          final Camera camera =
+              Camera(textureId: 1, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..isVideoTypeSupported = isVideoTypeSupported;
 
           await camera.initialize();
           await camera.play();
@@ -1372,13 +1308,10 @@ void main() {
           await camera.startVideoRecording();
 
           final List<String> capturedEvents = <String>[];
-          mockMediaRecorder.removeEventListener = (
-            String type,
-            EventListener? callback, [
-            JSAny? options,
-          ]) {
-            capturedEvents.add(type);
-          }.toJS;
+          mockMediaRecorder.removeEventListener =
+              (String type, EventListener? callback, [JSAny? options]) {
+                capturedEvents.add(type);
+              }.toJS;
 
           videoRecordingStoppedListener.callAsFunction(null, Event('stop'));
 
@@ -1390,14 +1323,13 @@ void main() {
           );
         });
 
-        testWidgets('stops listening to the media recorder stop events',
-            (WidgetTester tester) async {
-          final Camera camera = Camera(
-            textureId: 1,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..isVideoTypeSupported = isVideoTypeSupported;
+        testWidgets('stops listening to the media recorder stop events', (
+          WidgetTester tester,
+        ) async {
+          final Camera camera =
+              Camera(textureId: 1, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..isVideoTypeSupported = isVideoTypeSupported;
 
           await camera.initialize();
           await camera.play();
@@ -1405,41 +1337,35 @@ void main() {
           await camera.startVideoRecording();
 
           final List<String> capturedEvents = <String>[];
-          mockMediaRecorder.removeEventListener = (
-            String type,
-            EventListener? callback, [
-            JSAny? options,
-          ]) {
-            capturedEvents.add(type);
-          }.toJS;
+          mockMediaRecorder.removeEventListener =
+              (String type, EventListener? callback, [JSAny? options]) {
+                capturedEvents.add(type);
+              }.toJS;
 
           videoRecordingStoppedListener.callAsFunction(null, Event('stop'));
 
           await Future<void>.microtask(() {});
 
-          expect(
-            capturedEvents.where((String e) => e == 'stop').length,
-            1,
-          );
+          expect(capturedEvents.where((String e) => e == 'stop').length, 1);
         });
 
-        testWidgets('stops listening to the media recorder errors',
-            (WidgetTester tester) async {
+        testWidgets('stops listening to the media recorder errors', (
+          WidgetTester tester,
+        ) async {
           final StreamController<ErrorEvent> onErrorStreamController =
               StreamController<ErrorEvent>();
           final MockEventStreamProvider<Event> provider =
               MockEventStreamProvider<Event>();
 
-          final Camera camera = Camera(
-            textureId: 1,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..isVideoTypeSupported = isVideoTypeSupported
-            ..mediaRecorderOnErrorProvider = provider;
+          final Camera camera =
+              Camera(textureId: 1, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..isVideoTypeSupported = isVideoTypeSupported
+                ..mediaRecorderOnErrorProvider = provider;
 
-          when(provider.forTarget(mediaRecorder))
-              .thenAnswer((_) => onErrorStreamController.stream);
+          when(
+            provider.forTarget(mediaRecorder),
+          ).thenAnswer((_) => onErrorStreamController.stream);
 
           await camera.initialize();
           await camera.play();
@@ -1450,17 +1376,15 @@ void main() {
 
           await Future<void>.microtask(() {});
 
-          expect(
-            onErrorStreamController.hasListener,
-            isFalse,
-          );
+          expect(onErrorStreamController.hasListener, isFalse);
         });
       });
     });
 
     group('dispose', () {
-      testWidgets("resets the video element's source",
-          (WidgetTester tester) async {
+      testWidgets("resets the video element's source", (
+        WidgetTester tester,
+      ) async {
         final Camera camera = Camera(
           textureId: textureId,
           cameraService: cameraService,
@@ -1481,14 +1405,12 @@ void main() {
         await camera.initialize();
         await camera.dispose();
 
-        expect(
-          camera.onEndedController.isClosed,
-          isTrue,
-        );
+        expect(camera.onEndedController.isClosed, isTrue);
       });
 
-      testWidgets('closes the onVideoRecordedEvent stream',
-          (WidgetTester tester) async {
+      testWidgets('closes the onVideoRecordedEvent stream', (
+        WidgetTester tester,
+      ) async {
         final Camera camera = Camera(
           textureId: textureId,
           cameraService: cameraService,
@@ -1497,14 +1419,12 @@ void main() {
         await camera.initialize();
         await camera.dispose();
 
-        expect(
-          camera.videoRecorderController.isClosed,
-          isTrue,
-        );
+        expect(camera.videoRecorderController.isClosed, isTrue);
       });
 
-      testWidgets('closes the onVideoRecordingError stream',
-          (WidgetTester tester) async {
+      testWidgets('closes the onVideoRecordingError stream', (
+        WidgetTester tester,
+      ) async {
         final Camera camera = Camera(
           textureId: textureId,
           cameraService: cameraService,
@@ -1513,17 +1433,13 @@ void main() {
         await camera.initialize();
         await camera.dispose();
 
-        expect(
-          camera.videoRecordingErrorController.isClosed,
-          isTrue,
-        );
+        expect(camera.videoRecordingErrorController.isClosed, isTrue);
       });
     });
 
     group('events', () {
       group('onVideoRecordedEvent', () {
-        testWidgets(
-            'emits a VideoRecordedEvent '
+        testWidgets('emits a VideoRecordedEvent '
             'when a video recording is created', (WidgetTester tester) async {
           const String supportedVideoType = 'video/webm';
 
@@ -1531,12 +1447,10 @@ void main() {
           final MediaRecorder mediaRecorder =
               createJSInteropWrapper(mockMediaRecorder) as MediaRecorder;
 
-          final Camera camera = Camera(
-            textureId: 1,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..isVideoTypeSupported = (String type) => type == 'video/webm';
+          final Camera camera =
+              Camera(textureId: 1, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..isVideoTypeSupported = (String type) => type == 'video/webm';
 
           await camera.initialize();
           await camera.play();
@@ -1544,17 +1458,14 @@ void main() {
           late EventListener videoDataAvailableListener;
           late EventListener videoRecordingStoppedListener;
 
-          mockMediaRecorder.addEventListener = (
-            String type,
-            EventListener? callback, [
-            JSAny? options,
-          ]) {
-            if (type == 'dataavailable') {
-              videoDataAvailableListener = callback!;
-            } else if (type == 'stop') {
-              videoRecordingStoppedListener = callback!;
-            }
-          }.toJS;
+          mockMediaRecorder.addEventListener =
+              (String type, EventListener? callback, [JSAny? options]) {
+                if (type == 'dataavailable') {
+                  videoDataAvailableListener = callback!;
+                } else if (type == 'stop') {
+                  videoRecordingStoppedListener = callback!;
+                }
+              }.toJS;
 
           final StreamQueue<VideoRecordedEvent> streamQueue =
               StreamQueue<VideoRecordedEvent>(camera.onVideoRecordedEvent);
@@ -1605,8 +1516,7 @@ void main() {
       });
 
       group('onEnded', () {
-        testWidgets(
-            'emits the default video track '
+        testWidgets('emits the default video track '
             'when it emits an ended event', (WidgetTester tester) async {
           final Camera camera = Camera(
             textureId: textureId,
@@ -1624,16 +1534,12 @@ void main() {
 
           defaultVideoTrack.dispatchEvent(Event('ended'));
 
-          expect(
-            await streamQueue.next,
-            equals(defaultVideoTrack),
-          );
+          expect(await streamQueue.next, equals(defaultVideoTrack));
 
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits the default video track '
+        testWidgets('emits the default video track '
             'when the camera is stopped', (WidgetTester tester) async {
           final Camera camera = Camera(
             textureId: textureId,
@@ -1651,18 +1557,14 @@ void main() {
 
           camera.stop();
 
-          expect(
-            await streamQueue.next,
-            equals(defaultVideoTrack),
-          );
+          expect(await streamQueue.next, equals(defaultVideoTrack));
 
           await streamQueue.cancel();
         });
       });
 
       group('onVideoRecordingError', () {
-        testWidgets(
-            'emits an ErrorEvent '
+        testWidgets('emits an ErrorEvent '
             'when the media recorder fails '
             'when recording a video', (WidgetTester tester) async {
           final MockMediaRecorder mockMediaRecorder = MockMediaRecorder();
@@ -1673,18 +1575,18 @@ void main() {
           final MockEventStreamProvider<Event> provider =
               MockEventStreamProvider<Event>();
 
-          final Camera camera = Camera(
-            textureId: textureId,
-            cameraService: cameraService,
-          )
-            ..mediaRecorder = mediaRecorder
-            ..mediaRecorderOnErrorProvider = provider;
+          final Camera camera =
+              Camera(textureId: textureId, cameraService: cameraService)
+                ..mediaRecorder = mediaRecorder
+                ..mediaRecorderOnErrorProvider = provider;
 
-          when(provider.forTarget(mediaRecorder))
-              .thenAnswer((_) => errorController.stream);
+          when(
+            provider.forTarget(mediaRecorder),
+          ).thenAnswer((_) => errorController.stream);
 
-          final StreamQueue<ErrorEvent> streamQueue =
-              StreamQueue<ErrorEvent>(camera.onVideoRecordingError);
+          final StreamQueue<ErrorEvent> streamQueue = StreamQueue<ErrorEvent>(
+            camera.onVideoRecordingError,
+          );
 
           await camera.initialize();
           await camera.play();
@@ -1694,10 +1596,7 @@ void main() {
           final ErrorEvent errorEvent = ErrorEvent('type');
           errorController.add(errorEvent);
 
-          expect(
-            await streamQueue.next,
-            equals(errorEvent),
-          );
+          expect(await streamQueue.next, equals(errorEvent));
 
           await streamQueue.cancel();
         });

--- a/packages/camera/camera_web/example/integration_test/camera_web_exception_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_exception_test.dart
@@ -16,22 +16,29 @@ void main() {
       const CameraErrorCode code = CameraErrorCode.notFound;
       const String description = 'The camera is not found.';
 
-      final CameraWebException exception =
-          CameraWebException(cameraId, code, description);
+      final CameraWebException exception = CameraWebException(
+        cameraId,
+        code,
+        description,
+      );
 
       expect(exception.cameraId, equals(cameraId));
       expect(exception.code, equals(code));
       expect(exception.description, equals(description));
     });
 
-    testWidgets('toString includes all properties',
-        (WidgetTester tester) async {
+    testWidgets('toString includes all properties', (
+      WidgetTester tester,
+    ) async {
       const int cameraId = 2;
       const CameraErrorCode code = CameraErrorCode.notReadable;
       const String description = 'The camera is not readable.';
 
-      final CameraWebException exception =
-          CameraWebException(cameraId, code, description);
+      final CameraWebException exception = CameraWebException(
+        cameraId,
+        code,
+        description,
+      );
 
       expect(
         exception.toString(),

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -93,17 +93,15 @@ void main() {
           any,
           cameraId: anyNamed('cameraId'),
         ),
-      ).thenAnswer(
-        (_) async => videoElement.captureStream(),
-      );
+      ).thenAnswer((_) async => videoElement.captureStream());
 
-      CameraPlatform.instance = CameraPlugin(
-        cameraService: cameraService,
-      )..window = window;
+      CameraPlatform.instance = CameraPlugin(cameraService: cameraService)
+        ..window = window;
     });
 
-    testWidgets('CameraPlugin is the live instance',
-        (WidgetTester tester) async {
+    testWidgets('CameraPlugin is the live instance', (
+      WidgetTester tester,
+    ) async {
       expect(CameraPlatform.instance, isA<CameraPlugin>());
     });
 
@@ -111,11 +109,12 @@ void main() {
       setUp(() {
         when(cameraService.getFacingModeForVideoTrack(any)).thenReturn(null);
 
-        mockMediaDevices.enumerateDevices = () {
-          return Future<JSArray<MediaDeviceInfo>>.value(
-            <MediaDeviceInfo>[].toJS,
-          ).toJS;
-        }.toJS;
+        mockMediaDevices.enumerateDevices =
+            () {
+              return Future<JSArray<MediaDeviceInfo>>.value(
+                <MediaDeviceInfo>[].toJS,
+              ).toJS;
+            }.toJS;
       });
 
       testWidgets('requests video permissions', (WidgetTester tester) async {
@@ -127,25 +126,26 @@ void main() {
         ).called(1);
       });
 
-      testWidgets(
-          'releases the camera stream '
+      testWidgets('releases the camera stream '
           'used to request video permissions', (WidgetTester tester) async {
         final MockMediaStreamTrack mockVideoTrack = MockMediaStreamTrack();
         final MediaStreamTrack videoTrack =
             createJSInteropWrapper(mockVideoTrack) as MediaStreamTrack;
 
         bool videoTrackStopped = false;
-        mockVideoTrack.stop = () {
-          videoTrackStopped = true;
-        }.toJS;
+        mockVideoTrack.stop =
+            () {
+              videoTrackStopped = true;
+            }.toJS;
 
         when(
           cameraService.getMediaStreamForOptions(const CameraOptions()),
         ).thenAnswer(
           (_) => Future<MediaStream>.value(
             createJSInteropWrapper(
-              FakeMediaStream(<MediaStreamTrack>[videoTrack]),
-            ) as MediaStream,
+                  FakeMediaStream(<MediaStreamTrack>[videoTrack]),
+                )
+                as MediaStream,
           ),
         );
 
@@ -155,22 +155,24 @@ void main() {
         expect(videoTrackStopped, isTrue);
       });
 
-      testWidgets(
-          'gets a video stream '
+      testWidgets('gets a video stream '
           'for a video input device', (WidgetTester tester) async {
-        final MediaDeviceInfo videoDevice = createJSInteropWrapper(
-          FakeMediaDeviceInfo(
-            '1',
-            'Camera 1',
-            MediaDeviceKind.videoInput,
-          ),
-        ) as MediaDeviceInfo;
+        final MediaDeviceInfo videoDevice =
+            createJSInteropWrapper(
+                  FakeMediaDeviceInfo(
+                    '1',
+                    'Camera 1',
+                    MediaDeviceKind.videoInput,
+                  ),
+                )
+                as MediaDeviceInfo;
 
-        mockMediaDevices.enumerateDevices = () {
-          return Future<JSArray<MediaDeviceInfo>>.value(
-                  <MediaDeviceInfo>[videoDevice].toJS)
-              .toJS;
-        }.toJS;
+        mockMediaDevices.enumerateDevices =
+            () {
+              return Future<JSArray<MediaDeviceInfo>>.value(
+                <MediaDeviceInfo>[videoDevice].toJS,
+              ).toJS;
+            }.toJS;
 
         final List<CameraDescription> _ =
             await CameraPlatform.instance.availableCameras();
@@ -178,31 +180,31 @@ void main() {
         verify(
           cameraService.getMediaStreamForOptions(
             CameraOptions(
-              video: VideoConstraints(
-                deviceId: videoDevice.deviceId,
-              ),
+              video: VideoConstraints(deviceId: videoDevice.deviceId),
             ),
           ),
         ).called(1);
       });
 
-      testWidgets(
-          'does not get a video stream '
+      testWidgets('does not get a video stream '
           'for the video input device '
           'with an empty device id', (WidgetTester tester) async {
-        final MediaDeviceInfo videoDevice = createJSInteropWrapper(
-          FakeMediaDeviceInfo(
-            '',
-            'Camera 1',
-            MediaDeviceKind.videoInput,
-          ),
-        ) as MediaDeviceInfo;
+        final MediaDeviceInfo videoDevice =
+            createJSInteropWrapper(
+                  FakeMediaDeviceInfo(
+                    '',
+                    'Camera 1',
+                    MediaDeviceKind.videoInput,
+                  ),
+                )
+                as MediaDeviceInfo;
 
-        mockMediaDevices.enumerateDevices = () {
-          return Future<JSArray<MediaDeviceInfo>>.value(
-                  <MediaDeviceInfo>[videoDevice].toJS)
-              .toJS;
-        }.toJS;
+        mockMediaDevices.enumerateDevices =
+            () {
+              return Future<JSArray<MediaDeviceInfo>>.value(
+                <MediaDeviceInfo>[videoDevice].toJS,
+              ).toJS;
+            }.toJS;
 
         final List<CameraDescription> _ =
             await CameraPlatform.instance.availableCameras();
@@ -210,36 +212,35 @@ void main() {
         verifyNever(
           cameraService.getMediaStreamForOptions(
             CameraOptions(
-              video: VideoConstraints(
-                deviceId: videoDevice.deviceId,
-              ),
+              video: VideoConstraints(deviceId: videoDevice.deviceId),
             ),
           ),
         );
       });
 
-      testWidgets(
-          'gets the facing mode '
+      testWidgets('gets the facing mode '
           'from the first available video track '
           'of the video input device', (WidgetTester tester) async {
-        final MediaDeviceInfo videoDevice = createJSInteropWrapper(
-          FakeMediaDeviceInfo(
-            '1',
-            'Camera 1',
-            MediaDeviceKind.videoInput,
-          ),
-        ) as MediaDeviceInfo;
+        final MediaDeviceInfo videoDevice =
+            createJSInteropWrapper(
+                  FakeMediaDeviceInfo(
+                    '1',
+                    'Camera 1',
+                    MediaDeviceKind.videoInput,
+                  ),
+                )
+                as MediaDeviceInfo;
 
-        final MediaStream videoStream = createJSInteropWrapper(
-          FakeMediaStream(
-            <MediaStreamTrack>[
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-            ],
-          ),
-        ) as MediaStream;
+        final MediaStream videoStream =
+            createJSInteropWrapper(
+                  FakeMediaStream(<MediaStreamTrack>[
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                  ]),
+                )
+                as MediaStream;
 
         when(
           cameraService.getMediaStreamForOptions(
@@ -249,11 +250,12 @@ void main() {
           ),
         ).thenAnswer((_) => Future<MediaStream>.value(videoStream));
 
-        mockMediaDevices.enumerateDevices = () {
-          return Future<JSArray<MediaDeviceInfo>>.value(
-                  <MediaDeviceInfo>[videoDevice].toJS)
-              .toJS;
-        }.toJS;
+        mockMediaDevices.enumerateDevices =
+            () {
+              return Future<JSArray<MediaDeviceInfo>>.value(
+                <MediaDeviceInfo>[videoDevice].toJS,
+              ).toJS;
+            }.toJS;
 
         final List<CameraDescription> _ =
             await CameraPlatform.instance.availableCameras();
@@ -265,72 +267,78 @@ void main() {
         ).called(1);
       });
 
-      testWidgets(
-          'returns appropriate camera descriptions '
+      testWidgets('returns appropriate camera descriptions '
           'for multiple video devices '
           'based on video streams', (WidgetTester tester) async {
-        final MediaDeviceInfo firstVideoDevice = createJSInteropWrapper(
-          FakeMediaDeviceInfo(
-            '1',
-            'Camera 1',
-            MediaDeviceKind.videoInput,
-          ),
-        ) as MediaDeviceInfo;
+        final MediaDeviceInfo firstVideoDevice =
+            createJSInteropWrapper(
+                  FakeMediaDeviceInfo(
+                    '1',
+                    'Camera 1',
+                    MediaDeviceKind.videoInput,
+                  ),
+                )
+                as MediaDeviceInfo;
 
-        final MediaDeviceInfo secondVideoDevice = createJSInteropWrapper(
-          FakeMediaDeviceInfo(
-            '4',
-            'Camera 4',
-            MediaDeviceKind.videoInput,
-          ),
-        ) as MediaDeviceInfo;
+        final MediaDeviceInfo secondVideoDevice =
+            createJSInteropWrapper(
+                  FakeMediaDeviceInfo(
+                    '4',
+                    'Camera 4',
+                    MediaDeviceKind.videoInput,
+                  ),
+                )
+                as MediaDeviceInfo;
 
         // Create a video stream for the first video device.
-        final MediaStream firstVideoStream = createJSInteropWrapper(
-          FakeMediaStream(
-            <MediaStreamTrack>[
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-            ],
-          ),
-        ) as MediaStream;
+        final MediaStream firstVideoStream =
+            createJSInteropWrapper(
+                  FakeMediaStream(<MediaStreamTrack>[
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                  ]),
+                )
+                as MediaStream;
 
         // Create a video stream for the second video device.
-        final MediaStream secondVideoStream = createJSInteropWrapper(
-          FakeMediaStream(
-            <MediaStreamTrack>[
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-            ],
-          ),
-        ) as MediaStream;
+        final MediaStream secondVideoStream =
+            createJSInteropWrapper(
+                  FakeMediaStream(<MediaStreamTrack>[
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                  ]),
+                )
+                as MediaStream;
 
         // Mock media devices to return two video input devices
         // and two audio devices.
-        mockMediaDevices.enumerateDevices = () {
-          return Future<JSArray<MediaDeviceInfo>>.value(
-            <MediaDeviceInfo>[
-              firstVideoDevice,
-              createJSInteropWrapper(
-                FakeMediaDeviceInfo(
-                  '2',
-                  'Audio Input 2',
-                  MediaDeviceKind.audioInput,
-                ),
-              ) as MediaDeviceInfo,
-              createJSInteropWrapper(
-                FakeMediaDeviceInfo(
-                  '3',
-                  'Audio Output 3',
-                  MediaDeviceKind.audioOutput,
-                ),
-              ) as MediaDeviceInfo,
-              secondVideoDevice,
-            ].toJS,
-          ).toJS;
-        }.toJS;
+        mockMediaDevices.enumerateDevices =
+            () {
+              return Future<JSArray<MediaDeviceInfo>>.value(
+                <MediaDeviceInfo>[
+                  firstVideoDevice,
+                  createJSInteropWrapper(
+                        FakeMediaDeviceInfo(
+                          '2',
+                          'Audio Input 2',
+                          MediaDeviceKind.audioInput,
+                        ),
+                      )
+                      as MediaDeviceInfo,
+                  createJSInteropWrapper(
+                        FakeMediaDeviceInfo(
+                          '3',
+                          'Audio Output 3',
+                          MediaDeviceKind.audioOutput,
+                        ),
+                      )
+                      as MediaDeviceInfo,
+                  secondVideoDevice,
+                ].toJS,
+              ).toJS;
+            }.toJS;
 
         // Mock camera service to return the first video stream
         // for the first video device.
@@ -360,8 +368,9 @@ void main() {
           ),
         ).thenReturn('user');
 
-        when(cameraService.mapFacingModeToLensDirection('user'))
-            .thenReturn(CameraLensDirection.front);
+        when(
+          cameraService.mapFacingModeToLensDirection('user'),
+        ).thenReturn(CameraLensDirection.front);
 
         // Mock camera service to return an environment facing mode
         // for the second video stream.
@@ -371,8 +380,9 @@ void main() {
           ),
         ).thenReturn('environment');
 
-        when(cameraService.mapFacingModeToLensDirection('environment'))
-            .thenReturn(CameraLensDirection.back);
+        when(
+          cameraService.mapFacingModeToLensDirection('environment'),
+        ).thenReturn(CameraLensDirection.back);
 
         final List<CameraDescription> cameras =
             await CameraPlatform.instance.availableCameras();
@@ -390,38 +400,40 @@ void main() {
               name: secondVideoDevice.label,
               lensDirection: CameraLensDirection.back,
               sensorOrientation: 0,
-            )
+            ),
           ]),
         );
       });
 
-      testWidgets(
-          'sets camera metadata '
+      testWidgets('sets camera metadata '
           'for the camera description', (WidgetTester tester) async {
-        final MediaDeviceInfo videoDevice = createJSInteropWrapper(
-          FakeMediaDeviceInfo(
-            '1',
-            'Camera 1',
-            MediaDeviceKind.videoInput,
-          ),
-        ) as MediaDeviceInfo;
+        final MediaDeviceInfo videoDevice =
+            createJSInteropWrapper(
+                  FakeMediaDeviceInfo(
+                    '1',
+                    'Camera 1',
+                    MediaDeviceKind.videoInput,
+                  ),
+                )
+                as MediaDeviceInfo;
 
-        final MediaStream videoStream = createJSInteropWrapper(
-          FakeMediaStream(
-            <MediaStreamTrack>[
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-              createJSInteropWrapper(MockMediaStreamTrack())
-                  as MediaStreamTrack,
-            ],
-          ),
-        ) as MediaStream;
+        final MediaStream videoStream =
+            createJSInteropWrapper(
+                  FakeMediaStream(<MediaStreamTrack>[
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                    createJSInteropWrapper(MockMediaStreamTrack())
+                        as MediaStreamTrack,
+                  ]),
+                )
+                as MediaStream;
 
-        mockMediaDevices.enumerateDevices = () {
-          return Future<JSArray<MediaDeviceInfo>>.value(
-                  <MediaDeviceInfo>[videoDevice].toJS)
-              .toJS;
-        }.toJS;
+        mockMediaDevices.enumerateDevices =
+            () {
+              return Future<JSArray<MediaDeviceInfo>>.value(
+                <MediaDeviceInfo>[videoDevice].toJS,
+              ).toJS;
+            }.toJS;
 
         when(
           cameraService.getMediaStreamForOptions(
@@ -437,8 +449,9 @@ void main() {
           ),
         ).thenReturn('left');
 
-        when(cameraService.mapFacingModeToLensDirection('left'))
-            .thenReturn(CameraLensDirection.external);
+        when(
+          cameraService.mapFacingModeToLensDirection('left'),
+        ).thenReturn(CameraLensDirection.external);
 
         final CameraDescription camera =
             (await CameraPlatform.instance.availableCameras()).first;
@@ -449,40 +462,43 @@ void main() {
             camera: CameraMetadata(
               deviceId: videoDevice.deviceId,
               facingMode: 'left',
-            )
+            ),
           }),
         );
       });
 
-      testWidgets(
-          'releases the video stream '
+      testWidgets('releases the video stream '
           'of a video input device', (WidgetTester tester) async {
-        final MediaDeviceInfo videoDevice = createJSInteropWrapper(
-          FakeMediaDeviceInfo(
-            '1',
-            'Camera 1',
-            MediaDeviceKind.videoInput,
-          ),
-        ) as MediaDeviceInfo;
+        final MediaDeviceInfo videoDevice =
+            createJSInteropWrapper(
+                  FakeMediaDeviceInfo(
+                    '1',
+                    'Camera 1',
+                    MediaDeviceKind.videoInput,
+                  ),
+                )
+                as MediaDeviceInfo;
 
         final List<MediaStreamTrack> tracks = <MediaStreamTrack>[];
         final List<bool> stops = List<bool>.generate(2, (_) => false);
         for (int i = 0; i < stops.length; i++) {
           final MockMediaStreamTrack track = MockMediaStreamTrack();
-          track.stop = () {
-            stops[i] = true;
-          }.toJS;
+          track.stop =
+              () {
+                stops[i] = true;
+              }.toJS;
           tracks.add(createJSInteropWrapper(track) as MediaStreamTrack);
         }
 
         final MediaStream videoStream =
             createJSInteropWrapper(FakeMediaStream(tracks)) as MediaStream;
 
-        mockMediaDevices.enumerateDevices = () {
-          return Future<JSArray<MediaDeviceInfo>>.value(
-                  <MediaDeviceInfo>[videoDevice].toJS)
-              .toJS;
-        }.toJS;
+        mockMediaDevices.enumerateDevices =
+            () {
+              return Future<JSArray<MediaDeviceInfo>>.value(
+                <MediaDeviceInfo>[videoDevice].toJS,
+              ).toJS;
+            }.toJS;
 
         when(
           cameraService.getMediaStreamForOptions(
@@ -499,17 +515,19 @@ void main() {
       });
 
       group('throws CameraException', () {
-        testWidgets('when MediaDevices.enumerateDevices throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when MediaDevices.enumerateDevices throws DomException', (
+          WidgetTester tester,
+        ) async {
           final DOMException exception = DOMException('UnknownError');
 
-          mockMediaDevices.enumerateDevices = () {
-            throw exception;
-            // ignore: dead_code
-            return Future<JSArray<MediaDeviceInfo>>.value(
-              <MediaDeviceInfo>[].toJS,
-            ).toJS;
-          }.toJS;
+          mockMediaDevices.enumerateDevices =
+              () {
+                throw exception;
+                // ignore: dead_code
+                return Future<JSArray<MediaDeviceInfo>>.value(
+                  <MediaDeviceInfo>[].toJS,
+                ).toJS;
+              }.toJS;
 
           expect(
             () => CameraPlatform.instance.availableCameras(),
@@ -523,8 +541,7 @@ void main() {
           );
         });
 
-        testWidgets(
-            'when CameraService.getMediaStreamForOptions '
+        testWidgets('when CameraService.getMediaStreamForOptions '
             'throws CameraWebException', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -532,8 +549,9 @@ void main() {
             'description',
           );
 
-          when(cameraService.getMediaStreamForOptions(any))
-              .thenThrow(exception);
+          when(
+            cameraService.getMediaStreamForOptions(any),
+          ).thenThrow(exception);
 
           expect(
             CameraPlatform.instance.availableCameras(),
@@ -547,16 +565,16 @@ void main() {
           );
         });
 
-        testWidgets(
-            'when CameraService.getMediaStreamForOptions '
+        testWidgets('when CameraService.getMediaStreamForOptions '
             'throws PlatformException', (WidgetTester tester) async {
           final PlatformException exception = PlatformException(
             code: CameraErrorCode.notSupported.toString(),
             message: 'message',
           );
 
-          when(cameraService.getMediaStreamForOptions(any))
-              .thenThrow(exception);
+          when(
+            cameraService.getMediaStreamForOptions(any),
+          ).thenThrow(exception);
 
           expect(
             () => CameraPlatform.instance.availableCameras(),
@@ -591,7 +609,8 @@ void main() {
         setUp(() {
           // Add metadata for the camera description.
           (CameraPlatform.instance as CameraPlugin)
-              .camerasMetadata[cameraDescription] = cameraMetadata;
+                  .camerasMetadata[cameraDescription] =
+              cameraMetadata;
 
           when(
             cameraService.mapFacingModeToCameraType('user'),
@@ -615,31 +634,38 @@ void main() {
           expect(camera, isA<Camera>());
           expect(camera!.textureId, cameraId);
           expect(camera.options.audio.enabled, isTrue);
-          expect(camera.options.video.facingMode,
-              equals(FacingModeConstraint(CameraType.user)));
-          expect(camera.options.video.width!.ideal,
-              ultraHighResolutionSize.width.toInt());
-          expect(camera.options.video.height!.ideal,
-              ultraHighResolutionSize.height.toInt());
+          expect(
+            camera.options.video.facingMode,
+            equals(FacingModeConstraint(CameraType.user)),
+          );
+          expect(
+            camera.options.video.width!.ideal,
+            ultraHighResolutionSize.width.toInt(),
+          );
+          expect(
+            camera.options.video.height!.ideal,
+            ultraHighResolutionSize.height.toInt(),
+          );
           expect(camera.options.video.deviceId, cameraMetadata.deviceId);
         });
 
-        testWidgets('with appropriate createCameraWithSettings options',
-            (WidgetTester tester) async {
+        testWidgets('with appropriate createCameraWithSettings options', (
+          WidgetTester tester,
+        ) async {
           when(
             cameraService.mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
           ).thenReturn(ultraHighResolutionSize);
 
-          final int cameraId =
-              await CameraPlatform.instance.createCameraWithSettings(
-            cameraDescription,
-            const MediaSettings(
-              resolutionPreset: ResolutionPreset.ultraHigh,
-              videoBitrate: 200000,
-              audioBitrate: 32000,
-              enableAudio: true,
-            ),
-          );
+          final int cameraId = await CameraPlatform.instance
+              .createCameraWithSettings(
+                cameraDescription,
+                const MediaSettings(
+                  resolutionPreset: ResolutionPreset.ultraHigh,
+                  videoBitrate: 200000,
+                  audioBitrate: 32000,
+                  enableAudio: true,
+                ),
+              );
 
           final Camera? camera =
               (CameraPlatform.instance as CameraPlugin).cameras[cameraId];
@@ -647,17 +673,22 @@ void main() {
           expect(camera, isA<Camera>());
           expect(camera!.textureId, cameraId);
           expect(camera.options.audio.enabled, isTrue);
-          expect(camera.options.video.facingMode,
-              equals(FacingModeConstraint(CameraType.user)));
-          expect(camera.options.video.width!.ideal,
-              ultraHighResolutionSize.width.toInt());
-          expect(camera.options.video.height!.ideal,
-              ultraHighResolutionSize.height.toInt());
+          expect(
+            camera.options.video.facingMode,
+            equals(FacingModeConstraint(CameraType.user)),
+          );
+          expect(
+            camera.options.video.width!.ideal,
+            ultraHighResolutionSize.width.toInt(),
+          );
+          expect(
+            camera.options.video.height!.ideal,
+            ultraHighResolutionSize.height.toInt(),
+          );
           expect(camera.options.video.deviceId, cameraMetadata.deviceId);
         });
 
-        testWidgets(
-            'with a max resolution preset '
+        testWidgets('with a max resolution preset '
             'and enabled audio set to false '
             'when no options are specified', (WidgetTester tester) async {
           when(
@@ -675,17 +706,22 @@ void main() {
           expect(camera, isA<Camera>());
           expect(camera!.textureId, cameraId);
           expect(camera.options.audio.enabled, isFalse);
-          expect(camera.options.video.facingMode,
-              equals(FacingModeConstraint(CameraType.user)));
-          expect(camera.options.video.width!.ideal,
-              maxResolutionSize.width.toInt());
-          expect(camera.options.video.height!.ideal,
-              maxResolutionSize.height.toInt());
+          expect(
+            camera.options.video.facingMode,
+            equals(FacingModeConstraint(CameraType.user)),
+          );
+          expect(
+            camera.options.video.width!.ideal,
+            maxResolutionSize.width.toInt(),
+          );
+          expect(
+            camera.options.video.height!.ideal,
+            maxResolutionSize.height.toInt(),
+          );
           expect(camera.options.video.deviceId, cameraMetadata.deviceId);
         });
 
-        testWidgets(
-            'with a max resolution preset '
+        testWidgets('with a max resolution preset '
             'and enabled audio set to false '
             'when no options are specified '
             'using createCameraWithSettings', (WidgetTester tester) async {
@@ -693,31 +729,34 @@ void main() {
             cameraService.mapResolutionPresetToSize(ResolutionPreset.max),
           ).thenReturn(maxResolutionSize);
 
-          final int cameraId =
-              await CameraPlatform.instance.createCameraWithSettings(
-            cameraDescription,
-            const MediaSettings(
-              resolutionPreset: ResolutionPreset.max,
-            ),
-          );
+          final int cameraId = await CameraPlatform.instance
+              .createCameraWithSettings(
+                cameraDescription,
+                const MediaSettings(resolutionPreset: ResolutionPreset.max),
+              );
 
           final Camera? camera =
               (CameraPlatform.instance as CameraPlugin).cameras[cameraId];
 
           expect(camera, isA<Camera>());
           expect(camera!.options.audio.enabled, isFalse);
-          expect(camera.options.video.facingMode,
-              equals(FacingModeConstraint(CameraType.user)));
-          expect(camera.options.video.width!.ideal,
-              maxResolutionSize.width.toInt());
-          expect(camera.options.video.height!.ideal,
-              maxResolutionSize.height.toInt());
+          expect(
+            camera.options.video.facingMode,
+            equals(FacingModeConstraint(CameraType.user)),
+          );
+          expect(
+            camera.options.video.width!.ideal,
+            maxResolutionSize.width.toInt(),
+          );
+          expect(
+            camera.options.video.height!.ideal,
+            maxResolutionSize.height.toInt(),
+          );
           expect(camera.options.video.deviceId, cameraMetadata.deviceId);
         });
       });
 
-      testWidgets(
-          'throws CameraException '
+      testWidgets('throws CameraException '
           'with missingMetadata error '
           'if there is no metadata '
           'for the given camera description', (WidgetTester tester) async {
@@ -740,8 +779,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'throws CameraException '
+      testWidgets('throws CameraException '
           'with missingMetadata error '
           'if there is no metadata '
           'for the given camera description '
@@ -816,8 +854,9 @@ void main() {
         when(camera.onEnded).thenAnswer((_) => endedStreamController.stream);
       });
 
-      testWidgets('initializes and plays the camera',
-          (WidgetTester tester) async {
+      testWidgets('initializes and plays the camera', (
+        WidgetTester tester,
+      ) async {
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
@@ -827,22 +866,25 @@ void main() {
         verify(camera.play()).called(1);
       });
 
-      testWidgets('starts listening to the camera video error and abort events',
-          (WidgetTester tester) async {
-        // Save the camera in the camera plugin.
-        (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+      testWidgets(
+        'starts listening to the camera video error and abort events',
+        (WidgetTester tester) async {
+          // Save the camera in the camera plugin.
+          (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
-        expect(errorStreamController.hasListener, isFalse);
-        expect(abortStreamController.hasListener, isFalse);
+          expect(errorStreamController.hasListener, isFalse);
+          expect(abortStreamController.hasListener, isFalse);
 
-        await CameraPlatform.instance.initializeCamera(cameraId);
+          await CameraPlatform.instance.initializeCamera(cameraId);
 
-        expect(errorStreamController.hasListener, isTrue);
-        expect(abortStreamController.hasListener, isTrue);
-      });
+          expect(errorStreamController.hasListener, isTrue);
+          expect(abortStreamController.hasListener, isTrue);
+        },
+      );
 
-      testWidgets('starts listening to the camera ended events',
-          (WidgetTester tester) async {
+      testWidgets('starts listening to the camera ended events', (
+        WidgetTester tester,
+      ) async {
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
@@ -854,8 +896,7 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () => CameraPlatform.instance.initializeCamera(cameraId),
@@ -869,8 +910,9 @@ void main() {
           );
         });
 
-        testWidgets('when camera throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when camera throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
             CameraErrorCode.permissionDenied,
@@ -894,8 +936,9 @@ void main() {
           );
         });
 
-        testWidgets('when camera throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when camera throws DomException', (
+          WidgetTester tester,
+        ) async {
           final DOMException exception = DOMException('NotAllowedError');
 
           when(camera.initialize()).thenAnswer((_) => Future<void>.value());
@@ -925,14 +968,14 @@ void main() {
         ).thenReturn(OrientationType.portraitPrimary);
       });
 
-      testWidgets(
-          'requests full-screen mode '
+      testWidgets('requests full-screen mode '
           'on documentElement', (WidgetTester tester) async {
         int fullscreenCalls = 0;
-        mockDocumentElement.requestFullscreen = ([FullscreenOptions? options]) {
-          fullscreenCalls++;
-          return Future<void>.value().toJS;
-        }.toJS;
+        mockDocumentElement.requestFullscreen =
+            ([FullscreenOptions? options]) {
+              fullscreenCalls++;
+              return Future<void>.value().toJS;
+            }.toJS;
 
         await CameraPlatform.instance.lockCaptureOrientation(
           cameraId,
@@ -942,8 +985,7 @@ void main() {
         expect(fullscreenCalls, 1);
       });
 
-      testWidgets(
-          'locks the capture orientation '
+      testWidgets('locks the capture orientation '
           'based on the given device orientation', (WidgetTester tester) async {
         when(
           cameraService.mapDeviceOrientationToOrientationType(
@@ -952,10 +994,11 @@ void main() {
         ).thenReturn(OrientationType.landscapeSecondary);
 
         final List<OrientationLockType> capturedTypes = <OrientationLockType>[];
-        mockScreenOrientation.lock = (OrientationLockType orientation) {
-          capturedTypes.add(orientation);
-          return Future<void>.value().toJS;
-        }.toJS;
+        mockScreenOrientation.lock =
+            (OrientationLockType orientation) {
+              capturedTypes.add(orientation);
+              return Future<void>.value().toJS;
+            }.toJS;
 
         await CameraPlatform.instance.lockCaptureOrientation(
           cameraId,
@@ -973,10 +1016,10 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with orientationNotSupported error '
-            'when documentElement is not available',
-            (WidgetTester tester) async {
+        testWidgets('with orientationNotSupported error '
+            'when documentElement is not available', (
+          WidgetTester tester,
+        ) async {
           mockDocument.documentElement = null;
 
           expect(
@@ -996,15 +1039,17 @@ void main() {
           mockDocument.documentElement = documentElement;
         });
 
-        testWidgets('when lock throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when lock throws DomException', (
+          WidgetTester tester,
+        ) async {
           final DOMException exception = DOMException('NotAllowedError');
 
-          mockScreenOrientation.lock = (OrientationLockType orientation) {
-            throw exception;
-            // ignore: dead_code
-            return Future<void>.value().toJS;
-          }.toJS;
+          mockScreenOrientation.lock =
+              (OrientationLockType orientation) {
+                throw exception;
+                // ignore: dead_code
+                return Future<void>.value().toJS;
+              }.toJS;
 
           expect(
             () => CameraPlatform.instance.lockCaptureOrientation(
@@ -1030,31 +1075,29 @@ void main() {
         ).thenReturn(OrientationType.portraitPrimary);
       });
 
-      testWidgets('unlocks the capture orientation',
-          (WidgetTester tester) async {
+      testWidgets('unlocks the capture orientation', (
+        WidgetTester tester,
+      ) async {
         int unlocks = 0;
-        mockScreenOrientation.unlock = () {
-          unlocks++;
-        }.toJS;
+        mockScreenOrientation.unlock =
+            () {
+              unlocks++;
+            }.toJS;
 
-        await CameraPlatform.instance.unlockCaptureOrientation(
-          cameraId,
-        );
+        await CameraPlatform.instance.unlockCaptureOrientation(cameraId);
 
         expect(unlocks, 1);
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with orientationNotSupported error '
-            'when documentElement is not available',
-            (WidgetTester tester) async {
+        testWidgets('with orientationNotSupported error '
+            'when documentElement is not available', (
+          WidgetTester tester,
+        ) async {
           mockDocument.documentElement = null;
 
           expect(
-            () => CameraPlatform.instance.unlockCaptureOrientation(
-              cameraId,
-            ),
+            () => CameraPlatform.instance.unlockCaptureOrientation(cameraId),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1067,20 +1110,20 @@ void main() {
           mockDocument.documentElement = documentElement;
         });
 
-        testWidgets('when unlock throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when unlock throws DomException', (
+          WidgetTester tester,
+        ) async {
           final DOMException exception = DOMException('NotAllowedError');
 
-          mockScreenOrientation.unlock = () {
-            throw exception;
-            // ignore: dead_code
-            return Future<void>.value().toJS;
-          }.toJS;
+          mockScreenOrientation.unlock =
+              () {
+                throw exception;
+                // ignore: dead_code
+                return Future<void>.value().toJS;
+              }.toJS;
 
           expect(
-            () => CameraPlatform.instance.unlockCaptureOrientation(
-              cameraId,
-            ),
+            () => CameraPlatform.instance.unlockCaptureOrientation(cameraId),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1103,8 +1146,9 @@ void main() {
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
-        final XFile picture =
-            await CameraPlatform.instance.takePicture(cameraId);
+        final XFile picture = await CameraPlatform.instance.takePicture(
+          cameraId,
+        );
 
         verify(camera.takePicture()).called(1);
 
@@ -1112,8 +1156,7 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () => CameraPlatform.instance.takePicture(cameraId),
@@ -1127,8 +1170,9 @@ void main() {
           );
         });
 
-        testWidgets('when takePicture throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when takePicture throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('NotSupportedError');
 
@@ -1149,8 +1193,9 @@ void main() {
           );
         });
 
-        testWidgets('when takePicture throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when takePicture throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -1185,8 +1230,9 @@ void main() {
 
         when(camera.startVideoRecording()).thenAnswer((_) async {});
 
-        when(camera.onVideoRecordingError)
-            .thenAnswer((_) => const Stream<ErrorEvent>.empty());
+        when(
+          camera.onVideoRecordingError,
+        ).thenAnswer((_) => const Stream<ErrorEvent>.empty());
       });
 
       testWidgets('starts a video recording', (WidgetTester tester) async {
@@ -1198,28 +1244,26 @@ void main() {
         verify(camera.startVideoRecording()).called(1);
       });
 
-      testWidgets('listens to the onVideoRecordingError stream',
-          (WidgetTester tester) async {
+      testWidgets('listens to the onVideoRecordingError stream', (
+        WidgetTester tester,
+      ) async {
         final StreamController<ErrorEvent> videoRecordingErrorController =
             StreamController<ErrorEvent>();
 
-        when(camera.onVideoRecordingError)
-            .thenAnswer((_) => videoRecordingErrorController.stream);
+        when(
+          camera.onVideoRecordingError,
+        ).thenAnswer((_) => videoRecordingErrorController.stream);
 
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
         await CameraPlatform.instance.startVideoRecording(cameraId);
 
-        expect(
-          videoRecordingErrorController.hasListener,
-          isTrue,
-        );
+        expect(videoRecordingErrorController.hasListener, isTrue);
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () => CameraPlatform.instance.startVideoRecording(cameraId),
@@ -1233,8 +1277,9 @@ void main() {
           );
         });
 
-        testWidgets('when startVideoRecording throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when startVideoRecording throws DomException', (
+          WidgetTester tester,
+        ) async {
           final DOMException exception = DOMException('InvalidStateError');
 
           when(camera.startVideoRecording()).thenThrow(exception);
@@ -1254,8 +1299,9 @@ void main() {
           );
         });
 
-        testWidgets('when startVideoRecording throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when startVideoRecording throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
             CameraErrorCode.notStarted,
@@ -1289,8 +1335,9 @@ void main() {
 
         when(camera.startVideoRecording()).thenAnswer((_) async {});
 
-        when(camera.onVideoRecordingError)
-            .thenAnswer((_) => const Stream<ErrorEvent>.empty());
+        when(
+          camera.onVideoRecordingError,
+        ).thenAnswer((_) => const Stream<ErrorEvent>.empty());
       });
 
       testWidgets('fails if trying to stream', (WidgetTester tester) async {
@@ -1298,12 +1345,13 @@ void main() {
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
         expect(
-          () => CameraPlatform.instance.startVideoCapturing(VideoCaptureOptions(
+          () => CameraPlatform.instance.startVideoCapturing(
+            VideoCaptureOptions(
               cameraId,
-              streamCallback: (CameraImageData imageData) {})),
-          throwsA(
-            isA<UnimplementedError>(),
+              streamCallback: (CameraImageData imageData) {},
+            ),
           ),
+          throwsA(isA<UnimplementedError>()),
         );
       });
     });
@@ -1313,22 +1361,25 @@ void main() {
         final MockCamera camera = MockCamera();
         final XFile capturedVideo = XFile('/bogus/test');
 
-        when(camera.stopVideoRecording())
-            .thenAnswer((_) async => capturedVideo);
+        when(
+          camera.stopVideoRecording(),
+        ).thenAnswer((_) async => capturedVideo);
 
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
-        final XFile video =
-            await CameraPlatform.instance.stopVideoRecording(cameraId);
+        final XFile video = await CameraPlatform.instance.stopVideoRecording(
+          cameraId,
+        );
 
         verify(camera.stopVideoRecording()).called(1);
 
         expect(video, capturedVideo);
       });
 
-      testWidgets('stops listening to the onVideoRecordingError stream',
-          (WidgetTester tester) async {
+      testWidgets('stops listening to the onVideoRecordingError stream', (
+        WidgetTester tester,
+      ) async {
         final MockCamera camera = MockCamera();
         final StreamController<ErrorEvent> videoRecordingErrorController =
             StreamController<ErrorEvent>();
@@ -1336,28 +1387,27 @@ void main() {
 
         when(camera.startVideoRecording()).thenAnswer((_) async {});
 
-        when(camera.stopVideoRecording())
-            .thenAnswer((_) async => capturedVideo);
+        when(
+          camera.stopVideoRecording(),
+        ).thenAnswer((_) async => capturedVideo);
 
-        when(camera.onVideoRecordingError)
-            .thenAnswer((_) => videoRecordingErrorController.stream);
+        when(
+          camera.onVideoRecordingError,
+        ).thenAnswer((_) => videoRecordingErrorController.stream);
 
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
         await CameraPlatform.instance.startVideoRecording(cameraId);
-        final XFile _ =
-            await CameraPlatform.instance.stopVideoRecording(cameraId);
-
-        expect(
-          videoRecordingErrorController.hasListener,
-          isFalse,
+        final XFile _ = await CameraPlatform.instance.stopVideoRecording(
+          cameraId,
         );
+
+        expect(videoRecordingErrorController.hasListener, isFalse);
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () => CameraPlatform.instance.stopVideoRecording(cameraId),
@@ -1371,8 +1421,9 @@ void main() {
           );
         });
 
-        testWidgets('when stopVideoRecording throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when stopVideoRecording throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('InvalidStateError');
 
@@ -1393,8 +1444,9 @@ void main() {
           );
         });
 
-        testWidgets('when stopVideoRecording throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when stopVideoRecording throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -1436,8 +1488,7 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () => CameraPlatform.instance.pauseVideoRecording(cameraId),
@@ -1451,8 +1502,9 @@ void main() {
           );
         });
 
-        testWidgets('when pauseVideoRecording throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when pauseVideoRecording throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('InvalidStateError');
 
@@ -1473,8 +1525,9 @@ void main() {
           );
         });
 
-        testWidgets('when pauseVideoRecording throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when pauseVideoRecording throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -1516,8 +1569,7 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () => CameraPlatform.instance.resumeVideoRecording(cameraId),
@@ -1531,8 +1583,9 @@ void main() {
           );
         });
 
-        testWidgets('when resumeVideoRecording throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when resumeVideoRecording throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('InvalidStateError');
 
@@ -1553,8 +1606,9 @@ void main() {
           );
         });
 
-        testWidgets('when resumeVideoRecording throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when resumeVideoRecording throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -1582,25 +1636,22 @@ void main() {
     });
 
     group('setFlashMode', () {
-      testWidgets('calls setFlashMode on the camera',
-          (WidgetTester tester) async {
+      testWidgets('calls setFlashMode on the camera', (
+        WidgetTester tester,
+      ) async {
         final MockCamera camera = MockCamera();
         const FlashMode flashMode = FlashMode.always;
 
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
-        await CameraPlatform.instance.setFlashMode(
-          cameraId,
-          flashMode,
-        );
+        await CameraPlatform.instance.setFlashMode(cameraId, flashMode);
 
         verify(camera.setFlashMode(flashMode)).called(1);
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () => CameraPlatform.instance.setFlashMode(
@@ -1617,8 +1668,9 @@ void main() {
           );
         });
 
-        testWidgets('when setFlashMode throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when setFlashMode throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('NotSupportedError');
 
@@ -1642,8 +1694,9 @@ void main() {
           );
         });
 
-        testWidgets('when setFlashMode throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when setFlashMode throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -1657,10 +1710,8 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
           expect(
-            () => CameraPlatform.instance.setFlashMode(
-              cameraId,
-              FlashMode.torch,
-            ),
+            () =>
+                CameraPlatform.instance.setFlashMode(cameraId, FlashMode.torch),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1673,8 +1724,9 @@ void main() {
       });
     });
 
-    testWidgets('setExposureMode throws UnimplementedError',
-        (WidgetTester tester) async {
+    testWidgets('setExposureMode throws UnimplementedError', (
+      WidgetTester tester,
+    ) async {
       expect(
         () => CameraPlatform.instance.setExposureMode(
           cameraId,
@@ -1684,8 +1736,9 @@ void main() {
       );
     });
 
-    testWidgets('setExposurePoint throws UnimplementedError',
-        (WidgetTester tester) async {
+    testWidgets('setExposurePoint throws UnimplementedError', (
+      WidgetTester tester,
+    ) async {
       expect(
         () => CameraPlatform.instance.setExposurePoint(
           cameraId,
@@ -1695,54 +1748,54 @@ void main() {
       );
     });
 
-    testWidgets('getMinExposureOffset throws UnimplementedError',
-        (WidgetTester tester) async {
+    testWidgets('getMinExposureOffset throws UnimplementedError', (
+      WidgetTester tester,
+    ) async {
       expect(
         () => CameraPlatform.instance.getMinExposureOffset(cameraId),
         throwsUnimplementedError,
       );
     });
 
-    testWidgets('getMaxExposureOffset throws UnimplementedError',
-        (WidgetTester tester) async {
+    testWidgets('getMaxExposureOffset throws UnimplementedError', (
+      WidgetTester tester,
+    ) async {
       expect(
         () => CameraPlatform.instance.getMaxExposureOffset(cameraId),
         throwsUnimplementedError,
       );
     });
 
-    testWidgets('getExposureOffsetStepSize throws UnimplementedError',
-        (WidgetTester tester) async {
+    testWidgets('getExposureOffsetStepSize throws UnimplementedError', (
+      WidgetTester tester,
+    ) async {
       expect(
         () => CameraPlatform.instance.getExposureOffsetStepSize(cameraId),
         throwsUnimplementedError,
       );
     });
 
-    testWidgets('setExposureOffset throws UnimplementedError',
-        (WidgetTester tester) async {
+    testWidgets('setExposureOffset throws UnimplementedError', (
+      WidgetTester tester,
+    ) async {
       expect(
-        () => CameraPlatform.instance.setExposureOffset(
-          cameraId,
-          0,
-        ),
+        () => CameraPlatform.instance.setExposureOffset(cameraId, 0),
         throwsUnimplementedError,
       );
     });
 
-    testWidgets('setFocusMode throws UnimplementedError',
-        (WidgetTester tester) async {
+    testWidgets('setFocusMode throws UnimplementedError', (
+      WidgetTester tester,
+    ) async {
       expect(
-        () => CameraPlatform.instance.setFocusMode(
-          cameraId,
-          FocusMode.auto,
-        ),
+        () => CameraPlatform.instance.setFocusMode(cameraId, FocusMode.auto),
         throwsUnimplementedError,
       );
     });
 
-    testWidgets('setFocusPoint throws UnimplementedError',
-        (WidgetTester tester) async {
+    testWidgets('setFocusPoint throws UnimplementedError', (
+      WidgetTester tester,
+    ) async {
       expect(
         () => CameraPlatform.instance.setFocusPoint(
           cameraId,
@@ -1753,8 +1806,9 @@ void main() {
     });
 
     group('getMaxZoomLevel', () {
-      testWidgets('calls getMaxZoomLevel on the camera',
-          (WidgetTester tester) async {
+      testWidgets('calls getMaxZoomLevel on the camera', (
+        WidgetTester tester,
+      ) async {
         final MockCamera camera = MockCamera();
         const double maximumZoomLevel = 100.0;
 
@@ -1764,9 +1818,7 @@ void main() {
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
         expect(
-          await CameraPlatform.instance.getMaxZoomLevel(
-            cameraId,
-          ),
+          await CameraPlatform.instance.getMaxZoomLevel(cameraId),
           equals(maximumZoomLevel),
         );
 
@@ -1774,13 +1826,10 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
-            () async => CameraPlatform.instance.getMaxZoomLevel(
-              cameraId,
-            ),
+            () async => CameraPlatform.instance.getMaxZoomLevel(cameraId),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1791,8 +1840,9 @@ void main() {
           );
         });
 
-        testWidgets('when getMaxZoomLevel throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when getMaxZoomLevel throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('NotSupportedError');
 
@@ -1802,9 +1852,7 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
           expect(
-            () async => CameraPlatform.instance.getMaxZoomLevel(
-              cameraId,
-            ),
+            () async => CameraPlatform.instance.getMaxZoomLevel(cameraId),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1815,8 +1863,9 @@ void main() {
           );
         });
 
-        testWidgets('when getMaxZoomLevel throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when getMaxZoomLevel throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -1830,9 +1879,7 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
           expect(
-            () async => CameraPlatform.instance.getMaxZoomLevel(
-              cameraId,
-            ),
+            () async => CameraPlatform.instance.getMaxZoomLevel(cameraId),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1846,8 +1893,9 @@ void main() {
     });
 
     group('getMinZoomLevel', () {
-      testWidgets('calls getMinZoomLevel on the camera',
-          (WidgetTester tester) async {
+      testWidgets('calls getMinZoomLevel on the camera', (
+        WidgetTester tester,
+      ) async {
         final MockCamera camera = MockCamera();
         const double minimumZoomLevel = 100.0;
 
@@ -1857,9 +1905,7 @@ void main() {
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
         expect(
-          await CameraPlatform.instance.getMinZoomLevel(
-            cameraId,
-          ),
+          await CameraPlatform.instance.getMinZoomLevel(cameraId),
           equals(minimumZoomLevel),
         );
 
@@ -1867,13 +1913,10 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
-            () async => CameraPlatform.instance.getMinZoomLevel(
-              cameraId,
-            ),
+            () async => CameraPlatform.instance.getMinZoomLevel(cameraId),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1884,8 +1927,9 @@ void main() {
           );
         });
 
-        testWidgets('when getMinZoomLevel throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when getMinZoomLevel throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('NotSupportedError');
 
@@ -1895,9 +1939,7 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
           expect(
-            () async => CameraPlatform.instance.getMinZoomLevel(
-              cameraId,
-            ),
+            () async => CameraPlatform.instance.getMinZoomLevel(cameraId),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1908,8 +1950,9 @@ void main() {
           );
         });
 
-        testWidgets('when getMinZoomLevel throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when getMinZoomLevel throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -1923,9 +1966,7 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
           expect(
-            () async => CameraPlatform.instance.getMinZoomLevel(
-              cameraId,
-            ),
+            () async => CameraPlatform.instance.getMinZoomLevel(cameraId),
             throwsA(
               isA<PlatformException>().having(
                 (PlatformException e) => e.code,
@@ -1939,8 +1980,9 @@ void main() {
     });
 
     group('setZoomLevel', () {
-      testWidgets('calls setZoomLevel on the camera',
-          (WidgetTester tester) async {
+      testWidgets('calls setZoomLevel on the camera', (
+        WidgetTester tester,
+      ) async {
         final MockCamera camera = MockCamera();
 
         // Save the camera in the camera plugin.
@@ -1954,14 +1996,10 @@ void main() {
       });
 
       group('throws CameraException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
-            () async => CameraPlatform.instance.setZoomLevel(
-              cameraId,
-              100.0,
-            ),
+            () async => CameraPlatform.instance.setZoomLevel(cameraId, 100.0),
             throwsA(
               isA<CameraException>().having(
                 (CameraException e) => e.code,
@@ -1972,8 +2010,9 @@ void main() {
           );
         });
 
-        testWidgets('when setZoomLevel throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when setZoomLevel throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('NotSupportedError');
 
@@ -1983,10 +2022,7 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
           expect(
-            () async => CameraPlatform.instance.setZoomLevel(
-              cameraId,
-              100.0,
-            ),
+            () async => CameraPlatform.instance.setZoomLevel(cameraId, 100.0),
             throwsA(
               isA<CameraException>().having(
                 (CameraException e) => e.code,
@@ -1997,8 +2033,9 @@ void main() {
           );
         });
 
-        testWidgets('when setZoomLevel throws PlatformException',
-            (WidgetTester tester) async {
+        testWidgets('when setZoomLevel throws PlatformException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final PlatformException exception = PlatformException(
             code: CameraErrorCode.notSupported.toString(),
@@ -2011,10 +2048,7 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
           expect(
-            () async => CameraPlatform.instance.setZoomLevel(
-              cameraId,
-              100.0,
-            ),
+            () async => CameraPlatform.instance.setZoomLevel(cameraId, 100.0),
             throwsA(
               isA<CameraException>().having(
                 (CameraException e) => e.code,
@@ -2025,8 +2059,9 @@ void main() {
           );
         });
 
-        testWidgets('when setZoomLevel throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when setZoomLevel throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2040,10 +2075,7 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
           expect(
-            () async => CameraPlatform.instance.setZoomLevel(
-              cameraId,
-              100.0,
-            ),
+            () async => CameraPlatform.instance.setZoomLevel(cameraId, 100.0),
             throwsA(
               isA<CameraException>().having(
                 (CameraException e) => e.code,
@@ -2069,8 +2101,7 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () async => CameraPlatform.instance.pausePreview(cameraId),
@@ -2084,8 +2115,9 @@ void main() {
           );
         });
 
-        testWidgets('when pause throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when pause throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('NotSupportedError');
 
@@ -2123,8 +2155,7 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () async => CameraPlatform.instance.resumePreview(cameraId),
@@ -2138,8 +2169,9 @@ void main() {
           );
         });
 
-        testWidgets('when play throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when play throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('NotSupportedError');
 
@@ -2160,8 +2192,9 @@ void main() {
           );
         });
 
-        testWidgets('when play throws CameraWebException',
-            (WidgetTester tester) async {
+        testWidgets('when play throws CameraWebException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2188,8 +2221,7 @@ void main() {
       });
     });
 
-    testWidgets(
-        'buildPreview returns an HtmlElementView '
+    testWidgets('buildPreview returns an HtmlElementView '
         'with an appropriate view type', (WidgetTester tester) async {
       final Camera camera = Camera(
         textureId: cameraId,
@@ -2255,8 +2287,9 @@ void main() {
 
         when(camera.onEnded).thenAnswer((_) => endedStreamController.stream);
 
-        when(camera.onVideoRecordingError)
-            .thenAnswer((_) => videoRecordingErrorController.stream);
+        when(
+          camera.onVideoRecordingError,
+        ).thenAnswer((_) => videoRecordingErrorController.stream);
 
         when(camera.startVideoRecording()).thenAnswer((_) async {});
       });
@@ -2287,14 +2320,13 @@ void main() {
         // The first camera should be removed from the camera plugin.
         expect(
           (CameraPlatform.instance as CameraPlugin).cameras,
-          equals(<int, Camera>{
-            secondCameraId: secondCamera,
-          }),
+          equals(<int, Camera>{secondCameraId: secondCamera}),
         );
       });
 
-      testWidgets('cancels the camera video error and abort subscriptions',
-          (WidgetTester tester) async {
+      testWidgets('cancels the camera video error and abort subscriptions', (
+        WidgetTester tester,
+      ) async {
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
@@ -2305,8 +2337,9 @@ void main() {
         expect(abortStreamController.hasListener, isFalse);
       });
 
-      testWidgets('cancels the camera ended subscriptions',
-          (WidgetTester tester) async {
+      testWidgets('cancels the camera ended subscriptions', (
+        WidgetTester tester,
+      ) async {
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
@@ -2316,8 +2349,9 @@ void main() {
         expect(endedStreamController.hasListener, isFalse);
       });
 
-      testWidgets('cancels the camera video recording error subscriptions',
-          (WidgetTester tester) async {
+      testWidgets('cancels the camera video recording error subscriptions', (
+        WidgetTester tester,
+      ) async {
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
@@ -2329,8 +2363,7 @@ void main() {
       });
 
       group('throws PlatformException', () {
-        testWidgets(
-            'with notFound error '
+        testWidgets('with notFound error '
             'if the camera does not exist', (WidgetTester tester) async {
           expect(
             () => CameraPlatform.instance.dispose(cameraId),
@@ -2344,8 +2377,9 @@ void main() {
           );
         });
 
-        testWidgets('when dispose throws DomException',
-            (WidgetTester tester) async {
+        testWidgets('when dispose throws DomException', (
+          WidgetTester tester,
+        ) async {
           final MockCamera camera = MockCamera();
           final DOMException exception = DOMException('InvalidAccessError');
 
@@ -2384,8 +2418,7 @@ void main() {
         );
       });
 
-      testWidgets(
-          'throws PlatformException '
+      testWidgets('throws PlatformException '
           'with notFound error '
           'if the camera does not exist', (WidgetTester tester) async {
         expect(
@@ -2446,14 +2479,14 @@ void main() {
 
         when(camera.onEnded).thenAnswer((_) => endedStreamController.stream);
 
-        when(camera.onVideoRecordingError)
-            .thenAnswer((_) => videoRecordingErrorController.stream);
+        when(
+          camera.onVideoRecordingError,
+        ).thenAnswer((_) => videoRecordingErrorController.stream);
 
         when(camera.startVideoRecording()).thenAnswer((_) async {});
       });
 
-      testWidgets(
-          'onCameraInitialized emits a CameraInitializedEvent '
+      testWidgets('onCameraInitialized emits a CameraInitializedEvent '
           'on initializeCamera', (WidgetTester tester) async {
         // Mock the camera to use a blank video stream of size 1280x720.
         const Size videoSize = Size(1280, 720);
@@ -2461,10 +2494,7 @@ void main() {
         videoElement = getVideoElementWithBlankStream(videoSize);
 
         when(
-          cameraService.getMediaStreamForOptions(
-            any,
-            cameraId: cameraId,
-          ),
+          cameraService.getMediaStreamForOptions(any, cameraId: cameraId),
         ).thenAnswer((_) async => videoElement.captureStream());
 
         final Camera camera = Camera(
@@ -2475,8 +2505,9 @@ void main() {
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
-        final Stream<CameraInitializedEvent> eventStream =
-            CameraPlatform.instance.onCameraInitialized(cameraId);
+        final Stream<CameraInitializedEvent> eventStream = CameraPlatform
+            .instance
+            .onCameraInitialized(cameraId);
 
         final StreamQueue<CameraInitializedEvent> streamQueue =
             StreamQueue<CameraInitializedEvent>(eventStream);
@@ -2501,21 +2532,22 @@ void main() {
         await streamQueue.cancel();
       });
 
-      testWidgets('onCameraResolutionChanged emits an empty stream',
-          (WidgetTester tester) async {
-        final Stream<CameraResolutionChangedEvent> stream =
-            CameraPlatform.instance.onCameraResolutionChanged(cameraId);
+      testWidgets('onCameraResolutionChanged emits an empty stream', (
+        WidgetTester tester,
+      ) async {
+        final Stream<CameraResolutionChangedEvent> stream = CameraPlatform
+            .instance
+            .onCameraResolutionChanged(cameraId);
         expect(await stream.isEmpty, isTrue);
       });
 
-      testWidgets(
-          'onCameraClosing emits a CameraClosingEvent '
+      testWidgets('onCameraClosing emits a CameraClosingEvent '
           'on the camera ended event', (WidgetTester tester) async {
         // Save the camera in the camera plugin.
         (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
 
-        final Stream<CameraClosingEvent> eventStream =
-            CameraPlatform.instance.onCameraClosing(cameraId);
+        final Stream<CameraClosingEvent> eventStream = CameraPlatform.instance
+            .onCameraClosing(cameraId);
 
         final StreamQueue<CameraClosingEvent> streamQueue =
             StreamQueue<CameraClosingEvent>(eventStream);
@@ -2528,9 +2560,7 @@ void main() {
 
         expect(
           await streamQueue.next,
-          equals(
-            const CameraClosingEvent(cameraId),
-          ),
+          equals(const CameraClosingEvent(cameraId)),
         );
 
         await streamQueue.cancel();
@@ -2542,27 +2572,29 @@ void main() {
           (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on the camera video error event '
             'with a message', (WidgetTester tester) async {
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           await CameraPlatform.instance.initializeCamera(cameraId);
 
-          final MediaError error = createJSInteropWrapper(
-            FakeMediaError(
-              MediaError.MEDIA_ERR_NETWORK,
-              'A network error occurred.',
-            ),
-          ) as MediaError;
+          final MediaError error =
+              createJSInteropWrapper(
+                    FakeMediaError(
+                      MediaError.MEDIA_ERR_NETWORK,
+                      'A network error occurred.',
+                    ),
+                  )
+                  as MediaError;
 
-          final CameraErrorCode errorCode =
-              CameraErrorCode.fromMediaError(error);
+          final CameraErrorCode errorCode = CameraErrorCode.fromMediaError(
+            error,
+          );
 
           mockVideoElement.error = error;
           errorStreamController.add(Event('error'));
@@ -2580,23 +2612,25 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on the camera video error event '
             'with no message', (WidgetTester tester) async {
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           await CameraPlatform.instance.initializeCamera(cameraId);
 
-          final MediaError error = createJSInteropWrapper(
-            FakeMediaError(MediaError.MEDIA_ERR_NETWORK),
-          ) as MediaError;
-          final CameraErrorCode errorCode =
-              CameraErrorCode.fromMediaError(error);
+          final MediaError error =
+              createJSInteropWrapper(
+                    FakeMediaError(MediaError.MEDIA_ERR_NETWORK),
+                  )
+                  as MediaError;
+          final CameraErrorCode errorCode = CameraErrorCode.fromMediaError(
+            error,
+          );
 
           mockVideoElement.error = error;
           errorStreamController.add(Event('error'));
@@ -2614,11 +2648,10 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on the camera video abort event', (WidgetTester tester) async {
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
@@ -2640,8 +2673,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on takePicture error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2651,17 +2683,15 @@ void main() {
 
           when(camera.takePicture()).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
             () async => CameraPlatform.instance.takePicture(cameraId),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -2677,8 +2707,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on setFlashMode error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2688,8 +2717,8 @@ void main() {
 
           when(camera.setFlashMode(any)).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
@@ -2699,9 +2728,7 @@ void main() {
               cameraId,
               FlashMode.always,
             ),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -2717,8 +2744,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on getMaxZoomLevel error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2728,19 +2754,15 @@ void main() {
 
           when(camera.getMaxZoomLevel()).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
-            () async => CameraPlatform.instance.getMaxZoomLevel(
-              cameraId,
-            ),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            () async => CameraPlatform.instance.getMaxZoomLevel(cameraId),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -2756,8 +2778,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on getMinZoomLevel error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2767,19 +2788,15 @@ void main() {
 
           when(camera.getMinZoomLevel()).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
-            () async => CameraPlatform.instance.getMinZoomLevel(
-              cameraId,
-            ),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            () async => CameraPlatform.instance.getMinZoomLevel(cameraId),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -2795,8 +2812,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on setZoomLevel error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2806,20 +2822,15 @@ void main() {
 
           when(camera.setZoomLevel(any)).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
-            () async => CameraPlatform.instance.setZoomLevel(
-              cameraId,
-              100.0,
-            ),
-            throwsA(
-              isA<CameraException>(),
-            ),
+            () async => CameraPlatform.instance.setZoomLevel(cameraId, 100.0),
+            throwsA(isA<CameraException>()),
           );
 
           expect(
@@ -2835,8 +2846,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on resumePreview error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2846,17 +2856,15 @@ void main() {
 
           when(camera.play()).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
             () async => CameraPlatform.instance.resumePreview(cameraId),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -2872,8 +2880,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on startVideoRecording error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2881,22 +2888,21 @@ void main() {
             'description',
           );
 
-          when(camera.onVideoRecordingError)
-              .thenAnswer((_) => const Stream<ErrorEvent>.empty());
+          when(
+            camera.onVideoRecordingError,
+          ).thenAnswer((_) => const Stream<ErrorEvent>.empty());
 
           when(camera.startVideoRecording()).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
             () async => CameraPlatform.instance.startVideoRecording(cameraId),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -2912,12 +2918,12 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
-            'on the camera video recording error event',
-            (WidgetTester tester) async {
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+        testWidgets('emits a CameraErrorEvent '
+            'on the camera video recording error event', (
+          WidgetTester tester,
+        ) async {
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
@@ -2944,8 +2950,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on stopVideoRecording error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2955,17 +2960,15 @@ void main() {
 
           when(camera.stopVideoRecording()).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
             () async => CameraPlatform.instance.stopVideoRecording(cameraId),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -2981,8 +2984,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on pauseVideoRecording error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -2992,17 +2994,15 @@ void main() {
 
           when(camera.pauseVideoRecording()).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
             () async => CameraPlatform.instance.pauseVideoRecording(cameraId),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -3018,8 +3018,7 @@ void main() {
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a CameraErrorEvent '
+        testWidgets('emits a CameraErrorEvent '
             'on resumeVideoRecording error', (WidgetTester tester) async {
           final CameraWebException exception = CameraWebException(
             cameraId,
@@ -3029,17 +3028,15 @@ void main() {
 
           when(camera.resumeVideoRecording()).thenThrow(exception);
 
-          final Stream<CameraErrorEvent> eventStream =
-              CameraPlatform.instance.onCameraError(cameraId);
+          final Stream<CameraErrorEvent> eventStream = CameraPlatform.instance
+              .onCameraError(cameraId);
 
           final StreamQueue<CameraErrorEvent> streamQueue =
               StreamQueue<CameraErrorEvent>(eventStream);
 
           expect(
             () async => CameraPlatform.instance.resumeVideoRecording(cameraId),
-            throwsA(
-              isA<PlatformException>(),
-            ),
+            throwsA(isA<PlatformException>()),
           );
 
           expect(
@@ -3056,13 +3053,15 @@ void main() {
         });
       });
 
-      testWidgets('onVideoRecordedEvent emits a VideoRecordedEvent',
-          (WidgetTester tester) async {
+      testWidgets('onVideoRecordedEvent emits a VideoRecordedEvent', (
+        WidgetTester tester,
+      ) async {
         final MockCamera camera = MockCamera();
         final XFile capturedVideo = XFile('/bogus/test');
         final Stream<VideoRecordedEvent> stream =
             Stream<VideoRecordedEvent>.value(
-                VideoRecordedEvent(cameraId, capturedVideo, Duration.zero));
+              VideoRecordedEvent(cameraId, capturedVideo, Duration.zero),
+            );
         when(camera.onVideoRecordedEvent).thenAnswer((_) => stream);
 
         // Save the camera in the camera plugin.
@@ -3070,13 +3069,12 @@ void main() {
 
         final StreamQueue<VideoRecordedEvent> streamQueue =
             StreamQueue<VideoRecordedEvent>(
-                CameraPlatform.instance.onVideoRecordedEvent(cameraId));
+              CameraPlatform.instance.onVideoRecordedEvent(cameraId),
+            );
 
         expect(
           await streamQueue.next,
-          equals(
-            VideoRecordedEvent(cameraId, capturedVideo, Duration.zero),
-          ),
+          equals(VideoRecordedEvent(cameraId, capturedVideo, Duration.zero)),
         );
       });
 
@@ -3089,12 +3087,14 @@ void main() {
               MockEventStreamProvider<Event>();
           (CameraPlatform.instance as CameraPlugin)
               .orientationOnChangeProvider = provider;
-          when(provider.forTarget(any))
-              .thenAnswer((_) => eventStreamController.stream);
+          when(
+            provider.forTarget(any),
+          ).thenAnswer((_) => eventStreamController.stream);
         });
 
-        testWidgets('emits the initial DeviceOrientationChangedEvent',
-            (WidgetTester tester) async {
+        testWidgets('emits the initial DeviceOrientationChangedEvent', (
+          WidgetTester tester,
+        ) async {
           when(
             cameraService.mapOrientationTypeToDeviceOrientation(
               OrientationType.portraitPrimary,
@@ -3113,19 +3113,17 @@ void main() {
           expect(
             await streamQueue.next,
             equals(
-              const DeviceOrientationChangedEvent(
-                DeviceOrientation.portraitUp,
-              ),
+              const DeviceOrientationChangedEvent(DeviceOrientation.portraitUp),
             ),
           );
 
           await streamQueue.cancel();
         });
 
-        testWidgets(
-            'emits a DeviceOrientationChangedEvent '
-            'when the screen orientation is changed',
-            (WidgetTester tester) async {
+        testWidgets('emits a DeviceOrientationChangedEvent '
+            'when the screen orientation is changed', (
+          WidgetTester tester,
+        ) async {
           when(
             cameraService.mapOrientationTypeToDeviceOrientation(
               OrientationType.landscapePrimary,

--- a/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
+++ b/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
@@ -81,9 +81,10 @@ class MockScreen {
 @JSExport()
 class MockScreenOrientation {
   /// JSPromise<JSAny?> Function(web.OrientationLockType orientation)
-  JSFunction lock = (web.OrientationLockType orientation) {
-    return Future<void>.value().toJS;
-  }.toJS;
+  JSFunction lock =
+      (web.OrientationLockType orientation) {
+        return Future<void>.value().toJS;
+      }.toJS;
 
   /// void Function()
   late JSFunction unlock;
@@ -98,9 +99,10 @@ class MockDocument {
 @JSExport()
 class MockElement {
   /// JSPromise<JSAny?> Function([FullscreenOptions options])
-  JSFunction requestFullscreen = ([web.FullscreenOptions? options]) {
-    return Future<void>.value().toJS;
-  }.toJS;
+  JSFunction requestFullscreen =
+      ([web.FullscreenOptions? options]) {
+        return Future<void>.value().toJS;
+      }.toJS;
 }
 
 @JSExport()
@@ -126,9 +128,10 @@ class MockMediaStreamTrack {
   late JSFunction getCapabilities;
 
   /// web.MediaTrackSettings Function()
-  JSFunction getSettings = () {
-    return web.MediaTrackSettings();
-  }.toJS;
+  JSFunction getSettings =
+      () {
+        return web.MediaTrackSettings();
+      }.toJS;
 
   /// JSPromise<JSAny?> Function([web.MediaTrackConstraints? constraints])
   late JSFunction applyConstraints;
@@ -191,10 +194,7 @@ class FakeMediaDeviceInfo {
 /// A fake [MediaError] that returns the provided error [_code] and [_message].
 @JSExport()
 class FakeMediaError {
-  FakeMediaError(
-    this.code, [
-    this.message = '',
-  ]);
+  FakeMediaError(this.code, [this.message = '']);
 
   final int code;
   final String message;
@@ -208,8 +208,12 @@ class FakeElementStream<T extends web.Event> extends Fake
   final Stream<T> _stream;
 
   @override
-  StreamSubscription<T> listen(void Function(T event)? onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+  StreamSubscription<T> listen(
+    void Function(T event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
     return _stream.listen(
       onData,
       onError: onError,
@@ -230,10 +234,7 @@ class FakeBlobEvent {
 /// A fake [DomException] that returns the provided error [_name] and [_message].
 @JSExport()
 class FakeErrorEvent {
-  FakeErrorEvent(
-    this.type, [
-    this.message = '',
-  ]);
+  FakeErrorEvent(this.type, [this.message = '']);
 
   final String type;
   final String message;
@@ -247,13 +248,14 @@ class FakeErrorEvent {
 /// final videoStream = videoElement.captureStream();
 /// ```
 web.HTMLVideoElement getVideoElementWithBlankStream(Size videoSize) {
-  final web.HTMLCanvasElement canvasElement = web.HTMLCanvasElement()
-    ..width = videoSize.width.toInt()
-    ..height = videoSize.height.toInt()
-    ..context2D.fillRect(0, 0, videoSize.width, videoSize.height);
+  final web.HTMLCanvasElement canvasElement =
+      web.HTMLCanvasElement()
+        ..width = videoSize.width.toInt()
+        ..height = videoSize.height.toInt()
+        ..context2D.fillRect(0, 0, videoSize.width, videoSize.height);
 
-  final web.HTMLVideoElement videoElement = web.HTMLVideoElement()
-    ..srcObject = canvasElement.captureStream();
+  final web.HTMLVideoElement videoElement =
+      web.HTMLVideoElement()..srcObject = canvasElement.captureStream();
 
   return videoElement;
 }
@@ -261,32 +263,28 @@ web.HTMLVideoElement getVideoElementWithBlankStream(Size videoSize) {
 class MockEventStreamProvider<T extends web.Event> extends Mock
     implements web.EventStreamProvider<T> {
   @override
-  Stream<T> forTarget(
-    web.EventTarget? e, {
-    bool? useCapture = false,
-  }) {
+  Stream<T> forTarget(web.EventTarget? e, {bool? useCapture = false}) {
     return super.noSuchMethod(
-      Invocation.method(
-        #forTarget,
-        <Object?>[e],
-        <Symbol, Object?>{#useCapture: useCapture},
-      ),
-      returnValue: Stream<T>.empty(),
-    ) as Stream<T>;
+          Invocation.method(
+            #forTarget,
+            <Object?>[e],
+            <Symbol, Object?>{#useCapture: useCapture},
+          ),
+          returnValue: Stream<T>.empty(),
+        )
+        as Stream<T>;
   }
 
   @override
-  ElementStream<T> forElement(
-    web.Element? e, {
-    bool? useCapture = false,
-  }) {
+  ElementStream<T> forElement(web.Element? e, {bool? useCapture = false}) {
     return super.noSuchMethod(
-      Invocation.method(
-        #forElement,
-        <Object?>[e],
-        <Symbol, Object?>{#useCapture: useCapture},
-      ),
-      returnValue: FakeElementStream<T>(Stream<T>.empty()),
-    ) as ElementStream<T>;
+          Invocation.method(
+            #forElement,
+            <Object?>[e],
+            <Symbol, Object?>{#useCapture: useCapture},
+          ),
+          returnValue: FakeElementStream<T>(Stream<T>.empty()),
+        )
+        as ElementStream<T>;
   }
 }

--- a/packages/camera/camera_web/example/integration_test/helpers/mocks.mocks.dart
+++ b/packages/camera/camera_web/example/integration_test/helpers/mocks.mocks.dart
@@ -36,52 +36,52 @@ import 'mocks.dart' as _i9;
 
 class _FakeJsUtil_0 extends _i1.SmartFake implements _i2.JsUtil {
   _FakeJsUtil_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 class _FakeZoomLevelCapability_1 extends _i1.SmartFake
     implements _i3.ZoomLevelCapability {
   _FakeZoomLevelCapability_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 class _FakeSize_2 extends _i1.SmartFake implements _i4.Size {
   _FakeSize_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 class _FakeCameraOptions_3 extends _i1.SmartFake implements _i3.CameraOptions {
   _FakeCameraOptions_3(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 class _FakeStreamController_4<T> extends _i1.SmartFake
     implements _i5.StreamController<T> {
   _FakeStreamController_4(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 class _FakeEventStreamProvider_5<T extends _i6.Event> extends _i1.SmartFake
     implements _i6.EventStreamProvider<T> {
   _FakeEventStreamProvider_5(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 class _FakeXFile_6 extends _i1.SmartFake implements _i7.XFile {
   _FakeXFile_6(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 class _FakeAudioConstraints_7 extends _i1.SmartFake
     implements _i3.AudioConstraints {
   _FakeAudioConstraints_7(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 class _FakeVideoConstraints_8 extends _i1.SmartFake
     implements _i3.VideoConstraints {
   _FakeVideoConstraints_8(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [CameraService].
@@ -89,33 +89,37 @@ class _FakeVideoConstraints_8 extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockCameraService extends _i1.Mock implements _i8.CameraService {
   @override
-  _i6.Window get window => (super.noSuchMethod(
-        Invocation.getter(#window),
-        returnValue: _i9.windowShim(),
-        returnValueForMissingStub: _i9.windowShim(),
-      ) as _i6.Window);
+  _i6.Window get window =>
+      (super.noSuchMethod(
+            Invocation.getter(#window),
+            returnValue: _i9.windowShim(),
+            returnValueForMissingStub: _i9.windowShim(),
+          )
+          as _i6.Window);
 
   @override
   set window(_i6.Window? _window) => super.noSuchMethod(
-        Invocation.setter(#window, _window),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#window, _window),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  _i2.JsUtil get jsUtil => (super.noSuchMethod(
-        Invocation.getter(#jsUtil),
-        returnValue: _FakeJsUtil_0(this, Invocation.getter(#jsUtil)),
-        returnValueForMissingStub: _FakeJsUtil_0(
-          this,
-          Invocation.getter(#jsUtil),
-        ),
-      ) as _i2.JsUtil);
+  _i2.JsUtil get jsUtil =>
+      (super.noSuchMethod(
+            Invocation.getter(#jsUtil),
+            returnValue: _FakeJsUtil_0(this, Invocation.getter(#jsUtil)),
+            returnValueForMissingStub: _FakeJsUtil_0(
+              this,
+              Invocation.getter(#jsUtil),
+            ),
+          )
+          as _i2.JsUtil);
 
   @override
   set jsUtil(_i2.JsUtil? _jsUtil) => super.noSuchMethod(
-        Invocation.setter(#jsUtil, _jsUtil),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#jsUtil, _jsUtil),
+    returnValueForMissingStub: null,
+  );
 
   @override
   _i5.Future<_i6.MediaStream> getMediaStreamForOptions(
@@ -123,131 +127,141 @@ class MockCameraService extends _i1.Mock implements _i8.CameraService {
     int? cameraId = 0,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getMediaStreamForOptions,
-          [options],
-          {#cameraId: cameraId},
-        ),
-        returnValue: _i9.getMediaStreamForOptionsShim(
-          options,
-          cameraId: cameraId,
-        ),
-        returnValueForMissingStub: _i9.getMediaStreamForOptionsShim(
-          options,
-          cameraId: cameraId,
-        ),
-      ) as _i5.Future<_i6.MediaStream>);
+            Invocation.method(
+              #getMediaStreamForOptions,
+              [options],
+              {#cameraId: cameraId},
+            ),
+            returnValue: _i9.getMediaStreamForOptionsShim(
+              options,
+              cameraId: cameraId,
+            ),
+            returnValueForMissingStub: _i9.getMediaStreamForOptionsShim(
+              options,
+              cameraId: cameraId,
+            ),
+          )
+          as _i5.Future<_i6.MediaStream>);
 
   @override
   _i3.ZoomLevelCapability getZoomLevelCapabilityForCamera(
     _i10.Camera? camera,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(#getZoomLevelCapabilityForCamera, [camera]),
-        returnValue: _FakeZoomLevelCapability_1(
-          this,
-          Invocation.method(#getZoomLevelCapabilityForCamera, [camera]),
-        ),
-        returnValueForMissingStub: _FakeZoomLevelCapability_1(
-          this,
-          Invocation.method(#getZoomLevelCapabilityForCamera, [camera]),
-        ),
-      ) as _i3.ZoomLevelCapability);
+            Invocation.method(#getZoomLevelCapabilityForCamera, [camera]),
+            returnValue: _FakeZoomLevelCapability_1(
+              this,
+              Invocation.method(#getZoomLevelCapabilityForCamera, [camera]),
+            ),
+            returnValueForMissingStub: _FakeZoomLevelCapability_1(
+              this,
+              Invocation.method(#getZoomLevelCapabilityForCamera, [camera]),
+            ),
+          )
+          as _i3.ZoomLevelCapability);
 
   @override
   String? getFacingModeForVideoTrack(_i6.MediaStreamTrack? videoTrack) =>
       (super.noSuchMethod(
-        Invocation.method(#getFacingModeForVideoTrack, [videoTrack]),
-        returnValueForMissingStub: null,
-      ) as String?);
+            Invocation.method(#getFacingModeForVideoTrack, [videoTrack]),
+            returnValueForMissingStub: null,
+          )
+          as String?);
 
   @override
   _i7.CameraLensDirection mapFacingModeToLensDirection(String? facingMode) =>
       (super.noSuchMethod(
-        Invocation.method(#mapFacingModeToLensDirection, [facingMode]),
-        returnValue: _i7.CameraLensDirection.front,
-        returnValueForMissingStub: _i7.CameraLensDirection.front,
-      ) as _i7.CameraLensDirection);
+            Invocation.method(#mapFacingModeToLensDirection, [facingMode]),
+            returnValue: _i7.CameraLensDirection.front,
+            returnValueForMissingStub: _i7.CameraLensDirection.front,
+          )
+          as _i7.CameraLensDirection);
 
   @override
   _i3.CameraType mapFacingModeToCameraType(String? facingMode) =>
       (super.noSuchMethod(
-        Invocation.method(#mapFacingModeToCameraType, [facingMode]),
-        returnValue: _i3.CameraType.environment,
-        returnValueForMissingStub: _i3.CameraType.environment,
-      ) as _i3.CameraType);
+            Invocation.method(#mapFacingModeToCameraType, [facingMode]),
+            returnValue: _i3.CameraType.environment,
+            returnValueForMissingStub: _i3.CameraType.environment,
+          )
+          as _i3.CameraType);
 
   @override
   _i4.Size mapResolutionPresetToSize(_i7.ResolutionPreset? resolutionPreset) =>
       (super.noSuchMethod(
-        Invocation.method(#mapResolutionPresetToSize, [resolutionPreset]),
-        returnValue: _FakeSize_2(
-          this,
-          Invocation.method(#mapResolutionPresetToSize, [resolutionPreset]),
-        ),
-        returnValueForMissingStub: _FakeSize_2(
-          this,
-          Invocation.method(#mapResolutionPresetToSize, [resolutionPreset]),
-        ),
-      ) as _i4.Size);
+            Invocation.method(#mapResolutionPresetToSize, [resolutionPreset]),
+            returnValue: _FakeSize_2(
+              this,
+              Invocation.method(#mapResolutionPresetToSize, [resolutionPreset]),
+            ),
+            returnValueForMissingStub: _FakeSize_2(
+              this,
+              Invocation.method(#mapResolutionPresetToSize, [resolutionPreset]),
+            ),
+          )
+          as _i4.Size);
 
   @override
   int mapResolutionPresetToVideoBitrate(
     _i7.ResolutionPreset? resolutionPreset,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(#mapResolutionPresetToVideoBitrate, [
-          resolutionPreset,
-        ]),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as int);
+            Invocation.method(#mapResolutionPresetToVideoBitrate, [
+              resolutionPreset,
+            ]),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
 
   @override
   int mapResolutionPresetToAudioBitrate(
     _i7.ResolutionPreset? resolutionPreset,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(#mapResolutionPresetToAudioBitrate, [
-          resolutionPreset,
-        ]),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as int);
+            Invocation.method(#mapResolutionPresetToAudioBitrate, [
+              resolutionPreset,
+            ]),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
 
   @override
   String mapDeviceOrientationToOrientationType(
     _i11.DeviceOrientation? deviceOrientation,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(#mapDeviceOrientationToOrientationType, [
-          deviceOrientation,
-        ]),
-        returnValue: _i12.dummyValue<String>(
-          this,
-          Invocation.method(#mapDeviceOrientationToOrientationType, [
-            deviceOrientation,
-          ]),
-        ),
-        returnValueForMissingStub: _i12.dummyValue<String>(
-          this,
-          Invocation.method(#mapDeviceOrientationToOrientationType, [
-            deviceOrientation,
-          ]),
-        ),
-      ) as String);
+            Invocation.method(#mapDeviceOrientationToOrientationType, [
+              deviceOrientation,
+            ]),
+            returnValue: _i12.dummyValue<String>(
+              this,
+              Invocation.method(#mapDeviceOrientationToOrientationType, [
+                deviceOrientation,
+              ]),
+            ),
+            returnValueForMissingStub: _i12.dummyValue<String>(
+              this,
+              Invocation.method(#mapDeviceOrientationToOrientationType, [
+                deviceOrientation,
+              ]),
+            ),
+          )
+          as String);
 
   @override
   _i11.DeviceOrientation mapOrientationTypeToDeviceOrientation(
     String? orientationType,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(#mapOrientationTypeToDeviceOrientation, [
-          orientationType,
-        ]),
-        returnValue: _i11.DeviceOrientation.portraitUp,
-        returnValueForMissingStub: _i11.DeviceOrientation.portraitUp,
-      ) as _i11.DeviceOrientation);
+            Invocation.method(#mapOrientationTypeToDeviceOrientation, [
+              orientationType,
+            ]),
+            returnValue: _i11.DeviceOrientation.portraitUp,
+            returnValueForMissingStub: _i11.DeviceOrientation.portraitUp,
+          )
+          as _i11.DeviceOrientation);
 }
 
 /// A class which mocks [JsUtil].
@@ -255,18 +269,21 @@ class MockCameraService extends _i1.Mock implements _i8.CameraService {
 /// See the documentation for Mockito's code generation for more information.
 class MockJsUtil extends _i1.Mock implements _i2.JsUtil {
   @override
-  bool hasProperty(_i13.JSObject? o, _i13.JSAny? name) => (super.noSuchMethod(
-        Invocation.method(#hasProperty, [o, name]),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool hasProperty(_i13.JSObject? o, _i13.JSAny? name) =>
+      (super.noSuchMethod(
+            Invocation.method(#hasProperty, [o, name]),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 
   @override
   _i13.JSAny? getProperty(_i13.JSObject? o, _i13.JSAny? name) =>
       (super.noSuchMethod(
-        Invocation.method(#getProperty, [o, name]),
-        returnValueForMissingStub: null,
-      ) as _i13.JSAny?);
+            Invocation.method(#getProperty, [o, name]),
+            returnValueForMissingStub: null,
+          )
+          as _i13.JSAny?);
 }
 
 /// A class which mocks [Camera].
@@ -274,151 +291,166 @@ class MockJsUtil extends _i1.Mock implements _i2.JsUtil {
 /// See the documentation for Mockito's code generation for more information.
 class MockCamera extends _i1.Mock implements _i10.Camera {
   @override
-  int get textureId => (super.noSuchMethod(
-        Invocation.getter(#textureId),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as int);
+  int get textureId =>
+      (super.noSuchMethod(
+            Invocation.getter(#textureId),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
 
   @override
-  _i3.CameraOptions get options => (super.noSuchMethod(
-        Invocation.getter(#options),
-        returnValue: _FakeCameraOptions_3(
-          this,
-          Invocation.getter(#options),
-        ),
-        returnValueForMissingStub: _FakeCameraOptions_3(
-          this,
-          Invocation.getter(#options),
-        ),
-      ) as _i3.CameraOptions);
+  _i3.CameraOptions get options =>
+      (super.noSuchMethod(
+            Invocation.getter(#options),
+            returnValue: _FakeCameraOptions_3(
+              this,
+              Invocation.getter(#options),
+            ),
+            returnValueForMissingStub: _FakeCameraOptions_3(
+              this,
+              Invocation.getter(#options),
+            ),
+          )
+          as _i3.CameraOptions);
 
   @override
   ({int? audioBitrate, int? videoBitrate}) get recorderOptions =>
       (super.noSuchMethod(
-        Invocation.getter(#recorderOptions),
-        returnValue: (audioBitrate: null, videoBitrate: null),
-        returnValueForMissingStub: (audioBitrate: null, videoBitrate: null),
-      ) as ({int? audioBitrate, int? videoBitrate}));
+            Invocation.getter(#recorderOptions),
+            returnValue: (audioBitrate: null, videoBitrate: null),
+            returnValueForMissingStub: (audioBitrate: null, videoBitrate: null),
+          )
+          as ({int? audioBitrate, int? videoBitrate}));
 
   @override
-  _i6.HTMLVideoElement get videoElement => (super.noSuchMethod(
-        Invocation.getter(#videoElement),
-        returnValue: _i9.videoElementShim(),
-        returnValueForMissingStub: _i9.videoElementShim(),
-      ) as _i6.HTMLVideoElement);
+  _i6.HTMLVideoElement get videoElement =>
+      (super.noSuchMethod(
+            Invocation.getter(#videoElement),
+            returnValue: _i9.videoElementShim(),
+            returnValueForMissingStub: _i9.videoElementShim(),
+          )
+          as _i6.HTMLVideoElement);
 
   @override
   set videoElement(_i6.HTMLVideoElement? _videoElement) => super.noSuchMethod(
-        Invocation.setter(#videoElement, _videoElement),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#videoElement, _videoElement),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  _i6.HTMLDivElement get divElement => (super.noSuchMethod(
-        Invocation.getter(#divElement),
-        returnValue: _i9.divElementShim(),
-        returnValueForMissingStub: _i9.divElementShim(),
-      ) as _i6.HTMLDivElement);
+  _i6.HTMLDivElement get divElement =>
+      (super.noSuchMethod(
+            Invocation.getter(#divElement),
+            returnValue: _i9.divElementShim(),
+            returnValueForMissingStub: _i9.divElementShim(),
+          )
+          as _i6.HTMLDivElement);
 
   @override
   set divElement(_i6.HTMLDivElement? _divElement) => super.noSuchMethod(
-        Invocation.setter(#divElement, _divElement),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#divElement, _divElement),
+    returnValueForMissingStub: null,
+  );
 
   @override
   set stream(_i6.MediaStream? _stream) => super.noSuchMethod(
-        Invocation.setter(#stream, _stream),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#stream, _stream),
+    returnValueForMissingStub: null,
+  );
 
   @override
   _i5.StreamController<_i6.MediaStreamTrack> get onEndedController =>
       (super.noSuchMethod(
-        Invocation.getter(#onEndedController),
-        returnValue: _FakeStreamController_4<_i6.MediaStreamTrack>(
-          this,
-          Invocation.getter(#onEndedController),
-        ),
-        returnValueForMissingStub:
-            _FakeStreamController_4<_i6.MediaStreamTrack>(
-          this,
-          Invocation.getter(#onEndedController),
-        ),
-      ) as _i5.StreamController<_i6.MediaStreamTrack>);
+            Invocation.getter(#onEndedController),
+            returnValue: _FakeStreamController_4<_i6.MediaStreamTrack>(
+              this,
+              Invocation.getter(#onEndedController),
+            ),
+            returnValueForMissingStub:
+                _FakeStreamController_4<_i6.MediaStreamTrack>(
+                  this,
+                  Invocation.getter(#onEndedController),
+                ),
+          )
+          as _i5.StreamController<_i6.MediaStreamTrack>);
 
   @override
   _i6.EventStreamProvider<_i6.Event> get mediaRecorderOnErrorProvider =>
       (super.noSuchMethod(
-        Invocation.getter(#mediaRecorderOnErrorProvider),
-        returnValue: _FakeEventStreamProvider_5<_i6.Event>(
-          this,
-          Invocation.getter(#mediaRecorderOnErrorProvider),
-        ),
-        returnValueForMissingStub: _FakeEventStreamProvider_5<_i6.Event>(
-          this,
-          Invocation.getter(#mediaRecorderOnErrorProvider),
-        ),
-      ) as _i6.EventStreamProvider<_i6.Event>);
+            Invocation.getter(#mediaRecorderOnErrorProvider),
+            returnValue: _FakeEventStreamProvider_5<_i6.Event>(
+              this,
+              Invocation.getter(#mediaRecorderOnErrorProvider),
+            ),
+            returnValueForMissingStub: _FakeEventStreamProvider_5<_i6.Event>(
+              this,
+              Invocation.getter(#mediaRecorderOnErrorProvider),
+            ),
+          )
+          as _i6.EventStreamProvider<_i6.Event>);
 
   @override
   set mediaRecorderOnErrorProvider(
     _i6.EventStreamProvider<_i6.Event>? _mediaRecorderOnErrorProvider,
-  ) =>
-      super.noSuchMethod(
-        Invocation.setter(
-          #mediaRecorderOnErrorProvider,
-          _mediaRecorderOnErrorProvider,
-        ),
-        returnValueForMissingStub: null,
-      );
+  ) => super.noSuchMethod(
+    Invocation.setter(
+      #mediaRecorderOnErrorProvider,
+      _mediaRecorderOnErrorProvider,
+    ),
+    returnValueForMissingStub: null,
+  );
 
   @override
   _i5.StreamController<_i6.ErrorEvent> get videoRecordingErrorController =>
       (super.noSuchMethod(
-        Invocation.getter(#videoRecordingErrorController),
-        returnValue: _FakeStreamController_4<_i6.ErrorEvent>(
-          this,
-          Invocation.getter(#videoRecordingErrorController),
-        ),
-        returnValueForMissingStub: _FakeStreamController_4<_i6.ErrorEvent>(
-          this,
-          Invocation.getter(#videoRecordingErrorController),
-        ),
-      ) as _i5.StreamController<_i6.ErrorEvent>);
+            Invocation.getter(#videoRecordingErrorController),
+            returnValue: _FakeStreamController_4<_i6.ErrorEvent>(
+              this,
+              Invocation.getter(#videoRecordingErrorController),
+            ),
+            returnValueForMissingStub: _FakeStreamController_4<_i6.ErrorEvent>(
+              this,
+              Invocation.getter(#videoRecordingErrorController),
+            ),
+          )
+          as _i5.StreamController<_i6.ErrorEvent>);
 
   @override
   set flashMode(_i7.FlashMode? _flashMode) => super.noSuchMethod(
-        Invocation.setter(#flashMode, _flashMode),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#flashMode, _flashMode),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  _i6.Window get window => (super.noSuchMethod(
-        Invocation.getter(#window),
-        returnValue: _i9.windowShim(),
-        returnValueForMissingStub: _i9.windowShim(),
-      ) as _i6.Window);
+  _i6.Window get window =>
+      (super.noSuchMethod(
+            Invocation.getter(#window),
+            returnValue: _i9.windowShim(),
+            returnValueForMissingStub: _i9.windowShim(),
+          )
+          as _i6.Window);
 
   @override
   set window(_i6.Window? _window) => super.noSuchMethod(
-        Invocation.setter(#window, _window),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#window, _window),
+    returnValueForMissingStub: null,
+  );
 
   @override
   set mediaRecorder(_i6.MediaRecorder? _mediaRecorder) => super.noSuchMethod(
-        Invocation.setter(#mediaRecorder, _mediaRecorder),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#mediaRecorder, _mediaRecorder),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  bool Function(String) get isVideoTypeSupported => (super.noSuchMethod(
-        Invocation.getter(#isVideoTypeSupported),
-        returnValue: (String __p0) => false,
-        returnValueForMissingStub: (String __p0) => false,
-      ) as bool Function(String));
+  bool Function(String) get isVideoTypeSupported =>
+      (super.noSuchMethod(
+            Invocation.getter(#isVideoTypeSupported),
+            returnValue: (String __p0) => false,
+            returnValueForMissingStub: (String __p0) => false,
+          )
+          as bool Function(String));
 
   @override
   set isVideoTypeSupported(bool Function(String)? _isVideoTypeSupported) =>
@@ -430,10 +462,11 @@ class MockCamera extends _i1.Mock implements _i10.Camera {
   @override
   _i6.Blob Function(List<_i6.Blob>, String) get blobBuilder =>
       (super.noSuchMethod(
-        Invocation.getter(#blobBuilder),
-        returnValue: _i9.blobBuilderShim(),
-        returnValueForMissingStub: _i9.blobBuilderShim(),
-      ) as _i6.Blob Function(List<_i6.Blob>, String));
+            Invocation.getter(#blobBuilder),
+            returnValue: _i9.blobBuilderShim(),
+            returnValueForMissingStub: _i9.blobBuilderShim(),
+          )
+          as _i6.Blob Function(List<_i6.Blob>, String));
 
   @override
   set blobBuilder(_i6.Blob Function(List<_i6.Blob>, String)? _blobBuilder) =>
@@ -445,167 +478,198 @@ class MockCamera extends _i1.Mock implements _i10.Camera {
   @override
   _i5.StreamController<_i7.VideoRecordedEvent> get videoRecorderController =>
       (super.noSuchMethod(
-        Invocation.getter(#videoRecorderController),
-        returnValue: _FakeStreamController_4<_i7.VideoRecordedEvent>(
-          this,
-          Invocation.getter(#videoRecorderController),
-        ),
-        returnValueForMissingStub:
-            _FakeStreamController_4<_i7.VideoRecordedEvent>(
-          this,
-          Invocation.getter(#videoRecorderController),
-        ),
-      ) as _i5.StreamController<_i7.VideoRecordedEvent>);
+            Invocation.getter(#videoRecorderController),
+            returnValue: _FakeStreamController_4<_i7.VideoRecordedEvent>(
+              this,
+              Invocation.getter(#videoRecorderController),
+            ),
+            returnValueForMissingStub:
+                _FakeStreamController_4<_i7.VideoRecordedEvent>(
+                  this,
+                  Invocation.getter(#videoRecorderController),
+                ),
+          )
+          as _i5.StreamController<_i7.VideoRecordedEvent>);
 
   @override
-  _i5.Stream<_i6.MediaStreamTrack> get onEnded => (super.noSuchMethod(
-        Invocation.getter(#onEnded),
-        returnValue: _i5.Stream<_i6.MediaStreamTrack>.empty(),
-        returnValueForMissingStub: _i5.Stream<_i6.MediaStreamTrack>.empty(),
-      ) as _i5.Stream<_i6.MediaStreamTrack>);
+  _i5.Stream<_i6.MediaStreamTrack> get onEnded =>
+      (super.noSuchMethod(
+            Invocation.getter(#onEnded),
+            returnValue: _i5.Stream<_i6.MediaStreamTrack>.empty(),
+            returnValueForMissingStub: _i5.Stream<_i6.MediaStreamTrack>.empty(),
+          )
+          as _i5.Stream<_i6.MediaStreamTrack>);
 
   @override
-  _i5.Stream<_i6.ErrorEvent> get onVideoRecordingError => (super.noSuchMethod(
-        Invocation.getter(#onVideoRecordingError),
-        returnValue: _i5.Stream<_i6.ErrorEvent>.empty(),
-        returnValueForMissingStub: _i5.Stream<_i6.ErrorEvent>.empty(),
-      ) as _i5.Stream<_i6.ErrorEvent>);
+  _i5.Stream<_i6.ErrorEvent> get onVideoRecordingError =>
+      (super.noSuchMethod(
+            Invocation.getter(#onVideoRecordingError),
+            returnValue: _i5.Stream<_i6.ErrorEvent>.empty(),
+            returnValueForMissingStub: _i5.Stream<_i6.ErrorEvent>.empty(),
+          )
+          as _i5.Stream<_i6.ErrorEvent>);
 
   @override
   _i5.Stream<_i7.VideoRecordedEvent> get onVideoRecordedEvent =>
       (super.noSuchMethod(
-        Invocation.getter(#onVideoRecordedEvent),
-        returnValue: _i5.Stream<_i7.VideoRecordedEvent>.empty(),
-        returnValueForMissingStub: _i5.Stream<_i7.VideoRecordedEvent>.empty(),
-      ) as _i5.Stream<_i7.VideoRecordedEvent>);
+            Invocation.getter(#onVideoRecordedEvent),
+            returnValue: _i5.Stream<_i7.VideoRecordedEvent>.empty(),
+            returnValueForMissingStub:
+                _i5.Stream<_i7.VideoRecordedEvent>.empty(),
+          )
+          as _i5.Stream<_i7.VideoRecordedEvent>);
 
   @override
-  _i5.Future<void> initialize() => (super.noSuchMethod(
-        Invocation.method(#initialize, []),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> initialize() =>
+      (super.noSuchMethod(
+            Invocation.method(#initialize, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> play() => (super.noSuchMethod(
-        Invocation.method(#play, []),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> play() =>
+      (super.noSuchMethod(
+            Invocation.method(#play, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
   void pause() => super.noSuchMethod(
-        Invocation.method(#pause, []),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#pause, []),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void stop() => super.noSuchMethod(
-        Invocation.method(#stop, []),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#stop, []),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  _i5.Future<_i7.XFile> takePicture() => (super.noSuchMethod(
-        Invocation.method(#takePicture, []),
-        returnValue: _i5.Future<_i7.XFile>.value(
-          _FakeXFile_6(this, Invocation.method(#takePicture, [])),
-        ),
-        returnValueForMissingStub: _i5.Future<_i7.XFile>.value(
-          _FakeXFile_6(this, Invocation.method(#takePicture, [])),
-        ),
-      ) as _i5.Future<_i7.XFile>);
+  _i5.Future<_i7.XFile> takePicture() =>
+      (super.noSuchMethod(
+            Invocation.method(#takePicture, []),
+            returnValue: _i5.Future<_i7.XFile>.value(
+              _FakeXFile_6(this, Invocation.method(#takePicture, [])),
+            ),
+            returnValueForMissingStub: _i5.Future<_i7.XFile>.value(
+              _FakeXFile_6(this, Invocation.method(#takePicture, [])),
+            ),
+          )
+          as _i5.Future<_i7.XFile>);
 
   @override
-  _i4.Size getVideoSize() => (super.noSuchMethod(
-        Invocation.method(#getVideoSize, []),
-        returnValue: _FakeSize_2(
-          this,
-          Invocation.method(#getVideoSize, []),
-        ),
-        returnValueForMissingStub: _FakeSize_2(
-          this,
-          Invocation.method(#getVideoSize, []),
-        ),
-      ) as _i4.Size);
+  _i4.Size getVideoSize() =>
+      (super.noSuchMethod(
+            Invocation.method(#getVideoSize, []),
+            returnValue: _FakeSize_2(
+              this,
+              Invocation.method(#getVideoSize, []),
+            ),
+            returnValueForMissingStub: _FakeSize_2(
+              this,
+              Invocation.method(#getVideoSize, []),
+            ),
+          )
+          as _i4.Size);
 
   @override
   void setFlashMode(_i7.FlashMode? mode) => super.noSuchMethod(
-        Invocation.method(#setFlashMode, [mode]),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#setFlashMode, [mode]),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  double getMaxZoomLevel() => (super.noSuchMethod(
-        Invocation.method(#getMaxZoomLevel, []),
-        returnValue: 0.0,
-        returnValueForMissingStub: 0.0,
-      ) as double);
+  double getMaxZoomLevel() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMaxZoomLevel, []),
+            returnValue: 0.0,
+            returnValueForMissingStub: 0.0,
+          )
+          as double);
 
   @override
-  double getMinZoomLevel() => (super.noSuchMethod(
-        Invocation.method(#getMinZoomLevel, []),
-        returnValue: 0.0,
-        returnValueForMissingStub: 0.0,
-      ) as double);
+  double getMinZoomLevel() =>
+      (super.noSuchMethod(
+            Invocation.method(#getMinZoomLevel, []),
+            returnValue: 0.0,
+            returnValueForMissingStub: 0.0,
+          )
+          as double);
 
   @override
   void setZoomLevel(double? zoom) => super.noSuchMethod(
-        Invocation.method(#setZoomLevel, [zoom]),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#setZoomLevel, [zoom]),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  String getViewType() => (super.noSuchMethod(
-        Invocation.method(#getViewType, []),
-        returnValue: _i12.dummyValue<String>(
-          this,
-          Invocation.method(#getViewType, []),
-        ),
-        returnValueForMissingStub: _i12.dummyValue<String>(
-          this,
-          Invocation.method(#getViewType, []),
-        ),
-      ) as String);
+  String getViewType() =>
+      (super.noSuchMethod(
+            Invocation.method(#getViewType, []),
+            returnValue: _i12.dummyValue<String>(
+              this,
+              Invocation.method(#getViewType, []),
+            ),
+            returnValueForMissingStub: _i12.dummyValue<String>(
+              this,
+              Invocation.method(#getViewType, []),
+            ),
+          )
+          as String);
 
   @override
-  _i5.Future<void> startVideoRecording() => (super.noSuchMethod(
-        Invocation.method(#startVideoRecording, []),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> startVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#startVideoRecording, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> pauseVideoRecording() => (super.noSuchMethod(
-        Invocation.method(#pauseVideoRecording, []),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> pauseVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#pauseVideoRecording, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> resumeVideoRecording() => (super.noSuchMethod(
-        Invocation.method(#resumeVideoRecording, []),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> resumeVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#resumeVideoRecording, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<_i7.XFile> stopVideoRecording() => (super.noSuchMethod(
-        Invocation.method(#stopVideoRecording, []),
-        returnValue: _i5.Future<_i7.XFile>.value(
-          _FakeXFile_6(this, Invocation.method(#stopVideoRecording, [])),
-        ),
-        returnValueForMissingStub: _i5.Future<_i7.XFile>.value(
-          _FakeXFile_6(this, Invocation.method(#stopVideoRecording, [])),
-        ),
-      ) as _i5.Future<_i7.XFile>);
+  _i5.Future<_i7.XFile> stopVideoRecording() =>
+      (super.noSuchMethod(
+            Invocation.method(#stopVideoRecording, []),
+            returnValue: _i5.Future<_i7.XFile>.value(
+              _FakeXFile_6(this, Invocation.method(#stopVideoRecording, [])),
+            ),
+            returnValueForMissingStub: _i5.Future<_i7.XFile>.value(
+              _FakeXFile_6(this, Invocation.method(#stopVideoRecording, [])),
+            ),
+          )
+          as _i5.Future<_i7.XFile>);
 
   @override
-  _i5.Future<void> dispose() => (super.noSuchMethod(
-        Invocation.method(#dispose, []),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> dispose() =>
+      (super.noSuchMethod(
+            Invocation.method(#dispose, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 }
 
 /// A class which mocks [CameraOptions].
@@ -614,35 +678,41 @@ class MockCamera extends _i1.Mock implements _i10.Camera {
 // ignore: must_be_immutable
 class MockCameraOptions extends _i1.Mock implements _i3.CameraOptions {
   @override
-  _i3.AudioConstraints get audio => (super.noSuchMethod(
-        Invocation.getter(#audio),
-        returnValue: _FakeAudioConstraints_7(
-          this,
-          Invocation.getter(#audio),
-        ),
-        returnValueForMissingStub: _FakeAudioConstraints_7(
-          this,
-          Invocation.getter(#audio),
-        ),
-      ) as _i3.AudioConstraints);
+  _i3.AudioConstraints get audio =>
+      (super.noSuchMethod(
+            Invocation.getter(#audio),
+            returnValue: _FakeAudioConstraints_7(
+              this,
+              Invocation.getter(#audio),
+            ),
+            returnValueForMissingStub: _FakeAudioConstraints_7(
+              this,
+              Invocation.getter(#audio),
+            ),
+          )
+          as _i3.AudioConstraints);
 
   @override
-  _i3.VideoConstraints get video => (super.noSuchMethod(
-        Invocation.getter(#video),
-        returnValue: _FakeVideoConstraints_8(
-          this,
-          Invocation.getter(#video),
-        ),
-        returnValueForMissingStub: _FakeVideoConstraints_8(
-          this,
-          Invocation.getter(#video),
-        ),
-      ) as _i3.VideoConstraints);
+  _i3.VideoConstraints get video =>
+      (super.noSuchMethod(
+            Invocation.getter(#video),
+            returnValue: _FakeVideoConstraints_8(
+              this,
+              Invocation.getter(#video),
+            ),
+            returnValueForMissingStub: _FakeVideoConstraints_8(
+              this,
+              Invocation.getter(#video),
+            ),
+          )
+          as _i3.VideoConstraints);
 
   @override
-  _i6.MediaStreamConstraints toMediaStreamConstraints() => (super.noSuchMethod(
-        Invocation.method(#toMediaStreamConstraints, []),
-        returnValue: _i9.toMediaStreamConstraintsShim(),
-        returnValueForMissingStub: _i9.toMediaStreamConstraintsShim(),
-      ) as _i6.MediaStreamConstraints);
+  _i6.MediaStreamConstraints toMediaStreamConstraints() =>
+      (super.noSuchMethod(
+            Invocation.method(#toMediaStreamConstraints, []),
+            returnValue: _i9.toMediaStreamConstraintsShim(),
+            returnValueForMissingStub: _i9.toMediaStreamConstraintsShim(),
+          )
+          as _i6.MediaStreamConstraints);
 }

--- a/packages/camera/camera_web/example/pubspec.yaml
+++ b/packages/camera/camera_web/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: camera_web_integration_tests
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   camera_platform_interface: ^2.6.0

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -170,11 +170,12 @@ class Camera {
 
     videoElement = web.HTMLVideoElement();
 
-    divElement = web.HTMLDivElement()
-      ..style.setProperty('object-fit', 'cover')
-      ..style.setProperty('height', '100%')
-      ..style.setProperty('width', '100%')
-      ..append(videoElement);
+    divElement =
+        web.HTMLDivElement()
+          ..style.setProperty('object-fit', 'cover')
+          ..style.setProperty('height', '100%')
+          ..style.setProperty('width', '100%')
+          ..append(videoElement);
 
     ui_web.platformViewRegistry.registerViewFactory(
       _getViewType(textureId),
@@ -197,8 +198,8 @@ class Camera {
       _onEndedSubscription = EventStreamProviders.endedEvent
           .forTarget(defaultVideoTrack)
           .listen((web.Event _) {
-        onEndedController.add(defaultVideoTrack);
-      });
+            onEndedController.add(defaultVideoTrack);
+          });
     }
   }
 
@@ -253,9 +254,10 @@ class Camera {
 
     final int videoWidth = videoElement.videoWidth;
     final int videoHeight = videoElement.videoHeight;
-    final web.HTMLCanvasElement canvas = web.HTMLCanvasElement()
-      ..width = videoWidth
-      ..height = videoHeight;
+    final web.HTMLCanvasElement canvas =
+        web.HTMLCanvasElement()
+          ..width = videoWidth
+          ..height = videoHeight;
     final bool isBackCamera = getLensDirection() == CameraLensDirection.back;
 
     // Flip the picture horizontally if it is not taken from a back camera.
@@ -296,7 +298,7 @@ class Camera {
   Size getVideoSize() {
     final List<web.MediaStreamTrack> videoTracks =
         (videoElement.srcObject as web.MediaStream?)?.getVideoTracks().toDart ??
-            <web.MediaStreamTrack>[];
+        <web.MediaStreamTrack>[];
 
     if (videoTracks.isEmpty) {
       return Size.zero;
@@ -355,7 +357,8 @@ class Camera {
 
     if (videoTracks.isNotEmpty) {
       final web.MediaStreamTrack defaultVideoTrack = videoTracks.first;
-      final bool canEnableTorchMode = defaultVideoTrack
+      final bool canEnableTorchMode =
+          defaultVideoTrack
               .getCapabilities()
               .torchNullable
               ?.toDart
@@ -365,7 +368,8 @@ class Camera {
 
       if (canEnableTorchMode) {
         defaultVideoTrack.applyWebTweakConstraints(
-            WebTweakMediaTrackConstraints(torch: enabled.toJS));
+          WebTweakMediaTrackConstraints(torch: enabled.toJS),
+        );
       } else {
         throw CameraWebException(
           textureId,
@@ -401,8 +405,8 @@ class Camera {
   /// Throws a [CameraWebException] if the zoom level is invalid,
   /// not supported or the camera has not been initialized or started.
   void setZoomLevel(double zoom) {
-    final ZoomLevelCapability zoomLevelCapability =
-        _cameraService.getZoomLevelCapabilityForCamera(this);
+    final ZoomLevelCapability zoomLevelCapability = _cameraService
+        .getZoomLevelCapabilityForCamera(this);
 
     if (zoom < zoomLevelCapability.minimum ||
         zoom > zoomLevelCapability.maximum) {
@@ -414,7 +418,8 @@ class Camera {
     }
 
     zoomLevelCapability.videoTrack.applyWebTweakConstraints(
-        WebTweakMediaTrackConstraints(zoom: zoom.toJS));
+      WebTweakMediaTrackConstraints(zoom: zoom.toJS),
+    );
   }
 
   /// Returns a lens direction of this camera.
@@ -424,7 +429,7 @@ class Camera {
   CameraLensDirection? getLensDirection() {
     final List<web.MediaStreamTrack> videoTracks =
         (videoElement.srcObject as web.MediaStream?)?.getVideoTracks().toDart ??
-            <web.MediaStreamTrack>[];
+        <web.MediaStreamTrack>[];
 
     if (videoTracks.isEmpty) {
       return null;
@@ -451,8 +456,9 @@ class Camera {
   /// Throws a [CameraWebException] if the browser does not support any of the
   /// available video mime types from [_videoMimeType].
   Future<void> startVideoRecording() async {
-    final web.MediaRecorderOptions options =
-        web.MediaRecorderOptions(mimeType: _videoMimeType);
+    final web.MediaRecorderOptions options = web.MediaRecorderOptions(
+      mimeType: _videoMimeType,
+    );
     if (recorderOptions.audioBitrate != null) {
       options.audioBitsPerSecond = recorderOptions.audioBitrate!;
     }
@@ -460,8 +466,10 @@ class Camera {
       options.videoBitsPerSecond = recorderOptions.videoBitrate!;
     }
 
-    mediaRecorder ??=
-        web.MediaRecorder(videoElement.srcObject! as web.MediaStream, options);
+    mediaRecorder ??= web.MediaRecorder(
+      videoElement.srcObject! as web.MediaStream,
+      options,
+    );
 
     _videoAvailableCompleter = Completer<XFile>();
 
@@ -484,9 +492,9 @@ class Camera {
     _onVideoRecordingErrorSubscription = mediaRecorderOnErrorProvider
         .forTarget(mediaRecorder)
         .listen((web.Event event) {
-      final web.ErrorEvent error = event as web.ErrorEvent;
-      videoRecordingErrorController.add(error);
-    });
+          final web.ErrorEvent error = event as web.ErrorEvent;
+          videoRecordingErrorController.add(error);
+        });
 
     mediaRecorder!.start();
   }
@@ -510,9 +518,7 @@ class Camera {
       );
 
       // Emit an event containing the recorded video file.
-      videoRecorderController.add(
-        VideoRecordedEvent(textureId, file, null),
-      );
+      videoRecorderController.add(VideoRecordedEvent(textureId, file, null));
 
       _videoAvailableCompleter?.complete(file);
     }
@@ -607,20 +613,22 @@ class Camera {
 
     return types.firstWhere(
       (String type) => isVideoTypeSupported(type),
-      orElse: () => throw CameraWebException(
-        textureId,
-        CameraErrorCode.notSupported,
-        'The browser does not support any of the following video types: ${types.join(',')}.',
-      ),
+      orElse:
+          () =>
+              throw CameraWebException(
+                textureId,
+                CameraErrorCode.notSupported,
+                'The browser does not support any of the following video types: ${types.join(',')}.',
+              ),
     );
   }
 
-  CameraWebException get _videoRecordingNotStartedException =>
-      CameraWebException(
-        textureId,
-        CameraErrorCode.videoRecordingNotStarted,
-        'The video recorder is uninitialized. The recording might not have been started. Make sure to call `startVideoRecording` first.',
-      );
+  CameraWebException
+  get _videoRecordingNotStartedException => CameraWebException(
+    textureId,
+    CameraErrorCode.videoRecordingNotStarted,
+    'The video recorder is uninitialized. The recording might not have been started. Make sure to call `startVideoRecording` first.',
+  );
 
   /// Applies default styles to the video [element].
   void _applyDefaultVideoStyles(web.HTMLVideoElement element) {

--- a/packages/camera/camera_web/lib/src/camera_service.dart
+++ b/packages/camera/camera_web/lib/src/camera_service.dart
@@ -35,9 +35,7 @@ class CameraService {
 
     try {
       return await mediaDevices
-          .getUserMedia(
-            options.toMediaStreamConstraints(),
-          )
+          .getUserMedia(options.toMediaStreamConstraints())
           .toDart;
     } on web.DOMException catch (e) {
       switch (e.name) {
@@ -110,9 +108,7 @@ class CameraService {
   ///
   /// Throws a [CameraWebException] if the zoom level is not supported
   /// or the camera has not been initialized or started.
-  ZoomLevelCapability getZoomLevelCapabilityForCamera(
-    Camera camera,
-  ) {
+  ZoomLevelCapability getZoomLevelCapabilityForCamera(Camera camera) {
     final web.MediaDevices mediaDevices = window.navigator.mediaDevices;
     final web.MediaTrackSupportedConstraints supportedConstraints =
         mediaDevices.getSupportedConstraints();
@@ -203,10 +199,10 @@ class CameraService {
 
       // A list of facing mode capabilities as
       // the camera may support multiple facing modes.
-      final List<String> facingModeCapabilities = videoTrackCapabilities
-          .facingMode.toDart
-          .map((JSString e) => e.toDart)
-          .toList();
+      final List<String> facingModeCapabilities =
+          videoTrackCapabilities.facingMode.toDart
+              .map((JSString e) => e.toDart)
+              .toList();
 
       if (facingModeCapabilities.isNotEmpty) {
         final String facingModeCapability = facingModeCapabilities.first;

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -30,13 +30,11 @@ class CameraPlugin extends CameraPlatform {
   /// Creates a new instance of [CameraPlugin]
   /// with the given [cameraService].
   CameraPlugin({required CameraService cameraService})
-      : _cameraService = cameraService;
+    : _cameraService = cameraService;
 
   /// Registers this class as the default instance of [CameraPlatform].
   static void registerWith(Registrar registrar) {
-    CameraPlatform.instance = CameraPlugin(
-      cameraService: CameraService(),
-    );
+    CameraPlatform.instance = CameraPlugin(cameraService: CameraService());
   }
 
   final CameraService _cameraService;
@@ -77,17 +75,16 @@ class CameraPlugin extends CameraPlatform {
       <int, StreamSubscription<web.Event>>{};
 
   final Map<int, StreamSubscription<web.MediaStreamTrack>>
-      _cameraEndedSubscriptions =
-      <int, StreamSubscription<web.MediaStreamTrack>>{};
+  _cameraEndedSubscriptions = <int, StreamSubscription<web.MediaStreamTrack>>{};
 
   final Map<int, StreamSubscription<web.ErrorEvent>>
-      _cameraVideoRecordingErrorSubscriptions =
+  _cameraVideoRecordingErrorSubscriptions =
       <int, StreamSubscription<web.ErrorEvent>>{};
 
   /// Returns a stream of camera events for the given [cameraId].
-  Stream<CameraEvent> _cameraEvents(int cameraId) =>
-      cameraEventStreamController.stream
-          .where((CameraEvent event) => event.cameraId == cameraId);
+  Stream<CameraEvent> _cameraEvents(int cameraId) => cameraEventStreamController
+      .stream
+      .where((CameraEvent event) => event.cameraId == cameraId);
 
   /// The stream provider for [web.ScreenOrientation] change events.
   @visibleForTesting
@@ -105,14 +102,13 @@ class CameraPlugin extends CameraPlatform {
       final List<CameraDescription> cameras = <CameraDescription>[];
 
       // Request video permissions only.
-      final web.MediaStream cameraStream =
-          await _cameraService.getMediaStreamForOptions(const CameraOptions());
+      final web.MediaStream cameraStream = await _cameraService
+          .getMediaStreamForOptions(const CameraOptions());
 
       // Release the camera stream used to request video permissions.
-      cameraStream
-          .getVideoTracks()
-          .toDart
-          .forEach((web.MediaStreamTrack videoTrack) => videoTrack.stop());
+      cameraStream.getVideoTracks().toDart.forEach(
+        (web.MediaStreamTrack videoTrack) => videoTrack.stop(),
+      );
 
       // Request available media devices.
       final List<web.MediaDeviceInfo> devices =
@@ -124,7 +120,6 @@ class CameraPlugin extends CameraPlatform {
             (web.MediaDeviceInfo device) =>
                 device.kind == MediaDeviceKind.videoInput,
           )
-
           /// The device id property is currently not supported on Internet Explorer:
           /// https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo/deviceId#browser_compatibility
           .where((web.MediaDeviceInfo device) => device.deviceId.isNotEmpty);
@@ -133,8 +128,9 @@ class CameraPlugin extends CameraPlatform {
       for (final web.MediaDeviceInfo videoInputDevice in videoInputDevices) {
         // Get the video stream for the current video input device
         // to later use for the available video tracks.
-        final web.MediaStream videoStream =
-            await _getVideoStreamForDevice(videoInputDevice.deviceId);
+        final web.MediaStream videoStream = await _getVideoStreamForDevice(
+          videoInputDevice.deviceId,
+        );
 
         // Get all video tracks in the video stream
         // to later extract the lens direction from the first track.
@@ -143,15 +139,17 @@ class CameraPlugin extends CameraPlatform {
 
         if (videoTracks.isNotEmpty) {
           // Get the facing mode from the first available video track.
-          final String? facingMode =
-              _cameraService.getFacingModeForVideoTrack(videoTracks.first);
+          final String? facingMode = _cameraService.getFacingModeForVideoTrack(
+            videoTracks.first,
+          );
 
           // Get the lens direction based on the facing mode.
           // Fallback to the external lens direction
           // if the facing mode is not available.
-          final CameraLensDirection lensDirection = facingMode != null
-              ? _cameraService.mapFacingModeToLensDirection(facingMode)
-              : CameraLensDirection.external;
+          final CameraLensDirection lensDirection =
+              facingMode != null
+                  ? _cameraService.mapFacingModeToLensDirection(facingMode)
+                  : CameraLensDirection.external;
 
           // Create a camera description.
           //
@@ -203,13 +201,10 @@ class CameraPlugin extends CameraPlatform {
     CameraDescription cameraDescription,
     ResolutionPreset? resolutionPreset, {
     bool enableAudio = false,
-  }) =>
-      createCameraWithSettings(
-          cameraDescription,
-          MediaSettings(
-            resolutionPreset: resolutionPreset,
-            enableAudio: enableAudio,
-          ));
+  }) => createCameraWithSettings(
+    cameraDescription,
+    MediaSettings(resolutionPreset: resolutionPreset, enableAudio: enableAudio),
+  );
 
   @override
   Future<int> createCameraWithSettings(
@@ -229,14 +224,18 @@ class CameraPlugin extends CameraPlatform {
 
       final CameraMetadata cameraMetadata = camerasMetadata[cameraDescription]!;
 
-      final CameraType? cameraType = cameraMetadata.facingMode != null
-          ? _cameraService.mapFacingModeToCameraType(cameraMetadata.facingMode!)
-          : null;
+      final CameraType? cameraType =
+          cameraMetadata.facingMode != null
+              ? _cameraService.mapFacingModeToCameraType(
+                cameraMetadata.facingMode!,
+              )
+              : null;
 
       // Use the highest resolution possible
       // if the resolution preset is not specified.
       final Size videoSize = _cameraService.mapResolutionPresetToSize(
-          mediaSettings?.resolutionPreset ?? ResolutionPreset.max);
+        mediaSettings?.resolutionPreset ?? ResolutionPreset.max,
+      );
 
       // Create a camera with the given audio and video constraints.
       // Sensor orientation is currently not supported.
@@ -248,12 +247,8 @@ class CameraPlugin extends CameraPlatform {
           video: VideoConstraints(
             facingMode:
                 cameraType != null ? FacingModeConstraint(cameraType) : null,
-            width: VideoSizeConstraint(
-              ideal: videoSize.width.toInt(),
-            ),
-            height: VideoSizeConstraint(
-              ideal: videoSize.height.toInt(),
-            ),
+            width: VideoSizeConstraint(ideal: videoSize.width.toInt()),
+            height: VideoSizeConstraint(ideal: videoSize.height.toInt()),
             deviceId: cameraMetadata.deviceId,
           ),
         ),
@@ -287,44 +282,45 @@ class CameraPlugin extends CameraPlatform {
       _cameraVideoErrorSubscriptions[cameraId] = videoElementOnErrorProvider
           .forElement(camera.videoElement)
           .listen((web.Event _) {
-        // The Event itself (_) doesn't contain information about the actual error.
-        // We need to look at the HTMLMediaElement.error.
-        // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/error
-        final web.MediaError error = camera.videoElement.error!;
-        final CameraErrorCode errorCode = CameraErrorCode.fromMediaError(error);
-        final String errorMessage =
-            error.message != '' ? error.message : _kDefaultErrorMessage;
+            // The Event itself (_) doesn't contain information about the actual error.
+            // We need to look at the HTMLMediaElement.error.
+            // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/error
+            final web.MediaError error = camera.videoElement.error!;
+            final CameraErrorCode errorCode = CameraErrorCode.fromMediaError(
+              error,
+            );
+            final String errorMessage =
+                error.message != '' ? error.message : _kDefaultErrorMessage;
 
-        cameraEventStreamController.add(
-          CameraErrorEvent(
-            cameraId,
-            'Error code: $errorCode, error message: $errorMessage',
-          ),
-        );
-      });
+            cameraEventStreamController.add(
+              CameraErrorEvent(
+                cameraId,
+                'Error code: $errorCode, error message: $errorMessage',
+              ),
+            );
+          });
 
       // Add camera's video abort events to the camera events stream.
       // The abort event fires when the video element's source has not fully loaded.
       _cameraVideoAbortSubscriptions[cameraId] = videoElementOnAbortProvider
           .forElement(camera.videoElement)
           .listen((web.Event _) {
-        cameraEventStreamController.add(
-          CameraErrorEvent(
-            cameraId,
-            "Error code: ${CameraErrorCode.abort}, error message: The video element's source has not fully loaded.",
-          ),
-        );
-      });
+            cameraEventStreamController.add(
+              CameraErrorEvent(
+                cameraId,
+                "Error code: ${CameraErrorCode.abort}, error message: The video element's source has not fully loaded.",
+              ),
+            );
+          });
 
       await camera.play();
 
       // Add camera's closing events to the camera events stream.
       // The onEnded stream fires when there is no more camera stream data.
-      _cameraEndedSubscriptions[cameraId] =
-          camera.onEnded.listen((web.MediaStreamTrack _) {
-        cameraEventStreamController.add(
-          CameraClosingEvent(cameraId),
-        );
+      _cameraEndedSubscriptions[cameraId] = camera.onEnded.listen((
+        web.MediaStreamTrack _,
+      ) {
+        cameraEventStreamController.add(CameraClosingEvent(cameraId));
       });
 
       final Size cameraSize = camera.getVideoSize();
@@ -391,13 +387,11 @@ class CameraPlugin extends CameraPlatform {
     return orientationOnChangeProvider
         .forTarget(orientation)
         .startWith(initialOrientationEvent)
-        .map(
-      (web.Event _) {
-        final DeviceOrientation deviceOrientation = _cameraService
-            .mapOrientationTypeToDeviceOrientation(orientation.type);
-        return DeviceOrientationChangedEvent(deviceOrientation);
-      },
-    );
+        .map((web.Event _) {
+          final DeviceOrientation deviceOrientation = _cameraService
+              .mapOrientationTypeToDeviceOrientation(orientation.type);
+          return DeviceOrientationChangedEvent(deviceOrientation);
+        });
   }
 
   @override
@@ -410,8 +404,8 @@ class CameraPlugin extends CameraPlatform {
       final web.Element? documentElement = window.document.documentElement;
 
       if (documentElement != null) {
-        final String orientationType =
-            _cameraService.mapDeviceOrientationToOrientationType(orientation);
+        final String orientationType = _cameraService
+            .mapDeviceOrientationToOrientationType(orientation);
 
         // Full-screen mode may be required to modify the device orientation.
         // See: https://w3c.github.io/screen-orientation/#interaction-with-fullscreen-api
@@ -485,8 +479,10 @@ class CameraPlugin extends CameraPlatform {
       // Add camera's video recording errors to the camera events stream.
       // The error event fires when the video recording is not allowed or an unsupported
       // codec is used.
-      _cameraVideoRecordingErrorSubscriptions[options.cameraId] =
-          camera.onVideoRecordingError.listen((web.ErrorEvent errorEvent) {
+      _cameraVideoRecordingErrorSubscriptions[options
+          .cameraId] = camera.onVideoRecordingError.listen((
+        web.ErrorEvent errorEvent,
+      ) {
         cameraEventStreamController.add(
           CameraErrorEvent(
             options.cameraId,
@@ -656,9 +652,7 @@ class CameraPlugin extends CameraPlatform {
 
   @override
   Widget buildPreview(int cameraId) {
-    return HtmlElementView(
-      viewType: getCamera(cameraId).getViewType(),
-    );
+    return HtmlElementView(viewType: getCamera(cameraId).getViewType());
   }
 
   @override
@@ -681,9 +675,7 @@ class CameraPlugin extends CameraPlatform {
   }
 
   /// Returns a media video stream for the device with the given [deviceId].
-  Future<web.MediaStream> _getVideoStreamForDevice(
-    String deviceId,
-  ) {
+  Future<web.MediaStream> _getVideoStreamForDevice(String deviceId) {
     // Create camera options with the desired device id.
     final CameraOptions cameraOptions = CameraOptions(
       video: VideoConstraints(deviceId: deviceId),

--- a/packages/camera/camera_web/lib/src/pkg_web_tweaks.dart
+++ b/packages/camera/camera_web/lib/src/pkg_web_tweaks.dart
@@ -42,11 +42,7 @@ extension NonStandardFieldsOnMediaTrackSettings on MediaTrackSettings {
 /// Brought over from package:web 1.0.0
 extension type WebTweakMediaSettingsRange._(JSObject _) implements JSObject {
   @JS('MediaSettingsRange')
-  external factory WebTweakMediaSettingsRange({
-    num max,
-    num min,
-    num step,
-  });
+  external factory WebTweakMediaSettingsRange({num max, num min, num step});
 
   external double get max;
   external set max(num value);
@@ -59,8 +55,9 @@ extension type WebTweakMediaSettingsRange._(JSObject _) implements JSObject {
 /// Adds an applyConstraints method that accepts the WebTweakMediaTrackConstraints.
 extension WebTweakMethodVersions on MediaStreamTrack {
   @JS('applyConstraints')
-  external JSPromise<JSAny?> applyWebTweakConstraints(
-      [WebTweakMediaTrackConstraints constraints]);
+  external JSPromise<JSAny?> applyWebTweakConstraints([
+    WebTweakMediaTrackConstraints constraints,
+  ]);
 }
 
 /// Allows creating the MediaTrackConstraints that are needed.

--- a/packages/camera/camera_web/lib/src/types/camera_error_code.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_error_code.dart
@@ -15,24 +15,28 @@ class CameraErrorCode {
   String toString() => _type;
 
   /// The camera is not supported.
-  static const CameraErrorCode notSupported =
-      CameraErrorCode._('cameraNotSupported');
+  static const CameraErrorCode notSupported = CameraErrorCode._(
+    'cameraNotSupported',
+  );
 
   /// The camera is not found.
   static const CameraErrorCode notFound = CameraErrorCode._('cameraNotFound');
 
   /// The camera is not readable.
-  static const CameraErrorCode notReadable =
-      CameraErrorCode._('cameraNotReadable');
+  static const CameraErrorCode notReadable = CameraErrorCode._(
+    'cameraNotReadable',
+  );
 
   /// The camera options are impossible to satisfy.
-  static const CameraErrorCode overconstrained =
-      CameraErrorCode._('cameraOverconstrained');
+  static const CameraErrorCode overconstrained = CameraErrorCode._(
+    'cameraOverconstrained',
+  );
 
   /// The camera cannot be used or the permission
   /// to access the camera is not granted.
-  static const CameraErrorCode permissionDenied =
-      CameraErrorCode._('CameraAccessDenied');
+  static const CameraErrorCode permissionDenied = CameraErrorCode._(
+    'CameraAccessDenied',
+  );
 
   /// The camera options are incorrect or attempted
   /// to access the media input from an insecure context.
@@ -45,32 +49,39 @@ class CameraErrorCode {
   static const CameraErrorCode security = CameraErrorCode._('cameraSecurity');
 
   /// The camera metadata is missing.
-  static const CameraErrorCode missingMetadata =
-      CameraErrorCode._('cameraMissingMetadata');
+  static const CameraErrorCode missingMetadata = CameraErrorCode._(
+    'cameraMissingMetadata',
+  );
 
   /// The camera orientation is not supported.
-  static const CameraErrorCode orientationNotSupported =
-      CameraErrorCode._('orientationNotSupported');
+  static const CameraErrorCode orientationNotSupported = CameraErrorCode._(
+    'orientationNotSupported',
+  );
 
   /// The camera torch mode is not supported.
-  static const CameraErrorCode torchModeNotSupported =
-      CameraErrorCode._('torchModeNotSupported');
+  static const CameraErrorCode torchModeNotSupported = CameraErrorCode._(
+    'torchModeNotSupported',
+  );
 
   /// The camera zoom level is not supported.
-  static const CameraErrorCode zoomLevelNotSupported =
-      CameraErrorCode._('zoomLevelNotSupported');
+  static const CameraErrorCode zoomLevelNotSupported = CameraErrorCode._(
+    'zoomLevelNotSupported',
+  );
 
   /// The camera zoom level is invalid.
-  static const CameraErrorCode zoomLevelInvalid =
-      CameraErrorCode._('zoomLevelInvalid');
+  static const CameraErrorCode zoomLevelInvalid = CameraErrorCode._(
+    'zoomLevelInvalid',
+  );
 
   /// The camera has not been initialized or started.
-  static const CameraErrorCode notStarted =
-      CameraErrorCode._('cameraNotStarted');
+  static const CameraErrorCode notStarted = CameraErrorCode._(
+    'cameraNotStarted',
+  );
 
   /// The video recording was not started.
-  static const CameraErrorCode videoRecordingNotStarted =
-      CameraErrorCode._('videoRecordingNotStarted');
+  static const CameraErrorCode videoRecordingNotStarted = CameraErrorCode._(
+    'videoRecordingNotStarted',
+  );
 
   /// An unknown camera error.
   static const CameraErrorCode unknown = CameraErrorCode._('cameraUnknown');

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -19,11 +19,9 @@ import 'package:web/web.dart' as web;
 class CameraOptions {
   /// Creates a new instance of [CameraOptions]
   /// with the given [audio] and [video] constraints.
-  const CameraOptions({
-    AudioConstraints? audio,
-    VideoConstraints? video,
-  })  : audio = audio ?? const AudioConstraints(),
-        video = video ?? const VideoConstraints();
+  const CameraOptions({AudioConstraints? audio, VideoConstraints? video})
+    : audio = audio ?? const AudioConstraints(),
+      video = video ?? const VideoConstraints();
 
   /// The audio constraints for the camera.
   final AudioConstraints audio;

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.3.5
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 0.2.6+2

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 0.2.6+2
 

--- a/packages/camera/camera_windows/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_windows/example/integration_test/camera_test.dart
@@ -19,68 +19,87 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('initializeCamera', () {
-    testWidgets('throws exception if camera is not created',
-        (WidgetTester _) async {
+    testWidgets('throws exception if camera is not created', (
+      WidgetTester _,
+    ) async {
       final CameraPlatform camera = CameraPlatform.instance;
 
-      expect(() async => camera.initializeCamera(1234),
-          throwsA(isA<CameraException>()));
+      expect(
+        () async => camera.initializeCamera(1234),
+        throwsA(isA<CameraException>()),
+      );
     });
   });
 
   group('takePicture', () {
-    testWidgets('throws exception if camera is not created',
-        (WidgetTester _) async {
+    testWidgets('throws exception if camera is not created', (
+      WidgetTester _,
+    ) async {
       final CameraPlatform camera = CameraPlatform.instance;
 
-      expect(() async => camera.takePicture(1234),
-          throwsA(isA<PlatformException>()));
+      expect(
+        () async => camera.takePicture(1234),
+        throwsA(isA<PlatformException>()),
+      );
     });
   });
 
   group('startVideoRecording', () {
-    testWidgets('throws exception if camera is not created',
-        (WidgetTester _) async {
+    testWidgets('throws exception if camera is not created', (
+      WidgetTester _,
+    ) async {
       final CameraPlatform camera = CameraPlatform.instance;
 
-      expect(() async => camera.startVideoRecording(1234),
-          throwsA(isA<PlatformException>()));
+      expect(
+        () async => camera.startVideoRecording(1234),
+        throwsA(isA<PlatformException>()),
+      );
     });
   });
 
   group('stopVideoRecording', () {
-    testWidgets('throws exception if camera is not created',
-        (WidgetTester _) async {
+    testWidgets('throws exception if camera is not created', (
+      WidgetTester _,
+    ) async {
       final CameraPlatform camera = CameraPlatform.instance;
 
-      expect(() async => camera.stopVideoRecording(1234),
-          throwsA(isA<PlatformException>()));
+      expect(
+        () async => camera.stopVideoRecording(1234),
+        throwsA(isA<PlatformException>()),
+      );
     });
   });
 
   group('pausePreview', () {
-    testWidgets('throws exception if camera is not created',
-        (WidgetTester _) async {
+    testWidgets('throws exception if camera is not created', (
+      WidgetTester _,
+    ) async {
       final CameraPlatform camera = CameraPlatform.instance;
 
-      expect(() async => camera.pausePreview(1234),
-          throwsA(isA<PlatformException>()));
+      expect(
+        () async => camera.pausePreview(1234),
+        throwsA(isA<PlatformException>()),
+      );
     });
   });
 
   group('resumePreview', () {
-    testWidgets('throws exception if camera is not created',
-        (WidgetTester _) async {
+    testWidgets('throws exception if camera is not created', (
+      WidgetTester _,
+    ) async {
       final CameraPlatform camera = CameraPlatform.instance;
 
-      expect(() async => camera.resumePreview(1234),
-          throwsA(isA<PlatformException>()));
+      expect(
+        () async => camera.resumePreview(1234),
+        throwsA(isA<PlatformException>()),
+      );
     });
   });
 
   group('onDeviceOrientationChanged', () {
-    testWidgets('emits the initial DeviceOrientationChangedEvent',
-        (WidgetTester _) async {
+    testWidgets('emits the initial DeviceOrientationChangedEvent', (
+      WidgetTester _,
+    ) async {
       final Stream<DeviceOrientationChangedEvent> eventStream =
           CameraPlatform.instance.onDeviceOrientationChanged();
 
@@ -90,9 +109,7 @@ void main() {
       expect(
         await streamQueue.next,
         equals(
-          const DeviceOrientationChangedEvent(
-            DeviceOrientation.landscapeRight,
-          ),
+          const DeviceOrientationChangedEvent(DeviceOrientation.landscapeRight),
         ),
       );
     });

--- a/packages/camera/camera_windows/example/lib/main.dart
+++ b/packages/camera/camera_windows/example/lib/main.dart
@@ -116,15 +116,10 @@ class _MyAppState extends State<MyApp> {
       final Future<CameraInitializedEvent> initialized =
           CameraPlatform.instance.onCameraInitialized(cameraId).first;
 
-      await CameraPlatform.instance.initializeCamera(
-        cameraId,
-      );
+      await CameraPlatform.instance.initializeCamera(cameraId);
 
       final CameraInitializedEvent event = await initialized;
-      _previewSize = Size(
-        event.previewWidth,
-        event.previewHeight,
-      );
+      _previewSize = Size(event.previewWidth, event.previewHeight);
 
       if (mounted) {
         setState(() {
@@ -197,18 +192,19 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _recordTimed(int seconds) async {
     if (_initialized && _cameraId > 0 && !_recordingTimed) {
-      unawaited(CameraPlatform.instance
-          .onVideoRecordedEvent(_cameraId)
-          .first
-          .then((VideoRecordedEvent event) async {
-        if (mounted) {
-          setState(() {
-            _recordingTimed = false;
-          });
+      unawaited(
+        CameraPlatform.instance.onVideoRecordedEvent(_cameraId).first.then((
+          VideoRecordedEvent event,
+        ) async {
+          if (mounted) {
+            setState(() {
+              _recordingTimed = false;
+            });
 
-          _showInSnackBar('Video captured to: ${event.file.path}');
-        }
-      }));
+            _showInSnackBar('Video captured to: ${event.file.path}');
+          }
+        }),
+      );
 
       await CameraPlatform.instance.startVideoRecording(
         _cameraId,
@@ -232,8 +228,9 @@ class _MyAppState extends State<MyApp> {
         if (!_recording) {
           await CameraPlatform.instance.startVideoRecording(_cameraId);
         } else {
-          final XFile file =
-              await CameraPlatform.instance.stopVideoRecording(_cameraId);
+          final XFile file = await CameraPlatform.instance.stopVideoRecording(
+            _cameraId,
+          );
 
           _showInSnackBar('Video captured to: ${file.path}');
         }
@@ -315,7 +312,8 @@ class _MyAppState extends State<MyApp> {
   void _onCameraError(CameraErrorEvent event) {
     if (mounted) {
       _scaffoldMessengerKey.currentState?.showSnackBar(
-          SnackBar(content: Text('Error: ${event.description}')));
+        SnackBar(content: Text('Error: ${event.description}')),
+      );
 
       // Dispose camera on camera error as it can not be used anymore.
       _disposeCurrentCamera();
@@ -330,10 +328,9 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _showInSnackBar(String message) {
-    _scaffoldMessengerKey.currentState?.showSnackBar(SnackBar(
-      content: Text(message),
-      duration: const Duration(seconds: 1),
-    ));
+    _scaffoldMessengerKey.currentState?.showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 1)),
+    );
   }
 
   final GlobalKey<ScaffoldMessengerState> _scaffoldMessengerKey =
@@ -342,27 +339,23 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     final List<DropdownMenuItem<ResolutionPreset>> resolutionItems =
-        ResolutionPreset.values
-            .map<DropdownMenuItem<ResolutionPreset>>((ResolutionPreset value) {
-      return DropdownMenuItem<ResolutionPreset>(
-        value: value,
-        child: Text(value.toString()),
-      );
-    }).toList();
+        ResolutionPreset.values.map<DropdownMenuItem<ResolutionPreset>>((
+          ResolutionPreset value,
+        ) {
+          return DropdownMenuItem<ResolutionPreset>(
+            value: value,
+            child: Text(value.toString()),
+          );
+        }).toList();
 
     return MaterialApp(
       scaffoldMessengerKey: _scaffoldMessengerKey,
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
+        appBar: AppBar(title: const Text('Plugin example app')),
         body: ListView(
           children: <Widget>[
             Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 5,
-                horizontal: 10,
-              ),
+              padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
               child: Text(_cameraInfo),
             ),
             if (_cameras.isEmpty)
@@ -386,15 +379,18 @@ class _MyAppState extends State<MyApp> {
                   const SizedBox(width: 20),
                   const Text('Audio:'),
                   Switch(
-                      value: _mediaSettings.enableAudio,
-                      onChanged: (bool state) => _onAudioChange(state)),
+                    value: _mediaSettings.enableAudio,
+                    onChanged: (bool state) => _onAudioChange(state),
+                  ),
                   const SizedBox(width: 20),
                   ElevatedButton(
-                    onPressed: _initialized
-                        ? _disposeCurrentCamera
-                        : _initializeCamera,
-                    child:
-                        Text(_initialized ? 'Dispose camera' : 'Create camera'),
+                    onPressed:
+                        _initialized
+                            ? _disposeCurrentCamera
+                            : _initializeCamera,
+                    child: Text(
+                      _initialized ? 'Dispose camera' : 'Create camera',
+                    ),
                   ),
                   const SizedBox(width: 5),
                   ElevatedButton(
@@ -419,35 +415,28 @@ class _MyAppState extends State<MyApp> {
                   ),
                   const SizedBox(width: 5),
                   ElevatedButton(
-                    onPressed: (_initialized && !_recording && !_recordingTimed)
-                        ? () => _recordTimed(5)
-                        : null,
-                    child: const Text(
-                      'Record 5 seconds',
-                    ),
+                    onPressed:
+                        (_initialized && !_recording && !_recordingTimed)
+                            ? () => _recordTimed(5)
+                            : null,
+                    child: const Text('Record 5 seconds'),
                   ),
                   if (_cameras.length > 1) ...<Widget>[
                     const SizedBox(width: 5),
                     ElevatedButton(
                       onPressed: _switchCamera,
-                      child: const Text(
-                        'Switch camera',
-                      ),
+                      child: const Text('Switch camera'),
                     ),
-                  ]
+                  ],
                 ],
               ),
             const SizedBox(height: 5),
             if (_initialized && _cameraId > 0 && _previewSize != null)
               Padding(
-                padding: const EdgeInsets.symmetric(
-                  vertical: 10,
-                ),
+                padding: const EdgeInsets.symmetric(vertical: 10),
                 child: Align(
                   child: Container(
-                    constraints: const BoxConstraints(
-                      maxHeight: 500,
-                    ),
+                    constraints: const BoxConstraints(maxHeight: 500),
                     child: AspectRatio(
                       aspectRatio: _previewSize!.width / _previewSize!.height,
                       child: _buildPreview(),

--- a/packages/camera/camera_windows/example/pubspec.yaml
+++ b/packages/camera/camera_windows/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the camera_windows plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   camera_platform_interface: ^2.6.0

--- a/packages/camera/camera_windows/lib/camera_windows.dart
+++ b/packages/camera/camera_windows/lib/camera_windows.dart
@@ -16,7 +16,7 @@ import 'src/messages.g.dart';
 class CameraWindows extends CameraPlatform {
   /// Creates a new Windows [CameraPlatform] implementation instance.
   CameraWindows({@visibleForTesting CameraApi? api})
-      : _hostApi = api ?? CameraApi();
+    : _hostApi = api ?? CameraApi();
 
   /// Registers the Windows implementation of CameraPlatform.
   static void registerWith() {
@@ -43,9 +43,9 @@ class CameraWindows extends CameraPlatform {
       StreamController<CameraEvent>.broadcast();
 
   /// Returns a stream of camera events for the given [cameraId].
-  Stream<CameraEvent> _cameraEvents(int cameraId) =>
-      cameraEventStreamController.stream
-          .where((CameraEvent event) => event.cameraId == cameraId);
+  Stream<CameraEvent> _cameraEvents(int cameraId) => cameraEventStreamController
+      .stream
+      .where((CameraEvent event) => event.cameraId == cameraId);
 
   @override
   Future<List<CameraDescription>> availableCameras() async {
@@ -74,13 +74,10 @@ class CameraWindows extends CameraPlatform {
     CameraDescription cameraDescription,
     ResolutionPreset? resolutionPreset, {
     bool enableAudio = false,
-  }) =>
-      createCameraWithSettings(
-          cameraDescription,
-          MediaSettings(
-            resolutionPreset: resolutionPreset,
-            enableAudio: enableAudio,
-          ));
+  }) => createCameraWithSettings(
+    cameraDescription,
+    MediaSettings(resolutionPreset: resolutionPreset, enableAudio: enableAudio),
+  );
 
   @override
   Future<int> createCameraWithSettings(
@@ -90,7 +87,9 @@ class CameraWindows extends CameraPlatform {
     try {
       // If resolutionPreset is not specified, plugin selects the highest resolution possible.
       return await _hostApi.create(
-          cameraDescription.name, _pigeonMediaSettings(mediaSettings));
+        cameraDescription.name,
+        _pigeonMediaSettings(mediaSettings),
+      );
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -101,8 +100,10 @@ class CameraWindows extends CameraPlatform {
     int cameraId, {
     ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,
   }) async {
-    hostCameraHandlers.putIfAbsent(cameraId,
-        () => HostCameraMessageHandler(cameraId, cameraEventStreamController));
+    hostCameraHandlers.putIfAbsent(
+      cameraId,
+      () => HostCameraMessageHandler(cameraId, cameraEventStreamController),
+    );
 
     final PlatformSize reply;
     try {
@@ -198,8 +199,10 @@ class CameraWindows extends CameraPlatform {
   }
 
   @override
-  Future<void> startVideoRecording(int cameraId,
-      {Duration? maxVideoDuration}) async {
+  Future<void> startVideoRecording(
+    int cameraId, {
+    Duration? maxVideoDuration,
+  }) async {
     // Ignore maxVideoDuration, as it is unimplemented and deprecated.
     return startVideoCapturing(VideoCaptureOptions(cameraId));
   }
@@ -208,7 +211,8 @@ class CameraWindows extends CameraPlatform {
   Future<void> startVideoCapturing(VideoCaptureOptions options) async {
     if (options.streamCallback != null || options.streamOptions != null) {
       throw UnimplementedError(
-          'Streaming is not currently supported on Windows');
+        'Streaming is not currently supported on Windows',
+      );
     }
 
     // Currently none of `options` is supported on Windows, so it's not passed.
@@ -225,13 +229,15 @@ class CameraWindows extends CameraPlatform {
   @override
   Future<void> pauseVideoRecording(int cameraId) async {
     throw UnsupportedError(
-        'pauseVideoRecording() is not supported due to Win32 API limitations.');
+      'pauseVideoRecording() is not supported due to Win32 API limitations.',
+    );
   }
 
   @override
   Future<void> resumeVideoRecording(int cameraId) async {
     throw UnsupportedError(
-        'resumeVideoRecording() is not supported due to Win32 API limitations.');
+      'resumeVideoRecording() is not supported due to Win32 API limitations.',
+    );
   }
 
   @override
@@ -252,7 +258,8 @@ class CameraWindows extends CameraPlatform {
     assert(point == null || point.y >= 0 && point.y <= 1);
 
     throw UnsupportedError(
-        'setExposurePoint() is not supported due to Win32 API limitations.');
+      'setExposurePoint() is not supported due to Win32 API limitations.',
+    );
   }
 
   @override
@@ -294,7 +301,8 @@ class CameraWindows extends CameraPlatform {
     assert(point == null || point.y >= 0 && point.y <= 1);
 
     throw UnsupportedError(
-        'setFocusPoint() is not supported due to Win32 API limitations.');
+      'setFocusPoint() is not supported due to Win32 API limitations.',
+    );
   }
 
   @override
@@ -345,7 +353,8 @@ class CameraWindows extends CameraPlatform {
 
   /// Returns a [ResolutionPreset]'s Pigeon representation.
   PlatformResolutionPreset _pigeonResolutionPreset(
-      ResolutionPreset? resolutionPreset) {
+    ResolutionPreset? resolutionPreset,
+  ) {
     if (resolutionPreset == null) {
       // Provide a default if one isn't provided, since the native side needs
       // to set something.

--- a/packages/camera/camera_windows/lib/src/messages.g.dart
+++ b/packages/camera/camera_windows/lib/src/messages.g.dart
@@ -18,8 +18,11 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({
+  Object? result,
+  PlatformException? error,
+  bool empty = false,
+}) {
   if (empty) {
     return <Object?>[];
   }
@@ -30,14 +33,7 @@ List<Object?> wrapResponse(
 }
 
 /// Pigeon version of platform interface's ResolutionPreset.
-enum PlatformResolutionPreset {
-  low,
-  medium,
-  high,
-  veryHigh,
-  ultraHigh,
-  max,
-}
+enum PlatformResolutionPreset { low, medium, high, veryHigh, ultraHigh, max }
 
 /// Pigeon version of MediaSettings.
 class PlatformMediaSettings {
@@ -83,20 +79,14 @@ class PlatformMediaSettings {
 
 /// A representation of a size from the native camera APIs.
 class PlatformSize {
-  PlatformSize({
-    required this.width,
-    required this.height,
-  });
+  PlatformSize({required this.width, required this.height});
 
   double width;
 
   double height;
 
   Object encode() {
-    return <Object?>[
-      width,
-      height,
-    ];
+    return <Object?>[width, height];
   }
 
   static PlatformSize decode(Object result) {
@@ -149,11 +139,12 @@ class CameraApi {
   /// Constructor for [CameraApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  CameraApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  CameraApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix =
+           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -166,10 +157,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.getAvailableCameras$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -196,12 +187,13 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.create$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[cameraName, settings]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[cameraName, settings])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -226,10 +218,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.initialize$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraId]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -256,10 +248,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.dispose$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraId]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -282,10 +274,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.takePicture$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraId]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -312,10 +304,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.startVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraId]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -338,10 +330,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.stopVideoRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraId]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -368,10 +360,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.pausePreview$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraId]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -393,10 +385,10 @@ class CameraApi {
         'dev.flutter.pigeon.camera_windows.CameraApi.resumePreview$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[cameraId]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -430,12 +422,12 @@ abstract class CameraEventApi {
     messageChannelSuffix =
         messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_windows.CameraEventApi.cameraClosing$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_windows.CameraEventApi.cameraClosing$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -447,28 +439,33 @@ abstract class CameraEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.camera_windows.CameraEventApi.error$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.camera_windows.CameraEventApi.error$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.camera_windows.CameraEventApi.error was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.camera_windows.CameraEventApi.error was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_errorMessage = (args[0] as String?);
-          assert(arg_errorMessage != null,
-              'Argument for dev.flutter.pigeon.camera_windows.CameraEventApi.error was null, expected non-null String.');
+          assert(
+            arg_errorMessage != null,
+            'Argument for dev.flutter.pigeon.camera_windows.CameraEventApi.error was null, expected non-null String.',
+          );
           try {
             api.error(arg_errorMessage!);
             return wrapResponse(empty: true);
@@ -476,7 +473,8 @@ abstract class CameraEventApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }

--- a/packages/camera/camera_windows/pigeons/messages.dart
+++ b/packages/camera/camera_windows/pigeons/messages.dart
@@ -4,14 +4,15 @@
 
 import 'package:pigeon/pigeon.dart';
 
-@ConfigurePigeon(PigeonOptions(
-  dartOut: 'lib/src/messages.g.dart',
-  cppOptions: CppOptions(namespace: 'camera_windows'),
-  cppHeaderOut: 'windows/messages.g.h',
-  cppSourceOut: 'windows/messages.g.cpp',
-  copyrightHeader: 'pigeons/copyright.txt',
-))
-
+@ConfigurePigeon(
+  PigeonOptions(
+    dartOut: 'lib/src/messages.g.dart',
+    cppOptions: CppOptions(namespace: 'camera_windows'),
+    cppHeaderOut: 'windows/messages.g.h',
+    cppSourceOut: 'windows/messages.g.cpp',
+    copyrightHeader: 'pigeons/copyright.txt',
+  ),
+)
 /// Pigeon version of platform interface's ResolutionPreset.
 enum PlatformResolutionPreset { low, medium, high, veryHigh, ultraHigh, max }
 

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.2.6+2
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera_windows/test/camera_windows_test.dart
+++ b/packages/camera/camera_windows/test/camera_windows_test.dart
@@ -35,9 +35,10 @@ void main() {
         // Act
         final int cameraId = await plugin.createCameraWithSettings(
           const CameraDescription(
-              name: cameraName,
-              lensDirection: CameraLensDirection.front,
-              sensorOrientation: 0),
+            name: cameraName,
+            lensDirection: CameraLensDirection.front,
+            sensorOrientation: 0,
+          ),
           const MediaSettings(
             resolutionPreset: ResolutionPreset.low,
             fps: 15,
@@ -47,8 +48,9 @@ void main() {
         );
 
         // Assert
-        final VerificationResult verification =
-            verify(mockApi.create(captureAny, captureAny));
+        final VerificationResult verification = verify(
+          mockApi.create(captureAny, captureAny),
+        );
         expect(verification.captured[0], cameraName);
         final PlatformMediaSettings? settings =
             verification.captured[1] as PlatformMediaSettings?;
@@ -58,37 +60,43 @@ void main() {
       });
 
       test(
-          'Should throw CameraException when create throws a PlatformException',
-          () {
-        // Arrange
-        const String exceptionCode = 'TESTING_ERROR_CODE';
-        const String exceptionMessage =
-            'Mock error message used during testing.';
-        final MockCameraApi mockApi = MockCameraApi();
-        when(mockApi.create(any, any)).thenAnswer((_) async {
-          throw PlatformException(
-              code: exceptionCode, message: exceptionMessage);
-        });
-        final CameraWindows camera = CameraWindows(api: mockApi);
+        'Should throw CameraException when create throws a PlatformException',
+        () {
+          // Arrange
+          const String exceptionCode = 'TESTING_ERROR_CODE';
+          const String exceptionMessage =
+              'Mock error message used during testing.';
+          final MockCameraApi mockApi = MockCameraApi();
+          when(mockApi.create(any, any)).thenAnswer((_) async {
+            throw PlatformException(
+              code: exceptionCode,
+              message: exceptionMessage,
+            );
+          });
+          final CameraWindows camera = CameraWindows(api: mockApi);
 
-        // Act
-        expect(
-          () => camera.createCamera(
-            const CameraDescription(
-              name: 'Test',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 0,
+          // Act
+          expect(
+            () => camera.createCamera(
+              const CameraDescription(
+                name: 'Test',
+                lensDirection: CameraLensDirection.back,
+                sensorOrientation: 0,
+              ),
+              ResolutionPreset.high,
             ),
-            ResolutionPreset.high,
-          ),
-          throwsA(
-            isA<CameraException>()
-                .having((CameraException e) => e.code, 'code', exceptionCode)
-                .having((CameraException e) => e.description, 'description',
-                    exceptionMessage),
-          ),
-        );
-      });
+            throwsA(
+              isA<CameraException>()
+                  .having((CameraException e) => e.code, 'code', exceptionCode)
+                  .having(
+                    (CameraException e) => e.description,
+                    'description',
+                    exceptionMessage,
+                  ),
+            ),
+          );
+        },
+      );
 
       test(
         'Should throw CameraException when initialize throws a PlatformException',
@@ -100,7 +108,9 @@ void main() {
           final MockCameraApi mockApi = MockCameraApi();
           when(mockApi.initialize(any)).thenAnswer((_) async {
             throw PlatformException(
-                code: exceptionCode, message: exceptionMessage);
+              code: exceptionCode,
+              message: exceptionMessage,
+            );
           });
           final CameraWindows plugin = CameraWindows(api: mockApi);
 
@@ -109,8 +119,11 @@ void main() {
             () => plugin.initializeCamera(0),
             throwsA(
               isA<CameraException>()
-                  .having((CameraException e) => e.code, 'code',
-                      'TESTING_ERROR_CODE')
+                  .having(
+                    (CameraException e) => e.code,
+                    'code',
+                    'TESTING_ERROR_CODE',
+                  )
                   .having(
                     (CameraException e) => e.description,
                     'description',
@@ -124,8 +137,9 @@ void main() {
       test('Should send initialization data', () async {
         // Arrange
         final MockCameraApi mockApi = MockCameraApi();
-        when(mockApi.initialize(any))
-            .thenAnswer((_) async => PlatformSize(width: 1920, height: 1080));
+        when(
+          mockApi.initialize(any),
+        ).thenAnswer((_) async => PlatformSize(width: 1920, height: 1080));
         final CameraWindows plugin = CameraWindows(api: mockApi);
         final int cameraId = await plugin.createCameraWithSettings(
           const CameraDescription(
@@ -146,16 +160,18 @@ void main() {
         await plugin.initializeCamera(cameraId);
 
         // Assert
-        final VerificationResult verification =
-            verify(mockApi.initialize(captureAny));
+        final VerificationResult verification = verify(
+          mockApi.initialize(captureAny),
+        );
         expect(verification.captured[0], cameraId);
       });
 
       test('Should send a disposal call on dispose', () async {
         // Arrange
         final MockCameraApi mockApi = MockCameraApi();
-        when(mockApi.initialize(any))
-            .thenAnswer((_) async => PlatformSize(width: 1920, height: 1080));
+        when(
+          mockApi.initialize(any),
+        ).thenAnswer((_) async => PlatformSize(width: 1920, height: 1080));
         final CameraWindows plugin = CameraWindows(api: mockApi);
         final int cameraId = await plugin.createCameraWithSettings(
           const CameraDescription(
@@ -177,8 +193,9 @@ void main() {
         await plugin.dispose(cameraId);
 
         // Assert
-        final VerificationResult verification =
-            verify(mockApi.dispose(captureAny));
+        final VerificationResult verification = verify(
+          mockApi.dispose(captureAny),
+        );
         expect(verification.captured[0], cameraId);
       });
     });
@@ -189,8 +206,9 @@ void main() {
       setUp(() async {
         final MockCameraApi mockApi = MockCameraApi();
         when(mockApi.create(any, any)).thenAnswer((_) async => 1);
-        when(mockApi.initialize(any))
-            .thenAnswer((_) async => PlatformSize(width: 1920, height: 1080));
+        when(
+          mockApi.initialize(any),
+        ).thenAnswer((_) async => PlatformSize(width: 1920, height: 1080));
         plugin = CameraWindows(api: mockApi);
         cameraId = await plugin.createCameraWithSettings(
           const CameraDescription(
@@ -211,8 +229,9 @@ void main() {
 
       test('Should receive camera closing events', () async {
         // Act
-        final Stream<CameraClosingEvent> eventStream =
-            plugin.onCameraClosing(cameraId);
+        final Stream<CameraClosingEvent> eventStream = plugin.onCameraClosing(
+          cameraId,
+        );
         final StreamQueue<CameraClosingEvent> streamQueue =
             StreamQueue<CameraClosingEvent>(eventStream);
 
@@ -233,8 +252,9 @@ void main() {
 
       test('Should receive camera error events', () async {
         // Act
-        final Stream<CameraErrorEvent> errorStream =
-            plugin.onCameraError(cameraId);
+        final Stream<CameraErrorEvent> errorStream = plugin.onCameraError(
+          cameraId,
+        );
         final StreamQueue<CameraErrorEvent> streamQueue =
             StreamQueue<CameraErrorEvent>(errorStream);
 
@@ -263,8 +283,9 @@ void main() {
       setUp(() async {
         mockApi = MockCameraApi();
         when(mockApi.create(any, any)).thenAnswer((_) async => 1);
-        when(mockApi.initialize(any))
-            .thenAnswer((_) async => PlatformSize(width: 1920, height: 1080));
+        when(
+          mockApi.initialize(any),
+        ).thenAnswer((_) async => PlatformSize(width: 1920, height: 1080));
         plugin = CameraWindows(api: mockApi);
         cameraId = await plugin.createCameraWithSettings(
           const CameraDescription(
@@ -284,50 +305,60 @@ void main() {
         clearInteractions(mockApi);
       });
 
-      test('Should fetch CameraDescription instances for available cameras',
-          () async {
-        // Arrange
-        final List<String> returnData = <String>[
-          'Test 1',
-          'Test 2',
-        ];
-        when(mockApi.getAvailableCameras()).thenAnswer((_) async => returnData);
+      test(
+        'Should fetch CameraDescription instances for available cameras',
+        () async {
+          // Arrange
+          final List<String> returnData = <String>['Test 1', 'Test 2'];
+          when(
+            mockApi.getAvailableCameras(),
+          ).thenAnswer((_) async => returnData);
 
-        // Act
-        final List<CameraDescription> cameras = await plugin.availableCameras();
+          // Act
+          final List<CameraDescription> cameras =
+              await plugin.availableCameras();
 
-        // Assert
-        expect(cameras.length, returnData.length);
-        for (int i = 0; i < returnData.length; i++) {
-          expect(cameras[i].name, returnData[i]);
-          // This value isn't provided by the platform, so is hard-coded to front.
-          expect(cameras[i].lensDirection, CameraLensDirection.front);
-          // This value isn't provided by the platform, so is hard-coded to 0.
-          expect(cameras[i].sensorOrientation, 0);
-        }
-      });
+          // Assert
+          expect(cameras.length, returnData.length);
+          for (int i = 0; i < returnData.length; i++) {
+            expect(cameras[i].name, returnData[i]);
+            // This value isn't provided by the platform, so is hard-coded to front.
+            expect(cameras[i].lensDirection, CameraLensDirection.front);
+            // This value isn't provided by the platform, so is hard-coded to 0.
+            expect(cameras[i].sensorOrientation, 0);
+          }
+        },
+      );
 
       test(
-          'Should throw CameraException when availableCameras throws a PlatformException',
-          () {
-        // Arrange
-        const String code = 'TESTING_ERROR_CODE';
-        const String message = 'Mock error message used during testing.';
-        when(mockApi.getAvailableCameras()).thenAnswer(
-            (_) async => throw PlatformException(code: code, message: message));
+        'Should throw CameraException when availableCameras throws a PlatformException',
+        () {
+          // Arrange
+          const String code = 'TESTING_ERROR_CODE';
+          const String message = 'Mock error message used during testing.';
+          when(mockApi.getAvailableCameras()).thenAnswer(
+            (_) async => throw PlatformException(code: code, message: message),
+          );
 
-        // Act
-        expect(
-          plugin.availableCameras,
-          throwsA(
-            isA<CameraException>()
-                .having(
-                    (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
-                .having((CameraException e) => e.description, 'description',
-                    'Mock error message used during testing.'),
-          ),
-        );
-      });
+          // Act
+          expect(
+            plugin.availableCameras,
+            throwsA(
+              isA<CameraException>()
+                  .having(
+                    (CameraException e) => e.code,
+                    'code',
+                    'TESTING_ERROR_CODE',
+                  )
+                  .having(
+                    (CameraException e) => e.description,
+                    'description',
+                    'Mock error message used during testing.',
+                  ),
+            ),
+          );
+        },
+      );
 
       test('Should take a picture and return an XFile instance', () async {
         // Arrange
@@ -360,8 +391,12 @@ void main() {
       test('capturing fails if trying to stream', () async {
         // Act and Assert
         expect(
-          () => plugin.startVideoCapturing(VideoCaptureOptions(cameraId,
-              streamCallback: (CameraImageData imageData) {})),
+          () => plugin.startVideoCapturing(
+            VideoCaptureOptions(
+              cameraId,
+              streamCallback: (CameraImageData imageData) {},
+            ),
+          ),
           throwsA(isA<UnimplementedError>()),
         );
       });
@@ -378,24 +413,27 @@ void main() {
         expect(file.path, '/test/path.mp4');
       });
 
-      test('Should throw UnsupportedError when pause video recording is called',
-          () async {
-        // Act
-        expect(
-          () => plugin.pauseVideoRecording(cameraId),
-          throwsA(isA<UnsupportedError>()),
-        );
-      });
+      test(
+        'Should throw UnsupportedError when pause video recording is called',
+        () async {
+          // Act
+          expect(
+            () => plugin.pauseVideoRecording(cameraId),
+            throwsA(isA<UnsupportedError>()),
+          );
+        },
+      );
 
       test(
-          'Should throw UnsupportedError when resume video recording is called',
-          () async {
-        // Act
-        expect(
-          () => plugin.resumeVideoRecording(cameraId),
-          throwsA(isA<UnsupportedError>()),
-        );
-      });
+        'Should throw UnsupportedError when resume video recording is called',
+        () async {
+          // Act
+          expect(
+            () => plugin.resumeVideoRecording(cameraId),
+            throwsA(isA<UnsupportedError>()),
+          );
+        },
+      );
 
       test('Should throw UnimplementedError when flash mode is set', () async {
         // Act
@@ -405,28 +443,33 @@ void main() {
         );
       });
 
-      test('Should throw UnimplementedError when exposure mode is set',
-          () async {
-        // Act
-        expect(
-          () => plugin.setExposureMode(cameraId, ExposureMode.auto),
-          throwsA(isA<UnimplementedError>()),
-        );
-      });
+      test(
+        'Should throw UnimplementedError when exposure mode is set',
+        () async {
+          // Act
+          expect(
+            () => plugin.setExposureMode(cameraId, ExposureMode.auto),
+            throwsA(isA<UnimplementedError>()),
+          );
+        },
+      );
 
-      test('Should throw UnsupportedError when exposure point is set',
-          () async {
-        // Act
-        expect(
-          () => plugin.setExposurePoint(cameraId, null),
-          throwsA(isA<UnsupportedError>()),
-        );
-      });
+      test(
+        'Should throw UnsupportedError when exposure point is set',
+        () async {
+          // Act
+          expect(
+            () => plugin.setExposurePoint(cameraId, null),
+            throwsA(isA<UnsupportedError>()),
+          );
+        },
+      );
 
       test('Should get the min exposure offset', () async {
         // Act
-        final double minExposureOffset =
-            await plugin.getMinExposureOffset(cameraId);
+        final double minExposureOffset = await plugin.getMinExposureOffset(
+          cameraId,
+        );
 
         // Assert
         expect(minExposureOffset, 0.0);
@@ -434,8 +477,9 @@ void main() {
 
       test('Should get the max exposure offset', () async {
         // Act
-        final double maxExposureOffset =
-            await plugin.getMaxExposureOffset(cameraId);
+        final double maxExposureOffset = await plugin.getMaxExposureOffset(
+          cameraId,
+        );
 
         // Assert
         expect(maxExposureOffset, 0.0);
@@ -443,21 +487,24 @@ void main() {
 
       test('Should get the exposure offset step size', () async {
         // Act
-        final double stepSize =
-            await plugin.getExposureOffsetStepSize(cameraId);
+        final double stepSize = await plugin.getExposureOffsetStepSize(
+          cameraId,
+        );
 
         // Assert
         expect(stepSize, 1.0);
       });
 
-      test('Should throw UnimplementedError when exposure offset is set',
-          () async {
-        // Act
-        expect(
-          () => plugin.setExposureOffset(cameraId, 0.5),
-          throwsA(isA<UnimplementedError>()),
-        );
-      });
+      test(
+        'Should throw UnimplementedError when exposure offset is set',
+        () async {
+          // Act
+          expect(
+            () => plugin.setExposureOffset(cameraId, 0.5),
+            throwsA(isA<UnimplementedError>()),
+          );
+        },
+      );
 
       test('Should throw UnimplementedError when focus mode is set', () async {
         // Act
@@ -467,14 +514,16 @@ void main() {
         );
       });
 
-      test('Should throw UnsupportedError when exposure point is set',
-          () async {
-        // Act
-        expect(
-          () => plugin.setFocusMode(cameraId, FocusMode.auto),
-          throwsA(isA<UnsupportedError>()),
-        );
-      });
+      test(
+        'Should throw UnsupportedError when exposure point is set',
+        () async {
+          // Act
+          expect(
+            () => plugin.setFocusMode(cameraId, FocusMode.auto),
+            throwsA(isA<UnsupportedError>()),
+          );
+        },
+      );
 
       test('Should build a texture widget as preview widget', () async {
         // Act
@@ -510,32 +559,35 @@ void main() {
       });
 
       test(
-          'Should throw UnimplementedError when lock capture orientation is called',
-          () async {
-        // Act
-        expect(
-          () => plugin.setZoomLevel(cameraId, 2.0),
-          throwsA(isA<UnimplementedError>()),
-        );
-      });
+        'Should throw UnimplementedError when lock capture orientation is called',
+        () async {
+          // Act
+          expect(
+            () => plugin.setZoomLevel(cameraId, 2.0),
+            throwsA(isA<UnimplementedError>()),
+          );
+        },
+      );
 
       test(
-          'Should throw UnimplementedError when unlock capture orientation is called',
-          () async {
-        // Act
-        expect(
-          () => plugin.unlockCaptureOrientation(cameraId),
-          throwsA(isA<UnimplementedError>()),
-        );
-      });
+        'Should throw UnimplementedError when unlock capture orientation is called',
+        () async {
+          // Act
+          expect(
+            () => plugin.unlockCaptureOrientation(cameraId),
+            throwsA(isA<UnimplementedError>()),
+          );
+        },
+      );
 
       test('Should pause the camera preview', () async {
         // Act
         await plugin.pausePreview(cameraId);
 
         // Assert
-        final VerificationResult verification =
-            verify(mockApi.pausePreview(captureAny));
+        final VerificationResult verification = verify(
+          mockApi.pausePreview(captureAny),
+        );
         expect(verification.captured[0], cameraId);
       });
 
@@ -544,8 +596,9 @@ void main() {
         await plugin.resumePreview(cameraId);
 
         // Assert
-        final VerificationResult verification =
-            verify(mockApi.resumePreview(captureAny));
+        final VerificationResult verification = verify(
+          mockApi.resumePreview(captureAny),
+        );
         expect(verification.captured[0], cameraId);
       });
     });

--- a/packages/camera/camera_windows/test/camera_windows_test.mocks.dart
+++ b/packages/camera/camera_windows/test/camera_windows_test.mocks.dart
@@ -23,13 +23,8 @@ import 'package:mockito/src/dummies.dart' as _i3;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakePlatformSize_0 extends _i1.SmartFake implements _i2.PlatformSize {
-  _FakePlatformSize_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakePlatformSize_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [CameraApi].
@@ -37,27 +32,30 @@ class _FakePlatformSize_0 extends _i1.SmartFake implements _i2.PlatformSize {
 /// See the documentation for Mockito's code generation for more information.
 class MockCameraApi extends _i1.Mock implements _i2.CameraApi {
   @override
-  String get pigeonVar_messageChannelSuffix => (super.noSuchMethod(
-        Invocation.getter(#pigeonVar_messageChannelSuffix),
-        returnValue: _i3.dummyValue<String>(
-          this,
-          Invocation.getter(#pigeonVar_messageChannelSuffix),
-        ),
-        returnValueForMissingStub: _i3.dummyValue<String>(
-          this,
-          Invocation.getter(#pigeonVar_messageChannelSuffix),
-        ),
-      ) as String);
+  String get pigeonVar_messageChannelSuffix =>
+      (super.noSuchMethod(
+            Invocation.getter(#pigeonVar_messageChannelSuffix),
+            returnValue: _i3.dummyValue<String>(
+              this,
+              Invocation.getter(#pigeonVar_messageChannelSuffix),
+            ),
+            returnValueForMissingStub: _i3.dummyValue<String>(
+              this,
+              Invocation.getter(#pigeonVar_messageChannelSuffix),
+            ),
+          )
+          as String);
 
   @override
-  _i4.Future<List<String>> getAvailableCameras() => (super.noSuchMethod(
-        Invocation.method(
-          #getAvailableCameras,
-          [],
-        ),
-        returnValue: _i4.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i4.Future<List<String>>.value(<String>[]),
-      ) as _i4.Future<List<String>>);
+  _i4.Future<List<String>> getAvailableCameras() =>
+      (super.noSuchMethod(
+            Invocation.method(#getAvailableCameras, []),
+            returnValue: _i4.Future<List<String>>.value(<String>[]),
+            returnValueForMissingStub: _i4.Future<List<String>>.value(
+              <String>[],
+            ),
+          )
+          as _i4.Future<List<String>>);
 
   @override
   _i4.Future<int> create(
@@ -65,143 +63,120 @@ class MockCameraApi extends _i1.Mock implements _i2.CameraApi {
     _i2.PlatformMediaSettings? settings,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #create,
-          [
-            cameraName,
-            settings,
-          ],
-        ),
-        returnValue: _i4.Future<int>.value(0),
-        returnValueForMissingStub: _i4.Future<int>.value(0),
-      ) as _i4.Future<int>);
+            Invocation.method(#create, [cameraName, settings]),
+            returnValue: _i4.Future<int>.value(0),
+            returnValueForMissingStub: _i4.Future<int>.value(0),
+          )
+          as _i4.Future<int>);
 
   @override
-  _i4.Future<_i2.PlatformSize> initialize(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #initialize,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<_i2.PlatformSize>.value(_FakePlatformSize_0(
-          this,
-          Invocation.method(
-            #initialize,
-            [cameraId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i4.Future<_i2.PlatformSize>.value(_FakePlatformSize_0(
-          this,
-          Invocation.method(
-            #initialize,
-            [cameraId],
-          ),
-        )),
-      ) as _i4.Future<_i2.PlatformSize>);
+  _i4.Future<_i2.PlatformSize> initialize(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#initialize, [cameraId]),
+            returnValue: _i4.Future<_i2.PlatformSize>.value(
+              _FakePlatformSize_0(
+                this,
+                Invocation.method(#initialize, [cameraId]),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<_i2.PlatformSize>.value(
+              _FakePlatformSize_0(
+                this,
+                Invocation.method(#initialize, [cameraId]),
+              ),
+            ),
+          )
+          as _i4.Future<_i2.PlatformSize>);
 
   @override
-  _i4.Future<void> dispose(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> dispose(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#dispose, [cameraId]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<String> takePicture(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #takePicture,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #takePicture,
-            [cameraId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #takePicture,
-            [cameraId],
-          ),
-        )),
-      ) as _i4.Future<String>);
+  _i4.Future<String> takePicture(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#takePicture, [cameraId]),
+            returnValue: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#takePicture, [cameraId]),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#takePicture, [cameraId]),
+              ),
+            ),
+          )
+          as _i4.Future<String>);
 
   @override
-  _i4.Future<void> startVideoRecording(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #startVideoRecording,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> startVideoRecording(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#startVideoRecording, [cameraId]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<String> stopVideoRecording(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #stopVideoRecording,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #stopVideoRecording,
-            [cameraId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i4.Future<String>.value(_i3.dummyValue<String>(
-          this,
-          Invocation.method(
-            #stopVideoRecording,
-            [cameraId],
-          ),
-        )),
-      ) as _i4.Future<String>);
+  _i4.Future<String> stopVideoRecording(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#stopVideoRecording, [cameraId]),
+            returnValue: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#stopVideoRecording, [cameraId]),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<String>.value(
+              _i3.dummyValue<String>(
+                this,
+                Invocation.method(#stopVideoRecording, [cameraId]),
+              ),
+            ),
+          )
+          as _i4.Future<String>);
 
   @override
-  _i4.Future<void> startImageStream(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #startImageStream,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> startImageStream(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#startImageStream, [cameraId]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> stopImageStream(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #stopImageStream,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> stopImageStream(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#stopImageStream, [cameraId]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> pausePreview(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #pausePreview,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> pausePreview(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#pausePreview, [cameraId]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> resumePreview(int? cameraId) => (super.noSuchMethod(
-        Invocation.method(
-          #resumePreview,
-          [cameraId],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> resumePreview(int? cameraId) =>
+      (super.noSuchMethod(
+            Invocation.method(#resumePreview, [cameraId]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 }

--- a/packages/google_maps_flutter/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter/README.md
@@ -137,10 +137,11 @@ class MapSampleState extends State<MapSample> {
   );
 
   static const CameraPosition _kLake = CameraPosition(
-      bearing: 192.8334901395799,
-      target: LatLng(37.43296265331129, -122.08832357078792),
-      tilt: 59.440717697143555,
-      zoom: 19.151926040649414);
+    bearing: 192.8334901395799,
+    target: LatLng(37.43296265331129, -122.08832357078792),
+    tilt: 59.440717697143555,
+    zoom: 19.151926040649414,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -165,6 +166,7 @@ class MapSampleState extends State<MapSample> {
     await controller.animateCamera(CameraUpdate.newCameraPosition(_kLake));
   }
 }
+
 ```
 
 See the `example` directory for a complete sample app.

--- a/packages/google_maps_flutter/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter/README.md
@@ -137,11 +137,10 @@ class MapSampleState extends State<MapSample> {
   );
 
   static const CameraPosition _kLake = CameraPosition(
-    bearing: 192.8334901395799,
-    target: LatLng(37.43296265331129, -122.08832357078792),
-    tilt: 59.440717697143555,
-    zoom: 19.151926040649414,
-  );
+      bearing: 192.8334901395799,
+      target: LatLng(37.43296265331129, -122.08832357078792),
+      tilt: 59.440717697143555,
+      zoom: 19.151926040649414);
 
   @override
   Widget build(BuildContext context) {
@@ -166,7 +165,6 @@ class MapSampleState extends State<MapSample> {
     await controller.animateCamera(CameraUpdate.newCameraPosition(_kLake));
   }
 }
-
 ```
 
 See the `example` directory for a complete sample app.


### PR DESCRIPTION
For the `camera` packages:
- Updates the min SDK version to 3.29
- Runs the autoformatter with the new format
- Update code excerpts

This does not update versions because pushing format changes (even in READMEs) isn't worth doing a release that drops an SDK version (which we don't normally version)

Prep for https://github.com/flutter/packages/pull/9816