### PR TITLE
[go_router] Fixes StatefulShellRoute PopScope behavior to respect back button

### DIFF
--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -124,7 +124,6 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
     while (walker is ShellRouteMatch) {
       final NavigatorState potentialCandidate =
           walker.navigatorKey.currentState!;
-
       final ModalRoute<dynamic>? modalRoute = ModalRoute.of(
         potentialCandidate.context,
       );

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -1569,7 +1569,15 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell>
         )
         .toList();
 
-    return widget.containerBuilder(context, widget, children);
+    return PopScope(
+      canPop: widget.currentIndex == 0,
+      onPopInvokedWithResult: (bool didPop, Object? result) {
+        if (!didPop && widget.currentIndex != 0) {
+          goBranch(0);
+        }
+      },
+      child: widget.containerBuilder(context, widget, children),
+    );
   }
 }
 

--- a/packages/go_router/pending_changelogs/change_2026_04_03_1775255636284.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_04_03_1775255636284.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix StatefulShellRoute PopScope behavior to orchestrate back button pops to the root branch when inner navigators cannot pop.
+version: patch

--- a/packages/go_router/test/shell_route_pop_scope_test.dart
+++ b/packages/go_router/test/shell_route_pop_scope_test.dart
@@ -1,0 +1,186 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  testWidgets(
+    'PopScope in StatefulShellRoute branch works on subsequent visits',
+    (WidgetTester tester) async {
+      int tabBPopCount = 0;
+
+      final routes = <RouteBase>[
+        StatefulShellRoute.indexedStack(
+          builder:
+              (
+                BuildContext context,
+                GoRouterState state,
+                StatefulNavigationShell navigationShell,
+              ) {
+                return Scaffold(
+                  body: navigationShell,
+                  bottomNavigationBar: BottomNavigationBar(
+                    currentIndex: navigationShell.currentIndex,
+                    onTap: (int index) => navigationShell.goBranch(index),
+                    items: const <BottomNavigationBarItem>[
+                      BottomNavigationBarItem(
+                        icon: Icon(Icons.home),
+                        label: 'A',
+                      ),
+                      BottomNavigationBarItem(
+                        icon: Icon(Icons.business),
+                        label: 'B',
+                      ),
+                    ],
+                  ),
+                );
+              },
+          branches: <StatefulShellBranch>[
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/tabA',
+                  builder: (BuildContext context, GoRouterState state) =>
+                      const DummyScreen(key: ValueKey<String>('tabA')),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/tabB',
+                  builder: (BuildContext context, GoRouterState state) {
+                    return PopScope(
+                      canPop: false,
+                      onPopInvokedWithResult: (bool didPop, Object? result) {
+                        tabBPopCount++;
+                        if (!didPop) {
+                          context.go('/tabA');
+                        }
+                      },
+                      child: const DummyScreen(key: ValueKey<String>('tabB')),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ];
+
+      final GoRouter router = await createRouter(
+        routes,
+        tester,
+        initialLocation: '/tabA',
+      );
+
+      // 1. Visit Tab A
+      expect(find.byKey(const ValueKey<String>('tabA')), findsOneWidget);
+      expect(find.byKey(const ValueKey<String>('tabB')), findsNothing);
+
+      // 2. Switch to Tab B
+      router.go('/tabB');
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey<String>('tabB')), findsOneWidget);
+
+      // 3. Press back button on Tab B (First Visit)
+      await simulateAndroidBackButton(tester);
+      await tester.pumpAndSettle();
+
+      // Should have switched back to Tab A
+      expect(find.byKey(const ValueKey<String>('tabA')), findsOneWidget);
+      expect(tabBPopCount, 1);
+
+      // 4. Switch to Tab B again (Second Visit)
+      router.go('/tabB');
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey<String>('tabB')), findsOneWidget);
+
+      // 5. Press back button on Tab B (Second Visit)
+      await simulateAndroidBackButton(tester);
+      await tester.pumpAndSettle();
+
+      // Verify that the PopScope was triggered again
+      expect(tabBPopCount, 2);
+
+      // Should have switched back to Tab A again
+      expect(find.byKey(const ValueKey<String>('tabA')), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'StatefulShellRoute switches to root branch by default on back button',
+    (WidgetTester tester) async {
+      final routes = <RouteBase>[
+        StatefulShellRoute.indexedStack(
+          builder:
+              (
+                BuildContext context,
+                GoRouterState state,
+                StatefulNavigationShell navigationShell,
+              ) {
+                return Scaffold(
+                  body: navigationShell,
+                  bottomNavigationBar: BottomNavigationBar(
+                    currentIndex: navigationShell.currentIndex,
+                    onTap: (int index) => navigationShell.goBranch(index),
+                    items: const <BottomNavigationBarItem>[
+                      BottomNavigationBarItem(
+                        icon: Icon(Icons.home),
+                        label: 'A',
+                      ),
+                      BottomNavigationBarItem(
+                        icon: Icon(Icons.business),
+                        label: 'B',
+                      ),
+                    ],
+                  ),
+                );
+              },
+          branches: <StatefulShellBranch>[
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/tabA',
+                  builder: (BuildContext context, GoRouterState state) =>
+                      const DummyScreen(key: ValueKey<String>('tabA')),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/tabB',
+                  builder: (BuildContext context, GoRouterState state) =>
+                      const DummyScreen(key: ValueKey<String>('tabB')),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ];
+
+      final GoRouter router = await createRouter(
+        routes,
+        tester,
+        initialLocation: '/tabA',
+      );
+
+      expect(find.byKey(const ValueKey<String>('tabA')), findsOneWidget);
+
+      router.go('/tabB');
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey<String>('tabB')), findsOneWidget);
+
+      await simulateAndroidBackButton(tester);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey<String>('tabA')), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/181945

### Root Cause
StatefulShellRoute manages multiple branches, each with its own parallel navigation stack. When the system back button is pressed on a non-root branch (index > 0), the framework does not inherently know that it should oscillate back to the root branch (index 0) when the current branch's navigator cannot pop further. This caused system back events to exit the app or behave inconsistently.

### Fix
This PR adds a PopScope wrapper around the StatefulNavigationShell container:
1. **Conditional Blocking**: It sets `canPop: widget.currentIndex == 0`. This allows natural app exiting only from the root branch.
2. **Branch Oscillation**: When a pop is requested on a non-root branch, it is blocked, and the `onPopInvokedWithResult` handler calls `goBranch(0)` to switch back to the main tab.
3. **Compatibility**: Inner PopScope widgets placed within specific branches will still function for pops within their respective nested navigators.