### PR TITLE
[ci] Re-enable all Android legacy emulator tests

### DIFF
--- a/script/configs/exclude_integration_android_legacy_emulator.yaml
+++ b/script/configs/exclude_integration_android_legacy_emulator.yaml
@@ -1,13 +1,3 @@
-# This plugin no-ops below API 25, which is newer than the legacy emulator.
-# This can be removed once the legacy emulator test is using at least
-# API level 25.
-- quick_actions
-- quick_actions_android
-# Fails on the legacy emulator. See https://github.com/flutter/flutter/issues/136823
-# TODO(stuartmorgan): Remove this if the limitation can be worked around.
-- video_player
-- video_player_android
-# Hangs on the legacy emulator. See https://github.com/flutter/flutter/issues/136824
-# TODO(stuartmorgan): Remove this if the hang can be fixed.
-- webview_flutter
-- webview_flutter_android
+# Currently no plugins need to be excluded, but this file is left
+# since it is likely that we will need this functionality in the future.
+[]


### PR DESCRIPTION
Now that the legacy emulators are API 31, not 22, these exclusions are stale.

Fixes https://github.com/flutter/flutter/issues/136824
Fixes https://github.com/flutter/flutter/issues/136823