### PR TITLE
[video_player_android] Fix rendering freeze after full-screen transit…

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,6 +1,11 @@
-## 2.9.6
+## 2.9.7
 
 * Fixes a [bug](https://github.com/flutter/flutter/issues/184241) where the video freezes after returning from a full-screen transition on Android.
+
+## 2.9.6
+
+* Migrates to Built-in Kotlin to support AGP 9.
+* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 
 ## 2.9.5
 

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.9.6
 
-* Migrates to Built-in Kotlin to support AGP 9.
-* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+* Fixes a [bug](https://github.com/flutter/flutter/issues/184241) where the video freezes after returning from a full-screen transition on Android.
 
 ## 2.9.5
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.videoplayer.platformview;
 
 import android.content.Context;
 import android.os.Build;
+import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
@@ -30,23 +31,14 @@ public final class PlatformVideoView implements PlatformView {
    */
   @OptIn(markerClass = UnstableApi.class)
   public PlatformVideoView(@NonNull Context context, @NonNull ExoPlayer exoPlayer) {
-    surfaceView = new SurfaceView(context);
+    this.surfaceView = new VideoSurfaceView(context, exoPlayer);
 
-    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.P) {
-      // Workaround for rendering issues on Android 9 (API 28).
-      // On Android 9, using setVideoSurfaceView seems to lead to issues where the first frame is
-      // not displayed if the video is paused initially.
-      // To ensure the first frame is visible, the surface is directly set using holder.getSurface()
-      // when the surface is created, and ExoPlayer seeks to a position to force rendering of the
-      // first frame.
-      setupSurfaceWithCallback(exoPlayer);
-    } else {
-      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) {
-        // Avoid blank space instead of a video on Android versions below 8 by adjusting video's
-        // z-layer within the Android view hierarchy:
-        surfaceView.setZOrderMediaOverlay(true);
-      }
-      exoPlayer.setVideoSurfaceView(surfaceView);
+    setupSurfaceWithCallback(exoPlayer);
+
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) {
+      // Avoid blank space instead of a video on Android versions below 8 by adjusting video's
+      // z-layer within the Android view hierarchy:
+      surfaceView.setZOrderMediaOverlay(true);
     }
   }
 
@@ -57,22 +49,63 @@ public final class PlatformVideoView implements PlatformView {
             new SurfaceHolder.Callback() {
               @Override
               public void surfaceCreated(@NonNull SurfaceHolder holder) {
-                exoPlayer.setVideoSurface(holder.getSurface());
-                // Force first frame rendering:
-                exoPlayer.seekTo(1);
+                bindPlayerToSurface(exoPlayer, holder.getSurface());
               }
 
               @Override
               public void surfaceChanged(
-                  @NonNull SurfaceHolder holder, int format, int width, int height) {
-                // No implementation needed.
-              }
+                  @NonNull SurfaceHolder holder, int format, int width, int height) {}
 
               @Override
               public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
-                exoPlayer.setVideoSurface(null);
+                // Use clearVideoSurface to ensure we only unbind if this surface is currently active.
+                exoPlayer.clearVideoSurface(holder.getSurface());
               }
             });
