### PR TITLE
[shared_preferences] Updates min SDK to 3.29

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 * Updates README to indicate that Andoid SDK <21 is no longer supported.
 
 ## 2.5.3

--- a/packages/shared_preferences/shared_preferences/README.md
+++ b/packages/shared_preferences/shared_preferences/README.md
@@ -63,9 +63,11 @@ import 'package:shared_preferences_android/shared_preferences_android.dart';
 ```dart
 const SharedPreferencesAsyncAndroidOptions options =
     SharedPreferencesAsyncAndroidOptions(
-        backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
-        originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
-            fileName: 'the_name_of_a_file'));
+      backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
+      originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
+        fileName: 'the_name_of_a_file',
+      ),
+    );
 ```
 
 The [SharedPreferences] API uses the native [Android SharedPreferences](https://developer.android.com/reference/android/content/SharedPreferences) tool to store data.
@@ -136,8 +138,8 @@ await asyncPrefs.clear(allowList: <String>{'action', 'repeat'});
 ### SharedPreferencesWithCache
 <?code-excerpt "readme_excerpts.dart (WithCache)"?>
 ```dart
-final SharedPreferencesWithCache prefsWithCache =
-    await SharedPreferencesWithCache.create(
+final SharedPreferencesWithCache
+prefsWithCache = await SharedPreferencesWithCache.create(
   cacheOptions: const SharedPreferencesWithCacheOptions(
     // When an allowlist is included, any keys that aren't included cannot be used.
     allowList: <String>{'repeat', 'action'},

--- a/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_migration_util_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_migration_util_test.dart
@@ -41,32 +41,29 @@ void main() {
   });
 
   group('SharedPreferences with setPrefix and allowList', () {
-    runAllGroups(
-      () {
-        final Set<String> allowList = <String>{
-          'prefix.$boolKey',
-          'prefix.$intKey',
-          'prefix.$doubleKey',
-          'prefix.$listKey'
-        };
-        SharedPreferences.setPrefix('prefix.', allowList: allowList);
-      },
-      stringValue: null,
-    );
+    runAllGroups(() {
+      final Set<String> allowList = <String>{
+        'prefix.$boolKey',
+        'prefix.$intKey',
+        'prefix.$doubleKey',
+        'prefix.$listKey',
+      };
+      SharedPreferences.setPrefix('prefix.', allowList: allowList);
+    }, stringValue: null);
   });
 
   group('SharedPreferences with prefix set to empty string', () {
-    runAllGroups(
-      () {
-        SharedPreferences.setPrefix('');
-      },
-      keysCollide: true,
-    );
+    runAllGroups(() {
+      SharedPreferences.setPrefix('');
+    }, keysCollide: true);
   });
 }
 
-void runAllGroups(void Function() legacySharedPrefsConfig,
-    {String? stringValue = testString, bool keysCollide = false}) {
+void runAllGroups(
+  void Function() legacySharedPrefsConfig, {
+  String? stringValue = testString,
+  bool keysCollide = false,
+}) {
   group('default sharedPreferencesAsyncOptions', () {
     const SharedPreferencesOptions sharedPreferencesAsyncOptions =
         SharedPreferencesOptions();
@@ -84,21 +81,22 @@ void runAllGroups(void Function() legacySharedPrefsConfig,
     if (Platform.isAndroid) {
       sharedPreferencesAsyncOptions =
           const SharedPreferencesAsyncAndroidOptions(
-        backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
-        originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
-          fileName: 'fileName',
-        ),
-      );
+            backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
+            originalSharedPreferencesOptions:
+                AndroidSharedPreferencesStoreOptions(fileName: 'fileName'),
+          );
     } else if (Platform.isIOS || Platform.isMacOS) {
-      sharedPreferencesAsyncOptions =
-          SharedPreferencesAsyncFoundationOptions(suiteName: 'group.fileName');
+      sharedPreferencesAsyncOptions = SharedPreferencesAsyncFoundationOptions(
+        suiteName: 'group.fileName',
+      );
     } else if (Platform.isLinux) {
       sharedPreferencesAsyncOptions = const SharedPreferencesLinuxOptions(
         fileName: 'fileName',
       );
     } else if (Platform.isWindows) {
-      sharedPreferencesAsyncOptions =
-          const SharedPreferencesWindowsOptions(fileName: 'fileName');
+      sharedPreferencesAsyncOptions = const SharedPreferencesWindowsOptions(
+        fileName: 'fileName',
+      );
     } else {
       sharedPreferencesAsyncOptions = const SharedPreferencesOptions();
     }
@@ -114,10 +112,10 @@ void runAllGroups(void Function() legacySharedPrefsConfig,
     group('Android default sharedPreferences', () {
       const SharedPreferencesOptions sharedPreferencesAsyncOptions =
           SharedPreferencesAsyncAndroidOptions(
-        backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
-        originalSharedPreferencesOptions:
-            AndroidSharedPreferencesStoreOptions(),
-      );
+            backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
+            originalSharedPreferencesOptions:
+                AndroidSharedPreferencesStoreOptions(),
+          );
 
       runTests(
         sharedPreferencesAsyncOptions,
@@ -128,9 +126,12 @@ void runAllGroups(void Function() legacySharedPrefsConfig,
   }
 }
 
-void runTests(SharedPreferencesOptions sharedPreferencesAsyncOptions,
-    void Function() legacySharedPrefsConfig,
-    {String? stringValue = testString, bool keysAndNamesCollide = false}) {
+void runTests(
+  SharedPreferencesOptions sharedPreferencesAsyncOptions,
+  void Function() legacySharedPrefsConfig, {
+  String? stringValue = testString,
+  bool keysAndNamesCollide = false,
+}) {
   setUp(() async {
     // Configure and populate the source legacy shared preferences.
     SharedPreferences.resetStatic();
@@ -146,8 +147,9 @@ void runTests(SharedPreferencesOptions sharedPreferencesAsyncOptions,
   });
 
   tearDown(() async {
-    await SharedPreferencesAsync(options: sharedPreferencesAsyncOptions)
-        .clear();
+    await SharedPreferencesAsync(
+      options: sharedPreferencesAsyncOptions,
+    ).clear();
   });
 
   testWidgets('data is successfully transferred to new system', (_) async {
@@ -158,8 +160,9 @@ void runTests(SharedPreferencesOptions sharedPreferencesAsyncOptions,
       migrationCompletedKey: migrationCompletedKey,
     );
 
-    final SharedPreferencesAsync asyncPreferences =
-        SharedPreferencesAsync(options: sharedPreferencesAsyncOptions);
+    final SharedPreferencesAsync asyncPreferences = SharedPreferencesAsync(
+      options: sharedPreferencesAsyncOptions,
+    );
 
     expect(await asyncPreferences.getBool(boolKey), testBool);
     expect(await asyncPreferences.getInt(intKey), testInt);
@@ -176,8 +179,9 @@ void runTests(SharedPreferencesOptions sharedPreferencesAsyncOptions,
       migrationCompletedKey: migrationCompletedKey,
     );
 
-    final SharedPreferencesAsync asyncPreferences =
-        SharedPreferencesAsync(options: sharedPreferencesAsyncOptions);
+    final SharedPreferencesAsync asyncPreferences = SharedPreferencesAsync(
+      options: sharedPreferencesAsyncOptions,
+    );
 
     expect(await asyncPreferences.getBool(migrationCompletedKey), true);
   });
@@ -193,8 +197,9 @@ void runTests(SharedPreferencesOptions sharedPreferencesAsyncOptions,
         migrationCompletedKey: migrationCompletedKey,
       );
 
-      final SharedPreferencesAsync asyncPreferences =
-          SharedPreferencesAsync(options: sharedPreferencesAsyncOptions);
+      final SharedPreferencesAsync asyncPreferences = SharedPreferencesAsync(
+        options: sharedPreferencesAsyncOptions,
+      );
       await preferences.setInt(intKey, -0);
       await migrateLegacySharedPreferencesToSharedPreferencesAsyncIfNecessary(
         legacySharedPreferencesInstance: preferences,
@@ -204,7 +209,8 @@ void runTests(SharedPreferencesOptions sharedPreferencesAsyncOptions,
       expect(await asyncPreferences.getInt(intKey), testInt);
     },
     // Skips platforms that would be adding the preferences to the same file.
-    skip: keysAndNamesCollide &&
+    skip:
+        keysAndNamesCollide &&
         (Platform.isWindows ||
             Platform.isLinux ||
             Platform.isMacOS ||

--- a/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -234,7 +234,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
 
         final Map<String, Object?> gotAll = await preferences.getAll();
@@ -254,11 +254,12 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
 
-        final Map<String, Object?> gotAll =
-            await preferences.getAll(allowList: <String>{stringKey, boolKey});
+        final Map<String, Object?> gotAll = await preferences.getAll(
+          allowList: <String>{stringKey, boolKey},
+        );
 
         expect(gotAll.length, 2);
         expect(gotAll[stringKey], testString);
@@ -272,7 +273,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
 
         final Set<String?> keys = await preferences.getKeys();
@@ -292,11 +293,12 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
 
-        final Set<String?> keys =
-            await preferences.getKeys(allowList: <String>{stringKey, boolKey});
+        final Set<String?> keys = await preferences.getKeys(
+          allowList: <String>{stringKey, boolKey},
+        );
 
         expect(keys.length, 2);
         expect(keys, contains(stringKey));
@@ -320,7 +322,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
         await preferences.clear();
         expect(await preferences.getString(stringKey), null);
@@ -337,7 +339,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
         await preferences.clear(allowList: <String>{stringKey, boolKey});
         expect(await preferences.getString(stringKey), null);
@@ -347,8 +349,9 @@ void main() {
         expect(await preferences.getStringList(listKey), testList);
       });
 
-      testWidgets('throws TypeError when returned getBool type is incorrect',
-          (WidgetTester _) async {
+      testWidgets('throws TypeError when returned getBool type is incorrect', (
+        WidgetTester _,
+      ) async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await preferences.setString(stringKey, testString);
 
@@ -357,18 +360,21 @@ void main() {
         }, throwsA(isA<TypeError>()));
       });
 
-      testWidgets('throws TypeError when returned getString type is incorrect',
-          (WidgetTester _) async {
-        final SharedPreferencesAsync preferences = await getPreferences();
-        await preferences.setInt(stringKey, testInt);
+      testWidgets(
+        'throws TypeError when returned getString type is incorrect',
+        (WidgetTester _) async {
+          final SharedPreferencesAsync preferences = await getPreferences();
+          await preferences.setInt(stringKey, testInt);
 
-        expect(() async {
-          await preferences.getString(stringKey);
-        }, throwsA(isA<TypeError>()));
-      });
+          expect(() async {
+            await preferences.getString(stringKey);
+          }, throwsA(isA<TypeError>()));
+        },
+      );
 
-      testWidgets('throws TypeError when returned getInt type is incorrect',
-          (WidgetTester _) async {
+      testWidgets('throws TypeError when returned getInt type is incorrect', (
+        WidgetTester _,
+      ) async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await preferences.setString(stringKey, testString);
 
@@ -377,40 +383,40 @@ void main() {
         }, throwsA(isA<TypeError>()));
       });
 
-      testWidgets('throws TypeError when returned getDouble type is incorrect',
-          (WidgetTester _) async {
-        final SharedPreferencesAsync preferences = await getPreferences();
-        await preferences.setString(stringKey, testString);
+      testWidgets(
+        'throws TypeError when returned getDouble type is incorrect',
+        (WidgetTester _) async {
+          final SharedPreferencesAsync preferences = await getPreferences();
+          await preferences.setString(stringKey, testString);
 
-        expect(() async {
-          await preferences.getDouble(stringKey);
-        }, throwsA(isA<TypeError>()));
-      });
+          expect(() async {
+            await preferences.getDouble(stringKey);
+          }, throwsA(isA<TypeError>()));
+        },
+      );
 
       testWidgets(
-          'throws TypeError when returned getStringList type is incorrect',
-          (WidgetTester _) async {
-        final SharedPreferencesAsync preferences = await getPreferences();
-        await preferences.setString(stringKey, testString);
+        'throws TypeError when returned getStringList type is incorrect',
+        (WidgetTester _) async {
+          final SharedPreferencesAsync preferences = await getPreferences();
+          await preferences.setString(stringKey, testString);
 
-        expect(() async {
-          await preferences.getStringList(stringKey);
-        }, throwsA(isA<TypeError>()));
-      });
+          expect(() async {
+            await preferences.getStringList(stringKey);
+          }, throwsA(isA<TypeError>()));
+        },
+      );
     });
 
     group('withCache', () {
-      Future<
-          (
-            SharedPreferencesWithCache,
-            Map<String, Object?>,
-          )> getPreferences() async {
+      Future<(SharedPreferencesWithCache, Map<String, Object?>)>
+      getPreferences() async {
         final Map<String, Object?> cache = <String, Object?>{};
         final SharedPreferencesWithCache preferences =
             await SharedPreferencesWithCache.create(
-          cache: cache,
-          cacheOptions: const SharedPreferencesWithCacheOptions(),
-        );
+              cache: cache,
+              cacheOptions: const SharedPreferencesWithCacheOptions(),
+            );
         await preferences.clear();
         return (preferences, cache);
       }
@@ -458,7 +464,7 @@ void main() {
       testWidgets('reloading', (WidgetTester _) async {
         final (
           SharedPreferencesWithCache preferences,
-          Map<String, Object?> cache
+          Map<String, Object?> cache,
         ) = await getPreferences();
         await preferences.clear();
         await preferences.setString(stringKey, testString);
@@ -490,7 +496,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
 
         final Set<String> keys = preferences.keys;
@@ -511,7 +517,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
         await preferences.clear();
         expect(preferences.getString(stringKey), null);
@@ -523,37 +529,37 @@ void main() {
     });
 
     group('withCache with filter', () {
-      Future<
-          (
-            SharedPreferencesWithCache,
-            Map<String, Object?>,
-          )> getPreferences() async {
+      Future<(SharedPreferencesWithCache, Map<String, Object?>)>
+      getPreferences() async {
         final Map<String, Object?> cache = <String, Object?>{};
         final SharedPreferencesWithCache preferences =
             await SharedPreferencesWithCache.create(
-          cache: cache,
-          cacheOptions: const SharedPreferencesWithCacheOptions(
-            allowList: <String>{
-              stringKey,
-              boolKey,
-              intKey,
-              doubleKey,
-              listKey,
-            },
-          ),
-        );
+              cache: cache,
+              cacheOptions: const SharedPreferencesWithCacheOptions(
+                allowList: <String>{
+                  stringKey,
+                  boolKey,
+                  intKey,
+                  doubleKey,
+                  listKey,
+                },
+              ),
+            );
         await preferences.clear();
         return (preferences, cache);
       }
 
-      testWidgets('throws ArgumentError if key is not included in filter',
-          (WidgetTester _) async {
+      testWidgets('throws ArgumentError if key is not included in filter', (
+        WidgetTester _,
+      ) async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
         const String key = 'testKey';
 
-        expect(() async => preferences.setString(key, 'test'),
-            throwsArgumentError);
+        expect(
+          () async => preferences.setString(key, 'test'),
+          throwsArgumentError,
+        );
       });
 
       testWidgets('set and get String', (WidgetTester _) async {
@@ -596,11 +602,12 @@ void main() {
         expect(preferences.getStringList(listKey), testList);
       });
 
-      testWidgets('get StringList handles List<Object?>',
-          (WidgetTester _) async {
+      testWidgets('get StringList handles List<Object?>', (
+        WidgetTester _,
+      ) async {
         final (
           SharedPreferencesWithCache preferences,
-          Map<String, Object?> cache
+          Map<String, Object?> cache,
         ) = await getPreferences();
         final List<Object?> listObject = <Object?>['one', 'two'];
         cache[listKey] = listObject;
@@ -610,7 +617,7 @@ void main() {
       testWidgets('reloading', (WidgetTester _) async {
         final (
           SharedPreferencesWithCache preferences,
-          Map<String, Object?> cache
+          Map<String, Object?> cache,
         ) = await getPreferences();
         await preferences.clear();
         await preferences.setString(stringKey, testString);
@@ -641,7 +648,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
 
         final Set<String> keys = preferences.keys;
@@ -662,7 +669,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList)
+          preferences.setStringList(listKey, testList),
         ]);
         await preferences.clear();
 

--- a/packages/shared_preferences/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/main.dart
@@ -38,9 +38,11 @@ class SharedPreferencesDemo extends StatefulWidget {
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   final Future<SharedPreferencesWithCache> _prefs =
       SharedPreferencesWithCache.create(
-          cacheOptions: const SharedPreferencesWithCacheOptions(
-              // This cache will only accept the key 'counter'.
-              allowList: <String>{'counter'}));
+        cacheOptions: const SharedPreferencesWithCacheOptions(
+          // This cache will only accept the key 'counter'.
+          allowList: <String>{'counter'},
+        ),
+      );
   late Future<int> _counter;
   int _externalCounter = 0;
 
@@ -97,32 +99,31 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('SharedPreferencesWithCache Demo'),
-      ),
+      appBar: AppBar(title: const Text('SharedPreferencesWithCache Demo')),
       body: Center(
         child: _WaitForInitialization(
           initialized: _preferencesReady.future,
-          builder: (BuildContext context) => FutureBuilder<int>(
-            future: _counter,
-            builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-              switch (snapshot.connectionState) {
-                case ConnectionState.none:
-                case ConnectionState.waiting:
-                  return const CircularProgressIndicator();
-                case ConnectionState.active:
-                case ConnectionState.done:
-                  if (snapshot.hasError) {
-                    return Text('Error: ${snapshot.error}');
-                  } else {
-                    return Text(
-                      'Button tapped ${snapshot.data ?? 0 + _externalCounter} time${(snapshot.data ?? 0 + _externalCounter) == 1 ? '' : 's'}.\n\n'
-                      'This should persist across restarts.',
-                    );
+          builder:
+              (BuildContext context) => FutureBuilder<int>(
+                future: _counter,
+                builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+                  switch (snapshot.connectionState) {
+                    case ConnectionState.none:
+                    case ConnectionState.waiting:
+                      return const CircularProgressIndicator();
+                    case ConnectionState.active:
+                    case ConnectionState.done:
+                      if (snapshot.hasError) {
+                        return Text('Error: ${snapshot.error}');
+                      } else {
+                        return Text(
+                          'Button tapped ${snapshot.data ?? 0 + _externalCounter} time${(snapshot.data ?? 0 + _externalCounter) == 1 ? '' : 's'}.\n\n'
+                          'This should persist across restarts.',
+                        );
+                      }
                   }
-              }
-            },
-          ),
+                },
+              ),
         ),
       ),
       floatingActionButton: FloatingActionButton(

--- a/packages/shared_preferences/shared_preferences/example/lib/readme_excerpts.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/readme_excerpts.dart
@@ -64,8 +64,8 @@ Future<void> readmeSnippetsAsync() async {
 
 Future<void> readmeSnippetsWithCache() async {
   // #docregion WithCache
-  final SharedPreferencesWithCache prefsWithCache =
-      await SharedPreferencesWithCache.create(
+  final SharedPreferencesWithCache
+  prefsWithCache = await SharedPreferencesWithCache.create(
     cacheOptions: const SharedPreferencesWithCacheOptions(
       // When an allowlist is included, any keys that aren't included cannot be used.
       allowList: <String>{'repeat', 'action'},
@@ -99,7 +99,9 @@ Future<void> readmeTestSnippets() async {
 // #docregion Android_Options2
 const SharedPreferencesAsyncAndroidOptions options =
     SharedPreferencesAsyncAndroidOptions(
-        backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
-        originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
-            fileName: 'the_name_of_a_file'));
+      backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
+      originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
+        fileName: 'the_name_of_a_file',
+      ),
+    );
 // #enddocregion Android_Options2

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the shared_preferences plugin.
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences/example/test/example_app_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/test/example_app_test.dart
@@ -36,7 +36,9 @@ base class FakeSharedPreferencesAsync extends SharedPreferencesAsyncPlatform {
 
   @override
   Future<bool> clear(
-      ClearPreferencesParameters parameters, SharedPreferencesOptions options) {
+    ClearPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('clear', <Object>[...?parameters.filter.allowList]));
     return backend.clear(parameters, options);
   }
@@ -61,16 +63,21 @@ base class FakeSharedPreferencesAsync extends SharedPreferencesAsyncPlatform {
 
   @override
   Future<Set<String>> getKeys(
-      GetPreferencesParameters parameters, SharedPreferencesOptions options) {
+    GetPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('getKeys', <String>[...?parameters.filter.allowList]));
     return backend.getKeys(parameters, options);
   }
 
   @override
   Future<Map<String, Object>> getPreferences(
-      GetPreferencesParameters parameters, SharedPreferencesOptions options) {
-    log.add(MethodCall(
-        'getPreferences', <Object>[...?parameters.filter.allowList]));
+    GetPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) {
+    log.add(
+      MethodCall('getPreferences', <Object>[...?parameters.filter.allowList]),
+    );
     return backend.getPreferences(parameters, options);
   }
 
@@ -82,21 +89,29 @@ base class FakeSharedPreferencesAsync extends SharedPreferencesAsyncPlatform {
 
   @override
   Future<List<String>?> getStringList(
-      String key, SharedPreferencesOptions options) {
+    String key,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('getStringList', <String>[key]));
     return backend.getStringList(key, options);
   }
 
   @override
   Future<bool> setBool(
-      String key, bool value, SharedPreferencesOptions options) {
+    String key,
+    bool value,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('setBool', <Object>[key, value]));
     return backend.setBool(key, value, options);
   }
 
   @override
   Future<bool> setDouble(
-      String key, double value, SharedPreferencesOptions options) {
+    String key,
+    double value,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('setDouble', <Object>[key, value]));
     return backend.setDouble(key, value, options);
   }
@@ -109,14 +124,20 @@ base class FakeSharedPreferencesAsync extends SharedPreferencesAsyncPlatform {
 
   @override
   Future<bool> setString(
-      String key, String value, SharedPreferencesOptions options) {
+    String key,
+    String value,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('setString', <Object>[key, value]));
     return backend.setString(key, value, options);
   }
 
   @override
   Future<bool> setStringList(
-      String key, List<String> value, SharedPreferencesOptions options) {
+    String key,
+    List<String> value,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('setStringList', <Object>[key, value]));
     return backend.setStringList(key, value, options);
   }

--- a/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_async.dart
+++ b/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_async.dart
@@ -23,7 +23,8 @@ class SharedPreferencesAsync {
   }) : _options = options {
     if (SharedPreferencesAsyncPlatform.instance == null) {
       throw StateError(
-          'The SharedPreferencesAsyncPlatform instance must be set.');
+        'The SharedPreferencesAsyncPlatform instance must be set.',
+      );
     } else {
       _platform = SharedPreferencesAsyncPlatform.instance!;
     }
@@ -42,7 +43,8 @@ class SharedPreferencesAsync {
   /// Ignores any keys whose values are types which are incompatible with shared_preferences.
   Future<Set<String>> getKeys({Set<String>? allowList}) async {
     final GetPreferencesParameters parameters = GetPreferencesParameters(
-        filter: PreferencesFilters(allowList: allowList));
+      filter: PreferencesFilters(allowList: allowList),
+    );
     return _platform.getKeys(parameters, _options);
   }
 
@@ -53,7 +55,8 @@ class SharedPreferencesAsync {
   /// Ignores any entries of types which are incompatible with shared_preferences.
   Future<Map<String, Object?>> getAll({Set<String>? allowList}) async {
     final GetPreferencesParameters parameters = GetPreferencesParameters(
-        filter: PreferencesFilters(allowList: allowList));
+      filter: PreferencesFilters(allowList: allowList),
+    );
     return _platform.getPreferences(parameters, _options);
   }
 
@@ -126,9 +129,11 @@ class SharedPreferencesAsync {
   /// Removes an entry from the platform.
   Future<void> remove(String key) {
     return _platform.clear(
-        ClearPreferencesParameters(
-            filter: PreferencesFilters(allowList: <String>{key})),
-        _options);
+      ClearPreferencesParameters(
+        filter: PreferencesFilters(allowList: <String>{key}),
+      ),
+      _options,
+    );
   }
 
   /// Clears all preferences from the platform.
@@ -141,7 +146,8 @@ class SharedPreferencesAsync {
   /// It is highly recommended that an [allowList] be provided to this call.
   Future<void> clear({Set<String>? allowList}) {
     final ClearPreferencesParameters parameters = ClearPreferencesParameters(
-        filter: PreferencesFilters(allowList: allowList));
+      filter: PreferencesFilters(allowList: allowList),
+    );
     return _platform.clear(parameters, _options);
   }
 }
@@ -149,9 +155,7 @@ class SharedPreferencesAsync {
 /// Options necessary to create a [SharedPreferencesWithCache].
 class SharedPreferencesWithCacheOptions {
   /// Creates a new instance with the given options.
-  const SharedPreferencesWithCacheOptions({
-    this.allowList,
-  });
+  const SharedPreferencesWithCacheOptions({this.allowList});
 
   /// Information about what data will be fetched during `get` and `init`
   /// methods, what data can be `set`, as well as what data will be removed by `clear`.
@@ -179,10 +183,11 @@ class SharedPreferencesWithCache {
     required SharedPreferencesOptions sharedPreferencesOptions,
     required SharedPreferencesWithCacheOptions cacheOptions,
     Map<String, Object?>? cache,
-  })  : _cacheOptions = cacheOptions,
-        _platformMethods =
-            SharedPreferencesAsync(options: sharedPreferencesOptions),
-        _cache = cache ?? <String, Object?>{};
+  }) : _cacheOptions = cacheOptions,
+       _platformMethods = SharedPreferencesAsync(
+         options: sharedPreferencesOptions,
+       ),
+       _cache = cache ?? <String, Object?>{};
 
   /// Creates a new instance with the given options and reloads the cache from
   /// the platform data.
@@ -194,10 +199,10 @@ class SharedPreferencesWithCache {
   }) async {
     final SharedPreferencesWithCache preferences =
         SharedPreferencesWithCache._create(
-      sharedPreferencesOptions: sharedPreferencesOptions,
-      cacheOptions: cacheOptions,
-      cache: cache,
-    );
+          sharedPreferencesOptions: sharedPreferencesOptions,
+          cacheOptions: cacheOptions,
+          cache: cache,
+        );
 
     await preferences.reloadCache();
 
@@ -224,7 +229,8 @@ class SharedPreferencesWithCache {
   Future<void> reloadCache() async {
     _cache.clear();
     _cache.addAll(
-        await _platformMethods.getAll(allowList: _cacheOptions.allowList));
+      await _platformMethods.getAll(allowList: _cacheOptions.allowList),
+    );
   }
 
   /// Returns true if cache contains the given [key].
@@ -233,7 +239,8 @@ class SharedPreferencesWithCache {
   bool containsKey(String key) {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     return _cache.containsKey(key);
   }
@@ -247,7 +254,8 @@ class SharedPreferencesWithCache {
   Object? get(String key) {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     return _cache[key];
   }
@@ -259,7 +267,8 @@ class SharedPreferencesWithCache {
   bool? getBool(String key) {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     return get(key) as bool?;
   }
@@ -271,7 +280,8 @@ class SharedPreferencesWithCache {
   int? getInt(String key) {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     return get(key) as int?;
   }
@@ -283,7 +293,8 @@ class SharedPreferencesWithCache {
   double? getDouble(String key) {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     return get(key) as double?;
   }
@@ -295,7 +306,8 @@ class SharedPreferencesWithCache {
   String? getString(String key) {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     return get(key) as String?;
   }
@@ -307,7 +319,8 @@ class SharedPreferencesWithCache {
   List<String>? getStringList(String key) {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     // Make a copy of the list so that later mutations won't propagate
     return (_cache[key] as List<Object?>?)?.cast<String>().toList();
@@ -319,7 +332,8 @@ class SharedPreferencesWithCache {
   Future<void> setBool(String key, bool value) async {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     _cache[key] = value;
     return _platformMethods.setBool(key, value);
@@ -331,7 +345,8 @@ class SharedPreferencesWithCache {
   Future<void> setInt(String key, int value) async {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     _cache[key] = value;
     return _platformMethods.setInt(key, value);
@@ -346,7 +361,8 @@ class SharedPreferencesWithCache {
   Future<void> setDouble(String key, double value) async {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     _cache[key] = value;
     return _platformMethods.setDouble(key, value);
@@ -363,7 +379,8 @@ class SharedPreferencesWithCache {
   Future<void> setString(String key, String value) async {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     _cache[key] = value;
     return _platformMethods.setString(key, value);
@@ -375,7 +392,8 @@ class SharedPreferencesWithCache {
   Future<void> setStringList(String key, List<String> value) async {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     _cache[key] = value;
     return _platformMethods.setStringList(key, value);
@@ -387,7 +405,8 @@ class SharedPreferencesWithCache {
   Future<void> remove(String key) async {
     if (!_isValidKey(key)) {
       throw ArgumentError(
-          '$key is not included in the PreferencesFilter allowlist');
+        '$key is not included in the PreferencesFilter allowlist',
+      );
     }
     _cache.remove(key);
     return _platformMethods.remove(key);

--- a/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_devtools_extension_data.dart
+++ b/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_devtools_extension_data.dart
@@ -13,10 +13,8 @@ const String _eventPrefix = 'shared_preferences.';
 
 /// A typedef for the post event function.
 @visibleForTesting
-typedef PostEvent = void Function(
-  String eventKind,
-  Map<String, Object?> eventData,
-);
+typedef PostEvent =
+    void Function(String eventKind, Map<String, Object?> eventData);
 
 /// A helper class that provides data to the DevTools extension.
 ///
@@ -52,9 +50,9 @@ class SharedPreferencesDevToolsExtensionData {
           await SharedPreferences.getInstance();
       value = legacyPrefs.get(key);
     } else {
-      value = await SharedPreferencesAsync().getAll(allowList: <String>{
-        key
-      }).then((Map<String, Object?> map) => map.values.firstOrNull);
+      value = await SharedPreferencesAsync()
+          .getAll(allowList: <String>{key})
+          .then((Map<String, Object?> map) => map.values.firstOrNull);
     }
 
     _postEvent('${_eventPrefix}value', <String, Object?>{
@@ -109,10 +107,7 @@ class SharedPreferencesDevToolsExtensionData {
         case 'String':
           await prefs.setString(key, value! as String);
         case 'List<String>':
-          await prefs.setStringList(
-            key,
-            (value! as List<Object?>).cast(),
-          );
+          await prefs.setStringList(key, (value! as List<Object?>).cast());
       }
     }
     _postEvent('${_eventPrefix}change_value', <String, Object?>{});

--- a/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_legacy.dart
+++ b/packages/shared_preferences/shared_preferences/lib/src/shared_preferences_legacy.dart
@@ -199,10 +199,7 @@ class SharedPreferences {
       try {
         return _store.clearWithParameters(
           ClearParameters(
-            filter: PreferencesFilter(
-              prefix: _prefix,
-              allowList: _allowList,
-            ),
+            filter: PreferencesFilter(prefix: _prefix, allowList: _allowList),
           ),
         );
       } catch (e) {
@@ -238,10 +235,7 @@ Either update the implementation to support setPrefix, or do not call setPrefix.
         fromSystem.addAll(
           await _store.getAllWithParameters(
             GetAllParameters(
-              filter: PreferencesFilter(
-                prefix: _prefix,
-                allowList: _allowList,
-              ),
+              filter: PreferencesFilter(prefix: _prefix, allowList: _allowList),
             ),
           ),
         );
@@ -277,16 +271,18 @@ Either update the implementation to support setPrefix, or do not call setPrefix.
   /// If the singleton instance has been initialized already, it is nullified.
   @visibleForTesting
   static void setMockInitialValues(Map<String, Object> values) {
-    final Map<String, Object> newValues =
-        values.map<String, Object>((String key, Object value) {
+    final Map<String, Object> newValues = values.map<String, Object>((
+      String key,
+      Object value,
+    ) {
       String newKey = key;
       if (!key.startsWith(_prefix)) {
         newKey = '$_prefix$key';
       }
       return MapEntry<String, Object>(newKey, value);
     });
-    SharedPreferencesStorePlatform.instance =
-        InMemorySharedPreferencesStore.withData(newValues);
+    SharedPreferencesStorePlatform
+        .instance = InMemorySharedPreferencesStore.withData(newValues);
     _completer = null;
   }
 }

--- a/packages/shared_preferences/shared_preferences/lib/util/legacy_to_async_migration_util.dart
+++ b/packages/shared_preferences/shared_preferences/lib/util/legacy_to_async_migration_util.dart
@@ -56,8 +56,12 @@ Future<void> migrateLegacySharedPreferencesToSharedPreferencesAsyncIfNecessary({
       case const (List<dynamic>):
         try {
           await sharedPreferencesAsyncInstance.setStringList(
-              key, (value! as List<Object?>).cast<String>());
-        } on TypeError catch (_) {} // Pass over Lists containing non-String values.
+            key,
+            (value! as List<Object?>).cast<String>(),
+          );
+        } on TypeError catch (
+          _
+        ) {} // Pass over Lists containing non-String values.
     }
   }
 

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -6,8 +6,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.5.3
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_async_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_async_test.dart
@@ -36,134 +36,79 @@ void main() {
         FakeSharedPreferencesAsync store,
       ) = getPreferences();
       await preferences.setString(stringKey, testString);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setString', arguments: <dynamic>[
-            stringKey,
-            testString,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setString', arguments: <dynamic>[stringKey, testString]),
+      ]);
       store.log.clear();
       expect(await preferences.getString(stringKey), testString);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('getString', arguments: <dynamic>[
-            stringKey,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('getString', arguments: <dynamic>[stringKey]),
+      ]);
     });
 
     test('set and get bool', () async {
       final (
         SharedPreferencesAsync preferences,
-        FakeSharedPreferencesAsync store
+        FakeSharedPreferencesAsync store,
       ) = getPreferences();
       await preferences.setBool(boolKey, testBool);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setBool', arguments: <dynamic>[
-            boolKey,
-            testBool,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setBool', arguments: <dynamic>[boolKey, testBool]),
+      ]);
       store.log.clear();
       expect(await preferences.getBool(boolKey), testBool);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('getBool', arguments: <dynamic>[
-            boolKey,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('getBool', arguments: <dynamic>[boolKey]),
+      ]);
     });
 
     test('set and get int', () async {
       final (
         SharedPreferencesAsync preferences,
-        FakeSharedPreferencesAsync store
+        FakeSharedPreferencesAsync store,
       ) = getPreferences();
       await preferences.setInt(intKey, testInt);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setInt', arguments: <dynamic>[
-            intKey,
-            testInt,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setInt', arguments: <dynamic>[intKey, testInt]),
+      ]);
       store.log.clear();
 
       expect(await preferences.getInt(intKey), testInt);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('getInt', arguments: <dynamic>[
-            intKey,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('getInt', arguments: <dynamic>[intKey]),
+      ]);
     });
 
     test('set and get double', () async {
       final (
         SharedPreferencesAsync preferences,
-        FakeSharedPreferencesAsync store
+        FakeSharedPreferencesAsync store,
       ) = getPreferences();
       await preferences.setDouble(doubleKey, testDouble);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setDouble', arguments: <dynamic>[
-            doubleKey,
-            testDouble,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setDouble', arguments: <dynamic>[doubleKey, testDouble]),
+      ]);
       store.log.clear();
       expect(await preferences.getDouble(doubleKey), testDouble);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('getDouble', arguments: <dynamic>[
-            doubleKey,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('getDouble', arguments: <dynamic>[doubleKey]),
+      ]);
     });
 
     test('set and get StringList', () async {
       final (
         SharedPreferencesAsync preferences,
-        FakeSharedPreferencesAsync store
+        FakeSharedPreferencesAsync store,
       ) = getPreferences();
       await preferences.setStringList(listKey, testList);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setStringList', arguments: <dynamic>[
-            listKey,
-            testList,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setStringList', arguments: <dynamic>[listKey, testList]),
+      ]);
       store.log.clear();
       expect(await preferences.getStringList(listKey), testList);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('getStringList', arguments: <dynamic>[
-            listKey,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('getStringList', arguments: <dynamic>[listKey]),
+      ]);
     });
 
     test('getAll', () async {
@@ -173,7 +118,7 @@ void main() {
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getAll();
@@ -193,11 +138,12 @@ void main() {
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
 
-      final Map<String, Object?> gotAll =
-          await preferences.getAll(allowList: <String>{stringKey, boolKey});
+      final Map<String, Object?> gotAll = await preferences.getAll(
+        allowList: <String>{stringKey, boolKey},
+      );
 
       expect(gotAll.length, 2);
       expect(gotAll[stringKey], testString);
@@ -207,20 +153,18 @@ void main() {
     test('remove', () async {
       final (
         SharedPreferencesAsync preferences,
-        FakeSharedPreferencesAsync store
+        FakeSharedPreferencesAsync store,
       ) = getPreferences();
       const String key = 'testKey';
       await preferences.remove(key);
       expect(
-          store.log,
-          List<Matcher>.filled(
-            1,
-            isMethodCall(
-              'clear',
-              arguments: <String>[key],
-            ),
-            growable: true,
-          ));
+        store.log,
+        List<Matcher>.filled(
+          1,
+          isMethodCall('clear', arguments: <String>[key]),
+          growable: true,
+        ),
+      );
     });
 
     test('getKeys', () async {
@@ -230,7 +174,7 @@ void main() {
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
 
       final Set<String> keys = await preferences.getKeys();
@@ -250,11 +194,12 @@ void main() {
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
 
-      final Set<String> keys =
-          await preferences.getKeys(allowList: <String>{stringKey, boolKey});
+      final Set<String> keys = await preferences.getKeys(
+        allowList: <String>{stringKey, boolKey},
+      );
 
       expect(keys.length, 2);
       expect(keys, contains(stringKey));
@@ -274,19 +219,20 @@ void main() {
     test('clear', () async {
       final (
         SharedPreferencesAsync preferences,
-        FakeSharedPreferencesAsync store
+        FakeSharedPreferencesAsync store,
       ) = getPreferences();
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString),
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
       store.log.clear();
       await preferences.clear();
-      expect(
-          store.log, <Matcher>[isMethodCall('clear', arguments: <Object>[])]);
+      expect(store.log, <Matcher>[
+        isMethodCall('clear', arguments: <Object>[]),
+      ]);
       expect(await preferences.getString(stringKey), null);
       expect(await preferences.getBool(boolKey), null);
       expect(await preferences.getInt(intKey), null);
@@ -297,19 +243,19 @@ void main() {
     test('clear with filter', () async {
       final (
         SharedPreferencesAsync preferences,
-        FakeSharedPreferencesAsync store
+        FakeSharedPreferencesAsync store,
       ) = getPreferences();
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString),
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
       store.log.clear();
       await preferences.clear(allowList: <String>{stringKey, boolKey});
       expect(store.log, <Matcher>[
-        isMethodCall('clear', arguments: <Object>[stringKey, boolKey])
+        isMethodCall('clear', arguments: <Object>[stringKey, boolKey]),
       ]);
       expect(await preferences.getString(stringKey), null);
       expect(await preferences.getBool(boolKey), null);
@@ -321,19 +267,21 @@ void main() {
 
   group('withCache', () {
     Future<
-        (
-          SharedPreferencesWithCache,
-          FakeSharedPreferencesAsync,
-          Map<String, Object?>,
-        )> getPreferences() async {
+      (
+        SharedPreferencesWithCache,
+        FakeSharedPreferencesAsync,
+        Map<String, Object?>,
+      )
+    >
+    getPreferences() async {
       final Map<String, Object?> cache = <String, Object?>{};
       final FakeSharedPreferencesAsync store = FakeSharedPreferencesAsync();
       SharedPreferencesAsyncPlatform.instance = store;
       final SharedPreferencesWithCache preferences =
           await SharedPreferencesWithCache.create(
-        cache: cache,
-        cacheOptions: const SharedPreferencesWithCacheOptions(),
-      );
+            cache: cache,
+            cacheOptions: const SharedPreferencesWithCacheOptions(),
+          );
       store.log.clear();
       return (preferences, store, cache);
     }
@@ -345,21 +293,12 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setString(stringKey, testString);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setString', arguments: <dynamic>[
-            stringKey,
-            testString,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setString', arguments: <dynamic>[stringKey, testString]),
+      ]);
       store.log.clear();
       expect(preferences.getString(stringKey), testString);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('set and get bool', () async {
@@ -369,21 +308,12 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setBool(boolKey, testBool);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setBool', arguments: <dynamic>[
-            boolKey,
-            testBool,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setBool', arguments: <dynamic>[boolKey, testBool]),
+      ]);
       store.log.clear();
       expect(preferences.getBool(boolKey), testBool);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('set and get int', () async {
@@ -393,22 +323,13 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setInt(intKey, testInt);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setInt', arguments: <dynamic>[
-            intKey,
-            testInt,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setInt', arguments: <dynamic>[intKey, testInt]),
+      ]);
       store.log.clear();
 
       expect(preferences.getInt(intKey), testInt);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('set and get double', () async {
@@ -418,21 +339,12 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setDouble(doubleKey, testDouble);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setDouble', arguments: <dynamic>[
-            doubleKey,
-            testDouble,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setDouble', arguments: <dynamic>[doubleKey, testDouble]),
+      ]);
       store.log.clear();
       expect(preferences.getDouble(doubleKey), testDouble);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('set and get StringList', () async {
@@ -442,21 +354,12 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setStringList(listKey, testList);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setStringList', arguments: <dynamic>[
-            listKey,
-            testList,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setStringList', arguments: <dynamic>[listKey, testList]),
+      ]);
       store.log.clear();
       expect(preferences.getStringList(listKey), testList);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('reloading', () async {
@@ -476,11 +379,8 @@ void main() {
     });
 
     test('containsKey', () async {
-      final (
-        SharedPreferencesWithCache preferences,
-        _,
-        _,
-      ) = await getPreferences();
+      final (SharedPreferencesWithCache preferences, _, _) =
+          await getPreferences();
       const String key = 'testKey';
 
       expect(false, preferences.containsKey(key));
@@ -490,17 +390,14 @@ void main() {
     });
 
     test('getKeys', () async {
-      final (
-        SharedPreferencesWithCache preferences,
-        _,
-        _,
-      ) = await getPreferences();
+      final (SharedPreferencesWithCache preferences, _, _) =
+          await getPreferences();
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString),
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
 
       final Set<String> keys = preferences.keys;
@@ -522,15 +419,13 @@ void main() {
       const String key = 'testKey';
       await preferences.remove(key);
       expect(
-          store.log,
-          List<Matcher>.filled(
-            1,
-            isMethodCall(
-              'clear',
-              arguments: <String>[key],
-            ),
-            growable: true,
-          ));
+        store.log,
+        List<Matcher>.filled(
+          1,
+          isMethodCall('clear', arguments: <String>[key]),
+          growable: true,
+        ),
+      );
     });
 
     test('clear', () async {
@@ -544,12 +439,13 @@ void main() {
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
       store.log.clear();
       await preferences.clear();
-      expect(
-          store.log, <Matcher>[isMethodCall('clear', arguments: <Object>[])]);
+      expect(store.log, <Matcher>[
+        isMethodCall('clear', arguments: <Object>[]),
+      ]);
       expect(preferences.getString(stringKey), null);
       expect(preferences.getBool(boolKey), null);
       expect(preferences.getInt(intKey), null);
@@ -560,26 +456,29 @@ void main() {
 
   group('withCache with filter', () {
     Future<
-        (
-          SharedPreferencesWithCache,
-          FakeSharedPreferencesAsync,
-          Map<String, Object?>,
-        )> getPreferences() async {
+      (
+        SharedPreferencesWithCache,
+        FakeSharedPreferencesAsync,
+        Map<String, Object?>,
+      )
+    >
+    getPreferences() async {
       final Map<String, Object?> cache = <String, Object?>{};
       final FakeSharedPreferencesAsync store = FakeSharedPreferencesAsync();
       SharedPreferencesAsyncPlatform.instance = store;
       final SharedPreferencesWithCache preferences =
           await SharedPreferencesWithCache.create(
-        cache: cache,
-        cacheOptions:
-            const SharedPreferencesWithCacheOptions(allowList: <String>{
-          stringKey,
-          boolKey,
-          intKey,
-          doubleKey,
-          listKey,
-        }),
-      );
+            cache: cache,
+            cacheOptions: const SharedPreferencesWithCacheOptions(
+              allowList: <String>{
+                stringKey,
+                boolKey,
+                intKey,
+                doubleKey,
+                listKey,
+              },
+            ),
+          );
       store.log.clear();
       return (preferences, store, cache);
     }
@@ -591,21 +490,12 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setString(stringKey, testString);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setString', arguments: <dynamic>[
-            stringKey,
-            testString,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setString', arguments: <dynamic>[stringKey, testString]),
+      ]);
       store.log.clear();
       expect(preferences.getString(stringKey), testString);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('set and get bool', () async {
@@ -615,21 +505,12 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setBool(boolKey, testBool);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setBool', arguments: <dynamic>[
-            boolKey,
-            testBool,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setBool', arguments: <dynamic>[boolKey, testBool]),
+      ]);
       store.log.clear();
       expect(preferences.getBool(boolKey), testBool);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('set and get int', () async {
@@ -639,22 +520,13 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setInt(intKey, testInt);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setInt', arguments: <dynamic>[
-            intKey,
-            testInt,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setInt', arguments: <dynamic>[intKey, testInt]),
+      ]);
       store.log.clear();
 
       expect(preferences.getInt(intKey), testInt);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('set and get double', () async {
@@ -664,21 +536,12 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setDouble(doubleKey, testDouble);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setDouble', arguments: <dynamic>[
-            doubleKey,
-            testDouble,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setDouble', arguments: <dynamic>[doubleKey, testDouble]),
+      ]);
       store.log.clear();
       expect(preferences.getDouble(doubleKey), testDouble);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
 
     test('set and get StringList', () async {
@@ -688,21 +551,12 @@ void main() {
         _,
       ) = await getPreferences();
       await preferences.setStringList(listKey, testList);
-      expect(
-        store.log,
-        <Matcher>[
-          isMethodCall('setStringList', arguments: <dynamic>[
-            listKey,
-            testList,
-          ]),
-        ],
-      );
+      expect(store.log, <Matcher>[
+        isMethodCall('setStringList', arguments: <dynamic>[listKey, testList]),
+      ]);
       store.log.clear();
       expect(preferences.getStringList(listKey), testList);
-      expect(
-        store.log,
-        <Matcher>[],
-      );
+      expect(store.log, <Matcher>[]);
     });
     test('reloading', () async {
       final (
@@ -721,23 +575,19 @@ void main() {
     });
 
     test('throws ArgumentError if key is not included in filter', () async {
-      final (
-        SharedPreferencesWithCache preferences,
-        _,
-        _,
-      ) = await getPreferences();
+      final (SharedPreferencesWithCache preferences, _, _) =
+          await getPreferences();
       const String key = 'testKey';
 
       expect(
-          () async => preferences.setString(key, 'test'), throwsArgumentError);
+        () async => preferences.setString(key, 'test'),
+        throwsArgumentError,
+      );
     });
 
     test('containsKey', () async {
-      final (
-        SharedPreferencesWithCache preferences,
-        _,
-        _,
-      ) = await getPreferences();
+      final (SharedPreferencesWithCache preferences, _, _) =
+          await getPreferences();
 
       expect(false, preferences.containsKey(stringKey));
 
@@ -746,17 +596,14 @@ void main() {
     });
 
     test('getKeys', () async {
-      final (
-        SharedPreferencesWithCache preferences,
-        _,
-        _,
-      ) = await getPreferences();
+      final (SharedPreferencesWithCache preferences, _, _) =
+          await getPreferences();
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString),
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
 
       final Set<String> keys = preferences.keys;
@@ -777,15 +624,13 @@ void main() {
       ) = await getPreferences();
       await preferences.remove(stringKey);
       expect(
-          store.log,
-          List<Matcher>.filled(
-            1,
-            isMethodCall(
-              'clear',
-              arguments: <String>[stringKey],
-            ),
-            growable: true,
-          ));
+        store.log,
+        List<Matcher>.filled(
+          1,
+          isMethodCall('clear', arguments: <String>[stringKey]),
+          growable: true,
+        ),
+      );
     });
 
     test('clear', () async {
@@ -799,18 +644,15 @@ void main() {
         preferences.setBool(boolKey, testBool),
         preferences.setInt(intKey, testInt),
         preferences.setDouble(doubleKey, testDouble),
-        preferences.setStringList(listKey, testList)
+        preferences.setStringList(listKey, testList),
       ]);
       store.log.clear();
       await preferences.clear();
       expect(store.log, <Matcher>[
-        isMethodCall('clear', arguments: <Object>[
-          stringKey,
-          boolKey,
-          intKey,
-          doubleKey,
-          listKey,
-        ])
+        isMethodCall(
+          'clear',
+          arguments: <Object>[stringKey, boolKey, intKey, doubleKey, listKey],
+        ),
       ]);
 
       expect(preferences.getString(stringKey), null);
@@ -832,7 +674,9 @@ base class FakeSharedPreferencesAsync extends SharedPreferencesAsyncPlatform {
 
   @override
   Future<bool> clear(
-      ClearPreferencesParameters parameters, SharedPreferencesOptions options) {
+    ClearPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('clear', <Object>[...?parameters.filter.allowList]));
     return backend.clear(parameters, options);
   }
@@ -857,16 +701,21 @@ base class FakeSharedPreferencesAsync extends SharedPreferencesAsyncPlatform {
 
   @override
   Future<Set<String>> getKeys(
-      GetPreferencesParameters parameters, SharedPreferencesOptions options) {
+    GetPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('getKeys', <String>[...?parameters.filter.allowList]));
     return backend.getKeys(parameters, options);
   }
 
   @override
   Future<Map<String, Object>> getPreferences(
-      GetPreferencesParameters parameters, SharedPreferencesOptions options) {
-    log.add(MethodCall(
-        'getPreferences', <Object>[...?parameters.filter.allowList]));
+    GetPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) {
+    log.add(
+      MethodCall('getPreferences', <Object>[...?parameters.filter.allowList]),
+    );
     return backend.getPreferences(parameters, options);
   }
 
@@ -878,21 +727,29 @@ base class FakeSharedPreferencesAsync extends SharedPreferencesAsyncPlatform {
 
   @override
   Future<List<String>?> getStringList(
-      String key, SharedPreferencesOptions options) {
+    String key,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('getStringList', <String>[key]));
     return backend.getStringList(key, options);
   }
 
   @override
   Future<bool> setBool(
-      String key, bool value, SharedPreferencesOptions options) {
+    String key,
+    bool value,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('setBool', <Object>[key, value]));
     return backend.setBool(key, value, options);
   }
 
   @override
   Future<bool> setDouble(
-      String key, double value, SharedPreferencesOptions options) {
+    String key,
+    double value,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('setDouble', <Object>[key, value]));
     return backend.setDouble(key, value, options);
   }
@@ -905,14 +762,20 @@ base class FakeSharedPreferencesAsync extends SharedPreferencesAsyncPlatform {
 
   @override
   Future<bool> setString(
-      String key, String value, SharedPreferencesOptions options) {
+    String key,
+    String value,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('setString', <Object>[key, value]));
     return backend.setString(key, value, options);
   }
 
   @override
   Future<bool> setStringList(
-      String key, List<String> value, SharedPreferencesOptions options) {
+    String key,
+    List<String> value,
+    SharedPreferencesOptions options,
+  ) {
     log.add(MethodCall('setStringList', <Object>[key, value]));
     return backend.setStringList(key, value, options);
   }

--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_devtools_extension_data_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_devtools_extension_data_test.dart
@@ -16,10 +16,7 @@ typedef _Event = (String eventKind, Map<String, Object?> eventData);
 class _FakePostEvent {
   final List<_Event> eventLog = <_Event>[];
 
-  void call(
-    String eventKind,
-    Map<String, Object?> eventData,
-  ) {
+  void call(String eventKind, Map<String, Object?> eventData) {
     eventLog.add((eventKind, eventData));
   }
 }
@@ -48,14 +45,9 @@ void main() {
       await extension.requestAllKeys();
 
       expect(fakePostEvent.eventLog.length, equals(1));
-      final (
-        String eventKind,
-        Map<String, Object?> eventData,
-      ) = fakePostEvent.eventLog.first;
-      expect(
-        eventKind,
-        equals('shared_preferences.all_keys'),
-      );
+      final (String eventKind, Map<String, Object?> eventData) =
+          fakePostEvent.eventLog.first;
+      expect(eventKind, equals('shared_preferences.all_keys'));
       expect(
         eventData,
         equals(<String, List<String>>{
@@ -72,24 +64,13 @@ void main() {
       }) async {
         const bool legacy = false;
 
-        await extension.requestValue(
-          key,
-          legacy,
-        );
+        await extension.requestValue(key, legacy);
 
         expect(fakePostEvent.eventLog.length, equals(1));
-        final (
-          String eventKind,
-          Map<String, Object?> eventData,
-        ) = fakePostEvent.eventLog.first;
-        expect(
-          eventKind,
-          equals('shared_preferences.value'),
-        );
-        expect(
-          eventData,
-          equals(expectedData),
-        );
+        final (String eventKind, Map<String, Object?> eventData) =
+            fakePostEvent.eventLog.first;
+        expect(eventKind, equals('shared_preferences.value'));
+        expect(eventData, equals(expectedData));
       }
 
       test('should request bool value from async api', () async {
@@ -176,18 +157,10 @@ void main() {
         );
 
         expect(fakePostEvent.eventLog.length, equals(1));
-        final (
-          String eventKind,
-          Map<String, Object?> eventData,
-        ) = fakePostEvent.eventLog.first;
-        expect(
-          eventKind,
-          equals('shared_preferences.change_value'),
-        );
-        expect(
-          eventData,
-          equals(<String, Object?>{}),
-        );
+        final (String eventKind, Map<String, Object?> eventData) =
+            fakePostEvent.eventLog.first;
+        expect(eventKind, equals('shared_preferences.change_value'));
+        expect(eventData, equals(<String, Object?>{}));
       }
 
       test('should request int value change on async api', () async {
@@ -197,10 +170,7 @@ void main() {
 
         await testAsyncApiValueChange(key, expectedValue);
 
-        expect(
-          await asyncPreferences.getInt(key),
-          equals(expectedValue),
-        );
+        expect(await asyncPreferences.getInt(key), equals(expectedValue));
       });
 
       test('should request bool value change on async api', () async {
@@ -210,10 +180,7 @@ void main() {
 
         await testAsyncApiValueChange(key, expectedValue);
 
-        expect(
-          await asyncPreferences.getBool(key),
-          equals(expectedValue),
-        );
+        expect(await asyncPreferences.getBool(key), equals(expectedValue));
       });
 
       test('should request double value change on async api', () async {
@@ -223,10 +190,7 @@ void main() {
 
         await testAsyncApiValueChange(key, expectedValue);
 
-        expect(
-          await asyncPreferences.getDouble(key),
-          equals(expectedValue),
-        );
+        expect(await asyncPreferences.getDouble(key), equals(expectedValue));
       });
 
       test('should request string value change on async api', () async {
@@ -236,10 +200,7 @@ void main() {
 
         await testAsyncApiValueChange(key, expectedValue);
 
-        expect(
-          await asyncPreferences.getString(key),
-          equals(expectedValue),
-        );
+        expect(await asyncPreferences.getString(key), equals(expectedValue));
       });
 
       test('should request string list value change on async api', () async {
@@ -263,20 +224,12 @@ void main() {
       }) async {
         const bool legacy = true;
 
-        await extension.requestValue(
-          key,
-          legacy,
-        );
+        await extension.requestValue(key, legacy);
 
         expect(fakePostEvent.eventLog.length, equals(1));
-        final (
-          String eventKind,
-          Map<String, Object?> eventData,
-        ) = fakePostEvent.eventLog.first;
-        expect(
-          eventKind,
-          equals('shared_preferences.value'),
-        );
+        final (String eventKind, Map<String, Object?> eventData) =
+            fakePostEvent.eventLog.first;
+        expect(eventKind, equals('shared_preferences.value'));
         expect(eventData, equals(expectedData));
       }
 
@@ -287,10 +240,13 @@ void main() {
           key: expectedValue,
         });
 
-        await testLegacyApiRequestValue(key, expectedData: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'bool',
-        });
+        await testLegacyApiRequestValue(
+          key,
+          expectedData: <String, Object?>{
+            'value': expectedValue,
+            'kind': 'bool',
+          },
+        );
       });
 
       test('should request int value from legacy api', () async {
@@ -300,10 +256,13 @@ void main() {
           key: expectedValue,
         });
 
-        await testLegacyApiRequestValue(key, expectedData: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'int',
-        });
+        await testLegacyApiRequestValue(
+          key,
+          expectedData: <String, Object?>{
+            'value': expectedValue,
+            'kind': 'int',
+          },
+        );
       });
 
       test('should request double value from legacy api', () async {
@@ -313,10 +272,13 @@ void main() {
           key: expectedValue,
         });
 
-        await testLegacyApiRequestValue(key, expectedData: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'double',
-        });
+        await testLegacyApiRequestValue(
+          key,
+          expectedData: <String, Object?>{
+            'value': expectedValue,
+            'kind': 'double',
+          },
+        );
       });
 
       test('should request string value from legacy api', () async {
@@ -326,10 +288,13 @@ void main() {
           key: expectedValue,
         });
 
-        await testLegacyApiRequestValue(key, expectedData: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'String',
-        });
+        await testLegacyApiRequestValue(
+          key,
+          expectedData: <String, Object?>{
+            'value': expectedValue,
+            'kind': 'String',
+          },
+        );
       });
 
       test('should request string list value from legacy api', () async {
@@ -339,10 +304,13 @@ void main() {
           key: expectedValue,
         });
 
-        await testLegacyApiRequestValue(key, expectedData: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'List<String>',
-        });
+        await testLegacyApiRequestValue(
+          key,
+          expectedData: <String, Object?>{
+            'value': expectedValue,
+            'kind': 'List<String>',
+          },
+        );
       });
 
       Future<void> testLegacyApiValueChange(
@@ -359,26 +327,16 @@ void main() {
         );
 
         expect(fakePostEvent.eventLog.length, equals(1));
-        final (
-          String eventKind,
-          Map<String, Object?> eventData,
-        ) = fakePostEvent.eventLog.first;
-        expect(
-          eventKind,
-          equals('shared_preferences.change_value'),
-        );
-        expect(
-          eventData,
-          equals(<String, Object?>{}),
-        );
+        final (String eventKind, Map<String, Object?> eventData) =
+            fakePostEvent.eventLog.first;
+        expect(eventKind, equals('shared_preferences.change_value'));
+        expect(eventData, equals(<String, Object?>{}));
       }
 
       test('should request int value change on legacy api', () async {
         const String key = 'key';
         const int expectedValue = 42;
-        SharedPreferences.setMockInitialValues(<String, Object>{
-          key: 24,
-        });
+        SharedPreferences.setMockInitialValues(<String, Object>{key: 24});
 
         await testLegacyApiValueChange(key, expectedValue);
 
@@ -391,9 +349,7 @@ void main() {
       test('should request bool value change on legacy api', () async {
         const String key = 'key';
         const bool expectedValue = false;
-        SharedPreferences.setMockInitialValues(<String, Object>{
-          key: true,
-        });
+        SharedPreferences.setMockInitialValues(<String, Object>{key: true});
 
         await testLegacyApiValueChange(key, expectedValue);
 
@@ -406,9 +362,7 @@ void main() {
       test('should request double value change on legacy api', () async {
         const String key = 'key';
         const double expectedValue = 1.11;
-        SharedPreferences.setMockInitialValues(<String, Object>{
-          key: 2.22,
-        });
+        SharedPreferences.setMockInitialValues(<String, Object>{key: 2.22});
 
         await testLegacyApiValueChange(key, expectedValue);
 

--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
@@ -67,38 +67,30 @@ void main() {
       preferences.setBool('bool', testBool2),
       preferences.setInt('int', testInt2),
       preferences.setDouble('double', testDouble2),
-      preferences.setStringList('List', testList2)
+      preferences.setStringList('List', testList2),
     ]);
-    expect(
-      store.log,
-      <Matcher>[
-        isMethodCall('setValue', arguments: <dynamic>[
-          'String',
-          'flutter.String',
-          testString2,
-        ]),
-        isMethodCall('setValue', arguments: <dynamic>[
-          'Bool',
-          'flutter.bool',
-          testBool2,
-        ]),
-        isMethodCall('setValue', arguments: <dynamic>[
-          'Int',
-          'flutter.int',
-          testInt2,
-        ]),
-        isMethodCall('setValue', arguments: <dynamic>[
-          'Double',
-          'flutter.double',
-          testDouble2,
-        ]),
-        isMethodCall('setValue', arguments: <dynamic>[
-          'StringList',
-          'flutter.List',
-          testList2,
-        ]),
-      ],
-    );
+    expect(store.log, <Matcher>[
+      isMethodCall(
+        'setValue',
+        arguments: <dynamic>['String', 'flutter.String', testString2],
+      ),
+      isMethodCall(
+        'setValue',
+        arguments: <dynamic>['Bool', 'flutter.bool', testBool2],
+      ),
+      isMethodCall(
+        'setValue',
+        arguments: <dynamic>['Int', 'flutter.int', testInt2],
+      ),
+      isMethodCall(
+        'setValue',
+        arguments: <dynamic>['Double', 'flutter.double', testDouble2],
+      ),
+      isMethodCall(
+        'setValue',
+        arguments: <dynamic>['StringList', 'flutter.List', testList2],
+      ),
+    ]);
     store.log.clear();
 
     expect(preferences.getString('String'), testString2);
@@ -113,15 +105,13 @@ void main() {
     const String key = 'testKey';
     await preferences.remove(key);
     expect(
-        store.log,
-        List<Matcher>.filled(
-          1,
-          isMethodCall(
-            'remove',
-            arguments: 'flutter.$key',
-          ),
-          growable: true,
-        ));
+      store.log,
+      List<Matcher>.filled(
+        1,
+        isMethodCall('remove', arguments: 'flutter.$key'),
+        growable: true,
+      ),
+    );
   });
 
   test('containsKey', () async {
@@ -162,7 +152,7 @@ void main() {
 
   test('string list type is dynamic (usually from method channel)', () async {
     SharedPreferences.setMockInitialValues(<String, Object>{
-      'dynamic_list': <dynamic>['1', '2']
+      'dynamic_list': <dynamic>['1', '2'],
     });
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final List<String>? value = prefs.getStringList('dynamic_list');
@@ -174,16 +164,18 @@ void main() {
     const String prefixedKey = 'flutter.$key';
 
     test('test 1', () async {
-      SharedPreferences.setMockInitialValues(
-          <String, Object>{prefixedKey: 'my string'});
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        prefixedKey: 'my string',
+      });
       final SharedPreferences prefs = await SharedPreferences.getInstance();
       final String? value = prefs.getString(key);
       expect(value, 'my string');
     });
 
     test('test 2', () async {
-      SharedPreferences.setMockInitialValues(
-          <String, Object>{prefixedKey: 'my other string'});
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        prefixedKey: 'my other string',
+      });
       final SharedPreferences prefs = await SharedPreferences.getInstance();
       final String? value = prefs.getString(key);
       expect(value, 'my other string');
@@ -204,9 +196,7 @@ void main() {
   });
 
   test('calling mock initial values with non-prefixed keys succeeds', () async {
-    SharedPreferences.setMockInitialValues(<String, Object>{
-      'test': 'foo',
-    });
+    SharedPreferences.setMockInitialValues(<String, Object>{'test': 'foo'});
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final String? value = prefs.getString('test');
     expect(value, 'foo');
@@ -314,9 +304,9 @@ void main() {
     }
     expect(err, isA<UnimplementedError>());
     expect(
-        err.toString(),
-        contains(
-            "Shared Preferences doesn't yet support the setPrefix method"));
+      err.toString(),
+      contains("Shared Preferences doesn't yet support the setPrefix method"),
+    );
   });
 
   test(
@@ -342,7 +332,7 @@ void main() {
 
 class FakeSharedPreferencesStore extends SharedPreferencesStorePlatform {
   FakeSharedPreferencesStore(Map<String, Object> data)
-      : backend = InMemorySharedPreferencesStore.withData(data);
+    : backend = InMemorySharedPreferencesStore.withData(data);
 
   final InMemorySharedPreferencesStore backend;
   final List<MethodCall> log = <MethodCall>[];
@@ -367,7 +357,8 @@ class FakeSharedPreferencesStore extends SharedPreferencesStorePlatform {
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) {
+    GetAllParameters parameters,
+  ) {
     log.add(const MethodCall('getAllWithParameters'));
     return backend.getAllWithParameters(parameters);
   }
@@ -440,7 +431,8 @@ class ThrowingSharedPreferencesStore extends SharedPreferencesStorePlatform {
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) {
+    GetAllParameters parameters,
+  ) {
     throw StateError('State Error');
   }
 }

--- a/packages/shared_preferences/shared_preferences/tool/pre_publish.dart
+++ b/packages/shared_preferences/shared_preferences/tool/pre_publish.dart
@@ -13,9 +13,8 @@ Future<void> _runCommand({
 }) async {
   stdout.write(message);
   // The `packages/shared_preferences` directory.
-  final Directory sharedPreferencesToolParent = Directory(
-    p.dirname(Platform.script.path),
-  ).parent.parent;
+  final Directory sharedPreferencesToolParent =
+      Directory(p.dirname(Platform.script.path)).parent.parent;
 
   final ProcessResult pubGetResult = await Process.run(
     executable,

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+
 ## 2.4.11
 
 * Updates kotlin version to 2.2.0 to enable gradle 8.11 support.

--- a/packages/shared_preferences/shared_preferences_android/README.md
+++ b/packages/shared_preferences/shared_preferences_android/README.md
@@ -21,9 +21,11 @@ To use the `Android SharedPreferences` backend, use the `SharedPreferencesAsyncA
 ```dart
 const SharedPreferencesAsyncAndroidOptions options =
     SharedPreferencesAsyncAndroidOptions(
-        backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
-        originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
-            fileName: 'the_name_of_a_file'));
+      backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
+      originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
+        fileName: 'the_name_of_a_file',
+      ),
+    );
 ```
 
 The [SharedPreferences] API uses the native [Android SharedPreferences](https://developer.android.com/reference/android/content/SharedPreferences) tool to store data.

--- a/packages/shared_preferences/shared_preferences_android/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_android/example/integration_test/shared_preferences_test.dart
@@ -53,17 +53,13 @@ void main() {
 
     tearDown(() async {
       await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        ClearParameters(filter: PreferencesFilter(prefix: '')),
       );
     });
 
     testWidgets('reading', (WidgetTester _) async {
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
       expect(values['String'], isNull);
       expect(values['Bool'], isNull);
@@ -78,54 +74,114 @@ void main() {
       await preferences.setValue('Int', 'Int', allTestValues['Int']!);
       await preferences.setValue('Double', 'Double', allTestValues['Double']!);
       await preferences.setValue(
-          'StringList', 'StringList', allTestValues['StringList']!);
+        'StringList',
+        'StringList',
+        allTestValues['StringList']!,
+      );
       await preferences.setValue(
-          'String', 'prefix.String', allTestValues['prefix.String']!);
+        'String',
+        'prefix.String',
+        allTestValues['prefix.String']!,
+      );
       await preferences.setValue(
-          'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!);
+        'Bool',
+        'prefix.Bool',
+        allTestValues['prefix.Bool']!,
+      );
       await preferences.setValue(
-          'Int', 'prefix.Int', allTestValues['prefix.Int']!);
+        'Int',
+        'prefix.Int',
+        allTestValues['prefix.Int']!,
+      );
       await preferences.setValue(
-          'Double', 'prefix.Double', allTestValues['prefix.Double']!);
-      await preferences.setValue('StringList', 'prefix.StringList',
-          allTestValues['prefix.StringList']!);
+        'Double',
+        'prefix.Double',
+        allTestValues['prefix.Double']!,
+      );
       await preferences.setValue(
-          'String', 'flutter.String', allTestValues['flutter.String']!);
+        'StringList',
+        'prefix.StringList',
+        allTestValues['prefix.StringList']!,
+      );
       await preferences.setValue(
-          'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+        'String',
+        'flutter.String',
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue(
-          'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+        'Bool',
+        'flutter.Bool',
+        allTestValues['flutter.Bool']!,
+      );
       await preferences.setValue(
-          'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-      await preferences.setValue('StringList', 'flutter.StringList',
-          allTestValues['flutter.StringList']!);
+        'Int',
+        'flutter.Int',
+        allTestValues['flutter.Int']!,
+      );
+      await preferences.setValue(
+        'Double',
+        'flutter.Double',
+        allTestValues['flutter.Double']!,
+      );
+      await preferences.setValue(
+        'StringList',
+        'flutter.StringList',
+        allTestValues['flutter.StringList']!,
+      );
     }
 
     testWidgets('getAllWithPrefix', (WidgetTester _) async {
       await Future.wait(<Future<bool>>[
         preferences.setValue(
-            'String', 'prefix.String', allTestValues['prefix.String']!),
+          'String',
+          'prefix.String',
+          allTestValues['prefix.String']!,
+        ),
         preferences.setValue(
-            'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!),
+          'Bool',
+          'prefix.Bool',
+          allTestValues['prefix.Bool']!,
+        ),
         preferences.setValue('Int', 'prefix.Int', allTestValues['prefix.Int']!),
         preferences.setValue(
-            'Double', 'prefix.Double', allTestValues['prefix.Double']!),
-        preferences.setValue('StringList', 'prefix.StringList',
-            allTestValues['prefix.StringList']!),
+          'Double',
+          'prefix.Double',
+          allTestValues['prefix.Double']!,
+        ),
         preferences.setValue(
-            'String', 'flutter.String', allTestValues['flutter.String']!),
+          'StringList',
+          'prefix.StringList',
+          allTestValues['prefix.StringList']!,
+        ),
         preferences.setValue(
-            'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!),
+          'String',
+          'flutter.String',
+          allTestValues['flutter.String']!,
+        ),
         preferences.setValue(
-            'Int', 'flutter.Int', allTestValues['flutter.Int']!),
+          'Bool',
+          'flutter.Bool',
+          allTestValues['flutter.Bool']!,
+        ),
         preferences.setValue(
-            'Double', 'flutter.Double', allTestValues['flutter.Double']!),
-        preferences.setValue('StringList', 'flutter.StringList',
-            allTestValues['flutter.StringList']!)
+          'Int',
+          'flutter.Int',
+          allTestValues['flutter.Int']!,
+        ),
+        preferences.setValue(
+          'Double',
+          'flutter.Double',
+          allTestValues['flutter.Double']!,
+        ),
+        preferences.setValue(
+          'StringList',
+          'flutter.StringList',
+          allTestValues['flutter.StringList']!,
+        ),
       ]);
       final Map<String, Object> values =
-          // ignore: deprecated_member_use
-          await preferences.getAllWithPrefix('prefix.');
+      // ignore: deprecated_member_use
+      await preferences.getAllWithPrefix('prefix.');
       expect(values['prefix.String'], allTestValues['prefix.String']);
       expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
       expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -137,31 +193,61 @@ void main() {
       testWidgets('clearWithPrefix', (WidgetTester _) async {
         await Future.wait(<Future<bool>>[
           preferences.setValue(
-              'String', 'prefix.String', allTestValues['prefix.String']!),
+            'String',
+            'prefix.String',
+            allTestValues['prefix.String']!,
+          ),
           preferences.setValue(
-              'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!),
+            'Bool',
+            'prefix.Bool',
+            allTestValues['prefix.Bool']!,
+          ),
           preferences.setValue(
-              'Int', 'prefix.Int', allTestValues['prefix.Int']!),
+            'Int',
+            'prefix.Int',
+            allTestValues['prefix.Int']!,
+          ),
           preferences.setValue(
-              'Double', 'prefix.Double', allTestValues['prefix.Double']!),
-          preferences.setValue('StringList', 'prefix.StringList',
-              allTestValues['prefix.StringList']!),
+            'Double',
+            'prefix.Double',
+            allTestValues['prefix.Double']!,
+          ),
           preferences.setValue(
-              'String', 'flutter.String', allTestValues['flutter.String']!),
+            'StringList',
+            'prefix.StringList',
+            allTestValues['prefix.StringList']!,
+          ),
           preferences.setValue(
-              'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!),
+            'String',
+            'flutter.String',
+            allTestValues['flutter.String']!,
+          ),
           preferences.setValue(
-              'Int', 'flutter.Int', allTestValues['flutter.Int']!),
+            'Bool',
+            'flutter.Bool',
+            allTestValues['flutter.Bool']!,
+          ),
           preferences.setValue(
-              'Double', 'flutter.Double', allTestValues['flutter.Double']!),
-          preferences.setValue('StringList', 'flutter.StringList',
-              allTestValues['flutter.StringList']!)
+            'Int',
+            'flutter.Int',
+            allTestValues['flutter.Int']!,
+          ),
+          preferences.setValue(
+            'Double',
+            'flutter.Double',
+            allTestValues['flutter.Double']!,
+          ),
+          preferences.setValue(
+            'StringList',
+            'flutter.StringList',
+            allTestValues['flutter.StringList']!,
+          ),
         ]);
         // ignore: deprecated_member_use
         await preferences.clearWithPrefix('prefix.');
         Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('prefix.');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('prefix.');
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -174,7 +260,9 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
@@ -184,21 +272,39 @@ void main() {
           preferences.setValue('Int', 'Int', allTestValues['Int']!),
           preferences.setValue('Double', 'Double', allTestValues['Double']!),
           preferences.setValue(
-              'StringList', 'StringList', allTestValues['StringList']!),
+            'StringList',
+            'StringList',
+            allTestValues['StringList']!,
+          ),
           preferences.setValue(
-              'String', 'flutter.String', allTestValues['flutter.String']!),
+            'String',
+            'flutter.String',
+            allTestValues['flutter.String']!,
+          ),
           preferences.setValue(
-              'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!),
+            'Bool',
+            'flutter.Bool',
+            allTestValues['flutter.Bool']!,
+          ),
           preferences.setValue(
-              'Int', 'flutter.Int', allTestValues['flutter.Int']!),
+            'Int',
+            'flutter.Int',
+            allTestValues['flutter.Int']!,
+          ),
           preferences.setValue(
-              'Double', 'flutter.Double', allTestValues['flutter.Double']!),
-          preferences.setValue('StringList', 'flutter.StringList',
-              allTestValues['flutter.StringList']!)
+            'Double',
+            'flutter.Double',
+            allTestValues['flutter.Double']!,
+          ),
+          preferences.setValue(
+            'StringList',
+            'flutter.StringList',
+            allTestValues['flutter.StringList']!,
+          ),
         ]);
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('');
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -209,7 +315,9 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
@@ -219,23 +327,41 @@ void main() {
           preferences.setValue('Int', 'Int', allTestValues['Int']!),
           preferences.setValue('Double', 'Double', allTestValues['Double']!),
           preferences.setValue(
-              'StringList', 'StringList', allTestValues['StringList']!),
+            'StringList',
+            'StringList',
+            allTestValues['StringList']!,
+          ),
           preferences.setValue(
-              'String', 'flutter.String', allTestValues['flutter.String']!),
+            'String',
+            'flutter.String',
+            allTestValues['flutter.String']!,
+          ),
           preferences.setValue(
-              'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!),
+            'Bool',
+            'flutter.Bool',
+            allTestValues['flutter.Bool']!,
+          ),
           preferences.setValue(
-              'Int', 'flutter.Int', allTestValues['flutter.Int']!),
+            'Int',
+            'flutter.Int',
+            allTestValues['flutter.Int']!,
+          ),
           preferences.setValue(
-              'Double', 'flutter.Double', allTestValues['flutter.Double']!),
-          preferences.setValue('StringList', 'flutter.StringList',
-              allTestValues['flutter.StringList']!)
+            'Double',
+            'flutter.Double',
+            allTestValues['flutter.Double']!,
+          ),
+          preferences.setValue(
+            'StringList',
+            'flutter.StringList',
+            allTestValues['flutter.StringList']!,
+          ),
         ]);
         // ignore: deprecated_member_use
         await preferences.clearWithPrefix('');
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('');
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -252,9 +378,7 @@ void main() {
     testWidgets('get all with prefix', (WidgetTester _) async {
       await addData();
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: 'prefix.'),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
       );
       expect(values['prefix.String'], allTestValues['prefix.String']);
       expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
@@ -283,9 +407,7 @@ void main() {
     testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
       await addData();
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
       expect(values['String'], allTestValues['String']);
       expect(values['Bool'], allTestValues['Bool']);
@@ -302,14 +424,10 @@ void main() {
     testWidgets('clearWithParameters', (WidgetTester _) async {
       await addData();
       await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: 'prefix.'),
-        ),
+        ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
       );
       Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: 'prefix.'),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
       );
       expect(values['prefix.String'], null);
       expect(values['prefix.Bool'], null);
@@ -317,9 +435,7 @@ void main() {
       expect(values['prefix.Double'], null);
       expect(values['prefix.StringList'], null);
       values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: 'flutter.'),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
       );
       expect(values['flutter.String'], allTestValues['flutter.String']);
       expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
@@ -344,9 +460,7 @@ void main() {
         ),
       );
       Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: 'prefix.'),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
       );
       expect(values['prefix.String'], null);
       expect(values['prefix.Bool'], null);
@@ -354,9 +468,7 @@ void main() {
       expect(values['prefix.Double'], null);
       expect(values['prefix.StringList'], allTestValues['prefix.StringList']);
       values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: 'flutter.'),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
       );
       expect(values['flutter.String'], allTestValues['flutter.String']);
       expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
@@ -368,14 +480,10 @@ void main() {
     testWidgets('clearWithNoPrefix', (WidgetTester _) async {
       await addData();
       await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        ClearParameters(filter: PreferencesFilter(prefix: '')),
       );
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
       expect(values['String'], null);
       expect(values['Bool'], null);
@@ -391,15 +499,30 @@ void main() {
 
     testWidgets('getAll', (WidgetTester _) async {
       await preferences.setValue(
-          'String', 'flutter.String', allTestValues['flutter.String']!);
+        'String',
+        'flutter.String',
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue(
-          'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+        'Bool',
+        'flutter.Bool',
+        allTestValues['flutter.Bool']!,
+      );
       await preferences.setValue(
-          'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+        'Int',
+        'flutter.Int',
+        allTestValues['flutter.Int']!,
+      );
       await preferences.setValue(
-          'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-      await preferences.setValue('StringList', 'flutter.StringList',
-          allTestValues['flutter.StringList']!);
+        'Double',
+        'flutter.Double',
+        allTestValues['flutter.Double']!,
+      );
+      await preferences.setValue(
+        'StringList',
+        'flutter.StringList',
+        allTestValues['flutter.StringList']!,
+      );
       final Map<String, Object> values = await preferences.getAll();
       expect(values['flutter.String'], allTestValues['flutter.String']);
       expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
@@ -411,33 +534,55 @@ void main() {
     testWidgets('remove', (WidgetTester _) async {
       const String key = 'testKey';
       await preferences.setValue(
-          'String', key, allTestValues['flutter.String']!);
+        'String',
+        key,
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue('Bool', key, allTestValues['flutter.Bool']!);
       await preferences.setValue('Int', key, allTestValues['flutter.Int']!);
       await preferences.setValue(
-          'Double', key, allTestValues['flutter.Double']!);
+        'Double',
+        key,
+        allTestValues['flutter.Double']!,
+      );
       await preferences.setValue(
-          'StringList', key, allTestValues['flutter.StringList']!);
+        'StringList',
+        key,
+        allTestValues['flutter.StringList']!,
+      );
       await preferences.remove(key);
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
       expect(values[key], isNull);
     });
 
     testWidgets('clear', (WidgetTester _) async {
       await preferences.setValue(
-          'String', 'flutter.String', allTestValues['flutter.String']!);
+        'String',
+        'flutter.String',
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue(
-          'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+        'Bool',
+        'flutter.Bool',
+        allTestValues['flutter.Bool']!,
+      );
       await preferences.setValue(
-          'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+        'Int',
+        'flutter.Int',
+        allTestValues['flutter.Int']!,
+      );
       await preferences.setValue(
-          'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-      await preferences.setValue('StringList', 'flutter.StringList',
-          allTestValues['flutter.StringList']!);
+        'Double',
+        'flutter.Double',
+        allTestValues['flutter.Double']!,
+      );
+      await preferences.setValue(
+        'StringList',
+        'flutter.StringList',
+        allTestValues['flutter.StringList']!,
+      );
       await preferences.clear();
       final Map<String, Object> values = await preferences.getAll();
       expect(values['flutter.String'], null);
@@ -458,9 +603,7 @@ void main() {
       expect(result.where((bool element) => !element), isEmpty);
       // The last write should win.
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
       expect(values['Int'], writeCount);
     });
@@ -469,9 +612,7 @@ void main() {
       const String key = 'aKey';
       const String value = 'a string value';
       await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        ClearParameters(filter: PreferencesFilter(prefix: '')),
       );
 
       // Special prefixes used to store datatypes that can't be stored directly
@@ -483,50 +624,57 @@ void main() {
         'VGhpcyBpcyB0aGUgcHJlZml4IGZvciBEb3VibGUu',
       ];
       for (final String prefix in specialPrefixes) {
-        expect(preferences.setValue('String', key, prefix + value),
-            throwsA(isA<PlatformException>()));
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
+        expect(
+          preferences.setValue('String', key, prefix + value),
+          throwsA(isA<PlatformException>()),
         );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values[key], null);
       }
     });
 
     testWidgets(
-        'Platform list encoding with getPreferences can be re-added with new encoding without data loss',
-        (WidgetTester _) async {
-      await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
-      );
-      await preferences.setValue('String', 'String', allTestValues['String']!);
-      await preferences.setValue('Bool', 'Bool', allTestValues['Bool']!);
-      await preferences.setValue('Int', 'Int', allTestValues['Int']!);
-      await preferences.setValue('Double', 'Double', allTestValues['Double']!);
-      await (preferences as SharedPreferencesAndroid)
-          .api
-          .setDeprecatedStringList(
-              'StringList', allTestValues['StringList']! as List<String>);
-      Map<String, Object> prefs = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
-      );
-      expect(prefs['StringList'], allTestValues['StringList']);
-      await preferences.setValue(
-          'StringList', 'StringList', prefs['StringList']!);
-      prefs = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
-      );
+      'Platform list encoding with getPreferences can be re-added with new encoding without data loss',
+      (WidgetTester _) async {
+        await preferences.clearWithParameters(
+          ClearParameters(filter: PreferencesFilter(prefix: '')),
+        );
+        await preferences.setValue(
+          'String',
+          'String',
+          allTestValues['String']!,
+        );
+        await preferences.setValue('Bool', 'Bool', allTestValues['Bool']!);
+        await preferences.setValue('Int', 'Int', allTestValues['Int']!);
+        await preferences.setValue(
+          'Double',
+          'Double',
+          allTestValues['Double']!,
+        );
+        await (preferences as SharedPreferencesAndroid).api
+            .setDeprecatedStringList(
+              'StringList',
+              allTestValues['StringList']! as List<String>,
+            );
+        Map<String, Object> prefs = await preferences.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: '')),
+        );
+        expect(prefs['StringList'], allTestValues['StringList']);
+        await preferences.setValue(
+          'StringList',
+          'StringList',
+          prefs['StringList']!,
+        );
+        prefs = await preferences.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: '')),
+        );
 
-      expect(prefs['StringList'], allTestValues['StringList']);
-    });
+        expect(prefs['StringList'], allTestValues['StringList']);
+      },
+    );
   });
 
   const String stringKey = 'testString';
@@ -546,12 +694,14 @@ void main() {
     String? fileName,
   }) {
     return SharedPreferencesAsyncAndroidOptions(
-      backend: useDataStore
-          ? SharedPreferencesAndroidBackendLibrary.DataStore
-          : SharedPreferencesAndroidBackendLibrary.SharedPreferences,
-      originalSharedPreferencesOptions: fileName == null
-          ? null
-          : AndroidSharedPreferencesStoreOptions(fileName: fileName),
+      backend:
+          useDataStore
+              ? SharedPreferencesAndroidBackendLibrary.DataStore
+              : SharedPreferencesAndroidBackendLibrary.SharedPreferences,
+      originalSharedPreferencesOptions:
+          fileName == null
+              ? null
+              : AndroidSharedPreferencesStoreOptions(fileName: fileName),
     );
   }
 
@@ -560,8 +710,9 @@ void main() {
     SharedPreferencesAsyncAndroidOptions options,
   ) async {
     await preferences.clear(
-        const ClearPreferencesParameters(filter: PreferencesFilters()),
-        options);
+      const ClearPreferencesParameters(filter: PreferencesFilters()),
+      options,
+    );
   }
 
   SharedPreferencesAsyncPlatform getPreferences() {
@@ -575,8 +726,10 @@ void main() {
       final String backend = useDataStore ? 'DataStore' : 'SharedPreferences';
 
       testWidgets('set and get String with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
 
@@ -585,8 +738,10 @@ void main() {
       });
 
       testWidgets('set and get bool with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
 
@@ -595,8 +750,10 @@ void main() {
       });
 
       testWidgets('set and get int with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
 
@@ -605,8 +762,10 @@ void main() {
       });
 
       testWidgets('set and get double with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
 
@@ -614,10 +773,13 @@ void main() {
         expect(await preferences.getDouble(doubleKey, options), testDouble);
       });
 
-      testWidgets('set and get StringList with $backend',
-          (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+      testWidgets('set and get StringList with $backend', (
+        WidgetTester _,
+      ) async {
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
 
@@ -625,24 +787,32 @@ void main() {
         expect(await preferences.getStringList(listKey, options), testList);
       });
 
-      testWidgets('getStringList returns mutable list with $backend',
-          (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+      testWidgets('getStringList returns mutable list with $backend', (
+        WidgetTester _,
+      ) async {
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
 
         await preferences.setStringList(listKey, testList, options);
-        final List<String>? list =
-            await preferences.getStringList(listKey, options);
+        final List<String>? list = await preferences.getStringList(
+          listKey,
+          options,
+        );
         list?.add('value');
         expect(list?.length, testList.length + 1);
       });
 
-      testWidgets('getStringList throws type error for String with $backend',
-          (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+      testWidgets('getStringList throws type error for String with $backend', (
+        WidgetTester _,
+      ) async {
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
 
@@ -651,13 +821,17 @@ void main() {
         // Internally, List<String> is stored as a String on Android, but that
         // implementation detail shouldn't leak to clients; getting the wrong
         // type should still throw.
-        expect(preferences.getStringList(listKey, options),
-            throwsA(isA<TypeError>()));
+        expect(
+          preferences.getStringList(listKey, options),
+          throwsA(isA<TypeError>()),
+        );
       });
 
       testWidgets('getPreferences with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
         await Future.wait(<Future<void>>[
@@ -665,7 +839,7 @@ void main() {
           preferences.setBool(boolKey, testBool, options),
           preferences.setInt(intKey, testInt, options),
           preferences.setDouble(doubleKey, testDouble, options),
-          preferences.setStringList(listKey, testList, options)
+          preferences.setStringList(listKey, testList, options),
         ]);
 
         final Map<String, Object?> gotAll = await preferences.getPreferences(
@@ -681,10 +855,13 @@ void main() {
         expect(gotAll[listKey], testList);
       });
 
-      testWidgets('getPreferences with filter with $backend',
-          (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+      testWidgets('getPreferences with filter with $backend', (
+        WidgetTester _,
+      ) async {
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
         await Future.wait(<Future<void>>[
@@ -692,7 +869,7 @@ void main() {
           preferences.setBool(boolKey, testBool, options),
           preferences.setInt(intKey, testInt, options),
           preferences.setDouble(doubleKey, testDouble, options),
-          preferences.setStringList(listKey, testList, options)
+          preferences.setStringList(listKey, testList, options),
         ]);
 
         final Map<String, Object?> gotAll = await preferences.getPreferences(
@@ -708,8 +885,10 @@ void main() {
       });
 
       testWidgets('getKeys with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
         await Future.wait(<Future<void>>[
@@ -717,7 +896,7 @@ void main() {
           preferences.setBool(boolKey, testBool, options),
           preferences.setInt(intKey, testInt, options),
           preferences.setDouble(doubleKey, testDouble, options),
-          preferences.setStringList(listKey, testList, options)
+          preferences.setStringList(listKey, testList, options),
         ]);
 
         final Set<String> keys = await preferences.getKeys(
@@ -734,8 +913,10 @@ void main() {
       });
 
       testWidgets('getKeys with filter with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
         await Future.wait(<Future<void>>[
@@ -743,7 +924,7 @@ void main() {
           preferences.setBool(boolKey, testBool, options),
           preferences.setInt(intKey, testInt, options),
           preferences.setDouble(doubleKey, testDouble, options),
-          preferences.setStringList(listKey, testList, options)
+          preferences.setStringList(listKey, testList, options),
         ]);
 
         final Set<String> keys = await preferences.getKeys(
@@ -759,8 +940,10 @@ void main() {
       });
 
       testWidgets('clear with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
         await Future.wait(<Future<void>>[
@@ -768,7 +951,7 @@ void main() {
           preferences.setBool(boolKey, testBool, options),
           preferences.setInt(intKey, testInt, options),
           preferences.setDouble(doubleKey, testDouble, options),
-          preferences.setStringList(listKey, testList, options)
+          preferences.setStringList(listKey, testList, options),
         ]);
 
         await preferences.clear(
@@ -784,8 +967,10 @@ void main() {
       });
 
       testWidgets('clear with filter with $backend', (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
+        final SharedPreferencesAsyncAndroidOptions options = getOptions(
+          useDataStore: useDataStore,
+          fileName: 'notDefault',
+        );
         final SharedPreferencesAsyncPlatform preferences = getPreferences();
         await clearPreferences(preferences, options);
         await Future.wait(<Future<void>>[
@@ -793,7 +978,7 @@ void main() {
           preferences.setBool(boolKey, testBool, options),
           preferences.setInt(intKey, testInt, options),
           preferences.setDouble(doubleKey, testDouble, options),
-          preferences.setStringList(listKey, testList, options)
+          preferences.setStringList(listKey, testList, options),
         ]);
         await preferences.clear(
           const ClearPreferencesParameters(
@@ -809,90 +994,116 @@ void main() {
       });
 
       testWidgets(
-          'platform list encoding updates to JSON encoding process without data loss with $backend',
-          (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
-        final SharedPreferencesAsyncAndroid preferences =
-            getPreferences() as SharedPreferencesAsyncAndroid;
-        await clearPreferences(preferences, options);
-        final SharedPreferencesPigeonOptions pigeonOptions =
-            preferences.convertOptionsToPigeonOptions(options);
-        final SharedPreferencesAsyncApi api =
-            preferences.getApiForBackend(pigeonOptions);
-        await api.setDeprecatedStringList(listKey, testList, pigeonOptions);
-        final List<String>? platformEncodedList =
-            await preferences.getStringList(listKey, options);
-        expect(platformEncodedList, testList);
-        await preferences.setStringList(listKey, platformEncodedList!, options);
-        expect(await preferences.getStringList(listKey, options), testList);
-      });
+        'platform list encoding updates to JSON encoding process without data loss with $backend',
+        (WidgetTester _) async {
+          final SharedPreferencesAsyncAndroidOptions options = getOptions(
+            useDataStore: useDataStore,
+            fileName: 'notDefault',
+          );
+          final SharedPreferencesAsyncAndroid preferences =
+              getPreferences() as SharedPreferencesAsyncAndroid;
+          await clearPreferences(preferences, options);
+          final SharedPreferencesPigeonOptions pigeonOptions = preferences
+              .convertOptionsToPigeonOptions(options);
+          final SharedPreferencesAsyncApi api = preferences.getApiForBackend(
+            pigeonOptions,
+          );
+          await api.setDeprecatedStringList(listKey, testList, pigeonOptions);
+          final List<String>? platformEncodedList = await preferences
+              .getStringList(listKey, options);
+          expect(platformEncodedList, testList);
+          await preferences.setStringList(
+            listKey,
+            platformEncodedList!,
+            options,
+          );
+          expect(await preferences.getStringList(listKey, options), testList);
+        },
+      );
 
       testWidgets(
-          'platform list encoding still functions with getPreferences with $backend',
-          (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
-        final SharedPreferencesAsyncAndroid preferences =
-            getPreferences() as SharedPreferencesAsyncAndroid;
-        await clearPreferences(preferences, options);
-        await Future.wait(<Future<void>>[
-          preferences.setString(stringKey, testString, options),
-          preferences.setBool(boolKey, testBool, options),
-          preferences.setInt(intKey, testInt, options),
-          preferences.setDouble(doubleKey, testDouble, options),
-        ]);
-        final SharedPreferencesPigeonOptions pigeonOptions =
-            preferences.convertOptionsToPigeonOptions(options);
-        final SharedPreferencesAsyncApi api =
-            preferences.getApiForBackend(pigeonOptions);
-        await api.setDeprecatedStringList(listKey, testList, pigeonOptions);
+        'platform list encoding still functions with getPreferences with $backend',
+        (WidgetTester _) async {
+          final SharedPreferencesAsyncAndroidOptions options = getOptions(
+            useDataStore: useDataStore,
+            fileName: 'notDefault',
+          );
+          final SharedPreferencesAsyncAndroid preferences =
+              getPreferences() as SharedPreferencesAsyncAndroid;
+          await clearPreferences(preferences, options);
+          await Future.wait(<Future<void>>[
+            preferences.setString(stringKey, testString, options),
+            preferences.setBool(boolKey, testBool, options),
+            preferences.setInt(intKey, testInt, options),
+            preferences.setDouble(doubleKey, testDouble, options),
+          ]);
+          final SharedPreferencesPigeonOptions pigeonOptions = preferences
+              .convertOptionsToPigeonOptions(options);
+          final SharedPreferencesAsyncApi api = preferences.getApiForBackend(
+            pigeonOptions,
+          );
+          await api.setDeprecatedStringList(listKey, testList, pigeonOptions);
 
-        final Map<String, Object> prefs = await preferences.getPreferences(
+          final Map<String, Object> prefs = await preferences.getPreferences(
             const GetPreferencesParameters(filter: PreferencesFilters()),
-            options);
-        expect(prefs[listKey], testList);
-      });
+            options,
+          );
+          expect(prefs[listKey], testList);
+        },
+      );
 
       testWidgets(
-          'platform list encoding with getPreferences can be re-added with new encoding without data loss with $backend',
-          (WidgetTester _) async {
-        final SharedPreferencesAsyncAndroidOptions options =
-            getOptions(useDataStore: useDataStore, fileName: 'notDefault');
-        final SharedPreferencesAsyncAndroid preferences =
-            getPreferences() as SharedPreferencesAsyncAndroid;
-        await clearPreferences(preferences, options);
-        await Future.wait(<Future<void>>[
-          preferences.setString(stringKey, testString, options),
-          preferences.setBool(boolKey, testBool, options),
-          preferences.setInt(intKey, testInt, options),
-          preferences.setDouble(doubleKey, testDouble, options),
-        ]);
-        final SharedPreferencesPigeonOptions pigeonOptions =
-            preferences.convertOptionsToPigeonOptions(options);
-        final SharedPreferencesAsyncApi api =
-            preferences.getApiForBackend(pigeonOptions);
-        await api.setDeprecatedStringList(listKey, testList, pigeonOptions);
+        'platform list encoding with getPreferences can be re-added with new encoding without data loss with $backend',
+        (WidgetTester _) async {
+          final SharedPreferencesAsyncAndroidOptions options = getOptions(
+            useDataStore: useDataStore,
+            fileName: 'notDefault',
+          );
+          final SharedPreferencesAsyncAndroid preferences =
+              getPreferences() as SharedPreferencesAsyncAndroid;
+          await clearPreferences(preferences, options);
+          await Future.wait(<Future<void>>[
+            preferences.setString(stringKey, testString, options),
+            preferences.setBool(boolKey, testBool, options),
+            preferences.setInt(intKey, testInt, options),
+            preferences.setDouble(doubleKey, testDouble, options),
+          ]);
+          final SharedPreferencesPigeonOptions pigeonOptions = preferences
+              .convertOptionsToPigeonOptions(options);
+          final SharedPreferencesAsyncApi api = preferences.getApiForBackend(
+            pigeonOptions,
+          );
+          await api.setDeprecatedStringList(listKey, testList, pigeonOptions);
 
-        final Map<String, Object> prefs = await preferences.getPreferences(
+          final Map<String, Object> prefs = await preferences.getPreferences(
             const GetPreferencesParameters(filter: PreferencesFilters()),
-            options);
-        await preferences.setStringList(listKey,
-            (prefs[listKey]! as List<Object?>).cast<String>(), options);
-        expect(await preferences.getStringList(listKey, options), testList);
-      });
+            options,
+          );
+          await preferences.setStringList(
+            listKey,
+            (prefs[listKey]! as List<Object?>).cast<String>(),
+            options,
+          );
+          expect(await preferences.getStringList(listKey, options), testList);
+        },
+      );
     });
   }
 
   runAsyncTests(true);
   runAsyncTests(false);
 
-  testWidgets('Shared Preferences works with multiple files',
-      (WidgetTester _) async {
-    final SharedPreferencesAsyncAndroidOptions options1 =
-        getOptions(useDataStore: false, fileName: 'file1');
-    final SharedPreferencesAsyncAndroidOptions options2 =
-        getOptions(useDataStore: false, fileName: 'file2');
+  testWidgets('Shared Preferences works with multiple files', (
+    WidgetTester _,
+  ) async {
+    final SharedPreferencesAsyncAndroidOptions options1 = getOptions(
+      useDataStore: false,
+      fileName: 'file1',
+    );
+    final SharedPreferencesAsyncAndroidOptions options2 = getOptions(
+      useDataStore: false,
+      fileName: 'file2',
+    );
     final SharedPreferencesAsyncPlatform preferences = getPreferences();
     await clearPreferences(preferences, options1);
     await clearPreferences(preferences, options2);
@@ -903,27 +1114,37 @@ void main() {
     expect(await preferences.getInt(intKey, options2), 2);
   });
 
-  testWidgets('Shared Preferences can read default sharedPreferences',
-      (WidgetTester _) async {
-    final SharedPreferencesAsyncAndroidOptions options =
-        getOptions(useDataStore: false);
+  testWidgets('Shared Preferences can read default sharedPreferences', (
+    WidgetTester _,
+  ) async {
+    final SharedPreferencesAsyncAndroidOptions options = getOptions(
+      useDataStore: false,
+    );
     final SharedPreferencesAsyncPlatform preferences = getPreferences();
 
     expect(
-        await preferences.getString(
-            'thisStringIsWrittenInTheExampleAppJavaCode', options),
-        'testString');
+      await preferences.getString(
+        'thisStringIsWrittenInTheExampleAppJavaCode',
+        options,
+      ),
+      'testString',
+    );
   });
 
-  testWidgets('Shared Preferences can read ints by conversion to long',
-      (WidgetTester _) async {
-    final SharedPreferencesAsyncAndroidOptions options =
-        getOptions(useDataStore: false);
+  testWidgets('Shared Preferences can read ints by conversion to long', (
+    WidgetTester _,
+  ) async {
+    final SharedPreferencesAsyncAndroidOptions options = getOptions(
+      useDataStore: false,
+    );
     final SharedPreferencesAsyncPlatform preferences = getPreferences();
 
     expect(
-        await preferences.getInt(
-            'thisIntIsWrittenInTheExampleAppJavaCode', options),
-        5);
+      await preferences.getInt(
+        'thisIntIsWrittenInTheExampleAppJavaCode',
+        options,
+      ),
+      5,
+    );
   });
 }

--- a/packages/shared_preferences/shared_preferences_android/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_android/example/lib/main.dart
@@ -15,9 +15,11 @@ void main() {
 // #docregion Android_Options
 const SharedPreferencesAsyncAndroidOptions options =
     SharedPreferencesAsyncAndroidOptions(
-        backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
-        originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
-            fileName: 'the_name_of_a_file'));
+      backend: SharedPreferencesAndroidBackendLibrary.SharedPreferences,
+      originalSharedPreferencesOptions: AndroidSharedPreferencesStoreOptions(
+        fileName: 'the_name_of_a_file',
+      ),
+    );
 // #enddocregion Android_Options
 
 class MyApp extends StatelessWidget {
@@ -75,29 +77,29 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('SharedPreferences Demo'),
-      ),
+      appBar: AppBar(title: const Text('SharedPreferences Demo')),
       body: Center(
-          child: FutureBuilder<int>(
-              future: _counter,
-              builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-                switch (snapshot.connectionState) {
-                  case ConnectionState.none:
-                  case ConnectionState.waiting:
-                    return const CircularProgressIndicator();
-                  case ConnectionState.active:
-                  case ConnectionState.done:
-                    if (snapshot.hasError) {
-                      return Text('Error: ${snapshot.error}');
-                    } else {
-                      return Text(
-                        'Button tapped ${snapshot.data} time${snapshot.data == 1 ? '' : 's'}.\n\n'
-                        'This should persist across restarts.',
-                      );
-                    }
+        child: FutureBuilder<int>(
+          future: _counter,
+          builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+            switch (snapshot.connectionState) {
+              case ConnectionState.none:
+              case ConnectionState.waiting:
+                return const CircularProgressIndicator();
+              case ConnectionState.active:
+              case ConnectionState.done:
+                if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                } else {
+                  return Text(
+                    'Button tapped ${snapshot.data} time${snapshot.data == 1 ? '' : 's'}.\n\n'
+                    'This should persist across restarts.',
+                  );
                 }
-              })),
+            }
+          },
+        ),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,
         tooltip: 'Increment',

--- a/packages/shared_preferences/shared_preferences_android/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the shared_preferences plugin.
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_android/lib/src/messages.g.dart
+++ b/packages/shared_preferences/shared_preferences_android/lib/src/messages.g.dart
@@ -43,11 +43,12 @@ class SharedPreferencesApi {
   /// Constructor for [SharedPreferencesApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  SharedPreferencesApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  SharedPreferencesApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix =
+           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -60,10 +61,10 @@ class SharedPreferencesApi {
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.remove$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -90,10 +91,10 @@ class SharedPreferencesApi {
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.setBool$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -120,10 +121,10 @@ class SharedPreferencesApi {
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.setString$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -150,10 +151,10 @@ class SharedPreferencesApi {
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.setInt$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -180,10 +181,10 @@ class SharedPreferencesApi {
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.setDouble$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -210,10 +211,10 @@ class SharedPreferencesApi {
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.setEncodedStringList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -242,10 +243,10 @@ class SharedPreferencesApi {
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.setDeprecatedStringList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -272,12 +273,13 @@ class SharedPreferencesApi {
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.clear$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[prefix, allowList]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[prefix, allowList])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -298,17 +300,20 @@ class SharedPreferencesApi {
 
   /// Gets all properties from shared preferences data set with matching prefix.
   Future<Map<String, Object>> getAll(
-      String prefix, List<String>? allowList) async {
+    String prefix,
+    List<String>? allowList,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesApi.getAll$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[prefix, allowList]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[prefix, allowList])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {

--- a/packages/shared_preferences/shared_preferences_android/lib/src/messages_async.g.dart
+++ b/packages/shared_preferences/shared_preferences_android/lib/src/messages_async.g.dart
@@ -31,20 +31,14 @@ enum StringListLookupResultType {
 }
 
 class SharedPreferencesPigeonOptions {
-  SharedPreferencesPigeonOptions({
-    this.fileName,
-    this.useDataStore = true,
-  });
+  SharedPreferencesPigeonOptions({this.fileName, this.useDataStore = true});
 
   String? fileName;
 
   bool useDataStore;
 
   Object encode() {
-    return <Object?>[
-      fileName,
-      useDataStore,
-    ];
+    return <Object?>[fileName, useDataStore];
   }
 
   static SharedPreferencesPigeonOptions decode(Object result) {
@@ -57,10 +51,7 @@ class SharedPreferencesPigeonOptions {
 }
 
 class StringListResult {
-  StringListResult({
-    this.jsonEncodedValue,
-    required this.type,
-  });
+  StringListResult({this.jsonEncodedValue, required this.type});
 
   /// The JSON-encoded stored value, or null if something else was found.
   String? jsonEncodedValue;
@@ -69,10 +60,7 @@ class StringListResult {
   StringListLookupResultType type;
 
   Object encode() {
-    return <Object?>[
-      jsonEncodedValue,
-      type,
-    ];
+    return <Object?>[jsonEncodedValue, type];
   }
 
   static StringListResult decode(Object result) {
@@ -125,11 +113,12 @@ class SharedPreferencesAsyncApi {
   /// Constructor for [SharedPreferencesAsyncApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  SharedPreferencesAsyncApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  SharedPreferencesAsyncApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix =
+           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -138,17 +127,21 @@ class SharedPreferencesAsyncApi {
 
   /// Adds property to shared preferences data set of type bool.
   Future<void> setBool(
-      String key, bool value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    bool value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.setBool$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[key, value, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[key, value, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -164,17 +157,21 @@ class SharedPreferencesAsyncApi {
 
   /// Adds property to shared preferences data set of type String.
   Future<void> setString(
-      String key, String value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    String value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.setString$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[key, value, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[key, value, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -190,17 +187,21 @@ class SharedPreferencesAsyncApi {
 
   /// Adds property to shared preferences data set of type int.
   Future<void> setInt(
-      String key, int value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    int value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.setInt$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[key, value, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[key, value, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -216,17 +217,21 @@ class SharedPreferencesAsyncApi {
 
   /// Adds property to shared preferences data set of type double.
   Future<void> setDouble(
-      String key, double value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    double value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.setDouble$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[key, value, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[key, value, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -242,17 +247,21 @@ class SharedPreferencesAsyncApi {
 
   /// Adds property to shared preferences data set of type List<String>.
   Future<void> setEncodedStringList(
-      String key, String value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    String value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.setEncodedStringList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[key, value, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[key, value, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -269,18 +278,22 @@ class SharedPreferencesAsyncApi {
   /// Adds property to shared preferences data set of type List<String>.
   ///
   /// Deprecated, this is only here for testing purposes.
-  Future<void> setDeprecatedStringList(String key, List<String> value,
-      SharedPreferencesPigeonOptions options) async {
+  Future<void> setDeprecatedStringList(
+    String key,
+    List<String> value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.setDeprecatedStringList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[key, value, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[key, value, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -296,15 +309,17 @@ class SharedPreferencesAsyncApi {
 
   /// Gets individual String value stored with [key], if any.
   Future<String?> getString(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.getString$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, options]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -322,15 +337,17 @@ class SharedPreferencesAsyncApi {
 
   /// Gets individual  void value stored with [key], if any.
   Future<bool?> getBool(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.getBool$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, options]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -348,15 +365,17 @@ class SharedPreferencesAsyncApi {
 
   /// Gets individual double value stored with [key], if any.
   Future<double?> getDouble(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.getDouble$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, options]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -374,15 +393,17 @@ class SharedPreferencesAsyncApi {
 
   /// Gets individual int value stored with [key], if any.
   Future<int?> getInt(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.getInt$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, options]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -400,15 +421,17 @@ class SharedPreferencesAsyncApi {
 
   /// Gets individual List<String> value stored with [key], if any.
   Future<List<String>?> getPlatformEncodedStringList(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.getPlatformEncodedStringList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, options]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -426,15 +449,17 @@ class SharedPreferencesAsyncApi {
 
   /// Gets the JSON-encoded List<String> value stored with [key], if any.
   Future<StringListResult?> getStringList(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.getStringList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, options]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -452,17 +477,20 @@ class SharedPreferencesAsyncApi {
 
   /// Removes all properties from shared preferences data set with matching prefix.
   Future<void> clear(
-      List<String>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.clear$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[allowList, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[allowList, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -478,17 +506,20 @@ class SharedPreferencesAsyncApi {
 
   /// Gets all properties from shared preferences data set with matching prefix.
   Future<Map<String, Object>> getAll(
-      List<String>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.getAll$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[allowList, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[allowList, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -510,17 +541,20 @@ class SharedPreferencesAsyncApi {
 
   /// Gets all properties from shared preferences data set with matching prefix.
   Future<List<String>> getKeys(
-      List<String>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_android.SharedPreferencesAsyncApi.getKeys$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[allowList, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[allowList, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {

--- a/packages/shared_preferences/shared_preferences_android/lib/src/shared_preferences_android.dart
+++ b/packages/shared_preferences/shared_preferences_android/lib/src/shared_preferences_android.dart
@@ -18,9 +18,8 @@ import 'strings.dart';
 /// This class implements the `package:shared_preferences` functionality for Android.
 class SharedPreferencesAndroid extends SharedPreferencesStorePlatform {
   /// Creates a new plugin implementation instance.
-  SharedPreferencesAndroid({
-    @visibleForTesting SharedPreferencesApi? api,
-  }) : api = api ?? SharedPreferencesApi();
+  SharedPreferencesAndroid({@visibleForTesting SharedPreferencesApi? api})
+    : api = api ?? SharedPreferencesApi();
 
   /// The pigeon API used to send messages to the platform.
   @visibleForTesting
@@ -53,59 +52,60 @@ class SharedPreferencesAndroid extends SharedPreferencesStorePlatform {
         return api.setDouble(key, value as double);
       case 'StringList':
         return api.setEncodedStringList(
-            key, '$jsonListPrefix${jsonEncode(value)}');
+          key,
+          '$jsonListPrefix${jsonEncode(value)}',
+        );
     }
     // TODO(tarrinneal): change to ArgumentError across all platforms.
     throw PlatformException(
-        code: 'InvalidOperation',
-        message: '"$valueType" is not a supported type.');
+      code: 'InvalidOperation',
+      message: '"$valueType" is not a supported type.',
+    );
   }
 
   @override
   Future<bool> clear() async {
     return clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<bool> clearWithPrefix(String prefix) async {
     return clearWithParameters(
-        ClearParameters(filter: PreferencesFilter(prefix: prefix)));
+      ClearParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
   Future<bool> clearWithParameters(ClearParameters parameters) async {
     final PreferencesFilter filter = parameters.filter;
-    return api.clear(
-      filter.prefix,
-      filter.allowList?.toList(),
-    );
+    return api.clear(filter.prefix, filter.allowList?.toList());
   }
 
   @override
   Future<Map<String, Object>> getAll() async {
     return getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<Map<String, Object>> getAllWithPrefix(String prefix) async {
     return getAllWithParameters(
-        GetAllParameters(filter: PreferencesFilter(prefix: prefix)));
+      GetAllParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) async {
+    GetAllParameters parameters,
+  ) async {
     final PreferencesFilter filter = parameters.filter;
-    final Map<String?, Object?> data =
-        await api.getAll(filter.prefix, filter.allowList?.toList());
+    final Map<String?, Object?> data = await api.getAll(
+      filter.prefix,
+      filter.allowList?.toList(),
+    );
     data.forEach((String? key, Object? value) {
       if (value.runtimeType == String &&
           (value! as String).startsWith(jsonListPrefix)) {

--- a/packages/shared_preferences/shared_preferences_android/lib/src/shared_preferences_async_android.dart
+++ b/packages/shared_preferences/shared_preferences_android/lib/src/shared_preferences_async_android.dart
@@ -23,11 +23,14 @@ base class SharedPreferencesAsyncAndroid
   SharedPreferencesAsyncAndroid({
     @visibleForTesting SharedPreferencesAsyncApi? dataStoreApi,
     @visibleForTesting SharedPreferencesAsyncApi? sharedPreferencesApi,
-  })  : _dataStoreApi = dataStoreApi ??
-            SharedPreferencesAsyncApi(messageChannelSuffix: 'data_store'),
-        _sharedPreferencesApi = sharedPreferencesApi ??
-            SharedPreferencesAsyncApi(
-                messageChannelSuffix: 'shared_preferences');
+  }) : _dataStoreApi =
+           dataStoreApi ??
+           SharedPreferencesAsyncApi(messageChannelSuffix: 'data_store'),
+       _sharedPreferencesApi =
+           sharedPreferencesApi ??
+           SharedPreferencesAsyncApi(
+             messageChannelSuffix: 'shared_preferences',
+           );
 
   final SharedPreferencesAsyncApi _dataStoreApi;
   final SharedPreferencesAsyncApi _sharedPreferencesApi;
@@ -40,7 +43,8 @@ base class SharedPreferencesAsyncAndroid
   /// Returns a SharedPreferencesPigeonOptions for sending to platform.
   @visibleForTesting
   SharedPreferencesPigeonOptions convertOptionsToPigeonOptions(
-      SharedPreferencesOptions options) {
+    SharedPreferencesOptions options,
+  ) {
     if (options is SharedPreferencesAsyncAndroidOptions) {
       return SharedPreferencesPigeonOptions(
         fileName: options.originalSharedPreferencesOptions?.fileName,
@@ -55,7 +59,8 @@ base class SharedPreferencesAsyncAndroid
   /// the passed in [SharedPreferencesPigeonOptions].
   @visibleForTesting
   SharedPreferencesAsyncApi getApiForBackend(
-      SharedPreferencesPigeonOptions options) {
+    SharedPreferencesPigeonOptions options,
+  ) {
     return options.useDataStore ? _dataStoreApi : _sharedPreferencesApi;
   }
 
@@ -71,8 +76,7 @@ base class SharedPreferencesAsyncAndroid
     return (await api.getKeys(
       filter.allowList?.toList(),
       pigeonOptions,
-    ))
-        .toSet();
+    )).toSet();
   }
 
   @override
@@ -83,7 +87,8 @@ base class SharedPreferencesAsyncAndroid
   ) async {
     if (value.startsWith(_listPrefix)) {
       throw ArgumentError(
-          'StorageError: This string cannot be stored as it clashes with special identifier prefixes');
+        'StorageError: This string cannot be stored as it clashes with special identifier prefixes',
+      );
     }
     final SharedPreferencesPigeonOptions pigeonOptions =
         convertOptionsToPigeonOptions(options);
@@ -150,19 +155,18 @@ base class SharedPreferencesAsyncAndroid
         convertOptionsToPigeonOptions(options);
     final SharedPreferencesAsyncApi api = getApiForBackend(pigeonOptions);
     return _convertKnownExceptions<String>(
-        () async => api.getString(key, pigeonOptions));
+      () async => api.getString(key, pigeonOptions),
+    );
   }
 
   @override
-  Future<bool?> getBool(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async {
     final SharedPreferencesPigeonOptions pigeonOptions =
         convertOptionsToPigeonOptions(options);
     final SharedPreferencesAsyncApi api = getApiForBackend(pigeonOptions);
     return _convertKnownExceptions<bool>(
-        () async => api.getBool(key, pigeonOptions));
+      () async => api.getBool(key, pigeonOptions),
+    );
   }
 
   @override
@@ -174,19 +178,18 @@ base class SharedPreferencesAsyncAndroid
         convertOptionsToPigeonOptions(options);
     final SharedPreferencesAsyncApi api = getApiForBackend(pigeonOptions);
     return _convertKnownExceptions<double>(
-        () async => api.getDouble(key, pigeonOptions));
+      () async => api.getDouble(key, pigeonOptions),
+    );
   }
 
   @override
-  Future<int?> getInt(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
+  Future<int?> getInt(String key, SharedPreferencesOptions options) async {
     final SharedPreferencesPigeonOptions pigeonOptions =
         convertOptionsToPigeonOptions(options);
     final SharedPreferencesAsyncApi api = getApiForBackend(pigeonOptions);
     return _convertKnownExceptions<int>(
-        () async => api.getInt(key, pigeonOptions));
+      () async => api.getInt(key, pigeonOptions),
+    );
   }
 
   @override
@@ -200,7 +203,8 @@ base class SharedPreferencesAsyncAndroid
     // Request JSON encoded string list.
     final StringListResult? result =
         await _convertKnownExceptions<StringListResult?>(
-            () async => api.getStringList(key, pigeonOptions));
+          () async => api.getStringList(key, pigeonOptions),
+        );
     if (result == null) {
       return null;
     }
@@ -208,8 +212,9 @@ base class SharedPreferencesAsyncAndroid
       case StringListLookupResultType.jsonEncoded:
         // Force-unwrap is safe because a value is always set for this type.
         final String jsonEncodedStringList = result.jsonEncodedValue!;
-        final String jsonEncodedString =
-            jsonEncodedStringList.substring(jsonListPrefix.length);
+        final String jsonEncodedString = jsonEncodedStringList.substring(
+          jsonListPrefix.length,
+        );
         try {
           final List<String> decodedList =
               (jsonDecode(jsonEncodedString) as List<dynamic>).cast<String>();
@@ -219,8 +224,9 @@ base class SharedPreferencesAsyncAndroid
         }
       case StringListLookupResultType.platformEncoded:
         final List<String>? stringList =
-            await _convertKnownExceptions<List<String>?>(() async =>
-                api.getPlatformEncodedStringList(key, pigeonOptions));
+            await _convertKnownExceptions<List<String>?>(
+              () async => api.getPlatformEncodedStringList(key, pigeonOptions),
+            );
         return stringList?.cast<String>().toList();
       case StringListLookupResultType.unexpectedString:
         throw TypeError();
@@ -249,10 +255,7 @@ base class SharedPreferencesAsyncAndroid
     final SharedPreferencesPigeonOptions pigeonOptions =
         convertOptionsToPigeonOptions(options);
     final SharedPreferencesAsyncApi api = getApiForBackend(pigeonOptions);
-    return api.clear(
-      filter.allowList?.toList(),
-      pigeonOptions,
-    );
+    return api.clear(filter.allowList?.toList(), pigeonOptions);
   }
 
   @override
@@ -270,9 +273,10 @@ base class SharedPreferencesAsyncAndroid
     );
     data.forEach((String? key, Object? value) {
       if (value is String && value.startsWith(jsonListPrefix)) {
-        data[key!] = (jsonDecode(value.substring(jsonListPrefix.length))
-                as List<dynamic>)
-            .cast<String>();
+        data[key!] =
+            (jsonDecode(value.substring(jsonListPrefix.length))
+                    as List<dynamic>)
+                .cast<String>();
       }
     });
     return data.cast<String, Object>();

--- a/packages/shared_preferences/shared_preferences_android/pigeons/messages.dart
+++ b/packages/shared_preferences/shared_preferences_android/pigeons/messages.dart
@@ -4,15 +4,19 @@
 
 import 'package:pigeon/pigeon.dart';
 
-@ConfigurePigeon(PigeonOptions(
-  input: 'pigeons/messages.dart',
-  javaOut:
-      'android/src/main/java/io/flutter/plugins/sharedpreferences/Messages.java',
-  javaOptions: JavaOptions(
-      className: 'Messages', package: 'io.flutter.plugins.sharedpreferences'),
-  dartOut: 'lib/src/messages.g.dart',
-  copyrightHeader: 'pigeons/copyright.txt',
-))
+@ConfigurePigeon(
+  PigeonOptions(
+    input: 'pigeons/messages.dart',
+    javaOut:
+        'android/src/main/java/io/flutter/plugins/sharedpreferences/Messages.java',
+    javaOptions: JavaOptions(
+      className: 'Messages',
+      package: 'io.flutter.plugins.sharedpreferences',
+    ),
+    dartOut: 'lib/src/messages.g.dart',
+    copyrightHeader: 'pigeons/copyright.txt',
+  ),
+)
 @HostApi(dartHostTestHandler: 'TestSharedPreferencesApi')
 abstract class SharedPreferencesApi {
   /// Removes property from shared preferences data set.
@@ -47,15 +51,9 @@ abstract class SharedPreferencesApi {
 
   /// Removes all properties from shared preferences data set with matching prefix.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  bool clear(
-    String prefix,
-    List<String>? allowList,
-  );
+  bool clear(String prefix, List<String>? allowList);
 
   /// Gets all properties from shared preferences data set with matching prefix.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  Map<String, Object> getAll(
-    String prefix,
-    List<String>? allowList,
-  );
+  Map<String, Object> getAll(String prefix, List<String>? allowList);
 }

--- a/packages/shared_preferences/shared_preferences_android/pigeons/messages_async.dart
+++ b/packages/shared_preferences/shared_preferences_android/pigeons/messages_async.dart
@@ -4,18 +4,19 @@
 
 import 'package:pigeon/pigeon.dart';
 
-@ConfigurePigeon(PigeonOptions(
-  input: 'pigeons/messages_async.dart',
-  kotlinOut:
-      'android/src/main/kotlin/io/flutter/plugins/sharedpreferences/MessagesAsync.g.kt',
-  kotlinOptions: KotlinOptions(
-    package: 'io.flutter.plugins.sharedpreferences',
-    errorClassName: 'SharedPreferencesError',
+@ConfigurePigeon(
+  PigeonOptions(
+    input: 'pigeons/messages_async.dart',
+    kotlinOut:
+        'android/src/main/kotlin/io/flutter/plugins/sharedpreferences/MessagesAsync.g.kt',
+    kotlinOptions: KotlinOptions(
+      package: 'io.flutter.plugins.sharedpreferences',
+      errorClassName: 'SharedPreferencesError',
+    ),
+    dartOut: 'lib/src/messages_async.g.dart',
+    copyrightHeader: 'pigeons/copyright.txt',
   ),
-  dartOut: 'lib/src/messages_async.g.dart',
-  copyrightHeader: 'pigeons/copyright.txt',
-))
-
+)
 /// Possible types found during a getStringList call.
 enum StringListLookupResultType {
   /// A deprecated platform-side encoding string list.
@@ -32,19 +33,13 @@ enum StringListLookupResultType {
 }
 
 class SharedPreferencesPigeonOptions {
-  SharedPreferencesPigeonOptions({
-    this.fileName,
-    this.useDataStore = true,
-  });
+  SharedPreferencesPigeonOptions({this.fileName, this.useDataStore = true});
   String? fileName;
   bool useDataStore;
 }
 
 class StringListResult {
-  StringListResult({
-    required this.jsonEncodedValue,
-    required this.type,
-  });
+  StringListResult({required this.jsonEncodedValue, required this.type});
 
   /// The JSON-encoded stored value, or null if something else was found.
   String? jsonEncodedValue;
@@ -69,11 +64,7 @@ abstract class SharedPreferencesAsyncApi {
 
   /// Adds property to shared preferences data set of type int.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  void setInt(
-    String key,
-    int value,
-    SharedPreferencesPigeonOptions options,
-  );
+  void setInt(String key, int value, SharedPreferencesPigeonOptions options);
 
   /// Adds property to shared preferences data set of type double.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
@@ -103,31 +94,19 @@ abstract class SharedPreferencesAsyncApi {
 
   /// Gets individual String value stored with [key], if any.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  String? getString(
-    String key,
-    SharedPreferencesPigeonOptions options,
-  );
+  String? getString(String key, SharedPreferencesPigeonOptions options);
 
   /// Gets individual  void value stored with [key], if any.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  bool? getBool(
-    String key,
-    SharedPreferencesPigeonOptions options,
-  );
+  bool? getBool(String key, SharedPreferencesPigeonOptions options);
 
   /// Gets individual double value stored with [key], if any.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  double? getDouble(
-    String key,
-    SharedPreferencesPigeonOptions options,
-  );
+  double? getDouble(String key, SharedPreferencesPigeonOptions options);
 
   /// Gets individual int value stored with [key], if any.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  int? getInt(
-    String key,
-    SharedPreferencesPigeonOptions options,
-  );
+  int? getInt(String key, SharedPreferencesPigeonOptions options);
 
   /// Gets individual List<String> value stored with [key], if any.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
@@ -145,10 +124,7 @@ abstract class SharedPreferencesAsyncApi {
 
   /// Removes all properties from shared preferences data set with matching prefix.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  void clear(
-    List<String>? allowList,
-    SharedPreferencesPigeonOptions options,
-  );
+  void clear(List<String>? allowList, SharedPreferencesPigeonOptions options);
 
   /// Gets all properties from shared preferences data set with matching prefix.
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.4.11
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_android/test/shared_preferences_android_test.dart
+++ b/packages/shared_preferences/shared_preferences_android/test/shared_preferences_android_test.dart
@@ -65,8 +65,10 @@ void main() {
 
   test('registerWith', () async {
     SharedPreferencesAndroid.registerWith();
-    expect(SharedPreferencesStorePlatform.instance,
-        isA<SharedPreferencesAndroid>());
+    expect(
+      SharedPreferencesStorePlatform.instance,
+      isA<SharedPreferencesAndroid>(),
+    );
   });
 
   test('remove', () async {
@@ -101,22 +103,16 @@ void main() {
     }
 
     Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 5);
     await plugin.clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     all = await plugin.getAll();
     expect(all.length, 5);
     all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 0);
   });
@@ -127,9 +123,7 @@ void main() {
     }
 
     Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 5);
     await plugin.clearWithParameters(
@@ -143,9 +137,7 @@ void main() {
     all = await plugin.getAll();
     expect(all.length, 5);
     all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 4);
   });
@@ -185,9 +177,7 @@ void main() {
       api.items[key] = allTestValuesForAddingDirectlyToCache[key]!;
     }
     final Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 5);
     expect(all, prefixTestValues);
@@ -219,11 +209,13 @@ void main() {
     expect(await plugin.setValue('String', 'flutter.String', 'hi'), isTrue);
     expect(api.items['flutter.String'], 'hi');
     expect(
-        await plugin
-            .setValue('StringList', 'flutter.StringList', <String>['hi']),
-        isTrue);
-    expect(api.items['flutter.StringList'],
-        '$jsonListPrefix${jsonEncode(<String>['hi'])}');
+      await plugin.setValue('StringList', 'flutter.StringList', <String>['hi']),
+      isTrue,
+    );
+    expect(
+      api.items['flutter.StringList'],
+      '$jsonListPrefix${jsonEncode(<String>['hi'])}',
+    );
   });
 
   test('setValue with unsupported type', () async {
@@ -237,9 +229,7 @@ void main() {
       api.items[key] = allTestValuesForAddingDirectlyToCache[key]!;
     }
     final Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(all.length, 15);
     expect(all, allTestValuesForComparison);
@@ -251,20 +241,14 @@ void main() {
     }
 
     Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(all.length, 15);
     await plugin.clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: '')),
     );
     all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(all.length, 0);
   });
@@ -286,7 +270,7 @@ class _FakeSharedPreferencesApi implements SharedPreferencesApi {
       for (final String key in items.keys)
         if (key.startsWith(prefix) &&
             (allowSet == null || allowSet.contains(key)))
-          key: items[key]!
+          key: items[key]!,
     };
     filteredItems.forEach((String? key, Object? value) {
       if (value.runtimeType == String &&

--- a/packages/shared_preferences/shared_preferences_android/test/shared_preferences_async_test.dart
+++ b/packages/shared_preferences/shared_preferences_android/test/shared_preferences_async_test.dart
@@ -32,9 +32,9 @@ void main() {
     final _FakeSharedPreferencesApi api = _FakeSharedPreferencesApi();
     final SharedPreferencesAsyncAndroid preferences =
         SharedPreferencesAsyncAndroid(
-      dataStoreApi: api,
-      sharedPreferencesApi: api,
-    );
+          dataStoreApi: api,
+          sharedPreferencesApi: api,
+        );
 
     return preferences;
   }
@@ -44,68 +44,78 @@ void main() {
 
     final SharedPreferencesAsyncAndroidOptions emptyOptions =
         SharedPreferencesAsyncAndroidOptions(
-      backend: useDataStore
-          ? SharedPreferencesAndroidBackendLibrary.DataStore
-          : SharedPreferencesAndroidBackendLibrary.SharedPreferences,
-    );
+          backend:
+              useDataStore
+                  ? SharedPreferencesAndroidBackendLibrary.DataStore
+                  : SharedPreferencesAndroidBackendLibrary.SharedPreferences,
+        );
 
     test('set and get String with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
 
       await preferences.setString(stringKey, testString, emptyOptions);
       expect(await preferences.getString(stringKey, emptyOptions), testString);
     });
 
     test('set and get bool with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
 
       await preferences.setBool(boolKey, testBool, emptyOptions);
       expect(await preferences.getBool(boolKey, emptyOptions), testBool);
     });
 
     test('set and get int with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
 
       await preferences.setInt(intKey, testInt, emptyOptions);
       expect(await preferences.getInt(intKey, emptyOptions), testInt);
     });
 
     test('set and get double with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
 
       await preferences.setDouble(doubleKey, testDouble, emptyOptions);
       expect(await preferences.getDouble(doubleKey, emptyOptions), testDouble);
     });
 
     test('set and get StringList with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
 
       await preferences.setStringList(listKey, testList, emptyOptions);
-      final List<String>? response =
-          await preferences.getStringList(listKey, emptyOptions);
+      final List<String>? response = await preferences.getStringList(
+        listKey,
+        emptyOptions,
+      );
 
       expect(response, testList);
     });
 
     test('getPreferences with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString, emptyOptions),
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getPreferences(
-          const GetPreferencesParameters(filter: PreferencesFilters()),
-          emptyOptions);
+        const GetPreferencesParameters(filter: PreferencesFilters()),
+        emptyOptions,
+      );
 
       expect(gotAll.length, 5);
       expect(gotAll[stringKey], testString);
@@ -116,21 +126,23 @@ void main() {
     });
 
     test('getPreferences with filter with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString, emptyOptions),
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getPreferences(
-          const GetPreferencesParameters(
-              filter:
-                  PreferencesFilters(allowList: <String>{stringKey, boolKey})),
-          emptyOptions);
+        const GetPreferencesParameters(
+          filter: PreferencesFilters(allowList: <String>{stringKey, boolKey}),
+        ),
+        emptyOptions,
+      );
 
       expect(gotAll.length, 2);
       expect(gotAll[stringKey], testString);
@@ -138,14 +150,15 @@ void main() {
     });
 
     test('getKeys with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString, emptyOptions),
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Set<String> keys = await preferences.getKeys(
@@ -162,14 +175,15 @@ void main() {
     });
 
     test('getKeys with filter with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString, emptyOptions),
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Set<String> keys = await preferences.getKeys(
@@ -185,18 +199,20 @@ void main() {
     });
 
     test('clear with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString, emptyOptions),
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
       await preferences.clear(
-          const ClearPreferencesParameters(filter: PreferencesFilters()),
-          emptyOptions);
+        const ClearPreferencesParameters(filter: PreferencesFilters()),
+        emptyOptions,
+      );
       expect(await preferences.getString(stringKey, emptyOptions), null);
       expect(await preferences.getBool(boolKey, emptyOptions), null);
       expect(await preferences.getInt(intKey, emptyOptions), null);
@@ -205,14 +221,15 @@ void main() {
     });
 
     test('clear with filter with $backend', () async {
-      final SharedPreferencesAsyncAndroid preferences =
-          getPreferences(useDataStore);
+      final SharedPreferencesAsyncAndroid preferences = getPreferences(
+        useDataStore,
+      );
       await Future.wait(<Future<void>>[
         preferences.setString(stringKey, testString, emptyOptions),
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
       await preferences.clear(
         const ClearPreferencesParameters(
@@ -243,7 +260,9 @@ class _FakeSharedPreferencesApi implements SharedPreferencesAsyncApi {
 
   @override
   Future<bool> clear(
-      List<String?>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String?>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     if (allowList != null) {
       items.removeWhere((String key, _) => allowList.contains(key));
     } else {
@@ -255,7 +274,9 @@ class _FakeSharedPreferencesApi implements SharedPreferencesAsyncApi {
 
   @override
   Future<Map<String, Object>> getAll(
-      List<String?>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String?>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final Map<String, Object> filteredItems = <String, Object>{...items};
     if (allowList != null) {
       filteredItems.removeWhere((String key, _) => !allowList.contains(key));
@@ -265,25 +286,33 @@ class _FakeSharedPreferencesApi implements SharedPreferencesAsyncApi {
 
   @override
   Future<bool?> getBool(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     return items[key] as bool?;
   }
 
   @override
   Future<double?> getDouble(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     return items[key] as double?;
   }
 
   @override
   Future<int?> getInt(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     return items[key] as int?;
   }
 
   @override
   Future<List<String>> getKeys(
-      List<String?>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String?>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final List<String> filteredItems = items.keys.toList();
     if (allowList != null) {
       filteredItems.removeWhere((String key) => !allowList.contains(key));
@@ -293,65 +322,90 @@ class _FakeSharedPreferencesApi implements SharedPreferencesAsyncApi {
 
   @override
   Future<String?> getString(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     return items[key] as String?;
   }
 
   @override
   Future<StringListResult?> getStringList(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final Object? value = items[key];
     return value == null
         ? null
         : StringListResult(
-            jsonEncodedValue: value as String?,
-            type: StringListLookupResultType.jsonEncoded);
+          jsonEncodedValue: value as String?,
+          type: StringListLookupResultType.jsonEncoded,
+        );
   }
 
   @override
   Future<List<String>?> getPlatformEncodedStringList(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     return items[key] as List<String>?;
   }
 
   @override
   Future<bool> setBool(
-      String key, bool value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    bool value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     items[key] = value;
     return true;
   }
 
   @override
   Future<bool> setDouble(
-      String key, double value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    double value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     items[key] = value;
     return true;
   }
 
   @override
   Future<bool> setInt(
-      String key, int value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    int value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     items[key] = value;
     return true;
   }
 
   @override
   Future<bool> setString(
-      String key, String value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    String value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     items[key] = value;
     return true;
   }
 
   @override
   Future<bool> setEncodedStringList(
-      String key, String value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    String value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     items[key] = '$jsonListPrefix${jsonEncode(value)}';
     return true;
   }
 
   @override
-  Future<bool> setDeprecatedStringList(String key, List<String> value,
-      SharedPreferencesPigeonOptions options) async {
+  Future<bool> setDeprecatedStringList(
+    String key,
+    List<String> value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     items[key] = value;
     return true;
   }

--- a/packages/shared_preferences/shared_preferences_foundation/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_foundation/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 
 ## 2.5.4
 

--- a/packages/shared_preferences/shared_preferences_foundation/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/example/integration_test/shared_preferences_test.dart
@@ -51,17 +51,15 @@ void main() {
 
     tearDown(() async {
       await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        ClearParameters(filter: PreferencesFilter(prefix: '')),
       );
     });
 
     group('withPrefix', () {
       testWidgets('reading', (WidgetTester _) async {
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('');
         expect(values['String'], isNull);
         expect(values['Bool'], isNull);
         expect(values['Int'], isNull);
@@ -72,29 +70,59 @@ void main() {
       testWidgets('getAllWithPrefix', (WidgetTester _) async {
         await Future.wait(<Future<bool>>[
           preferences.setValue(
-              'String', 'prefix.String', allTestValues['prefix.String']!),
+            'String',
+            'prefix.String',
+            allTestValues['prefix.String']!,
+          ),
           preferences.setValue(
-              'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!),
+            'Bool',
+            'prefix.Bool',
+            allTestValues['prefix.Bool']!,
+          ),
           preferences.setValue(
-              'Int', 'prefix.Int', allTestValues['prefix.Int']!),
+            'Int',
+            'prefix.Int',
+            allTestValues['prefix.Int']!,
+          ),
           preferences.setValue(
-              'Double', 'prefix.Double', allTestValues['prefix.Double']!),
-          preferences.setValue('StringList', 'prefix.StringList',
-              allTestValues['prefix.StringList']!),
+            'Double',
+            'prefix.Double',
+            allTestValues['prefix.Double']!,
+          ),
           preferences.setValue(
-              'String', 'flutter.String', allTestValues['flutter.String']!),
+            'StringList',
+            'prefix.StringList',
+            allTestValues['prefix.StringList']!,
+          ),
           preferences.setValue(
-              'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!),
+            'String',
+            'flutter.String',
+            allTestValues['flutter.String']!,
+          ),
           preferences.setValue(
-              'Int', 'flutter.Int', allTestValues['flutter.Int']!),
+            'Bool',
+            'flutter.Bool',
+            allTestValues['flutter.Bool']!,
+          ),
           preferences.setValue(
-              'Double', 'flutter.Double', allTestValues['flutter.Double']!),
-          preferences.setValue('StringList', 'flutter.StringList',
-              allTestValues['flutter.StringList']!)
+            'Int',
+            'flutter.Int',
+            allTestValues['flutter.Int']!,
+          ),
+          preferences.setValue(
+            'Double',
+            'flutter.Double',
+            allTestValues['flutter.Double']!,
+          ),
+          preferences.setValue(
+            'StringList',
+            'flutter.StringList',
+            allTestValues['flutter.StringList']!,
+          ),
         ]);
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('prefix.');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('prefix.');
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
         expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -105,31 +133,61 @@ void main() {
       testWidgets('clearWithPrefix', (WidgetTester _) async {
         await Future.wait(<Future<bool>>[
           preferences.setValue(
-              'String', 'prefix.String', allTestValues['prefix.String']!),
+            'String',
+            'prefix.String',
+            allTestValues['prefix.String']!,
+          ),
           preferences.setValue(
-              'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!),
+            'Bool',
+            'prefix.Bool',
+            allTestValues['prefix.Bool']!,
+          ),
           preferences.setValue(
-              'Int', 'prefix.Int', allTestValues['prefix.Int']!),
+            'Int',
+            'prefix.Int',
+            allTestValues['prefix.Int']!,
+          ),
           preferences.setValue(
-              'Double', 'prefix.Double', allTestValues['prefix.Double']!),
-          preferences.setValue('StringList', 'prefix.StringList',
-              allTestValues['prefix.StringList']!),
+            'Double',
+            'prefix.Double',
+            allTestValues['prefix.Double']!,
+          ),
           preferences.setValue(
-              'String', 'flutter.String', allTestValues['flutter.String']!),
+            'StringList',
+            'prefix.StringList',
+            allTestValues['prefix.StringList']!,
+          ),
           preferences.setValue(
-              'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!),
+            'String',
+            'flutter.String',
+            allTestValues['flutter.String']!,
+          ),
           preferences.setValue(
-              'Int', 'flutter.Int', allTestValues['flutter.Int']!),
+            'Bool',
+            'flutter.Bool',
+            allTestValues['flutter.Bool']!,
+          ),
           preferences.setValue(
-              'Double', 'flutter.Double', allTestValues['flutter.Double']!),
-          preferences.setValue('StringList', 'flutter.StringList',
-              allTestValues['flutter.StringList']!)
+            'Int',
+            'flutter.Int',
+            allTestValues['flutter.Int']!,
+          ),
+          preferences.setValue(
+            'Double',
+            'flutter.Double',
+            allTestValues['flutter.Double']!,
+          ),
+          preferences.setValue(
+            'StringList',
+            'flutter.StringList',
+            allTestValues['flutter.StringList']!,
+          ),
         ]);
         // ignore: deprecated_member_use
         await preferences.clearWithPrefix('prefix.');
         Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('prefix.');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('prefix.');
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -142,7 +200,9 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
@@ -152,21 +212,39 @@ void main() {
           preferences.setValue('Int', 'Int', allTestValues['Int']!),
           preferences.setValue('Double', 'Double', allTestValues['Double']!),
           preferences.setValue(
-              'StringList', 'StringList', allTestValues['StringList']!),
+            'StringList',
+            'StringList',
+            allTestValues['StringList']!,
+          ),
           preferences.setValue(
-              'String', 'flutter.String', allTestValues['flutter.String']!),
+            'String',
+            'flutter.String',
+            allTestValues['flutter.String']!,
+          ),
           preferences.setValue(
-              'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!),
+            'Bool',
+            'flutter.Bool',
+            allTestValues['flutter.Bool']!,
+          ),
           preferences.setValue(
-              'Int', 'flutter.Int', allTestValues['flutter.Int']!),
+            'Int',
+            'flutter.Int',
+            allTestValues['flutter.Int']!,
+          ),
           preferences.setValue(
-              'Double', 'flutter.Double', allTestValues['flutter.Double']!),
-          preferences.setValue('StringList', 'flutter.StringList',
-              allTestValues['flutter.StringList']!)
+            'Double',
+            'flutter.Double',
+            allTestValues['flutter.Double']!,
+          ),
+          preferences.setValue(
+            'StringList',
+            'flutter.StringList',
+            allTestValues['flutter.StringList']!,
+          ),
         ]);
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('');
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -177,7 +255,9 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
@@ -187,23 +267,41 @@ void main() {
           preferences.setValue('Int', 'Int', allTestValues['Int']!),
           preferences.setValue('Double', 'Double', allTestValues['Double']!),
           preferences.setValue(
-              'StringList', 'StringList', allTestValues['StringList']!),
+            'StringList',
+            'StringList',
+            allTestValues['StringList']!,
+          ),
           preferences.setValue(
-              'String', 'flutter.String', allTestValues['flutter.String']!),
+            'String',
+            'flutter.String',
+            allTestValues['flutter.String']!,
+          ),
           preferences.setValue(
-              'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!),
+            'Bool',
+            'flutter.Bool',
+            allTestValues['flutter.Bool']!,
+          ),
           preferences.setValue(
-              'Int', 'flutter.Int', allTestValues['flutter.Int']!),
+            'Int',
+            'flutter.Int',
+            allTestValues['flutter.Int']!,
+          ),
           preferences.setValue(
-              'Double', 'flutter.Double', allTestValues['flutter.Double']!),
-          preferences.setValue('StringList', 'flutter.StringList',
-              allTestValues['flutter.StringList']!)
+            'Double',
+            'flutter.Double',
+            allTestValues['flutter.Double']!,
+          ),
+          preferences.setValue(
+            'StringList',
+            'flutter.StringList',
+            allTestValues['flutter.StringList']!,
+          ),
         ]);
         // ignore: deprecated_member_use
         await preferences.clearWithPrefix('');
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('');
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -219,12 +317,10 @@ void main() {
 
     group('withParameters', () {
       testWidgets('reading', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], isNull);
         expect(values['Bool'], isNull);
         expect(values['Int'], isNull);
@@ -234,43 +330,80 @@ void main() {
 
       Future<void> addData() async {
         await preferences.setValue(
-            'String', 'String', allTestValues['String']!);
+          'String',
+          'String',
+          allTestValues['String']!,
+        );
         await preferences.setValue('Bool', 'Bool', allTestValues['Bool']!);
         await preferences.setValue('Int', 'Int', allTestValues['Int']!);
         await preferences.setValue(
-            'Double', 'Double', allTestValues['Double']!);
+          'Double',
+          'Double',
+          allTestValues['Double']!,
+        );
         await preferences.setValue(
-            'StringList', 'StringList', allTestValues['StringList']!);
+          'StringList',
+          'StringList',
+          allTestValues['StringList']!,
+        );
         await preferences.setValue(
-            'String', 'prefix.String', allTestValues['prefix.String']!);
+          'String',
+          'prefix.String',
+          allTestValues['prefix.String']!,
+        );
         await preferences.setValue(
-            'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!);
+          'Bool',
+          'prefix.Bool',
+          allTestValues['prefix.Bool']!,
+        );
         await preferences.setValue(
-            'Int', 'prefix.Int', allTestValues['prefix.Int']!);
+          'Int',
+          'prefix.Int',
+          allTestValues['prefix.Int']!,
+        );
         await preferences.setValue(
-            'Double', 'prefix.Double', allTestValues['prefix.Double']!);
-        await preferences.setValue('StringList', 'prefix.StringList',
-            allTestValues['prefix.StringList']!);
+          'Double',
+          'prefix.Double',
+          allTestValues['prefix.Double']!,
+        );
         await preferences.setValue(
-            'String', 'flutter.String', allTestValues['flutter.String']!);
+          'StringList',
+          'prefix.StringList',
+          allTestValues['prefix.StringList']!,
+        );
         await preferences.setValue(
-            'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+          'String',
+          'flutter.String',
+          allTestValues['flutter.String']!,
+        );
         await preferences.setValue(
-            'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+          'Bool',
+          'flutter.Bool',
+          allTestValues['flutter.Bool']!,
+        );
         await preferences.setValue(
-            'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-        await preferences.setValue('StringList', 'flutter.StringList',
-            allTestValues['flutter.StringList']!);
+          'Int',
+          'flutter.Int',
+          allTestValues['flutter.Int']!,
+        );
+        await preferences.setValue(
+          'Double',
+          'flutter.Double',
+          allTestValues['flutter.Double']!,
+        );
+        await preferences.setValue(
+          'StringList',
+          'flutter.StringList',
+          allTestValues['flutter.StringList']!,
+        );
       }
 
       testWidgets('get all with prefix', (WidgetTester _) async {
         await addData();
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+            );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
         expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -280,15 +413,15 @@ void main() {
 
       testWidgets('get all with allow list', (WidgetTester _) async {
         await addData();
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(
-              prefix: 'prefix.',
-              allowList: <String>{'prefix.String'},
-            ),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(
+                filter: PreferencesFilter(
+                  prefix: 'prefix.',
+                  allowList: <String>{'prefix.String'},
+                ),
+              ),
+            );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -298,12 +431,10 @@ void main() {
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
         await addData();
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -314,20 +445,18 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithParameters', (WidgetTester _) async {
         await addData();
         await preferences.clearWithParameters(
-          ClearParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         Map<String, Object> values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
@@ -335,20 +464,21 @@ void main() {
         expect(values['prefix.Double'], null);
         expect(values['prefix.StringList'], null);
         values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'flutter.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
         );
         expect(values['flutter.String'], allTestValues['flutter.String']);
         expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
-      testWidgets('clearWithParameters with allow list',
-          (WidgetTester _) async {
+      testWidgets('clearWithParameters with allow list', (
+        WidgetTester _,
+      ) async {
         await addData();
         await preferences.clearWithParameters(
           ClearParameters(
@@ -359,9 +489,7 @@ void main() {
           ),
         );
         Map<String, Object> values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
@@ -369,31 +497,27 @@ void main() {
         expect(values['prefix.Double'], allTestValues['prefix.Double']);
         expect(values['prefix.StringList'], null);
         values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'flutter.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
         );
         expect(values['flutter.String'], allTestValues['flutter.String']);
         expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
         await addData();
         await preferences.clearWithParameters(
-          ClearParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
+          ClearParameters(filter: PreferencesFilter(prefix: '')),
         );
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -409,15 +533,30 @@ void main() {
 
     testWidgets('getAll', (WidgetTester _) async {
       await preferences.setValue(
-          'String', 'flutter.String', allTestValues['flutter.String']!);
+        'String',
+        'flutter.String',
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue(
-          'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+        'Bool',
+        'flutter.Bool',
+        allTestValues['flutter.Bool']!,
+      );
       await preferences.setValue(
-          'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+        'Int',
+        'flutter.Int',
+        allTestValues['flutter.Int']!,
+      );
       await preferences.setValue(
-          'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-      await preferences.setValue('StringList', 'flutter.StringList',
-          allTestValues['flutter.StringList']!);
+        'Double',
+        'flutter.Double',
+        allTestValues['flutter.Double']!,
+      );
+      await preferences.setValue(
+        'StringList',
+        'flutter.StringList',
+        allTestValues['flutter.StringList']!,
+      );
       final Map<String, Object> values = await preferences.getAll();
       expect(values['flutter.String'], allTestValues['flutter.String']);
       expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
@@ -429,33 +568,55 @@ void main() {
     testWidgets('remove', (WidgetTester _) async {
       const String key = 'testKey';
       await preferences.setValue(
-          'String', key, allTestValues['flutter.String']!);
+        'String',
+        key,
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue('Bool', key, allTestValues['flutter.Bool']!);
       await preferences.setValue('Int', key, allTestValues['flutter.Int']!);
       await preferences.setValue(
-          'Double', key, allTestValues['flutter.Double']!);
+        'Double',
+        key,
+        allTestValues['flutter.Double']!,
+      );
       await preferences.setValue(
-          'StringList', key, allTestValues['flutter.StringList']!);
+        'StringList',
+        key,
+        allTestValues['flutter.StringList']!,
+      );
       await preferences.remove(key);
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
       expect(values[key], isNull);
     });
 
     testWidgets('clear', (WidgetTester _) async {
       await preferences.setValue(
-          'String', 'flutter.String', allTestValues['flutter.String']!);
+        'String',
+        'flutter.String',
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue(
-          'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+        'Bool',
+        'flutter.Bool',
+        allTestValues['flutter.Bool']!,
+      );
       await preferences.setValue(
-          'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+        'Int',
+        'flutter.Int',
+        allTestValues['flutter.Int']!,
+      );
       await preferences.setValue(
-          'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-      await preferences.setValue('StringList', 'flutter.StringList',
-          allTestValues['flutter.StringList']!);
+        'Double',
+        'flutter.Double',
+        allTestValues['flutter.Double']!,
+      );
+      await preferences.setValue(
+        'StringList',
+        'flutter.StringList',
+        allTestValues['flutter.StringList']!,
+      );
       await preferences.clear();
       final Map<String, Object> values = await preferences.getAll();
       expect(values['flutter.String'], null);
@@ -476,9 +637,7 @@ void main() {
       expect(result.where((bool element) => !element), isEmpty);
       // The last write should win.
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
       expect(values['Int'], writeCount);
     });
@@ -489,7 +648,8 @@ void main() {
         SharedPreferencesAsyncFoundationOptions();
     final SharedPreferencesAsyncFoundationOptions optionsWithSuiteName =
         SharedPreferencesAsyncFoundationOptions(
-            suiteName: 'group.example.sharedPreferencesFoundation');
+          suiteName: 'group.example.sharedPreferencesFoundation',
+        );
 
     const String stringKey = 'testString';
     const String boolKey = 'testBool';
@@ -507,11 +667,13 @@ void main() {
       final SharedPreferencesAsyncPlatform preferences =
           SharedPreferencesAsyncPlatform.instance!;
       await preferences.clear(
-          const ClearPreferencesParameters(filter: PreferencesFilters()),
-          emptyOptions);
+        const ClearPreferencesParameters(filter: PreferencesFilters()),
+        emptyOptions,
+      );
       await preferences.clear(
-          const ClearPreferencesParameters(filter: PreferencesFilters()),
-          optionsWithSuiteName);
+        const ClearPreferencesParameters(filter: PreferencesFilters()),
+        optionsWithSuiteName,
+      );
       return preferences;
     }
 
@@ -554,8 +716,10 @@ void main() {
       final SharedPreferencesAsyncPlatform preferences = await getPreferences();
 
       await preferences.setStringList(listKey, testList, emptyOptions);
-      final List<String>? list =
-          await preferences.getStringList(listKey, emptyOptions);
+      final List<String>? list = await preferences.getStringList(
+        listKey,
+        emptyOptions,
+      );
       list?.add('value');
       expect(list?.length, testList.length + 1);
     });
@@ -567,7 +731,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getPreferences(
@@ -590,20 +754,20 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, optionsWithSuiteName),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, optionsWithSuiteName)
+        preferences.setStringList(listKey, testList, optionsWithSuiteName),
       ]);
 
-      final Map<String, Object?> preferencesWithEmptyOptions =
-          await preferences.getPreferences(
-        const GetPreferencesParameters(filter: PreferencesFilters()),
-        emptyOptions,
-      );
+      final Map<String, Object?> preferencesWithEmptyOptions = await preferences
+          .getPreferences(
+            const GetPreferencesParameters(filter: PreferencesFilters()),
+            emptyOptions,
+          );
 
-      final Map<String, Object?> preferencesWithSuiteName =
-          await preferences.getPreferences(
-        const GetPreferencesParameters(filter: PreferencesFilters()),
-        optionsWithSuiteName,
-      );
+      final Map<String, Object?> preferencesWithSuiteName = await preferences
+          .getPreferences(
+            const GetPreferencesParameters(filter: PreferencesFilters()),
+            optionsWithSuiteName,
+          );
 
       expect(preferencesWithEmptyOptions.length, 2);
       expect(preferencesWithSuiteName.length, 3);
@@ -623,7 +787,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getPreferences(
@@ -645,7 +809,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Set<String> keys = await preferences.getKeys(
@@ -668,7 +832,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, optionsWithSuiteName),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, optionsWithSuiteName)
+        preferences.setStringList(listKey, testList, optionsWithSuiteName),
       ]);
 
       final Set<String> keysWithEmptyOptions = await preferences.getKeys(
@@ -699,7 +863,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Set<String> keys = await preferences.getKeys(
@@ -721,7 +885,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       await preferences.clear(
@@ -743,7 +907,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
       await preferences.clear(
         const ClearPreferencesParameters(

--- a/packages/shared_preferences/shared_preferences_foundation/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/example/lib/main.dart
@@ -67,29 +67,29 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('SharedPreferences Demo'),
-      ),
+      appBar: AppBar(title: const Text('SharedPreferences Demo')),
       body: Center(
-          child: FutureBuilder<int>(
-              future: _counter,
-              builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-                switch (snapshot.connectionState) {
-                  case ConnectionState.none:
-                  case ConnectionState.waiting:
-                    return const CircularProgressIndicator();
-                  case ConnectionState.active:
-                  case ConnectionState.done:
-                    if (snapshot.hasError) {
-                      return Text('Error: ${snapshot.error}');
-                    } else {
-                      return Text(
-                        'Button tapped ${snapshot.data} time${snapshot.data == 1 ? '' : 's'}.\n\n'
-                        'This should persist across restarts.',
-                      );
-                    }
+        child: FutureBuilder<int>(
+          future: _counter,
+          builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+            switch (snapshot.connectionState) {
+              case ConnectionState.none:
+              case ConnectionState.waiting:
+                return const CircularProgressIndicator();
+              case ConnectionState.active:
+              case ConnectionState.done:
+                if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                } else {
+                  return Text(
+                    'Button tapped ${snapshot.data} time${snapshot.data == 1 ? '' : 's'}.\n\n'
+                    'This should persist across restarts.',
+                  );
                 }
-              })),
+            }
+          },
+        ),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,
         tooltip: 'Increment',

--- a/packages/shared_preferences/shared_preferences_foundation/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_foundation/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Testbed for the shared_preferences_foundation implementation.
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_foundation/lib/src/messages.g.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/lib/src/messages.g.dart
@@ -18,8 +18,11 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({
+  Object? result,
+  PlatformException? error,
+  bool empty = false,
+}) {
   if (empty) {
     return <Object?>[];
   }
@@ -30,23 +33,17 @@ List<Object?> wrapResponse(
 }
 
 class SharedPreferencesPigeonOptions {
-  SharedPreferencesPigeonOptions({
-    this.suiteName,
-  });
+  SharedPreferencesPigeonOptions({this.suiteName});
 
   String? suiteName;
 
   Object encode() {
-    return <Object?>[
-      suiteName,
-    ];
+    return <Object?>[suiteName];
   }
 
   static SharedPreferencesPigeonOptions decode(Object result) {
     result as List<Object?>;
-    return SharedPreferencesPigeonOptions(
-      suiteName: result[0] as String?,
-    );
+    return SharedPreferencesPigeonOptions(suiteName: result[0] as String?);
   }
 }
 
@@ -80,11 +77,12 @@ class LegacyUserDefaultsApi {
   /// Constructor for [LegacyUserDefaultsApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  LegacyUserDefaultsApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  LegacyUserDefaultsApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix =
+           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -96,10 +94,10 @@ class LegacyUserDefaultsApi {
         'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.remove$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -120,10 +118,10 @@ class LegacyUserDefaultsApi {
         'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -144,10 +142,10 @@ class LegacyUserDefaultsApi {
         'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -168,10 +166,10 @@ class LegacyUserDefaultsApi {
         'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, value]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -188,17 +186,20 @@ class LegacyUserDefaultsApi {
   }
 
   Future<Map<String, Object>> getAll(
-      String prefix, List<String>? allowList) async {
+    String prefix,
+    List<String>? allowList,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.getAll$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[prefix, allowList]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[prefix, allowList])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -223,12 +224,13 @@ class LegacyUserDefaultsApi {
         'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.clear$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[prefix, allowList]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[prefix, allowList])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -252,11 +254,12 @@ class UserDefaultsApi {
   /// Constructor for [UserDefaultsApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  UserDefaultsApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  UserDefaultsApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix =
+           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -265,17 +268,21 @@ class UserDefaultsApi {
 
   /// Adds property to shared preferences data set of type String.
   Future<void> set(
-      String key, Object value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    Object value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[key, value, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[key, value, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -291,17 +298,20 @@ class UserDefaultsApi {
 
   /// Removes all properties from shared preferences data set with matching prefix.
   Future<void> clear(
-      List<String>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.clear$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[allowList, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[allowList, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -317,17 +327,20 @@ class UserDefaultsApi {
 
   /// Gets all properties from shared preferences data set with matching prefix.
   Future<Map<String, Object>> getAll(
-      List<String>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getAll$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[allowList, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[allowList, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -349,15 +362,17 @@ class UserDefaultsApi {
 
   /// Gets individual value stored with [key], if any.
   Future<Object?> getValue(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[key, options]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -375,17 +390,20 @@ class UserDefaultsApi {
 
   /// Gets all properties from shared preferences data set with matching prefix.
   Future<List<String>> getKeys(
-      List<String>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getKeys$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[allowList, options]) as List<Object?>?;
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(<Object?>[allowList, options])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {

--- a/packages/shared_preferences/shared_preferences_foundation/lib/src/shared_preferences_async_foundation.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/lib/src/shared_preferences_async_foundation.dart
@@ -17,9 +17,8 @@ const String _argumentErrorCode = 'Argument Error';
 base class SharedPreferencesAsyncFoundation
     extends SharedPreferencesAsyncPlatform {
   /// Creates a new plugin implementation instance.
-  SharedPreferencesAsyncFoundation({
-    @visibleForTesting UserDefaultsApi? api,
-  }) : _api = api ?? UserDefaultsApi();
+  SharedPreferencesAsyncFoundation({@visibleForTesting UserDefaultsApi? api})
+    : _api = api ?? UserDefaultsApi();
 
   final UserDefaultsApi _api;
 
@@ -31,12 +30,11 @@ base class SharedPreferencesAsyncFoundation
 
   /// Returns a SharedPreferencesPigeonOptions for sending to platform.
   SharedPreferencesPigeonOptions _convertOptionsToPigeonOptions(
-      SharedPreferencesOptions options) {
+    SharedPreferencesOptions options,
+  ) {
     if (options is SharedPreferencesAsyncFoundationOptions) {
       final String? suiteName = options.suiteName;
-      return SharedPreferencesPigeonOptions(
-        suiteName: suiteName,
-      );
+      return SharedPreferencesPigeonOptions(suiteName: suiteName);
     }
     return SharedPreferencesPigeonOptions();
   }
@@ -48,11 +46,11 @@ base class SharedPreferencesAsyncFoundation
   ) async {
     final PreferencesFilters filter = parameters.filter;
     return (await _convertKnownExceptions<List<String>>(
-            () async => _api.getKeys(
-                  filter.allowList?.toList(),
-                  _convertOptionsToPigeonOptions(options),
-                )))!
-        .toSet();
+      () async => _api.getKeys(
+        filter.allowList?.toList(),
+        _convertOptionsToPigeonOptions(options),
+      ),
+    ))!.toSet();
   }
 
   Future<void> _setValue(
@@ -60,8 +58,9 @@ base class SharedPreferencesAsyncFoundation
     Object value,
     SharedPreferencesOptions options,
   ) async {
-    return _convertKnownExceptions<void>(() async =>
-        _api.set(key, value, _convertOptionsToPigeonOptions(options)));
+    return _convertKnownExceptions<void>(
+      () async => _api.set(key, value, _convertOptionsToPigeonOptions(options)),
+    );
   }
 
   @override
@@ -114,17 +113,20 @@ base class SharedPreferencesAsyncFoundation
     String key,
     SharedPreferencesOptions options,
   ) async {
-    return _convertKnownExceptions<String>(() async => (await _api.getValue(
-        key, _convertOptionsToPigeonOptions(options))) as String?);
+    return _convertKnownExceptions<String>(
+      () async =>
+          (await _api.getValue(key, _convertOptionsToPigeonOptions(options)))
+              as String?,
+    );
   }
 
   @override
-  Future<bool?> getBool(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
-    return _convertKnownExceptions<bool>(() async => await _api.getValue(
-        key, _convertOptionsToPigeonOptions(options)) as bool?);
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async {
+    return _convertKnownExceptions<bool>(
+      () async =>
+          await _api.getValue(key, _convertOptionsToPigeonOptions(options))
+              as bool?,
+    );
   }
 
   @override
@@ -132,17 +134,20 @@ base class SharedPreferencesAsyncFoundation
     String key,
     SharedPreferencesOptions options,
   ) async {
-    return _convertKnownExceptions<double>(() async => await _api.getValue(
-        key, _convertOptionsToPigeonOptions(options)) as double?);
+    return _convertKnownExceptions<double>(
+      () async =>
+          await _api.getValue(key, _convertOptionsToPigeonOptions(options))
+              as double?,
+    );
   }
 
   @override
-  Future<int?> getInt(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
-    return _convertKnownExceptions<int>(() async => await _api.getValue(
-        key, _convertOptionsToPigeonOptions(options)) as int?);
+  Future<int?> getInt(String key, SharedPreferencesOptions options) async {
+    return _convertKnownExceptions<int>(
+      () async =>
+          await _api.getValue(key, _convertOptionsToPigeonOptions(options))
+              as int?,
+    );
   }
 
   @override
@@ -152,11 +157,13 @@ base class SharedPreferencesAsyncFoundation
   ) async {
     // Since `getValue` is not strongly typed, the array type won't be set
     // during deserialization, and needs to be manually cast.
-    return _convertKnownExceptions<List<String>>(() async =>
-        ((await _api.getValue(key, _convertOptionsToPigeonOptions(options)))
-                as List<Object?>?)
-            ?.cast<String>()
-            .toList());
+    return _convertKnownExceptions<List<String>>(
+      () async =>
+          ((await _api.getValue(key, _convertOptionsToPigeonOptions(options)))
+                  as List<Object?>?)
+              ?.cast<String>()
+              .toList(),
+    );
   }
 
   @override
@@ -165,10 +172,12 @@ base class SharedPreferencesAsyncFoundation
     SharedPreferencesOptions options,
   ) async {
     final PreferencesFilters filter = parameters.filter;
-    return _convertKnownExceptions<void>(() async => _api.clear(
-          filter.allowList?.toList(),
-          _convertOptionsToPigeonOptions(options),
-        ));
+    return _convertKnownExceptions<void>(
+      () async => _api.clear(
+        filter.allowList?.toList(),
+        _convertOptionsToPigeonOptions(options),
+      ),
+    );
   }
 
   @override
@@ -178,10 +187,11 @@ base class SharedPreferencesAsyncFoundation
   ) async {
     final PreferencesFilters filter = parameters.filter;
     return (await _convertKnownExceptions<Map<String, Object>>(
-        () async => _api.getAll(
-              filter.allowList?.toList(),
-              _convertOptionsToPigeonOptions(options),
-            )))!;
+      () async => _api.getAll(
+        filter.allowList?.toList(),
+        _convertOptionsToPigeonOptions(options),
+      ),
+    ))!;
   }
 
   Future<T?> _convertKnownExceptions<T>(Future<T?> Function() method) async {
@@ -191,7 +201,8 @@ base class SharedPreferencesAsyncFoundation
     } on PlatformException catch (e) {
       if (e.code == _argumentErrorCode) {
         throw ArgumentError(
-            'shared_preferences_foundation argument error ${e.message ?? ''}');
+          'shared_preferences_foundation argument error ${e.message ?? ''}',
+        );
       } else {
         rethrow;
       }
@@ -203,9 +214,7 @@ base class SharedPreferencesAsyncFoundation
 @immutable
 class SharedPreferencesAsyncFoundationOptions extends SharedPreferencesOptions {
   /// Creates a new instance with the given options.
-  SharedPreferencesAsyncFoundationOptions({
-    this.suiteName,
-  }) {
+  SharedPreferencesAsyncFoundationOptions({this.suiteName}) {
     // Ensure that use of suite is compliant with required reason API category 1C8F.1; see
     // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
     if (Platform.isIOS && !(suiteName?.startsWith('group.') ?? true)) {
@@ -224,7 +233,8 @@ class SharedPreferencesAsyncFoundationOptions extends SharedPreferencesOptions {
   /// Returns a new instance of [SharedPreferencesAsyncFoundationOptions] from an existing
   /// [SharedPreferencesOptions].
   static SharedPreferencesAsyncFoundationOptions fromSharedPreferencesOptions(
-      SharedPreferencesOptions options) {
+    SharedPreferencesOptions options,
+  ) {
     if (options is SharedPreferencesAsyncFoundationOptions) {
       return options;
     }

--- a/packages/shared_preferences/shared_preferences_foundation/lib/src/shared_preferences_foundation.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/lib/src/shared_preferences_foundation.dart
@@ -45,45 +45,41 @@ class SharedPreferencesFoundation extends SharedPreferencesStorePlatform {
   @override
   Future<bool> clear() async {
     return clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<bool> clearWithPrefix(String prefix) async {
     return clearWithParameters(
-        ClearParameters(filter: PreferencesFilter(prefix: prefix)));
+      ClearParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
   Future<bool> clearWithParameters(ClearParameters parameters) async {
     final PreferencesFilter filter = parameters.filter;
-    return _api.clear(
-      filter.prefix,
-      filter.allowList?.toList(),
-    );
+    return _api.clear(filter.prefix, filter.allowList?.toList());
   }
 
   @override
   Future<Map<String, Object>> getAll() async {
     return getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<Map<String, Object>> getAllWithPrefix(String prefix) async {
     return getAllWithParameters(
-        GetAllParameters(filter: PreferencesFilter(prefix: prefix)));
+      GetAllParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) async {
+    GetAllParameters parameters,
+  ) async {
     final PreferencesFilter filter = parameters.filter;
     return _api.getAll(filter.prefix, filter.allowList?.toList());
   }
@@ -99,8 +95,9 @@ class SharedPreferencesFoundation extends SharedPreferencesStorePlatform {
     final _Setter? setter = _setters[valueType];
     if (setter == null) {
       throw PlatformException(
-          code: 'InvalidOperation',
-          message: '"$valueType" is not a supported type.');
+        code: 'InvalidOperation',
+        message: '"$valueType" is not a supported type.',
+      );
     }
     await setter(key, value);
     return true;

--- a/packages/shared_preferences/shared_preferences_foundation/pigeons/messages.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/pigeons/messages.dart
@@ -4,13 +4,15 @@
 
 import 'package:pigeon/pigeon.dart';
 
-@ConfigurePigeon(PigeonOptions(
-  dartOut: 'lib/src/messages.g.dart',
-  dartTestOut: 'test/test_api.g.dart',
-  swiftOut:
-      'darwin/shared_preferences_foundation/Sources/shared_preferences_foundation/messages.g.swift',
-  copyrightHeader: 'pigeons/copyright_header.txt',
-))
+@ConfigurePigeon(
+  PigeonOptions(
+    dartOut: 'lib/src/messages.g.dart',
+    dartTestOut: 'test/test_api.g.dart',
+    swiftOut:
+        'darwin/shared_preferences_foundation/Sources/shared_preferences_foundation/messages.g.swift',
+    copyrightHeader: 'pigeons/copyright_header.txt',
+  ),
+)
 @HostApi(dartHostTestHandler: 'TestUserDefaultsApi')
 abstract class LegacyUserDefaultsApi {
   void remove(String key);
@@ -22,9 +24,7 @@ abstract class LegacyUserDefaultsApi {
 }
 
 class SharedPreferencesPigeonOptions {
-  SharedPreferencesPigeonOptions({
-    this.suiteName,
-  });
+  SharedPreferencesPigeonOptions({this.suiteName});
   String? suiteName;
 }
 
@@ -32,17 +32,10 @@ class SharedPreferencesPigeonOptions {
 abstract class UserDefaultsApi {
   /// Adds property to shared preferences data set of type String.
   @SwiftFunction('set(key:value:options:)')
-  void set(
-    String key,
-    Object value,
-    SharedPreferencesPigeonOptions options,
-  );
+  void set(String key, Object value, SharedPreferencesPigeonOptions options);
 
   /// Removes all properties from shared preferences data set with matching prefix.
-  void clear(
-    List<String>? allowList,
-    SharedPreferencesPigeonOptions options,
-  );
+  void clear(List<String>? allowList, SharedPreferencesPigeonOptions options);
 
   /// Gets all properties from shared preferences data set with matching prefix.
   Map<String, Object> getAll(
@@ -51,10 +44,7 @@ abstract class UserDefaultsApi {
   );
 
   /// Gets individual value stored with [key], if any.
-  Object? getValue(
-    String key,
-    SharedPreferencesPigeonOptions options,
-  );
+  Object? getValue(String key, SharedPreferencesPigeonOptions options);
 
   /// Gets all properties from shared preferences data set with matching prefix.
   List<String> getKeys(

--- a/packages/shared_preferences/shared_preferences_foundation/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_foundation/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.5.4
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_foundation/test/shared_preferences_async_foundation_test.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/test/shared_preferences_async_foundation_test.dart
@@ -76,12 +76,13 @@ void main() {
       preferences.setBool(boolKey, testBool, emptyOptions),
       preferences.setInt(intKey, testInt, emptyOptions),
       preferences.setDouble(doubleKey, testDouble, emptyOptions),
-      preferences.setStringList(listKey, testList, emptyOptions)
+      preferences.setStringList(listKey, testList, emptyOptions),
     ]);
 
     final Map<String, Object?> gotAll = await preferences.getPreferences(
-        const GetPreferencesParameters(filter: PreferencesFilters()),
-        emptyOptions);
+      const GetPreferencesParameters(filter: PreferencesFilters()),
+      emptyOptions,
+    );
 
     expect(gotAll.length, 5);
     expect(gotAll[stringKey], testString);
@@ -98,14 +99,15 @@ void main() {
       preferences.setBool(boolKey, testBool, emptyOptions),
       preferences.setInt(intKey, testInt, emptyOptions),
       preferences.setDouble(doubleKey, testDouble, emptyOptions),
-      preferences.setStringList(listKey, testList, emptyOptions)
+      preferences.setStringList(listKey, testList, emptyOptions),
     ]);
 
     final Map<String, Object?> gotAll = await preferences.getPreferences(
-        const GetPreferencesParameters(
-            filter:
-                PreferencesFilters(allowList: <String>{stringKey, boolKey})),
-        emptyOptions);
+      const GetPreferencesParameters(
+        filter: PreferencesFilters(allowList: <String>{stringKey, boolKey}),
+      ),
+      emptyOptions,
+    );
 
     expect(gotAll.length, 2);
     expect(gotAll[stringKey], testString);
@@ -119,7 +121,7 @@ void main() {
       preferences.setBool(boolKey, testBool, emptyOptions),
       preferences.setInt(intKey, testInt, emptyOptions),
       preferences.setDouble(doubleKey, testDouble, emptyOptions),
-      preferences.setStringList(listKey, testList, emptyOptions)
+      preferences.setStringList(listKey, testList, emptyOptions),
     ]);
 
     final Set<String> keys = await preferences.getKeys(
@@ -142,7 +144,7 @@ void main() {
       preferences.setBool(boolKey, testBool, emptyOptions),
       preferences.setInt(intKey, testInt, emptyOptions),
       preferences.setDouble(doubleKey, testDouble, emptyOptions),
-      preferences.setStringList(listKey, testList, emptyOptions)
+      preferences.setStringList(listKey, testList, emptyOptions),
     ]);
 
     final Set<String> keys = await preferences.getKeys(
@@ -164,11 +166,12 @@ void main() {
       preferences.setBool(boolKey, testBool, emptyOptions),
       preferences.setInt(intKey, testInt, emptyOptions),
       preferences.setDouble(doubleKey, testDouble, emptyOptions),
-      preferences.setStringList(listKey, testList, emptyOptions)
+      preferences.setStringList(listKey, testList, emptyOptions),
     ]);
     await preferences.clear(
-        const ClearPreferencesParameters(filter: PreferencesFilters()),
-        emptyOptions);
+      const ClearPreferencesParameters(filter: PreferencesFilters()),
+      emptyOptions,
+    );
     expect(await preferences.getString(stringKey, emptyOptions), null);
     expect(await preferences.getBool(boolKey, emptyOptions), null);
     expect(await preferences.getInt(intKey, emptyOptions), null);
@@ -183,7 +186,7 @@ void main() {
       preferences.setBool(boolKey, testBool, emptyOptions),
       preferences.setInt(intKey, testInt, emptyOptions),
       preferences.setDouble(doubleKey, testDouble, emptyOptions),
-      preferences.setStringList(listKey, testList, emptyOptions)
+      preferences.setStringList(listKey, testList, emptyOptions),
     ]);
     await preferences.clear(
       const ClearPreferencesParameters(
@@ -204,7 +207,9 @@ class _FakeSharedPreferencesApi implements UserDefaultsApi {
 
   @override
   Future<bool> clear(
-      List<String?>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String?>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     if (allowList != null) {
       items.removeWhere((String key, _) => allowList.contains(key));
     } else {
@@ -216,7 +221,9 @@ class _FakeSharedPreferencesApi implements UserDefaultsApi {
 
   @override
   Future<Map<String, Object>> getAll(
-      List<String?>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String?>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final Map<String, Object> filteredItems = <String, Object>{...items};
     if (allowList != null) {
       filteredItems.removeWhere((String key, _) => !allowList.contains(key));
@@ -226,7 +233,9 @@ class _FakeSharedPreferencesApi implements UserDefaultsApi {
 
   @override
   Future<List<String>> getKeys(
-      List<String?>? allowList, SharedPreferencesPigeonOptions options) async {
+    List<String?>? allowList,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     final List<String> filteredItems = items.keys.toList();
     if (allowList != null) {
       filteredItems.removeWhere((String key) => !allowList.contains(key));
@@ -236,13 +245,18 @@ class _FakeSharedPreferencesApi implements UserDefaultsApi {
 
   @override
   Future<void> set(
-      String key, Object value, SharedPreferencesPigeonOptions options) async {
+    String key,
+    Object value,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     items[key] = value;
   }
 
   @override
   Future<Object?> getValue(
-      String key, SharedPreferencesPigeonOptions options) async {
+    String key,
+    SharedPreferencesPigeonOptions options,
+  ) async {
     return items[key];
   }
 

--- a/packages/shared_preferences/shared_preferences_foundation/test/shared_preferences_foundation_test.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/test/shared_preferences_foundation_test.dart
@@ -14,10 +14,7 @@ class _MockSharedPreferencesApi implements TestUserDefaultsApi {
   final Map<String, Object> items = <String, Object>{};
 
   @override
-  Map<String, Object> getAll(
-    String prefix,
-    List<String?>? allowList,
-  ) {
+  Map<String, Object> getAll(String prefix, List<String?>? allowList) {
     Set<String?>? allowSet;
     if (allowList != null) {
       allowSet = Set<String>.from(allowList);
@@ -26,7 +23,7 @@ class _MockSharedPreferencesApi implements TestUserDefaultsApi {
       for (final MapEntry<String, Object> entry in items.entries)
         if (entry.key.startsWith(prefix) &&
             (allowSet == null || allowSet.contains(entry.key)))
-          entry.key: entry.value
+          entry.key: entry.value,
     };
   }
 
@@ -103,8 +100,10 @@ void main() {
 
   test('registerWith', () async {
     SharedPreferencesFoundation.registerWith();
-    expect(SharedPreferencesStorePlatform.instance,
-        isA<SharedPreferencesFoundation>());
+    expect(
+      SharedPreferencesStorePlatform.instance,
+      isA<SharedPreferencesFoundation>(),
+    );
   });
 
   test('remove', () async {
@@ -143,22 +142,16 @@ void main() {
     }
 
     Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 5);
     await plugin.clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     all = await plugin.getAll();
     expect(all.length, 5);
     all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 0);
   });
@@ -170,9 +163,7 @@ void main() {
     }
 
     Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 5);
     await plugin.clearWithParameters(
@@ -186,9 +177,7 @@ void main() {
     all = await plugin.getAll();
     expect(all.length, 5);
     all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 4);
   });
@@ -219,9 +208,7 @@ void main() {
       api.items[key] = allTestValues[key]!;
     }
     final Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(all.length, 5);
     expect(all, prefixTestValues);
@@ -255,9 +242,9 @@ void main() {
     expect(await plugin.setValue('String', 'flutter.String', 'hi'), isTrue);
     expect(api.items['flutter.String'], 'hi');
     expect(
-        await plugin
-            .setValue('StringList', 'flutter.StringList', <String>['hi']),
-        isTrue);
+      await plugin.setValue('StringList', 'flutter.StringList', <String>['hi']),
+      isTrue,
+    );
     expect(api.items['flutter.StringList'], <String>['hi']);
   });
 
@@ -297,9 +284,7 @@ void main() {
       api.items[key] = allTestValues[key]!;
     }
     final Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(all.length, 15);
     expect(all, allTestValues);
@@ -312,20 +297,14 @@ void main() {
     }
 
     Map<String?, Object?> all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(all.length, 15);
     await plugin.clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: '')),
     );
     all = await plugin.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(all.length, 0);
   });

--- a/packages/shared_preferences/shared_preferences_foundation/test/test_api.g.dart
+++ b/packages/shared_preferences/shared_preferences_foundation/test/test_api.g.dart
@@ -64,60 +64,75 @@ abstract class TestUserDefaultsApi {
     messageChannelSuffix =
         messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.remove$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.remove$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.remove was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final String? arg_key = (args[0] as String?);
-          assert(arg_key != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.remove was null, expected non-null String.');
-          try {
-            api.remove(arg_key!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.remove was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final String? arg_key = (args[0] as String?);
+              assert(
+                arg_key != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.remove was null, expected non-null String.',
+              );
+              try {
+                api.remove(arg_key!);
+                return wrapResponse(empty: true);
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool was null.');
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_key = (args[0] as String?);
-          assert(arg_key != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool was null, expected non-null String.');
+          assert(
+            arg_key != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool was null, expected non-null String.',
+          );
           final bool? arg_value = (args[1] as bool?);
-          assert(arg_value != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool was null, expected non-null bool.');
+          assert(
+            arg_value != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setBool was null, expected non-null bool.',
+          );
           try {
             api.setBool(arg_key!, arg_value!);
             return wrapResponse(empty: true);
@@ -125,34 +140,41 @@ abstract class TestUserDefaultsApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble was null.');
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_key = (args[0] as String?);
-          assert(arg_key != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble was null, expected non-null String.');
+          assert(
+            arg_key != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble was null, expected non-null String.',
+          );
           final double? arg_value = (args[1] as double?);
-          assert(arg_value != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble was null, expected non-null double.');
+          assert(
+            arg_value != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setDouble was null, expected non-null double.',
+          );
           try {
             api.setDouble(arg_key!, arg_value!);
             return wrapResponse(empty: true);
@@ -160,34 +182,41 @@ abstract class TestUserDefaultsApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue was null.');
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_key = (args[0] as String?);
-          assert(arg_key != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue was null, expected non-null String.');
+          assert(
+            arg_key != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue was null, expected non-null String.',
+          );
           final Object? arg_value = (args[1] as Object?);
-          assert(arg_value != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue was null, expected non-null Object.');
+          assert(
+            arg_value != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.setValue was null, expected non-null Object.',
+          );
           try {
             api.setValue(arg_key!, arg_value!);
             return wrapResponse(empty: true);
@@ -195,78 +224,99 @@ abstract class TestUserDefaultsApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.getAll$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.getAll$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.getAll was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final String? arg_prefix = (args[0] as String?);
-          assert(arg_prefix != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.getAll was null, expected non-null String.');
-          final List<String>? arg_allowList =
-              (args[1] as List<Object?>?)?.cast<String>();
-          try {
-            final Map<String, Object> output =
-                api.getAll(arg_prefix!, arg_allowList);
-            return <Object?>[output];
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.getAll was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final String? arg_prefix = (args[0] as String?);
+              assert(
+                arg_prefix != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.getAll was null, expected non-null String.',
+              );
+              final List<String>? arg_allowList =
+                  (args[1] as List<Object?>?)?.cast<String>();
+              try {
+                final Map<String, Object> output = api.getAll(
+                  arg_prefix!,
+                  arg_allowList,
+                );
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.clear$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.clear$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.clear was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final String? arg_prefix = (args[0] as String?);
-          assert(arg_prefix != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.clear was null, expected non-null String.');
-          final List<String>? arg_allowList =
-              (args[1] as List<Object?>?)?.cast<String>();
-          try {
-            final bool output = api.clear(arg_prefix!, arg_allowList);
-            return <Object?>[output];
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.clear was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final String? arg_prefix = (args[0] as String?);
+              assert(
+                arg_prefix != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.LegacyUserDefaultsApi.clear was null, expected non-null String.',
+              );
+              final List<String>? arg_allowList =
+                  (args[1] as List<Object?>?)?.cast<String>();
+              try {
+                final bool output = api.clear(arg_prefix!, arg_allowList);
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
       }
     }
   }
@@ -285,14 +335,18 @@ abstract class TestSharedPreferencesAsyncApi {
 
   /// Gets all properties from shared preferences data set with matching prefix.
   Map<String, Object> getAll(
-      List<String>? allowList, SharedPreferencesPigeonOptions options);
+    List<String>? allowList,
+    SharedPreferencesPigeonOptions options,
+  );
 
   /// Gets individual value stored with [key], if any.
   Object? getValue(String key, SharedPreferencesPigeonOptions options);
 
   /// Gets all properties from shared preferences data set with matching prefix.
   List<String> getKeys(
-      List<String>? allowList, SharedPreferencesPigeonOptions options);
+    List<String>? allowList,
+    SharedPreferencesPigeonOptions options,
+  );
 
   static void setUp(
     TestSharedPreferencesAsyncApi? api, {
@@ -302,32 +356,40 @@ abstract class TestSharedPreferencesAsyncApi {
     messageChannelSuffix =
         messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set was null.');
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_key = (args[0] as String?);
-          assert(arg_key != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set was null, expected non-null String.');
+          assert(
+            arg_key != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set was null, expected non-null String.',
+          );
           final Object? arg_value = (args[1] as Object?);
-          assert(arg_value != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set was null, expected non-null Object.');
+          assert(
+            arg_value != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set was null, expected non-null Object.',
+          );
           final SharedPreferencesPigeonOptions? arg_options =
               (args[2] as SharedPreferencesPigeonOptions?);
-          assert(arg_options != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set was null, expected non-null SharedPreferencesPigeonOptions.');
+          assert(
+            arg_options != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.set was null, expected non-null SharedPreferencesPigeonOptions.',
+          );
           try {
             api.set(arg_key!, arg_value!, arg_options!);
             return wrapResponse(empty: true);
@@ -335,106 +397,133 @@ abstract class TestSharedPreferencesAsyncApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.clear$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.clear$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.clear was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final List<String>? arg_allowList =
-              (args[0] as List<Object?>?)?.cast<String>();
-          final SharedPreferencesPigeonOptions? arg_options =
-              (args[1] as SharedPreferencesPigeonOptions?);
-          assert(arg_options != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.clear was null, expected non-null SharedPreferencesPigeonOptions.');
-          try {
-            api.clear(arg_allowList, arg_options!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.clear was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final List<String>? arg_allowList =
+                  (args[0] as List<Object?>?)?.cast<String>();
+              final SharedPreferencesPigeonOptions? arg_options =
+                  (args[1] as SharedPreferencesPigeonOptions?);
+              assert(
+                arg_options != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.clear was null, expected non-null SharedPreferencesPigeonOptions.',
+              );
+              try {
+                api.clear(arg_allowList, arg_options!);
+                return wrapResponse(empty: true);
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getAll$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getAll$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getAll was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final List<String>? arg_allowList =
-              (args[0] as List<Object?>?)?.cast<String>();
-          final SharedPreferencesPigeonOptions? arg_options =
-              (args[1] as SharedPreferencesPigeonOptions?);
-          assert(arg_options != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getAll was null, expected non-null SharedPreferencesPigeonOptions.');
-          try {
-            final Map<String, Object> output =
-                api.getAll(arg_allowList, arg_options!);
-            return <Object?>[output];
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getAll was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final List<String>? arg_allowList =
+                  (args[0] as List<Object?>?)?.cast<String>();
+              final SharedPreferencesPigeonOptions? arg_options =
+                  (args[1] as SharedPreferencesPigeonOptions?);
+              assert(
+                arg_options != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getAll was null, expected non-null SharedPreferencesPigeonOptions.',
+              );
+              try {
+                final Map<String, Object> output = api.getAll(
+                  arg_allowList,
+                  arg_options!,
+                );
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue was null.');
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_key = (args[0] as String?);
-          assert(arg_key != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue was null, expected non-null String.');
+          assert(
+            arg_key != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue was null, expected non-null String.',
+          );
           final SharedPreferencesPigeonOptions? arg_options =
               (args[1] as SharedPreferencesPigeonOptions?);
-          assert(arg_options != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue was null, expected non-null SharedPreferencesPigeonOptions.');
+          assert(
+            arg_options != null,
+            'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getValue was null, expected non-null SharedPreferencesPigeonOptions.',
+          );
           try {
             final Object? output = api.getValue(arg_key!, arg_options!);
             return <Object?>[output];
@@ -442,45 +531,57 @@ abstract class TestSharedPreferencesAsyncApi {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getKeys$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getKeys$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
-                (Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getKeys was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final List<String>? arg_allowList =
-              (args[0] as List<Object?>?)?.cast<String>();
-          final SharedPreferencesPigeonOptions? arg_options =
-              (args[1] as SharedPreferencesPigeonOptions?);
-          assert(arg_options != null,
-              'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getKeys was null, expected non-null SharedPreferencesPigeonOptions.');
-          try {
-            final List<String> output =
-                api.getKeys(arg_allowList, arg_options!);
-            return <Object?>[output];
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getKeys was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final List<String>? arg_allowList =
+                  (args[0] as List<Object?>?)?.cast<String>();
+              final SharedPreferencesPigeonOptions? arg_options =
+                  (args[1] as SharedPreferencesPigeonOptions?);
+              assert(
+                arg_options != null,
+                'Argument for dev.flutter.pigeon.shared_preferences_foundation.UserDefaultsApi.getKeys was null, expected non-null SharedPreferencesPigeonOptions.',
+              );
+              try {
+                final List<String> output = api.getKeys(
+                  arg_allowList,
+                  arg_options!,
+                );
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
       }
     }
   }

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 
 ## 2.4.1
 

--- a/packages/shared_preferences/shared_preferences_linux/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/integration_test/shared_preferences_test.dart
@@ -50,27 +50,60 @@ void main() {
       await preferences.setValue('Int', 'Int', allTestValues['Int']!);
       await preferences.setValue('Double', 'Double', allTestValues['Double']!);
       await preferences.setValue(
-          'StringList', 'StringList', allTestValues['StringList']!);
+        'StringList',
+        'StringList',
+        allTestValues['StringList']!,
+      );
       await preferences.setValue(
-          'String', 'prefix.String', allTestValues['prefix.String']!);
+        'String',
+        'prefix.String',
+        allTestValues['prefix.String']!,
+      );
       await preferences.setValue(
-          'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!);
+        'Bool',
+        'prefix.Bool',
+        allTestValues['prefix.Bool']!,
+      );
       await preferences.setValue(
-          'Int', 'prefix.Int', allTestValues['prefix.Int']!);
+        'Int',
+        'prefix.Int',
+        allTestValues['prefix.Int']!,
+      );
       await preferences.setValue(
-          'Double', 'prefix.Double', allTestValues['prefix.Double']!);
-      await preferences.setValue('StringList', 'prefix.StringList',
-          allTestValues['prefix.StringList']!);
+        'Double',
+        'prefix.Double',
+        allTestValues['prefix.Double']!,
+      );
       await preferences.setValue(
-          'String', 'flutter.String', allTestValues['flutter.String']!);
+        'StringList',
+        'prefix.StringList',
+        allTestValues['prefix.StringList']!,
+      );
       await preferences.setValue(
-          'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+        'String',
+        'flutter.String',
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue(
-          'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+        'Bool',
+        'flutter.Bool',
+        allTestValues['flutter.Bool']!,
+      );
       await preferences.setValue(
-          'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-      await preferences.setValue('StringList', 'flutter.StringList',
-          allTestValues['flutter.StringList']!);
+        'Int',
+        'flutter.Int',
+        allTestValues['flutter.Int']!,
+      );
+      await preferences.setValue(
+        'Double',
+        'flutter.Double',
+        allTestValues['flutter.Double']!,
+      );
+      await preferences.setValue(
+        'StringList',
+        'flutter.StringList',
+        allTestValues['flutter.StringList']!,
+      );
     }
 
     setUp(() async {
@@ -80,9 +113,7 @@ void main() {
 
     tearDown(() async {
       await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        ClearParameters(filter: PreferencesFilter(prefix: '')),
       );
     });
 
@@ -99,8 +130,9 @@ void main() {
       testWidgets('remove', (WidgetTester _) async {
         const String key = 'flutter.String';
         await preferences.remove(key);
-        final Map<String, Object> values =
-            await preferences.getAllWithPrefix('');
+        final Map<String, Object> values = await preferences.getAllWithPrefix(
+          '',
+        );
         expect(values[key], isNull);
       });
 
@@ -115,8 +147,9 @@ void main() {
       });
 
       testWidgets('get all with prefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithPrefix('prefix.');
+        final Map<String, Object> values = await preferences.getAllWithPrefix(
+          'prefix.',
+        );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
         expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -125,8 +158,9 @@ void main() {
       });
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithPrefix('');
+        final Map<String, Object> values = await preferences.getAllWithPrefix(
+          '',
+        );
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -137,13 +171,16 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithPrefix', (WidgetTester _) async {
         await preferences.clearWithPrefix('prefix.');
-        Map<String, Object> values =
-            await preferences.getAllWithPrefix('prefix.');
+        Map<String, Object> values = await preferences.getAllWithPrefix(
+          'prefix.',
+        );
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -155,13 +192,16 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
         await preferences.clearWithPrefix('');
-        final Map<String, Object> values =
-            await preferences.getAllWithPrefix('');
+        final Map<String, Object> values = await preferences.getAllWithPrefix(
+          '',
+        );
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -179,12 +219,10 @@ void main() {
       testWidgets('remove', (WidgetTester _) async {
         const String key = 'flutter.String';
         await preferences.remove(key);
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values[key], isNull);
       });
 
@@ -199,12 +237,10 @@ void main() {
       });
 
       testWidgets('get all with prefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+            );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
         expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -213,15 +249,15 @@ void main() {
       });
 
       testWidgets('get all with allow list', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(
-              prefix: 'prefix.',
-              allowList: <String>{'prefix.String'},
-            ),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(
+                filter: PreferencesFilter(
+                  prefix: 'prefix.',
+                  allowList: <String>{'prefix.String'},
+                ),
+              ),
+            );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -230,12 +266,10 @@ void main() {
       });
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -246,19 +280,17 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithParameters', (WidgetTester _) async {
         await preferences.clearWithParameters(
-          ClearParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         Map<String, Object> values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
@@ -266,20 +298,21 @@ void main() {
         expect(values['prefix.Double'], null);
         expect(values['prefix.StringList'], null);
         values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'flutter.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
         );
         expect(values['flutter.String'], allTestValues['flutter.String']);
         expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
-      testWidgets('clearWithParameters with allow list',
-          (WidgetTester _) async {
+      testWidgets('clearWithParameters with allow list', (
+        WidgetTester _,
+      ) async {
         await addData();
         await preferences.clearWithParameters(
           ClearParameters(
@@ -290,9 +323,7 @@ void main() {
           ),
         );
         Map<String, Object> values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
@@ -300,30 +331,26 @@ void main() {
         expect(values['prefix.Double'], allTestValues['prefix.Double']);
         expect(values['prefix.StringList'], null);
         values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'flutter.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
         );
         expect(values['flutter.String'], allTestValues['flutter.String']);
         expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
         await preferences.clearWithParameters(
-          ClearParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
+          ClearParameters(filter: PreferencesFilter(prefix: '')),
         );
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -354,14 +381,16 @@ void main() {
     const double testDouble = 3.14159;
     const List<String> testList = <String>['foo', 'bar'];
 
-    Future<SharedPreferencesAsyncPlatform> getPreferences(
-        {bool clear = true}) async {
+    Future<SharedPreferencesAsyncPlatform> getPreferences({
+      bool clear = true,
+    }) async {
       final SharedPreferencesAsyncPlatform preferences =
           SharedPreferencesAsyncPlatform.instance!;
       if (clear) {
         await preferences.clear(
-            const ClearPreferencesParameters(filter: PreferencesFilters()),
-            emptyOptions);
+          const ClearPreferencesParameters(filter: PreferencesFilters()),
+          emptyOptions,
+        );
       }
       return preferences;
     }
@@ -400,8 +429,9 @@ void main() {
       await preferences.setStringList(listKey, testList, emptyOptions);
       expect(await preferences.getStringList(listKey, emptyOptions), testList);
     });
-    testWidgets('getStringList does not throw cast error',
-        (WidgetTester _) async {
+    testWidgets('getStringList does not throw cast error', (
+      WidgetTester _,
+    ) async {
       final SharedPreferencesAsyncPlatform preferences = await getPreferences();
 
       await preferences.setStringList(listKey, testList, emptyOptions);
@@ -413,8 +443,10 @@ void main() {
       final SharedPreferencesAsyncPlatform preferences = await getPreferences();
 
       await preferences.setStringList(listKey, testList, emptyOptions);
-      final List<String>? list =
-          await preferences.getStringList(listKey, emptyOptions);
+      final List<String>? list = await preferences.getStringList(
+        listKey,
+        emptyOptions,
+      );
       list?.add('value');
       expect(list?.length, testList.length + 1);
     });
@@ -426,7 +458,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getPreferences(
@@ -449,7 +481,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getPreferences(
@@ -471,7 +503,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Set<String> keys = await preferences.getKeys(
@@ -494,7 +526,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Set<String> keys = await preferences.getKeys(
@@ -516,7 +548,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       await preferences.clear(
@@ -538,7 +570,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
       await preferences.clear(
         const ClearPreferencesParameters(

--- a/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
@@ -67,29 +67,29 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('SharedPreferences Demo'),
-      ),
+      appBar: AppBar(title: const Text('SharedPreferences Demo')),
       body: Center(
-          child: FutureBuilder<int>(
-              future: _counter,
-              builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-                switch (snapshot.connectionState) {
-                  case ConnectionState.none:
-                  case ConnectionState.waiting:
-                    return const CircularProgressIndicator();
-                  case ConnectionState.active:
-                  case ConnectionState.done:
-                    if (snapshot.hasError) {
-                      return Text('Error: ${snapshot.error}');
-                    } else {
-                      return Text(
-                        'Button tapped ${snapshot.data} time${snapshot.data == 1 ? '' : 's'}.\n\n'
-                        'This should persist across restarts.',
-                      );
-                    }
+        child: FutureBuilder<int>(
+          future: _counter,
+          builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+            switch (snapshot.connectionState) {
+              case ConnectionState.none:
+              case ConnectionState.waiting:
+                return const CircularProgressIndicator();
+              case ConnectionState.active:
+              case ConnectionState.done:
+                if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                } else {
+                  return Text(
+                    'Button tapped ${snapshot.data} time${snapshot.data == 1 ? '' : 's'}.\n\n'
+                    'This should persist across restarts.',
+                  );
                 }
-              })),
+            }
+          },
+        ),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,
         tooltip: 'Increment',

--- a/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the shared_preferences_linux plugin.
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
+++ b/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
@@ -59,16 +59,15 @@ class SharedPreferencesLinux extends SharedPreferencesStorePlatform {
   @override
   Future<bool> clear() async {
     return clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<bool> clearWithPrefix(String prefix) async {
     return clearWithParameters(
-        ClearParameters(filter: PreferencesFilter(prefix: prefix)));
+      ClearParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
@@ -76,9 +75,11 @@ class SharedPreferencesLinux extends SharedPreferencesStorePlatform {
     final PreferencesFilter filter = parameters.filter;
 
     final Map<String, Object> preferences = await _readPreferences();
-    preferences.removeWhere((String key, _) =>
-        key.startsWith(filter.prefix) &&
-        (filter.allowList == null || filter.allowList!.contains(key)));
+    preferences.removeWhere(
+      (String key, _) =>
+          key.startsWith(filter.prefix) &&
+          (filter.allowList == null || filter.allowList!.contains(key)),
+    );
     return _writePreferences(
       preferences,
       _defaultFileName,
@@ -90,26 +91,30 @@ class SharedPreferencesLinux extends SharedPreferencesStorePlatform {
   @override
   Future<Map<String, Object>> getAll() async {
     return getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<Map<String, Object>> getAllWithPrefix(String prefix) async {
     return getAllWithParameters(
-        GetAllParameters(filter: PreferencesFilter(prefix: prefix)));
+      GetAllParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) async {
+    GetAllParameters parameters,
+  ) async {
     final PreferencesFilter filter = parameters.filter;
-    final Map<String, Object> withPrefix =
-        Map<String, Object>.from(await _readPreferences());
-    withPrefix.removeWhere((String key, _) => !(key.startsWith(filter.prefix) &&
-        (filter.allowList?.contains(key) ?? true)));
+    final Map<String, Object> withPrefix = Map<String, Object>.from(
+      await _readPreferences(),
+    );
+    withPrefix.removeWhere(
+      (String key, _) =>
+          !(key.startsWith(filter.prefix) &&
+              (filter.allowList?.contains(key) ?? true)),
+    );
     return withPrefix;
   }
 
@@ -194,11 +199,7 @@ base class SharedPreferencesAsyncLinux extends SharedPreferencesAsyncPlatform {
   }
 
   @override
-  Future<void> setInt(
-    String key,
-    int value,
-    SharedPreferencesOptions options,
-  ) {
+  Future<void> setInt(String key, int value, SharedPreferencesOptions options) {
     return _setValue(key, value, options);
   }
 
@@ -221,10 +222,7 @@ base class SharedPreferencesAsyncLinux extends SharedPreferencesAsyncPlatform {
   }
 
   @override
-  Future<bool?> getBool(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async {
     final Map<String, Object> data = await _readAll(<String>{key}, options);
     return data[key] as bool?;
   }
@@ -239,10 +237,7 @@ base class SharedPreferencesAsyncLinux extends SharedPreferencesAsyncPlatform {
   }
 
   @override
-  Future<int?> getInt(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
+  Future<int?> getInt(String key, SharedPreferencesOptions options) async {
     final Map<String, Object> data = await _readAll(<String>{key}, options);
     return data[key] as int?;
   }
@@ -257,15 +252,20 @@ base class SharedPreferencesAsyncLinux extends SharedPreferencesAsyncPlatform {
   }
 
   @override
-  Future<void> clear(ClearPreferencesParameters parameters,
-      SharedPreferencesOptions options) async {
+  Future<void> clear(
+    ClearPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) async {
     final SharedPreferencesLinuxOptions linuxOptions =
         SharedPreferencesLinuxOptions.fromSharedPreferencesOptions(options);
     final PreferencesFilters filter = parameters.filter;
-    final Map<String, Object> preferences =
-        await _readPreferences(linuxOptions.fileName);
-    preferences.removeWhere((String key, _) =>
-        filter.allowList == null || filter.allowList!.contains(key));
+    final Map<String, Object> preferences = await _readPreferences(
+      linuxOptions.fileName,
+    );
+    preferences.removeWhere(
+      (String key, _) =>
+          filter.allowList == null || filter.allowList!.contains(key),
+    );
     await _writePreferences(
       preferences,
       linuxOptions.fileName,
@@ -284,9 +284,7 @@ base class SharedPreferencesAsyncLinux extends SharedPreferencesAsyncPlatform {
 
   /// Reloads preferences from file.
   @visibleForTesting
-  Future<void> reload(
-    SharedPreferencesLinuxOptions options,
-  ) async {
+  Future<void> reload(SharedPreferencesLinuxOptions options) async {
     _cachedPreferences = await _reload(options.fileName);
   }
 
@@ -296,18 +294,23 @@ base class SharedPreferencesAsyncLinux extends SharedPreferencesAsyncPlatform {
   ) async {
     final SharedPreferencesLinuxOptions linuxOptions =
         SharedPreferencesLinuxOptions.fromSharedPreferencesOptions(options);
-    final Map<String, Object> prefs =
-        Map<String, Object>.from(await _readPreferences(linuxOptions.fileName));
+    final Map<String, Object> prefs = Map<String, Object>.from(
+      await _readPreferences(linuxOptions.fileName),
+    );
     prefs.removeWhere((String key, _) => !(allowList?.contains(key) ?? true));
     return prefs;
   }
 
   Future<void> _setValue(
-      String key, Object value, SharedPreferencesOptions options) async {
+    String key,
+    Object value,
+    SharedPreferencesOptions options,
+  ) async {
     final SharedPreferencesLinuxOptions linuxOptions =
         SharedPreferencesLinuxOptions.fromSharedPreferencesOptions(options);
-    final Map<String, Object> preferences =
-        await _readPreferences(linuxOptions.fileName);
+    final Map<String, Object> preferences = await _readPreferences(
+      linuxOptions.fileName,
+    );
     preferences[key] = value;
     await _writePreferences(
       preferences,
@@ -401,9 +404,7 @@ Future<bool> _writePreferences(
 /// Linux specific SharedPreferences Options.
 class SharedPreferencesLinuxOptions extends SharedPreferencesOptions {
   /// Constructor for SharedPreferencesLinuxOptions.
-  const SharedPreferencesLinuxOptions({
-    this.fileName = 'shared_preferences',
-  });
+  const SharedPreferencesLinuxOptions({this.fileName = 'shared_preferences'});
 
   /// The name of the file to store preferences in.
   final String fileName;
@@ -411,7 +412,8 @@ class SharedPreferencesLinuxOptions extends SharedPreferencesOptions {
   /// Returns a new instance of [SharedPreferencesLinuxOptions] from an existing
   /// [SharedPreferencesOptions].
   static SharedPreferencesLinuxOptions fromSharedPreferencesOptions(
-      SharedPreferencesOptions options) {
+    SharedPreferencesOptions options,
+  ) {
     if (options is SharedPreferencesLinuxOptions) {
       return options;
     }

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.4.1
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_linux/test/legacy_shared_preferences_linux_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/test/legacy_shared_preferences_linux_test.dart
@@ -79,7 +79,9 @@ void main() {
   test('registered instance', () async {
     SharedPreferencesLinux.registerWith();
     expect(
-        SharedPreferencesStorePlatform.instance, isA<SharedPreferencesLinux>());
+      SharedPreferencesStorePlatform.instance,
+      isA<SharedPreferencesLinux>(),
+    );
   });
 
   test('getAll', () async {
@@ -105,9 +107,7 @@ void main() {
     final SharedPreferencesLinux prefs = getPreferences();
 
     final Map<String, Object> values = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(values, hasLength(5));
     expect(values, prefixTestValues);
@@ -161,8 +161,9 @@ void main() {
     await writeTestFile(json.encode(flutterTestValues));
     final SharedPreferencesLinux prefs = getPreferences();
     await prefs.clearWithPrefix('prefix.');
-    final Map<String, Object> noValues =
-        await prefs.getAllWithPrefix('prefix.');
+    final Map<String, Object> noValues = await prefs.getAllWithPrefix(
+      'prefix.',
+    );
     expect(noValues, hasLength(0));
 
     final Map<String, Object> values = await prefs.getAll();
@@ -191,14 +192,10 @@ void main() {
     await writeTestFile(json.encode(flutterTestValues));
     final SharedPreferencesLinux prefs = getPreferences();
     await prefs.clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     final Map<String, Object> noValues = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(noValues, hasLength(0));
 
@@ -219,9 +216,7 @@ void main() {
       ),
     );
     final Map<String, Object> someValues = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(someValues, hasLength(4));
   });
@@ -231,9 +226,7 @@ void main() {
     final SharedPreferencesLinux prefs = getPreferences();
 
     final Map<String, Object> values = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(values, hasLength(15));
     expect(values, allTestValues);
@@ -243,14 +236,10 @@ void main() {
     await writeTestFile(json.encode(flutterTestValues));
     final SharedPreferencesLinux prefs = getPreferences();
     await prefs.clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: '')),
     );
     final Map<String, Object> noValues = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(noValues, hasLength(0));
   });

--- a/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_async_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_async_test.dart
@@ -88,8 +88,9 @@ void main() {
     await preferences.setStringList(listKey, testList, emptyOptions);
 
     final Map<String, Object?> gotAll = await preferences.getPreferences(
-        const GetPreferencesParameters(filter: PreferencesFilters()),
-        emptyOptions);
+      const GetPreferencesParameters(filter: PreferencesFilters()),
+      emptyOptions,
+    );
 
     expect(gotAll.length, 5);
     expect(gotAll[stringKey], testString);
@@ -109,10 +110,11 @@ void main() {
     await preferences.setStringList(listKey, testList, emptyOptions);
 
     final Map<String, Object?> gotAll = await preferences.getPreferences(
-        const GetPreferencesParameters(
-            filter:
-                PreferencesFilters(allowList: <String>{stringKey, boolKey})),
-        emptyOptions);
+      const GetPreferencesParameters(
+        filter: PreferencesFilters(allowList: <String>{stringKey, boolKey}),
+      ),
+      emptyOptions,
+    );
 
     expect(gotAll.length, 2);
     expect(gotAll[stringKey], testString);
@@ -171,8 +173,9 @@ void main() {
     await preferences.setDouble(doubleKey, testDouble, emptyOptions);
     await preferences.setStringList(listKey, testList, emptyOptions);
     await preferences.clear(
-        const ClearPreferencesParameters(filter: PreferencesFilters()),
-        emptyOptions);
+      const ClearPreferencesParameters(filter: PreferencesFilters()),
+      emptyOptions,
+    );
     expect(await preferences.getString(stringKey, emptyOptions), null);
     expect(await preferences.getBool(boolKey, emptyOptions), null);
     expect(await preferences.getInt(intKey, emptyOptions), null);

--- a/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 
 ## 2.4.1
 

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/in_memory_shared_preferences_async.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/in_memory_shared_preferences_async.dart
@@ -17,7 +17,7 @@ base class InMemorySharedPreferencesAsync
 
   /// Instantiates an in-memory preferences store containing a copy of [data].
   InMemorySharedPreferencesAsync.withData(Map<String, Object> data)
-      : _data = Map<String, Object>.from(data);
+    : _data = Map<String, Object>.from(data);
 
   final Map<String, Object> _data;
 
@@ -42,8 +42,10 @@ base class InMemorySharedPreferencesAsync
   ) async {
     final PreferencesFilters filter = parameters.filter;
     final Map<String, Object> preferences = Map<String, Object>.from(_data);
-    preferences.removeWhere((String key, _) =>
-        filter.allowList != null && !filter.allowList!.contains(key));
+    preferences.removeWhere(
+      (String key, _) =>
+          filter.allowList != null && !filter.allowList!.contains(key),
+    );
     return preferences;
   }
 
@@ -110,10 +112,7 @@ base class InMemorySharedPreferencesAsync
   }
 
   @override
-  Future<bool?> getBool(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async {
     return _data[key] as bool?;
   }
 
@@ -126,10 +125,7 @@ base class InMemorySharedPreferencesAsync
   }
 
   @override
-  Future<int?> getInt(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
+  Future<int?> getInt(String key, SharedPreferencesOptions options) async {
     return _data[key] as int?;
   }
 
@@ -150,7 +146,8 @@ base class InMemorySharedPreferencesAsync
     final Set<String> keys = _data.keys.toSet();
     if (parameters.filter.allowList != null) {
       keys.retainWhere(
-          (String element) => parameters.filter.allowList!.contains(element));
+        (String element) => parameters.filter.allowList!.contains(element),
+      );
     }
 
     return keys;

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/method_channel_shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/method_channel_shared_preferences.dart
@@ -9,8 +9,9 @@ import 'package:flutter/services.dart';
 import 'shared_preferences_platform_interface.dart';
 import 'types.dart';
 
-const MethodChannel _kChannel =
-    MethodChannel('plugins.flutter.io/shared_preferences');
+const MethodChannel _kChannel = MethodChannel(
+  'plugins.flutter.io/shared_preferences',
+);
 
 /// Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android), providing
 /// a persistent store for simple data.
@@ -20,10 +21,9 @@ class MethodChannelSharedPreferencesStore
     extends SharedPreferencesStorePlatform {
   @override
   Future<bool> remove(String key) async {
-    return (await _kChannel.invokeMethod<bool>(
-      'remove',
-      <String, dynamic>{'key': key},
-    ))!;
+    return (await _kChannel.invokeMethod<bool>('remove', <String, dynamic>{
+      'key': key,
+    }))!;
   }
 
   @override
@@ -43,9 +43,7 @@ class MethodChannelSharedPreferencesStore
   @Deprecated('Use clearWithParameters instead')
   Future<bool> clearWithPrefix(String prefix) async {
     return clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: prefix),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: prefix)),
     );
   }
 
@@ -74,22 +72,21 @@ class MethodChannelSharedPreferencesStore
     Set<String>? allowList,
   }) async {
     return getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: prefix),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: prefix)),
     );
   }
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) async {
+    GetAllParameters parameters,
+  ) async {
     final PreferencesFilter filter = parameters.filter;
     final List<String>? allowListAsList = filter.allowList?.toList();
     return await _kChannel.invokeMapMethod<String, Object>(
           'getAllWithParameters',
           <String, dynamic>{
             'prefix': filter.prefix,
-            'allowList': allowListAsList
+            'allowList': allowListAsList,
           },
         ) ??
         <String, Object>{};

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_async_platform_interface.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_async_platform_interface.dart
@@ -36,11 +36,7 @@ abstract base class SharedPreferencesAsyncPlatform {
   );
 
   /// Stores the int [value] associated with the [key].
-  Future<void> setInt(
-    String key,
-    int value,
-    SharedPreferencesOptions options,
-  );
+  Future<void> setInt(String key, int value, SharedPreferencesOptions options);
 
   /// Stores the List<String> [value] associated with the [key].
   Future<void> setStringList(
@@ -53,37 +49,25 @@ abstract base class SharedPreferencesAsyncPlatform {
   ///
   /// Throws a [TypeError] if the returned type is not a String.
   /// May return null for unsupported types.
-  Future<String?> getString(
-    String key,
-    SharedPreferencesOptions options,
-  );
+  Future<String?> getString(String key, SharedPreferencesOptions options);
 
   /// Retrieves the bool [value] associated with the [key], if any.
   ///
   /// Throws a [TypeError] if the returned type is not a bool.
   /// May return null for unsupported types.
-  Future<bool?> getBool(
-    String key,
-    SharedPreferencesOptions options,
-  );
+  Future<bool?> getBool(String key, SharedPreferencesOptions options);
 
   /// Retrieves the double [value] associated with the [key], if any.
   ///
   /// Throws a [TypeError] if the returned type is not a double.
   /// May return null for unsupported types.
-  Future<double?> getDouble(
-    String key,
-    SharedPreferencesOptions options,
-  );
+  Future<double?> getDouble(String key, SharedPreferencesOptions options);
 
   /// Retrieves the int [value] associated with the [key], if any.
   ///
   /// Throws a [TypeError] if the returned type is not an int.
   /// May return null for unsupported types.
-  Future<int?> getInt(
-    String key,
-    SharedPreferencesOptions options,
-  );
+  Future<int?> getInt(String key, SharedPreferencesOptions options);
 
   /// Retrieves the List<String> [value] associated with the [key], if any.
   ///

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_platform_interface.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_platform_interface.dart
@@ -96,7 +96,8 @@ abstract class SharedPreferencesStorePlatform extends PlatformInterface {
 
   /// Returns all key/value pairs persisting in this store that match [options].
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) {
+    GetAllParameters parameters,
+  ) {
     throw UnimplementedError('getAllWithParameters is not implemented.');
   }
 }
@@ -110,7 +111,7 @@ class InMemorySharedPreferencesStore extends SharedPreferencesStorePlatform {
 
   /// Instantiates an in-memory preferences store containing a copy of [data].
   InMemorySharedPreferencesStore.withData(Map<String, Object> data)
-      : _data = Map<String, Object>.from(data);
+    : _data = Map<String, Object>.from(data);
 
   final Map<String, Object> _data;
   static const String _defaultPrefix = 'flutter.';
@@ -118,18 +119,14 @@ class InMemorySharedPreferencesStore extends SharedPreferencesStorePlatform {
   @override
   Future<bool> clear() async {
     return clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<bool> clearWithPrefix(String prefix) async {
     return clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: prefix),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: prefix)),
     );
   }
 
@@ -137,8 +134,10 @@ class InMemorySharedPreferencesStore extends SharedPreferencesStorePlatform {
   Future<bool> clearWithParameters(ClearParameters parameters) async {
     final PreferencesFilter filter = parameters.filter;
     if (filter.allowList != null) {
-      _data.removeWhere((String key, _) =>
-          key.startsWith(filter.prefix) && filter.allowList!.contains(key));
+      _data.removeWhere(
+        (String key, _) =>
+            key.startsWith(filter.prefix) && filter.allowList!.contains(key),
+      );
     } else {
       _data.removeWhere((String key, _) => key.startsWith(filter.prefix));
     }
@@ -148,29 +147,28 @@ class InMemorySharedPreferencesStore extends SharedPreferencesStorePlatform {
   @override
   Future<Map<String, Object>> getAll() async {
     return getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<Map<String, Object>> getAllWithPrefix(String prefix) async {
     return getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: prefix),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: prefix)),
     );
   }
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) async {
+    GetAllParameters parameters,
+  ) async {
     final PreferencesFilter filter = parameters.filter;
     final Map<String, Object> preferences = Map<String, Object>.from(_data);
-    preferences.removeWhere((String key, _) =>
-        !key.startsWith(filter.prefix) ||
-        (filter.allowList != null && !filter.allowList!.contains(key)));
+    preferences.removeWhere(
+      (String key, _) =>
+          !key.startsWith(filter.prefix) ||
+          (filter.allowList != null && !filter.allowList!.contains(key)),
+    );
     return preferences;
   }
 

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/types.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/types.dart
@@ -20,9 +20,7 @@ class SharedPreferencesOptions {
 @immutable
 class PreferencesFilters {
   /// Creates a new instance with the given options.
-  const PreferencesFilters({
-    this.allowList,
-  });
+  const PreferencesFilters({this.allowList});
 
   /// A list of preference keys that will limit getting and clearing to only
   /// items included in this list.
@@ -58,10 +56,7 @@ class ClearPreferencesParameters {
 /// Filter options used to get and clear preferences on legacy_shared_preferences.
 class PreferencesFilter {
   /// Creates a new instance with the given options.
-  PreferencesFilter({
-    required this.prefix,
-    this.allowList,
-  });
+  PreferencesFilter({required this.prefix, this.allowList});
 
   /// A prefix to limit getting and clearing to only items that begin with
   /// this string.

--- a/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.4.1
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/deprecated_method_channel_shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/deprecated_method_channel_shared_preferences_test.dart
@@ -61,72 +61,79 @@ void main() {
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-        log.add(methodCall);
-        if (methodCall.method == 'getAll') {
-          return testData.getAll();
-        }
-        if (methodCall.method == 'getAllWithParameters') {
-          final Map<String, Object?> arguments =
-              getArgumentDictionary(methodCall);
-          final String prefix = arguments['prefix']! as String;
-          Set<String>? allowSet;
-          final List<dynamic>? allowList =
-              arguments['allowList'] as List<dynamic>?;
-          if (allowList != null) {
-            allowSet = <String>{};
-            for (final dynamic key in allowList) {
-              allowSet.add(key as String);
+            log.add(methodCall);
+            if (methodCall.method == 'getAll') {
+              return testData.getAll();
             }
-          }
-          return testData.getAllWithParameters(
-            GetAllParameters(
-              filter: PreferencesFilter(
-                prefix: prefix,
-                allowList: allowSet,
-              ),
-            ),
-          );
-        }
-        if (methodCall.method == 'remove') {
-          final Map<String, Object?> arguments =
-              getArgumentDictionary(methodCall);
-          final String key = arguments['key']! as String;
-          return testData.remove(key);
-        }
-        if (methodCall.method == 'clear') {
-          return testData.clear();
-        }
-        if (methodCall.method == 'clearWithParameters') {
-          final Map<String, Object?> arguments =
-              getArgumentDictionary(methodCall);
-          final String prefix = arguments['prefix']! as String;
-          Set<String>? allowSet;
-          final List<dynamic>? allowList =
-              arguments['allowList'] as List<dynamic>?;
-          if (allowList != null) {
-            allowSet = <String>{};
-            for (final dynamic key in allowList) {
-              allowSet.add(key as String);
+            if (methodCall.method == 'getAllWithParameters') {
+              final Map<String, Object?> arguments = getArgumentDictionary(
+                methodCall,
+              );
+              final String prefix = arguments['prefix']! as String;
+              Set<String>? allowSet;
+              final List<dynamic>? allowList =
+                  arguments['allowList'] as List<dynamic>?;
+              if (allowList != null) {
+                allowSet = <String>{};
+                for (final dynamic key in allowList) {
+                  allowSet.add(key as String);
+                }
+              }
+              return testData.getAllWithParameters(
+                GetAllParameters(
+                  filter: PreferencesFilter(
+                    prefix: prefix,
+                    allowList: allowSet,
+                  ),
+                ),
+              );
             }
-          }
-          return testData.clearWithParameters(
-            ClearParameters(
-              filter: PreferencesFilter(prefix: prefix, allowList: allowSet),
-            ),
-          );
-        }
-        final RegExp setterRegExp = RegExp(r'set(.*)');
-        final Match? match = setterRegExp.matchAsPrefix(methodCall.method);
-        if (match?.groupCount == 1) {
-          final String valueType = match!.group(1)!;
-          final Map<String, Object?> arguments =
-              getArgumentDictionary(methodCall);
-          final String key = arguments['key']! as String;
-          final Object value = arguments['value']!;
-          return testData.setValue(valueType, key, value);
-        }
-        fail('Unexpected method call: ${methodCall.method}');
-      });
+            if (methodCall.method == 'remove') {
+              final Map<String, Object?> arguments = getArgumentDictionary(
+                methodCall,
+              );
+              final String key = arguments['key']! as String;
+              return testData.remove(key);
+            }
+            if (methodCall.method == 'clear') {
+              return testData.clear();
+            }
+            if (methodCall.method == 'clearWithParameters') {
+              final Map<String, Object?> arguments = getArgumentDictionary(
+                methodCall,
+              );
+              final String prefix = arguments['prefix']! as String;
+              Set<String>? allowSet;
+              final List<dynamic>? allowList =
+                  arguments['allowList'] as List<dynamic>?;
+              if (allowList != null) {
+                allowSet = <String>{};
+                for (final dynamic key in allowList) {
+                  allowSet.add(key as String);
+                }
+              }
+              return testData.clearWithParameters(
+                ClearParameters(
+                  filter: PreferencesFilter(
+                    prefix: prefix,
+                    allowList: allowSet,
+                  ),
+                ),
+              );
+            }
+            final RegExp setterRegExp = RegExp(r'set(.*)');
+            final Match? match = setterRegExp.matchAsPrefix(methodCall.method);
+            if (match?.groupCount == 1) {
+              final String valueType = match!.group(1)!;
+              final Map<String, Object?> arguments = getArgumentDictionary(
+                methodCall,
+              );
+              final String key = arguments['key']! as String;
+              final Object value = arguments['value']!;
+              return testData.setValue(valueType, key, value);
+            }
+            fail('Unexpected method call: ${methodCall.method}');
+          });
       store = MethodChannelSharedPreferencesStore();
       log.clear();
     });
@@ -144,12 +151,11 @@ void main() {
     test('getAllWithParameters with Prefix', () async {
       testData = InMemorySharedPreferencesStore.withData(allTestValues);
       expect(
-          await store.getAllWithParameters(
-            GetAllParameters(
-              filter: PreferencesFilter(prefix: 'prefix.'),
-            ),
-          ),
-          prefixTestValues);
+        await store.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+        ),
+        prefixTestValues,
+      );
       expect(log.single.method, 'getAllWithParameters');
     });
 
@@ -212,91 +218,85 @@ void main() {
       testData = InMemorySharedPreferencesStore.withData(allTestValues);
 
       expect(
-          await testData.getAllWithParameters(
-            GetAllParameters(
-              filter: PreferencesFilter(prefix: 'prefix.'),
-            ),
-          ),
-          isNotEmpty);
+        await testData.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+        ),
+        isNotEmpty,
+      );
       expect(
-          await store.clearWithParameters(
-            ClearParameters(
-              filter: PreferencesFilter(prefix: 'prefix.'),
-            ),
-          ),
-          true);
+        await store.clearWithParameters(
+          ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+        ),
+        true,
+      );
       expect(
-          await testData.getAllWithParameters(
-            GetAllParameters(
-              filter: PreferencesFilter(prefix: 'prefix.'),
-            ),
-          ),
-          isEmpty);
+        await testData.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+        ),
+        isEmpty,
+      );
     });
 
     test('getAllWithParameters with no Prefix', () async {
       testData = InMemorySharedPreferencesStore.withData(allTestValues);
 
       expect(
-          await testData.getAllWithParameters(
-            GetAllParameters(
-              filter: PreferencesFilter(prefix: ''),
-            ),
-          ),
-          hasLength(15));
+        await testData.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: '')),
+        ),
+        hasLength(15),
+      );
     });
 
     test('clearWithNoPrefix', () async {
       testData = InMemorySharedPreferencesStore.withData(allTestValues);
 
       expect(
-          await testData.getAllWithParameters(
-            GetAllParameters(
-              filter: PreferencesFilter(prefix: ''),
-            ),
-          ),
-          isNotEmpty);
+        await testData.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: '')),
+        ),
+        isNotEmpty,
+      );
       expect(
-          await store.clearWithParameters(
-            ClearParameters(
-              filter: PreferencesFilter(prefix: ''),
-            ),
-          ),
-          true);
+        await store.clearWithParameters(
+          ClearParameters(filter: PreferencesFilter(prefix: '')),
+        ),
+        true,
+      );
       expect(
-          await testData.getAllWithParameters(
-            GetAllParameters(
-              filter: PreferencesFilter(prefix: ''),
-            ),
-          ),
-          isEmpty);
+        await testData.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: '')),
+        ),
+        isEmpty,
+      );
     });
 
     test('clearWithParameters with allow list', () async {
       testData = InMemorySharedPreferencesStore.withData(allTestValues);
 
       expect(
-          await testData.getAllWithParameters(
-            GetAllParameters(
-              filter: PreferencesFilter(prefix: 'prefix.'),
+        await testData.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+        ),
+        isNotEmpty,
+      );
+      expect(
+        await store.clearWithParameters(
+          ClearParameters(
+            filter: PreferencesFilter(
+              prefix: 'prefix.',
+              allowList: <String>{'prefix.String'},
             ),
           ),
-          isNotEmpty);
+        ),
+        true,
+      );
       expect(
-          await store.clearWithParameters(
-            ClearParameters(
-              filter: PreferencesFilter(
-                prefix: 'prefix.',
-                allowList: <String>{'prefix.String'},
-              ),
-            ),
-          ),
-          true);
-      expect(
-          (await testData.getAllWithParameters(GetAllParameters(
-                  filter: PreferencesFilter(prefix: 'prefix.'))))
-              .length,
-          4);
+        (await testData.getAllWithParameters(
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+        )).length,
+        4,
+      );
     });
   });
 }

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
@@ -12,17 +12,19 @@ void main() {
 
   group(SharedPreferencesStorePlatform, () {
     test('disallows implementing interface', () {
-      expect(() {
-        SharedPreferencesStorePlatform.instance = IllegalImplementation();
-      },
-          // In versions of `package:plugin_platform_interface` prior to fixing
-          // https://github.com/flutter/flutter/issues/109339, an attempt to
-          // implement a platform interface using `implements` would sometimes
-          // throw a `NoSuchMethodError` and other times throw an
-          // `AssertionError`. After the issue is fixed, an `AssertionError` will
-          // always be thrown. For the purpose of this test, we don't really care
-          // what exception is thrown, so just allow any exception.
-          throwsA(anything));
+      expect(
+        () {
+          SharedPreferencesStorePlatform.instance = IllegalImplementation();
+        },
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`. After the issue is fixed, an `AssertionError` will
+        // always be thrown. For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+        throwsA(anything),
+      );
     });
 
     test('supports MockPlatformInterfaceMixin', () {
@@ -69,7 +71,8 @@ class IllegalImplementation implements SharedPreferencesStorePlatform {
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) {
+    GetAllParameters parameters,
+  ) {
     throw UnimplementedError();
   }
 
@@ -115,7 +118,8 @@ class LegacyIsMockImplementation implements SharedPreferencesStorePlatform {
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) {
+    GetAllParameters parameters,
+  ) {
     throw UnimplementedError();
   }
 
@@ -163,7 +167,8 @@ class ModernMockImplementation
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) {
+    GetAllParameters parameters,
+  ) {
     throw UnimplementedError();
   }
 

--- a/packages/shared_preferences/shared_preferences_tool/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/main.dart
@@ -18,9 +18,7 @@ class _SharedPreferencesTool extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const DevToolsExtension(
-      child: _ConnectionManager(),
-    );
+    return const DevToolsExtension(child: _ConnectionManager());
   }
 }
 
@@ -48,17 +46,16 @@ class _ConnectionManagerState extends State<_ConnectionManager> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<Object>(
-        future: serviceManager.onServiceAvailable,
-        builder: (BuildContext context, AsyncSnapshot<Object> snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
+      future: serviceManager.onServiceAvailable,
+      builder: (BuildContext context, AsyncSnapshot<Object> snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
 
-          return const SharedPreferencesStateProvider(
-            child: SharedPreferencesBody(),
-          );
-        });
+        return const SharedPreferencesStateProvider(
+          child: SharedPreferencesBody(),
+        );
+      },
+    );
   }
 }

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/async_state.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/async_state.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/foundation.dart';
 
 @immutable
-
 /// A class that represents the state of an asynchronous operation.
 ///
 /// It has three possible states:
@@ -28,9 +27,7 @@ sealed class AsyncState<T> {
 
   /// Returns a [AsyncState] with the same type `T` but with the data transformed by the `onData` function.
   /// If the current state is not [AsyncStateData], it returns the current state.
-  AsyncState<T> whenData(
-    T Function(T data) onData,
-  ) {
+  AsyncState<T> whenData(T Function(T data) onData) {
     return switch (this) {
       AsyncStateData<T>(data: final T data) => AsyncState<T>.data(onData(data)),
       _ => this,
@@ -44,9 +41,7 @@ sealed class AsyncState<T> {
   /// returns the current state, but with the type mapped.
   /// If the current state is [AsyncStateData], it returns a new data state with
   /// the data transformed by the `onData` function.
-  AsyncState<R> mapWhenData<R>(
-    R Function(T data) onData,
-  ) {
+  AsyncState<R> mapWhenData<R>(R Function(T data) onData) {
     return flatMapWhenData((T data) => AsyncState<R>.data(onData(data)));
   }
 
@@ -57,9 +52,7 @@ sealed class AsyncState<T> {
   /// returns the current state, but with the type mapped.
   /// If the current state is [AsyncStateData], it returns the result of the
   /// `onData` function.
-  AsyncState<R> flatMapWhenData<R>(
-    AsyncState<R> Function(T data) onData,
-  ) {
+  AsyncState<R> flatMapWhenData<R>(AsyncState<R> Function(T data) onData) {
     return switch (this) {
       AsyncStateData<T>(data: final T data) => onData(data),
       AsyncStateError<T>(
@@ -98,14 +91,14 @@ sealed class AsyncState<T> {
 
   @override
   int get hashCode => switch (this) {
-        AsyncStateLoading<T>() => 0,
-        AsyncStateData<T>(data: final T data) => data.hashCode,
-        AsyncStateError<T>(
-          error: final Object error,
-          stackTrace: final StackTrace? stackTrace,
-        ) =>
-          error.hashCode ^ stackTrace.hashCode,
-      };
+    AsyncStateLoading<T>() => 0,
+    AsyncStateData<T>(data: final T data) => data.hashCode,
+    AsyncStateError<T>(
+      error: final Object error,
+      stackTrace: final StackTrace? stackTrace,
+    ) =>
+      error.hashCode ^ stackTrace.hashCode,
+  };
 
   @override
   String toString() {

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/shared_preferences_state.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/shared_preferences_state.dart
@@ -11,7 +11,6 @@ import 'async_state.dart';
 const Object _undefined = Object();
 
 @immutable
-
 /// A class that represents the state of the shared preferences tool.
 class SharedPreferencesState {
   /// Default constructor for [SharedPreferencesState].
@@ -42,24 +41,26 @@ class SharedPreferencesState {
     SelectedSharedPreferencesKey? selectedKey,
     bool editing,
     bool legacyApi,
-  }) get copyWith => ({
-        Object allKeys = _undefined,
-        Object? selectedKey = _undefined,
-        Object editing = _undefined,
-        Object legacyApi = _undefined,
-      }) {
-        return SharedPreferencesState(
-          allKeys: allKeys == _undefined
+  })
+  get copyWith => ({
+    Object allKeys = _undefined,
+    Object? selectedKey = _undefined,
+    Object editing = _undefined,
+    Object legacyApi = _undefined,
+  }) {
+    return SharedPreferencesState(
+      allKeys:
+          allKeys == _undefined
               ? this.allKeys
               : allKeys as AsyncState<List<String>>,
-          selectedKey: selectedKey == _undefined
+      selectedKey:
+          selectedKey == _undefined
               ? this.selectedKey
               : selectedKey as SelectedSharedPreferencesKey?,
-          editing: editing == _undefined ? this.editing : editing as bool,
-          legacyApi:
-              legacyApi == _undefined ? this.legacyApi : legacyApi as bool,
-        );
-      };
+      editing: editing == _undefined ? this.editing : editing as bool,
+      legacyApi: legacyApi == _undefined ? this.legacyApi : legacyApi as bool,
+    );
+  };
 
   @override
   bool operator ==(Object other) {
@@ -72,12 +73,7 @@ class SharedPreferencesState {
   }
 
   @override
-  int get hashCode => Object.hash(
-        allKeys,
-        selectedKey,
-        editing,
-        legacyApi,
-      );
+  int get hashCode => Object.hash(allKeys, selectedKey, editing, legacyApi);
 
   @override
   String toString() {
@@ -86,15 +82,11 @@ class SharedPreferencesState {
 }
 
 @immutable
-
 /// A class that represents the selected key and its value in the shared
 /// preferences of the target debug session.
 class SelectedSharedPreferencesKey {
   /// Default constructor for [SelectedSharedPreferencesKey].
-  const SelectedSharedPreferencesKey({
-    required this.key,
-    required this.value,
-  });
+  const SelectedSharedPreferencesKey({required this.key, required this.value});
 
   /// The user selected key.
   final String key;
@@ -125,27 +117,22 @@ abstract interface class _SharedPreferencesData<T> {
 }
 
 @immutable
-
 /// A class that represents the data of a shared preference in the target
 /// debug session.
 sealed class SharedPreferencesData implements _SharedPreferencesData<Object> {
   const SharedPreferencesData();
 
-  const factory SharedPreferencesData.string({
-    required String value,
-  }) = SharedPreferencesDataString._;
+  const factory SharedPreferencesData.string({required String value}) =
+      SharedPreferencesDataString._;
 
-  const factory SharedPreferencesData.int({
-    required int value,
-  }) = SharedPreferencesDataInt._;
+  const factory SharedPreferencesData.int({required int value}) =
+      SharedPreferencesDataInt._;
 
-  const factory SharedPreferencesData.double({
-    required double value,
-  }) = SharedPreferencesDataDouble._;
+  const factory SharedPreferencesData.double({required double value}) =
+      SharedPreferencesDataDouble._;
 
-  const factory SharedPreferencesData.bool({
-    required bool value,
-  }) = SharedPreferencesDataBool._;
+  const factory SharedPreferencesData.bool({required bool value}) =
+      SharedPreferencesDataBool._;
 
   const factory SharedPreferencesData.stringList({
     required List<String> value,
@@ -154,10 +141,8 @@ sealed class SharedPreferencesData implements _SharedPreferencesData<Object> {
   /// The string representation of the value.
   String get valueAsString {
     return switch (this) {
-      final SharedPreferencesDataStringList data => '\n${<String>[
-          for (final (int index, String str) in data.value.indexed)
-            '$index -> $str',
-        ].join('\n')}',
+      final SharedPreferencesDataStringList data =>
+        '\n${<String>[for (final (int index, String str) in data.value.indexed) '$index -> $str'].join('\n')}',
       _ => '$value',
     };
   }
@@ -179,17 +164,21 @@ sealed class SharedPreferencesData implements _SharedPreferencesData<Object> {
   /// preference value.
   SharedPreferencesData changeValue(String newValue) {
     return switch (this) {
-      SharedPreferencesDataString() =>
-        SharedPreferencesData.string(value: newValue),
-      SharedPreferencesDataInt() =>
-        SharedPreferencesData.int(value: int.parse(newValue)),
-      SharedPreferencesDataDouble() =>
-        SharedPreferencesData.double(value: double.parse(newValue)),
-      SharedPreferencesDataBool() =>
-        SharedPreferencesData.bool(value: bool.parse(newValue)),
+      SharedPreferencesDataString() => SharedPreferencesData.string(
+        value: newValue,
+      ),
+      SharedPreferencesDataInt() => SharedPreferencesData.int(
+        value: int.parse(newValue),
+      ),
+      SharedPreferencesDataDouble() => SharedPreferencesData.double(
+        value: double.parse(newValue),
+      ),
+      SharedPreferencesDataBool() => SharedPreferencesData.bool(
+        value: bool.parse(newValue),
+      ),
       SharedPreferencesDataStringList() => SharedPreferencesData.stringList(
-          value: (jsonDecode(newValue) as List<dynamic>).cast(),
-        ),
+        value: (jsonDecode(newValue) as List<dynamic>).cast(),
+      ),
     };
   }
 
@@ -216,9 +205,7 @@ sealed class SharedPreferencesData implements _SharedPreferencesData<Object> {
 
 /// A class that represents a shared preference with a string value.
 class SharedPreferencesDataString extends SharedPreferencesData {
-  const SharedPreferencesDataString._({
-    required this.value,
-  });
+  const SharedPreferencesDataString._({required this.value});
 
   /// The string value of the shared preference.
   @override
@@ -227,9 +214,7 @@ class SharedPreferencesDataString extends SharedPreferencesData {
 
 /// A class that represents a shared preference with an integer value.
 class SharedPreferencesDataInt extends SharedPreferencesData {
-  const SharedPreferencesDataInt._({
-    required this.value,
-  });
+  const SharedPreferencesDataInt._({required this.value});
 
   /// The integer value of the shared preference.
   @override
@@ -238,9 +223,7 @@ class SharedPreferencesDataInt extends SharedPreferencesData {
 
 /// A class that represents a shared preference with a double value.
 class SharedPreferencesDataDouble extends SharedPreferencesData {
-  const SharedPreferencesDataDouble._({
-    required this.value,
-  });
+  const SharedPreferencesDataDouble._({required this.value});
 
   /// The double value of the shared preference.
   @override
@@ -249,9 +232,7 @@ class SharedPreferencesDataDouble extends SharedPreferencesData {
 
 /// A class that represents a shared preference with a boolean value.
 class SharedPreferencesDataBool extends SharedPreferencesData {
-  const SharedPreferencesDataBool._({
-    required this.value,
-  });
+  const SharedPreferencesDataBool._({required this.value});
 
   /// The boolean value of the shared preference.
   @override
@@ -260,9 +241,7 @@ class SharedPreferencesDataBool extends SharedPreferencesData {
 
 /// A class that represents a shared preference with a list of string values.
 class SharedPreferencesDataStringList extends SharedPreferencesData {
-  const SharedPreferencesDataStringList._({
-    required this.value,
-  });
+  const SharedPreferencesDataStringList._({required this.value});
 
   /// The list of string values of the shared preference.
   @override

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/shared_preferences_state_notifier.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/shared_preferences_state_notifier.dart
@@ -15,9 +15,8 @@ class SharedPreferencesStateNotifier
   /// Default constructor that takes an instance of [SharedPreferencesToolEval].
   ///
   /// You don't need to call this constructor directly. Use [SharedPreferencesStateNotifierProvider] instead.
-  SharedPreferencesStateNotifier(
-    this._eval,
-  ) : super(const SharedPreferencesState());
+  SharedPreferencesStateNotifier(this._eval)
+    : super(const SharedPreferencesState());
 
   final SharedPreferencesToolEval _eval;
 
@@ -72,8 +71,10 @@ class SharedPreferencesStateNotifier
     );
 
     try {
-      final SharedPreferencesData keyValue =
-          await _eval.fetchValue(key, _legacyApi);
+      final SharedPreferencesData keyValue = await _eval.fetchValue(
+        key,
+        _legacyApi,
+      );
       value = value.copyWith(
         selectedKey: SelectedSharedPreferencesKey(
           key: key,
@@ -84,10 +85,7 @@ class SharedPreferencesStateNotifier
       value = value.copyWith(
         selectedKey: SelectedSharedPreferencesKey(
           key: key,
-          value: AsyncState<SharedPreferencesData>.error(
-            error,
-            stackTrace,
-          ),
+          value: AsyncState<SharedPreferencesData>.error(error, stackTrace),
         ),
       );
     }
@@ -107,9 +105,7 @@ class SharedPreferencesStateNotifier
   }
 
   /// Changes the value of the selected key in the shared preferences of the target debug session.
-  Future<void> changeValue(
-    SharedPreferencesData newValue,
-  ) async {
+  Future<void> changeValue(SharedPreferencesData newValue) async {
     if (value.selectedKey case final SelectedSharedPreferencesKey selectedKey) {
       value = value.copyWith(
         selectedKey: SelectedSharedPreferencesKey(

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/shared_preferences_state_provider.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/shared_preferences_state_provider.dart
@@ -18,10 +18,7 @@ import 'shared_preferences_tool_eval.dart';
 /// Check [SharedPreferencesStateProviderExtension] for more info.
 class _StateInheritedWidget extends InheritedWidget {
   /// Default constructor for [_StateInheritedWidget].
-  const _StateInheritedWidget({
-    required super.child,
-    required this.notifier,
-  });
+  const _StateInheritedWidget({required super.child, required this.notifier});
 
   final SharedPreferencesStateNotifier notifier;
 
@@ -83,7 +80,6 @@ class _SharedPreferencesStateInheritedModel
 }
 
 @visibleForTesting
-
 /// A class that provides a [SharedPreferencesStateNotifier] to its descendants.
 ///
 /// Only used for testing. You can override the notifier with a mock when testing.
@@ -107,11 +103,7 @@ class InnerSharedPreferencesStateProvider extends StatelessWidget {
       notifier: notifier,
       child: ValueListenableBuilder<SharedPreferencesState>(
         valueListenable: notifier,
-        builder: (
-          BuildContext context,
-          SharedPreferencesState value,
-          _,
-        ) {
+        builder: (BuildContext context, SharedPreferencesState value, _) {
           return _SharedPreferencesStateInheritedModel(
             state: value,
             child: child,
@@ -125,10 +117,7 @@ class InnerSharedPreferencesStateProvider extends StatelessWidget {
 /// A provider that creates a [SharedPreferencesStateNotifier] and provides it to its descendants.
 class SharedPreferencesStateProvider extends StatefulWidget {
   /// Default constructor for [SharedPreferencesStateProvider].
-  const SharedPreferencesStateProvider({
-    super.key,
-    required this.child,
-  });
+  const SharedPreferencesStateProvider({super.key, required this.child});
 
   /// Returns the async state of the list of all keys.
   /// [_SharedPreferencesStateInheritedModel] ancestor.
@@ -139,9 +128,8 @@ class SharedPreferencesStateProvider extends StatefulWidget {
   static AsyncState<List<String>> keysListStateOf(BuildContext context) {
     return context
         .dependOnInheritedWidgetOfExactType<
-            _SharedPreferencesStateInheritedModel>(
-          aspect: _StateInheritedModelAspect.keysList,
-        )!
+          _SharedPreferencesStateInheritedModel
+        >(aspect: _StateInheritedModelAspect.keysList)!
         .state
         .allKeys;
   }
@@ -155,9 +143,8 @@ class SharedPreferencesStateProvider extends StatefulWidget {
   static SelectedSharedPreferencesKey? selectedKeyOf(BuildContext context) {
     return context
         .dependOnInheritedWidgetOfExactType<
-            _SharedPreferencesStateInheritedModel>(
-          aspect: _StateInheritedModelAspect.selectedKey,
-        )!
+          _SharedPreferencesStateInheritedModel
+        >(aspect: _StateInheritedModelAspect.selectedKey)!
         .state
         .selectedKey;
   }
@@ -167,7 +154,8 @@ class SharedPreferencesStateProvider extends StatefulWidget {
   ///
   /// Throws an error if the selected key is null.
   static SelectedSharedPreferencesKey requireSelectedKeyOf(
-      BuildContext context) {
+    BuildContext context,
+  ) {
     return selectedKeyOf(context)!;
   }
 
@@ -181,9 +169,8 @@ class SharedPreferencesStateProvider extends StatefulWidget {
   ) {
     return context
         .dependOnInheritedWidgetOfExactType<
-            _SharedPreferencesStateInheritedModel>(
-          aspect: _StateInheritedModelAspect.selectedKeyData,
-        )!
+          _SharedPreferencesStateInheritedModel
+        >(aspect: _StateInheritedModelAspect.selectedKeyData)!
         .state
         .selectedKey
         ?.value;
@@ -197,9 +184,8 @@ class SharedPreferencesStateProvider extends StatefulWidget {
   static bool editingOf(BuildContext context) {
     return context
         .dependOnInheritedWidgetOfExactType<
-            _SharedPreferencesStateInheritedModel>(
-          aspect: _StateInheritedModelAspect.editing,
-        )!
+          _SharedPreferencesStateInheritedModel
+        >(aspect: _StateInheritedModelAspect.editing)!
         .state
         .editing;
   }
@@ -212,9 +198,8 @@ class SharedPreferencesStateProvider extends StatefulWidget {
   static bool legacyApiOf(BuildContext context) {
     return context
         .dependOnInheritedWidgetOfExactType<
-            _SharedPreferencesStateInheritedModel>(
-          aspect: _StateInheritedModelAspect.legacyApi,
-        )!
+          _SharedPreferencesStateInheritedModel
+        >(aspect: _StateInheritedModelAspect.legacyApi)!
         .state
         .legacyApi;
   }

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/shared_preferences_tool_eval.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/shared_preferences_tool_eval.dart
@@ -12,10 +12,7 @@ import 'shared_preferences_state.dart';
 
 /// A representation of the keys in the shared preferences of the target debug
 /// session.
-typedef KeysResult = ({
-  List<String> asyncKeys,
-  List<String> legacyKeys,
-});
+typedef KeysResult = ({List<String> asyncKeys, List<String> legacyKeys});
 
 /// A class that provides methods to interact with the shared preferences
 /// of the target debug session.
@@ -25,10 +22,7 @@ class SharedPreferencesToolEval {
   /// Default constructor for [SharedPreferencesToolEval].
   /// Do not call this constructor directly.
   /// Use [SharedPreferencesStateNotifierProvider] instead.
-  SharedPreferencesToolEval(
-    this._service,
-    this._eval,
-  );
+  SharedPreferencesToolEval(this._service, this._eval);
 
   final VmService _service;
   final EvalOnDartLibrary _eval;
@@ -105,24 +99,14 @@ class SharedPreferencesToolEval {
     // gets interpreted as an int. If this was not and issue
     // we'd only need to do a simple pattern matching on value.
     return switch (kind) {
-      'int' => SharedPreferencesData.int(
-          value: value as int,
-        ),
-      'bool' => SharedPreferencesData.bool(
-          value: value as bool,
-        ),
-      'double' => SharedPreferencesData.double(
-          value: value as double,
-        ),
-      'String' => SharedPreferencesData.string(
-          value: value as String,
-        ),
+      'int' => SharedPreferencesData.int(value: value as int),
+      'bool' => SharedPreferencesData.bool(value: value as bool),
+      'double' => SharedPreferencesData.double(value: value as double),
+      'String' => SharedPreferencesData.string(value: value as String),
       String() when kind.contains('List') => SharedPreferencesData.stringList(
-          value: (value as List<Object?>).cast(),
-        ),
-      _ => throw UnsupportedError(
-          'Unsupported value type: $kind',
-        ),
+        value: (value as List<Object?>).cast(),
+      ),
+      _ => throw UnsupportedError('Unsupported value type: $kind'),
     };
   }
 

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/ui/api_switch.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/ui/api_switch.dart
@@ -10,9 +10,7 @@ import '../shared_preferences_state_provider.dart';
 /// A switch to toggle between the legacy and async APIs.
 class ApiSwitch extends StatelessWidget {
   /// Default constructor for [ApiSwitch].
-  const ApiSwitch({
-    super.key,
-  });
+  const ApiSwitch({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -21,16 +19,15 @@ class ApiSwitch extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(vertical: denseSpacing),
       decoration: BoxDecoration(
-        border: Border(
-          bottom: BorderSide(color: Theme.of(context).focusColor),
-        ),
+        border: Border(bottom: BorderSide(color: Theme.of(context).focusColor)),
       ),
       child: Center(
         child: DevToolsToggleButtonGroup(
           selectedStates: <bool>[legacyApi, !legacyApi],
           onPressed: (int index) {
-            context.sharedPreferencesStateNotifier
-                .selectApi(legacyApi: index == 0);
+            context.sharedPreferencesStateNotifier.selectApi(
+              legacyApi: index == 0,
+            );
           },
           children: const <Widget>[
             Padding(

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/ui/data_panel.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/ui/data_panel.dart
@@ -40,30 +40,22 @@ class _DataPanelState extends State<DataPanel> {
     return RoundedOutlinedBorder(
       clip: true,
       child: switch (selectedKeyData) {
-        null => const Center(
-            child: Text('Select a key to view its data.'),
-          ),
+        null => const Center(child: Text('Select a key to view its data.')),
         AsyncStateLoading<SharedPreferencesData>() => const Center(
-            child: CircularProgressIndicator(),
-          ),
+          child: CircularProgressIndicator(),
+        ),
         final AsyncStateError<SharedPreferencesData> value => ErrorPanel(
-            error: value.error,
-            stackTrace: value.stackTrace,
-          ),
+          error: value.error,
+          stackTrace: value.stackTrace,
+        ),
         AsyncStateData<SharedPreferencesData>(
           data: final SharedPreferencesData data,
         ) =>
           Column(
             children: <Widget>[
-              _Header(
-                currentValue: currentValue,
-                data: data,
-              ),
+              _Header(currentValue: currentValue, data: data),
               Expanded(
-                child: _Content(
-                  data: data,
-                  setCurrentValue: _setCurrentValue,
-                ),
+                child: _Content(data: data, setCurrentValue: _setCurrentValue),
               ),
             ],
           ),
@@ -73,10 +65,7 @@ class _DataPanelState extends State<DataPanel> {
 }
 
 class _Header extends StatelessWidget {
-  const _Header({
-    required this.currentValue,
-    required this.data,
-  });
+  const _Header({required this.currentValue, required this.data});
 
   final String? currentValue;
   final SharedPreferencesData data;
@@ -93,10 +82,7 @@ class _Header extends StatelessWidget {
       roundedTopBorder: false,
       includeTopBorder: false,
       tall: true,
-      title: Text(
-        selectedKey,
-        style: Theme.of(context).textTheme.titleSmall,
-      ),
+      title: Text(selectedKey, style: Theme.of(context).textTheme.titleSmall),
       actions: <Widget>[
         if (editing) ...<Widget>[
           DevToolsButton(
@@ -134,18 +120,19 @@ class _Header extends StatelessWidget {
                   context.sharedPreferencesStateNotifier;
               showDialog<void>(
                 context: context,
-                builder: (BuildContext context) => _ConfirmRemoveDialog(
-                  selectedKey: selectedKey,
-                  notifier: notifier,
-                ),
+                builder:
+                    (BuildContext context) => _ConfirmRemoveDialog(
+                      selectedKey: selectedKey,
+                      notifier: notifier,
+                    ),
               );
             },
             label: 'Remove',
           ),
           const SizedBox(width: denseRowSpacing),
           DevToolsButton(
-            onPressed: () =>
-                context.sharedPreferencesStateNotifier.startEditing(),
+            onPressed:
+                () => context.sharedPreferencesStateNotifier.startEditing(),
             label: 'Edit',
           ),
         ],
@@ -167,9 +154,7 @@ class _ConfirmRemoveDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return DevToolsDialog(
       title: const Text('Remove Key'),
-      content: Text(
-        'Are you sure you want to remove $selectedKey?',
-      ),
+      content: Text('Are you sure you want to remove $selectedKey?'),
       actions: <Widget>[
         const DialogCancelButton(),
         DialogTextButton(
@@ -191,10 +176,7 @@ class _ConfirmRemoveDialog extends StatelessWidget {
 }
 
 class _Content extends StatelessWidget {
-  const _Content({
-    required this.data,
-    required this.setCurrentValue,
-  });
+  const _Content({required this.data, required this.setCurrentValue});
 
   final SharedPreferencesData data;
   final ValueChanged<String> setCurrentValue;
@@ -217,36 +199,32 @@ class _Content extends StatelessWidget {
                 const SizedBox(height: denseSpacing),
                 switch (data) {
                   final SharedPreferencesDataBool state => _EditBoolean(
-                      initialValue: state.value,
-                      setCurrentValue: setCurrentValue,
-                    ),
+                    initialValue: state.value,
+                    setCurrentValue: setCurrentValue,
+                  ),
                   final SharedPreferencesDataStringList state =>
                     _EditStringList(
                       initialData: state.value,
                       onChanged: setCurrentValue,
                     ),
                   _ => TextFormField(
-                      autofocus: true,
-                      initialValue: data.valueAsString,
-                      inputFormatters: switch (data) {
-                        SharedPreferencesDataInt() => <TextInputFormatter>[
-                            FilteringTextInputFormatter.allow(
-                              RegExp(r'^-?\d*'),
-                            ),
-                          ],
-                        SharedPreferencesDataDouble() => <TextInputFormatter>[
-                            FilteringTextInputFormatter.allow(
-                              RegExp(r'^-?\d*\.?\d*'),
-                            ),
-                          ],
-                        _ => <TextInputFormatter>[],
-                      },
-                      onChanged: setCurrentValue,
-                    )
+                    autofocus: true,
+                    initialValue: data.valueAsString,
+                    inputFormatters: switch (data) {
+                      SharedPreferencesDataInt() => <TextInputFormatter>[
+                        FilteringTextInputFormatter.allow(RegExp(r'^-?\d*')),
+                      ],
+                      SharedPreferencesDataDouble() => <TextInputFormatter>[
+                        FilteringTextInputFormatter.allow(
+                          RegExp(r'^-?\d*\.?\d*'),
+                        ),
+                      ],
+                      _ => <TextInputFormatter>[],
+                    },
+                    onChanged: setCurrentValue,
+                  ),
                 },
-              ] else ...<Widget>[
-                Text('Value: ${data.valueAsString}'),
-              ],
+              ] else ...<Widget>[Text('Value: ${data.valueAsString}')],
             ],
           ),
         ),
@@ -272,24 +250,15 @@ class _EditBoolean extends StatelessWidget {
         setCurrentValue(value.toString());
       },
       dropdownMenuEntries: const <DropdownMenuEntry<bool>>[
-        DropdownMenuEntry<bool>(
-          label: 'true',
-          value: true,
-        ),
-        DropdownMenuEntry<bool>(
-          label: 'false',
-          value: false,
-        ),
+        DropdownMenuEntry<bool>(label: 'true', value: true),
+        DropdownMenuEntry<bool>(label: 'false', value: false),
       ],
     );
   }
 }
 
 class _EditStringList extends StatefulWidget {
-  const _EditStringList({
-    required this.initialData,
-    required this.onChanged,
-  });
+  const _EditStringList({required this.initialData, required this.onChanged});
 
   final List<String> initialData;
   final ValueChanged<String> onChanged;
@@ -310,11 +279,9 @@ class _EditStringListState extends State<_EditStringList> {
   }
 
   void _updateValue() {
-    widget.onChanged(jsonEncode(
-      <String>[
-        for (final (_, String value) in _currentList) value,
-      ],
-    ));
+    widget.onChanged(
+      jsonEncode(<String>[for (final (_, String value) in _currentList) value]),
+    );
   }
 
   @override
@@ -334,9 +301,7 @@ class _EditStringListState extends State<_EditStringList> {
         for (final (int index, (int keyValue, String str))
             in _currentList.indexed) ...<Widget>[
           if (index > 0) const SizedBox(height: largeSpacing),
-          _AddListElement(
-            onPressed: () => _addElementAt(index),
-          ),
+          _AddListElement(onPressed: () => _addElementAt(index)),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: densePadding),
             child: Row(
@@ -361,44 +326,31 @@ class _EditStringListState extends State<_EditStringList> {
                     });
                     _updateValue();
                   },
-                )
+                ),
               ],
             ),
           ),
         ],
         const SizedBox(height: largeSpacing),
-        _AddListElement(
-          onPressed: () => _addElementAt(_currentList.length),
-        ),
+        _AddListElement(onPressed: () => _addElementAt(_currentList.length)),
       ],
     );
   }
 }
 
 class _AddListElement extends StatelessWidget {
-  const _AddListElement({
-    required this.onPressed,
-  });
+  const _AddListElement({required this.onPressed});
 
   final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: DevToolsButton(
-        icon: Icons.add,
-        onPressed: onPressed,
-      ),
-    );
+    return Center(child: DevToolsButton(icon: Icons.add, onPressed: onPressed));
   }
 }
 
 extension on BuildContext {
   void showSnackBar(String message) {
-    ScaffoldMessenger.of(this).showSnackBar(
-      SnackBar(
-        content: Text(message),
-      ),
-    );
+    ScaffoldMessenger.of(this).showSnackBar(SnackBar(content: Text(message)));
   }
 }

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/ui/error_panel.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/ui/error_panel.dart
@@ -8,11 +8,7 @@ import 'package:flutter/material.dart';
 /// A panel that displays an error message and a stack trace.
 class ErrorPanel extends StatelessWidget {
   /// Default constructor for [ErrorPanel].
-  const ErrorPanel({
-    super.key,
-    required this.error,
-    required this.stackTrace,
-  });
+  const ErrorPanel({super.key, required this.error, required this.stackTrace});
 
   /// The error message to display.
   /// This will be displayed as a string.

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/ui/keys_panel.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/ui/keys_panel.dart
@@ -61,9 +61,7 @@ class _KeysPanelState extends State<KeysPanel> {
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
                 if (searching) ...<Widget>[
-                  const SizedBox(
-                    width: denseSpacing,
-                  ),
+                  const SizedBox(width: denseSpacing),
                   Expanded(
                     child: _SearchField(
                       searchFocusNode: searchFocusNode,
@@ -78,9 +76,7 @@ class _KeysPanelState extends State<KeysPanel> {
                     onPressed: _startSearching,
                   ),
                 ],
-                const SizedBox(
-                  width: denseRowSpacing,
-                ),
+                const SizedBox(width: denseRowSpacing),
                 _ToolbarAction(
                   tooltipMessage: 'Refresh',
                   icon: Icons.refresh,
@@ -93,9 +89,7 @@ class _KeysPanelState extends State<KeysPanel> {
             ),
           ),
           const ApiSwitch(),
-          const Expanded(
-            child: _StateMapper(),
-          ),
+          const Expanded(child: _StateMapper()),
         ],
       ),
     );
@@ -155,9 +149,7 @@ class _SearchField extends StatelessWidget {
       child: TextField(
         autofocus: true,
         decoration: InputDecoration(
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: densePadding,
-          ),
+          contentPadding: const EdgeInsets.symmetric(horizontal: densePadding),
           hintText: 'Search',
           border: const OutlineInputBorder(),
           suffix: _ToolbarAction(
@@ -180,24 +172,20 @@ class _StateMapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return switch (SharedPreferencesStateProvider.keysListStateOf(context)) {
-      final AsyncStateData<List<String>> value => _KeysList(
-          keys: value.data,
-        ),
+      final AsyncStateData<List<String>> value => _KeysList(keys: value.data),
       final AsyncStateError<List<String>> value => ErrorPanel(
-          error: value.error,
-          stackTrace: value.stackTrace,
-        ),
+        error: value.error,
+        stackTrace: value.stackTrace,
+      ),
       AsyncStateLoading<List<String>>() => const Center(
-          child: CircularProgressIndicator(),
-        ),
+        child: CircularProgressIndicator(),
+      ),
     };
   }
 }
 
 class _KeysList extends StatefulWidget {
-  const _KeysList({
-    required this.keys,
-  });
+  const _KeysList({required this.keys});
 
   final List<String> keys;
 
@@ -221,10 +209,7 @@ class _KeysListState extends State<_KeysList> {
       child: ListView(
         controller: scrollController,
         children: <Widget>[
-          for (final String keyName in widget.keys)
-            _KeyItem(
-              keyName: keyName,
-            ),
+          for (final String keyName in widget.keys) _KeyItem(keyName: keyName),
         ],
       ),
     );
@@ -232,9 +217,7 @@ class _KeysListState extends State<_KeysList> {
 }
 
 class _KeyItem extends StatelessWidget {
-  const _KeyItem({
-    required this.keyName,
-  });
+  const _KeyItem({required this.keyName});
 
   final String keyName;
 
@@ -259,10 +242,7 @@ class _KeyItem extends StatelessWidget {
           top: densePadding,
           bottom: densePadding,
         ),
-        child: Text(
-          keyName,
-          style: Theme.of(context).textTheme.titleSmall,
-        ),
+        child: Text(keyName, style: Theme.of(context).textTheme.titleSmall),
       ),
     );
   }

--- a/packages/shared_preferences/shared_preferences_tool/lib/src/ui/shared_preferences_body.dart
+++ b/packages/shared_preferences/shared_preferences_tool/lib/src/ui/shared_preferences_body.dart
@@ -21,10 +21,7 @@ class SharedPreferencesBody extends StatelessWidget {
     return SplitPane(
       axis: splitAxis,
       initialFractions: const <double>[0.33, 0.67],
-      children: const <Widget>[
-        KeysPanel(),
-        DataPanel(),
-      ],
+      children: const <Widget>[KeysPanel(), DataPanel()],
     );
   }
 }

--- a/packages/shared_preferences/shared_preferences_tool/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_tool/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.1
 
 environment:
-  sdk: '>=3.6.0 <4.0.0'
+  sdk: ^3.7.0
 
 dependencies:
   devtools_app_shared: ^0.3.0

--- a/packages/shared_preferences/shared_preferences_tool/test/src/shared_preferences_state_notifier_test.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/src/shared_preferences_state_notifier_test.dart
@@ -13,7 +13,7 @@ import 'package:shared_preferences_tool/src/shared_preferences_tool_eval.dart';
 
 @GenerateNiceMocks(<MockSpec<dynamic>>[
   MockSpec<SharedPreferencesToolEval>(),
-  MockSpec<ConnectedApp>()
+  MockSpec<ConnectedApp>(),
 ])
 import 'shared_preferences_state_notifier_test.mocks.dart';
 
@@ -32,21 +32,15 @@ void main() {
     });
 
     test('should start with the default state', () {
-      expect(
-        notifier.value,
-        const SharedPreferencesState(),
-      );
+      expect(notifier.value, const SharedPreferencesState());
     });
 
     test('should fetch all keys', () async {
       const List<String> asyncKeys = <String>['key1', 'key2'];
       const List<String> legacyKeys = <String>['key11', 'key22'];
-      when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: asyncKeys,
-          legacyKeys: legacyKeys,
-        ),
-      );
+      when(
+        evalMock.fetchAllKeys(),
+      ).thenAnswer((_) async => (asyncKeys: asyncKeys, legacyKeys: legacyKeys));
 
       await notifier.fetchAllKeys();
 
@@ -56,34 +50,26 @@ void main() {
     test('should filter out keys with "flutter." prefix async keys', () async {
       const List<String> asyncKeys = <String>['flutter.key1', 'key2'];
       const List<String> legacyKeys = <String>['key1', 'key3'];
-      when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: asyncKeys,
-          legacyKeys: legacyKeys,
-        ),
-      );
+      when(
+        evalMock.fetchAllKeys(),
+      ).thenAnswer((_) async => (asyncKeys: asyncKeys, legacyKeys: legacyKeys));
 
       await notifier.fetchAllKeys();
 
-      expect(
-        notifier.value.allKeys.dataOrNull,
-        equals(<String>['key2']),
-      );
+      expect(notifier.value.allKeys.dataOrNull, equals(<String>['key2']));
     });
 
     test('should select key', () async {
       const List<String> keys = <String>['key1', 'key2'];
-      const SharedPreferencesData keyValue =
-          SharedPreferencesData.string(value: 'value');
+      const SharedPreferencesData keyValue = SharedPreferencesData.string(
+        value: 'value',
+      );
       when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: keys,
-          legacyKeys: const <String>[],
-        ),
+        (_) async => (asyncKeys: keys, legacyKeys: const <String>[]),
       );
-      when(evalMock.fetchValue('key1', false)).thenAnswer(
-        (_) async => keyValue,
-      );
+      when(
+        evalMock.fetchValue('key1', false),
+      ).thenAnswer((_) async => keyValue);
       await notifier.fetchAllKeys();
 
       await notifier.selectKey('key1');
@@ -101,17 +87,13 @@ void main() {
 
     test('should select key for legacy api', () async {
       const List<String> keys = <String>['key1', 'key2'];
-      const SharedPreferencesData keyValue =
-          SharedPreferencesData.string(value: 'value');
+      const SharedPreferencesData keyValue = SharedPreferencesData.string(
+        value: 'value',
+      );
       when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: const <String>[],
-          legacyKeys: keys,
-        ),
+        (_) async => (asyncKeys: const <String>[], legacyKeys: keys),
       );
-      when(evalMock.fetchValue('key1', true)).thenAnswer(
-        (_) async => keyValue,
-      );
+      when(evalMock.fetchValue('key1', true)).thenAnswer((_) async => keyValue);
       await notifier.fetchAllKeys();
       notifier.selectApi(legacyApi: true);
 
@@ -135,12 +117,9 @@ void main() {
     test('should filter keys and clear filter', () async {
       const List<String> asyncKeys = <String>['key1', 'key2'];
       const List<String> legacyKeys = <String>['key11', 'key22'];
-      when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: asyncKeys,
-          legacyKeys: legacyKeys,
-        ),
-      );
+      when(
+        evalMock.fetchAllKeys(),
+      ).thenAnswer((_) async => (asyncKeys: asyncKeys, legacyKeys: legacyKeys));
       await notifier.fetchAllKeys();
 
       notifier.filter('key1');
@@ -155,12 +134,9 @@ void main() {
     test('should start/stop editing', () async {
       const List<String> asyncKeys = <String>['key1', 'key2'];
       const List<String> legacyKeys = <String>['key11', 'key22'];
-      when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: asyncKeys,
-          legacyKeys: legacyKeys,
-        ),
-      );
+      when(
+        evalMock.fetchAllKeys(),
+      ).thenAnswer((_) async => (asyncKeys: asyncKeys, legacyKeys: legacyKeys));
       await notifier.fetchAllKeys();
       notifier.startEditing();
 
@@ -174,18 +150,15 @@ void main() {
     test('should change value', () async {
       const List<String> asyncKeys = <String>['key1', 'key2'];
       const List<String> legacyKeys = <String>['key11', 'key22'];
-      when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: asyncKeys,
-          legacyKeys: legacyKeys,
-        ),
-      );
+      when(
+        evalMock.fetchAllKeys(),
+      ).thenAnswer((_) async => (asyncKeys: asyncKeys, legacyKeys: legacyKeys));
       const SharedPreferencesData keyValue = SharedPreferencesData.string(
         value: 'value',
       );
-      when(evalMock.fetchValue('key1', false)).thenAnswer(
-        (_) async => keyValue,
-      );
+      when(
+        evalMock.fetchValue('key1', false),
+      ).thenAnswer((_) async => keyValue);
       await notifier.fetchAllKeys();
       await notifier.selectKey('key1');
 
@@ -197,16 +170,15 @@ void main() {
     test('should change value', () async {
       const List<String> asyncKeys = <String>['key1', 'key2'];
       const List<String> legacyKeys = <String>['key11', 'key22'];
-      when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: asyncKeys,
-          legacyKeys: legacyKeys,
-        ),
+      when(
+        evalMock.fetchAllKeys(),
+      ).thenAnswer((_) async => (asyncKeys: asyncKeys, legacyKeys: legacyKeys));
+      const SharedPreferencesData keyValue = SharedPreferencesData.string(
+        value: 'value',
       );
-      const SharedPreferencesData keyValue =
-          SharedPreferencesData.string(value: 'value');
-      when(evalMock.fetchValue('key1', false))
-          .thenAnswer((_) async => keyValue);
+      when(
+        evalMock.fetchValue('key1', false),
+      ).thenAnswer((_) async => keyValue);
       await notifier.fetchAllKeys();
       await notifier.selectKey('key1');
 
@@ -226,12 +198,9 @@ void main() {
     test('should change select legacy api and async api', () async {
       const List<String> asyncKeys = <String>['key1', 'key2'];
       const List<String> legacyKeys = <String>['key11', 'key22'];
-      when(evalMock.fetchAllKeys()).thenAnswer(
-        (_) async => (
-          asyncKeys: asyncKeys,
-          legacyKeys: legacyKeys,
-        ),
-      );
+      when(
+        evalMock.fetchAllKeys(),
+      ).thenAnswer((_) async => (asyncKeys: asyncKeys, legacyKeys: legacyKeys));
       await notifier.fetchAllKeys();
 
       notifier.selectApi(legacyApi: true);

--- a/packages/shared_preferences/shared_preferences_tool/test/src/shared_preferences_state_notifier_test.mocks.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/src/shared_preferences_state_notifier_test.mocks.dart
@@ -27,13 +27,8 @@ import 'package:shared_preferences_tool/src/shared_preferences_tool_eval.dart'
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeCompleter_0<T> extends _i1.SmartFake implements _i2.Completer<T> {
-  _FakeCompleter_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeCompleter_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [SharedPreferencesToolEval].
@@ -43,59 +38,37 @@ class MockSharedPreferencesToolEval extends _i1.Mock
     implements _i3.SharedPreferencesToolEval {
   @override
   _i2.Future<({List<String> asyncKeys, List<String> legacyKeys})>
-      fetchAllKeys() => (super.noSuchMethod(
-            Invocation.method(
-              #fetchAllKeys,
-              [],
-            ),
+  fetchAllKeys() =>
+      (super.noSuchMethod(
+            Invocation.method(#fetchAllKeys, []),
             returnValue: _i2.Future<
-                ({
-                  List<String> asyncKeys,
-                  List<String> legacyKeys
-                })>.value((asyncKeys: <String>[], legacyKeys: <String>[])),
+              ({List<String> asyncKeys, List<String> legacyKeys})
+            >.value((asyncKeys: <String>[], legacyKeys: <String>[])),
             returnValueForMissingStub: _i2.Future<
-                ({
-                  List<String> asyncKeys,
-                  List<String> legacyKeys
-                })>.value((asyncKeys: <String>[], legacyKeys: <String>[])),
-          ) as _i2.Future<({List<String> asyncKeys, List<String> legacyKeys})>);
+              ({List<String> asyncKeys, List<String> legacyKeys})
+            >.value((asyncKeys: <String>[], legacyKeys: <String>[])),
+          )
+          as _i2.Future<({List<String> asyncKeys, List<String> legacyKeys})>);
 
   @override
-  _i2.Future<_i4.SharedPreferencesData> fetchValue(
-    String? key,
-    bool? legacy,
-  ) =>
+  _i2.Future<_i4.SharedPreferencesData> fetchValue(String? key, bool? legacy) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #fetchValue,
-          [
-            key,
-            legacy,
-          ],
-        ),
-        returnValue: _i2.Future<_i4.SharedPreferencesData>.value(
-            _i5.dummyValue<_i4.SharedPreferencesData>(
-          this,
-          Invocation.method(
-            #fetchValue,
-            [
-              key,
-              legacy,
-            ],
-          ),
-        )),
-        returnValueForMissingStub: _i2.Future<_i4.SharedPreferencesData>.value(
-            _i5.dummyValue<_i4.SharedPreferencesData>(
-          this,
-          Invocation.method(
-            #fetchValue,
-            [
-              key,
-              legacy,
-            ],
-          ),
-        )),
-      ) as _i2.Future<_i4.SharedPreferencesData>);
+            Invocation.method(#fetchValue, [key, legacy]),
+            returnValue: _i2.Future<_i4.SharedPreferencesData>.value(
+              _i5.dummyValue<_i4.SharedPreferencesData>(
+                this,
+                Invocation.method(#fetchValue, [key, legacy]),
+              ),
+            ),
+            returnValueForMissingStub:
+                _i2.Future<_i4.SharedPreferencesData>.value(
+                  _i5.dummyValue<_i4.SharedPreferencesData>(
+                    this,
+                    Invocation.method(#fetchValue, [key, legacy]),
+                  ),
+                ),
+          )
+          as _i2.Future<_i4.SharedPreferencesData>);
 
   @override
   _i2.Future<void> changeValue(
@@ -104,43 +77,26 @@ class MockSharedPreferencesToolEval extends _i1.Mock
     bool? legacy,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #changeValue,
-          [
-            key,
-            value,
-            legacy,
-          ],
-        ),
-        returnValue: _i2.Future<void>.value(),
-        returnValueForMissingStub: _i2.Future<void>.value(),
-      ) as _i2.Future<void>);
+            Invocation.method(#changeValue, [key, value, legacy]),
+            returnValue: _i2.Future<void>.value(),
+            returnValueForMissingStub: _i2.Future<void>.value(),
+          )
+          as _i2.Future<void>);
 
   @override
-  _i2.Future<void> deleteKey(
-    String? key,
-    bool? legacy,
-  ) =>
+  _i2.Future<void> deleteKey(String? key, bool? legacy) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #deleteKey,
-          [
-            key,
-            legacy,
-          ],
-        ),
-        returnValue: _i2.Future<void>.value(),
-        returnValueForMissingStub: _i2.Future<void>.value(),
-      ) as _i2.Future<void>);
+            Invocation.method(#deleteKey, [key, legacy]),
+            returnValue: _i2.Future<void>.value(),
+            returnValueForMissingStub: _i2.Future<void>.value(),
+          )
+          as _i2.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#dispose, []),
+    returnValueForMissingStub: null,
+  );
 }
 
 /// A class which mocks [ConnectedApp].
@@ -148,122 +104,137 @@ class MockSharedPreferencesToolEval extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockConnectedApp extends _i1.Mock implements _i6.ConnectedApp {
   @override
-  _i2.Completer<bool> get initialized => (super.noSuchMethod(
-        Invocation.getter(#initialized),
-        returnValue: _FakeCompleter_0<bool>(
-          this,
-          Invocation.getter(#initialized),
-        ),
-        returnValueForMissingStub: _FakeCompleter_0<bool>(
-          this,
-          Invocation.getter(#initialized),
-        ),
-      ) as _i2.Completer<bool>);
+  _i2.Completer<bool> get initialized =>
+      (super.noSuchMethod(
+            Invocation.getter(#initialized),
+            returnValue: _FakeCompleter_0<bool>(
+              this,
+              Invocation.getter(#initialized),
+            ),
+            returnValueForMissingStub: _FakeCompleter_0<bool>(
+              this,
+              Invocation.getter(#initialized),
+            ),
+          )
+          as _i2.Completer<bool>);
 
   @override
   set initialized(_i2.Completer<bool>? _initialized) => super.noSuchMethod(
-        Invocation.setter(
-          #initialized,
-          _initialized,
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#initialized, _initialized),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  bool get connectedAppInitialized => (super.noSuchMethod(
-        Invocation.getter(#connectedAppInitialized),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get connectedAppInitialized =>
+      (super.noSuchMethod(
+            Invocation.getter(#connectedAppInitialized),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 
   @override
-  String get operatingSystem => (super.noSuchMethod(
-        Invocation.getter(#operatingSystem),
-        returnValue: _i5.dummyValue<String>(
-          this,
-          Invocation.getter(#operatingSystem),
-        ),
-        returnValueForMissingStub: _i5.dummyValue<String>(
-          this,
-          Invocation.getter(#operatingSystem),
-        ),
-      ) as String);
+  String get operatingSystem =>
+      (super.noSuchMethod(
+            Invocation.getter(#operatingSystem),
+            returnValue: _i5.dummyValue<String>(
+              this,
+              Invocation.getter(#operatingSystem),
+            ),
+            returnValueForMissingStub: _i5.dummyValue<String>(
+              this,
+              Invocation.getter(#operatingSystem),
+            ),
+          )
+          as String);
 
   @override
-  _i2.Future<bool> get isFlutterApp => (super.noSuchMethod(
-        Invocation.getter(#isFlutterApp),
-        returnValue: _i2.Future<bool>.value(false),
-        returnValueForMissingStub: _i2.Future<bool>.value(false),
-      ) as _i2.Future<bool>);
+  _i2.Future<bool> get isFlutterApp =>
+      (super.noSuchMethod(
+            Invocation.getter(#isFlutterApp),
+            returnValue: _i2.Future<bool>.value(false),
+            returnValueForMissingStub: _i2.Future<bool>.value(false),
+          )
+          as _i2.Future<bool>);
 
   @override
-  _i2.Future<bool> get isProfileBuild => (super.noSuchMethod(
-        Invocation.getter(#isProfileBuild),
-        returnValue: _i2.Future<bool>.value(false),
-        returnValueForMissingStub: _i2.Future<bool>.value(false),
-      ) as _i2.Future<bool>);
+  _i2.Future<bool> get isProfileBuild =>
+      (super.noSuchMethod(
+            Invocation.getter(#isProfileBuild),
+            returnValue: _i2.Future<bool>.value(false),
+            returnValueForMissingStub: _i2.Future<bool>.value(false),
+          )
+          as _i2.Future<bool>);
 
   @override
-  _i2.Future<bool> get isDartWebApp => (super.noSuchMethod(
-        Invocation.getter(#isDartWebApp),
-        returnValue: _i2.Future<bool>.value(false),
-        returnValueForMissingStub: _i2.Future<bool>.value(false),
-      ) as _i2.Future<bool>);
+  _i2.Future<bool> get isDartWebApp =>
+      (super.noSuchMethod(
+            Invocation.getter(#isDartWebApp),
+            returnValue: _i2.Future<bool>.value(false),
+            returnValueForMissingStub: _i2.Future<bool>.value(false),
+          )
+          as _i2.Future<bool>);
 
   @override
-  bool get isFlutterWebAppNow => (super.noSuchMethod(
-        Invocation.getter(#isFlutterWebAppNow),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get isFlutterWebAppNow =>
+      (super.noSuchMethod(
+            Invocation.getter(#isFlutterWebAppNow),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 
   @override
-  bool get isFlutterNativeAppNow => (super.noSuchMethod(
-        Invocation.getter(#isFlutterNativeAppNow),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get isFlutterNativeAppNow =>
+      (super.noSuchMethod(
+            Invocation.getter(#isFlutterNativeAppNow),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 
   @override
-  bool get isDebugFlutterAppNow => (super.noSuchMethod(
-        Invocation.getter(#isDebugFlutterAppNow),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get isDebugFlutterAppNow =>
+      (super.noSuchMethod(
+            Invocation.getter(#isDebugFlutterAppNow),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 
   @override
-  _i2.Future<bool> get isDartCliApp => (super.noSuchMethod(
-        Invocation.getter(#isDartCliApp),
-        returnValue: _i2.Future<bool>.value(false),
-        returnValueForMissingStub: _i2.Future<bool>.value(false),
-      ) as _i2.Future<bool>);
+  _i2.Future<bool> get isDartCliApp =>
+      (super.noSuchMethod(
+            Invocation.getter(#isDartCliApp),
+            returnValue: _i2.Future<bool>.value(false),
+            returnValueForMissingStub: _i2.Future<bool>.value(false),
+          )
+          as _i2.Future<bool>);
 
   @override
-  bool get isDartCliAppNow => (super.noSuchMethod(
-        Invocation.getter(#isDartCliAppNow),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get isDartCliAppNow =>
+      (super.noSuchMethod(
+            Invocation.getter(#isDartCliAppNow),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 
   @override
   _i2.Future<void> initializeValues({void Function()? onComplete}) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #initializeValues,
-          [],
-          {#onComplete: onComplete},
-        ),
-        returnValue: _i2.Future<void>.value(),
-        returnValueForMissingStub: _i2.Future<void>.value(),
-      ) as _i2.Future<void>);
+            Invocation.method(#initializeValues, [], {#onComplete: onComplete}),
+            returnValue: _i2.Future<void>.value(),
+            returnValueForMissingStub: _i2.Future<void>.value(),
+          )
+          as _i2.Future<void>);
 
   @override
-  Map<String, Object?> toJson() => (super.noSuchMethod(
-        Invocation.method(
-          #toJson,
-          [],
-        ),
-        returnValue: <String, Object?>{},
-        returnValueForMissingStub: <String, Object?>{},
-      ) as Map<String, Object?>);
+  Map<String, Object?> toJson() =>
+      (super.noSuchMethod(
+            Invocation.method(#toJson, []),
+            returnValue: <String, Object?>{},
+            returnValueForMissingStub: <String, Object?>{},
+          )
+          as Map<String, Object?>);
 }

--- a/packages/shared_preferences/shared_preferences_tool/test/src/shared_preferences_state_test.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/src/shared_preferences_state_test.dart
@@ -25,19 +25,22 @@ void main() {
 
   group('SharedPreferencesData', () {
     test('value as string should return formatted value', () {
-      const SharedPreferencesData stringData =
-          SharedPreferencesData.string(value: 'value');
+      const SharedPreferencesData stringData = SharedPreferencesData.string(
+        value: 'value',
+      );
       expect(stringData.valueAsString, 'value');
 
       const SharedPreferencesData intData = SharedPreferencesData.int(value: 1);
       expect(intData.valueAsString, '1');
 
-      const SharedPreferencesData doubleData =
-          SharedPreferencesData.double(value: 1.1);
+      const SharedPreferencesData doubleData = SharedPreferencesData.double(
+        value: 1.1,
+      );
       expect(doubleData.valueAsString, '1.1');
 
-      const SharedPreferencesData boolData =
-          SharedPreferencesData.bool(value: true);
+      const SharedPreferencesData boolData = SharedPreferencesData.bool(
+        value: true,
+      );
       expect(boolData.valueAsString, 'true');
 
       const SharedPreferencesData stringListData =
@@ -47,19 +50,22 @@ void main() {
   });
 
   test('should return pretty type', () {
-    const SharedPreferencesData stringData =
-        SharedPreferencesData.string(value: 'value');
+    const SharedPreferencesData stringData = SharedPreferencesData.string(
+      value: 'value',
+    );
     expect(stringData.kind, 'String');
 
     const SharedPreferencesData intData = SharedPreferencesData.int(value: 1);
     expect(intData.kind, 'int');
 
-    const SharedPreferencesData doubleData =
-        SharedPreferencesData.double(value: 1.0);
+    const SharedPreferencesData doubleData = SharedPreferencesData.double(
+      value: 1.0,
+    );
     expect(doubleData.kind, 'double');
 
-    const SharedPreferencesData boolData =
-        SharedPreferencesData.bool(value: true);
+    const SharedPreferencesData boolData = SharedPreferencesData.bool(
+      value: true,
+    );
     expect(boolData.kind, 'bool');
 
     const SharedPreferencesData stringListData =
@@ -68,8 +74,9 @@ void main() {
   });
 
   test('should change value', () {
-    const SharedPreferencesData stringData =
-        SharedPreferencesData.string(value: 'value');
+    const SharedPreferencesData stringData = SharedPreferencesData.string(
+      value: 'value',
+    );
     const String newStringValue = 'newValue';
     expect(
       stringData.changeValue(newStringValue),
@@ -91,8 +98,9 @@ void main() {
       ),
     );
 
-    const SharedPreferencesData doubleData =
-        SharedPreferencesData.double(value: 1.0);
+    const SharedPreferencesData doubleData = SharedPreferencesData.double(
+      value: 1.0,
+    );
     const String newDoubleValue = '2.0';
     expect(
       doubleData.changeValue(newDoubleValue),
@@ -103,8 +111,9 @@ void main() {
       ),
     );
 
-    const SharedPreferencesData boolData =
-        SharedPreferencesData.bool(value: true);
+    const SharedPreferencesData boolData = SharedPreferencesData.bool(
+      value: true,
+    );
     const String newBoolValue = 'false';
     expect(
       boolData.changeValue(newBoolValue),

--- a/packages/shared_preferences/shared_preferences_tool/test/src/shared_preferences_tool_eval_test.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/src/shared_preferences_tool_eval_test.dart
@@ -15,11 +15,11 @@ typedef _Event = (String eventKind, Map<String, Object?> eventData);
 // ignore: subtype_of_sealed_class
 class _FakeEvalOnDartLibrary extends EvalOnDartLibrary {
   _FakeEvalOnDartLibrary(VmService vmService)
-      : super(
-          'fake_library',
-          vmService,
-          serviceManager: ServiceManager<VmService>(),
-        );
+    : super(
+        'fake_library',
+        vmService,
+        serviceManager: ServiceManager<VmService>(),
+      );
 
   final List<_Event> eventLog = <_Event>[];
 
@@ -32,14 +32,7 @@ class _FakeEvalOnDartLibrary extends EvalOnDartLibrary {
     Map<String, String>? scope,
     bool shouldLogError = true,
   }) async {
-    eventLog.add(
-      (
-        'eval',
-        <String, Object?>{
-          'expression': expression,
-        },
-      ),
-    );
+    eventLog.add(('eval', <String, Object?>{'expression': expression}));
     return onEval();
   }
 }
@@ -97,14 +90,8 @@ void main() {
 
       final KeysResult allKeys = await sharedPreferencesToolEval.fetchAllKeys();
 
-      expect(
-        allKeys.asyncKeys,
-        equals(expectedAsyncKeys),
-      );
-      expect(
-        allKeys.legacyKeys,
-        equals(expectedLegacyKeys),
-      );
+      expect(allKeys.asyncKeys, equals(expectedAsyncKeys));
+      expect(allKeys.legacyKeys, equals(expectedLegacyKeys));
     });
 
     test('should fetch int value', () async {
@@ -113,22 +100,15 @@ void main() {
       stubEvalMethod(
         eventKind: 'value',
         method: "requestValue('$key', false)",
-        response: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'int',
-        },
+        response: <String, Object?>{'value': expectedValue, 'kind': 'int'},
       );
 
-      final SharedPreferencesData data =
-          await sharedPreferencesToolEval.fetchValue(key, false);
+      final SharedPreferencesData data = await sharedPreferencesToolEval
+          .fetchValue(key, false);
 
       expect(
         data,
-        equals(
-          const SharedPreferencesData.int(
-            value: expectedValue,
-          ),
-        ),
+        equals(const SharedPreferencesData.int(value: expectedValue)),
       );
     });
 
@@ -138,22 +118,15 @@ void main() {
       stubEvalMethod(
         eventKind: 'value',
         method: "requestValue('$key', false)",
-        response: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'bool',
-        },
+        response: <String, Object?>{'value': expectedValue, 'kind': 'bool'},
       );
 
-      final SharedPreferencesData data =
-          await sharedPreferencesToolEval.fetchValue(key, false);
+      final SharedPreferencesData data = await sharedPreferencesToolEval
+          .fetchValue(key, false);
 
       expect(
         data,
-        equals(
-          const SharedPreferencesData.bool(
-            value: expectedValue,
-          ),
-        ),
+        equals(const SharedPreferencesData.bool(value: expectedValue)),
       );
     });
 
@@ -163,22 +136,15 @@ void main() {
       stubEvalMethod(
         eventKind: 'value',
         method: "requestValue('$key', false)",
-        response: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'double',
-        },
+        response: <String, Object?>{'value': expectedValue, 'kind': 'double'},
       );
 
-      final SharedPreferencesData data =
-          await sharedPreferencesToolEval.fetchValue(key, false);
+      final SharedPreferencesData data = await sharedPreferencesToolEval
+          .fetchValue(key, false);
 
       expect(
         data,
-        equals(
-          const SharedPreferencesData.double(
-            value: expectedValue,
-          ),
-        ),
+        equals(const SharedPreferencesData.double(value: expectedValue)),
       );
     });
 
@@ -188,22 +154,15 @@ void main() {
       stubEvalMethod(
         eventKind: 'value',
         method: "requestValue('$key', false)",
-        response: <String, Object?>{
-          'value': expectedValue,
-          'kind': 'String',
-        },
+        response: <String, Object?>{'value': expectedValue, 'kind': 'String'},
       );
 
-      final SharedPreferencesData data =
-          await sharedPreferencesToolEval.fetchValue(key, false);
+      final SharedPreferencesData data = await sharedPreferencesToolEval
+          .fetchValue(key, false);
 
       expect(
         data,
-        equals(
-          const SharedPreferencesData.string(
-            value: expectedValue,
-          ),
-        ),
+        equals(const SharedPreferencesData.string(value: expectedValue)),
       );
     });
 
@@ -219,16 +178,12 @@ void main() {
         },
       );
 
-      final SharedPreferencesData data =
-          await sharedPreferencesToolEval.fetchValue(key, true);
+      final SharedPreferencesData data = await sharedPreferencesToolEval
+          .fetchValue(key, true);
 
       expect(
         data,
-        equals(
-          const SharedPreferencesData.stringList(
-            value: expectedValue,
-          ),
-        ),
+        equals(const SharedPreferencesData.stringList(value: expectedValue)),
       );
     });
 
@@ -237,10 +192,7 @@ void main() {
       stubEvalMethod(
         eventKind: 'value',
         method: "requestValue('$key', true)",
-        response: <String, Object?>{
-          'value': 'error',
-          'kind': 'SomeClass',
-        },
+        response: <String, Object?>{'value': 'error', 'kind': 'SomeClass'},
       );
 
       expect(
@@ -265,14 +217,9 @@ void main() {
       );
 
       expect(eval.eventLog.length, equals(1));
-      final (
-        String eventKind,
-        Map<String, Object?> eventData,
-      ) = eval.eventLog.first;
-      expect(
-        eventKind,
-        equals('eval'),
-      );
+      final (String eventKind, Map<String, Object?> eventData) =
+          eval.eventLog.first;
+      expect(eventKind, equals('eval'));
       expect(
         eventData,
         equals(<String, Object?>{
@@ -290,10 +237,7 @@ void main() {
         response: <String, Object?>{},
       );
 
-      await sharedPreferencesToolEval.deleteKey(
-        key,
-        false,
-      );
+      await sharedPreferencesToolEval.deleteKey(key, false);
 
       expect(eval.eventLog.length, equals(1));
     });

--- a/packages/shared_preferences/shared_preferences_tool/test/src/ui/data_panel_test.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/src/ui/data_panel_test.dart
@@ -50,12 +50,13 @@ void main() {
         SharedPreferencesState(
           allKeys: const AsyncState<List<String>>.data(<String>[selectedKey]),
           editing: editing,
-          selectedKey: state == null
-              ? null
-              : SelectedSharedPreferencesKey(
-                  key: selectedKey,
-                  value: state,
-                ),
+          selectedKey:
+              state == null
+                  ? null
+                  : SelectedSharedPreferencesKey(
+                    key: selectedKey,
+                    value: state,
+                  ),
         ),
       );
     }
@@ -130,8 +131,11 @@ void main() {
     });
 
     testWidgets('should show string list value', (WidgetTester tester) async {
-      stubDataState(const SharedPreferencesData.stringList(
-          value: <String>['value1', 'value2']));
+      stubDataState(
+        const SharedPreferencesData.stringList(
+          value: <String>['value1', 'value2'],
+        ),
+      );
       await pumpDataPanel(tester);
 
       expect(find.text('Type: List<String>'), findsOneWidget);
@@ -155,60 +159,55 @@ void main() {
       verify(notifierMock.startEditing()).called(1);
     });
 
-    testWidgets(
-      'on remove should show confirmation modal',
-      (WidgetTester tester) async {
-        stubDataState(const SharedPreferencesData.string(value: 'value'));
-        await pumpDataPanel(tester);
+    testWidgets('on remove should show confirmation modal', (
+      WidgetTester tester,
+    ) async {
+      stubDataState(const SharedPreferencesData.string(value: 'value'));
+      await pumpDataPanel(tester);
 
-        await tester.tap(find.text('Remove'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('Remove'));
+      await tester.pumpAndSettle();
 
-        expect(
-          find.text('Are you sure you want to remove selectedTestKey?'),
-          findsOneWidget,
-        );
-        expect(find.text('CANCEL'), findsOneWidget);
-        expect(find.text('REMOVE'), findsOneWidget);
-      },
-    );
+      expect(
+        find.text('Are you sure you want to remove selectedTestKey?'),
+        findsOneWidget,
+      );
+      expect(find.text('CANCEL'), findsOneWidget);
+      expect(find.text('REMOVE'), findsOneWidget);
+    });
 
-    testWidgets(
-      'on removed confirmed should remove key',
-      (WidgetTester tester) async {
-        const SharedPreferencesData value = SharedPreferencesData.string(
-          value: 'value',
-        );
-        stubDataState(value);
-        await pumpDataPanel(tester);
-        await tester.tap(find.text('Remove'));
-        await tester.pumpAndSettle();
+    testWidgets('on removed confirmed should remove key', (
+      WidgetTester tester,
+    ) async {
+      const SharedPreferencesData value = SharedPreferencesData.string(
+        value: 'value',
+      );
+      stubDataState(value);
+      await pumpDataPanel(tester);
+      await tester.tap(find.text('Remove'));
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('REMOVE'));
+      await tester.tap(find.text('REMOVE'));
 
-        verify(
-          notifierMock.deleteSelectedKey(),
-        ).called(1);
-      },
-    );
+      verify(notifierMock.deleteSelectedKey()).called(1);
+    });
 
-    testWidgets(
-      'on remove canceled should cancel remove',
-      (WidgetTester tester) async {
-        stubDataState(const SharedPreferencesData.string(value: 'value'));
-        await pumpDataPanel(tester);
-        await tester.tap(find.text('Remove'));
-        await tester.pumpAndSettle();
+    testWidgets('on remove canceled should cancel remove', (
+      WidgetTester tester,
+    ) async {
+      stubDataState(const SharedPreferencesData.string(value: 'value'));
+      await pumpDataPanel(tester);
+      await tester.tap(find.text('Remove'));
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('CANCEL'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('CANCEL'));
+      await tester.pumpAndSettle();
 
-        expect(
-          find.text('Are you sure you want to remove selectedTestKey?'),
-          findsNothing,
-        );
-      },
-    );
+      expect(
+        find.text('Are you sure you want to remove selectedTestKey?'),
+        findsNothing,
+      );
+    });
 
     testWidgets('should show editing state', (WidgetTester tester) async {
       stubDataState(
@@ -220,163 +219,152 @@ void main() {
       expect(find.text('Cancel'), findsOneWidget);
     });
 
-    testWidgets(
-      'should show string editing state',
-      (WidgetTester tester) async {
-        const String value = 'value';
-        stubDataState(
-          const SharedPreferencesData.string(value: value),
-          editing: true,
-        );
-        await pumpDataPanel(tester);
+    testWidgets('should show string editing state', (
+      WidgetTester tester,
+    ) async {
+      const String value = 'value';
+      stubDataState(
+        const SharedPreferencesData.string(value: value),
+        editing: true,
+      );
+      await pumpDataPanel(tester);
 
-        expect(find.text('Type: String'), findsOneWidget);
-        expect(find.text('Value:'), findsOneWidget);
-        expect(find.text(value), findsOneWidget);
-        expect(find.byType(TextField), findsOneWidget);
-      },
-    );
+      expect(find.text('Type: String'), findsOneWidget);
+      expect(find.text('Value:'), findsOneWidget);
+      expect(find.text(value), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+    });
 
-    testWidgets(
-      'should show int editing state',
-      (WidgetTester tester) async {
-        const int value = 42;
-        stubDataState(
-          const SharedPreferencesData.int(value: value),
-          editing: true,
-        );
-        await pumpDataPanel(tester);
+    testWidgets('should show int editing state', (WidgetTester tester) async {
+      const int value = 42;
+      stubDataState(
+        const SharedPreferencesData.int(value: value),
+        editing: true,
+      );
+      await pumpDataPanel(tester);
 
-        expect(find.text('Type: int'), findsOneWidget);
-        expect(find.text('Value:'), findsOneWidget);
-        expect(find.text('$value'), findsOneWidget);
-        expect(find.byType(TextField), findsOneWidget);
-        expect(
-          tester.textInputFormatterPattern,
-          equals(RegExp(r'^-?\d*').toString()),
-        );
-      },
-    );
+      expect(find.text('Type: int'), findsOneWidget);
+      expect(find.text('Value:'), findsOneWidget);
+      expect(find.text('$value'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+      expect(
+        tester.textInputFormatterPattern,
+        equals(RegExp(r'^-?\d*').toString()),
+      );
+    });
 
-    testWidgets(
-      'should show double editing state',
-      (WidgetTester tester) async {
-        const double value = 42.0;
-        stubDataState(
-          const SharedPreferencesData.double(value: value),
-          editing: true,
-        );
-        await pumpDataPanel(tester);
+    testWidgets('should show double editing state', (
+      WidgetTester tester,
+    ) async {
+      const double value = 42.0;
+      stubDataState(
+        const SharedPreferencesData.double(value: value),
+        editing: true,
+      );
+      await pumpDataPanel(tester);
 
-        expect(find.text('Type: double'), findsOneWidget);
-        expect(find.text('Value:'), findsOneWidget);
-        expect(find.text('$value'), findsOneWidget);
-        expect(find.byType(TextField), findsOneWidget);
-        expect(
-          tester.textInputFormatterPattern,
-          equals(RegExp(r'^-?\d*\.?\d*').toString()),
-        );
-      },
-    );
+      expect(find.text('Type: double'), findsOneWidget);
+      expect(find.text('Value:'), findsOneWidget);
+      expect(find.text('$value'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+      expect(
+        tester.textInputFormatterPattern,
+        equals(RegExp(r'^-?\d*\.?\d*').toString()),
+      );
+    });
 
-    testWidgets(
-      'should show boolean editing state',
-      (WidgetTester tester) async {
-        const bool value = true;
-        stubDataState(
-          const SharedPreferencesData.bool(value: value),
-          editing: true,
-        );
-        await pumpDataPanel(tester);
+    testWidgets('should show boolean editing state', (
+      WidgetTester tester,
+    ) async {
+      const bool value = true;
+      stubDataState(
+        const SharedPreferencesData.bool(value: value),
+        editing: true,
+      );
+      await pumpDataPanel(tester);
 
-        expect(find.text('Type: bool'), findsOneWidget);
-        expect(find.text('Value:'), findsOneWidget);
-        expect(find.byType(DropdownMenu<bool>), findsOneWidget);
-      },
-    );
+      expect(find.text('Type: bool'), findsOneWidget);
+      expect(find.text('Value:'), findsOneWidget);
+      expect(find.byType(DropdownMenu<bool>), findsOneWidget);
+    });
 
-    testWidgets(
-      'should show string list editing state',
-      (WidgetTester tester) async {
-        stubDataState(
-          const SharedPreferencesData.stringList(
-            value: <String>['value1', 'value2'],
-          ),
-          editing: true,
-        );
-        await pumpDataPanel(tester);
+    testWidgets('should show string list editing state', (
+      WidgetTester tester,
+    ) async {
+      stubDataState(
+        const SharedPreferencesData.stringList(
+          value: <String>['value1', 'value2'],
+        ),
+        editing: true,
+      );
+      await pumpDataPanel(tester);
 
-        expect(find.text('Type: List<String>'), findsOneWidget);
-        expect(find.text('Value:'), findsOneWidget);
-        expect(find.text('value1'), findsOneWidget);
-        expect(find.text('value2'), findsOneWidget);
-        expect(find.byType(TextField), findsNWidgets(2));
-        // Finds 3 add buttons:
-        // +
-        // value1
-        // +
-        // value2
-        // +
-        expect(find.byIcon(Icons.add), findsNWidgets(3));
-      },
-    );
+      expect(find.text('Type: List<String>'), findsOneWidget);
+      expect(find.text('Value:'), findsOneWidget);
+      expect(find.text('value1'), findsOneWidget);
+      expect(find.text('value2'), findsOneWidget);
+      expect(find.byType(TextField), findsNWidgets(2));
+      // Finds 3 add buttons:
+      // +
+      // value1
+      // +
+      // value2
+      // +
+      expect(find.byIcon(Icons.add), findsNWidgets(3));
+    });
 
-    testWidgets(
-      'should show apply changes button on value changed',
-      (WidgetTester tester) async {
-        stubDataState(
-          const SharedPreferencesData.string(value: 'value'),
-          editing: true,
-        );
-        await pumpDataPanel(tester);
+    testWidgets('should show apply changes button on value changed', (
+      WidgetTester tester,
+    ) async {
+      stubDataState(
+        const SharedPreferencesData.string(value: 'value'),
+        editing: true,
+      );
+      await pumpDataPanel(tester);
 
-        await tester.enterText(find.byType(TextField), 'newValue');
+      await tester.enterText(find.byType(TextField), 'newValue');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Apply changes'), findsOneWidget);
+    });
+
+    testWidgets('pressing an add button on the string list editing state '
+        'should add element in the right index', (WidgetTester tester) async {
+      stubDataState(
+        const SharedPreferencesData.stringList(
+          value: <String>['value1', 'value2'],
+        ),
+        editing: true,
+      );
+      await pumpDataPanel(tester);
+
+      for (int i = 0; i < 3; i++) {
+        await tester.tap(find.byIcon(Icons.add).at(i));
         await tester.pumpAndSettle();
+        await tester.enterText(find.byType(TextField).at(i), '$i');
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Apply changes'));
+        await tester.pumpAndSettle();
+      }
 
-        expect(find.text('Apply changes'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'pressing an add button on the string list editing state '
-      'should add element in the right index',
-      (WidgetTester tester) async {
-        stubDataState(
+      verifyInOrder(<Future<void>>[
+        notifierMock.changeValue(
           const SharedPreferencesData.stringList(
-            value: <String>['value1', 'value2'],
+            value: <String>['0', 'value1', 'value2'],
           ),
-          editing: true,
-        );
-        await pumpDataPanel(tester);
-
-        for (int i = 0; i < 3; i++) {
-          await tester.tap(find.byIcon(Icons.add).at(i));
-          await tester.pumpAndSettle();
-          await tester.enterText(find.byType(TextField).at(i), '$i');
-          await tester.pumpAndSettle();
-          await tester.tap(find.text('Apply changes'));
-          await tester.pumpAndSettle();
-        }
-
-        verifyInOrder(<Future<void>>[
-          notifierMock.changeValue(
-            const SharedPreferencesData.stringList(
-              value: <String>['0', 'value1', 'value2'],
-            ),
+        ),
+        notifierMock.changeValue(
+          const SharedPreferencesData.stringList(
+            value: <String>['0', '1', 'value1', 'value2'],
           ),
-          notifierMock.changeValue(
-            const SharedPreferencesData.stringList(
-              value: <String>['0', '1', 'value1', 'value2'],
-            ),
+        ),
+        notifierMock.changeValue(
+          const SharedPreferencesData.stringList(
+            value: <String>['0', '1', '2', 'value1', 'value2'],
           ),
-          notifierMock.changeValue(
-            const SharedPreferencesData.stringList(
-              value: <String>['0', '1', '2', 'value1', 'value2'],
-            ),
-          ),
-        ]);
-      },
-    );
+        ),
+      ]);
+    });
   });
 }
 

--- a/packages/shared_preferences/shared_preferences_tool/test/src/ui/error_panel_test.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/src/ui/error_panel_test.dart
@@ -12,27 +12,23 @@ import 'package:shared_preferences_tool/src/ui/error_panel.dart';
 
 void main() {
   group('ErrorPanel', () {
-    testWidgets(
-      'should show error and stacktrace',
-      (WidgetTester tester) async {
-        const String error = 'error';
-        final StackTrace stackTrace = StackTrace.current;
+    testWidgets('should show error and stacktrace', (
+      WidgetTester tester,
+    ) async {
+      const String error = 'error';
+      final StackTrace stackTrace = StackTrace.current;
 
-        await tester.pumpWidget(
-          DevToolsExtension(
-            requiresRunningApplication: false,
-            child: Directionality(
-              textDirection: TextDirection.ltr,
-              child: ErrorPanel(
-                error: error,
-                stackTrace: stackTrace,
-              ),
-            ),
+      await tester.pumpWidget(
+        DevToolsExtension(
+          requiresRunningApplication: false,
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: ErrorPanel(error: error, stackTrace: stackTrace),
           ),
-        );
+        ),
+      );
 
-        expect(find.text('Error:\n$error\n\n$stackTrace'), findsOneWidget);
-      },
-    );
+      expect(find.text('Error:\n$error\n\n$stackTrace'), findsOneWidget);
+    });
   });
 }

--- a/packages/shared_preferences/shared_preferences_tool/test/src/ui/keys_panel_test.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/src/ui/keys_panel_test.dart
@@ -42,8 +42,9 @@ void main() {
     }
 
     void stubDataState({
-      AsyncState<List<String>> allKeys =
-          const AsyncState<List<String>>.data(<String>[]),
+      AsyncState<List<String>> allKeys = const AsyncState<List<String>>.data(
+        <String>[],
+      ),
       SelectedSharedPreferencesKey? selectedKey,
       bool editing = false,
     }) {
@@ -57,9 +58,7 @@ void main() {
     }
 
     testWidgets('should show loading state', (WidgetTester tester) async {
-      stubDataState(
-        allKeys: const AsyncState<List<String>>.loading(),
-      );
+      stubDataState(allKeys: const AsyncState<List<String>>.loading());
       await pumpKeysPanel(tester);
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
@@ -77,12 +76,11 @@ void main() {
       expect(find.byType(ErrorPanel), findsOneWidget);
     });
 
-    testWidgets('should show keys list with all keys',
-        (WidgetTester tester) async {
+    testWidgets('should show keys list with all keys', (
+      WidgetTester tester,
+    ) async {
       const List<String> allKeys = <String>['key1', 'key2'];
-      stubDataState(
-        allKeys: const AsyncState<List<String>>.data(allKeys),
-      );
+      stubDataState(allKeys: const AsyncState<List<String>>.data(allKeys));
 
       await pumpKeysPanel(tester);
 
@@ -91,115 +89,108 @@ void main() {
       }
     });
 
-    testWidgets(
-      'only selected key should be highlighted',
-      (WidgetTester tester) async {
-        const String selectedKey = 'selectedKey';
-        const List<String> keys = <String>['key1', selectedKey, 'key2'];
+    testWidgets('only selected key should be highlighted', (
+      WidgetTester tester,
+    ) async {
+      const String selectedKey = 'selectedKey';
+      const List<String> keys = <String>['key1', selectedKey, 'key2'];
 
-        stubDataState(
-          allKeys: const AsyncState<List<String>>.data(keys),
-          selectedKey: const SelectedSharedPreferencesKey(
-            key: selectedKey,
-            value: AsyncState<SharedPreferencesData>.loading(),
-          ),
-        );
+      stubDataState(
+        allKeys: const AsyncState<List<String>>.data(keys),
+        selectedKey: const SelectedSharedPreferencesKey(
+          key: selectedKey,
+          value: AsyncState<SharedPreferencesData>.loading(),
+        ),
+      );
 
-        await pumpKeysPanel(tester);
+      await pumpKeysPanel(tester);
 
-        final Element selectedKeyElement =
-            tester.element(find.text(selectedKey));
-        final ColorScheme colorScheme =
-            Theme.of(selectedKeyElement).colorScheme;
+      final Element selectedKeyElement = tester.element(find.text(selectedKey));
+      final ColorScheme colorScheme = Theme.of(selectedKeyElement).colorScheme;
 
-        Color? bgColorFor(String key) {
-          final Container? container = tester
-              .element(find.text(key))
-              .findAncestorWidgetOfExactType<Container>();
-          return container?.color;
-        }
+      Color? bgColorFor(String key) {
+        final Container? container =
+            tester
+                .element(find.text(key))
+                .findAncestorWidgetOfExactType<Container>();
+        return container?.color;
+      }
 
-        for (final String key in <String>[...keys]..remove(selectedKey)) {
-          expect(
-            bgColorFor(key),
-            isNot(equals(colorScheme.selectedRowBackgroundColor)),
-          );
-        }
+      for (final String key in <String>[...keys]..remove(selectedKey)) {
         expect(
-          bgColorFor(selectedKey),
-          equals(colorScheme.selectedRowBackgroundColor),
+          bgColorFor(key),
+          isNot(equals(colorScheme.selectedRowBackgroundColor)),
         );
-      },
-    );
+      }
+      expect(
+        bgColorFor(selectedKey),
+        equals(colorScheme.selectedRowBackgroundColor),
+      );
+    });
 
-    testWidgets(
-      'should start searching when clicking the search icon',
-      (WidgetTester tester) async {
-        stubDataState();
-        await pumpKeysPanel(tester);
+    testWidgets('should start searching when clicking the search icon', (
+      WidgetTester tester,
+    ) async {
+      stubDataState();
+      await pumpKeysPanel(tester);
 
-        await tester.tap(find.byIcon(Icons.search));
-        await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.search));
+      await tester.pumpAndSettle();
 
-        expect(find.byType(TextField), findsOneWidget);
-      },
-    );
+      expect(find.byType(TextField), findsOneWidget);
+    });
 
-    testWidgets(
-      'should stop searching when clicking the close icon',
-      (WidgetTester tester) async {
-        stubDataState();
-        await pumpKeysPanel(tester);
-        await tester.tap(find.byIcon(Icons.search));
-        await tester.pumpAndSettle();
+    testWidgets('should stop searching when clicking the close icon', (
+      WidgetTester tester,
+    ) async {
+      stubDataState();
+      await pumpKeysPanel(tester);
+      await tester.tap(find.byIcon(Icons.search));
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.byIcon(Icons.close));
-        await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
 
-        expect(find.byType(TextField), findsNothing);
-      },
-    );
+      expect(find.byType(TextField), findsNothing);
+    });
 
-    testWidgets(
-      'should filter keys when searching',
-      (WidgetTester tester) async {
-        stubDataState();
-        await pumpKeysPanel(tester);
-        await tester.tap(find.byIcon(Icons.search));
-        await tester.pumpAndSettle();
+    testWidgets('should filter keys when searching', (
+      WidgetTester tester,
+    ) async {
+      stubDataState();
+      await pumpKeysPanel(tester);
+      await tester.tap(find.byIcon(Icons.search));
+      await tester.pumpAndSettle();
 
-        await tester.enterText(find.byType(TextField), 'key2');
+      await tester.enterText(find.byType(TextField), 'key2');
 
-        verify(notifierMock.filter('key2')).called(1);
-      },
-    );
+      verify(notifierMock.filter('key2')).called(1);
+    });
 
-    testWidgets(
-      'should refresh on refresh icon clicked',
-      (WidgetTester tester) async {
-        stubDataState();
-        await pumpKeysPanel(tester);
+    testWidgets('should refresh on refresh icon clicked', (
+      WidgetTester tester,
+    ) async {
+      stubDataState();
+      await pumpKeysPanel(tester);
 
-        await tester.tap(find.byIcon(Icons.refresh));
-        await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.refresh));
+      await tester.pumpAndSettle();
 
-        verify(notifierMock.fetchAllKeys()).called(1);
-      },
-    );
+      verify(notifierMock.fetchAllKeys()).called(1);
+    });
 
-    testWidgets(
-      'should select key on key clicked',
-      (WidgetTester tester) async {
-        const String keyToSelect = 'keyToSelect';
-        stubDataState(
-          allKeys: const AsyncState<List<String>>.data(<String>[keyToSelect]),
-        );
-        await pumpKeysPanel(tester);
+    testWidgets('should select key on key clicked', (
+      WidgetTester tester,
+    ) async {
+      const String keyToSelect = 'keyToSelect';
+      stubDataState(
+        allKeys: const AsyncState<List<String>>.data(<String>[keyToSelect]),
+      );
+      await pumpKeysPanel(tester);
 
-        await tester.tap(find.text(keyToSelect));
+      await tester.tap(find.text(keyToSelect));
 
-        verify(notifierMock.selectKey(keyToSelect)).called(1);
-      },
-    );
+      verify(notifierMock.selectKey(keyToSelect)).called(1);
+    });
   });
 }

--- a/packages/shared_preferences/shared_preferences_tool/test/src/ui/shared_preferences_body_test.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/src/ui/shared_preferences_body_test.dart
@@ -21,26 +21,25 @@ void main() {
   group('group name', () {
     setupDummies();
 
-    testWidgets(
-      'should show keys and data panels',
-      (WidgetTester tester) async {
-        final MockSharedPreferencesStateNotifier notifier =
-            MockSharedPreferencesStateNotifier();
-        when(notifier.value).thenReturn(const SharedPreferencesState());
+    testWidgets('should show keys and data panels', (
+      WidgetTester tester,
+    ) async {
+      final MockSharedPreferencesStateNotifier notifier =
+          MockSharedPreferencesStateNotifier();
+      when(notifier.value).thenReturn(const SharedPreferencesState());
 
-        await tester.pumpWidget(
-          DevToolsExtension(
-            requiresRunningApplication: false,
-            child: InnerSharedPreferencesStateProvider(
-              notifier: notifier,
-              child: const SharedPreferencesBody(),
-            ),
+      await tester.pumpWidget(
+        DevToolsExtension(
+          requiresRunningApplication: false,
+          child: InnerSharedPreferencesStateProvider(
+            notifier: notifier,
+            child: const SharedPreferencesBody(),
           ),
-        );
+        ),
+      );
 
-        expect(find.byType(KeysPanel), findsOneWidget);
-        expect(find.byType(DataPanel), findsOneWidget);
-      },
-    );
+      expect(find.byType(KeysPanel), findsOneWidget);
+      expect(find.byType(DataPanel), findsOneWidget);
+    });
   });
 }

--- a/packages/shared_preferences/shared_preferences_tool/test/test_helpers/notifier_mocking_helpers.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/test_helpers/notifier_mocking_helpers.dart
@@ -23,9 +23,7 @@ void setupDummies() {
       ),
     );
     provideDummy(
-      const AsyncState<SharedPreferencesState>.data(
-        SharedPreferencesState(),
-      ),
+      const AsyncState<SharedPreferencesState>.data(SharedPreferencesState()),
     );
   });
 }

--- a/packages/shared_preferences/shared_preferences_tool/test/test_helpers/notifier_mocking_helpers.mocks.dart
+++ b/packages/shared_preferences/shared_preferences_tool/test/test_helpers/notifier_mocking_helpers.mocks.dart
@@ -27,13 +27,8 @@ import 'package:shared_preferences_tool/src/shared_preferences_state_notifier.da
 
 class _FakeSharedPreferencesState_0 extends _i1.SmartFake
     implements _i2.SharedPreferencesState {
-  _FakeSharedPreferencesState_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeSharedPreferencesState_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [SharedPreferencesStateNotifier].
@@ -42,145 +37,116 @@ class _FakeSharedPreferencesState_0 extends _i1.SmartFake
 class MockSharedPreferencesStateNotifier extends _i1.Mock
     implements _i3.SharedPreferencesStateNotifier {
   @override
-  _i2.SharedPreferencesState get value => (super.noSuchMethod(
-        Invocation.getter(#value),
-        returnValue: _FakeSharedPreferencesState_0(
-          this,
-          Invocation.getter(#value),
-        ),
-        returnValueForMissingStub: _FakeSharedPreferencesState_0(
-          this,
-          Invocation.getter(#value),
-        ),
-      ) as _i2.SharedPreferencesState);
+  _i2.SharedPreferencesState get value =>
+      (super.noSuchMethod(
+            Invocation.getter(#value),
+            returnValue: _FakeSharedPreferencesState_0(
+              this,
+              Invocation.getter(#value),
+            ),
+            returnValueForMissingStub: _FakeSharedPreferencesState_0(
+              this,
+              Invocation.getter(#value),
+            ),
+          )
+          as _i2.SharedPreferencesState);
 
   @override
   set value(_i2.SharedPreferencesState? newValue) => super.noSuchMethod(
-        Invocation.setter(
-          #value,
-          newValue,
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#value, newValue),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  bool get hasListeners => (super.noSuchMethod(
-        Invocation.getter(#hasListeners),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get hasListeners =>
+      (super.noSuchMethod(
+            Invocation.getter(#hasListeners),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 
   @override
-  _i4.Future<void> fetchAllKeys() => (super.noSuchMethod(
-        Invocation.method(
-          #fetchAllKeys,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> fetchAllKeys() =>
+      (super.noSuchMethod(
+            Invocation.method(#fetchAllKeys, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> selectKey(String? key) => (super.noSuchMethod(
-        Invocation.method(
-          #selectKey,
-          [key],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> selectKey(String? key) =>
+      (super.noSuchMethod(
+            Invocation.method(#selectKey, [key]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   void filter(String? token) => super.noSuchMethod(
-        Invocation.method(
-          #filter,
-          [token],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#filter, [token]),
+    returnValueForMissingStub: null,
+  );
 
   @override
   _i4.Future<void> changeValue(_i2.SharedPreferencesData? newValue) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #changeValue,
-          [newValue],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+            Invocation.method(#changeValue, [newValue]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
-  _i4.Future<void> deleteSelectedKey() => (super.noSuchMethod(
-        Invocation.method(
-          #deleteSelectedKey,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+  _i4.Future<void> deleteSelectedKey() =>
+      (super.noSuchMethod(
+            Invocation.method(#deleteSelectedKey, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   void startEditing() => super.noSuchMethod(
-        Invocation.method(
-          #startEditing,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#startEditing, []),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void stopEditing() => super.noSuchMethod(
-        Invocation.method(
-          #stopEditing,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#stopEditing, []),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void selectApi({required bool? legacyApi}) => super.noSuchMethod(
-        Invocation.method(
-          #selectApi,
-          [],
-          {#legacyApi: legacyApi},
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#selectApi, [], {#legacyApi: legacyApi}),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#addListener, [listener]),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#removeListener, [listener]),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#dispose, []),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#notifyListeners, []),
+    returnValueForMissingStub: null,
+  );
 }

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 
 ## 2.4.3
 

--- a/packages/shared_preferences/shared_preferences_web/example/integration_test/shared_preferences_web_test.dart
+++ b/packages/shared_preferences/shared_preferences_web/example/integration_test/shared_preferences_web_test.dart
@@ -22,11 +22,15 @@ void main() {
     testWidgets('registers itself', (WidgetTester tester) async {
       SharedPreferencesStorePlatform.instance =
           MethodChannelSharedPreferencesStore();
-      expect(SharedPreferencesStorePlatform.instance,
-          isNot(isA<SharedPreferencesPlugin>()));
+      expect(
+        SharedPreferencesStorePlatform.instance,
+        isNot(isA<SharedPreferencesPlugin>()),
+      );
       SharedPreferencesPlugin.registerWith(null);
-      expect(SharedPreferencesStorePlatform.instance,
-          isA<SharedPreferencesPlugin>());
+      expect(
+        SharedPreferencesStorePlatform.instance,
+        isA<SharedPreferencesPlugin>(),
+      );
     });
 
     const Map<String, Object> flutterTestValues = <String, Object>{
@@ -67,9 +71,7 @@ void main() {
 
     tearDown(() async {
       await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        ClearParameters(filter: PreferencesFilter(prefix: '')),
       );
     });
 
@@ -84,27 +86,60 @@ void main() {
       await preferences.setValue('Int', 'Int', allTestValues['Int']!);
       await preferences.setValue('Double', 'Double', allTestValues['Double']!);
       await preferences.setValue(
-          'StringList', 'StringList', allTestValues['StringList']!);
+        'StringList',
+        'StringList',
+        allTestValues['StringList']!,
+      );
       await preferences.setValue(
-          'String', 'prefix.String', allTestValues['prefix.String']!);
+        'String',
+        'prefix.String',
+        allTestValues['prefix.String']!,
+      );
       await preferences.setValue(
-          'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!);
+        'Bool',
+        'prefix.Bool',
+        allTestValues['prefix.Bool']!,
+      );
       await preferences.setValue(
-          'Int', 'prefix.Int', allTestValues['prefix.Int']!);
+        'Int',
+        'prefix.Int',
+        allTestValues['prefix.Int']!,
+      );
       await preferences.setValue(
-          'Double', 'prefix.Double', allTestValues['prefix.Double']!);
-      await preferences.setValue('StringList', 'prefix.StringList',
-          allTestValues['prefix.StringList']!);
+        'Double',
+        'prefix.Double',
+        allTestValues['prefix.Double']!,
+      );
       await preferences.setValue(
-          'String', 'flutter.String', allTestValues['flutter.String']!);
+        'StringList',
+        'prefix.StringList',
+        allTestValues['prefix.StringList']!,
+      );
       await preferences.setValue(
-          'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+        'String',
+        'flutter.String',
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue(
-          'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+        'Bool',
+        'flutter.Bool',
+        allTestValues['flutter.Bool']!,
+      );
       await preferences.setValue(
-          'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-      await preferences.setValue('StringList', 'flutter.StringList',
-          allTestValues['flutter.StringList']!);
+        'Int',
+        'flutter.Int',
+        allTestValues['flutter.Int']!,
+      );
+      await preferences.setValue(
+        'Double',
+        'flutter.Double',
+        allTestValues['flutter.Double']!,
+      );
+      await preferences.setValue(
+        'StringList',
+        'flutter.StringList',
+        allTestValues['flutter.StringList']!,
+      );
     }
 
     testWidgets('keys', (WidgetTester _) async {
@@ -136,15 +171,15 @@ void main() {
         const String key = 'flutter.String';
         await preferences.remove(key);
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('');
         expect(values[key], isNull);
       });
 
       testWidgets('get all with prefix', (WidgetTester _) async {
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('prefix.');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('prefix.');
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
         expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -154,8 +189,8 @@ void main() {
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('');
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -166,15 +201,17 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithPrefix', (WidgetTester _) async {
         // ignore: deprecated_member_use
         await preferences.clearWithPrefix('prefix.');
         Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('prefix.');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('prefix.');
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -187,15 +224,17 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
         // ignore: deprecated_member_use
         await preferences.clearWithPrefix('');
         final Map<String, Object> values =
-            // ignore: deprecated_member_use
-            await preferences.getAllWithPrefix('');
+        // ignore: deprecated_member_use
+        await preferences.getAllWithPrefix('');
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -217,22 +256,18 @@ void main() {
       testWidgets('remove', (WidgetTester _) async {
         const String key = 'flutter.String';
         await preferences.remove(key);
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values[key], isNull);
       });
 
       testWidgets('get all with prefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+            );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
         expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -241,15 +276,15 @@ void main() {
       });
 
       testWidgets('get all with allow list', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(
-              prefix: 'prefix.',
-              allowList: <String>{'prefix.String'},
-            ),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(
+                filter: PreferencesFilter(
+                  prefix: 'prefix.',
+                  allowList: <String>{'prefix.String'},
+                ),
+              ),
+            );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -258,12 +293,10 @@ void main() {
       });
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -274,19 +307,17 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithParameters', (WidgetTester _) async {
         await preferences.clearWithParameters(
-          ClearParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         Map<String, Object> values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
@@ -294,20 +325,21 @@ void main() {
         expect(values['prefix.Double'], null);
         expect(values['prefix.StringList'], null);
         values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'flutter.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
         );
         expect(values['flutter.String'], allTestValues['flutter.String']);
         expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
-      testWidgets('clearWithParameters with allow list',
-          (WidgetTester _) async {
+      testWidgets('clearWithParameters with allow list', (
+        WidgetTester _,
+      ) async {
         await addData();
         await preferences.clearWithParameters(
           ClearParameters(
@@ -318,9 +350,7 @@ void main() {
           ),
         );
         Map<String, Object> values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
@@ -328,30 +358,26 @@ void main() {
         expect(values['prefix.Double'], allTestValues['prefix.Double']);
         expect(values['prefix.StringList'], null);
         values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'flutter.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
         );
         expect(values['flutter.String'], allTestValues['flutter.String']);
         expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
         await preferences.clearWithParameters(
-          ClearParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
+          ClearParameters(filter: PreferencesFilter(prefix: '')),
         );
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -376,9 +402,7 @@ void main() {
       expect(result.where((bool element) => !element), isEmpty);
       // The last write should win.
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
       expect(values['Int'], writeCount);
     });
@@ -391,9 +415,7 @@ void main() {
       html.window.localStorage.setItem(validJsonDataKey, '"$value"');
 
       final Map<String, Object> values = await preferences.getAllWithParameters(
-        GetAllParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        GetAllParameters(filter: PreferencesFilter(prefix: '')),
       );
 
       expect(values.containsKey(invalidJsonDataKey), isFalse);
@@ -422,8 +444,9 @@ void main() {
       final SharedPreferencesAsyncPlatform preferences =
           SharedPreferencesAsyncPlatform.instance!;
       await preferences.clear(
-          const ClearPreferencesParameters(filter: PreferencesFilters()),
-          emptyOptions);
+        const ClearPreferencesParameters(filter: PreferencesFilters()),
+        emptyOptions,
+      );
       return preferences;
     }
 
@@ -466,34 +489,34 @@ void main() {
       final SharedPreferencesAsyncPlatform preferences = await getPreferences();
 
       await preferences.setStringList(listKey, testList, emptyOptions);
-      final List<String>? list =
-          await preferences.getStringList(listKey, emptyOptions);
+      final List<String>? list = await preferences.getStringList(
+        listKey,
+        emptyOptions,
+      );
       list?.add('value');
       expect(list?.length, testList.length + 1);
     });
 
-    testWidgets(
-      'returns null when reading invalid JSON value',
-      (WidgetTester _) async {
-        const String value = 'value';
-        const String invalidJsonDataKey = 'invalidJsonData';
-        const String validJsonDataKey = 'validJsonData';
-        final SharedPreferencesAsyncPlatform preferences =
-            await getPreferences();
+    testWidgets('returns null when reading invalid JSON value', (
+      WidgetTester _,
+    ) async {
+      const String value = 'value';
+      const String invalidJsonDataKey = 'invalidJsonData';
+      const String validJsonDataKey = 'validJsonData';
+      final SharedPreferencesAsyncPlatform preferences = await getPreferences();
 
-        html.window.localStorage.setItem(invalidJsonDataKey, value);
-        html.window.localStorage.setItem(validJsonDataKey, '"$value"');
+      html.window.localStorage.setItem(invalidJsonDataKey, value);
+      html.window.localStorage.setItem(validJsonDataKey, '"$value"');
 
-        expect(
-          await preferences.getString(invalidJsonDataKey, emptyOptions),
-          isNull,
-        );
-        expect(
-          await preferences.getString(validJsonDataKey, emptyOptions),
-          equals(value),
-        );
-      },
-    );
+      expect(
+        await preferences.getString(invalidJsonDataKey, emptyOptions),
+        isNull,
+      );
+      expect(
+        await preferences.getString(validJsonDataKey, emptyOptions),
+        equals(value),
+      );
+    });
 
     testWidgets('getPreferences', (WidgetTester _) async {
       final SharedPreferencesAsyncPlatform preferences = await getPreferences();
@@ -502,7 +525,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getPreferences(
@@ -525,7 +548,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Map<String, Object?> gotAll = await preferences.getPreferences(
@@ -547,7 +570,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Set<String> keys = await preferences.getKeys(
@@ -570,7 +593,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       final Set<String> keys = await preferences.getKeys(
@@ -592,7 +615,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
 
       await preferences.clear(
@@ -614,7 +637,7 @@ void main() {
         preferences.setBool(boolKey, testBool, emptyOptions),
         preferences.setInt(intKey, testInt, emptyOptions),
         preferences.setDouble(doubleKey, testDouble, emptyOptions),
-        preferences.setStringList(listKey, testList, emptyOptions)
+        preferences.setStringList(listKey, testList, emptyOptions),
       ]);
       await preferences.clear(
         const ClearPreferencesParameters(

--- a/packages/shared_preferences/shared_preferences_web/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: shared_preferences_web_integration_tests
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_web/lib/shared_preferences_web.dart
+++ b/packages/shared_preferences/shared_preferences_web/lib/shared_preferences_web.dart
@@ -28,16 +28,15 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
   @override
   Future<bool> clear() async {
     return clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<bool> clearWithPrefix(String prefix) async {
     return clearWithParameters(
-        ClearParameters(filter: PreferencesFilter(prefix: prefix)));
+      ClearParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
@@ -46,35 +45,40 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
     // IMPORTANT: Do not use html.window.localStorage.clear() as that will
     //            remove _all_ local data, not just the keys prefixed with
     //            _prefix
-    _getPrefixedKeys(filter.prefix, allowList: filter.allowList)
-        .forEach(remove);
+    _getPrefixedKeys(
+      filter.prefix,
+      allowList: filter.allowList,
+    ).forEach(remove);
     return true;
   }
 
   @override
   Future<Map<String, Object>> getAll() async {
     return getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<Map<String, Object>> getAllWithPrefix(String prefix) async {
     return getAllWithParameters(
-        GetAllParameters(filter: PreferencesFilter(prefix: prefix)));
+      GetAllParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) async {
+    GetAllParameters parameters,
+  ) async {
     final PreferencesFilter filter = parameters.filter;
     final Map<String, Object> allData = <String, Object>{};
-    for (final String key
-        in _getPrefixedKeys(filter.prefix, allowList: filter.allowList)) {
-      final Object? value =
-          _decodeValue(html.window.localStorage.getItem(key)!);
+    for (final String key in _getPrefixedKeys(
+      filter.prefix,
+      allowList: filter.allowList,
+    )) {
+      final Object? value = _decodeValue(
+        html.window.localStorage.getItem(key)!,
+      );
       if (value != null) {
         allData[key] = value;
       }
@@ -94,12 +98,10 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
     return true;
   }
 
-  Iterable<String> _getPrefixedKeys(
-    String prefix, {
-    Set<String>? allowList,
-  }) {
-    return _getAllowedKeys(allowList: allowList)
-        .where((String key) => key.startsWith(prefix));
+  Iterable<String> _getPrefixedKeys(String prefix, {Set<String>? allowList}) {
+    return _getAllowedKeys(
+      allowList: allowList,
+    ).where((String key) => key.startsWith(prefix));
   }
 }
 
@@ -118,8 +120,9 @@ base class SharedPreferencesAsyncWeb extends SharedPreferencesAsyncPlatform {
     SharedPreferencesOptions options,
   ) async {
     final PreferencesFilters filter = parameters.filter;
-    _getAllowedKeys(allowList: filter.allowList)
-        .forEach((String key) => html.window.localStorage.removeItem(key));
+    _getAllowedKeys(
+      allowList: filter.allowList,
+    ).forEach((String key) => html.window.localStorage.removeItem(key));
   }
 
   @override
@@ -136,8 +139,9 @@ base class SharedPreferencesAsyncWeb extends SharedPreferencesAsyncPlatform {
   ) async {
     final Map<String, Object> allData = <String, Object>{};
     for (final String key in _getAllowedKeys(allowList: allowList)) {
-      final Object? value =
-          _decodeValue(html.window.localStorage.getItem(key)!);
+      final Object? value = _decodeValue(
+        html.window.localStorage.getItem(key)!,
+      );
       if (value != null) {
         allData[key] = value;
       }
@@ -146,8 +150,10 @@ base class SharedPreferencesAsyncWeb extends SharedPreferencesAsyncPlatform {
   }
 
   @override
-  Future<Set<String>> getKeys(GetPreferencesParameters parameters,
-      SharedPreferencesOptions options) async {
+  Future<Set<String>> getKeys(
+    GetPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) async {
     return (await getPreferences(parameters, options)).keys.toSet();
   }
 
@@ -179,11 +185,7 @@ base class SharedPreferencesAsyncWeb extends SharedPreferencesAsyncPlatform {
   }
 
   @override
-  Future<void> setInt(
-    String key,
-    int value,
-    SharedPreferencesOptions options,
-  ) {
+  Future<void> setInt(String key, int value, SharedPreferencesOptions options) {
     return _setValue(key, value, options);
   }
 
@@ -209,18 +211,17 @@ base class SharedPreferencesAsyncWeb extends SharedPreferencesAsyncPlatform {
     String key,
     SharedPreferencesOptions options,
   ) async {
-    final Map<String, Object> data =
-        await _readAllFromLocalStorage(<String>{key}, options);
+    final Map<String, Object> data = await _readAllFromLocalStorage(<String>{
+      key,
+    }, options);
     return data[key] as String?;
   }
 
   @override
-  Future<bool?> getBool(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
-    final Map<String, Object> data =
-        await _readAllFromLocalStorage(<String>{key}, options);
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async {
+    final Map<String, Object> data = await _readAllFromLocalStorage(<String>{
+      key,
+    }, options);
     return data[key] as bool?;
   }
 
@@ -229,18 +230,17 @@ base class SharedPreferencesAsyncWeb extends SharedPreferencesAsyncPlatform {
     String key,
     SharedPreferencesOptions options,
   ) async {
-    final Map<String, Object> data =
-        await _readAllFromLocalStorage(<String>{key}, options);
+    final Map<String, Object> data = await _readAllFromLocalStorage(<String>{
+      key,
+    }, options);
     return data[key] as double?;
   }
 
   @override
-  Future<int?> getInt(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
-    final Map<String, Object> data =
-        await _readAllFromLocalStorage(<String>{key}, options);
+  Future<int?> getInt(String key, SharedPreferencesOptions options) async {
+    final Map<String, Object> data = await _readAllFromLocalStorage(<String>{
+      key,
+    }, options);
     return data[key] as int?;
   }
 
@@ -249,17 +249,17 @@ base class SharedPreferencesAsyncWeb extends SharedPreferencesAsyncPlatform {
     String key,
     SharedPreferencesOptions options,
   ) async {
-    final Map<String, Object> data =
-        await _readAllFromLocalStorage(<String>{key}, options);
+    final Map<String, Object> data = await _readAllFromLocalStorage(<String>{
+      key,
+    }, options);
     return (data[key] as List<String>?)?.toList();
   }
 }
 
-Iterable<String> _getAllowedKeys({
-  Set<String>? allowList,
-}) {
-  return html.window.localStorage.keys
-      .where((String key) => allowList?.contains(key) ?? true);
+Iterable<String> _getAllowedKeys({Set<String>? allowList}) {
+  return html.window.localStorage.keys.where(
+    (String key) => allowList?.contains(key) ?? true,
+  );
 }
 
 String _encodeValue(Object? value) {

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.4.3
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
+* Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 
 ## 2.4.1
 

--- a/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
@@ -50,27 +50,60 @@ void main() {
       await preferences.setValue('Int', 'Int', allTestValues['Int']!);
       await preferences.setValue('Double', 'Double', allTestValues['Double']!);
       await preferences.setValue(
-          'StringList', 'StringList', allTestValues['StringList']!);
+        'StringList',
+        'StringList',
+        allTestValues['StringList']!,
+      );
       await preferences.setValue(
-          'String', 'prefix.String', allTestValues['prefix.String']!);
+        'String',
+        'prefix.String',
+        allTestValues['prefix.String']!,
+      );
       await preferences.setValue(
-          'Bool', 'prefix.Bool', allTestValues['prefix.Bool']!);
+        'Bool',
+        'prefix.Bool',
+        allTestValues['prefix.Bool']!,
+      );
       await preferences.setValue(
-          'Int', 'prefix.Int', allTestValues['prefix.Int']!);
+        'Int',
+        'prefix.Int',
+        allTestValues['prefix.Int']!,
+      );
       await preferences.setValue(
-          'Double', 'prefix.Double', allTestValues['prefix.Double']!);
-      await preferences.setValue('StringList', 'prefix.StringList',
-          allTestValues['prefix.StringList']!);
+        'Double',
+        'prefix.Double',
+        allTestValues['prefix.Double']!,
+      );
       await preferences.setValue(
-          'String', 'flutter.String', allTestValues['flutter.String']!);
+        'StringList',
+        'prefix.StringList',
+        allTestValues['prefix.StringList']!,
+      );
       await preferences.setValue(
-          'Bool', 'flutter.Bool', allTestValues['flutter.Bool']!);
+        'String',
+        'flutter.String',
+        allTestValues['flutter.String']!,
+      );
       await preferences.setValue(
-          'Int', 'flutter.Int', allTestValues['flutter.Int']!);
+        'Bool',
+        'flutter.Bool',
+        allTestValues['flutter.Bool']!,
+      );
       await preferences.setValue(
-          'Double', 'flutter.Double', allTestValues['flutter.Double']!);
-      await preferences.setValue('StringList', 'flutter.StringList',
-          allTestValues['flutter.StringList']!);
+        'Int',
+        'flutter.Int',
+        allTestValues['flutter.Int']!,
+      );
+      await preferences.setValue(
+        'Double',
+        'flutter.Double',
+        allTestValues['flutter.Double']!,
+      );
+      await preferences.setValue(
+        'StringList',
+        'flutter.StringList',
+        allTestValues['flutter.StringList']!,
+      );
     }
 
     setUp(() async {
@@ -80,9 +113,7 @@ void main() {
 
     tearDown(() async {
       await preferences.clearWithParameters(
-        ClearParameters(
-          filter: PreferencesFilter(prefix: ''),
-        ),
+        ClearParameters(filter: PreferencesFilter(prefix: '')),
       );
     });
 
@@ -99,8 +130,9 @@ void main() {
       testWidgets('remove', (WidgetTester _) async {
         const String key = 'flutter.String';
         await preferences.remove(key);
-        final Map<String, Object> values =
-            await preferences.getAllWithPrefix('');
+        final Map<String, Object> values = await preferences.getAllWithPrefix(
+          '',
+        );
         expect(values[key], isNull);
       });
 
@@ -115,8 +147,9 @@ void main() {
       });
 
       testWidgets('get all with prefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithPrefix('prefix.');
+        final Map<String, Object> values = await preferences.getAllWithPrefix(
+          'prefix.',
+        );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
         expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -125,8 +158,9 @@ void main() {
       });
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithPrefix('');
+        final Map<String, Object> values = await preferences.getAllWithPrefix(
+          '',
+        );
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -137,13 +171,16 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithPrefix', (WidgetTester _) async {
         await preferences.clearWithPrefix('prefix.');
-        Map<String, Object> values =
-            await preferences.getAllWithPrefix('prefix.');
+        Map<String, Object> values = await preferences.getAllWithPrefix(
+          'prefix.',
+        );
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -155,13 +192,16 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
         await preferences.clearWithPrefix('');
-        final Map<String, Object> values =
-            await preferences.getAllWithPrefix('');
+        final Map<String, Object> values = await preferences.getAllWithPrefix(
+          '',
+        );
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -179,12 +219,10 @@ void main() {
       testWidgets('remove', (WidgetTester _) async {
         const String key = 'flutter.String';
         await preferences.remove(key);
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values[key], isNull);
       });
 
@@ -199,12 +237,10 @@ void main() {
       });
 
       testWidgets('get all with prefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
+            );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
         expect(values['prefix.Int'], allTestValues['prefix.Int']);
@@ -213,15 +249,15 @@ void main() {
       });
 
       testWidgets('get all with allow list', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(
-              prefix: 'prefix.',
-              allowList: <String>{'prefix.String'},
-            ),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(
+                filter: PreferencesFilter(
+                  prefix: 'prefix.',
+                  allowList: <String>{'prefix.String'},
+                ),
+              ),
+            );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], null);
         expect(values['prefix.Int'], null);
@@ -230,12 +266,10 @@ void main() {
       });
 
       testWidgets('getAllWithNoPrefix', (WidgetTester _) async {
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], allTestValues['String']);
         expect(values['Bool'], allTestValues['Bool']);
         expect(values['Int'], allTestValues['Int']);
@@ -246,19 +280,17 @@ void main() {
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithParameters', (WidgetTester _) async {
         await preferences.clearWithParameters(
-          ClearParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         Map<String, Object> values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         expect(values['prefix.String'], null);
         expect(values['prefix.Bool'], null);
@@ -266,20 +298,21 @@ void main() {
         expect(values['prefix.Double'], null);
         expect(values['prefix.StringList'], null);
         values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'flutter.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
         );
         expect(values['flutter.String'], allTestValues['flutter.String']);
         expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
-      testWidgets('clearWithParameters with allow list',
-          (WidgetTester _) async {
+      testWidgets('clearWithParameters with allow list', (
+        WidgetTester _,
+      ) async {
         await addData();
         await preferences.clearWithParameters(
           ClearParameters(
@@ -290,9 +323,7 @@ void main() {
           ),
         );
         Map<String, Object> values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'prefix.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
         );
         expect(values['prefix.String'], allTestValues['prefix.String']);
         expect(values['prefix.Bool'], allTestValues['prefix.Bool']);
@@ -300,30 +331,26 @@ void main() {
         expect(values['prefix.Double'], allTestValues['prefix.Double']);
         expect(values['prefix.StringList'], null);
         values = await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: 'flutter.'),
-          ),
+          GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
         );
         expect(values['flutter.String'], allTestValues['flutter.String']);
         expect(values['flutter.Bool'], allTestValues['flutter.Bool']);
         expect(values['flutter.Int'], allTestValues['flutter.Int']);
         expect(values['flutter.Double'], allTestValues['flutter.Double']);
         expect(
-            values['flutter.StringList'], allTestValues['flutter.StringList']);
+          values['flutter.StringList'],
+          allTestValues['flutter.StringList'],
+        );
       });
 
       testWidgets('clearWithNoPrefix', (WidgetTester _) async {
         await preferences.clearWithParameters(
-          ClearParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
+          ClearParameters(filter: PreferencesFilter(prefix: '')),
         );
-        final Map<String, Object> values =
-            await preferences.getAllWithParameters(
-          GetAllParameters(
-            filter: PreferencesFilter(prefix: ''),
-          ),
-        );
+        final Map<String, Object> values = await preferences
+            .getAllWithParameters(
+              GetAllParameters(filter: PreferencesFilter(prefix: '')),
+            );
         expect(values['String'], null);
         expect(values['Bool'], null);
         expect(values['Int'], null);
@@ -354,14 +381,16 @@ void main() {
     const double testDouble = 3.14159;
     const List<String> testList = <String>['foo', 'bar'];
 
-    Future<SharedPreferencesAsyncPlatform> getPreferences(
-        {bool clear = true}) async {
+    Future<SharedPreferencesAsyncPlatform> getPreferences({
+      bool clear = true,
+    }) async {
       final SharedPreferencesAsyncPlatform preferences =
           SharedPreferencesAsyncPlatform.instance!;
       if (clear) {
         await preferences.clear(
-            const ClearPreferencesParameters(filter: PreferencesFilters()),
-            emptyOptions);
+          const ClearPreferencesParameters(filter: PreferencesFilters()),
+          emptyOptions,
+        );
       }
       return preferences;
     }
@@ -401,8 +430,9 @@ void main() {
       expect(await preferences.getStringList(listKey, emptyOptions), testList);
     });
 
-    testWidgets('getStringList does not throw cast error',
-        (WidgetTester _) async {
+    testWidgets('getStringList does not throw cast error', (
+      WidgetTester _,
+    ) async {
       final SharedPreferencesAsyncPlatform preferences = await getPreferences();
 
       await preferences.setStringList(listKey, testList, emptyOptions);
@@ -414,8 +444,10 @@ void main() {
       final SharedPreferencesAsyncPlatform preferences = await getPreferences();
 
       await preferences.setStringList(listKey, testList, emptyOptions);
-      final List<String>? list =
-          await preferences.getStringList(listKey, emptyOptions);
+      final List<String>? list = await preferences.getStringList(
+        listKey,
+        emptyOptions,
+      );
       list?.add('value');
       expect(list?.length, testList.length + 1);
     });

--- a/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
@@ -67,29 +67,29 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('SharedPreferences Demo'),
-      ),
+      appBar: AppBar(title: const Text('SharedPreferences Demo')),
       body: Center(
-          child: FutureBuilder<int>(
-              future: _counter,
-              builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-                switch (snapshot.connectionState) {
-                  case ConnectionState.none:
-                  case ConnectionState.waiting:
-                    return const CircularProgressIndicator();
-                  case ConnectionState.active:
-                  case ConnectionState.done:
-                    if (snapshot.hasError) {
-                      return Text('Error: ${snapshot.error}');
-                    } else {
-                      return Text(
-                        'Button tapped ${snapshot.data} time${snapshot.data == 1 ? '' : 's'}.\n\n'
-                        'This should persist across restarts.',
-                      );
-                    }
+        child: FutureBuilder<int>(
+          future: _counter,
+          builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+            switch (snapshot.connectionState) {
+              case ConnectionState.none:
+              case ConnectionState.waiting:
+                return const CircularProgressIndicator();
+              case ConnectionState.active:
+              case ConnectionState.done:
+                if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                } else {
+                  return Text(
+                    'Button tapped ${snapshot.data} time${snapshot.data == 1 ? '' : 's'}.\n\n'
+                    'This should persist across restarts.',
+                  );
                 }
-              })),
+            }
+          },
+        ),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,
         tooltip: 'Increment',

--- a/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the shared_preferences_windows plugin.
 publish_to: none
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
+++ b/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
@@ -59,16 +59,15 @@ class SharedPreferencesWindows extends SharedPreferencesStorePlatform {
   @override
   Future<bool> clear() async {
     return clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<bool> clearWithPrefix(String prefix) async {
     return clearWithParameters(
-        ClearParameters(filter: PreferencesFilter(prefix: prefix)));
+      ClearParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
@@ -76,9 +75,11 @@ class SharedPreferencesWindows extends SharedPreferencesStorePlatform {
     final PreferencesFilter filter = parameters.filter;
 
     final Map<String, Object> preferences = await _readPreferences();
-    preferences.removeWhere((String key, _) =>
-        key.startsWith(filter.prefix) &&
-        (filter.allowList == null || filter.allowList!.contains(key)));
+    preferences.removeWhere(
+      (String key, _) =>
+          key.startsWith(filter.prefix) &&
+          (filter.allowList == null || filter.allowList!.contains(key)),
+    );
     return _writePreferences(
       preferences,
       _defaultFileName,
@@ -90,26 +91,30 @@ class SharedPreferencesWindows extends SharedPreferencesStorePlatform {
   @override
   Future<Map<String, Object>> getAll() async {
     return getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: _defaultPrefix),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
     );
   }
 
   @override
   Future<Map<String, Object>> getAllWithPrefix(String prefix) async {
     return getAllWithParameters(
-        GetAllParameters(filter: PreferencesFilter(prefix: prefix)));
+      GetAllParameters(filter: PreferencesFilter(prefix: prefix)),
+    );
   }
 
   @override
   Future<Map<String, Object>> getAllWithParameters(
-      GetAllParameters parameters) async {
+    GetAllParameters parameters,
+  ) async {
     final PreferencesFilter filter = parameters.filter;
-    final Map<String, Object> withPrefix =
-        Map<String, Object>.from(await _readPreferences());
-    withPrefix.removeWhere((String key, _) => !(key.startsWith(filter.prefix) &&
-        (filter.allowList?.contains(key) ?? true)));
+    final Map<String, Object> withPrefix = Map<String, Object>.from(
+      await _readPreferences(),
+    );
+    withPrefix.removeWhere(
+      (String key, _) =>
+          !(key.startsWith(filter.prefix) &&
+              (filter.allowList?.contains(key) ?? true)),
+    );
     return withPrefix;
   }
 
@@ -195,11 +200,7 @@ base class SharedPreferencesAsyncWindows
   }
 
   @override
-  Future<void> setInt(
-    String key,
-    int value,
-    SharedPreferencesOptions options,
-  ) {
+  Future<void> setInt(String key, int value, SharedPreferencesOptions options) {
     return _setValue(key, value, options);
   }
 
@@ -222,10 +223,7 @@ base class SharedPreferencesAsyncWindows
   }
 
   @override
-  Future<bool?> getBool(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async {
     final Map<String, Object> data = await _readAll(<String>{key}, options);
     return data[key] as bool?;
   }
@@ -240,10 +238,7 @@ base class SharedPreferencesAsyncWindows
   }
 
   @override
-  Future<int?> getInt(
-    String key,
-    SharedPreferencesOptions options,
-  ) async {
+  Future<int?> getInt(String key, SharedPreferencesOptions options) async {
     final Map<String, Object> data = await _readAll(<String>{key}, options);
     return data[key] as int?;
   }
@@ -258,15 +253,20 @@ base class SharedPreferencesAsyncWindows
   }
 
   @override
-  Future<void> clear(ClearPreferencesParameters parameters,
-      SharedPreferencesOptions options) async {
+  Future<void> clear(
+    ClearPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) async {
     final SharedPreferencesWindowsOptions windowsOptions =
         SharedPreferencesWindowsOptions.fromSharedPreferencesOptions(options);
     final PreferencesFilters filter = parameters.filter;
-    final Map<String, Object> preferences =
-        await _readPreferences(windowsOptions.fileName);
-    preferences.removeWhere((String key, _) =>
-        filter.allowList == null || filter.allowList!.contains(key));
+    final Map<String, Object> preferences = await _readPreferences(
+      windowsOptions.fileName,
+    );
+    preferences.removeWhere(
+      (String key, _) =>
+          filter.allowList == null || filter.allowList!.contains(key),
+    );
     await _writePreferences(
       preferences,
       windowsOptions.fileName,
@@ -285,9 +285,7 @@ base class SharedPreferencesAsyncWindows
 
   /// Reloads preferences from file.
   @visibleForTesting
-  Future<void> reload(
-    SharedPreferencesWindowsOptions options,
-  ) async {
+  Future<void> reload(SharedPreferencesWindowsOptions options) async {
     _cachedPreferences = await _readFromFile(options.fileName);
   }
 
@@ -298,17 +296,22 @@ base class SharedPreferencesAsyncWindows
     final SharedPreferencesWindowsOptions windowsOptions =
         SharedPreferencesWindowsOptions.fromSharedPreferencesOptions(options);
     final Map<String, Object> prefs = Map<String, Object>.from(
-        await _readPreferences(windowsOptions.fileName));
+      await _readPreferences(windowsOptions.fileName),
+    );
     prefs.removeWhere((String key, _) => !(allowList?.contains(key) ?? true));
     return prefs;
   }
 
   Future<void> _setValue(
-      String key, Object value, SharedPreferencesOptions options) async {
+    String key,
+    Object value,
+    SharedPreferencesOptions options,
+  ) async {
     final SharedPreferencesWindowsOptions windowsOptions =
         SharedPreferencesWindowsOptions.fromSharedPreferencesOptions(options);
-    final Map<String, Object> preferences =
-        await _readPreferences(windowsOptions.fileName);
+    final Map<String, Object> preferences = await _readPreferences(
+      windowsOptions.fileName,
+    );
     preferences[key] = value;
     await _writePreferences(
       preferences,
@@ -412,7 +415,8 @@ class SharedPreferencesWindowsOptions extends SharedPreferencesOptions {
   /// Returns a new instance of [SharedPreferencesWindowsOptions] from an existing
   /// [SharedPreferencesOptions].
   static SharedPreferencesWindowsOptions fromSharedPreferencesOptions(
-      SharedPreferencesOptions options) {
+    SharedPreferencesOptions options,
+  ) {
     if (options is SharedPreferencesWindowsOptions) {
       return options;
     }

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 2.4.1
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_windows/test/legacy_shared_preferences_windows_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/test/legacy_shared_preferences_windows_test.dart
@@ -79,8 +79,10 @@ void main() {
 
   test('registered instance', () async {
     SharedPreferencesWindows.registerWith();
-    expect(SharedPreferencesStorePlatform.instance,
-        isA<SharedPreferencesWindows>());
+    expect(
+      SharedPreferencesStorePlatform.instance,
+      isA<SharedPreferencesWindows>(),
+    );
   });
 
   test('getAll', () async {
@@ -106,9 +108,7 @@ void main() {
     final SharedPreferencesWindows prefs = getPreferences();
 
     final Map<String, Object> values = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(values, hasLength(5));
     expect(values, prefixTestValues);
@@ -162,8 +162,9 @@ void main() {
     await writeTestFile(json.encode(flutterTestValues));
     final SharedPreferencesWindows prefs = getPreferences();
     await prefs.clearWithPrefix('prefix.');
-    final Map<String, Object> noValues =
-        await prefs.getAllWithPrefix('prefix.');
+    final Map<String, Object> noValues = await prefs.getAllWithPrefix(
+      'prefix.',
+    );
     expect(noValues, hasLength(0));
 
     final Map<String, Object> values = await prefs.getAll();
@@ -192,14 +193,10 @@ void main() {
     await writeTestFile(json.encode(flutterTestValues));
     final SharedPreferencesWindows prefs = getPreferences();
     await prefs.clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     final Map<String, Object> noValues = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(noValues, hasLength(0));
 
@@ -220,9 +217,7 @@ void main() {
       ),
     );
     final Map<String, Object> noValues = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: 'prefix.'),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: 'prefix.')),
     );
     expect(noValues, hasLength(4));
   });
@@ -232,9 +227,7 @@ void main() {
     final SharedPreferencesWindows prefs = getPreferences();
 
     final Map<String, Object> values = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(values, hasLength(15));
     expect(values, allTestValues);
@@ -244,14 +237,10 @@ void main() {
     await writeTestFile(json.encode(flutterTestValues));
     final SharedPreferencesWindows prefs = getPreferences();
     await prefs.clearWithParameters(
-      ClearParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      ClearParameters(filter: PreferencesFilter(prefix: '')),
     );
     final Map<String, Object> noValues = await prefs.getAllWithParameters(
-      GetAllParameters(
-        filter: PreferencesFilter(prefix: ''),
-      ),
+      GetAllParameters(filter: PreferencesFilter(prefix: '')),
     );
     expect(noValues, hasLength(0));
   });

--- a/packages/shared_preferences/shared_preferences_windows/test/shared_preferences_windows_async_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/test/shared_preferences_windows_async_test.dart
@@ -87,8 +87,9 @@ void main() {
     await preferences.setStringList(listKey, testList, emptyOptions);
 
     final Map<String, Object?> gotAll = await preferences.getPreferences(
-        const GetPreferencesParameters(filter: PreferencesFilters()),
-        emptyOptions);
+      const GetPreferencesParameters(filter: PreferencesFilters()),
+      emptyOptions,
+    );
 
     expect(gotAll.length, 5);
     expect(gotAll[stringKey], testString);
@@ -107,10 +108,11 @@ void main() {
     await preferences.setStringList(listKey, testList, emptyOptions);
 
     final Map<String, Object?> gotAll = await preferences.getPreferences(
-        const GetPreferencesParameters(
-            filter:
-                PreferencesFilters(allowList: <String>{stringKey, boolKey})),
-        emptyOptions);
+      const GetPreferencesParameters(
+        filter: PreferencesFilters(allowList: <String>{stringKey, boolKey}),
+      ),
+      emptyOptions,
+    );
 
     expect(gotAll.length, 2);
     expect(gotAll[stringKey], testString);
@@ -166,8 +168,9 @@ void main() {
     await preferences.setDouble(doubleKey, testDouble, emptyOptions);
     await preferences.setStringList(listKey, testList, emptyOptions);
     await preferences.clear(
-        const ClearPreferencesParameters(filter: PreferencesFilters()),
-        emptyOptions);
+      const ClearPreferencesParameters(filter: PreferencesFilters()),
+      emptyOptions,
+    );
     expect(await preferences.getString(stringKey, emptyOptions), null);
     expect(await preferences.getBool(boolKey, emptyOptions), null);
     expect(await preferences.getInt(intKey, emptyOptions), null);


### PR DESCRIPTION
For the `shared_preferences` packages:
- Updates the min SDK version to 3.29
- Runs the autoformatter with the new format
- Update code excerpts

This does not update versions because pushing format changes (even in READMEs) isn't worth doing a release that drops an SDK version (which we don't normally version)

Prep for https://github.com/flutter/packages/pull/9816