### PR TITLE
[go_router_builder] Ignore upcoming `experimental_member_use` warnings.

### DIFF
--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -645,6 +645,7 @@ abstract class RouteBaseConfig {
     }
 
     // TODO(kevmoo): validate that this MUST be a subtype of `GoRouteData`
+    // ignore: experimental_member_use
     final InterfaceElement2 classElement = typeParamType.element3;
 
     final RouteBaseConfig value;
@@ -945,6 +946,7 @@ String _enumMapConst(InterfaceType type) {
 
   final StringBuffer buffer = StringBuffer('const ${enumMapName(type)} = {');
 
+  // ignore: experimental_member_use
   for (final FieldElement2 enumField in type.element3.fields2.where(
     (FieldElement2 element) => element.isEnumConstant,
   )) {

--- a/packages/go_router_builder/lib/src/type_helpers.dart
+++ b/packages/go_router_builder/lib/src/type_helpers.dart
@@ -72,6 +72,7 @@ bool _isStringToStringFunction(
 /// Returns the custom codec for the annotation.
 String? _getCustomCodec(ElementAnnotation annotation, String name) {
   final ExecutableElement2? executableElement =
+      // ignore: experimental_member_use
       annotation.computeConstantValue()?.getField(name)?.toFunctionValue2();
   if (_isStringToStringFunction(executableElement, name)) {
     return executableElement!.displayName;
@@ -188,10 +189,12 @@ T? getNodeDeclaration<T extends AstNode>(InterfaceElement2 element) {
   }
 
   final ParsedLibraryResult parsedLibrary =
+      // ignore: experimental_member_use
       session.getParsedLibraryByElement2(element.library2)
           as ParsedLibraryResult;
   final FragmentDeclarationResult? declaration = parsedLibrary
-      .getFragmentDeclaration(element.firstFragment);
+  // ignore: experimental_member_use
+  .getFragmentDeclaration(element.firstFragment);
   final AstNode? node = declaration?.node;
 
   return node is T ? node : null;
@@ -684,6 +687,7 @@ class _TypeHelperJson extends _TypeHelperWithHelper {
 
     final MethodElement2? toJsonMethod = type.lookUpMethod3(
       'toJson',
+      // ignore: experimental_member_use
       type.element3.library2,
     );
     if (toJsonMethod == null ||
@@ -698,6 +702,7 @@ class _TypeHelperJson extends _TypeHelperWithHelper {
       return _matchesType(type.typeArguments.first);
     }
 
+    // ignore: experimental_member_use
     final ConstructorElement2? fromJsonMethod = type.element3
         .getNamedConstructor2('fromJson');
 
@@ -711,6 +716,7 @@ class _TypeHelperJson extends _TypeHelperWithHelper {
       throw InvalidGenerationSourceError(
         'The parameter type '
         '`${type.getDisplayString(withNullability: false)}` not have a supported fromJson definition.',
+        // ignore: experimental_member_use
         element: type.element3,
       );
     }
@@ -741,6 +747,7 @@ class _TypeHelperJson extends _TypeHelperWithHelper {
 
   bool _isNestedTemplate(InterfaceType type) {
     // check if has fromJson constructor
+    // ignore: experimental_member_use
     final ConstructorElement2? fromJsonMethod = type.element3
         .getNamedConstructor2('fromJson');
     if (fromJsonMethod == null || !fromJsonMethod.isPublic) {
@@ -764,6 +771,7 @@ class _TypeHelperJson extends _TypeHelperWithHelper {
       throw InvalidGenerationSourceError(
         'The parameter type '
         '`${type.getDisplayString(withNullability: false)}` not have a supported fromJson definition.',
+        // ignore: experimental_member_use
         element: type.element3,
       );
     }
@@ -782,6 +790,7 @@ class _TypeHelperJson extends _TypeHelperWithHelper {
       throw InvalidGenerationSourceError(
         'The parameter type '
         '`${type.getDisplayString(withNullability: false)}` not have a supported fromJson definition.',
+        // ignore: experimental_member_use
         element: type.element3,
       );
     }


### PR DESCRIPTION
In an upcoming Dart SDK change
(https://dart-review.googlesource.com/c/sdk/+/450970), I intend to add logic to the analyzer for generating a warning if an API marked `@experimental` is used. This will allow experimental analyzer features to be developed without creating a risk of breaking changes downstream.

Unfortunately, the `go_router_builder` package uses an old version of the analyzer in which some parts of the API were marked as `@experimental`, even though they were fully supported. So to avoid breaking trybots when the new warning rolls out, I need to add `// ignore` comments to ignore the upcoming warnings.

In a future PR, I intend to bump the `go_router_builder` package's analyzer dependency to 8.2.0; in that analyzer version, the erroneous `@experimental` annotations have been removed. Unfortunately, that can't be done yet, since `go_router_builder` still needs to support versions of flutter that pin analyzer to an earlier version. (See https://github.com/flutter/packages/pull/10079, which attempts to bump the analyzer dependency, but breaks trybots).

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