+  }
+
+  /**
+   * Binds the ExoPlayer to the provided surface and performs a seek operation to ensure the video
+   * frame is rendered. Includes special handling for Android 9.
+   */
+  private static void bindPlayerToSurface(@NonNull ExoPlayer exoPlayer, @NonNull Surface surface) {
+    if (surface.isValid()) {
+      exoPlayer.setVideoSurface(surface);
+
+      // Workaround for a rendering bug on Android 9 (API 28) where the decoder does not
+      // flush its output buffer when a new surface is attached while the player is paused,
+      // resulting in a black frame. A seek forces the codec to produce and display a frame.
+      if (!exoPlayer.getPlayWhenReady()) {
+        long current = exoPlayer.getCurrentPosition();
+        if (current == 0 && Build.VERSION.SDK_INT == Build.VERSION_CODES.P) {
+          exoPlayer.seekTo(1);
+        } else {
+          exoPlayer.seekTo(current);
+        }
+      }
+    }
+  }
+
+  /**
+   * A custom SurfaceView that handles visibility changes to ensure video rendering is restored
+   * during route transitions (e.g., returning from a full-screen view).
+   */
+  private static class VideoSurfaceView extends SurfaceView {
+    private final ExoPlayer exoPlayer;
+
+    public VideoSurfaceView(Context context, ExoPlayer exoPlayer) {
+      super(context);
+      this.exoPlayer = exoPlayer;
+    }
+
+    @Override
+    protected void onVisibilityChanged(@NonNull View changedView, int visibility) {
+      super.onVisibilityChanged(changedView, visibility);
+      // When the view becomes visible again, ensure the ExoPlayer is re-attached to the surface.
+      if (visibility == View.VISIBLE && isShown()) {
+        bindPlayerToSurface(exoPlayer, getHolder().getSurface());
+      }
+    }
   }
 
   /**

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
@@ -68,7 +68,7 @@ public final class PlatformVideoView implements PlatformView {
   /**
    * Binds the ExoPlayer to the provided surface.
    */
