### PR TITLE
Add WebWebViewController.runJavaScript

### DIFF
--- a/packages/webview_flutter/webview_flutter_web/AUTHORS
+++ b/packages/webview_flutter/webview_flutter_web/AUTHORS
@@ -5,4 +5,4 @@
 
 Google Inc.
 Bodhi Mulders <info@bemacized.net>
-
+Sophie Bremer

--- a/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Adds `runJavaScript`.
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
 ## 0.2.3+4

--- a/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:ui_web' as ui_web;
 
 import 'package:flutter/widgets.dart';
+import 'package:web/helpers.dart';
 import 'package:web/web.dart' as web;
 import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 
@@ -18,7 +20,7 @@ import 'http_request_factory.dart';
 @immutable
 class WebWebViewControllerCreationParams
     extends PlatformWebViewControllerCreationParams {
-  /// Creates a new [AndroidWebViewControllerCreationParams] instance.
+  /// Creates a new [WebWebViewControllerCreationParams] instance.
   WebWebViewControllerCreationParams({
     @visibleForTesting this.httpRequestFactory = const HttpRequestFactory(),
   }) : super();
@@ -44,6 +46,8 @@ class WebWebViewControllerCreationParams
     ..style.width = '100%'
     ..style.height = '100%'
     ..style.border = 'none';
+
+  final Duration _iFrameWaitDelay = const Duration(milliseconds: 100);
 }
 
 /// An implementation of [PlatformWebViewController] using Flutter for Web API.
@@ -58,13 +62,39 @@ class WebWebViewController extends PlatformWebViewController {
   WebWebViewControllerCreationParams get _webWebViewParams =>
       params as WebWebViewControllerCreationParams;
 
+  // Retrieves the iFrame's content body after attachment to DOM.
+  Future<web.HTMLBodyElement> _getIFrameBody() async {
+    final web.Document document = await _getIFrameDocument();
+
+    while (document.body == null) {
+      await Future<void>.delayed(_webWebViewParams._iFrameWaitDelay);
+    }
+
+    return document.body! as HTMLBodyElement;
+  }
+
+  // Retrieves the iFrame's content document after attachment to DOM.
+  Future<web.Document> _getIFrameDocument() async {
+    while (_webWebViewParams.iFrame.contentDocument == null) {
+      await Future<void>.delayed(_webWebViewParams._iFrameWaitDelay);
+    }
+
+    return _webWebViewParams.iFrame.contentDocument!;
+  }
+
   @override
-  Future<void> loadHtmlString(String html, {String? baseUrl}) async {
-    _webWebViewParams.iFrame.src = Uri.dataFromString(
-      html,
-      mimeType: 'text/html',
-      encoding: utf8,
-    ).toString();
+  Future<void> loadHtmlString(String html, {String? baseUrl}) {
+    final Completer<void> loading = Completer<void>();
+
+    _webWebViewParams.iFrame.addEventListener(
+        'load',
+        () {
+          _webWebViewParams.iFrame.contentDocument?.write(html.toJS);
+          loading.complete();
+        }.toJS);
+    _webWebViewParams.iFrame.src = baseUrl ?? 'about:blank';
+
+    return loading.future;
   }
 
   @override
@@ -81,6 +111,31 @@ class WebWebViewController extends PlatformWebViewController {
     } else {
       await _updateIFrameFromXhr(params);
     }
+  }
+
+  @override
+  Future<void> runJavaScript(String javaScript) async {
+    final Completer<void> run = Completer<void>();
+    final web.Document document = await _getIFrameDocument();
+    final web.HTMLBodyElement body = await _getIFrameBody();
+    final web.HTMLScriptElement script =
+        document.createElement('script') as web.HTMLScriptElement;
+
+    script.addEventListener(
+        'load',
+        () {
+          body.removeChild(script);
+          run.complete();
+        }.toJS);
+    script.src = Uri.dataFromString(
+      javaScript,
+      mimeType: 'text/javascript',
+      encoding: utf8,
+    ).toString();
+
+    body.appendChild(script);
+
+    await run.future;
   }
 
   /// Performs an AJAX request defined by [params].


### PR DESCRIPTION
This PR adds an implementation for `WebWebViewController.runJavaScript` and changes the way `WebWebViewController.loadHtmlString` injects HTML code while also adding support for the `baseUrl` option.

The following issues are fixed:
* https://github.com/flutter/flutter/issues/173899

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
