### PR TITLE
[in_app_purchase] Clarify billing dependency handling for Android in example README

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -5,7 +5,7 @@
   versions of the endorsed platform implementations.
   * Applications built with older versions of Flutter will continue to
     use compatible versions of the platform implementations.
-* Updates README to clarifiy Android billing dependency setup documentation for the integration in `example/README.md` to prevent users from manually adding conflicting dependencies.
+* Clarifies in the example's `README.md` that the Android billing dependency should not be added manually.
 
 ## 3.2.3
 * Updates minimum `in_app_purchase_storekit` version to 0.4.0.

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -5,6 +5,7 @@
   versions of the endorsed platform implementations.
   * Applications built with older versions of Flutter will continue to
     use compatible versions of the platform implementations.
+* Updates README to clarifiy Android billing dependency setup documentation for the integration in `example/README.md` to prevent users from manually adding conflicting dependencies.
 
 ## 3.2.3
 * Updates minimum `in_app_purchase_storekit` version to 0.4.0.

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,11 +1,12 @@
-## NEXT
+## 3.2.4
 
 * Updates minimum supported SDK version to Flutter 3.35/Dart 3.9.
 * Updates README to reflect currently supported OS versions for the latest
   versions of the endorsed platform implementations.
   * Applications built with older versions of Flutter will continue to
     use compatible versions of the platform implementations.
-* Clarifies in the example's `README.md` that the Android billing dependency should not be added manually.
+* Clarifies in the example's `README.md` that the Android billing dependency should not be added
+  manually.
 
 ## 3.2.3
 * Updates minimum `in_app_purchase_storekit` version to 0.4.0.

--- a/packages/in_app_purchase/in_app_purchase/example/README.md
+++ b/packages/in_app_purchase/in_app_purchase/example/README.md
@@ -58,6 +58,14 @@ below.
 8. Sign in to the test device with the test account from step #7. Then use
    `flutter run` to install the app to the device and test like normal.
 
+**Important:** The dependency snippet shown in the Google Play Billing Overview setup guide:
+```
+implementation "com.android.billingclient:billing:$billing_version"
+```
+should not be manually added when using this plugin.
+
+The plugin already manages the billing client dependency internally, and adding it manually may cause build conflicts or prevent the app from connecting to the Play Store billing service.
+
 ### iOS
 
 When using Xcode 12 and iOS 14 or higher you can run the example in the simulator or on a device without 

--- a/packages/in_app_purchase/in_app_purchase/example/README.md
+++ b/packages/in_app_purchase/in_app_purchase/example/README.md
@@ -19,6 +19,14 @@ below.
 
 ### Android
 
+> **NOTE:** The dependency snippet shown in the Google Play Billing Overview setup guide:
+> ```
+> implementation "com.android.billingclient:billing:$billing_version"
+> ```
+> should not be manually added when using this plugin. The plugin already manages the billing client
+> dependency internally, and adding it manually may cause build conflicts or prevent the app from
+> connecting to the Play Store billing service.
+
 1. Create a new app in the [Play Developer
    Console](https://play.google.com/apps/publish/) (PDC).
 
@@ -57,14 +65,6 @@ below.
 
 8. Sign in to the test device with the test account from step #7. Then use
    `flutter run` to install the app to the device and test like normal.
-
-**Important:** The dependency snippet shown in the Google Play Billing Overview setup guide:
-```
-implementation "com.android.billingclient:billing:$billing_version"
-```
-should not be manually added when using this plugin.
-
-The plugin already manages the billing client dependency internally, and adding it manually may cause build conflicts or prevent the app from connecting to the Play Store billing service.
 
 ### iOS
 

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.2.3
+version: 3.2.4
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Clarify misleading billing setup instructions in the Android example for in_app_purchase's README.md (or rather lack of clarification).

Following the instructions of Google Play Billing documentation setup and adding the dependency in `build.gradle` causes Play Store connectivity issues, and must _not_ be added.

## Pre-Review Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ x ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ x ] I signed the [CLA].
- [ x ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ x ] I [linked to at least one issue that this PR fixes] in the description above.
- [ x ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [ x ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [ x ] I updated/added any relevant documentation (doc comments with `///`).
- [ x ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ x ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[version change exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
