### PR TITLE
Revert "[url_launcher] fix: Link widget Tab traversal"

### DIFF
--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,6 +1,5 @@
-## 2.4.2
+## NEXT
 
-* Ensure link widget merge its semantic node with its children to avoid duplicate nodes.
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 
 ## 2.4.1

--- a/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
@@ -208,43 +208,6 @@ void main() {
         maxScrolls: 1000,
       );
     });
-
-    testWidgets('MergeSemantics is always present to avoid duplicate nodes', (
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Column(
-              children: <Widget>[
-                WebLinkDelegate(
-                  TestLinkInfo(
-                    uri: Uri.parse('https://dart.dev/xyz'),
-                    target: LinkTarget.blank,
-                    builder: (BuildContext context, FollowLink? followLink) {
-                      return ElevatedButton(
-                        onPressed: followLink,
-                        child: const Text('First Button'),
-                      );
-                    },
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      final Finder buttonFinder = find.byType(ElevatedButton);
-      expect(buttonFinder, findsOneWidget);
-
-      final Element buttonElement = tester.element(buttonFinder);
-      final MergeSemantics? parentWidget =
-          buttonElement.findAncestorWidgetOfExactType<MergeSemantics>();
-      expect(parentWidget, isNotNull);
-    });
   });
 
   group('Follows links', () {

--- a/packages/url_launcher/url_launcher_web/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/link.dart
@@ -117,15 +117,13 @@ class WebLinkDelegateState extends State<WebLinkDelegate> {
   }
 
   Widget _buildChild(BuildContext context) {
-    return MergeSemantics(
-      child: Semantics(
-        link: true,
-        identifier: _semanticsIdentifier,
-        linkUrl: widget.link.uri,
-        child: widget.link.builder(
-          context,
-          widget.link.isDisabled ? null : _followLink,
-        ),
+    return Semantics(
+      link: true,
+      identifier: _semanticsIdentifier,
+      linkUrl: widget.link.uri,
+      child: widget.link.builder(
+        context,
+        widget.link.isDisabled ? null : _followLink,
       ),
     );
   }

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.4.2
+version: 2.4.1
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
Reverts flutter/packages#9815

The tree is now broken in exactly the way the presubmits for that PR were broken; it should not have landed.