### PR TITLE
[webview_flutter_android] Add headers to NavigationRequest to tell if it isDownloadRequest from onDownloadStart

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.11.1
+
+* Adds `headers` to `NavigationRequest` to tell if it `isDownloadRequest` from `onDownloadStart`.
+
 ## 4.11.0
 
 * Adds support to opt out of Android inset changes. See

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
@@ -1680,7 +1680,18 @@ class AndroidNavigationDelegate extends PlatformNavigationDelegate {
             int contentLength,
           ) {
             if (weakThis.target != null) {
-              weakThis.target?._handleNavigation(url, isForMainFrame: true);
+              if (!contentDisposition.toLowerCase().startsWith('attachment')) {
+                contentDisposition = 'attachment; $contentDisposition'.trim();
+              }
+              weakThis.target?._handleNavigation(
+                url,
+                isForMainFrame: true,
+                headers: {
+                  'content-disposition': contentDisposition,
+                  'content-type': mimetype,
+                  'content-length': contentLength.toString(),
+                },
+              );
             }
           },
     );
@@ -1744,7 +1755,7 @@ class AndroidNavigationDelegate extends PlatformNavigationDelegate {
     }
 
     final FutureOr<NavigationDecision> returnValue = onNavigationRequest(
-      NavigationRequest(url: url, isMainFrame: isForMainFrame),
+      NavigationRequest(url: url, isMainFrame: isForMainFrame, headers: headers),
     );
 
     if (returnValue is NavigationDecision &&

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.11.0
+version: 4.11.1
 
 environment:
   sdk: ^3.9.0

--- a/packages/webview_flutter/webview_flutter_android/test/android_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_navigation_delegate_test.dart
@@ -579,6 +579,39 @@ void main() {
       },
     );
 
+    test(
+      'isDownloadRequest from onDownloadStart should be true',
+      () {
+        final androidNavigationDelegate = AndroidNavigationDelegate(
+          _buildCreationParams(),
+        );
+
+        androidNavigationDelegate.setOnLoadRequest((_) {
+          return Future.value();
+        });
+
+        late final NavigationRequest callbackNavigationRequest;
+        androidNavigationDelegate.setOnNavigationRequest((
+          NavigationRequest navigationRequest,
+        ) {
+          callbackNavigationRequest = navigationRequest;
+          return NavigationDecision.navigate;
+        });
+
+        CapturingDownloadListener.lastCreatedListener.onDownloadStart(
+          MockDownloadListener(),
+          'https://www.google.com',
+          '',
+          '',
+          '',
+          0,
+        );
+
+        expect(callbackNavigationRequest.url, 'https://www.google.com');
+        expect(callbackNavigationRequest.isDownloadRequest, true);
+      },
+    );
+
     test('onUrlChange', () {
       final androidNavigationDelegate = AndroidNavigationDelegate(
         _buildCreationParams(),

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.15.2
+
+* Adds `headers` and `isDownloadRequest` to `NavigationRequest`，so we can easily tell if it was made to download an attachment from `onDownloadStart`.
+
 ## 2.15.1
 
 * Fixes dartdoc comments that accidentally used HTML.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/navigation_request.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/navigation_request.dart
@@ -5,11 +5,18 @@
 /// Defines the parameters of the pending navigation callback.
 class NavigationRequest {
   /// Creates a [NavigationRequest].
-  const NavigationRequest({required this.url, required this.isMainFrame});
+  const NavigationRequest({required this.url, required this.isMainFrame, this.headers});
 
   /// The URL of the pending navigation request.
   final String url;
 
   /// Indicates whether the request was made in the web site's main frame or a subframe.
   final bool isMainFrame;
+
+  /// Headers for the request.
+  final Map<String, String>? headers;
+
+  /// Indicates whether the request was made to download an attachment.
+  bool get isDownloadRequest =>
+      headers?['content-disposition']?.toLowerCase().startsWith('attachment') ?? false;
 }

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/webview_flutt
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.15.1
+version: 2.15.2
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Add `headers` and `isDownloadRequest` to `NavigationRequest`，so we can easily tell if it was made to download an attachment from `onDownloadStart`.

*List which issues are fixed by this PR. You must list at least one issue.*
[132738](https://github.com/flutter/flutter/issues/132738)

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
