### PR TITLE
[google_sign_in] Remove references to dart:js_util

### DIFF
--- a/packages/google_sign_in/google_sign_in/example/lib/src/web_wrapper.dart
+++ b/packages/google_sign_in/google_sign_in/example/lib/src/web_wrapper.dart
@@ -2,4 +2,5 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'web_wrapper_stub.dart' if (dart.library.js_util) 'web_wrapper_web.dart';
+export 'web_wrapper_stub.dart'
+    if (dart.library.js_interop) 'web_wrapper_web.dart';


### PR DESCRIPTION
Flutter has already migrated from dart:js_util to dart:js_interop (which is unsupported by dart2wasm). This migrates a remaining reference to js_util which will be broken when dart2wasm drops the library entirely.