### PR TITLE
[video_player] Add adaptive bitrate streaming support

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.12.0
+
+* Adds `setBandwidthLimit` method for adaptive bitrate streaming control.
+* Adds internal `AdaptiveBitrateManager` for automatic quality adjustment based on buffering events.
+
 ## 2.11.1
 
 * Optimizes caption retrieval with binary search.

--- a/packages/video_player/video_player/lib/src/adaptive_bitrate_manager.dart
+++ b/packages/video_player/video_player/lib/src/adaptive_bitrate_manager.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+/// Manages adaptive bitrate selection for HLS/DASH streaming.
+///
+/// Monitors buffering events and adjusts the maximum bandwidth limit
+/// to help the native player select appropriate quality variants.
+///
+/// This acts as a supervisory controller on top of the native player's
+/// own ABR logic (ExoPlayer's [AdaptiveTrackSelection] on Android,
+/// AVFoundation on iOS). It forces quality down via [setBandwidthLimit]
+/// when persistent buffering is detected, and relaxes the limit when
+/// playback stabilizes.
+class AdaptiveBitrateManager {
+  /// Creates an [AdaptiveBitrateManager] for the given [playerId].
+  ///
+  /// The optional [clock] parameter is exposed for testing and defaults
+  /// to [DateTime.now].
+  AdaptiveBitrateManager({
+    required this.playerId,
+    required VideoPlayerPlatform platform,
+    @visibleForTesting DateTime Function()? clock,
+  }) : _platform = platform,
+       _clock = clock ?? DateTime.now;
+
+  /// The player ID this manager controls.
+  final int playerId;
+  final VideoPlayerPlatform _platform;
+  final DateTime Function() _clock;
+
+  Timer? _monitoringTimer;
+  int _bufferingCount = 0;
+  int _currentBandwidthLimit = qualityUnlimited;
+  late DateTime _lastQualityChange = _clock();
+  bool _isMonitoring = false;
+
+  /// Bandwidth cap for 360p quality (~500 kbps).
+  static const int quality360p = 500000;
+
+  /// Bandwidth cap for 480p quality (~800 kbps).
+  static const int quality480p = 800000;
+
+  /// Bandwidth cap for 720p quality (~1.2 Mbps).
+  static const int quality720p = 1200000;
+
+  /// Bandwidth cap for 1080p quality (~2.5 Mbps).
+  static const int quality1080p = 2500000;
+
+  /// No bandwidth limit — lets the native player choose freely.
+  static const int qualityUnlimited = 0;
+
+  static const Duration _monitorInterval = Duration(seconds: 3);
+  static const Duration _qualityChangeCooldown = Duration(seconds: 5);
+
+  /// Buffering count decay factor applied each monitoring cycle.
+  ///
+  /// This allows recovery to higher quality after transient buffering.
+  static const double _bufferingDecayFactor = 0.7;
+
+  /// Starts automatic quality monitoring and adjustment.
+  ///
+  /// Removes any existing bandwidth limit and begins periodic analysis.
+  /// Safe to call multiple times — subsequent calls are no-ops.
+  Future<void> startAutoAdaptiveQuality() async {
+    if (_isMonitoring) {
+      return;
+    }
+    _isMonitoring = true;
+
+    try {
+      await _platform.setBandwidthLimit(playerId, qualityUnlimited);
+    } catch (e) {
+      _isMonitoring = false;
+      return;
+    }
+
+    _monitoringTimer = Timer.periodic(_monitorInterval, (_) {
+      _analyzeAndAdjust();
+    });
+  }
+
+  /// Records a buffering event from the player.
+  ///
+  /// Called by [VideoPlayerController] when a [bufferingStart] event occurs.
+  void recordBufferingEvent() {
+    if (_isMonitoring) {
+      _bufferingCount++;
+    }
+  }
+
+  /// Analyzes recent buffering history and adjusts the bandwidth limit.
+  Future<void> _analyzeAndAdjust() async {
+    if (_clock().difference(_lastQualityChange) < _qualityChangeCooldown) {
+      return;
+    }
+
+    final int newLimit = _selectOptimalBandwidth();
+
+    // Apply decay so transient buffering doesn't permanently pin quality low.
+    _bufferingCount = (_bufferingCount * _bufferingDecayFactor).floor();
+
+    if (newLimit != _currentBandwidthLimit) {
+      try {
+        await _platform.setBandwidthLimit(playerId, newLimit);
+        _currentBandwidthLimit = newLimit;
+        _lastQualityChange = _clock();
+      } catch (e) {
+        // Silently ignore errors during auto-adjustment.
+      }
+    }
+  }
+
+  /// Selects optimal bandwidth based on recent buffering frequency.
+  int _selectOptimalBandwidth() {
+    if (_bufferingCount > 5) {
+      return quality360p;
+    }
+    if (_bufferingCount > 3) {
+      return quality480p;
+    }
+    if (_bufferingCount > 1) {
+      return quality720p;
+    }
+    if (_bufferingCount > 0) {
+      return quality1080p;
+    }
+    return qualityUnlimited;
+  }
+
+  /// Stops monitoring and releases resources.
+  void dispose() {
+    _isMonitoring = false;
+    _monitoringTimer?.cancel();
+    _monitoringTimer = null;
+  }
+}

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -13,6 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart'
     as platform_interface;
 
