### PR TITLE
[google_maps_flutter] Update web test for google_maps change

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/overlay_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/overlay_test.dart
@@ -41,9 +41,9 @@ void main() {
         tileOverlay: const TileOverlay(tileOverlayId: id),
       );
 
-      final gmaps.Size size = controller.gmMapType.tileSize;
-      expect(size.width, TileOverlayController.logicalTileSize);
-      expect(size.height, TileOverlayController.logicalTileSize);
+      final gmaps.Size? size = controller.gmMapType.tileSize;
+      expect(size?.width, TileOverlayController.logicalTileSize);
+      expect(size?.height, TileOverlayController.logicalTileSize);
       expect(
         controller.gmMapType.getTile(gmaps.Point(0, 0), 0, document),
         null,


### PR DESCRIPTION
`google_maps` 8.2.0 included a breaking change (changing a returned type from non-nullable to nullable), without a corresponding major version change, breaking tests. This updates the test to treat the value as nullable.

Fixes OOB tree breakage.