### PR TITLE
[various] Stanadrdize Gradle `namespace`

### DIFF
--- a/packages/camera/camera/example/android/app/build.gradle
+++ b/packages/camera/camera/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.cameraexample'
+    namespace = "io.flutter.plugins.cameraexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/camera/camera_android/android/build.gradle
+++ b/packages/camera/camera_android/android/build.gradle
@@ -30,7 +30,7 @@ android {
 buildFeatures {
         buildConfig true
     }
-    namespace 'io.flutter.plugins.camera'
+    namespace = "io.flutter.plugins.camera"
     compileSdk = 36
 
     defaultConfig {

--- a/packages/camera/camera_android/example/android/app/build.gradle
+++ b/packages/camera/camera_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.cameraexample'
+    namespace = "io.flutter.plugins.cameraexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/camera/camera_android_camerax/android/build.gradle
+++ b/packages/camera/camera_android_camerax/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'io.flutter.plugins.camerax'
+    namespace = "io.flutter.plugins.camerax"
     // CameraX dependencies require compilation against version 33 or later.
     compileSdk = flutter.compileSdkVersion
 

--- a/packages/camera/camera_android_camerax/example/android/app/build.gradle
+++ b/packages/camera/camera_android_camerax/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.cameraxexample'
+    namespace = "io.flutter.plugins.cameraxexample"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/espresso/android/build.gradle
+++ b/packages/espresso/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'com.example.espresso'
+    namespace = "com.example.espresso"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/espresso/example/android/app/build.gradle
+++ b/packages/espresso/example/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 android {
     compileSdk = flutter.compileSdkVersion
     // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-    namespace "com.example.espresso_example"
+    namespace = "com.example.espresso_example"
 
 
     defaultConfig {

--- a/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/build.gradle
+++ b/packages/extension_google_sign_in_as_googleapis_auth/example/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
             signingConfig signingConfigs.debug
         }
     }
-    namespace 'io.flutter.plugins.googlesigninexample'
+    namespace = "io.flutter.plugins.googlesigninexample"
 }
 
 flutter {

--- a/packages/file_selector/file_selector/example/android/app/build.gradle
+++ b/packages/file_selector/file_selector/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "dev.flutter.plugins.file_selector_example"
+    namespace = "dev.flutter.plugins.file_selector_example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/file_selector/file_selector_android/android/build.gradle
+++ b/packages/file_selector/file_selector_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'dev.flutter.packages.file_selector_android'
+    namespace = "dev.flutter.packages.file_selector_android"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/file_selector/file_selector_android/example/android/app/build.gradle
+++ b/packages/file_selector/file_selector_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "dev.flutter.packages.file_selector_android_example"
+    namespace = "dev.flutter.packages.file_selector_android_example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/flutter_plugin_android_lifecycle/android/build.gradle
+++ b/packages/flutter_plugin_android_lifecycle/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.flutter_plugin_android_lifecycle'
+    namespace = "io.flutter.plugins.flutter_plugin_android_lifecycle"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/flutter_plugin_android_lifecycle/example/android/app/build.gradle
+++ b/packages/flutter_plugin_android_lifecycle/example/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
             signingConfig signingConfigs.debug
         }
     }
-    namespace 'io.flutter.plugins.flutter_plugin_android_lifecycle_example'
+    namespace = "io.flutter.plugins.flutter_plugin_android_lifecycle_example"
     lint {
         disable 'InvalidPackage'
     }

--- a/packages/go_router/example/android/app/build.gradle
+++ b/packages/go_router/example/android/app/build.gradle
@@ -54,7 +54,7 @@ android {
             signingConfig signingConfigs.debug
         }
     }
