### PR TITLE
Flutter svg loader buffer fix

### DIFF
--- a/third_party/packages/flutter_svg/CHANGELOG.md
+++ b/third_party/packages/flutter_svg/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 
+## 2.2.1
+
+* Fixes message buffer access in SvgAssetLoader.
+
 ## 2.2.0
 
 * Exposes `renderingStrategy` in `SvgPicture` constructors.

--- a/third_party/packages/flutter_svg/lib/src/loaders.dart
+++ b/third_party/packages/flutter_svg/lib/src/loaders.dart
@@ -379,7 +379,7 @@ class SvgAssetLoader extends SvgLoader<ByteData> {
 
   @override
   String provideSvg(ByteData? message) =>
-      utf8.decode(Uint8List.sublistView(message!));
+      utf8.decode(Uint8List.sublistView(message!), allowMalformed: true);
 
   @override
   SvgCacheKey cacheKey(BuildContext? context) {

--- a/third_party/packages/flutter_svg/lib/src/loaders.dart
+++ b/third_party/packages/flutter_svg/lib/src/loaders.dart
@@ -379,7 +379,7 @@ class SvgAssetLoader extends SvgLoader<ByteData> {
 
   @override
   String provideSvg(ByteData? message) =>
-      utf8.decode(message!.buffer.asUint8List(), allowMalformed: true);
+      utf8.decode(Uint8List.sublistView(message!));
 
   @override
   SvgCacheKey cacheKey(BuildContext? context) {

--- a/third_party/packages/flutter_svg/pubspec.yaml
+++ b/third_party/packages/flutter_svg/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_svg
 description: An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
 repository: https://github.com/flutter/packages/tree/main/third_party/packages/flutter_svg
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_svg%22
-version: 2.2.0
+version: 2.2.1
 
 environment:
   sdk: ^3.7.0

--- a/third_party/packages/flutter_svg/test/loaders_test.dart
+++ b/third_party/packages/flutter_svg/test/loaders_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -62,6 +65,29 @@ void main() {
     );
     expect((await loader.prepareMessage(null))!.lengthInBytes, 0);
     expect((await packageLoader.prepareMessage(null))!.lengthInBytes, 1);
+  });
+
+  test('AssetLoader correctly accesses buffer', () async {
+    final ByteBuffer buffer = utf8.encode('foobar').buffer;
+    final TestBundle bundle = TestBundle(<String, ByteData>{
+      'foo': buffer.asByteData(0, 3),
+      'bar': buffer.asByteData(3, 3),
+    });
+    final SvgAssetLoader loaderFoo = SvgAssetLoader('foo', assetBundle: bundle);
+    final SvgAssetLoader loaderBar = SvgAssetLoader('bar', assetBundle: bundle);
+    final ByteData? byteDataFoo = await loaderFoo.prepareMessage(null);
+    final ByteData? byteDataBar = await loaderBar.prepareMessage(null);
+
+    expect(byteDataFoo!.buffer, equals(byteDataBar!.buffer));
+
+    expect(byteDataFoo.lengthInBytes, 3);
+    expect(byteDataFoo.offsetInBytes, 0);
+
+    expect(byteDataBar.offsetInBytes, 3);
+    expect(byteDataBar.lengthInBytes, 3);
+
+    expect(loaderFoo.provideSvg(byteDataFoo), equals('foo'));
+    expect(loaderFoo.provideSvg(byteDataBar), equals('bar'));
   });
 
   test('SvgNetworkLoader closes internal client', () async {


### PR DESCRIPTION
Fixes buffer access when loading svg from assets. Making it consistent with Image.asset loading. 

Basically changes: 
```String provideSvg(ByteData? message) => utf8.decode(message!.buffer.asUint8List(), allowMalformed: true);```
to:
```String provideSvg(ByteData? message) =>utf8.decode(Uint8List.sublistView(message!));```

since we do not want to decode whole buffer.
This is useful when using custom `AssetBundles`, like when they provide as slice of buffer on `load()` instead of allocating a new array of bytes.

Issue: https://github.com/flutter/flutter/issues/174526

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