+import 'src/adaptive_bitrate_manager.dart';
 import 'src/closed_caption_file.dart';
 
 export 'package:video_player_platform_interface/video_player_platform_interface.dart'
@@ -524,6 +525,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   Completer<void>? _creatingCompleter;
   StreamSubscription<dynamic>? _eventSubscription;
   _VideoAppLifeCycleObserver? _lifeCycleObserver;
+  AdaptiveBitrateManager? _adaptiveBitrateManager;
 
   /// The id of a player that hasn't been initialized.
   @visibleForTesting
@@ -588,6 +590,17 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         (await _videoPlayerPlatform.createWithOptions(creationOptions)) ??
         kUninitializedPlayerId;
     _creatingCompleter!.complete(null);
+
+    // Enable adaptive bitrate management only for network streams
+    // (local files and assets don't use HLS/DASH adaptive streaming).
+    if (dataSourceType == platform_interface.DataSourceType.network) {
+      _adaptiveBitrateManager = AdaptiveBitrateManager(
+        playerId: _playerId,
+        platform: _videoPlayerPlatform,
+      );
+      await _adaptiveBitrateManager!.startAutoAdaptiveQuality();
+    }
+
     final initializingCompleter = Completer<void>();
 
     // Apply the web-specific options
@@ -638,6 +651,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           value = value.copyWith(buffered: event.buffered);
         case platform_interface.VideoEventType.bufferingStart:
           value = value.copyWith(isBuffering: true);
+          _adaptiveBitrateManager?.recordBufferingEvent();
         case platform_interface.VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
         case platform_interface.VideoEventType.isPlayingStateUpdate:
@@ -684,6 +698,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       if (!_isDisposed) {
         _isDisposed = true;
         _timer?.cancel();
+        _adaptiveBitrateManager?.dispose();
         await _eventSubscription?.cancel();
         await _videoPlayerPlatform.dispose(_playerId);
       }
@@ -848,6 +863,44 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
     value = value.copyWith(playbackSpeed: speed);
     await _applyPlaybackSpeed();
+  }
+
+  /// Sets the bandwidth limit for HLS adaptive bitrate streaming.
+  ///
+  /// This method limits the maximum bandwidth used for video playback,
+  /// which affects which HLS variant streams the player can select.
+  ///
+  /// The native player will only select video variants with bitrate
+  /// less than or equal to the specified [maxBandwidthBps].
+  ///
+  /// Platforms:
+  /// - **Android**: Uses ExoPlayer's DefaultTrackSelector.setMaxVideoBitrate()
+  /// - **iOS/macOS**: Uses AVPlayer's preferredPeakBitRate property
+  /// - **Web**: Not supported (no-op)
+  ///
+  /// Parameters:
+  /// - [maxBandwidthBps]: Maximum bandwidth in bits per second.
+  ///   * 0 or negative: No limit (player auto-selects)
+  ///   * Positive value: Player selects variants ≤ this bandwidth
+  ///
+  /// Example:
+  /// ```dart
+  /// // Limit to 720p quality (~1.2 Mbps)
+  /// await controller.setBandwidthLimit(1200000);
+  ///
+  /// // No limit - let player decide
+  /// await controller.setBandwidthLimit(0);
+  /// ```
+  ///
+  /// Note: This is useful for HLS streams where you want to control
+  /// quality selection without reinitializing the player. The player
+  /// will seamlessly switch to appropriate variants as bandwidth
+  /// changes within the limit.
+  Future<void> setBandwidthLimit(int maxBandwidthBps) async {
+    if (_isDisposedOrNotInitialized) {
+      return;
+    }
+    await _videoPlayerPlatform.setBandwidthLimit(_playerId, maxBandwidthBps);
   }
 
   /// Sets the caption offset.

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, macOS and web.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.11.1
+version: 2.12.0
 
 environment:
   sdk: ^3.10.0
