### PR TITLE
[video_player] Add Picture-in-Picture support for iOS

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Adds Picture-in-Picture (PiP) support for iOS.
 * Adds `isPictureInPictureActive` field to `VideoPlayerValue`.
-* Adds `enablePictureInPicture()`, `disablePictureInPicture()`, `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods to `VideoPlayerController`.
+* Adds `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods to `VideoPlayerController`.
 
 ## 2.11.0
 

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.12.0
+
+* Adds Picture-in-Picture (PiP) support for iOS.
+* Adds `isPictureInPictureActive` field to `VideoPlayerValue`.
+* Adds `enablePictureInPicture()`, `disablePictureInPicture()`, `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods to `VideoPlayerController`.
+
 ## 2.11.0
 
 * Adds `getAudioTracks()` and `selectAudioTrack()` methods to retrieve and select available audio tracks.

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -172,6 +172,7 @@ class VideoPlayerValue {
     this.rotationCorrection = 0,
     this.errorDescription,
     this.isCompleted = false,
+    this.isPictureInPictureActive = false,
   });
 
   /// Returns an instance for a video that hasn't been loaded.
@@ -238,6 +239,9 @@ class VideoPlayerValue {
   /// Does not update if video is looping.
   final bool isCompleted;
 
+  /// Whether Picture-in-Picture is currently active.
+  final bool isPictureInPictureActive;
+
   /// The [size] of the currently loaded video.
   final Size size;
 
@@ -286,6 +290,7 @@ class VideoPlayerValue {
     int? rotationCorrection,
     String? errorDescription = _defaultErrorDescription,
     bool? isCompleted,
+    bool? isPictureInPictureActive,
   }) {
     return VideoPlayerValue(
       duration: duration ?? this.duration,
@@ -305,6 +310,8 @@ class VideoPlayerValue {
           ? errorDescription
           : this.errorDescription,
       isCompleted: isCompleted ?? this.isCompleted,
+      isPictureInPictureActive:
+          isPictureInPictureActive ?? this.isPictureInPictureActive,
     );
   }
 
@@ -324,7 +331,8 @@ class VideoPlayerValue {
         'volume: $volume, '
         'playbackSpeed: $playbackSpeed, '
         'errorDescription: $errorDescription, '
-        'isCompleted: $isCompleted),';
+        'isCompleted: $isCompleted, '
+        'isPictureInPictureActive: $isPictureInPictureActive),';
   }
 
   @override
@@ -346,7 +354,8 @@ class VideoPlayerValue {
           size == other.size &&
           rotationCorrection == other.rotationCorrection &&
           isInitialized == other.isInitialized &&
-          isCompleted == other.isCompleted;
+          isCompleted == other.isCompleted &&
+          isPictureInPictureActive == other.isPictureInPictureActive;
 
   @override
   int get hashCode => Object.hash(
@@ -365,6 +374,7 @@ class VideoPlayerValue {
     rotationCorrection,
     isInitialized,
     isCompleted,
+    isPictureInPictureActive,
   );
 }
 
@@ -646,6 +656,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           } else {
             value = value.copyWith(isPlaying: event.isPlaying);
           }
+        case platform_interface.VideoEventType.pipStarted:
+          value = value.copyWith(isPictureInPictureActive: true);
+        case platform_interface.VideoEventType.pipStopped:
+          value = value.copyWith(isPictureInPictureActive: false);
+        case platform_interface.VideoEventType.pipRestoreUserInterface:
+          break;
         case platform_interface.VideoEventType.unknown:
           break;
       }
@@ -986,6 +1002,71 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// ```
   bool isAudioTrackSupportAvailable() {
     return _videoPlayerPlatform.isAudioTrackSupportAvailable();
+  }
+
+  /// Enables Picture-in-Picture for this player.
+  ///
+  /// This must be called before [startPictureInPicture] to prepare the player
+  /// for PiP mode. On platforms that don't support PiP, this may be a no-op.
+  ///
+  /// Throws a [StateError] if the controller is disposed or not initialized.
+  Future<void> enablePictureInPicture() async {
+    if (_isDisposedOrNotInitialized) {
+      throw StateError('VideoPlayerController is disposed or not initialized');
+    }
+    await _videoPlayerPlatform.enablePictureInPicture(_playerId);
+  }
+
+  /// Disables Picture-in-Picture for this player.
+  ///
+  /// Throws a [StateError] if the controller is disposed or not initialized.
+  Future<void> disablePictureInPicture() async {
+    if (_isDisposedOrNotInitialized) {
+      throw StateError('VideoPlayerController is disposed or not initialized');
+    }
+    await _videoPlayerPlatform.disablePictureInPicture(_playerId);
+  }
+
+  /// Starts Picture-in-Picture mode for this player.
+  ///
+  /// [enablePictureInPicture] must be called before this method.
+  ///
+  /// Throws a [StateError] if the controller is disposed or not initialized.
+  Future<void> startPictureInPicture() async {
+    if (_isDisposedOrNotInitialized) {
+      throw StateError('VideoPlayerController is disposed or not initialized');
+    }
+    await _videoPlayerPlatform.startPictureInPicture(_playerId);
+  }
+
+  /// Stops Picture-in-Picture mode for this player.
+  ///
+  /// Throws a [StateError] if the controller is disposed or not initialized.
+  Future<void> stopPictureInPicture() async {
+    if (_isDisposedOrNotInitialized) {
+      throw StateError('VideoPlayerController is disposed or not initialized');
+    }
+    await _videoPlayerPlatform.stopPictureInPicture(_playerId);
+  }
+
+  /// Returns whether Picture-in-Picture is supported on this device.
+  ///
+  /// Throws a [StateError] if the controller is disposed or not initialized.
+  Future<bool> isPictureInPictureSupported() async {
+    if (_isDisposedOrNotInitialized) {
+      throw StateError('VideoPlayerController is disposed or not initialized');
+    }
+    return _videoPlayerPlatform.isPictureInPictureSupported(_playerId);
+  }
+
+  /// Returns whether Picture-in-Picture is currently active for this player.
+  ///
+  /// Throws a [StateError] if the controller is disposed or not initialized.
+  Future<bool> isPictureInPictureActive() async {
+    if (_isDisposedOrNotInitialized) {
+      throw StateError('VideoPlayerController is disposed or not initialized');
+    }
+    return _videoPlayerPlatform.isPictureInPictureActive(_playerId);
   }
 
   bool get _isDisposedOrNotInitialized => _isDisposed || !value.isInitialized;

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -661,7 +661,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case platform_interface.VideoEventType.pipStopped:
           value = value.copyWith(isPictureInPictureActive: false);
         case platform_interface.VideoEventType.pipRestoreUserInterface:
-          break;
         case platform_interface.VideoEventType.unknown:
           break;
       }
@@ -1004,32 +1003,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     return _videoPlayerPlatform.isAudioTrackSupportAvailable();
   }
 
-  /// Enables Picture-in-Picture for this player.
-  ///
-  /// This must be called before [startPictureInPicture] to prepare the player
-  /// for PiP mode. On platforms that don't support PiP, this may be a no-op.
-  ///
-  /// Throws a [StateError] if the controller is disposed or not initialized.
-  Future<void> enablePictureInPicture() async {
-    if (_isDisposedOrNotInitialized) {
-      throw StateError('VideoPlayerController is disposed or not initialized');
-    }
-    await _videoPlayerPlatform.enablePictureInPicture(_playerId);
-  }
-
-  /// Disables Picture-in-Picture for this player.
-  ///
-  /// Throws a [StateError] if the controller is disposed or not initialized.
-  Future<void> disablePictureInPicture() async {
-    if (_isDisposedOrNotInitialized) {
-      throw StateError('VideoPlayerController is disposed or not initialized');
-    }
-    await _videoPlayerPlatform.disablePictureInPicture(_playerId);
-  }
-
   /// Starts Picture-in-Picture mode for this player.
-  ///
-  /// [enablePictureInPicture] must be called before this method.
   ///
   /// Throws a [StateError] if the controller is disposed or not initialized.
   Future<void> startPictureInPicture() async {

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, macOS and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.11.0
+version: 2.12.0
 
 environment:
   sdk: ^3.10.0
@@ -26,8 +26,8 @@ dependencies:
     sdk: flutter
   html: ^0.15.0
   video_player_android: ^2.9.1
-  video_player_avfoundation: ^2.9.0
-  video_player_platform_interface: ^6.6.0
+  video_player_avfoundation: ^2.10.0
+  video_player_platform_interface: ^6.7.0
   video_player_web: ^2.1.0
 
 dev_dependencies:

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -130,6 +130,24 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
     return true;
   }
 
+  @override
+  Future<void> enablePictureInPicture() async {}
+
+  @override
+  Future<void> disablePictureInPicture() async {}
+
+  @override
+  Future<void> startPictureInPicture() async {}
+
+  @override
+  Future<void> stopPictureInPicture() async {}
+
+  @override
+  Future<bool> isPictureInPictureSupported() async => true;
+
+  @override
+  Future<bool> isPictureInPictureActive() async => false;
+
   String? selectedAudioTrackId;
 }
 
@@ -1050,6 +1068,128 @@ void main() {
       });
     });
 
