### PR TITLE
Handle automatic PopScope

### DIFF
--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -1258,6 +1258,10 @@ void main() {
         await verify(() => simulateAndroidBackButton(tester), <Object>[]);
       });
 
+      // Pump one frame between back buttons to allow any PopScope widgets to
+      // rebuild.
+      await tester.pump();
+
       // The second pop should exit the app.
       await tester.runAsync(() async {
         await verify(() => simulateAndroidBackButton(tester), <Object>[


### PR DESCRIPTION
This test was failing in https://github.com/flutter/flutter/pull/152330. That PR adds a PopScope inside of nested Navigators. When a back gesture happens, the PopScope takes 1 frame to rerender and update the state of its pop handling. The test was breaking because it performed two back gestures in one frame. Putting a pump in between them fixes it when the PR is  merged (and works fine without the PR too).

It took me so many hours to realize this one little pump was the fix I needed 😭 .