@@ -26,12 +26,13 @@ dependencies:
   flutter:
     sdk: flutter
   html: ^0.15.0
-  video_player_android: ^2.9.1
-  video_player_avfoundation: ^2.9.0
-  video_player_platform_interface: ^6.6.0
+  video_player_android: ^2.10.0
+  video_player_avfoundation: ^2.10.0
+  video_player_platform_interface: ^6.7.0
   video_player_web: ^2.1.0
 
 dev_dependencies:
+  fake_async: ^1.3.0
   flutter_test:
     sdk: flutter
   leak_tracker_flutter_testing: any

--- a/packages/video_player/video_player/test/adaptive_bitrate_manager_test.dart
+++ b/packages/video_player/video_player/test/adaptive_bitrate_manager_test.dart
@@ -1,0 +1,402 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/src/adaptive_bitrate_manager.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+void main() {
+  group('AdaptiveBitrateManager', () {
+    late _FakePlatform platform;
+    const playerId = 42;
+
+    setUp(() {
+      platform = _FakePlatform();
+    });
+
+    AdaptiveBitrateManager createManager(FakeAsync fakeAsync) {
+      return AdaptiveBitrateManager(
+        playerId: playerId,
+        platform: platform,
+        clock: () => fakeAsync.getClock(DateTime(2024)).now(),
+      );
+    }
+
+    test('startAutoAdaptiveQuality sets unlimited bandwidth initially', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        expect(
+          platform.bandwidthLimits[playerId],
+          AdaptiveBitrateManager.qualityUnlimited,
+        );
+        expect(platform.setBandwidthCalls, 1);
+
+        manager.dispose();
+      });
+    });
+
+    test('startAutoAdaptiveQuality is idempotent', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        // Only one setBandwidthLimit call — second start is a no-op.
+        expect(platform.setBandwidthCalls, 1);
+
+        manager.dispose();
+      });
+    });
+
+    test('recordBufferingEvent is ignored when not monitoring', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        // Record events before monitoring starts.
+        manager.recordBufferingEvent();
+        manager.recordBufferingEvent();
+
+        // Start monitoring and wait for analysis.
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 10));
+        async.flushMicrotasks();
+
+        // Only the initial unlimited call — no step-down since events were
+        // recorded before monitoring started.
+        expect(
+          platform.bandwidthLimits[playerId],
+          AdaptiveBitrateManager.qualityUnlimited,
+        );
+
+        manager.dispose();
+      });
+    });
+
+    test('single buffering event steps down to 1080p', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        // Advance past cooldown.
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        // Record one buffering event.
+        manager.recordBufferingEvent();
+
+        // Advance to next monitoring tick (3 seconds).
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+
+        expect(
+          platform.bandwidthLimits[playerId],
+          AdaptiveBitrateManager.quality1080p,
+        );
+
+        manager.dispose();
+      });
+    });
+
+    test('two buffering events step down to 720p', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        manager.recordBufferingEvent();
+        manager.recordBufferingEvent();
+
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+
+        expect(
+          platform.bandwidthLimits[playerId],
+          AdaptiveBitrateManager.quality720p,
+        );
+
+        manager.dispose();
+      });
+    });
+
+    test('four buffering events step down to 480p', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        for (var i = 0; i < 4; i++) {
+          manager.recordBufferingEvent();
+        }
+
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+
+        expect(
+          platform.bandwidthLimits[playerId],
+          AdaptiveBitrateManager.quality480p,
+        );
+
+        manager.dispose();
+      });
+    });
+
+    test('six buffering events step down to 360p', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        for (var i = 0; i < 6; i++) {
+          manager.recordBufferingEvent();
+        }
+
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+
+        expect(
+          platform.bandwidthLimits[playerId],
+          AdaptiveBitrateManager.quality360p,
+        );
+
+        manager.dispose();
+      });
+    });
+
+    test('cooldown prevents rapid quality changes', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        // Advance past initial cooldown and record events.
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        manager.recordBufferingEvent();
+
+        // First analysis fires → steps down to 1080p.
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+        expect(
+          platform.bandwidthLimits[playerId],
+          AdaptiveBitrateManager.quality1080p,
+        );
+        final int callsAfterFirstChange = platform.setBandwidthCalls;
+
+        // Record more events.
+        manager.recordBufferingEvent();
+        manager.recordBufferingEvent();
+
+        // Next tick is within cooldown — should NOT change bandwidth.
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+        expect(platform.setBandwidthCalls, callsAfterFirstChange);
+
+        manager.dispose();
+      });
+    });
+
+    test('quality recovers after buffering decays', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        // Advance past cooldown.
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        // Cause heavy buffering → 360p.
+        for (var i = 0; i < 6; i++) {
+          manager.recordBufferingEvent();
+        }
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+        expect(
+          platform.bandwidthLimits[playerId],
+          AdaptiveBitrateManager.quality360p,
+        );
+
+        // Let decay run with no new events. Each cycle multiplies by 0.7:
+        // 6→4 (after first analysis above), then 4→2, then 2→1, then 1→0
+        // We need multiple cycles past the cooldown for the quality to recover.
+        // Advance past cooldown (5s) + multiple monitoring intervals.
+        async.elapse(const Duration(seconds: 30));
+        async.flushMicrotasks();
+
+        // After enough decay cycles with no new buffering events,
+        // the quality should have recovered toward unlimited.
+        final int? finalLimit = platform.bandwidthLimits[playerId];
+        expect(
+          finalLimit == AdaptiveBitrateManager.qualityUnlimited ||
+              finalLimit == AdaptiveBitrateManager.quality1080p ||
+              finalLimit == AdaptiveBitrateManager.quality720p,
+          isTrue,
+          reason:
+              'Quality should recover after buffering decays, '
+              'got limit: $finalLimit',
+        );
+
+        manager.dispose();
+      });
+    });
+
+    test('dispose stops the monitoring timer', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+        final int callsBeforeDispose = platform.setBandwidthCalls;
+
+        manager.dispose();
+
+        // Record events and advance time — nothing should fire.
+        manager.recordBufferingEvent();
+        async.elapse(const Duration(seconds: 60));
+        async.flushMicrotasks();
+
+        expect(platform.setBandwidthCalls, callsBeforeDispose);
+      });
+    });
+
+    test('platform error during start prevents monitoring', () {
+      fakeAsync((FakeAsync async) {
+        platform.failOnSetBandwidth = true;
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        // Record events and advance time — nothing should fire since
+        // monitoring failed to start.
+        manager.recordBufferingEvent();
+        async.elapse(const Duration(seconds: 10));
+        async.flushMicrotasks();
+
+        // Only the one failed call, no subsequent calls.
+        expect(platform.setBandwidthCalls, 1);
+
+        manager.dispose();
+      });
+    });
+
+    test('platform error during adjustment is silently ignored', () {
+      fakeAsync((FakeAsync async) {
+        final AdaptiveBitrateManager manager = createManager(async);
+
+        manager.startAutoAdaptiveQuality();
+        async.flushMicrotasks();
+
+        // Advance past cooldown.
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        // Now make future calls fail.
+        platform.failOnSetBandwidth = true;
+
+        manager.recordBufferingEvent();
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+
+        // Should not throw — error is silently caught.
+        // The bandwidth limit in the platform won't be updated since it threw,
+        // but monitoring continues.
+        manager.dispose();
+      });
+    });
+
+    test('quality thresholds are correct constants', () {
+      expect(AdaptiveBitrateManager.quality360p, 500000);
+      expect(AdaptiveBitrateManager.quality480p, 800000);
+      expect(AdaptiveBitrateManager.quality720p, 1200000);
+      expect(AdaptiveBitrateManager.quality1080p, 2500000);
+      expect(AdaptiveBitrateManager.qualityUnlimited, 0);
+    });
+  });
+}
+
+/// Minimal fake platform that only implements [setBandwidthLimit].
+class _FakePlatform extends VideoPlayerPlatform {
+  final Map<int, int> bandwidthLimits = <int, int>{};
+  int setBandwidthCalls = 0;
+  bool failOnSetBandwidth = false;
+
+  @override
+  Future<void> setBandwidthLimit(int playerId, int maxBandwidthBps) async {
+    setBandwidthCalls++;
+    if (failOnSetBandwidth) {
+      throw Exception('setBandwidthLimit failed');
+    }
+    bandwidthLimits[playerId] = maxBandwidthBps;
+  }
+
+  // -- Unused stubs required by VideoPlayerPlatform. --
+
+  @override
+  Future<int?> create(DataSource dataSource) async => 0;
+
+  @override
+  Future<void> dispose(int playerId) async {}
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Stream<VideoEvent> videoEventsFor(int playerId) =>
+      const Stream<VideoEvent>.empty();
+
+  @override
+  Future<void> pause(int playerId) async {}
+
+  @override
+  Future<void> play(int playerId) async {}
+
+  @override
+  Future<Duration> getPosition(int playerId) async => Duration.zero;
+
+  @override
+  Future<void> seekTo(int playerId, Duration position) async {}
+
+  @override
+  Future<void> setLooping(int playerId, bool looping) async {}
+
+  @override
+  Future<void> setVolume(int playerId, double volume) async {}
+
+  @override
+  Future<void> setPlaybackSpeed(int playerId, double speed) async {}
+
+  @override
+  Future<void> setMixWithOthers(bool mixWithOthers) async {}
+
+  @override
+  Widget buildView(int playerId) => const SizedBox.shrink();
+}

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -130,6 +130,9 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
     return true;
   }
 
