### PR TITLE
[image_picker] Add videoQuality parameter - platform_interface

### DIFF
--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -281,6 +281,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     required ImageSource source,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
     Duration? maxDuration,
+    VideoQuality quality = VideoQuality.high,
   }) async {
     final String? path = await _getVideoPath(
       source: source,

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -241,6 +241,8 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.
   /// Defaults to [CameraDevice.rear].
   ///
+  /// The [quality] argument specifies the video quality for recording/picking. Defaults to [VideoQuality.high].
+  ///
   /// In Android, the MainActivity can be destroyed for various reasons. If that happens, the result will be lost
   /// in this call. You can then call [getLostData] when your app relaunches to retrieve the lost data.
   ///
@@ -249,6 +251,7 @@ abstract class ImagePickerPlatform extends PlatformInterface {
     required ImageSource source,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
     Duration? maxDuration,
+    VideoQuality quality = VideoQuality.high,
   }) {
     throw UnimplementedError('getVideo() has not been implemented.');
   }
@@ -390,6 +393,7 @@ abstract class CameraDelegatingImagePickerPlatform extends ImagePickerPlatform {
     required ImageSource source,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
     Duration? maxDuration,
+    VideoQuality quality = VideoQuality.high,
   }) async {
     if (source == ImageSource.camera) {
       final ImagePickerCameraDelegate? delegate = cameraDelegate;
@@ -410,6 +414,7 @@ abstract class CameraDelegatingImagePickerPlatform extends ImagePickerPlatform {
       source: source,
       preferredCameraDevice: preferredCameraDevice,
       maxDuration: maxDuration,
+      quality: quality,
     );
   }
 }

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/types.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/types.dart
@@ -13,6 +13,7 @@ export 'multi_image_picker_options.dart';
 export 'multi_video_picker_options.dart';
 export 'picked_file/picked_file.dart';
 export 'retrieve_type.dart';
+export 'video_quality.dart';
 
 /// Denotes that an image is being picked.
 const String kTypeImage = 'image';

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/video_quality.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/video_quality.dart
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Video quality setting for video recording/picking.
+///
+/// This enum corresponds to `UIImagePickerControllerQualityType` on iOS.
+enum VideoQuality {
+  /// Low quality video.
+  ///
+  /// Corresponds to `UIImagePickerControllerQualityTypeLow` on iOS.
+  low,
+
+  /// Medium quality video.
+  ///
+  /// Corresponds to `UIImagePickerControllerQualityTypeMedium` on iOS.
+  medium,
+
+  /// High quality video.
+  ///
+  /// Corresponds to `UIImagePickerControllerQualityTypeHigh` on iOS.
+  /// This is the default quality setting.
+  high,
+}


### PR DESCRIPTION
## Description
Adds `VideoQuality` enum and an optional `quality` parameter to `getVideo` 
in the platform interface, so callers can choose low, medium, or high quality 
when recording or picking video. Defaults to high quality for backward compatibility.

Part 1 of 3 for flutter/flutter#179940

## Related PRs
- PR 2 (platform implementations): https://github.com/flutter/packages/pull/11145
- PR 3 (app-facing package): https://github.com/flutter/packages/pull/11146

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.