### PR TITLE
[go_router_builder] Removes redundant arguments from annotations

### DIFF
--- a/packages/go_router_builder/test_inputs/shell_route_data.dart
+++ b/packages/go_router_builder/test_inputs/shell_route_data.dart
@@ -4,21 +4,15 @@
 
 import 'package:go_router/go_router.dart';
 
-@TypedShellRoute<ShellRouteNoConstConstructor>(
-  routes: <TypedRoute<RouteData>>[],
-)
+@TypedShellRoute<ShellRouteNoConstConstructor>()
 class ShellRouteNoConstConstructor extends ShellRouteData {}
 
-@TypedShellRoute<ShellRouteWithConstConstructor>(
-  routes: <TypedRoute<RouteData>>[],
-)
+@TypedShellRoute<ShellRouteWithConstConstructor>()
 class ShellRouteWithConstConstructor extends ShellRouteData {
   const ShellRouteWithConstConstructor();
 }
 
-@TypedShellRoute<ShellRouteWithRestorationScopeId>(
-  routes: <TypedRoute<RouteData>>[],
-)
+@TypedShellRoute<ShellRouteWithRestorationScopeId>()
 class ShellRouteWithRestorationScopeId extends ShellRouteData {
   const ShellRouteWithRestorationScopeId();
 

--- a/packages/go_router_builder/test_inputs/shell_route_data_without_unnamed_constructor.dart
+++ b/packages/go_router_builder/test_inputs/shell_route_data_without_unnamed_constructor.dart
@@ -4,9 +4,7 @@
 
 import 'package:go_router/go_router.dart';
 
-@TypedShellRoute<ShellRouteWithoutUnnamedConstructor>(
-  routes: <TypedRoute<RouteData>>[],
-)
+@TypedShellRoute<ShellRouteWithoutUnnamedConstructor>()
 class ShellRouteWithoutUnnamedConstructor extends ShellRouteData {
   const ShellRouteWithoutUnnamedConstructor.namedConstructor();
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_wrappers/sk_product_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_wrappers/sk_product_wrapper.dart
@@ -384,7 +384,7 @@ class SKProductDiscountWrapper {
   /// A string used to uniquely identify a discount offer for a product.
   ///
   /// You set up offers and their identifiers in App Store Connect.
-  @JsonKey(defaultValue: null)
+  @JsonKey()
   final String? identifier;
 
   /// Values representing the types of discount offers an app can present.


### PR DESCRIPTION
It was found, at the issue below, a false-negative for the `avoid_redundant_argument_values` lint where it wasn't triggered for annotations. This PR simply removes the redundant arguments.

- https://github.com/dart-lang/sdk/issues/61456

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