+  @override
+  Future<void> setBandwidthLimit(int maxBandwidthBps) async {}
+
   String? selectedAudioTrackId;
 }
 
@@ -1103,6 +1106,34 @@ void main() {
         expect(track.sampleRate, null);
         expect(track.channelCount, null);
         expect(track.codec, null);
+      });
+    });
+
+    group('setBandwidthLimit', () {
+      test('delegates to platform', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+        await controller.initialize();
+
+        await controller.setBandwidthLimit(5000000);
+
+        expect(fakeVideoPlayerPlatform.calls, contains('setBandwidthLimit'));
+        expect(
+          fakeVideoPlayerPlatform.bandwidthLimits[controller.playerId],
+          5000000,
+        );
+      });
+
+      test('does nothing when not initialized', () async {
+        final controller = VideoPlayerController.networkUrl(_localhostUri);
+        addTearDown(controller.dispose);
+
+        await controller.setBandwidthLimit(5000000);
+
+        expect(
+          fakeVideoPlayerPlatform.calls,
+          isNot(contains('setBandwidthLimit')),
+        );
       });
     });
 
@@ -2289,4 +2320,18 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   }
 
   final Map<int, String> selectedAudioTrackIds = <int, String>{};
+
+  @override
+  Future<void> setBandwidthLimit(int playerId, int maxBandwidthBps) async {
+    calls.add('setBandwidthLimit');
+    bandwidthLimits[playerId] = maxBandwidthBps;
+  }
+
+  @override
+  bool isBandwidthLimitSupportAvailable() {
+    calls.add('isBandwidthLimitSupportAvailable');
+    return true;
+  }
+
+  final Map<int, int> bandwidthLimits = <int, int>{};
 }