-    namespace 'com.example.example'
+    namespace = "com.example.example"
 }
 
 flutter {

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/build.gradle
@@ -60,7 +60,7 @@ android {
         api 'androidx.test:core:1.4.0'
         testImplementation 'com.google.android.gms:play-services-maps:17.0.0'
     }
-    namespace 'io.flutter.plugins.googlemapsexample'
+    namespace = "io.flutter.plugins.googlemapsexample"
     lint {
         disable 'InvalidPackage'
     }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.googlemaps'
+    namespace = "io.flutter.plugins.googlemaps"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.googlemapsexample'
+    namespace = "io.flutter.plugins.googlemapsexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/google_sign_in/google_sign_in/example/android/app/build.gradle
+++ b/packages/google_sign_in/google_sign_in/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.googlesigninexample'
+    namespace = "io.flutter.plugins.googlesigninexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/google_sign_in/google_sign_in_android/android/build.gradle
+++ b/packages/google_sign_in/google_sign_in_android/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'io.flutter.plugins.googlesignin'
+    namespace = "io.flutter.plugins.googlesignin"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/google_sign_in/google_sign_in_android/example/android/app/build.gradle
+++ b/packages/google_sign_in/google_sign_in_android/example/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.googlesigninexample'
+    namespace = "io.flutter.plugins.googlesigninexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/image_picker/image_picker/example/android/app/build.gradle
+++ b/packages/image_picker/image_picker/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.imagepickerexample'
+    namespace = "io.flutter.plugins.imagepickerexample"
     compileSdk = flutter.compileSdkVersion
     testOptions.unitTests.includeAndroidResources = true
 

--- a/packages/image_picker/image_picker_android/android/build.gradle
+++ b/packages/image_picker/image_picker_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.imagepicker'
+    namespace = "io.flutter.plugins.imagepicker"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/image_picker/image_picker_android/example/android/app/build.gradle
+++ b/packages/image_picker/image_picker_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.imagepickerexample'
+    namespace = "io.flutter.plugins.imagepickerexample"
     compileSdk = flutter.compileSdkVersion
     testOptions.unitTests.includeAndroidResources = true
 

--- a/packages/in_app_purchase/in_app_purchase/example/android/app/build.gradle
+++ b/packages/in_app_purchase/in_app_purchase/example/android/app/build.gradle
@@ -52,7 +52,7 @@ if (!configured) {
 }
 
 android {
-    namespace 'io.flutter.plugins.inapppurchaseexample'
+    namespace = "io.flutter.plugins.inapppurchaseexample"
     signingConfigs {
         release {
             storeFile project.KEYSTORE_STORE_FILE

--- a/packages/in_app_purchase/in_app_purchase_android/android/build.gradle
+++ b/packages/in_app_purchase/in_app_purchase_android/android/build.gradle
@@ -26,7 +26,7 @@ android {
         buildConfig true
     }
 
-    namespace 'io.flutter.plugins.inapppurchase'
+    namespace = "io.flutter.plugins.inapppurchase"
 
     compileSdk = flutter.compileSdkVersion
 

--- a/packages/in_app_purchase/in_app_purchase_android/example/android/app/build.gradle
+++ b/packages/in_app_purchase/in_app_purchase_android/example/android/app/build.gradle
@@ -52,7 +52,7 @@ if (!configured) {
 }
 
 android {
-    namespace 'io.flutter.plugins.inapppurchaseexample'
+    namespace = "io.flutter.plugins.inapppurchaseexample"
     compileSdk = flutter.compileSdkVersion
 
     signingConfigs {

--- a/packages/interactive_media_ads/android/build.gradle
+++ b/packages/interactive_media_ads/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'dev.flutter.packages.interactive_media_ads'
+    namespace = "dev.flutter.packages.interactive_media_ads"
 
     compileSdk = flutter.compileSdkVersion
 

--- a/packages/interactive_media_ads/example/android/app/build.gradle
+++ b/packages/interactive_media_ads/example/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 // #docregion android_desugaring
 android {
 // #enddocregion android_desugaring
-    namespace "dev.flutter.packages.interactive_media_ads_example"
+    namespace = "dev.flutter.packages.interactive_media_ads_example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/local_auth/local_auth/example/android/app/build.gradle
+++ b/packages/local_auth/local_auth/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.localauthexample'
+    namespace = "io.flutter.plugins.localauthexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/local_auth/local_auth_android/android/build.gradle
+++ b/packages/local_auth/local_auth_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.localauth'
+    namespace = "io.flutter.plugins.localauth"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/local_auth/local_auth_android/example/android/app/build.gradle
+++ b/packages/local_auth/local_auth_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.localauthexample'
+    namespace = "io.flutter.plugins.localauthexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/path_provider/path_provider/example/android/app/build.gradle
+++ b/packages/path_provider/path_provider/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.pathproviderexample'
+    namespace = "io.flutter.plugins.pathproviderexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/path_provider/path_provider_android/android/build.gradle
+++ b/packages/path_provider/path_provider_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.pathprovider'
+    namespace = "io.flutter.plugins.pathprovider"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/path_provider/path_provider_android/example/android/app/build.gradle
+++ b/packages/path_provider/path_provider_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.pathproviderexample'
+    namespace = "io.flutter.plugins.pathproviderexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/pigeon/example/app/android/app/build.gradle
+++ b/packages/pigeon/example/app/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "dev.flutter.pigeon_example_app"
+    namespace = "dev.flutter.pigeon_example_app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'com.example.alternate_language_test_plugin'
+    namespace = "com.example.alternate_language_test_plugin"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/app/build.gradle
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'com.example.alternate_language_test_plugin_example'
+    namespace = "com.example.alternate_language_test_plugin_example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/pigeon/platform_tests/test_plugin/android/build.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'com.example.test_plugin'
+    namespace = "com.example.test_plugin"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/pigeon/platform_tests/test_plugin/example/android/app/build.gradle
+++ b/packages/pigeon/platform_tests/test_plugin/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'com.example.test_plugin_example'
+    namespace = "com.example.test_plugin_example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/quick_actions/quick_actions/example/android/app/build.gradle
+++ b/packages/quick_actions/quick_actions/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.quickactionsexample'
+    namespace = "io.flutter.plugins.quickactionsexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/quick_actions/quick_actions_android/android/build.gradle
+++ b/packages/quick_actions/quick_actions_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.quickactions'
+    namespace = "io.flutter.plugins.quickactions"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/quick_actions/quick_actions_android/example/android/app/build.gradle
+++ b/packages/quick_actions/quick_actions_android/example/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 def androidXTestVersion = '1.4.0'
 
 android {
-    namespace 'io.flutter.plugins.quickactionsexample'
+    namespace = "io.flutter.plugins.quickactionsexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/rfw/example/hello/android/app/build.gradle
+++ b/packages/rfw/example/hello/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'dev.flutter.rfw.examples.hello'
+    namespace = "dev.flutter.rfw.examples.hello"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/rfw/example/local/android/app/build.gradle
+++ b/packages/rfw/example/local/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'dev.flutter.rfw.examples.local'
+    namespace = "dev.flutter.rfw.examples.local"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/rfw/example/remote/android/app/build.gradle
+++ b/packages/rfw/example/remote/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'dev.flutter.rfw.examples.remote'
+    namespace = "dev.flutter.rfw.examples.remote"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/shared_preferences/shared_preferences/example/android/app/build.gradle
+++ b/packages/shared_preferences/shared_preferences/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.sharedpreferencesexample'
+    namespace = "io.flutter.plugins.sharedpreferencesexample"
     compileSdk = flutter.compileSdkVersion
 
     sourceSets {

--- a/packages/shared_preferences/shared_preferences_android/android/build.gradle
+++ b/packages/shared_preferences/shared_preferences_android/android/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'io.flutter.plugins.sharedpreferences'
+    namespace = "io.flutter.plugins.sharedpreferences"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/shared_preferences/shared_preferences_android/example/android/app/build.gradle
+++ b/packages/shared_preferences/shared_preferences_android/example/android/app/build.gradle
@@ -36,7 +36,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "dev.flutter.plugins.shared_preferences_example"
+    namespace = "dev.flutter.plugins.shared_preferences_example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/two_dimensional_scrollables/example/android/app/build.gradle
+++ b/packages/two_dimensional_scrollables/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'dev.flutter.packages.two_dimensional_scrollables.example'
+    namespace = "dev.flutter.packages.two_dimensional_scrollables.example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -58,7 +58,6 @@ android {
             signingConfig signingConfigs.debug
         }
     }
-    namespace 'com.example.example'
 }
 
 flutter {

--- a/packages/url_launcher/url_launcher/example/android/app/build.gradle
+++ b/packages/url_launcher/url_launcher/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.urllauncherexample'
+    namespace = "io.flutter.plugins.urllauncherexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -25,7 +25,7 @@ android {
     buildFeatures {
         buildConfig true
     }
-    namespace 'io.flutter.plugins.urllauncher'
+    namespace = "io.flutter.plugins.urllauncher"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/url_launcher/url_launcher_android/example/android/app/build.gradle
+++ b/packages/url_launcher/url_launcher_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.urllauncherexample'
+    namespace = "io.flutter.plugins.urllauncherexample"
     compileSdk = flutter.compileSdkVersion
 
 

--- a/packages/video_player/video_player/example/android/app/build.gradle
+++ b/packages/video_player/video_player/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.videoplayerexample'
+    namespace = "io.flutter.plugins.videoplayerexample"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'io.flutter.plugins.videoplayer'
+    namespace = "io.flutter.plugins.videoplayer"
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {

--- a/packages/video_player/video_player_android/example/android/app/build.gradle
+++ b/packages/video_player/video_player_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.videoplayerexample'
+    namespace = "io.flutter.plugins.videoplayerexample"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/webview_flutter/webview_flutter/example/android/app/build.gradle
+++ b/packages/webview_flutter/webview_flutter/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.webviewflutterexample'
+    namespace = "io.flutter.plugins.webviewflutterexample"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/packages/webview_flutter/webview_flutter_android/android/build.gradle
+++ b/packages/webview_flutter/webview_flutter_android/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'io.flutter.plugins.webviewflutter'
+    namespace = "io.flutter.plugins.webviewflutter"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/webview_flutter/webview_flutter_android/example/android/app/build.gradle
+++ b/packages/webview_flutter/webview_flutter_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.webviewflutterexample'
+    namespace = "io.flutter.plugins.webviewflutterexample"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 

--- a/script/tool/lib/src/gradle_check_command.dart
+++ b/script/tool/lib/src/gradle_check_command.dart
@@ -294,12 +294,11 @@ plugins {
   /// compatibility with apps that use AGP 8+.
   bool _validateNamespace(RepositoryPackage package, String gradleContents,
       {required bool isExample}) {
-    // Regex to validate that either of the following namespace definitions
+    // Regex to validate that either the following namespace definition
     // are found (where the single quotes can be single or double):
-    //  - namespace 'dev.flutter.foo'
     //  - namespace = 'dev.flutter.foo'
     final RegExp nameSpaceRegex =
-        RegExp('^\\s*namespace\\s+=?\\s*[\'"](.*?)[\'"]', multiLine: true);
+        RegExp('^\\s*namespace\\s+=\\s*[\'"](.*?)[\'"]', multiLine: true);
     final RegExpMatch? nameSpaceRegexMatch =
         nameSpaceRegex.firstMatch(gradleContents);
 
@@ -308,7 +307,7 @@ plugins {
 build.gradle must set a "namespace":
 
     android {
-        namespace 'dev.flutter.foo'
+        namespace = "dev.flutter.foo"
     }
 
 The value must match the "package" attribute in AndroidManifest.xml, if one is

--- a/script/tool/test/gradle_check_command_test.dart
+++ b/script/tool/test/gradle_check_command_test.dart
@@ -73,7 +73,7 @@ java {
     final String targetCompat =
         '${commentSourceLanguage ? '// ' : ''}targetCompatibility JavaVersion.VERSION_11';
     final String namespace =
-        "    ${commentNamespace ? '// ' : ''}namespace '$_defaultFakeNamespace'";
+        "    ${commentNamespace ? '// ' : ''}namespace = '$_defaultFakeNamespace'";
 
     buildGradle.writeAsStringSync('''
 group 'dev.flutter.plugins.fake'
@@ -274,7 +274,7 @@ dependencies {
     required String pluginName,
     bool includeNamespace = true,
     bool commentNamespace = false,
-    bool includeNameSpaceAsDeclaration = false,
+    bool includeNameSpaceAsDeclaration = true,
     bool warningsConfigured = true,
     String? kotlinVersion,
     bool includeBuildArtifactHub = true,
@@ -608,14 +608,14 @@ dependencies {
     );
   });
 
-  test('passes when namespace is declared with "=" declaration', () async {
+  test('fails when namespace is declared without "=" declaration', () async {
     const String pluginName = 'a_plugin';
     final RepositoryPackage package = createFakePlugin(pluginName, packagesDir);
     writeFakePluginBuildGradle(package, includeLanguageVersion: true);
     writeFakeManifest(package);
     final RepositoryPackage example = package.getExamples().first;
     writeFakeExampleBuildGradles(example,
-        pluginName: pluginName, includeNameSpaceAsDeclaration: true);
+        pluginName: pluginName, includeNameSpaceAsDeclaration: false);
     writeFakeManifest(example, isApp: true);
 
     final List<String> output = await runCapturingPrint(

--- a/third_party/packages/flutter_svg/example/android/app/build.gradle
+++ b/third_party/packages/flutter_svg/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.fluttersvgexample'
+    namespace = "io.flutter.plugins.fluttersvgexample"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {


### PR DESCRIPTION
Standardizes namespace on the `=` form of property assignment, and updates the existing namespace check to require that version.

Also standardizes these lines on `"` rather than `'` while touching them.

Part of https://github.com/flutter/flutter/issues/176065

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