+    group('Picture-in-Picture', () {
+      test('enablePictureInPicture calls platform', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+        await controller.enablePictureInPicture();
+
+        expect(fakeVideoPlayerPlatform.calls.last, 'enablePictureInPicture');
+      });
+
+      test('disablePictureInPicture calls platform', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+        await controller.disablePictureInPicture();
+
+        expect(fakeVideoPlayerPlatform.calls.last, 'disablePictureInPicture');
+      });
+
+      test('startPictureInPicture calls platform', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+        await controller.startPictureInPicture();
+
+        expect(fakeVideoPlayerPlatform.calls.last, 'startPictureInPicture');
+      });
+
+      test('stopPictureInPicture calls platform', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+        await controller.stopPictureInPicture();
+
+        expect(fakeVideoPlayerPlatform.calls.last, 'stopPictureInPicture');
+      });
+
+      test('isPictureInPictureSupported returns result', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+        final bool result = await controller.isPictureInPictureSupported();
+
+        expect(result, true);
+        expect(
+          fakeVideoPlayerPlatform.calls.last,
+          'isPictureInPictureSupported',
+        );
+      });
+
+      test('isPictureInPictureActive returns result', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+        final bool result = await controller.isPictureInPictureActive();
+
+        expect(result, false);
+        expect(fakeVideoPlayerPlatform.calls.last, 'isPictureInPictureActive');
+      });
+
+      test('PiP methods before initialization throw', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        expect(
+          () => controller.enablePictureInPicture(),
+          throwsA(isA<StateError>()),
+        );
+        expect(
+          () => controller.startPictureInPicture(),
+          throwsA(isA<StateError>()),
+        );
+        expect(
+          () => controller.stopPictureInPicture(),
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      test('pipStarted event updates VideoPlayerValue', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+
+        expect(controller.value.isPictureInPictureActive, false);
+
+        fakeVideoPlayerPlatform.streams[controller.playerId]!.add(
+          VideoEvent(eventType: VideoEventType.pipStarted),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(controller.value.isPictureInPictureActive, true);
+      });
+
+      test('pipStopped event updates VideoPlayerValue', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+
+        // Simulate PiP started first.
+        fakeVideoPlayerPlatform.streams[controller.playerId]!.add(
+          VideoEvent(eventType: VideoEventType.pipStarted),
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(controller.value.isPictureInPictureActive, true);
+
+        // Now stop PiP.
+        fakeVideoPlayerPlatform.streams[controller.playerId]!.add(
+          VideoEvent(eventType: VideoEventType.pipStopped),
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(controller.value.isPictureInPictureActive, false);
+      });
+    });
+
     group('caption', () {
       test('works when position updates', () async {
         final controller = VideoPlayerController.networkUrl(
@@ -1476,7 +1616,8 @@ void main() {
         'volume: 0.5, '
         'playbackSpeed: 1.5, '
         'errorDescription: null, '
-        'isCompleted: false),',
+        'isCompleted: false, '
+        'isPictureInPictureActive: false),',
       );
     });
 
@@ -1904,4 +2045,36 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   }
 
   final Map<int, String> selectedAudioTrackIds = <int, String>{};
+
+  @override
+  Future<void> enablePictureInPicture(int playerId) async {
+    calls.add('enablePictureInPicture');
+  }
+
+  @override
+  Future<void> disablePictureInPicture(int playerId) async {
+    calls.add('disablePictureInPicture');
+  }
+
+  @override
+  Future<void> startPictureInPicture(int playerId) async {
+    calls.add('startPictureInPicture');
+  }
+
+  @override
+  Future<void> stopPictureInPicture(int playerId) async {
+    calls.add('stopPictureInPicture');
+  }
+
+  @override
+  Future<bool> isPictureInPictureSupported(int playerId) async {
+    calls.add('isPictureInPictureSupported');
+    return true;
+  }
+
+  @override
+  Future<bool> isPictureInPictureActive(int playerId) async {
+    calls.add('isPictureInPictureActive');
+    return false;
+  }
 }

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -131,12 +131,6 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
   }
 
   @override
-  Future<void> enablePictureInPicture() async {}
-
-  @override
-  Future<void> disablePictureInPicture() async {}
-
-  @override
   Future<void> startPictureInPicture() async {}
 
   @override
@@ -1069,26 +1063,6 @@ void main() {
     });
 
     group('Picture-in-Picture', () {
-      test('enablePictureInPicture calls platform', () async {
-        final controller = VideoPlayerController.networkUrl(_localhostUri);
-        addTearDown(controller.dispose);
-
-        await controller.initialize();
-        await controller.enablePictureInPicture();
-
-        expect(fakeVideoPlayerPlatform.calls.last, 'enablePictureInPicture');
-      });
-
-      test('disablePictureInPicture calls platform', () async {
-        final controller = VideoPlayerController.networkUrl(_localhostUri);
-        addTearDown(controller.dispose);
-
-        await controller.initialize();
-        await controller.disablePictureInPicture();
-
-        expect(fakeVideoPlayerPlatform.calls.last, 'disablePictureInPicture');
-      });
-
       test('startPictureInPicture calls platform', () async {
         final controller = VideoPlayerController.networkUrl(_localhostUri);
         addTearDown(controller.dispose);
@@ -1138,10 +1112,6 @@ void main() {
         final controller = VideoPlayerController.networkUrl(_localhostUri);
         addTearDown(controller.dispose);
 
-        expect(
-          () => controller.enablePictureInPicture(),
-          throwsA(isA<StateError>()),
-        );
         expect(
           () => controller.startPictureInPicture(),
           throwsA(isA<StateError>()),
@@ -2045,16 +2015,6 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   }
 
   final Map<int, String> selectedAudioTrackIds = <int, String>{};
-
-  @override
-  Future<void> enablePictureInPicture(int playerId) async {
-    calls.add('enablePictureInPicture');
-  }
-
-  @override
-  Future<void> disablePictureInPicture(int playerId) async {
-    calls.add('disablePictureInPicture');
-  }
 
   @override
   Future<void> startPictureInPicture(int playerId) async {

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.10.0
 
 * Adds Picture-in-Picture (PiP) support for iOS.
-* Implements `enablePictureInPicture()`, `disablePictureInPicture()`, `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods.
+* Implements `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods.
 
 ## 2.9.3
 

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.10.0
+
+* Adds Picture-in-Picture (PiP) support for iOS.
+* Implements `enablePictureInPicture()`, `disablePictureInPicture()`, `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods.
+
 ## 2.9.3
 
 * Fixes a regression where HTTP headers were ignored.

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPEventBridge.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPEventBridge.m
@@ -103,6 +103,18 @@
   [self sendOrQueue:@{@"event" : @"isPlayingStateUpdate", @"isPlaying" : @(playing)}];
 }
 
+- (void)videoPlayerDidStartPictureInPicture {
+  [self sendOrQueue:@{@"event" : @"pipStarted"}];
+}
+
+- (void)videoPlayerDidStopPictureInPicture {
+  [self sendOrQueue:@{@"event" : @"pipStopped"}];
+}
+
+- (void)videoPlayerShouldRestoreUserInterfaceForPictureInPicture {
+  [self sendOrQueue:@{@"event" : @"pipRestoreUserInterface"}];
+}
+
 - (void)videoPlayerWasDisposed {
   [self.eventChannel setStreamHandler:nil];
 }

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPNativeVideoViewFactory.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPNativeVideoViewFactory.m
@@ -6,6 +6,7 @@
 
 #import "../video_player_avfoundation/include/video_player_avfoundation/FVPNativeVideoView.h"
 #import "../video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer.h"
+#import "../video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer_Internal.h"
 #import "../video_player_avfoundation/include/video_player_avfoundation/messages.g.h"
 
 @interface FVPNativeVideoViewFactory ()
@@ -37,7 +38,16 @@
 #endif
   NSNumber *playerIdentifier = @(args.playerId);
   FVPVideoPlayer *player = self.playerByIdProvider(playerIdentifier);
-  return [[FVPNativeVideoView alloc] initWithPlayer:player.player];
+  FVPNativeVideoView *nativeView = [[FVPNativeVideoView alloc] initWithPlayer:player.player];
+
+#if TARGET_OS_IOS
+  // Set up PiP with the platform view's player layer.
+  if (@available(iOS 14.2, *)) {
+    [player setupPictureInPictureWithPlayerLayer:nativeView.playerLayer];
+  }
+#endif
+
+  return nativeView;
 }
 
 - (NSObject<FlutterMessageCodec> *)createArgsCodec {

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPTextureBasedVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPTextureBasedVideoPlayer.m
@@ -60,6 +60,13 @@
     CALayer *flutterLayer = viewProvider.view.layer;
 #endif
     [flutterLayer addSublayer:self.playerLayer];
+
+#if TARGET_OS_IOS
+    // Set up PiP using the existing invisible player layer.
+    if (@available(iOS 14.2, *)) {
+      [self setupPictureInPictureWithPlayerLayer:_playerLayer];
+    }
+#endif
   }
   return self;
 }

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayer.m
@@ -165,6 +165,12 @@ static NSDictionary<NSString *, NSValue *> *FVPGetPlayerItemObservations(void) {
   }
   _disposed = YES;
 
+#if TARGET_OS_IOS
+  if (@available(iOS 14.2, *)) {
+    [self tearDownPictureInPicture];
+  }
+#endif
+
   if (_listenersRegistered) {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     FVPRemoveKeyValueObservers(self, FVPGetPlayerItemObservations(), self.player.currentItem);
@@ -507,6 +513,178 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
     [currentItem selectMediaOption:option inMediaSelectionGroup:audioGroup];
   }
 }
+
+#pragma mark - Picture-in-Picture
+
+#if TARGET_OS_IOS
+
+- (void)setupPictureInPictureWithPlayerLayer:(AVPlayerLayer *)playerLayer {
+  if (@available(iOS 14.2, *)) {
+    if (![AVPictureInPictureController isPictureInPictureSupported]) {
+      return;
+    }
+    _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer:playerLayer];
+    _pipController.delegate = (id<AVPictureInPictureControllerDelegate>)self;
+  }
+}
+
+- (void)tearDownPictureInPicture API_AVAILABLE(ios(14.2)) {
+  if (_pipController.isPictureInPictureActive) {
+    [_pipController stopPictureInPicture];
+  }
+  _pipController = nil;
+}
+
+- (void)enablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
+  if (@available(iOS 14.2, *)) {
+    // PiP controller is already set up automatically for texture-based players.
+    // For platform view players, it's set up when the view is created.
+    if (!_pipController) {
+      *error = [FlutterError
+          errorWithCode:@"pip_not_available"
+                message:@"PiP controller not configured. Ensure a player layer is available."
+                details:nil];
+    }
+  } else {
+    *error = [FlutterError errorWithCode:@"pip_not_supported"
+                                  message:@"PiP requires iOS 14.2+"
+                                  details:nil];
+  }
+}
+
+- (void)disablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
+  if (@available(iOS 14.2, *)) {
+    [self tearDownPictureInPicture];
+  }
+}
+
+- (void)startPictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
+  if (@available(iOS 14.2, *)) {
+    if (!_pipController) {
+      *error = [FlutterError errorWithCode:@"pip_not_possible"
+                                    message:@"PiP is not possible at this time"
+                                    details:nil];
+      return;
+    }
+
+    if (_pipController.isPictureInPicturePossible) {
+      [_pipController startPictureInPicture];
+      return;
+    }
+
+    // Float-up animation workaround: pause to make PiP possible with empty frame,
+    // then resume immediately after starting PiP.
+    AVPlayer *player = _pipController.playerLayer.player;
+    BOOL wasPlaying = player.rate > 0;
+    if (wasPlaying && CGRectIsEmpty(_pipController.playerLayer.frame)) {
+      [player pause];
+
+      if (_pipController.isPictureInPicturePossible) {
+        [_pipController startPictureInPicture];
+        [player play];
+        return;
+      }
+
+      // isPossible may update asynchronously; retry on next run loop.
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_pipController.isPictureInPicturePossible) {
+          [self->_pipController startPictureInPicture];
+        }
+        // Restore playback regardless — PiP will continue playing independently.
+        [player play];
+      });
+      return;
+    }
+
+    *error = [FlutterError errorWithCode:@"pip_not_possible"
+                                  message:@"PiP is not possible at this time"
+                                  details:nil];
+  } else {
+    *error = [FlutterError errorWithCode:@"pip_not_supported"
+                                  message:@"PiP requires iOS 14.2+"
+                                  details:nil];
+  }
+}
+
+- (void)stopPictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
+  if (@available(iOS 14.2, *)) {
+    if (_pipController && _pipController.isPictureInPictureActive) {
+      [_pipController stopPictureInPicture];
+    }
+  }
+}
+
+- (nullable NSNumber *)isPictureInPictureSupported:(FlutterError *_Nullable *_Nonnull)error {
+  if (@available(iOS 14.2, *)) {
+    return @([AVPictureInPictureController isPictureInPictureSupported]);
+  }
+  return @(NO);
+}
+
+- (nullable NSNumber *)isPictureInPictureActive:(FlutterError *_Nullable *_Nonnull)error {
+  if (@available(iOS 14.2, *)) {
+    return @(_pipController != nil && _pipController.isPictureInPictureActive);
+  }
+  return @(NO);
+}
+
+#pragma mark - AVPictureInPictureControllerDelegate
+
+- (void)pictureInPictureControllerDidStartPictureInPicture:
+    (AVPictureInPictureController *)controller {
+  [self.eventListener videoPlayerDidStartPictureInPicture];
+}
+
+- (void)pictureInPictureControllerDidStopPictureInPicture:
+    (AVPictureInPictureController *)controller {
+  [self.eventListener videoPlayerDidStopPictureInPicture];
+  [self updatePlayingState];
+}
+
+- (void)pictureInPictureController:(AVPictureInPictureController *)controller
+    restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:
+        (void (^)(BOOL))completionHandler {
+  [self.eventListener videoPlayerShouldRestoreUserInterfaceForPictureInPicture];
+  // In a production implementation, this should wait for the Dart side to confirm UI restoration.
+  // For now, immediately signal completion.
+  completionHandler(YES);
+}
+
+- (void)pictureInPictureController:(AVPictureInPictureController *)controller
+    failedToStartPictureInPictureWithError:(NSError *)error {
+  NSLog(@"Failed to start Picture-in-Picture: %@", error);
+}
+
+#else
+// macOS stubs - PiP is iOS only in this implementation.
+
+- (void)enablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
+  *error = [FlutterError errorWithCode:@"pip_not_supported"
+                                message:@"PiP is only supported on iOS"
+                                details:nil];
+}
+
+- (void)disablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
+}
+
+- (void)startPictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
+  *error = [FlutterError errorWithCode:@"pip_not_supported"
+                                message:@"PiP is only supported on iOS"
+                                details:nil];
+}
+
+- (void)stopPictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
+}
+
+- (nullable NSNumber *)isPictureInPictureSupported:(FlutterError *_Nullable *_Nonnull)error {
+  return @(NO);
+}
+
+- (nullable NSNumber *)isPictureInPictureActive:(FlutterError *_Nullable *_Nonnull)error {
+  return @(NO);
+}
+
+#endif
 
 #pragma mark - Private
 

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayer.m
@@ -535,29 +535,6 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   _pipController = nil;
 }
 
-- (void)enablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
-  if (@available(iOS 14.2, *)) {
-    // PiP controller is already set up automatically for texture-based players.
-    // For platform view players, it's set up when the view is created.
-    if (!_pipController) {
-      *error = [FlutterError
-          errorWithCode:@"pip_not_available"
-                message:@"PiP controller not configured. Ensure a player layer is available."
-                details:nil];
-    }
-  } else {
-    *error = [FlutterError errorWithCode:@"pip_not_supported"
-                                  message:@"PiP requires iOS 14.2+"
-                                  details:nil];
-  }
-}
-
-- (void)disablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
-  if (@available(iOS 14.2, *)) {
-    [self tearDownPictureInPicture];
-  }
-}
-
 - (void)startPictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
   if (@available(iOS 14.2, *)) {
     if (!_pipController) {
@@ -657,15 +634,6 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
 
 #else
 // macOS stubs - PiP is iOS only in this implementation.
-
-- (void)enablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
-  *error = [FlutterError errorWithCode:@"pip_not_supported"
-                                message:@"PiP is only supported on iOS"
-                                details:nil];
-}
-
-- (void)disablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
-}
 
 - (void)startPictureInPicture:(FlutterError *_Nullable *_Nonnull)error {
   *error = [FlutterError errorWithCode:@"pip_not_supported"

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPNativeVideoView.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPNativeVideoView.h
@@ -20,4 +20,8 @@
 /// Initializes a new instance of a native view.
 /// It creates a video view instance and sets the provided AVPlayer instance to it.
 - (instancetype)initWithPlayer:(AVPlayer *)player;
+#if TARGET_OS_IOS
+/// Returns the AVPlayerLayer used by this view, for PiP controller setup.
+- (AVPlayerLayer *)playerLayer;
+#endif
 @end

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoEventListener.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoEventListener.h
@@ -27,6 +27,12 @@
 - (void)videoPlayerDidUpdateBufferRegions:(NSArray<NSArray<NSNumber *> *> *)regions;
 /// Called when the player starts or stops playing.
 - (void)videoPlayerDidSetPlaying:(BOOL)playing;
+/// Called when Picture-in-Picture playback starts.
+- (void)videoPlayerDidStartPictureInPicture;
+/// Called when Picture-in-Picture playback stops.
+- (void)videoPlayerDidStopPictureInPicture;
+/// Called when the user taps the restore button in the PiP window.
+- (void)videoPlayerShouldRestoreUserInterfaceForPictureInPicture;
 /// Called when the video player has been disposed on the Dart side.
 - (void)videoPlayerWasDisposed;
 @end

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer_Internal.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/FVPVideoPlayer_Internal.h
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 @import AVFoundation;
+#if TARGET_OS_IOS
+@import AVKit;
+#endif
 
 #import "FVPAVFactory.h"
 #import "FVPVideoEventListener.h"
@@ -35,6 +38,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Updates the playing state of the video player.
 - (void)updatePlayingState;
+
+#if TARGET_OS_IOS
+/// The Picture-in-Picture controller. Created when setupPictureInPictureWithPlayerLayer: is called.
+@property(nonatomic, nullable) AVPictureInPictureController *pipController
+    API_AVAILABLE(ios(14.2));
+
+/// Sets up the PiP controller with the given player layer.
+/// Called by subclasses or view factories that have access to an AVPlayerLayer.
+- (void)setupPictureInPictureWithPlayerLayer:(AVPlayerLayer *)playerLayer
+    API_AVAILABLE(ios(14.2));
+#endif
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
@@ -91,10 +91,6 @@ extern void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMesseng
 /// @return `nil` only when `error != nil`.
 - (nullable NSArray<FVPMediaSelectionAudioTrackData *> *)getAudioTracks:(FlutterError *_Nullable *_Nonnull)error;
 - (void)selectAudioTrackAtIndex:(NSInteger)trackIndex error:(FlutterError *_Nullable *_Nonnull)error;
-/// Enables Picture-in-Picture for this player.
-- (void)enablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error;
-/// Disables Picture-in-Picture for this player.
-- (void)disablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error;
 /// Starts Picture-in-Picture playback.
 - (void)startPictureInPicture:(FlutterError *_Nullable *_Nonnull)error;
 /// Stops Picture-in-Picture playback.

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
@@ -22,41 +22,42 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FVPPlatformVideoViewCreationParams : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)makeWithPlayerId:(NSInteger)playerId;
-@property(nonatomic, assign) NSInteger playerId;
++ (instancetype)makeWithPlayerId:(NSInteger )playerId;
+@property(nonatomic, assign) NSInteger  playerId;
 @end
 
 @interface FVPCreationOptions : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)makeWithUri:(NSString *)uri
-                httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders;
-@property(nonatomic, copy) NSString *uri;
-@property(nonatomic, copy) NSDictionary<NSString *, NSString *> *httpHeaders;
+    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders;
+@property(nonatomic, copy) NSString * uri;
+@property(nonatomic, copy) NSDictionary<NSString *, NSString *> * httpHeaders;
 @end
 
 @interface FVPTexturePlayerIds : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)makeWithPlayerId:(NSInteger)playerId textureId:(NSInteger)textureId;
-@property(nonatomic, assign) NSInteger playerId;
-@property(nonatomic, assign) NSInteger textureId;
++ (instancetype)makeWithPlayerId:(NSInteger )playerId
+    textureId:(NSInteger )textureId;
+@property(nonatomic, assign) NSInteger  playerId;
+@property(nonatomic, assign) NSInteger  textureId;
 @end
 
 /// Raw audio track data from AVMediaSelectionOption (for HLS streams).
 @interface FVPMediaSelectionAudioTrackData : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)makeWithIndex:(NSInteger)index
-                  displayName:(nullable NSString *)displayName
-                 languageCode:(nullable NSString *)languageCode
-                   isSelected:(BOOL)isSelected
-          commonMetadataTitle:(nullable NSString *)commonMetadataTitle;
-@property(nonatomic, assign) NSInteger index;
-@property(nonatomic, copy, nullable) NSString *displayName;
-@property(nonatomic, copy, nullable) NSString *languageCode;
-@property(nonatomic, assign) BOOL isSelected;
-@property(nonatomic, copy, nullable) NSString *commonMetadataTitle;
++ (instancetype)makeWithIndex:(NSInteger )index
+    displayName:(nullable NSString *)displayName
+    languageCode:(nullable NSString *)languageCode
+    isSelected:(BOOL )isSelected
+    commonMetadataTitle:(nullable NSString *)commonMetadataTitle;
+@property(nonatomic, assign) NSInteger  index;
+@property(nonatomic, copy, nullable) NSString * displayName;
+@property(nonatomic, copy, nullable) NSString * languageCode;
+@property(nonatomic, assign) BOOL  isSelected;
+@property(nonatomic, copy, nullable) NSString * commonMetadataTitle;
 @end
 
 /// The codec used by all APIs.
@@ -65,25 +66,17 @@ NSObject<FlutterMessageCodec> *FVPGetMessagesCodec(void);
 @protocol FVPAVFoundationVideoPlayerApi
 - (void)initialize:(FlutterError *_Nullable *_Nonnull)error;
 /// @return `nil` only when `error != nil`.
-- (nullable NSNumber *)createPlatformViewPlayerWithOptions:(FVPCreationOptions *)params
-                                                     error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSNumber *)createPlatformViewPlayerWithOptions:(FVPCreationOptions *)params error:(FlutterError *_Nullable *_Nonnull)error;
 /// @return `nil` only when `error != nil`.
-- (nullable FVPTexturePlayerIds *)
-    createTexturePlayerWithOptions:(FVPCreationOptions *)creationOptions
-                             error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable FVPTexturePlayerIds *)createTexturePlayerWithOptions:(FVPCreationOptions *)creationOptions error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)setMixWithOthers:(BOOL)mixWithOthers error:(FlutterError *_Nullable *_Nonnull)error;
-- (nullable NSString *)fileURLForAssetWithName:(NSString *)asset
-                                       package:(nullable NSString *)package
-                                         error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSString *)fileURLForAssetWithName:(NSString *)asset package:(nullable NSString *)package error:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
-extern void SetUpFVPAVFoundationVideoPlayerApi(
-    id<FlutterBinaryMessenger> binaryMessenger,
-    NSObject<FVPAVFoundationVideoPlayerApi> *_Nullable api);
+extern void SetUpFVPAVFoundationVideoPlayerApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPAVFoundationVideoPlayerApi> *_Nullable api);
 
-extern void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(
-    id<FlutterBinaryMessenger> binaryMessenger,
-    NSObject<FVPAVFoundationVideoPlayerApi> *_Nullable api, NSString *messageChannelSuffix);
+extern void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPAVFoundationVideoPlayerApi> *_Nullable api, NSString *messageChannelSuffix);
+
 
 @protocol FVPVideoPlayerInstanceApi
 - (void)setLooping:(BOOL)looping error:(FlutterError *_Nullable *_Nonnull)error;
@@ -96,17 +89,28 @@ extern void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(
 - (void)pauseWithError:(FlutterError *_Nullable *_Nonnull)error;
 - (void)disposeWithError:(FlutterError *_Nullable *_Nonnull)error;
 /// @return `nil` only when `error != nil`.
-- (nullable NSArray<FVPMediaSelectionAudioTrackData *> *)getAudioTracks:
-    (FlutterError *_Nullable *_Nonnull)error;
-- (void)selectAudioTrackAtIndex:(NSInteger)trackIndex
-                          error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable NSArray<FVPMediaSelectionAudioTrackData *> *)getAudioTracks:(FlutterError *_Nullable *_Nonnull)error;
+- (void)selectAudioTrackAtIndex:(NSInteger)trackIndex error:(FlutterError *_Nullable *_Nonnull)error;
+/// Enables Picture-in-Picture for this player.
+- (void)enablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error;
+/// Disables Picture-in-Picture for this player.
+- (void)disablePictureInPicture:(FlutterError *_Nullable *_Nonnull)error;
+/// Starts Picture-in-Picture playback.
+- (void)startPictureInPicture:(FlutterError *_Nullable *_Nonnull)error;
+/// Stops Picture-in-Picture playback.
+- (void)stopPictureInPicture:(FlutterError *_Nullable *_Nonnull)error;
+/// Returns whether Picture-in-Picture is supported on this device.
+///
+/// @return `nil` only when `error != nil`.
+- (nullable NSNumber *)isPictureInPictureSupported:(FlutterError *_Nullable *_Nonnull)error;
+/// Returns whether Picture-in-Picture is currently active.
+///
+/// @return `nil` only when `error != nil`.
+- (nullable NSNumber *)isPictureInPictureActive:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
-extern void SetUpFVPVideoPlayerInstanceApi(id<FlutterBinaryMessenger> binaryMessenger,
-                                           NSObject<FVPVideoPlayerInstanceApi> *_Nullable api);
+extern void SetUpFVPVideoPlayerInstanceApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPVideoPlayerInstanceApi> *_Nullable api);
 
-extern void SetUpFVPVideoPlayerInstanceApiWithSuffix(
-    id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPVideoPlayerInstanceApi> *_Nullable api,
-    NSString *messageChannelSuffix);
+extern void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPVideoPlayerInstanceApi> *_Nullable api, NSString *messageChannelSuffix);
 
 NS_ASSUME_NONNULL_END

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
@@ -51,15 +51,13 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 @end
 
 @implementation FVPPlatformVideoViewCreationParams
-+ (instancetype)makeWithPlayerId:(NSInteger)playerId {
-  FVPPlatformVideoViewCreationParams *pigeonResult =
-      [[FVPPlatformVideoViewCreationParams alloc] init];
++ (instancetype)makeWithPlayerId:(NSInteger )playerId {
+  FVPPlatformVideoViewCreationParams* pigeonResult = [[FVPPlatformVideoViewCreationParams alloc] init];
   pigeonResult.playerId = playerId;
   return pigeonResult;
 }
 + (FVPPlatformVideoViewCreationParams *)fromList:(NSArray<id> *)list {
-  FVPPlatformVideoViewCreationParams *pigeonResult =
-      [[FVPPlatformVideoViewCreationParams alloc] init];
+  FVPPlatformVideoViewCreationParams *pigeonResult = [[FVPPlatformVideoViewCreationParams alloc] init];
   pigeonResult.playerId = [GetNullableObjectAtIndex(list, 0) integerValue];
   return pigeonResult;
 }
@@ -75,8 +73,8 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 
 @implementation FVPCreationOptions
 + (instancetype)makeWithUri:(NSString *)uri
-                httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders {
-  FVPCreationOptions *pigeonResult = [[FVPCreationOptions alloc] init];
+    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders {
+  FVPCreationOptions* pigeonResult = [[FVPCreationOptions alloc] init];
   pigeonResult.uri = uri;
   pigeonResult.httpHeaders = httpHeaders;
   return pigeonResult;
@@ -99,8 +97,9 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 @end
 
 @implementation FVPTexturePlayerIds
-+ (instancetype)makeWithPlayerId:(NSInteger)playerId textureId:(NSInteger)textureId {
-  FVPTexturePlayerIds *pigeonResult = [[FVPTexturePlayerIds alloc] init];
++ (instancetype)makeWithPlayerId:(NSInteger )playerId
+    textureId:(NSInteger )textureId {
+  FVPTexturePlayerIds* pigeonResult = [[FVPTexturePlayerIds alloc] init];
   pigeonResult.playerId = playerId;
   pigeonResult.textureId = textureId;
   return pigeonResult;
@@ -123,12 +122,12 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 @end
 
 @implementation FVPMediaSelectionAudioTrackData
-+ (instancetype)makeWithIndex:(NSInteger)index
-                  displayName:(nullable NSString *)displayName
-                 languageCode:(nullable NSString *)languageCode
-                   isSelected:(BOOL)isSelected
-          commonMetadataTitle:(nullable NSString *)commonMetadataTitle {
-  FVPMediaSelectionAudioTrackData *pigeonResult = [[FVPMediaSelectionAudioTrackData alloc] init];
++ (instancetype)makeWithIndex:(NSInteger )index
+    displayName:(nullable NSString *)displayName
+    languageCode:(nullable NSString *)languageCode
+    isSelected:(BOOL )isSelected
+    commonMetadataTitle:(nullable NSString *)commonMetadataTitle {
+  FVPMediaSelectionAudioTrackData* pigeonResult = [[FVPMediaSelectionAudioTrackData alloc] init];
   pigeonResult.index = index;
   pigeonResult.displayName = displayName;
   pigeonResult.languageCode = languageCode;
@@ -164,13 +163,13 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 @implementation FVPMessagesPigeonCodecReader
 - (nullable id)readValueOfType:(UInt8)type {
   switch (type) {
-    case 129:
+    case 129: 
       return [FVPPlatformVideoViewCreationParams fromList:[self readValue]];
-    case 130:
+    case 130: 
       return [FVPCreationOptions fromList:[self readValue]];
-    case 131:
+    case 131: 
       return [FVPTexturePlayerIds fromList:[self readValue]];
-    case 132:
+    case 132: 
       return [FVPMediaSelectionAudioTrackData fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
@@ -215,35 +214,25 @@ NSObject<FlutterMessageCodec> *FVPGetMessagesCodec(void) {
   static FlutterStandardMessageCodec *sSharedObject = nil;
   static dispatch_once_t sPred = 0;
   dispatch_once(&sPred, ^{
-    FVPMessagesPigeonCodecReaderWriter *readerWriter =
-        [[FVPMessagesPigeonCodecReaderWriter alloc] init];
+    FVPMessagesPigeonCodecReaderWriter *readerWriter = [[FVPMessagesPigeonCodecReaderWriter alloc] init];
     sSharedObject = [FlutterStandardMessageCodec codecWithReaderWriter:readerWriter];
   });
   return sSharedObject;
 }
-void SetUpFVPAVFoundationVideoPlayerApi(id<FlutterBinaryMessenger> binaryMessenger,
-                                        NSObject<FVPAVFoundationVideoPlayerApi> *api) {
+void SetUpFVPAVFoundationVideoPlayerApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPAVFoundationVideoPlayerApi> *api) {
   SetUpFVPAVFoundationVideoPlayerApiWithSuffix(binaryMessenger, api, @"");
 }
 
-void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
-                                                  NSObject<FVPAVFoundationVideoPlayerApi> *api,
-                                                  NSString *messageChannelSuffix) {
-  messageChannelSuffix = messageChannelSuffix.length > 0
-                             ? [NSString stringWithFormat:@".%@", messageChannelSuffix]
-                             : @"";
+void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPAVFoundationVideoPlayerApi> *api, NSString *messageChannelSuffix) {
+  messageChannelSuffix = messageChannelSuffix.length > 0 ? [NSString stringWithFormat: @".%@", messageChannelSuffix] : @"";
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"AVFoundationVideoPlayerApi.initialize",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.initialize", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(initialize:)],
-                @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to @selector(initialize:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(initialize:)], @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to @selector(initialize:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         [api initialize:&error];
@@ -254,19 +243,13 @@ void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> bin
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString
-                            stringWithFormat:@"%@%@",
-                                             @"dev.flutter.pigeon.video_player_avfoundation."
-                                             @"AVFoundationVideoPlayerApi.createForPlatformView",
-                                             messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.createForPlatformView", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(createPlatformViewPlayerWithOptions:error:)],
-                @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to "
-                @"@selector(createPlatformViewPlayerWithOptions:error:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(createPlatformViewPlayerWithOptions:error:)], @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to @selector(createPlatformViewPlayerWithOptions:error:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         FVPCreationOptions *arg_params = GetNullableObjectAtIndex(args, 0);
@@ -279,25 +262,18 @@ void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> bin
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString
-                            stringWithFormat:@"%@%@",
-                                             @"dev.flutter.pigeon.video_player_avfoundation."
-                                             @"AVFoundationVideoPlayerApi.createForTextureView",
-                                             messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.createForTextureView", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(createTexturePlayerWithOptions:error:)],
-                @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to "
-                @"@selector(createTexturePlayerWithOptions:error:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(createTexturePlayerWithOptions:error:)], @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to @selector(createTexturePlayerWithOptions:error:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         FVPCreationOptions *arg_creationOptions = GetNullableObjectAtIndex(args, 0);
         FlutterError *error;
-        FVPTexturePlayerIds *output = [api createTexturePlayerWithOptions:arg_creationOptions
-                                                                    error:&error];
+        FVPTexturePlayerIds *output = [api createTexturePlayerWithOptions:arg_creationOptions error:&error];
         callback(wrapResult(output, error));
       }];
     } else {
@@ -305,18 +281,13 @@ void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> bin
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"AVFoundationVideoPlayerApi.setMixWithOthers",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.setMixWithOthers", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(setMixWithOthers:error:)],
-                @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to "
-                @"@selector(setMixWithOthers:error:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(setMixWithOthers:error:)], @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to @selector(setMixWithOthers:error:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         BOOL arg_mixWithOthers = [GetNullableObjectAtIndex(args, 0) boolValue];
@@ -329,18 +300,13 @@ void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> bin
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"AVFoundationVideoPlayerApi.getAssetUrl",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.getAssetUrl", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(fileURLForAssetWithName:package:error:)],
-                @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to "
-                @"@selector(fileURLForAssetWithName:package:error:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(fileURLForAssetWithName:package:error:)], @"FVPAVFoundationVideoPlayerApi api (%@) doesn't respond to @selector(fileURLForAssetWithName:package:error:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_asset = GetNullableObjectAtIndex(args, 0);
@@ -354,30 +320,20 @@ void SetUpFVPAVFoundationVideoPlayerApiWithSuffix(id<FlutterBinaryMessenger> bin
     }
   }
 }
-void SetUpFVPVideoPlayerInstanceApi(id<FlutterBinaryMessenger> binaryMessenger,
-                                    NSObject<FVPVideoPlayerInstanceApi> *api) {
+void SetUpFVPVideoPlayerInstanceApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPVideoPlayerInstanceApi> *api) {
   SetUpFVPVideoPlayerInstanceApiWithSuffix(binaryMessenger, api, @"");
 }
 
-void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
-                                              NSObject<FVPVideoPlayerInstanceApi> *api,
-                                              NSString *messageChannelSuffix) {
-  messageChannelSuffix = messageChannelSuffix.length > 0
-                             ? [NSString stringWithFormat:@".%@", messageChannelSuffix]
-                             : @"";
+void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FVPVideoPlayerInstanceApi> *api, NSString *messageChannelSuffix) {
+  messageChannelSuffix = messageChannelSuffix.length > 0 ? [NSString stringWithFormat: @".%@", messageChannelSuffix] : @"";
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.setLooping",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setLooping", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(setLooping:error:)],
-          @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(setLooping:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(setLooping:error:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(setLooping:error:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         BOOL arg_looping = [GetNullableObjectAtIndex(args, 0) boolValue];
@@ -390,18 +346,13 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.setVolume",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setVolume", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(setVolume:error:)],
-          @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(setVolume:error:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(setVolume:error:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(setVolume:error:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         double arg_volume = [GetNullableObjectAtIndex(args, 0) doubleValue];
@@ -414,18 +365,13 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.setPlaybackSpeed",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setPlaybackSpeed", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(setPlaybackSpeed:error:)],
-                @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to "
-                @"@selector(setPlaybackSpeed:error:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(setPlaybackSpeed:error:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(setPlaybackSpeed:error:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         double arg_speed = [GetNullableObjectAtIndex(args, 0) doubleValue];
@@ -438,17 +384,13 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.play",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.play", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(playWithError:)],
-                @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(playWithError:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(playWithError:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(playWithError:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         [api playWithError:&error];
@@ -459,16 +401,13 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.getPosition",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.getPosition", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(position:)],
-                @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(position:)", api);
+      NSCAssert([api respondsToSelector:@selector(position:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(position:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         NSNumber *output = [api position:&error];
@@ -479,42 +418,32 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.seekTo",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.seekTo", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(seekTo:completion:)],
-          @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(seekTo:completion:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(seekTo:completion:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(seekTo:completion:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSInteger arg_position = [GetNullableObjectAtIndex(args, 0) integerValue];
-        [api seekTo:arg_position
-            completion:^(FlutterError *_Nullable error) {
-              callback(wrapResult(nil, error));
-            }];
+        [api seekTo:arg_position completion:^(FlutterError *_Nullable error) {
+          callback(wrapResult(nil, error));
+        }];
       }];
     } else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.pause",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.pause", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(pauseWithError:)],
-                @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(pauseWithError:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(pauseWithError:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(pauseWithError:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         [api pauseWithError:&error];
@@ -525,18 +454,13 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.dispose",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.dispose", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert(
-          [api respondsToSelector:@selector(disposeWithError:)],
-          @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(disposeWithError:)",
-          api);
+      NSCAssert([api respondsToSelector:@selector(disposeWithError:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(disposeWithError:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         [api disposeWithError:&error];
@@ -547,17 +471,13 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.getAudioTracks",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.getAudioTracks", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(getAudioTracks:)],
-                @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(getAudioTracks:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(getAudioTracks:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(getAudioTracks:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         NSArray<FVPMediaSelectionAudioTrackData *> *output = [api getAudioTracks:&error];
@@ -568,24 +488,127 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
-           initWithName:[NSString stringWithFormat:@"%@%@",
-                                                   @"dev.flutter.pigeon.video_player_avfoundation."
-                                                   @"VideoPlayerInstanceApi.selectAudioTrack",
-                                                   messageChannelSuffix]
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.selectAudioTrack", messageChannelSuffix]
         binaryMessenger:binaryMessenger
-                  codec:FVPGetMessagesCodec()];
+        codec:FVPGetMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(selectAudioTrackAtIndex:error:)],
-                @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to "
-                @"@selector(selectAudioTrackAtIndex:error:)",
-                api);
+      NSCAssert([api respondsToSelector:@selector(selectAudioTrackAtIndex:error:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(selectAudioTrackAtIndex:error:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSInteger arg_trackIndex = [GetNullableObjectAtIndex(args, 0) integerValue];
         FlutterError *error;
         [api selectAudioTrackAtIndex:arg_trackIndex error:&error];
         callback(wrapResult(nil, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  /// Enables Picture-in-Picture for this player.
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.enablePictureInPicture", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:FVPGetMessagesCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(enablePictureInPicture:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(enablePictureInPicture:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        FlutterError *error;
+        [api enablePictureInPicture:&error];
+        callback(wrapResult(nil, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  /// Disables Picture-in-Picture for this player.
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.disablePictureInPicture", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:FVPGetMessagesCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(disablePictureInPicture:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(disablePictureInPicture:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        FlutterError *error;
+        [api disablePictureInPicture:&error];
+        callback(wrapResult(nil, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  /// Starts Picture-in-Picture playback.
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.startPictureInPicture", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:FVPGetMessagesCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(startPictureInPicture:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(startPictureInPicture:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        FlutterError *error;
+        [api startPictureInPicture:&error];
+        callback(wrapResult(nil, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  /// Stops Picture-in-Picture playback.
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.stopPictureInPicture", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:FVPGetMessagesCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(stopPictureInPicture:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(stopPictureInPicture:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        FlutterError *error;
+        [api stopPictureInPicture:&error];
+        callback(wrapResult(nil, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  /// Returns whether Picture-in-Picture is supported on this device.
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.isPictureInPictureSupported", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:FVPGetMessagesCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(isPictureInPictureSupported:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(isPictureInPictureSupported:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        FlutterError *error;
+        NSNumber *output = [api isPictureInPictureSupported:&error];
+        callback(wrapResult(output, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  /// Returns whether Picture-in-Picture is currently active.
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.isPictureInPictureActive", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:FVPGetMessagesCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(isPictureInPictureActive:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(isPictureInPictureActive:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        FlutterError *error;
+        NSNumber *output = [api isPictureInPictureActive:&error];
+        callback(wrapResult(output, error));
       }];
     } else {
       [channel setMessageHandler:nil];

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
@@ -506,42 +506,6 @@ void SetUpFVPVideoPlayerInstanceApiWithSuffix(id<FlutterBinaryMessenger> binaryM
       [channel setMessageHandler:nil];
     }
   }
-  /// Enables Picture-in-Picture for this player.
-  {
-    FlutterBasicMessageChannel *channel =
-      [[FlutterBasicMessageChannel alloc]
-        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.enablePictureInPicture", messageChannelSuffix]
-        binaryMessenger:binaryMessenger
-        codec:FVPGetMessagesCodec()];
-    if (api) {
-      NSCAssert([api respondsToSelector:@selector(enablePictureInPicture:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(enablePictureInPicture:)", api);
-      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
-        FlutterError *error;
-        [api enablePictureInPicture:&error];
-        callback(wrapResult(nil, error));
-      }];
-    } else {
-      [channel setMessageHandler:nil];
-    }
-  }
-  /// Disables Picture-in-Picture for this player.
-  {
-    FlutterBasicMessageChannel *channel =
-      [[FlutterBasicMessageChannel alloc]
-        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.disablePictureInPicture", messageChannelSuffix]
-        binaryMessenger:binaryMessenger
-        codec:FVPGetMessagesCodec()];
-    if (api) {
-      NSCAssert([api respondsToSelector:@selector(disablePictureInPicture:)], @"FVPVideoPlayerInstanceApi api (%@) doesn't respond to @selector(disablePictureInPicture:)", api);
-      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
-        FlutterError *error;
-        [api disablePictureInPicture:&error];
-        callback(wrapResult(nil, error));
-      }];
-    } else {
-      [channel setMessageHandler:nil];
-    }
-  }
   /// Starts Picture-in-Picture playback.
   {
     FlutterBasicMessageChannel *channel =

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_ios/FVPNativeVideoView.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_ios/FVPNativeVideoView.m
@@ -35,4 +35,8 @@
 - (FVPPlayerView *)view {
   return self.playerView;
 }
+
+- (AVPlayerLayer *)playerLayer {
+  return (AVPlayerLayer *)self.playerView.layer;
+}
 @end

--- a/packages/video_player/video_player_avfoundation/example/ios/Runner/Info.plist
+++ b/packages/video_player/video_player_avfoundation/example/ios/Runner/Info.plist
@@ -52,5 +52,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/packages/video_player/video_player_avfoundation/example/lib/main.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/main.dart
@@ -325,6 +325,10 @@ class _ControlsOverlay extends StatelessWidget {
           },
         ),
         Align(
+          alignment: Alignment.topLeft,
+          child: _PipButton(controller: controller),
+        ),
+        Align(
           alignment: Alignment.topRight,
           child: PopupMenuButton<double>(
             initialValue: controller.value.playbackSpeed,
@@ -351,6 +355,79 @@ class _ControlsOverlay extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _PipButton extends StatefulWidget {
+  const _PipButton({required this.controller});
+
+  final MiniController controller;
+
+  @override
+  State<_PipButton> createState() => _PipButtonState();
+}
+
+class _PipButtonState extends State<_PipButton> {
+  bool _isSupported = false;
+  bool _waitingForInit = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.controller.value.isInitialized) {
+      _querySupport();
+    } else {
+      _waitingForInit = true;
+      widget.controller.addListener(_onInitialized);
+    }
+  }
+
+  @override
+  void dispose() {
+    if (_waitingForInit) {
+      widget.controller.removeListener(_onInitialized);
+    }
+    super.dispose();
+  }
+
+  void _onInitialized() {
+    if (widget.controller.value.isInitialized) {
+      _waitingForInit = false;
+      widget.controller.removeListener(_onInitialized);
+      _querySupport();
+    }
+  }
+
+  Future<void> _querySupport() async {
+    final bool supported = await widget.controller
+        .isPictureInPictureSupported();
+    if (mounted) {
+      setState(() {
+        _isSupported = supported;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isSupported) {
+      return const SizedBox.shrink();
+    }
+    final bool isActive = widget.controller.value.isPictureInPictureActive;
+    return IconButton(
+      icon: Icon(
+        isActive ? Icons.picture_in_picture : Icons.picture_in_picture_alt,
+        color: Colors.white,
+      ),
+      tooltip: isActive ? 'Stop PiP' : 'Start PiP',
+      onPressed: () async {
+        if (isActive) {
+          await widget.controller.stopPictureInPicture();
+        } else {
+          await widget.controller.startPictureInPicture();
+        }
+      },
     );
   }
 }

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -36,6 +36,7 @@ class VideoPlayerValue {
     this.isBuffering = false,
     this.playbackSpeed = 1.0,
     this.errorDescription,
+    this.isPictureInPictureActive = false,
   });
 
   /// Returns an instance for a video that hasn't been loaded.
@@ -81,6 +82,9 @@ class VideoPlayerValue {
   /// Indicates whether or not the video has been loaded and is ready to play.
   final bool isInitialized;
 
+  /// Whether Picture-in-Picture is currently active.
+  final bool isPictureInPictureActive;
+
   /// Indicates whether or not the video is in an error state. If this is true
   /// [errorDescription] should have information about the problem.
   bool get hasError => errorDescription != null;
@@ -114,6 +118,7 @@ class VideoPlayerValue {
     bool? isBuffering,
     double? playbackSpeed,
     String? errorDescription,
+    bool? isPictureInPictureActive,
   }) {
     return VideoPlayerValue(
       duration: duration ?? this.duration,
@@ -125,6 +130,8 @@ class VideoPlayerValue {
       isBuffering: isBuffering ?? this.isBuffering,
       playbackSpeed: playbackSpeed ?? this.playbackSpeed,
       errorDescription: errorDescription ?? this.errorDescription,
+      isPictureInPictureActive:
+          isPictureInPictureActive ?? this.isPictureInPictureActive,
     );
   }
 
@@ -141,7 +148,8 @@ class VideoPlayerValue {
           playbackSpeed == other.playbackSpeed &&
           errorDescription == other.errorDescription &&
           size == other.size &&
-          isInitialized == other.isInitialized;
+          isInitialized == other.isInitialized &&
+          isPictureInPictureActive == other.isPictureInPictureActive;
 
   @override
   int get hashCode => Object.hash(
@@ -154,6 +162,7 @@ class VideoPlayerValue {
     errorDescription,
     size,
     isInitialized,
+    isPictureInPictureActive,
   );
 }
 
@@ -278,6 +287,13 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
           value = value.copyWith(isBuffering: false);
         case VideoEventType.isPlayingStateUpdate:
           value = value.copyWith(isPlaying: event.isPlaying);
+        case VideoEventType.pipStarted:
+          value = value.copyWith(isPictureInPictureActive: true);
+        case VideoEventType.pipStopped:
+          value = value.copyWith(isPictureInPictureActive: false);
+        case VideoEventType.pipRestoreUserInterface:
+          // Return to the app from PiP.
+          break;
         case VideoEventType.unknown:
           break;
       }
@@ -371,6 +387,26 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
 
   void _updatePosition(Duration position) {
     value = value.copyWith(position: position);
+  }
+
+  /// Enables Picture-in-Picture for this player.
+  Future<void> enablePictureInPicture() async {
+    await _platform.enablePictureInPicture(_playerId);
+  }
+
+  /// Starts Picture-in-Picture playback.
+  Future<void> startPictureInPicture() async {
+    await _platform.startPictureInPicture(_playerId);
+  }
+
+  /// Stops Picture-in-Picture playback.
+  Future<void> stopPictureInPicture() async {
+    await _platform.stopPictureInPicture(_playerId);
+  }
+
+  /// Returns whether Picture-in-Picture is supported on this device.
+  Future<bool> isPictureInPictureSupported() async {
+    return _platform.isPictureInPictureSupported(_playerId);
   }
 }
 

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -292,8 +292,6 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.pipStopped:
           value = value.copyWith(isPictureInPictureActive: false);
         case VideoEventType.pipRestoreUserInterface:
-          // Return to the app from PiP.
-          break;
         case VideoEventType.unknown:
           break;
       }
@@ -387,11 +385,6 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
 
   void _updatePosition(Duration position) {
     value = value.copyWith(position: position);
-  }
-
-  /// Enables Picture-in-Picture for this player.
-  Future<void> enablePictureInPicture() async {
-    await _platform.enablePictureInPicture(_playerId);
   }
 
   /// Starts Picture-in-Picture playback.

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -243,6 +243,36 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     );
   }
 
+  @override
+  Future<void> enablePictureInPicture(int playerId) {
+    return _playerWith(id: playerId).enablePictureInPicture();
+  }
+
+  @override
+  Future<void> disablePictureInPicture(int playerId) {
+    return _playerWith(id: playerId).disablePictureInPicture();
+  }
+
+  @override
+  Future<void> startPictureInPicture(int playerId) {
+    return _playerWith(id: playerId).startPictureInPicture();
+  }
+
+  @override
+  Future<void> stopPictureInPicture(int playerId) {
+    return _playerWith(id: playerId).stopPictureInPicture();
+  }
+
+  @override
+  Future<bool> isPictureInPictureSupported(int playerId) {
+    return _playerWith(id: playerId).isPictureInPictureSupported();
+  }
+
+  @override
+  Future<bool> isPictureInPictureActive(int playerId) {
+    return _playerWith(id: playerId).isPictureInPictureActive();
+  }
+
   _PlayerInstance _playerWith({required int id}) {
     final _PlayerInstance? player = _players[id];
     return player ?? (throw StateError('No active player with ID $id.'));
@@ -289,6 +319,19 @@ class _PlayerInstance {
   Future<void> selectAudioTrack(int trackIndex) =>
       _api.selectAudioTrack(trackIndex);
 
+  Future<void> enablePictureInPicture() => _api.enablePictureInPicture();
+
+  Future<void> disablePictureInPicture() => _api.disablePictureInPicture();
+
+  Future<void> startPictureInPicture() => _api.startPictureInPicture();
+
+  Future<void> stopPictureInPicture() => _api.stopPictureInPicture();
+
+  Future<bool> isPictureInPictureSupported() =>
+      _api.isPictureInPictureSupported();
+
+  Future<bool> isPictureInPictureActive() => _api.isPictureInPictureActive();
+
   Stream<VideoEvent> get videoEvents {
     _eventSubscription ??= _eventChannel.receiveBroadcastStream().listen(
       _onStreamEvent,
@@ -330,6 +373,11 @@ class _PlayerInstance {
       'isPlayingStateUpdate' => VideoEvent(
         eventType: VideoEventType.isPlayingStateUpdate,
         isPlaying: map['isPlaying'] as bool,
+      ),
+      'pipStarted' => VideoEvent(eventType: VideoEventType.pipStarted),
+      'pipStopped' => VideoEvent(eventType: VideoEventType.pipStopped),
+      'pipRestoreUserInterface' => VideoEvent(
+        eventType: VideoEventType.pipRestoreUserInterface,
       ),
       _ => VideoEvent(eventType: VideoEventType.unknown),
     });

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -183,21 +183,14 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     final List<MediaSelectionAudioTrackData> nativeData = await _playerWith(
       id: playerId,
     ).getAudioTracks();
-    final tracks = <VideoAudioTrack>[];
-
-    for (final track in nativeData) {
-      final String? label = track.commonMetadataTitle ?? track.displayName;
-      tracks.add(
-        VideoAudioTrack(
-          id: track.index.toString(),
-          label: label,
-          language: track.languageCode,
-          isSelected: track.isSelected,
-        ),
+    return nativeData.map((MediaSelectionAudioTrackData track) {
+      return VideoAudioTrack(
+        id: track.index.toString(),
+        label: track.commonMetadataTitle ?? track.displayName,
+        language: track.languageCode,
+        isSelected: track.isSelected,
       );
-    }
-
-    return tracks;
+    }).toList();
   }
 
   @override
@@ -241,16 +234,6 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
         creationParamsCodec: AVFoundationVideoPlayerApi.pigeonChannelCodec,
       ),
     );
-  }
-
-  @override
-  Future<void> enablePictureInPicture(int playerId) {
-    return _playerWith(id: playerId).enablePictureInPicture();
-  }
-
-  @override
-  Future<void> disablePictureInPicture(int playerId) {
-    return _playerWith(id: playerId).disablePictureInPicture();
   }
 
   @override
@@ -318,10 +301,6 @@ class _PlayerInstance {
 
   Future<void> selectAudioTrack(int trackIndex) =>
       _api.selectAudioTrack(trackIndex);
-
-  Future<void> enablePictureInPicture() => _api.enablePictureInPicture();
-
-  Future<void> disablePictureInPicture() => _api.disablePictureInPicture();
 
   Future<void> startPictureInPicture() => _api.startPictureInPicture();
 

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -678,4 +678,158 @@ class VideoPlayerInstanceApi {
       return;
     }
   }
+
+  /// Enables Picture-in-Picture for this player.
+  Future<void> enablePictureInPicture() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.enablePictureInPicture$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Disables Picture-in-Picture for this player.
+  Future<void> disablePictureInPicture() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.disablePictureInPicture$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Starts Picture-in-Picture playback.
+  Future<void> startPictureInPicture() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.startPictureInPicture$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Stops Picture-in-Picture playback.
+  Future<void> stopPictureInPicture() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.stopPictureInPicture$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Returns whether Picture-in-Picture is supported on this device.
+  Future<bool> isPictureInPictureSupported() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.isPictureInPictureSupported$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as bool?)!;
+    }
+  }
+
+  /// Returns whether Picture-in-Picture is currently active.
+  Future<bool> isPictureInPictureActive() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.isPictureInPictureActive$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as bool?)!;
+    }
+  }
 }

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -17,49 +17,49 @@ PlatformException _createConnectionError(String channelName) {
     message: 'Unable to establish connection on channel: "$channelName".',
   );
 }
-
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed.every(
-          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
-        );
+        a.indexed
+        .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
-    return a.length == b.length &&
-        a.entries.every(
-          (MapEntry<Object?, Object?> entry) =>
-              (b as Map<Object?, Object?>).containsKey(entry.key) &&
-              _deepEquals(entry.value, b[entry.key]),
-        );
+    return a.length == b.length && a.entries.every((MapEntry<Object?, Object?> entry) =>
+        (b as Map<Object?, Object?>).containsKey(entry.key) &&
+        _deepEquals(entry.value, b[entry.key]));
   }
   return a == b;
 }
 
+
 /// Information passed to the platform view creation.
 class PlatformVideoViewCreationParams {
-  PlatformVideoViewCreationParams({required this.playerId});
+  PlatformVideoViewCreationParams({
+    required this.playerId,
+  });
 
   int playerId;
 
   List<Object?> _toList() {
-    return <Object?>[playerId];
+    return <Object?>[
+      playerId,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static PlatformVideoViewCreationParams decode(Object result) {
     result as List<Object?>;
-    return PlatformVideoViewCreationParams(playerId: result[0]! as int);
+    return PlatformVideoViewCreationParams(
+      playerId: result[0]! as int,
+    );
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! PlatformVideoViewCreationParams ||
-        other.runtimeType != runtimeType) {
+    if (other is! PlatformVideoViewCreationParams || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -70,30 +70,35 @@ class PlatformVideoViewCreationParams {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class CreationOptions {
-  CreationOptions({required this.uri, required this.httpHeaders});
+  CreationOptions({
+    required this.uri,
+    required this.httpHeaders,
+  });
 
   String uri;
 
   Map<String, String> httpHeaders;
 
   List<Object?> _toList() {
-    return <Object?>[uri, httpHeaders];
+    return <Object?>[
+      uri,
+      httpHeaders,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static CreationOptions decode(Object result) {
     result as List<Object?>;
     return CreationOptions(
       uri: result[0]! as String,
-      httpHeaders: (result[1] as Map<Object?, Object?>?)!
-          .cast<String, String>(),
+      httpHeaders: (result[1] as Map<Object?, Object?>?)!.cast<String, String>(),
     );
   }
 
@@ -111,23 +116,29 @@ class CreationOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class TexturePlayerIds {
-  TexturePlayerIds({required this.playerId, required this.textureId});
+  TexturePlayerIds({
+    required this.playerId,
+    required this.textureId,
+  });
 
   int playerId;
 
   int textureId;
 
   List<Object?> _toList() {
-    return <Object?>[playerId, textureId];
+    return <Object?>[
+      playerId,
+      textureId,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TexturePlayerIds decode(Object result) {
     result as List<Object?>;
@@ -151,7 +162,8 @@ class TexturePlayerIds {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// Raw audio track data from AVMediaSelectionOption (for HLS streams).
@@ -185,8 +197,7 @@ class MediaSelectionAudioTrackData {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static MediaSelectionAudioTrackData decode(Object result) {
     result as List<Object?>;
@@ -202,8 +213,7 @@ class MediaSelectionAudioTrackData {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! MediaSelectionAudioTrackData ||
-        other.runtimeType != runtimeType) {
+    if (other is! MediaSelectionAudioTrackData || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -214,8 +224,10 @@ class MediaSelectionAudioTrackData {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -224,16 +236,16 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is PlatformVideoViewCreationParams) {
+    }    else if (value is PlatformVideoViewCreationParams) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is CreationOptions) {
+    }    else if (value is CreationOptions) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is TexturePlayerIds) {
+    }    else if (value is TexturePlayerIds) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is MediaSelectionAudioTrackData) {
+    }    else if (value is MediaSelectionAudioTrackData) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
     } else {
@@ -244,13 +256,13 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129:
+      case 129: 
         return PlatformVideoViewCreationParams.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return CreationOptions.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return TexturePlayerIds.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return MediaSelectionAudioTrackData.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -262,13 +274,9 @@ class AVFoundationVideoPlayerApi {
   /// Constructor for [AVFoundationVideoPlayerApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  AVFoundationVideoPlayerApi({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  AVFoundationVideoPlayerApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -276,8 +284,7 @@ class AVFoundationVideoPlayerApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> initialize() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.initialize$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.initialize$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -299,16 +306,13 @@ class AVFoundationVideoPlayerApi {
   }
 
   Future<int> createForPlatformView(CreationOptions params) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.createForPlatformView$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.createForPlatformView$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[params],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[params]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -328,19 +332,14 @@ class AVFoundationVideoPlayerApi {
     }
   }
 
-  Future<TexturePlayerIds> createForTextureView(
-    CreationOptions creationOptions,
-  ) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.createForTextureView$pigeonVar_messageChannelSuffix';
+  Future<TexturePlayerIds> createForTextureView(CreationOptions creationOptions) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.createForTextureView$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[creationOptions],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[creationOptions]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -361,16 +360,13 @@ class AVFoundationVideoPlayerApi {
   }
 
   Future<void> setMixWithOthers(bool mixWithOthers) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.setMixWithOthers$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.setMixWithOthers$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[mixWithOthers],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[mixWithOthers]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -386,16 +382,13 @@ class AVFoundationVideoPlayerApi {
   }
 
   Future<String?> getAssetUrl(String asset, String? package) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.getAssetUrl$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.AVFoundationVideoPlayerApi.getAssetUrl$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[asset, package],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[asset, package]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -415,13 +408,9 @@ class VideoPlayerInstanceApi {
   /// Constructor for [VideoPlayerInstanceApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  VideoPlayerInstanceApi({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  VideoPlayerInstanceApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -429,16 +418,13 @@ class VideoPlayerInstanceApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> setLooping(bool looping) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setLooping$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setLooping$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[looping],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[looping]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -454,16 +440,13 @@ class VideoPlayerInstanceApi {
   }
 
   Future<void> setVolume(double volume) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setVolume$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setVolume$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[volume],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[volume]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -479,16 +462,13 @@ class VideoPlayerInstanceApi {
   }
 
   Future<void> setPlaybackSpeed(double speed) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setPlaybackSpeed$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.setPlaybackSpeed$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[speed],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[speed]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -504,8 +484,7 @@ class VideoPlayerInstanceApi {
   }
 
   Future<void> play() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.play$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.play$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -527,8 +506,7 @@ class VideoPlayerInstanceApi {
   }
 
   Future<int> getPosition() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.getPosition$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.getPosition$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -555,16 +533,13 @@ class VideoPlayerInstanceApi {
   }
 
   Future<void> seekTo(int position) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.seekTo$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.seekTo$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[position],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[position]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -580,8 +555,7 @@ class VideoPlayerInstanceApi {
   }
 
   Future<void> pause() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.pause$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.pause$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -603,8 +577,7 @@ class VideoPlayerInstanceApi {
   }
 
   Future<void> dispose() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.dispose$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.dispose$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -626,8 +599,7 @@ class VideoPlayerInstanceApi {
   }
 
   Future<List<MediaSelectionAudioTrackData>> getAudioTracks() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.getAudioTracks$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.getAudioTracks$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -649,70 +621,18 @@ class VideoPlayerInstanceApi {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (pigeonVar_replyList[0] as List<Object?>?)!
-          .cast<MediaSelectionAudioTrackData>();
+      return (pigeonVar_replyList[0] as List<Object?>?)!.cast<MediaSelectionAudioTrackData>();
     }
   }
 
   Future<void> selectAudioTrack(int trackIndex) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.selectAudioTrack$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.selectAudioTrack$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[trackIndex],
-    );
-    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
-    if (pigeonVar_replyList == null) {
-      throw _createConnectionError(pigeonVar_channelName);
-    } else if (pigeonVar_replyList.length > 1) {
-      throw PlatformException(
-        code: pigeonVar_replyList[0]! as String,
-        message: pigeonVar_replyList[1] as String?,
-        details: pigeonVar_replyList[2],
-      );
-    } else {
-      return;
-    }
-  }
-
-  /// Enables Picture-in-Picture for this player.
-  Future<void> enablePictureInPicture() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.enablePictureInPicture$pigeonVar_messageChannelSuffix';
-    final pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
-    if (pigeonVar_replyList == null) {
-      throw _createConnectionError(pigeonVar_channelName);
-    } else if (pigeonVar_replyList.length > 1) {
-      throw PlatformException(
-        code: pigeonVar_replyList[0]! as String,
-        message: pigeonVar_replyList[1] as String?,
-        details: pigeonVar_replyList[2],
-      );
-    } else {
-      return;
-    }
-  }
-
-  /// Disables Picture-in-Picture for this player.
-  Future<void> disablePictureInPicture() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.disablePictureInPicture$pigeonVar_messageChannelSuffix';
-    final pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[trackIndex]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -729,8 +649,7 @@ class VideoPlayerInstanceApi {
 
   /// Starts Picture-in-Picture playback.
   Future<void> startPictureInPicture() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.startPictureInPicture$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.startPictureInPicture$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -753,8 +672,7 @@ class VideoPlayerInstanceApi {
 
   /// Stops Picture-in-Picture playback.
   Future<void> stopPictureInPicture() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.stopPictureInPicture$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.stopPictureInPicture$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -777,8 +695,7 @@ class VideoPlayerInstanceApi {
 
   /// Returns whether Picture-in-Picture is supported on this device.
   Future<bool> isPictureInPictureSupported() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.isPictureInPictureSupported$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.isPictureInPictureSupported$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -806,8 +723,7 @@ class VideoPlayerInstanceApi {
 
   /// Returns whether Picture-in-Picture is currently active.
   Future<bool> isPictureInPictureActive() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.isPictureInPictureActive$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.video_player_avfoundation.VideoPlayerInstanceApi.isPictureInPictureActive$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -94,14 +94,6 @@ abstract class VideoPlayerInstanceApi {
   @ObjCSelector('selectAudioTrackAtIndex:')
   void selectAudioTrack(int trackIndex);
 
-  /// Enables Picture-in-Picture for this player.
-  @ObjCSelector('enablePictureInPicture')
-  void enablePictureInPicture();
-
-  /// Disables Picture-in-Picture for this player.
-  @ObjCSelector('disablePictureInPicture')
-  void disablePictureInPicture();
-
   /// Starts Picture-in-Picture playback.
   @ObjCSelector('startPictureInPicture')
   void startPictureInPicture();

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -93,4 +93,28 @@ abstract class VideoPlayerInstanceApi {
   List<MediaSelectionAudioTrackData> getAudioTracks();
   @ObjCSelector('selectAudioTrackAtIndex:')
   void selectAudioTrack(int trackIndex);
+
+  /// Enables Picture-in-Picture for this player.
+  @ObjCSelector('enablePictureInPicture')
+  void enablePictureInPicture();
+
+  /// Disables Picture-in-Picture for this player.
+  @ObjCSelector('disablePictureInPicture')
+  void disablePictureInPicture();
+
+  /// Starts Picture-in-Picture playback.
+  @ObjCSelector('startPictureInPicture')
+  void startPictureInPicture();
+
+  /// Stops Picture-in-Picture playback.
+  @ObjCSelector('stopPictureInPicture')
+  void stopPictureInPicture();
+
+  /// Returns whether Picture-in-Picture is supported on this device.
+  @ObjCSelector('isPictureInPictureSupported')
+  bool isPictureInPictureSupported();
+
+  /// Returns whether Picture-in-Picture is currently active.
+  @ObjCSelector('isPictureInPictureActive')
+  bool isPictureInPictureActive();
 }

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.9.3
+version: 2.10.0
 
 environment:
   sdk: ^3.10.0
@@ -24,7 +24,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ^6.6.0
+  video_player_platform_interface: ^6.7.0
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -690,5 +690,160 @@ void main() {
         ]),
       );
     });
+
+    group('Picture-in-Picture', () {
+      test('enablePictureInPicture', () async {
+        final (
+          AVFoundationVideoPlayer player,
+          _,
+          MockVideoPlayerInstanceApi playerApi,
+        ) = setUpMockPlayer(
+          playerId: 1,
+        );
+        await player.enablePictureInPicture(1);
+
+        verify(playerApi.enablePictureInPicture());
+      });
+
+      test('disablePictureInPicture', () async {
+        final (
+          AVFoundationVideoPlayer player,
+          _,
+          MockVideoPlayerInstanceApi playerApi,
+        ) = setUpMockPlayer(
+          playerId: 1,
+        );
+        await player.disablePictureInPicture(1);
+
+        verify(playerApi.disablePictureInPicture());
+      });
+
+      test('startPictureInPicture', () async {
+        final (
+          AVFoundationVideoPlayer player,
+          _,
+          MockVideoPlayerInstanceApi playerApi,
+        ) = setUpMockPlayer(
+          playerId: 1,
+        );
+        await player.startPictureInPicture(1);
+
+        verify(playerApi.startPictureInPicture());
+      });
+
+      test('stopPictureInPicture', () async {
+        final (
+          AVFoundationVideoPlayer player,
+          _,
+          MockVideoPlayerInstanceApi playerApi,
+        ) = setUpMockPlayer(
+          playerId: 1,
+        );
+        await player.stopPictureInPicture(1);
+
+        verify(playerApi.stopPictureInPicture());
+      });
+
+      test('isPictureInPictureSupported', () async {
+        final (
+          AVFoundationVideoPlayer player,
+          _,
+          MockVideoPlayerInstanceApi playerApi,
+        ) = setUpMockPlayer(
+          playerId: 1,
+        );
+        when(
+          playerApi.isPictureInPictureSupported(),
+        ).thenAnswer((_) async => true);
+
+        final bool result = await player.isPictureInPictureSupported(1);
+
+        expect(result, true);
+        verify(playerApi.isPictureInPictureSupported());
+      });
+
+      test('isPictureInPictureActive', () async {
+        final (
+          AVFoundationVideoPlayer player,
+          _,
+          MockVideoPlayerInstanceApi playerApi,
+        ) = setUpMockPlayer(
+          playerId: 1,
+        );
+        when(
+          playerApi.isPictureInPictureActive(),
+        ).thenAnswer((_) async => false);
+
+        final bool result = await player.isPictureInPictureActive(1);
+
+        expect(result, false);
+        verify(playerApi.isPictureInPictureActive());
+      });
+    });
+
+    test('videoEventsFor emits PiP events', () async {
+      const playerId = 1;
+      final (
+        AVFoundationVideoPlayer player,
+        MockAVFoundationVideoPlayerApi api,
+        _,
+      ) = setUpMockPlayer(
+        playerId: playerId,
+      );
+      const mockChannel = 'flutter.dev/videoPlayer/videoEvents$playerId';
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMessageHandler(mockChannel, (ByteData? message) async {
+            final MethodCall methodCall = const StandardMethodCodec()
+                .decodeMethodCall(message);
+            if (methodCall.method == 'listen') {
+              await TestDefaultBinaryMessengerBinding
+                  .instance
+                  .defaultBinaryMessenger
+                  .handlePlatformMessage(
+                    mockChannel,
+                    const StandardMethodCodec().encodeSuccessEnvelope(
+                      <String, dynamic>{'event': 'pipStarted'},
+                    ),
+                    (ByteData? data) {},
+                  );
+
+              await TestDefaultBinaryMessengerBinding
+                  .instance
+                  .defaultBinaryMessenger
+                  .handlePlatformMessage(
+                    mockChannel,
+                    const StandardMethodCodec().encodeSuccessEnvelope(
+                      <String, dynamic>{'event': 'pipStopped'},
+                    ),
+                    (ByteData? data) {},
+                  );
+
+              await TestDefaultBinaryMessengerBinding
+                  .instance
+                  .defaultBinaryMessenger
+                  .handlePlatformMessage(
+                    mockChannel,
+                    const StandardMethodCodec().encodeSuccessEnvelope(
+                      <String, dynamic>{'event': 'pipRestoreUserInterface'},
+                    ),
+                    (ByteData? data) {},
+                  );
+
+              return const StandardMethodCodec().encodeSuccessEnvelope(null);
+            } else if (methodCall.method == 'cancel') {
+              return const StandardMethodCodec().encodeSuccessEnvelope(null);
+            } else {
+              fail('Expected listen or cancel');
+            }
+          });
+      expect(
+        player.videoEventsFor(playerId),
+        emitsInOrder(<dynamic>[
+          VideoEvent(eventType: VideoEventType.pipStarted),
+          VideoEvent(eventType: VideoEventType.pipStopped),
+          VideoEvent(eventType: VideoEventType.pipRestoreUserInterface),
+        ]),
+      );
+    });
   });
 }

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -692,32 +692,6 @@ void main() {
     });
 
     group('Picture-in-Picture', () {
-      test('enablePictureInPicture', () async {
-        final (
-          AVFoundationVideoPlayer player,
-          _,
-          MockVideoPlayerInstanceApi playerApi,
-        ) = setUpMockPlayer(
-          playerId: 1,
-        );
-        await player.enablePictureInPicture(1);
-
-        verify(playerApi.enablePictureInPicture());
-      });
-
-      test('disablePictureInPicture', () async {
-        final (
-          AVFoundationVideoPlayer player,
-          _,
-          MockVideoPlayerInstanceApi playerApi,
-        ) = setUpMockPlayer(
-          playerId: 1,
-        );
-        await player.disablePictureInPicture(1);
-
-        verify(playerApi.disablePictureInPicture());
-      });
-
       test('startPictureInPicture', () async {
         final (
           AVFoundationVideoPlayer player,

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.mocks.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.mocks.dart
@@ -225,24 +225,6 @@ class MockVideoPlayerInstanceApi extends _i1.Mock
           as _i4.Future<void>);
 
   @override
-  _i4.Future<void> enablePictureInPicture() =>
-      (super.noSuchMethod(
-            Invocation.method(#enablePictureInPicture, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
-
-  @override
-  _i4.Future<void> disablePictureInPicture() =>
-      (super.noSuchMethod(
-            Invocation.method(#disablePictureInPicture, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
-
-  @override
   _i4.Future<void> startPictureInPicture() =>
       (super.noSuchMethod(
             Invocation.method(#startPictureInPicture, []),

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.mocks.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.mocks.dart
@@ -22,6 +22,7 @@ import 'package:video_player_avfoundation/src/messages.g.dart' as _i2;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeTexturePlayerIds_0 extends _i1.SmartFake
     implements _i2.TexturePlayerIds {
@@ -198,4 +199,82 @@ class MockVideoPlayerInstanceApi extends _i1.Mock
             returnValueForMissingStub: _i4.Future<void>.value(),
           )
           as _i4.Future<void>);
+
+  @override
+  _i4.Future<List<_i2.MediaSelectionAudioTrackData>> getAudioTracks() =>
+      (super.noSuchMethod(
+            Invocation.method(#getAudioTracks, []),
+            returnValue:
+                _i4.Future<List<_i2.MediaSelectionAudioTrackData>>.value(
+                  <_i2.MediaSelectionAudioTrackData>[],
+                ),
+            returnValueForMissingStub:
+                _i4.Future<List<_i2.MediaSelectionAudioTrackData>>.value(
+                  <_i2.MediaSelectionAudioTrackData>[],
+                ),
+          )
+          as _i4.Future<List<_i2.MediaSelectionAudioTrackData>>);
+
+  @override
+  _i4.Future<void> selectAudioTrack(int? trackIndex) =>
+      (super.noSuchMethod(
+            Invocation.method(#selectAudioTrack, [trackIndex]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> enablePictureInPicture() =>
+      (super.noSuchMethod(
+            Invocation.method(#enablePictureInPicture, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> disablePictureInPicture() =>
+      (super.noSuchMethod(
+            Invocation.method(#disablePictureInPicture, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> startPictureInPicture() =>
+      (super.noSuchMethod(
+            Invocation.method(#startPictureInPicture, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> stopPictureInPicture() =>
+      (super.noSuchMethod(
+            Invocation.method(#stopPictureInPicture, []),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
+  _i4.Future<bool> isPictureInPictureSupported() =>
+      (super.noSuchMethod(
+            Invocation.method(#isPictureInPictureSupported, []),
+            returnValue: _i4.Future<bool>.value(false),
+            returnValueForMissingStub: _i4.Future<bool>.value(false),
+          )
+          as _i4.Future<bool>);
+
+  @override
+  _i4.Future<bool> isPictureInPictureActive() =>
+      (super.noSuchMethod(
+            Invocation.method(#isPictureInPictureActive, []),
+            returnValue: _i4.Future<bool>.value(false),
+            returnValueForMissingStub: _i4.Future<bool>.value(false),
+          )
+          as _i4.Future<bool>);
 }

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.7.0
 
 * Updates minimum supported SDK version to Flutter 3.35/Dart 3.9.
-* Adds `enablePictureInPicture()`, `disablePictureInPicture()`, `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods for Picture-in-Picture support.
+* Adds `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods for Picture-in-Picture support.
 * Adds `pipStarted`, `pipStopped`, and `pipRestoreUserInterface` event types to `VideoEventType`.
 
 ## 6.6.0

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,6 +1,8 @@
-## NEXT
+## 6.7.0
 
 * Updates minimum supported SDK version to Flutter 3.35/Dart 3.9.
+* Adds `enablePictureInPicture()`, `disablePictureInPicture()`, `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods for Picture-in-Picture support.
+* Adds `pipStarted`, `pipStopped`, and `pipRestoreUserInterface` event types to `VideoEventType`.
 
 ## 6.6.0
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -154,20 +154,6 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
     return false;
   }
 
-  /// Enables Picture-in-Picture for the given player.
-  Future<void> enablePictureInPicture(int playerId) {
-    throw UnimplementedError(
-      'enablePictureInPicture() has not been implemented.',
-    );
-  }
-
-  /// Disables Picture-in-Picture for the given player.
-  Future<void> disablePictureInPicture(int playerId) {
-    throw UnimplementedError(
-      'disablePictureInPicture() has not been implemented.',
-    );
-  }
-
   /// Starts Picture-in-Picture mode for the given player.
   Future<void> startPictureInPicture(int playerId) {
     throw UnimplementedError(

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -153,6 +153,48 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   bool isAudioTrackSupportAvailable() {
     return false;
   }
+
+  /// Enables Picture-in-Picture for the given player.
+  Future<void> enablePictureInPicture(int playerId) {
+    throw UnimplementedError(
+      'enablePictureInPicture() has not been implemented.',
+    );
+  }
+
+  /// Disables Picture-in-Picture for the given player.
+  Future<void> disablePictureInPicture(int playerId) {
+    throw UnimplementedError(
+      'disablePictureInPicture() has not been implemented.',
+    );
+  }
+
+  /// Starts Picture-in-Picture mode for the given player.
+  Future<void> startPictureInPicture(int playerId) {
+    throw UnimplementedError(
+      'startPictureInPicture() has not been implemented.',
+    );
+  }
+
+  /// Stops Picture-in-Picture mode for the given player.
+  Future<void> stopPictureInPicture(int playerId) {
+    throw UnimplementedError(
+      'stopPictureInPicture() has not been implemented.',
+    );
+  }
+
+  /// Returns whether Picture-in-Picture is supported on this device.
+  Future<bool> isPictureInPictureSupported(int playerId) {
+    throw UnimplementedError(
+      'isPictureInPictureSupported() has not been implemented.',
+    );
+  }
+
+  /// Returns whether Picture-in-Picture is currently active for the given player.
+  Future<bool> isPictureInPictureActive(int playerId) {
+    throw UnimplementedError(
+      'isPictureInPictureActive() has not been implemented.',
+    );
+  }
 }
 
 class _PlaceholderImplementation extends VideoPlayerPlatform {}
@@ -354,6 +396,15 @@ enum VideoEventType {
   /// This event is fired when the video starts or pauses due to user actions or
   /// phone calls, or other app media such as music players.
   isPlayingStateUpdate,
+
+  /// Picture-in-Picture playback started.
+  pipStarted,
+
+  /// Picture-in-Picture playback stopped.
+  pipStopped,
+
+  /// The user tapped the restore button in the PiP window to return to the app.
+  pipRestoreUserInterface,
 
   /// An unknown event has been received.
   unknown,

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/video_player/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.6.0
+version: 6.7.0
 
 environment:
   sdk: ^3.9.0

--- a/packages/video_player/video_player_platform_interface/test/video_player_platform_interface_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/video_player_platform_interface_test.dart
@@ -42,26 +42,6 @@ void main() {
   });
 
   test(
-    'default implementation enablePictureInPicture throws unimplemented',
-    () async {
-      await expectLater(
-        () => initialInstance.enablePictureInPicture(1),
-        throwsUnimplementedError,
-      );
-    },
-  );
-
-  test(
-    'default implementation disablePictureInPicture throws unimplemented',
-    () async {
-      await expectLater(
-        () => initialInstance.disablePictureInPicture(1),
-        throwsUnimplementedError,
-      );
-    },
-  );
-
-  test(
     'default implementation startPictureInPicture throws unimplemented',
     () async {
       await expectLater(

--- a/packages/video_player/video_player_platform_interface/test/video_player_platform_interface_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/video_player_platform_interface_test.dart
@@ -40,4 +40,64 @@ void main() {
   test('default implementation isAudioTrackSupportAvailable returns false', () {
     expect(initialInstance.isAudioTrackSupportAvailable(), false);
   });
+
+  test(
+    'default implementation enablePictureInPicture throws unimplemented',
+    () async {
+      await expectLater(
+        () => initialInstance.enablePictureInPicture(1),
+        throwsUnimplementedError,
+      );
+    },
+  );
+
+  test(
+    'default implementation disablePictureInPicture throws unimplemented',
+    () async {
+      await expectLater(
+        () => initialInstance.disablePictureInPicture(1),
+        throwsUnimplementedError,
+      );
+    },
+  );
+
+  test(
+    'default implementation startPictureInPicture throws unimplemented',
+    () async {
+      await expectLater(
+        () => initialInstance.startPictureInPicture(1),
+        throwsUnimplementedError,
+      );
+    },
+  );
+
+  test(
+    'default implementation stopPictureInPicture throws unimplemented',
+    () async {
+      await expectLater(
+        () => initialInstance.stopPictureInPicture(1),
+        throwsUnimplementedError,
+      );
+    },
+  );
+
+  test(
+    'default implementation isPictureInPictureSupported throws unimplemented',
+    () async {
+      await expectLater(
+        () => initialInstance.isPictureInPictureSupported(1),
+        throwsUnimplementedError,
+      );
+    },
+  );
+
+  test(
+    'default implementation isPictureInPictureActive throws unimplemented',
+    () async {
+      await expectLater(
+        () => initialInstance.isPictureInPictureActive(1),
+        throwsUnimplementedError,
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Description

Adds Picture-in-Picture (PiP) support for iOS to the video_player plugin across three packages.

Fixes https://github.com/flutter/flutter/issues/60048

### video_player_platform_interface (6.6.0 → 6.7.0)
- Add `enablePictureInPicture()`, `disablePictureInPicture()`, `startPictureInPicture()`, `stopPictureInPicture()`, `isPictureInPictureSupported()`, and `isPictureInPictureActive()` methods
- Add `pipStarted`, `pipStopped`, `pipRestoreUserInterface` event types to `VideoEventType`

### video_player_avfoundation (2.9.3 → 2.10.0)
- Integrate `AVPictureInPictureController` with `AVPlayerLayer`
- Support both texture-based and platform view players
- Implement PiP delegate callbacks (start/stop/restore UI)
- Add float-up animation workaround for texture-based players
- macOS returns stub implementations (PiP not supported on macOS)
- Requires iOS 14.2+

### video_player (2.11.0 → 2.12.0)
- Add `isPictureInPictureActive` field to `VideoPlayerValue`
- Add PiP methods to `VideoPlayerController`
- Handle `pipStarted`, `pipStopped`, `pipRestoreUserInterface` events

### Example app
- Add PiP demo controls to avfoundation example

## Test plan
- [x] Unit tests for all PiP platform interface methods (platform_interface)
- [x] Unit tests for all PiP Pigeon API calls (avfoundation)
- [x] Unit tests for PiP event conversion (avfoundation)
- [x] Unit tests for PiP methods on `VideoPlayerController` (video_player)
- [x] Unit tests for `VideoPlayerValue.isPictureInPictureActive` state updates (video_player)
- [x] Unit tests for PiP methods before initialization throw `StateError` (video_player)
- [ ] Manual test: PiP enable/disable on iOS device
- [ ] Manual test: PiP start/stop on iOS device
- [ ] Manual test: PiP events fire correctly

> **Note**: PiP requires `AVPictureInPictureController` which is only available on real iOS devices (iOS 14.2+). Native XCTest unit tests are not included as PiP functionality cannot be tested in the simulator.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[video_player]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under[^1].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: See the [docs on contributing](https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#version-and-changelog-updates) for details.