### PR DESCRIPTION
Adds adaptive bitrate streaming (ABR) support to the app-facing `video_player` package.

### Changes

- **`setBandwidthLimit(int maxBandwidthBps)`** on `VideoPlayerController` — Exposes manual quality control for HLS/DASH streams. Delegates to the platform interface.
- **`AdaptiveBitrateManager`** (internal) — Automatically adjusts streaming quality based on buffering events:
  - Monitors buffering on a **3-second interval**
  - Steps down quality as buffering increases: unlimited → 1080p (2.5 Mbps) → 720p (1.2 Mbps) → 480p (800 kbps) → 360p (500 kbps)
  - **0.7x decay** per cycle — buffering count decays so quality recovers when conditions improve
  - **5-second cooldown** between quality changes to prevent oscillation
  - Only activates for **network data sources** (not file/asset/contentUri)

### Design

The `AdaptiveBitrateManager` is a supervisory layer on top of the native player's own ABR. Native ABR (ExoPlayer/AVFoundation) handles buffer and bandwidth estimation at the segment level. The Dart-level manager provides a coarser, user-experience-oriented response to sustained buffering by capping the maximum selectable bitrate. This two-tier approach ensures both fine-grained adaptation and protection against persistent poor conditions.

**Design doc:** https://docs.google.com/document/d/1g3RSytVLgWtheZO1ZFKvSfpFjh2_GstLv4SIwJMmYdw/edit?usp=sharing

**Versioned as 2.12.0** — minor version bump. Requires `video_player_platform_interface ^6.7.0`, `video_player_android ^2.10.0`, `video_player_avfoundation ^2.10.0`.

Depends on all three preceding PRs:
- PR #11322 (`video_player_platform_interface`)
- PR #11323 (`video_player_android`)
- PR #11324 (`video_player_avfoundation`)

Fixes flutter/flutter#183941

**AI Disclosure:** This PR was developed with assistance from AI tools (GitHub Copilot / Claude). All code has been reviewed, tested, and validated by the author.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