-  private static void bindPlayerToSurface(@NonNull ExoPlayer exoPlayer, @NonNull Surface surface) {
+  static void bindPlayerToSurface(@NonNull ExoPlayer exoPlayer, @NonNull Surface surface) {
     if (surface.isValid()) {
       exoPlayer.setVideoSurface(surface);
     }
@@ -78,7 +78,7 @@ public final class PlatformVideoView implements PlatformView {
    * Workaround for a rendering bug on Android 9 (API 28) where the decoder does not flush its
    * output buffer when a new surface is attached while the player is paused.
    */
-  private static void forceFirstFrameForAndroid9(@NonNull ExoPlayer exoPlayer) {
+  static void forceFirstFrameForAndroid9(@NonNull ExoPlayer exoPlayer) {
     if (Build.VERSION.SDK_INT == Build.VERSION_CODES.P && !exoPlayer.getPlayWhenReady()) {
       long position = exoPlayer.getCurrentPosition();
       exoPlayer.seekTo(position == 0 ? 1 : position);

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
@@ -65,9 +65,7 @@ public final class PlatformVideoView implements PlatformView {
             });
   }
 
-  /**
-   * Binds the ExoPlayer to the provided surface.
-   */
+  /** Binds the ExoPlayer to the provided surface. */
   static void bindPlayerToSurface(@NonNull ExoPlayer exoPlayer, @NonNull Surface surface) {
     if (surface.isValid()) {
       exoPlayer.setVideoSurface(surface);

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
@@ -50,6 +50,7 @@ public final class PlatformVideoView implements PlatformView {
               @Override
               public void surfaceCreated(@NonNull SurfaceHolder holder) {
                 bindPlayerToSurface(exoPlayer, holder.getSurface());
+                forceFirstFrameForAndroid9(exoPlayer);
               }
 
               @Override
@@ -65,30 +66,28 @@ public final class PlatformVideoView implements PlatformView {
   }
 
   /**
-   * Binds the ExoPlayer to the provided surface and performs a seek operation to ensure the video
-   * frame is rendered. Includes special handling for Android 9.
+   * Binds the ExoPlayer to the provided surface.
    */
   private static void bindPlayerToSurface(@NonNull ExoPlayer exoPlayer, @NonNull Surface surface) {
     if (surface.isValid()) {
       exoPlayer.setVideoSurface(surface);
-
-      // Workaround for a rendering bug on Android 9 (API 28) where the decoder does not
-      // flush its output buffer when a new surface is attached while the player is paused,
-      // resulting in a black frame. A seek forces the codec to produce and display a frame.
-      if (!exoPlayer.getPlayWhenReady()) {
-        long current = exoPlayer.getCurrentPosition();
-        if (current == 0 && Build.VERSION.SDK_INT == Build.VERSION_CODES.P) {
-          exoPlayer.seekTo(1);
-        } else {
-          exoPlayer.seekTo(current);
-        }
-      }
     }
   }
 
   /**
-   * A custom SurfaceView that handles visibility changes to ensure video rendering is restored
-   * during route transitions (e.g., returning from a full-screen view).
+   * Workaround for a rendering bug on Android 9 (API 28) where the decoder does not flush its
+   * output buffer when a new surface is attached while the player is paused.
+   */
+  private static void forceFirstFrameForAndroid9(@NonNull ExoPlayer exoPlayer) {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.P && !exoPlayer.getPlayWhenReady()) {
+      long position = exoPlayer.getCurrentPosition();
+      exoPlayer.seekTo(position == 0 ? 1 : position);
+    }
+  }
+
+  /**
+   * A custom SurfaceView that re-attaches the player surface when the view becomes visible again,
+   * such as after returning from a full-screen route transition.
    */
   private static class VideoSurfaceView extends SurfaceView {
     private final ExoPlayer exoPlayer;
@@ -101,7 +100,7 @@ public final class PlatformVideoView implements PlatformView {
     @Override
     protected void onVisibilityChanged(@NonNull View changedView, int visibility) {
       super.onVisibilityChanged(changedView, visibility);
-      // When the view becomes visible again, ensure the ExoPlayer is re-attached to the surface.
+      // When the view becomes visible again, re-attach the current surface.
       if (visibility == View.VISIBLE && isShown()) {
         bindPlayerToSurface(exoPlayer, getHolder().getSurface());
       }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformVideoView.java
@@ -59,7 +59,8 @@ public final class PlatformVideoView implements PlatformView {
 
               @Override
               public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
-                // Use clearVideoSurface to ensure we only unbind if this surface is currently active.
+                // Use clearVideoSurface to ensure we only unbind if this surface is currently
+                // active.
                 exoPlayer.clearVideoSurface(holder.getSurface());
               }
             });

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/PlatformVideoViewTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/PlatformVideoViewTest.java
@@ -8,18 +8,27 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 import android.content.Context;
+import android.view.Surface;
+import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.View;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.test.core.app.ApplicationProvider;
 import io.flutter.plugins.videoplayer.platformview.PlatformVideoView;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowSurfaceView;
 
-/** Unit tests for {@link PlatformVideoViewTest}. */
+/** Unit tests for {@link PlatformVideoView}. */
 @RunWith(RobolectricTestRunner.class)
 public class PlatformVideoViewTest {
+
   @Test
   public void createsSurfaceViewAndSetsItForExoPlayer() throws Exception {
     final Context context = ApplicationProvider.getApplicationContext();
@@ -27,12 +36,63 @@ public class PlatformVideoViewTest {
 
     final PlatformVideoView view = new PlatformVideoView(context, exoPlayer);
 
+    // Get the internal SurfaceView via reflection for testing.
     final Field field = PlatformVideoView.class.getDeclaredField("surfaceView");
     field.setAccessible(true);
     final SurfaceView surfaceView = (SurfaceView) field.get(view);
 
-    assertNotNull(surfaceView);
-    verify(exoPlayer).setVideoSurfaceView(surfaceView);
+    // Bypass FakeSurfaceHolder to get the callback registered by PlatformVideoView
+    ShadowSurfaceView shadowView = Shadows.shadowOf(surfaceView);
+    Iterable<SurfaceHolder.Callback> callbacks = shadowView.getFakeSurfaceHolder().getCallbacks();
+    assertNotNull("SurfaceCallbacks should not be null", callbacks);
+    
+    SurfaceHolder.Callback callback = callbacks.iterator().next();
+    assertNotNull("Callback must exist", callback);
+
+    Surface mockSurface = mock(Surface.class);
+    when(mockSurface.isValid()).thenReturn(true);
+    SurfaceHolder mockHolder = mock(SurfaceHolder.class);
+    when(mockHolder.getSurface()).thenReturn(mockSurface);
+
+    // Trigger manually
+    callback.surfaceCreated(mockHolder);
+
+    // Verify it used the manual surface mechanism instead of setVideoSurfaceView()
+    verify(exoPlayer).setVideoSurface(mockSurface);
+
+    // For Android 9 bug workaround
+    verify(exoPlayer).seekTo(anyLong());
+
+    exoPlayer.release();
+  }
+
+  @Test
+  public void rebindsSurfaceWhenVisibilityChangesToVisible() throws Exception {
+    final Context context = ApplicationProvider.getApplicationContext();
+    final ExoPlayer exoPlayer = spy(new ExoPlayer.Builder(context).build());
+    final PlatformVideoView view = new PlatformVideoView(context, exoPlayer);
+
+    final Field field = PlatformVideoView.class.getDeclaredField("surfaceView");
+    field.setAccessible(true);
+    final SurfaceView surfaceView = spy((SurfaceView) Objects.requireNonNull(field.get(view)));
+    when(surfaceView.isShown()).thenReturn(true);
+    field.set(view, surfaceView); // Inject the spy back
+
+    Surface mockSurface = mock(Surface.class);
+    when(mockSurface.isValid()).thenReturn(true);
+    SurfaceHolder mockHolder = mock(SurfaceHolder.class);
+    when(mockHolder.getSurface()).thenReturn(mockSurface);
+    when(surfaceView.getHolder()).thenReturn(mockHolder);
+
+    // Trigger visibility changed
+    Method method = View.class.getDeclaredMethod("onVisibilityChanged", View.class, int.class);
+    method.setAccessible(true);
+    
+    reset(exoPlayer);
+    method.invoke(surfaceView, surfaceView, View.VISIBLE);
+
+    verify(exoPlayer).setVideoSurface(mockSurface);
+    verify(exoPlayer).seekTo(anyLong());
 
     exoPlayer.release();
   }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/PlatformVideoViewTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/PlatformVideoViewTest.java
@@ -19,7 +19,6 @@ import io.flutter.plugins.videoplayer.platformview.PlatformVideoView;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Objects;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/PlatformVideoViewTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/PlatformVideoViewTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 import android.content.Context;
+import android.os.Build;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -23,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowSurfaceView;
 
 /** Unit tests for {@link PlatformVideoView}. */
@@ -30,9 +32,10 @@ import org.robolectric.shadows.ShadowSurfaceView;
 public class PlatformVideoViewTest {
 
   @Test
-  public void createsSurfaceViewAndSetsItForExoPlayer() throws Exception {
+  @Config(sdk = 34)
+  public void surfaceCreatedBindsSurfaceWithoutSeekOutsideAndroid9() throws Exception {
     final Context context = ApplicationProvider.getApplicationContext();
-    final ExoPlayer exoPlayer = spy(new ExoPlayer.Builder(context).build());
+    final ExoPlayer exoPlayer = mock(ExoPlayer.class);
 
     final PlatformVideoView view = new PlatformVideoView(context, exoPlayer);
 
@@ -45,7 +48,7 @@ public class PlatformVideoViewTest {
     ShadowSurfaceView shadowView = Shadows.shadowOf(surfaceView);
     Iterable<SurfaceHolder.Callback> callbacks = shadowView.getFakeSurfaceHolder().getCallbacks();
     assertNotNull("SurfaceCallbacks should not be null", callbacks);
-    
+
     SurfaceHolder.Callback callback = callbacks.iterator().next();
     assertNotNull("Callback must exist", callback);
 
@@ -59,17 +62,45 @@ public class PlatformVideoViewTest {
 
     // Verify it used the manual surface mechanism instead of setVideoSurfaceView()
     verify(exoPlayer).setVideoSurface(mockSurface);
-
-    // For Android 9 bug workaround
-    verify(exoPlayer).seekTo(anyLong());
-
-    exoPlayer.release();
+    verify(exoPlayer, never()).seekTo(anyLong());
   }
 
   @Test
+  @Config(sdk = Build.VERSION_CODES.P)
+  public void surfaceCreatedSeeksOnAndroid9() throws Exception {
+    final Context context = ApplicationProvider.getApplicationContext();
+    final ExoPlayer exoPlayer = mock(ExoPlayer.class);
+    final PlatformVideoView view = new PlatformVideoView(context, exoPlayer);
+
+    final Field field = PlatformVideoView.class.getDeclaredField("surfaceView");
+    field.setAccessible(true);
+    final SurfaceView surfaceView = (SurfaceView) field.get(view);
+
+    ShadowSurfaceView shadowView = Shadows.shadowOf(surfaceView);
+    Iterable<SurfaceHolder.Callback> callbacks = shadowView.getFakeSurfaceHolder().getCallbacks();
+    assertNotNull("SurfaceCallbacks should not be null", callbacks);
+
+    SurfaceHolder.Callback callback = callbacks.iterator().next();
+    assertNotNull("Callback must exist", callback);
+
+    Surface mockSurface = mock(Surface.class);
+    when(mockSurface.isValid()).thenReturn(true);
+    SurfaceHolder mockHolder = mock(SurfaceHolder.class);
+    when(mockHolder.getSurface()).thenReturn(mockSurface);
+    when(exoPlayer.getPlayWhenReady()).thenReturn(false);
+    when(exoPlayer.getCurrentPosition()).thenReturn(0L);
+
+    callback.surfaceCreated(mockHolder);
+
+    verify(exoPlayer).setVideoSurface(mockSurface);
+    verify(exoPlayer).seekTo(1);
+  }
+
+  @Test
+  @Config(sdk = 34)
   public void rebindsSurfaceWhenVisibilityChangesToVisible() throws Exception {
     final Context context = ApplicationProvider.getApplicationContext();
-    final ExoPlayer exoPlayer = spy(new ExoPlayer.Builder(context).build());
+    final ExoPlayer exoPlayer = mock(ExoPlayer.class);
     final PlatformVideoView view = new PlatformVideoView(context, exoPlayer);
 
     final Field field = PlatformVideoView.class.getDeclaredField("surfaceView");
@@ -87,13 +118,9 @@ public class PlatformVideoViewTest {
     // Trigger visibility changed
     Method method = View.class.getDeclaredMethod("onVisibilityChanged", View.class, int.class);
     method.setAccessible(true);
-    
-    reset(exoPlayer);
     method.invoke(surfaceView, surfaceView, View.VISIBLE);
 
     verify(exoPlayer).setVideoSurface(mockSurface);
-    verify(exoPlayer).seekTo(anyLong());
-
-    exoPlayer.release();
+    verify(exoPlayer, never()).seekTo(anyLong());
   }
 }

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.9.6
+version: 2.9.7
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/184241

## Description

When using `PlatformView` mode on Android, the video freezes (frozen on a specific frame) after returning from a full-screen dialog or route transition. This happens because the `Surface` is destroyed when the view is hidden, and `ExoPlayer` does not automatically re-attach to the new `Surface` when it becomes visible again.

### Changes

- Introduced a custom `VideoSurfaceView` subclass that overrides `onVisibilityChanged` to re-bind `ExoPlayer` to the current `Surface` whenever the view becomes visible again.
- Extracted a `bindPlayerToSurface` helper to centralize surface binding and the Android 9 seek workaround.
- Used `clearVideoSurface(surface)` in `surfaceDestroyed` to safely unbind only the current surface.
- Updated `PlatformVideoViewTest` to use Robolectric's `ShadowSurfaceView` API for lifecycle simulation.

## Pre-Review Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I read the AI contribution guidelines and understand my responsibilities, or I am not using AI tools.
- [x] I read the Tree Hygiene page, which explains my responsibilities.
- [x] I read and followed the relevant style guides and ran the auto-formatter.
- [x] I signed the CLA.
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I linked to at least one issue that this PR fixes in the description above.
- [x] I followed the version and CHANGELOG instructions, using semantic versioning and the repository CHANGELOG style, or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which test exemption this PR falls under.
- [x] All existing and new tests are passing.
