### PR TITLE
camera_android_camerax: Write exposure time to EXIF when missing

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1+1
+
+* Writes exposure time to EXIF metadata when the device's JPEG encoder omits it. Uses Camera2 interop to capture `SENSOR_EXPOSURE_TIME` and patches EXIF after CameraX saves the file.
+
 ## 0.7.1
 
 * Removes outdated restrictions against concurrent camera use cases.

--- a/packages/camera/camera_android_camerax/android/build.gradle
+++ b/packages/camera/camera_android_camerax/android/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation("androidx.camera:camera-lifecycle:${camerax_version}")
     implementation("androidx.camera:camera-video:${camerax_version}")
     implementation("com.google.guava:guava:33.5.0-android")
+    implementation("androidx.exifinterface:exifinterface:1.3.7")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.mockito:mockito-inline:5.2.0")

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/ImageCaptureProxyApi.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/ImageCaptureProxyApi.java
@@ -4,14 +4,25 @@
 
 package io.flutter.plugins.camerax;
 
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.CaptureResult;
+import android.hardware.camera2.TotalCaptureResult;
+import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.OptIn;
+import androidx.annotation.VisibleForTesting;
+import androidx.camera.camera2.interop.Camera2Interop;
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop;
 import androidx.camera.core.ImageCapture;
 import androidx.camera.core.ImageCaptureException;
 import androidx.camera.core.resolutionselector.ResolutionSelector;
