### PR TITLE
[google_font] Move the httpClient from a package level variable to the Config object

### DIFF
--- a/packages/google_fonts/CHANGELOG.md
+++ b/packages/google_fonts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.0
+
+- Adds the ability to supply a custom HTTP client to `GoogleFonts.config`.
+
 ## 8.0.2
 
 - Fixes a bug where exceptions thrown during return within try blocks in an async function were not correctly caught, aligning behavior with expected Dart semantics (see [dart-lang/sdk#44395](https://github.com/dart-lang/sdk/issues/44395)).

--- a/packages/google_fonts/generator/google_fonts.tmpl
+++ b/packages/google_fonts/generator/google_fonts.tmpl
@@ -9,6 +9,7 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 
 import 'google_fonts_base.dart';
 {{#allParts}}
@@ -21,6 +22,13 @@ class Config {
   /// Whether or not the GoogleFonts library can make requests to
   /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
   bool allowRuntimeFetching = true;
+
+  /// The HTTP client used to fetch fonts.
+  ///
+  /// If this is null, a shared default [http.Client] will be used.
+  ///
+  /// If you supply a client, you are responsible for closing it.
+  http.Client? httpClient;
 }
 
 /// Provides configuration, and static methods to obtain [TextStyle]s and [TextTheme]s.

--- a/packages/google_fonts/lib/src/google_fonts_all_parts.dart
+++ b/packages/google_fonts/lib/src/google_fonts_all_parts.dart
@@ -47,7 +47,11 @@ class Config {
   bool allowRuntimeFetching = true;
 
   /// The HTTP client used to fetch fonts.
-  http.Client httpClient = http.Client();
+  ///
+  /// If this is null, a shared default [http.Client] will be used.
+  ///
+  /// If you supply a client, you are responsible for closing it.
+  http.Client? httpClient;
 }
 
 /// Provides configuration, and static methods to obtain [TextStyle]s and [TextTheme]s.

--- a/packages/google_fonts/lib/src/google_fonts_all_parts.dart
+++ b/packages/google_fonts/lib/src/google_fonts_all_parts.dart
@@ -9,6 +9,7 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 
 import 'google_fonts_base.dart';
 import 'google_fonts_parts/part_a.dart';
@@ -44,6 +45,9 @@ class Config {
   /// Whether or not the GoogleFonts library can make requests to
   /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
   bool allowRuntimeFetching = true;
+
+  /// The HTTP client used to fetch fonts.
+  http.Client httpClient = http.Client();
 }
 
 /// Provides configuration, and static methods to obtain [TextStyle]s and [TextTheme]s.

--- a/packages/google_fonts/lib/src/google_fonts_base.dart
+++ b/packages/google_fonts/lib/src/google_fonts_base.dart
@@ -32,6 +32,9 @@ void clearCache() => _loadedFonts.clear();
 /// the [FontLoader], that future is removed from this set.
 final Set<Future<void>> pendingFontFutures = <Future<void>>{};
 
+/// Default client used to fetch fonts when one is not supplied.
+final http.Client _httpClient = http.Client();
+
 /// The asset manifest to use for loading pre-bundled fonts.
 @visibleForTesting
 AssetManifest? assetManifest;
@@ -256,8 +259,9 @@ Future<ByteData> _httpFetchFontAndSaveToDevice(
   }
 
   http.Response response;
+  final http.Client client = GoogleFonts.config.httpClient ?? _httpClient;
   try {
-    response = await GoogleFonts.config.httpClient.get(uri);
+    response = await client.get(uri);
   } catch (e) {
     throw Exception('Failed to load font with url ${file.url}: $e');
   }

--- a/packages/google_fonts/lib/src/google_fonts_base.dart
+++ b/packages/google_fonts/lib/src/google_fonts_base.dart
@@ -32,10 +32,6 @@ void clearCache() => _loadedFonts.clear();
 /// the [FontLoader], that future is removed from this set.
 final Set<Future<void>> pendingFontFutures = <Future<void>>{};
 
-/// The client used to fetch fonts.
-@visibleForTesting
-http.Client httpClient = http.Client();
-
 /// The asset manifest to use for loading pre-bundled fonts.
 @visibleForTesting
 AssetManifest? assetManifest;
@@ -261,7 +257,7 @@ Future<ByteData> _httpFetchFontAndSaveToDevice(
 
   http.Response response;
   try {
-    response = await httpClient.get(uri);
+    response = await GoogleFonts.config.httpClient.get(uri);
   } catch (e) {
     throw Exception('Failed to load font with url ${file.url}: $e');
   }

--- a/packages/google_fonts/pubspec.yaml
+++ b/packages/google_fonts/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_fonts
 description: A Flutter package to use fonts from fonts.google.com. Supports HTTP fetching, caching, and asset bundling.
 repository: https://github.com/flutter/packages/tree/main/packages/google_fonts
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_fonts%22
-version: 8.0.2
+version: 8.1.0
 
 environment:
   sdk: ^3.9.0

--- a/packages/google_fonts/test/google_fonts_text_style_test.dart
+++ b/packages/google_fonts/test/google_fonts_text_style_test.dart
@@ -57,9 +57,9 @@ void main() {
   late MockHttpClient mockHttpClient;
 
   setUp(() async {
-    mockHttpClient = MockHttpClient();
-    httpClient = mockHttpClient;
     assetManifest = MockAssetManifest();
+    mockHttpClient = MockHttpClient();
+    GoogleFonts.config.httpClient = mockHttpClient;
     GoogleFonts.config.allowRuntimeFetching = true;
     when(mockHttpClient.gets(any)).thenAnswer((_) async {
       return http.Response(_fakeResponse, 200);

--- a/packages/google_fonts/test/load_font_if_necessary_test.dart
+++ b/packages/google_fonts/test/load_font_if_necessary_test.dart
@@ -116,9 +116,9 @@ void main() {
   late MockHttpClient mockHttpClient;
 
   setUp(() async {
-    mockHttpClient = MockHttpClient();
-    httpClient = mockHttpClient;
     assetManifest = MockAssetManifest();
+    mockHttpClient = MockHttpClient();
+    GoogleFonts.config.httpClient = mockHttpClient;
     GoogleFonts.config.allowRuntimeFetching = true;
     when(mockHttpClient.gets(any)).thenAnswer((_) async {
       return http.Response(_fakeResponse, 200);

--- a/packages/google_fonts/test/load_font_if_necessary_with_local_fonts_test.dart
+++ b/packages/google_fonts/test/load_font_if_necessary_with_local_fonts_test.dart
@@ -76,9 +76,9 @@ void main() {
   late MockHttpClient mockHttpClient;
 
   setUp(() async {
-    mockHttpClient = MockHttpClient();
-    httpClient = mockHttpClient;
     assetManifest = MockAssetManifest();
+    mockHttpClient = MockHttpClient();
+    GoogleFonts.config.httpClient = mockHttpClient;
     GoogleFonts.config.allowRuntimeFetching = true;
     when(mockHttpClient.gets(any)).thenAnswer((_) async {
       return http.Response(_fakeResponse, 200);


### PR DESCRIPTION
Move the httpClient from a package level variable, to be on the Config object

This allows the user to customise the httpClient as well as mock it out in tests.

Fixes [#182429](https://github.com/flutter/flutter/issues/182429)


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
