### PR TITLE
[file_selector] Fix example on iOS

### DIFF
--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.0.4
 
+* Updates the example app and README examples to work on iOS.
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
 * Updates README to indicate that Andoid SDK <21 is no longer supported.
 

--- a/packages/file_selector/file_selector/README.md
+++ b/packages/file_selector/file_selector/README.md
@@ -38,6 +38,7 @@ Please also take a look at our [example][example] app.
 const XTypeGroup typeGroup = XTypeGroup(
   label: 'images',
   extensions: <String>['jpg', 'png'],
+  uniformTypeIdentifiers: <String>['public.jpeg', 'public.png'],
 );
 final XFile? file = await openFile(
   acceptedTypeGroups: <XTypeGroup>[typeGroup],
@@ -51,10 +52,12 @@ final XFile? file = await openFile(
 const XTypeGroup jpgsTypeGroup = XTypeGroup(
   label: 'JPEGs',
   extensions: <String>['jpg', 'jpeg'],
+  uniformTypeIdentifiers: <String>['public.jpeg'],
 );
 const XTypeGroup pngTypeGroup = XTypeGroup(
   label: 'PNGs',
   extensions: <String>['png'],
+  uniformTypeIdentifiers: <String>['public.png'],
 );
 final List<XFile> files = await openFiles(
   acceptedTypeGroups: <XTypeGroup>[jpgsTypeGroup, pngTypeGroup],

--- a/packages/file_selector/file_selector/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_image_page.dart
@@ -18,6 +18,7 @@ class OpenImagePage extends StatelessWidget {
     const XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
       extensions: <String>['jpg', 'png'],
+      uniformTypeIdentifiers: <String>['public.jpeg', 'public.png'],
     );
     final XFile? file = await openFile(
       acceptedTypeGroups: <XTypeGroup>[typeGroup],

--- a/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
@@ -18,10 +18,12 @@ class OpenMultipleImagesPage extends StatelessWidget {
     const XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
       extensions: <String>['jpg', 'jpeg'],
+      uniformTypeIdentifiers: <String>['public.jpeg'],
     );
     const XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
       extensions: <String>['png'],
+      uniformTypeIdentifiers: <String>['public.png'],
     );
     final List<XFile> files = await openFiles(
       acceptedTypeGroups: <XTypeGroup>[jpgsTypeGroup, pngTypeGroup],

--- a/packages/file_selector/file_selector/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_text_page.dart
@@ -16,6 +16,7 @@ class OpenTextPage extends StatelessWidget {
     const XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
       extensions: <String>['txt', 'json'],
+      uniformTypeIdentifiers: <String>['public.text'],
     );
     // This demonstrates using an initial directory for the prompt, which should
     // only be done in cases where the application can likely predict where the

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for opening and saving files, or selecting
   directories, using native file selection UI.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 1.0.3
+version: 1.0.4
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
Fixes the example app to work on iOS; unlike the other platforms, iOS doesn't support `extensions`, so `uniformTypeIdentifiers` must also be set. This should have been done when we endorsed the iOS implementation package, but I forgot.

Fixes https://github.com/flutter/flutter/issues/175381

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