+import androidx.exifinterface.media.ExifInterface;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import kotlin.Result;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
@@ -22,8 +33,13 @@ import kotlin.jvm.functions.Function1;
  * native class or an instance of that class.
  */
 class ImageCaptureProxyApi extends PigeonApiImageCapture {
+  private static final String TAG = "ImageCaptureProxyApi";
+
   static final String TEMPORARY_FILE_NAME = "CAP";
   static final String JPG_FILE_TYPE = ".jpg";
+
+  @VisibleForTesting
+  final AtomicReference<Long> lastExposureTimeNs = new AtomicReference<>();
 
   ImageCaptureProxyApi(@NonNull ProxyApiRegistrar pigeonRegistrar) {
     super(pigeonRegistrar);
@@ -35,6 +51,7 @@ class ImageCaptureProxyApi extends PigeonApiImageCapture {
     return (ProxyApiRegistrar) super.getPigeonRegistrar();
   }
 
+  @OptIn(markerClass = ExperimentalCamera2Interop.class)
   @NonNull
   @Override
   public ImageCapture pigeon_defaultConstructor(
@@ -62,6 +79,22 @@ class ImageCaptureProxyApi extends PigeonApiImageCapture {
     if (resolutionSelector != null) {
       builder.setResolutionSelector(resolutionSelector);
     }
+
+    Camera2Interop.Extender<ImageCapture> extender = new Camera2Interop.Extender<>(builder);
+    extender.setSessionCaptureCallback(
+        new CameraCaptureSession.CaptureCallback() {
+          @Override
+          public void onCaptureCompleted(
+              @NonNull CameraCaptureSession session,
+              @NonNull CaptureRequest request,
+              @NonNull TotalCaptureResult result) {
+            Long exposureTime = result.get(CaptureResult.SENSOR_EXPOSURE_TIME);
+            if (exposureTime != null) {
+              lastExposureTimeNs.set(exposureTime);
+            }
+          }
+        });
+
     return builder.build();
   }
 
@@ -128,6 +161,7 @@ class ImageCaptureProxyApi extends PigeonApiImageCapture {
     return new ImageCapture.OnImageSavedCallback() {
       @Override
       public void onImageSaved(@NonNull ImageCapture.OutputFileResults outputFileResults) {
+        patchExifExposureTime(file, lastExposureTimeNs.get());
         ResultCompat.success(file.getAbsolutePath(), callback);
       }
 
@@ -159,6 +193,24 @@ class ImageCaptureProxyApi extends PigeonApiImageCapture {
         return "The ImageCapture use case was bound to an invalid camera by the Flutter camera plugin. If you see this error, please file an issue if you cannot find one that already exists: https://github.com/flutter/flutter/issues/.";
       default:
         return "An unknown error has occurred while attempting to take a picture. Check the logs for more details.";
+    }
+  }
+
+  @VisibleForTesting
+  static void patchExifExposureTime(@NonNull File file, @Nullable Long exposureTimeNs) {
+    if (exposureTimeNs == null) {
+      return;
+    }
+    try {
+      ExifInterface exif = new ExifInterface(file.getAbsolutePath());
+      String existingExposureTime = exif.getAttribute(ExifInterface.TAG_EXPOSURE_TIME);
+      if (existingExposureTime == null || existingExposureTime.isEmpty()) {
+        double exposureTimeInSeconds = exposureTimeNs / 1_000_000_000.0;
+        exif.setAttribute(ExifInterface.TAG_EXPOSURE_TIME, String.valueOf(exposureTimeInSeconds));
+        exif.saveAttributes();
+      }
+    } catch (IOException e) {
+      Log.w(TAG, "Failed to write exposure time to EXIF", e);
     }
   }
 }

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/ImageCaptureTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/ImageCaptureTest.java
@@ -6,8 +6,11 @@ package io.flutter.plugins.camerax;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -18,19 +21,25 @@ import androidx.annotation.NonNull;
 import androidx.camera.core.ImageCapture;
 import androidx.camera.core.ImageCaptureException;
 import androidx.camera.core.resolutionselector.ResolutionSelector;
+import androidx.exifinterface.media.ExifInterface;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Executor;
 import kotlin.Result;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
 public class ImageCaptureTest {
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
   @Test
   public void pigeon_defaultConstructor_createsImageCaptureWithCorrectConfiguration() {
     final PigeonApiImageCapture api = new TestProxyApiRegistrar().getPigeonApiImageCapture();
@@ -244,5 +253,82 @@ public class ImageCaptureTest {
     api.setTargetRotation(instance, rotation);
 
     verify(instance).setTargetRotation((int) rotation);
+  }
+
+  @Test
+  public void patchExifExposureTime_writesExposureTimeWhenMissing() throws IOException {
+    final File file = tempFolder.newFile("test.jpg");
+    try (MockedConstruction<ExifInterface> mockedExif =
+        mockConstruction(
+            ExifInterface.class,
+            (mock, ctx) ->
+                when(mock.getAttribute(ExifInterface.TAG_EXPOSURE_TIME)).thenReturn(null))) {
+      ImageCaptureProxyApi.patchExifExposureTime(file, 500_000_000L);
+      ExifInterface exif = mockedExif.constructed().get(0);
+      verify(exif).setAttribute(ExifInterface.TAG_EXPOSURE_TIME, String.valueOf(0.5));
+      verify(exif).saveAttributes();
+    }
+  }
+
+  @Test
+  public void patchExifExposureTime_doesNotOverwriteExistingExposureTime() throws IOException {
+    final File file = tempFolder.newFile("test.jpg");
+    try (MockedConstruction<ExifInterface> mockedExif =
+        mockConstruction(
+            ExifInterface.class,
+            (mock, ctx) ->
+                when(mock.getAttribute(ExifInterface.TAG_EXPOSURE_TIME)).thenReturn("0.8"))) {
+      ImageCaptureProxyApi.patchExifExposureTime(file, 1_000_000_000L);
+      ExifInterface exif = mockedExif.constructed().get(0);
+      verify(exif).getAttribute(ExifInterface.TAG_EXPOSURE_TIME);
+      verify(exif, never()).setAttribute(eq(ExifInterface.TAG_EXPOSURE_TIME), any());
+      verify(exif, never()).saveAttributes();
+    }
+  }
+
+  @Test
+  public void patchExifExposureTime_doesNothingWhenExposureTimeIsNull() throws IOException {
+    final File file = tempFolder.newFile("test.jpg");
+    try (MockedConstruction<ExifInterface> mockedExif =
+        mockConstruction(ExifInterface.class)) {
+      ImageCaptureProxyApi.patchExifExposureTime(file, null);
+      assertEquals(0, mockedExif.constructed().size());
+    }
+  }
+
+  @Test
+  public void patchExifExposureTime_continuesOnExifError() {
+    final File nonExistentFile = new File("/non/existent/path.jpg");
+    // Should not throw even when ExifInterface fails to open the file
+    ImageCaptureProxyApi.patchExifExposureTime(nonExistentFile, 1_000_000_000L);
+  }
+
+  @Test
+  public void onImageSaved_callsPatchExifExposureTime() {
+    final ProxyApiRegistrar mockApiRegistrar = mock(ProxyApiRegistrar.class);
+    final ImageCaptureProxyApi api = new ImageCaptureProxyApi(mockApiRegistrar);
+    api.lastExposureTimeNs.set(123_000_000L);
+
+    final File mockFile = mock(File.class);
+    when(mockFile.getAbsolutePath()).thenReturn("test/path.jpg");
+
+    final String[] result = {null};
+    final ImageCapture.OnImageSavedCallback callback =
+        api.createOnImageSavedCallback(
+            mockFile,
+            mock(SystemServicesManager.class),
+            ResultCompat.asCompatCallback(
+                reply -> {
+                  result[0] = reply.getOrNull();
+                  return null;
+                }));
+
+    try (MockedStatic<ImageCaptureProxyApi> mockedApi =
+        mockStatic(ImageCaptureProxyApi.class)) {
+      callback.onImageSaved(mock(ImageCapture.OutputFileResults.class));
+      mockedApi.verify(
+          () -> ImageCaptureProxyApi.patchExifExposureTime(mockFile, 123_000_000L));
+    }
+    assertEquals("test/path.jpg", result[0]);
   }
 }

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.7.1
+version: 0.7.1+1
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
## Description

Some devices (e.g. Honor) omit `ExposureTime` in JPEG EXIF when using CameraX `ImageCapture.takePicture` with file output. This mirrors the fix for `camera_android` (Camera2) in [flutter/packages#11326](https://github.com/flutter/packages/pull/11326), but targets the default Android implementation (`camera_android_camerax`).

## What changed

- Attach a `Camera2Interop.Extender` session `CaptureCallback` on `ImageCapture` to record `CaptureResult.SENSOR_EXPOSURE_TIME`.
- After CameraX saves the still image, if EXIF `TAG_EXPOSURE_TIME` is missing, write it using `androidx.exifinterface` (nanoseconds → seconds), without failing the capture on EXIF errors.
- Add `androidx.exifinterface:exifinterface:1.3.7` and unit tests in `ImageCaptureTest`.

## Tests

- `:camera_android_camerax:testDebugUnitTest --tests io.flutter.plugins.camerax.ImageCaptureTest` (from the plugin example after `flutter build apk --config-only`).

## Version

- Bumps `camera_android_camerax` to `0.6.25+1` and updates CHANGELOG.


Made with [Cursor](https://cursor.com)