### PR TITLE
[two_dimensional_scrollables] trailing pinned row/col for TableView

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.4.2
 
-* Adds support for trailing pinned columns and rows in TableView.
+* Fixes an issue where merged cells would unmerge when the first cell was overlaid by a pinned row or column.
 
 ## 0.4.1
 

--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.3
+## 0.5.0
 
 * Adds support for trailing pinned columns and rows in TableView.
 

--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.4.3
+
+* Adds support for trailing pinned columns and rows in TableView.
+
 ## 0.4.2
 
-* Fixes an issue where merged cells would unmerge when the first cell was overlaid by a pinned row or column.
+* Adds support for trailing pinned columns and rows in TableView.
 
 ## 0.4.1
 

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -1095,12 +1095,10 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
 
     final double trailingPinnedColumnOffset = _firstTrailingPinnedColumn != null
-        ? -(viewportDimension.width - _trailingPinnedColumnsExtent) -
-              _hAlignmentOffset
+        ? -(viewportDimension.width - _trailingPinnedColumnsExtent)
         : 0.0;
     final double trailingPinnedRowOffset = _firstTrailingPinnedRow != null
-        ? -(viewportDimension.height - _trailingPinnedRowsExtent) -
-              _vAlignmentOffset
+        ? -(viewportDimension.height - _trailingPinnedRowsExtent)
         : 0.0;
 
     final double? offsetIntoColumn = _firstNonPinnedColumn != null
@@ -1582,8 +1580,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         offset,
         Rect.fromLTWH(
           reversedH
-              ? viewportDimension.width - _leadingPinnedColumnsExtent
-              : 0.0,
+              ? viewportDimension.width - _leadingPinnedColumnsExtent - _hAlignmentOffset
+              : _hAlignmentOffset,
           (reversedV ? _trailingPinnedRowsExtent : _leadingPinnedRowsExtent) +
               (reversedV ? -_vAlignmentOffset : _vAlignmentOffset),
           _leadingPinnedColumnsExtent,
@@ -1615,8 +1613,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         offset,
         Rect.fromLTWH(
           reversedH
-              ? 0.0
-              : viewportDimension.width - _trailingPinnedColumnsExtent,
+              ? _hAlignmentOffset
+              : viewportDimension.width - _trailingPinnedColumnsExtent - _hAlignmentOffset,
           (reversedV ? _trailingPinnedRowsExtent : _leadingPinnedRowsExtent) +
               (reversedV ? -_vAlignmentOffset : _vAlignmentOffset),
           _trailingPinnedColumnsExtent,
@@ -1654,7 +1652,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
                   ? _trailingPinnedColumnsExtent
                   : _leadingPinnedColumnsExtent) +
               (reversedH ? -_hAlignmentOffset : _hAlignmentOffset),
-          reversedV ? viewportDimension.height - _leadingPinnedRowsExtent : 0.0,
+          reversedV
+              ? viewportDimension.height - _leadingPinnedRowsExtent - _vAlignmentOffset
+              : _vAlignmentOffset,
           viewportDimension.width - _pinnedColumnsExtent,
           _leadingPinnedRowsExtent,
         ),
@@ -1691,8 +1691,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
                   : _leadingPinnedColumnsExtent) +
               (reversedH ? -_hAlignmentOffset : _hAlignmentOffset),
           reversedV
-              ? 0.0
-              : viewportDimension.height - _trailingPinnedRowsExtent,
+              ? _vAlignmentOffset
+              : viewportDimension.height - _trailingPinnedRowsExtent - _vAlignmentOffset,
           viewportDimension.width - _pinnedColumnsExtent,
           _trailingPinnedRowsExtent,
         ),

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -28,11 +28,19 @@ import 'table_span.dart';
 /// and columns through merging. The table supports lazy rendering and will only
 /// instantiate those cells that are currently visible in the table's viewport
 /// and those that extend into the [cacheExtent]. Therefore, when merging cells
-/// in a [TableView], the same child must be returned from every vicinity the
-/// merged cell contains. The `build` method will only be called once for a
-/// merged cell, but since the table's children are lazily laid out, returning
-/// the same child ensures the merged cell can be built no matter which part of
-/// it is visible.
+/// in a [TableView], the same child with the same merge information must be
+/// returned from every vicinity the merged cell contains. The `build` method
+/// will only be called once for a merged cell, but since the table's children
+/// are lazily laid out, returning the same child and merge information ensures
+/// the merged cell can be built no matter which part of it is visible.
+///
+/// For example, if a cell is configured to span 3 columns, starting at column 1,
+/// the [cellBuilder] must return a [TableViewCell] with the same [child],
+/// [columnMergeStart] as 1, and [columnMergeSpan] as 3 for all three
+/// [TableVicinity]s (column 1, 2, and 3). If the merge information is only
+/// provided for the first vicinity (column 1), and that vicinity is scrolled
+/// out of the viewport and [cacheExtent], the table will not know the following
+/// vicinities (column 2 and 3) are part of a merge and will "unmerge" them.
 ///
 /// The layout of the table (e.g. how many rows/columns there are and their
 /// extents) as well as the content of the individual cells is defined by
@@ -1384,8 +1392,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
             )) {
               // Both row and column are pinned at this cell, or just pinned row.
               (true, true) || (false, true) =>
-                firstRow >=
-                        (_firstTrailingPinnedRow ?? double.maxFinite.toInt())
+                _firstTrailingPinnedRow != null &&
+                        firstRow >= _firstTrailingPinnedRow!
                     ? viewportDimension.height - _trailingPinnedRowsExtent
                     : 0.0,
               // Cell is within a pinned column, or no pinned area at all.
@@ -1430,8 +1438,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
             )) {
               // Both row and column are pinned at this cell, or just pinned column.
               (true, true) || (false, true) =>
-                firstColumn >=
-                        (_firstTrailingPinnedColumn ?? double.maxFinite.toInt())
+                _firstTrailingPinnedColumn != null &&
+                        firstColumn >= _firstTrailingPinnedColumn!
                     ? viewportDimension.width - _trailingPinnedColumnsExtent
                     : 0.0,
               // Cell is within a pinned row, or no pinned area at all.
@@ -2231,6 +2239,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
   void dispose() {
     _clipPinnedRowsHandle.layer = null;
     _clipPinnedColumnsHandle.layer = null;
+    _clipTrailingPinnedRowsHandle.layer = null;
+    _clipTrailingPinnedColumnsHandle.layer = null;
     _clipCellsHandle.layer = null;
     for (final _Span span in _rowMetrics.values) {
       span.dispose();

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -162,11 +162,17 @@ class TableView extends TwoDimensionalScrollView {
   }) : assert(pinnedRowCount >= 0),
        assert(trailingPinnedRowCount >= 0),
        assert(rowCount == null || rowCount >= 0),
-       assert(rowCount == null || rowCount >= pinnedRowCount + trailingPinnedRowCount),
+       assert(
+         rowCount == null ||
+             rowCount >= pinnedRowCount + trailingPinnedRowCount,
+       ),
        assert(columnCount == null || columnCount >= 0),
        assert(pinnedColumnCount >= 0),
        assert(trailingPinnedColumnCount >= 0),
-       assert(columnCount == null || columnCount >= pinnedColumnCount + trailingPinnedColumnCount),
+       assert(
+         columnCount == null ||
+             columnCount >= pinnedColumnCount + trailingPinnedColumnCount,
+       ),
        super(
          delegate: TableCellBuilderDelegate(
            columnCount: columnCount,
@@ -453,12 +459,12 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
 
   int? get _firstTrailingPinnedRow =>
       delegate.trailingPinnedRowCount > 0 && delegate.rowCount != null
-          ? delegate.rowCount! - delegate.trailingPinnedRowCount
-          : null;
+      ? delegate.rowCount! - delegate.trailingPinnedRowCount
+      : null;
   int? get _firstTrailingPinnedColumn =>
       delegate.trailingPinnedColumnCount > 0 && delegate.columnCount != null
-          ? delegate.columnCount! - delegate.trailingPinnedColumnCount
-          : null;
+      ? delegate.columnCount! - delegate.trailingPinnedColumnCount
+      : null;
 
   double get _leadingPinnedRowsExtent => delegate.pinnedRowCount > 0
       ? _rowMetrics[delegate.pinnedRowCount - 1]!.trailingOffset
@@ -510,7 +516,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           'from being visible.',
         );
       } else if (_pinnedColumnsExtent == viewportDimension.width) {
-        final bool hasUnpinnedColumns = delegate.columnCount == null ||
+        final bool hasUnpinnedColumns =
+            delegate.columnCount == null ||
             delegate.columnCount! >
                 delegate.pinnedColumnCount + delegate.trailingPinnedColumnCount;
         if (hasUnpinnedColumns) {
@@ -529,7 +536,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           'from being visible.',
         );
       } else if (_pinnedRowsExtent == viewportDimension.height) {
-        final bool hasUnpinnedRows = delegate.rowCount == null ||
+        final bool hasUnpinnedRows =
+            delegate.rowCount == null ||
             delegate.rowCount! >
                 delegate.pinnedRowCount + delegate.trailingPinnedRowCount;
         if (hasUnpinnedRows) {
@@ -635,7 +643,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
     // If we are computing up to a specific index, we are getting info for a
     // merged cell, do not change the visible cells.
-    _firstNonPinnedColumn = toColumnIndex == null ? null : _firstNonPinnedColumn;
+    _firstNonPinnedColumn = toColumnIndex == null
+        ? null
+        : _firstNonPinnedColumn;
     _lastNonPinnedColumn = toColumnIndex == null ? null : _lastNonPinnedColumn;
     int column = appendColumns ? _columnMetrics.length : 0;
 
@@ -658,14 +668,15 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
 
     while (!reachedColumnEnd()) {
-      final bool isPinned = column < delegate.pinnedColumnCount ||
+      final bool isPinned =
+          column < delegate.pinnedColumnCount ||
           (delegate.columnCount != null &&
               column >=
                   delegate.columnCount! - delegate.trailingPinnedColumnCount);
       final leadingOffset = isPinned
           ? (column < delegate.pinnedColumnCount
-              ? startOfPinnedColumn
-              : startOfTrailingPinnedColumn)
+                ? startOfPinnedColumn
+                : startOfTrailingPinnedColumn)
           : startOfRegularColumn;
       _Span? span = _columnMetrics.remove(column);
       final TableSpan? configuration =
@@ -718,8 +729,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       _lastNonPinnedColumn ??= _columnNullTerminatedIndex != null
           ? _columnNullTerminatedIndex! - 1
           : (delegate.columnCount != null
-              ? delegate.columnCount! - delegate.trailingPinnedColumnCount - 1
-              : null);
+                ? delegate.columnCount! - delegate.trailingPinnedColumnCount - 1
+                : null);
     }
   }
 
@@ -775,13 +786,14 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
 
     while (!reachedRowEnd()) {
-      final bool isPinned = row < delegate.pinnedRowCount ||
+      final bool isPinned =
+          row < delegate.pinnedRowCount ||
           (delegate.rowCount != null &&
               row >= delegate.rowCount! - delegate.trailingPinnedRowCount);
       final leadingOffset = isPinned
           ? (row < delegate.pinnedRowCount
-              ? startOfPinnedRow
-              : startOfTrailingPinnedRow)
+                ? startOfPinnedRow
+                : startOfTrailingPinnedRow)
           : startOfRegularRow;
       _Span? span = _rowMetrics.remove(row);
       final TableSpan? configuration =
@@ -835,21 +847,21 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       _lastNonPinnedRow ??= _rowNullTerminatedIndex != null
           ? _rowNullTerminatedIndex! - 1
           : (delegate.rowCount != null
-              ? delegate.rowCount! - delegate.trailingPinnedRowCount - 1
-              : null);
+                ? delegate.rowCount! - delegate.trailingPinnedRowCount - 1
+                : null);
     }
   }
 
   int? get _lastRegularColumnIndex => delegate.columnCount == null
       ? _columnNullTerminatedIndex != null
-          ? _columnNullTerminatedIndex! - 1
-          : null
+            ? _columnNullTerminatedIndex! - 1
+            : null
       : delegate.columnCount! - delegate.trailingPinnedColumnCount - 1;
 
   int? get _lastRegularRowIndex => delegate.rowCount == null
       ? _rowNullTerminatedIndex != null
-          ? _rowNullTerminatedIndex! - 1
-          : null
+            ? _rowNullTerminatedIndex! - 1
+            : null
       : delegate.rowCount! - delegate.trailingPinnedRowCount - 1;
 
   void _updateScrollBounds() {
@@ -1076,24 +1088,24 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
 
     final double trailingPinnedColumnOffset = _firstTrailingPinnedColumn != null
         ? -(viewportDimension.width - _trailingPinnedColumnsExtent) -
-            _hAlignmentOffset
+              _hAlignmentOffset
         : 0.0;
     final double trailingPinnedRowOffset = _firstTrailingPinnedRow != null
         ? -(viewportDimension.height - _trailingPinnedRowsExtent) -
-            _vAlignmentOffset
+              _vAlignmentOffset
         : 0.0;
 
     final double? offsetIntoColumn = _firstNonPinnedColumn != null
         ? horizontalOffset.pixels -
-            _columnMetrics[_firstNonPinnedColumn]!.leadingOffset -
-            _leadingPinnedColumnsExtent -
-            _hAlignmentOffset
+              _columnMetrics[_firstNonPinnedColumn]!.leadingOffset -
+              _leadingPinnedColumnsExtent -
+              _hAlignmentOffset
         : null;
     final double? offsetIntoRow = _firstNonPinnedRow != null
         ? verticalOffset.pixels -
-            _rowMetrics[_firstNonPinnedRow]!.leadingOffset -
-            _leadingPinnedRowsExtent -
-            _vAlignmentOffset
+              _rowMetrics[_firstNonPinnedRow]!.leadingOffset -
+              _leadingPinnedRowsExtent -
+              _vAlignmentOffset
         : null;
 
     // Row Category L (Leading Pinned)
@@ -1113,7 +1125,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         _layoutCells(
           start: TableVicinity(column: _firstNonPinnedColumn!, row: 0),
           end: TableVicinity(
-              column: _lastNonPinnedColumn!, row: _lastPinnedRow!),
+            column: _lastNonPinnedColumn!,
+            row: _lastPinnedRow!,
+          ),
           offset: Offset(offsetIntoColumn!, -_vAlignmentOffset),
         );
       }
@@ -1122,7 +1136,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         _layoutCells(
           start: TableVicinity(column: _firstTrailingPinnedColumn!, row: 0),
           end: TableVicinity(
-              column: delegate.columnCount! - 1, row: _lastPinnedRow!),
+            column: delegate.columnCount! - 1,
+            row: _lastPinnedRow!,
+          ),
           offset: Offset(trailingPinnedColumnOffset, -_vAlignmentOffset),
         );
       }
@@ -1137,7 +1153,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         _layoutCells(
           start: TableVicinity(column: 0, row: _firstNonPinnedRow!),
           end: TableVicinity(
-              column: _lastPinnedColumn!, row: _lastNonPinnedRow!),
+            column: _lastPinnedColumn!,
+            row: _lastNonPinnedRow!,
+          ),
           offset: Offset(-_hAlignmentOffset, offsetIntoRow!),
         );
       }
@@ -1147,9 +1165,13 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         assert(offsetIntoColumn != null);
         _layoutCells(
           start: TableVicinity(
-              column: _firstNonPinnedColumn!, row: _firstNonPinnedRow!),
+            column: _firstNonPinnedColumn!,
+            row: _firstNonPinnedRow!,
+          ),
           end: TableVicinity(
-              column: _lastNonPinnedColumn!, row: _lastNonPinnedRow!),
+            column: _lastNonPinnedColumn!,
+            row: _lastNonPinnedRow!,
+          ),
           offset: Offset(offsetIntoColumn!, offsetIntoRow!),
         );
       }
@@ -1157,9 +1179,13 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       if (_firstTrailingPinnedColumn != null) {
         _layoutCells(
           start: TableVicinity(
-              column: _firstTrailingPinnedColumn!, row: _firstNonPinnedRow!),
+            column: _firstTrailingPinnedColumn!,
+            row: _firstNonPinnedRow!,
+          ),
           end: TableVicinity(
-              column: delegate.columnCount! - 1, row: _lastNonPinnedRow!),
+            column: delegate.columnCount! - 1,
+            row: _lastNonPinnedRow!,
+          ),
           offset: Offset(trailingPinnedColumnOffset, offsetIntoRow!),
         );
       }
@@ -1172,7 +1198,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         _layoutCells(
           start: TableVicinity(column: 0, row: _firstTrailingPinnedRow!),
           end: TableVicinity(
-              column: _lastPinnedColumn!, row: delegate.rowCount! - 1),
+            column: _lastPinnedColumn!,
+            row: delegate.rowCount! - 1,
+          ),
           offset: Offset(-_hAlignmentOffset, trailingPinnedRowOffset),
         );
       }
@@ -1182,9 +1210,13 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         assert(offsetIntoColumn != null);
         _layoutCells(
           start: TableVicinity(
-              column: _firstNonPinnedColumn!, row: _firstTrailingPinnedRow!),
+            column: _firstNonPinnedColumn!,
+            row: _firstTrailingPinnedRow!,
+          ),
           end: TableVicinity(
-              column: _lastNonPinnedColumn!, row: delegate.rowCount! - 1),
+            column: _lastNonPinnedColumn!,
+            row: delegate.rowCount! - 1,
+          ),
           offset: Offset(offsetIntoColumn!, trailingPinnedRowOffset),
         );
       }
@@ -1192,15 +1224,17 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       if (_firstTrailingPinnedColumn != null) {
         _layoutCells(
           start: TableVicinity(
-              column: _firstTrailingPinnedColumn!,
-              row: _firstTrailingPinnedRow!),
+            column: _firstTrailingPinnedColumn!,
+            row: _firstTrailingPinnedRow!,
+          ),
           end: TableVicinity(
-              column: delegate.columnCount! - 1, row: delegate.rowCount! - 1),
+            column: delegate.columnCount! - 1,
+            row: delegate.rowCount! - 1,
+          ),
           offset: Offset(trailingPinnedColumnOffset, trailingPinnedRowOffset),
         );
       }
     }
-
   }
 
   bool _debugCheckMergeBounds({
@@ -1241,7 +1275,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         '$lowerSpanOrientation ${pinnedSpanCount - 1}.',
       );
     }
-    if (spanCount != null && spanMergeEnd >= spanCount - trailingPinnedSpanCount) {
+    if (spanCount != null &&
+        spanMergeEnd >= spanCount - trailingPinnedSpanCount) {
       // Merged cells cannot span trailing pinned and unpinned cells.
       assert(
         spanMergeStart >= spanCount - trailingPinnedSpanCount,
@@ -1348,12 +1383,14 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
               rowIsPinned,
             )) {
               // Both row and column are pinned at this cell, or just pinned row.
-              (true, true) || (false, true) => firstRow >= (_firstTrailingPinnedRow ?? double.maxFinite.toInt())
-                  ? viewportDimension.height - _trailingPinnedRowsExtent
-                  : 0.0,
+              (true, true) || (false, true) =>
+                firstRow >=
+                        (_firstTrailingPinnedRow ?? double.maxFinite.toInt())
+                    ? viewportDimension.height - _trailingPinnedRowsExtent
+                    : 0.0,
               // Cell is within a pinned column, or no pinned area at all.
-              (true, false) ||
-              (false, false) => _leadingPinnedRowsExtent - verticalOffset.pixels,
+              (true, false) || (false, false) =>
+                _leadingPinnedRowsExtent - verticalOffset.pixels,
             };
             mergedRowOffset =
                 baseRowOffset +
@@ -1392,12 +1429,14 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
               columnIsPinned,
             )) {
               // Both row and column are pinned at this cell, or just pinned column.
-              (true, true) || (false, true) => firstColumn >= (_firstTrailingPinnedColumn ?? double.maxFinite.toInt())
-                  ? viewportDimension.width - _trailingPinnedColumnsExtent
-                  : 0.0,
+              (true, true) || (false, true) =>
+                firstColumn >=
+                        (_firstTrailingPinnedColumn ?? double.maxFinite.toInt())
+                    ? viewportDimension.width - _trailingPinnedColumnsExtent
+                    : 0.0,
               // Cell is within a pinned row, or no pinned area at all.
-              (true, false) ||
-              (false, false) => _leadingPinnedColumnsExtent - horizontalOffset.pixels,
+              (true, false) || (false, false) =>
+                _leadingPinnedColumnsExtent - horizontalOffset.pixels,
             };
             mergedColumnOffset =
                 baseColumnOffset +
@@ -1480,8 +1519,6 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
   final LayerHandle<ClipRectLayer> _clipTrailingPinnedColumnsHandle =
       LayerHandle<ClipRectLayer>();
   final LayerHandle<ClipRectLayer> _clipCellsHandle =
-      LayerHandle<ClipRectLayer>();
-  final LayerHandle<ClipRectLayer> _clipIntersectionsHandle =
       LayerHandle<ClipRectLayer>();
 
   @override
@@ -1617,8 +1654,10 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           _paintCells(
             context: context,
             offset: offset,
-            leadingVicinity:
-                TableVicinity(column: _firstNonPinnedColumn!, row: 0),
+            leadingVicinity: TableVicinity(
+              column: _firstNonPinnedColumn!,
+              row: 0,
+            ),
             trailingVicinity: TableVicinity(
               column: _lastNonPinnedColumn!,
               row: _lastPinnedRow!,

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -28,19 +28,11 @@ import 'table_span.dart';
 /// and columns through merging. The table supports lazy rendering and will only
 /// instantiate those cells that are currently visible in the table's viewport
 /// and those that extend into the [cacheExtent]. Therefore, when merging cells
-/// in a [TableView], the same child with the same merge information must be
-/// returned from every vicinity the merged cell contains. The `build` method
-/// will only be called once for a merged cell, but since the table's children
-/// are lazily laid out, returning the same child and merge information ensures
-/// the merged cell can be built no matter which part of it is visible.
-///
-/// For example, if a cell is configured to span 3 columns, starting at column 1,
-/// the [cellBuilder] must return a [TableViewCell] with the same [child],
-/// [columnMergeStart] as 1, and [columnMergeSpan] as 3 for all three
-/// [TableVicinity]s (column 1, 2, and 3). If the merge information is only
-/// provided for the first vicinity (column 1), and that vicinity is scrolled
-/// out of the viewport and [cacheExtent], the table will not know the following
-/// vicinities (column 2 and 3) are part of a merge and will "unmerge" them.
+/// in a [TableView], the same child must be returned from every vicinity the
+/// merged cell contains. The `build` method will only be called once for a
+/// merged cell, but since the table's children are lazily laid out, returning
+/// the same child ensures the merged cell can be built no matter which part of
+/// it is visible.
 ///
 /// The layout of the table (e.g. how many rows/columns there are and their
 /// extents) as well as the content of the individual cells is defined by
@@ -159,6 +151,8 @@ class TableView extends TwoDimensionalScrollView {
     super.clipBehavior,
     int pinnedRowCount = 0,
     int pinnedColumnCount = 0,
+    int trailingPinnedRowCount = 0,
+    int trailingPinnedColumnCount = 0,
     int? columnCount,
     int? rowCount,
     required TableSpanBuilder columnBuilder,
@@ -166,17 +160,21 @@ class TableView extends TwoDimensionalScrollView {
     required TableViewCellBuilder cellBuilder,
     this.alignment = Alignment.topLeft,
   }) : assert(pinnedRowCount >= 0),
+       assert(trailingPinnedRowCount >= 0),
        assert(rowCount == null || rowCount >= 0),
-       assert(rowCount == null || rowCount >= pinnedRowCount),
+       assert(rowCount == null || rowCount >= pinnedRowCount + trailingPinnedRowCount),
        assert(columnCount == null || columnCount >= 0),
        assert(pinnedColumnCount >= 0),
-       assert(columnCount == null || columnCount >= pinnedColumnCount),
+       assert(trailingPinnedColumnCount >= 0),
+       assert(columnCount == null || columnCount >= pinnedColumnCount + trailingPinnedColumnCount),
        super(
          delegate: TableCellBuilderDelegate(
            columnCount: columnCount,
            rowCount: rowCount,
            pinnedColumnCount: pinnedColumnCount,
            pinnedRowCount: pinnedRowCount,
+           trailingPinnedColumnCount: trailingPinnedColumnCount,
+           trailingPinnedRowCount: trailingPinnedRowCount,
            cellBuilder: cellBuilder,
            columnBuilder: columnBuilder,
            rowBuilder: rowBuilder,
@@ -206,16 +204,22 @@ class TableView extends TwoDimensionalScrollView {
     super.clipBehavior,
     int pinnedRowCount = 0,
     int pinnedColumnCount = 0,
+    int trailingPinnedRowCount = 0,
+    int trailingPinnedColumnCount = 0,
     required TableSpanBuilder columnBuilder,
     required TableSpanBuilder rowBuilder,
     List<List<TableViewCell>> cells = const <List<TableViewCell>>[],
     this.alignment = Alignment.topLeft,
   }) : assert(pinnedRowCount >= 0),
        assert(pinnedColumnCount >= 0),
+       assert(trailingPinnedRowCount >= 0),
+       assert(trailingPinnedColumnCount >= 0),
        super(
          delegate: TableCellListDelegate(
            pinnedColumnCount: pinnedColumnCount,
            pinnedRowCount: pinnedRowCount,
+           trailingPinnedColumnCount: trailingPinnedColumnCount,
+           trailingPinnedRowCount: trailingPinnedRowCount,
            cells: cells,
            columnBuilder: columnBuilder,
            rowBuilder: rowBuilder,
@@ -388,7 +392,8 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
   // Where column layout begins, potentially outside of the visible area.
   double get _targetLeadingColumnPixel {
     return clampDouble(
-      horizontalOffset.pixels - math.max(_pinnedColumnsExtent, cacheExtent),
+      horizontalOffset.pixels -
+          math.max(_leadingPinnedColumnsExtent, cacheExtent),
       0,
       double.infinity,
     );
@@ -407,7 +412,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
   // Where row layout begins, potentially outside of the visible area.
   double get _targetLeadingRowPixel {
     return clampDouble(
-      verticalOffset.pixels - math.max(_pinnedRowsExtent, cacheExtent),
+      verticalOffset.pixels - math.max(_leadingPinnedRowsExtent, cacheExtent),
       0,
       double.infinity,
     );
@@ -446,12 +451,54 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
   int? get _lastPinnedColumn =>
       delegate.pinnedColumnCount > 0 ? delegate.pinnedColumnCount - 1 : null;
 
-  double get _pinnedRowsExtent => _lastPinnedRow != null
-      ? _rowMetrics[_lastPinnedRow]!.trailingOffset
+  int? get _firstTrailingPinnedRow =>
+      delegate.trailingPinnedRowCount > 0 && delegate.rowCount != null
+          ? delegate.rowCount! - delegate.trailingPinnedRowCount
+          : null;
+  int? get _firstTrailingPinnedColumn =>
+      delegate.trailingPinnedColumnCount > 0 && delegate.columnCount != null
+          ? delegate.columnCount! - delegate.trailingPinnedColumnCount
+          : null;
+
+  double get _leadingPinnedRowsExtent => delegate.pinnedRowCount > 0
+      ? _rowMetrics[delegate.pinnedRowCount - 1]!.trailingOffset
       : 0.0;
-  double get _pinnedColumnsExtent => _lastPinnedColumn != null
-      ? _columnMetrics[_lastPinnedColumn]!.trailingOffset
+
+  double get _leadingPinnedColumnsExtent => delegate.pinnedColumnCount > 0
+      ? _columnMetrics[delegate.pinnedColumnCount - 1]!.trailingOffset
       : 0.0;
+
+  double get _trailingPinnedRowsExtent {
+    if (_firstTrailingPinnedRow == null) {
+      return 0.0;
+    }
+    final int lastRow = delegate.rowCount! - 1;
+    final _Span? firstSpan = _rowMetrics[_firstTrailingPinnedRow!];
+    final _Span? lastSpan = _rowMetrics[lastRow];
+    if (firstSpan == null || lastSpan == null) {
+      return 0.0;
+    }
+    return lastSpan.trailingOffset - firstSpan.leadingOffset;
+  }
+
+  double get _trailingPinnedColumnsExtent {
+    if (_firstTrailingPinnedColumn == null) {
+      return 0.0;
+    }
+    final int lastColumn = delegate.columnCount! - 1;
+    final _Span? firstSpan = _columnMetrics[_firstTrailingPinnedColumn!];
+    final _Span? lastSpan = _columnMetrics[lastColumn];
+    if (firstSpan == null || lastSpan == null) {
+      return 0.0;
+    }
+    return lastSpan.trailingOffset - firstSpan.leadingOffset;
+  }
+
+  double get _pinnedRowsExtent =>
+      _leadingPinnedRowsExtent + _trailingPinnedRowsExtent;
+
+  double get _pinnedColumnsExtent =>
+      _leadingPinnedColumnsExtent + _trailingPinnedColumnsExtent;
 
   void _debugCheckPinnedExtent() {
     assert(() {
@@ -463,9 +510,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           'from being visible.',
         );
       } else if (_pinnedColumnsExtent == viewportDimension.width) {
-        final bool hasUnpinnedColumns =
-            delegate.columnCount == null ||
-            delegate.columnCount! > delegate.pinnedColumnCount;
+        final bool hasUnpinnedColumns = delegate.columnCount == null ||
+            delegate.columnCount! >
+                delegate.pinnedColumnCount + delegate.trailingPinnedColumnCount;
         if (hasUnpinnedColumns) {
           debugPrint(
             'TableView has pinned columns that fully consume the viewport width. '
@@ -482,9 +529,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           'from being visible.',
         );
       } else if (_pinnedRowsExtent == viewportDimension.height) {
-        final bool hasUnpinnedRows =
-            delegate.rowCount == null ||
-            delegate.rowCount! > delegate.pinnedRowCount;
+        final bool hasUnpinnedRows = delegate.rowCount == null ||
+            delegate.rowCount! >
+                delegate.pinnedRowCount + delegate.trailingPinnedRowCount;
         if (hasUnpinnedRows) {
           debugPrint(
             'TableView has pinned rows that fully consume the viewport height. '
@@ -573,6 +620,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }());
     var startOfRegularColumn = 0.0;
     var startOfPinnedColumn = 0.0;
+    var startOfTrailingPinnedColumn = 0.0;
     if (appendColumns) {
       // We are only adding to the metrics we already know, since we are lazily
       // compiling metrics. This should only be the case when the
@@ -587,9 +635,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
     // If we are computing up to a specific index, we are getting info for a
     // merged cell, do not change the visible cells.
-    _firstNonPinnedColumn = toColumnIndex == null
-        ? null
-        : _firstNonPinnedColumn;
+    _firstNonPinnedColumn = toColumnIndex == null ? null : _firstNonPinnedColumn;
     _lastNonPinnedColumn = toColumnIndex == null ? null : _lastNonPinnedColumn;
     int column = appendColumns ? _columnMetrics.length : 0;
 
@@ -612,9 +658,14 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
 
     while (!reachedColumnEnd()) {
-      final bool isPinned = column < delegate.pinnedColumnCount;
+      final bool isPinned = column < delegate.pinnedColumnCount ||
+          (delegate.columnCount != null &&
+              column >=
+                  delegate.columnCount! - delegate.trailingPinnedColumnCount);
       final leadingOffset = isPinned
-          ? startOfPinnedColumn
+          ? (column < delegate.pinnedColumnCount
+              ? startOfPinnedColumn
+              : startOfTrailingPinnedColumn)
           : startOfRegularColumn;
       _Span? span = _columnMetrics.remove(column);
       final TableSpan? configuration =
@@ -654,13 +705,22 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           _lastNonPinnedColumn = column;
         }
         startOfRegularColumn = span.trailingOffset;
-      } else {
+      } else if (column < delegate.pinnedColumnCount) {
         startOfPinnedColumn = span.trailingOffset;
+      } else {
+        startOfTrailingPinnedColumn = span.trailingOffset;
       }
       column++;
     }
 
     assert(_columnMetrics.length >= delegate.pinnedColumnCount);
+    if (_firstNonPinnedColumn != null) {
+      _lastNonPinnedColumn ??= _columnNullTerminatedIndex != null
+          ? _columnNullTerminatedIndex! - 1
+          : (delegate.columnCount != null
+              ? delegate.columnCount! - delegate.trailingPinnedColumnCount - 1
+              : null);
+    }
   }
 
   // Updates the cached row metrics for the table.
@@ -680,6 +740,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }());
     var startOfRegularRow = 0.0;
     var startOfPinnedRow = 0.0;
+    var startOfTrailingPinnedRow = 0.0;
     if (appendRows) {
       // We are only adding to the metrics we already know, since we are lazily
       // compiling metrics. This should only be the case when the
@@ -714,8 +775,14 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
 
     while (!reachedRowEnd()) {
-      final bool isPinned = row < delegate.pinnedRowCount;
-      final leadingOffset = isPinned ? startOfPinnedRow : startOfRegularRow;
+      final bool isPinned = row < delegate.pinnedRowCount ||
+          (delegate.rowCount != null &&
+              row >= delegate.rowCount! - delegate.trailingPinnedRowCount);
+      final leadingOffset = isPinned
+          ? (row < delegate.pinnedRowCount
+              ? startOfPinnedRow
+              : startOfTrailingPinnedRow)
+          : startOfRegularRow;
       _Span? span = _rowMetrics.remove(row);
       final TableSpan? configuration =
           span?.configuration ?? delegate.buildRow(row);
@@ -755,14 +822,35 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           _lastNonPinnedRow = row;
         }
         startOfRegularRow = span.trailingOffset;
-      } else {
+      } else if (row < delegate.pinnedRowCount) {
         startOfPinnedRow = span.trailingOffset;
+      } else {
+        startOfTrailingPinnedRow = span.trailingOffset;
       }
       row++;
     }
 
     assert(_rowMetrics.length >= delegate.pinnedRowCount);
+    if (_firstNonPinnedRow != null) {
+      _lastNonPinnedRow ??= _rowNullTerminatedIndex != null
+          ? _rowNullTerminatedIndex! - 1
+          : (delegate.rowCount != null
+              ? delegate.rowCount! - delegate.trailingPinnedRowCount - 1
+              : null);
+    }
   }
+
+  int? get _lastRegularColumnIndex => delegate.columnCount == null
+      ? _columnNullTerminatedIndex != null
+          ? _columnNullTerminatedIndex! - 1
+          : null
+      : delegate.columnCount! - delegate.trailingPinnedColumnCount - 1;
+
+  int? get _lastRegularRowIndex => delegate.rowCount == null
+      ? _rowNullTerminatedIndex != null
+          ? _rowNullTerminatedIndex! - 1
+          : null
+      : delegate.rowCount! - delegate.trailingPinnedRowCount - 1;
 
   void _updateScrollBounds() {
     final bool acceptedDimension =
@@ -777,20 +865,22 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     if (_columnsAreInfinite && _columnNullTerminatedIndex == null) {
       maxHorizontalScrollExtent = double.infinity;
     } else if (!_columnsAreInfinite &&
-        _columnMetrics.length <= delegate.pinnedColumnCount) {
+        _columnMetrics.length <=
+            delegate.pinnedColumnCount + delegate.trailingPinnedColumnCount) {
       assert(_firstNonPinnedColumn == null && _lastNonPinnedColumn == null);
       maxHorizontalScrollExtent = 0.0;
     } else {
-      final int lastColumn = _columnMetrics.length - 1;
-      if (_firstNonPinnedColumn != null) {
-        _lastNonPinnedColumn ??= lastColumn;
+      final int? lastColumn = _lastRegularColumnIndex;
+      if (lastColumn == null || _columnMetrics[lastColumn] == null) {
+        maxHorizontalScrollExtent = 0.0;
+      } else {
+        maxHorizontalScrollExtent = math.max(
+          0.0,
+          _columnMetrics[lastColumn]!.trailingOffset -
+              viewportDimension.width +
+              _pinnedColumnsExtent,
+        );
       }
-      maxHorizontalScrollExtent = math.max(
-        0.0,
-        _columnMetrics[lastColumn]!.trailingOffset -
-            viewportDimension.width +
-            _pinnedColumnsExtent,
-      );
     }
     return horizontalOffset.applyContentDimensions(
       0.0,
@@ -803,20 +893,22 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     if (_rowsAreInfinite && _rowNullTerminatedIndex == null) {
       maxVerticalScrollExtent = double.infinity;
     } else if (!_rowsAreInfinite &&
-        _rowMetrics.length <= delegate.pinnedRowCount) {
+        _rowMetrics.length <=
+            delegate.pinnedRowCount + delegate.trailingPinnedRowCount) {
       assert(_firstNonPinnedRow == null && _lastNonPinnedRow == null);
       maxVerticalScrollExtent = 0.0;
     } else {
-      final int lastRow = _rowMetrics.length - 1;
-      if (_firstNonPinnedRow != null) {
-        _lastNonPinnedRow ??= lastRow;
+      final int? lastRow = _lastRegularRowIndex;
+      if (lastRow == null || _rowMetrics[lastRow] == null) {
+        maxVerticalScrollExtent = 0.0;
+      } else {
+        maxVerticalScrollExtent = math.max(
+          0.0,
+          _rowMetrics[lastRow]!.trailingOffset -
+              viewportDimension.height +
+              _pinnedRowsExtent,
+        );
       }
-      maxVerticalScrollExtent = math.max(
-        0.0,
-        _rowMetrics[lastRow]!.trailingOffset -
-            viewportDimension.height +
-            _pinnedRowsExtent,
-      );
     }
     return verticalOffset.applyContentDimensions(0.0, maxVerticalScrollExtent);
   }
@@ -975,65 +1067,140 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
 
     if (_firstNonPinnedCell == null &&
         _lastPinnedRow == null &&
-        _lastPinnedColumn == null) {
+        _lastPinnedColumn == null &&
+        _firstTrailingPinnedRow == null &&
+        _firstTrailingPinnedColumn == null) {
       assert(_lastNonPinnedCell == null);
       return;
     }
 
+    final double trailingPinnedColumnOffset = _firstTrailingPinnedColumn != null
+        ? -(viewportDimension.width - _trailingPinnedColumnsExtent) -
+            _hAlignmentOffset
+        : 0.0;
+    final double trailingPinnedRowOffset = _firstTrailingPinnedRow != null
+        ? -(viewportDimension.height - _trailingPinnedRowsExtent) -
+            _vAlignmentOffset
+        : 0.0;
+
     final double? offsetIntoColumn = _firstNonPinnedColumn != null
         ? horizontalOffset.pixels -
-              _columnMetrics[_firstNonPinnedColumn]!.leadingOffset -
-              _pinnedColumnsExtent -
-              _hAlignmentOffset
+            _columnMetrics[_firstNonPinnedColumn]!.leadingOffset -
+            _leadingPinnedColumnsExtent -
+            _hAlignmentOffset
         : null;
     final double? offsetIntoRow = _firstNonPinnedRow != null
         ? verticalOffset.pixels -
-              _rowMetrics[_firstNonPinnedRow]!.leadingOffset -
-              _pinnedRowsExtent -
-              _vAlignmentOffset
+            _rowMetrics[_firstNonPinnedRow]!.leadingOffset -
+            _leadingPinnedRowsExtent -
+            _vAlignmentOffset
         : null;
-    if (_lastPinnedRow != null && _lastPinnedColumn != null) {
-      // Layout cells that are contained in both pinned rows and columns
-      _layoutCells(
-        start: TableVicinity.zero,
-        end: TableVicinity(column: _lastPinnedColumn!, row: _lastPinnedRow!),
-        offset: Offset(-_hAlignmentOffset, -_vAlignmentOffset),
-      );
+
+    // Row Category L (Leading Pinned)
+    if (_lastPinnedRow != null) {
+      // (L, L)
+      if (_lastPinnedColumn != null) {
+        _layoutCells(
+          start: TableVicinity.zero,
+          end: TableVicinity(column: _lastPinnedColumn!, row: _lastPinnedRow!),
+          offset: Offset(-_hAlignmentOffset, -_vAlignmentOffset),
+        );
+      }
+      // (L, N)
+      if (_firstNonPinnedColumn != null) {
+        assert(_lastNonPinnedColumn != null);
+        assert(offsetIntoColumn != null);
+        _layoutCells(
+          start: TableVicinity(column: _firstNonPinnedColumn!, row: 0),
+          end: TableVicinity(
+              column: _lastNonPinnedColumn!, row: _lastPinnedRow!),
+          offset: Offset(offsetIntoColumn!, -_vAlignmentOffset),
+        );
+      }
+      // (L, T)
+      if (_firstTrailingPinnedColumn != null) {
+        _layoutCells(
+          start: TableVicinity(column: _firstTrailingPinnedColumn!, row: 0),
+          end: TableVicinity(
+              column: delegate.columnCount! - 1, row: _lastPinnedRow!),
+          offset: Offset(trailingPinnedColumnOffset, -_vAlignmentOffset),
+        );
+      }
     }
 
-    if (_lastPinnedRow != null && _firstNonPinnedColumn != null) {
-      // Layout cells of pinned rows - those that do not intersect with pinned
-      // columns above
-      assert(_lastNonPinnedColumn != null);
-      assert(offsetIntoColumn != null);
-      _layoutCells(
-        start: TableVicinity(column: _firstNonPinnedColumn!, row: 0),
-        end: TableVicinity(column: _lastNonPinnedColumn!, row: _lastPinnedRow!),
-        offset: Offset(offsetIntoColumn!, -_vAlignmentOffset),
-      );
-    }
-    if (_lastPinnedColumn != null && _firstNonPinnedRow != null) {
-      // Layout cells of pinned columns - those that do not intersect with
-      // pinned rows above
+    // Row Category N (Non-Pinned)
+    if (_firstNonPinnedRow != null) {
       assert(_lastNonPinnedRow != null);
       assert(offsetIntoRow != null);
-      _layoutCells(
-        start: TableVicinity(column: 0, row: _firstNonPinnedRow!),
-        end: TableVicinity(column: _lastPinnedColumn!, row: _lastNonPinnedRow!),
-        offset: Offset(-_hAlignmentOffset, offsetIntoRow!),
-      );
+      // (N, L)
+      if (_lastPinnedColumn != null) {
+        _layoutCells(
+          start: TableVicinity(column: 0, row: _firstNonPinnedRow!),
+          end: TableVicinity(
+              column: _lastPinnedColumn!, row: _lastNonPinnedRow!),
+          offset: Offset(-_hAlignmentOffset, offsetIntoRow!),
+        );
+      }
+      // (N, N)
+      if (_firstNonPinnedColumn != null) {
+        assert(_lastNonPinnedColumn != null);
+        assert(offsetIntoColumn != null);
+        _layoutCells(
+          start: TableVicinity(
+              column: _firstNonPinnedColumn!, row: _firstNonPinnedRow!),
+          end: TableVicinity(
+              column: _lastNonPinnedColumn!, row: _lastNonPinnedRow!),
+          offset: Offset(offsetIntoColumn!, offsetIntoRow!),
+        );
+      }
+      // (N, T)
+      if (_firstTrailingPinnedColumn != null) {
+        _layoutCells(
+          start: TableVicinity(
+              column: _firstTrailingPinnedColumn!, row: _firstNonPinnedRow!),
+          end: TableVicinity(
+              column: delegate.columnCount! - 1, row: _lastNonPinnedRow!),
+          offset: Offset(trailingPinnedColumnOffset, offsetIntoRow!),
+        );
+      }
     }
-    if (_firstNonPinnedCell != null) {
-      // Layout all other cells.
-      assert(_lastNonPinnedCell != null);
-      assert(offsetIntoColumn != null);
-      assert(offsetIntoRow != null);
-      _layoutCells(
-        start: _firstNonPinnedCell!,
-        end: _lastNonPinnedCell!,
-        offset: Offset(offsetIntoColumn!, offsetIntoRow!),
-      );
+
+    // Row Category T (Trailing Pinned)
+    if (_firstTrailingPinnedRow != null) {
+      // (T, L)
+      if (_lastPinnedColumn != null) {
+        _layoutCells(
+          start: TableVicinity(column: 0, row: _firstTrailingPinnedRow!),
+          end: TableVicinity(
+              column: _lastPinnedColumn!, row: delegate.rowCount! - 1),
+          offset: Offset(-_hAlignmentOffset, trailingPinnedRowOffset),
+        );
+      }
+      // (T, N)
+      if (_firstNonPinnedColumn != null) {
+        assert(_lastNonPinnedColumn != null);
+        assert(offsetIntoColumn != null);
+        _layoutCells(
+          start: TableVicinity(
+              column: _firstNonPinnedColumn!, row: _firstTrailingPinnedRow!),
+          end: TableVicinity(
+              column: _lastNonPinnedColumn!, row: delegate.rowCount! - 1),
+          offset: Offset(offsetIntoColumn!, trailingPinnedRowOffset),
+        );
+      }
+      // (T, T)
+      if (_firstTrailingPinnedColumn != null) {
+        _layoutCells(
+          start: TableVicinity(
+              column: _firstTrailingPinnedColumn!,
+              row: _firstTrailingPinnedRow!),
+          end: TableVicinity(
+              column: delegate.columnCount! - 1, row: delegate.rowCount! - 1),
+          offset: Offset(trailingPinnedColumnOffset, trailingPinnedRowOffset),
+        );
+      }
     }
+
   }
 
   bool _debugCheckMergeBounds({
@@ -1043,6 +1210,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     required int spanMergeEnd,
     required int? spanCount,
     required int pinnedSpanCount,
+    required int trailingPinnedSpanCount,
     required TableVicinity currentVicinity,
   }) {
     if (spanMergeStart == spanMergeEnd) {
@@ -1064,13 +1232,23 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       '$spanMergeEnd. The TableView contains $spanCount.',
     );
     if (spanMergeStart < pinnedSpanCount) {
-      // Merged cells cannot span pinned and unpinned cells.
+      // Merged cells cannot span leading pinned and unpinned cells.
       assert(
         spanMergeEnd < pinnedSpanCount,
         'Merged cells cannot span pinned and unpinned cells. $spanOrientation '
         'merge containing $currentVicinity starts at $spanMergeStart, and ends '
         'at $spanMergeEnd. ${spanOrientation}s are currently pinned up to '
         '$lowerSpanOrientation ${pinnedSpanCount - 1}.',
+      );
+    }
+    if (spanCount != null && spanMergeEnd >= spanCount - trailingPinnedSpanCount) {
+      // Merged cells cannot span trailing pinned and unpinned cells.
+      assert(
+        spanMergeStart >= spanCount - trailingPinnedSpanCount,
+        'Merged cells cannot span pinned and unpinned cells. $spanOrientation '
+        'merge containing $currentVicinity starts at $spanMergeStart, and ends '
+        'at $spanMergeEnd. ${spanOrientation}s are currently pinned from '
+        '$lowerSpanOrientation ${spanCount - trailingPinnedSpanCount} to ${spanCount - 1}.',
       );
     }
     return true;
@@ -1123,6 +1301,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
                 spanMergeEnd: lastRow,
                 spanCount: delegate.rowCount,
                 pinnedSpanCount: delegate.pinnedRowCount,
+                trailingPinnedSpanCount: delegate.trailingPinnedRowCount,
                 currentVicinity: vicinity,
               ),
             );
@@ -1139,6 +1318,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
                 spanMergeEnd: lastColumn,
                 spanCount: delegate.columnCount,
                 pinnedSpanCount: delegate.pinnedColumnCount,
+                trailingPinnedSpanCount: delegate.trailingPinnedColumnCount,
                 currentVicinity: vicinity,
               ),
             );
@@ -1155,19 +1335,25 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
 
             // Compute height and layout offset for merged rows.
             final bool rowIsInPinnedColumn =
-                _lastPinnedColumn != null &&
-                vicinity.column <= _lastPinnedColumn!;
+                (_lastPinnedColumn != null &&
+                    vicinity.column <= _lastPinnedColumn!) ||
+                (_firstTrailingPinnedColumn != null &&
+                    vicinity.column >= _firstTrailingPinnedColumn!);
             final bool rowIsPinned =
-                _lastPinnedRow != null && firstRow <= _lastPinnedRow!;
+                (_lastPinnedRow != null && firstRow <= _lastPinnedRow!) ||
+                (_firstTrailingPinnedRow != null &&
+                    firstRow >= _firstTrailingPinnedRow!);
             final double baseRowOffset = switch ((
               rowIsInPinnedColumn,
               rowIsPinned,
             )) {
               // Both row and column are pinned at this cell, or just pinned row.
-              (true, true) || (false, true) => 0.0,
+              (true, true) || (false, true) => firstRow >= (_firstTrailingPinnedRow ?? double.maxFinite.toInt())
+                  ? viewportDimension.height - _trailingPinnedRowsExtent
+                  : 0.0,
               // Cell is within a pinned column, or no pinned area at all.
               (true, false) ||
-              (false, false) => _pinnedRowsExtent - verticalOffset.pixels,
+              (false, false) => _leadingPinnedRowsExtent - verticalOffset.pixels,
             };
             mergedRowOffset =
                 baseRowOffset +
@@ -1193,18 +1379,25 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
                 _rowMetrics[firstRow]!.configuration.padding.leading;
             // Compute width and layout offset for merged columns.
             final bool columnIsInPinnedRow =
-                _lastPinnedRow != null && vicinity.row <= _lastPinnedRow!;
+                (_lastPinnedRow != null && vicinity.row <= _lastPinnedRow!) ||
+                (_firstTrailingPinnedRow != null &&
+                    vicinity.row >= _firstTrailingPinnedRow!);
             final bool columnIsPinned =
-                _lastPinnedColumn != null && firstColumn <= _lastPinnedColumn!;
+                (_lastPinnedColumn != null &&
+                    firstColumn <= _lastPinnedColumn!) ||
+                (_firstTrailingPinnedColumn != null &&
+                    firstColumn >= _firstTrailingPinnedColumn!);
             final double baseColumnOffset = switch ((
               columnIsInPinnedRow,
               columnIsPinned,
             )) {
               // Both row and column are pinned at this cell, or just pinned column.
-              (true, true) || (false, true) => 0.0,
+              (true, true) || (false, true) => firstColumn >= (_firstTrailingPinnedColumn ?? double.maxFinite.toInt())
+                  ? viewportDimension.width - _trailingPinnedColumnsExtent
+                  : 0.0,
               // Cell is within a pinned row, or no pinned area at all.
               (true, false) ||
-              (false, false) => _pinnedColumnsExtent - horizontalOffset.pixels,
+              (false, false) => _leadingPinnedColumnsExtent - horizontalOffset.pixels,
             };
             mergedColumnOffset =
                 baseColumnOffset +
@@ -1282,22 +1475,25 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       LayerHandle<ClipRectLayer>();
   final LayerHandle<ClipRectLayer> _clipPinnedColumnsHandle =
       LayerHandle<ClipRectLayer>();
+  final LayerHandle<ClipRectLayer> _clipTrailingPinnedRowsHandle =
+      LayerHandle<ClipRectLayer>();
+  final LayerHandle<ClipRectLayer> _clipTrailingPinnedColumnsHandle =
+      LayerHandle<ClipRectLayer>();
   final LayerHandle<ClipRectLayer> _clipCellsHandle =
+      LayerHandle<ClipRectLayer>();
+  final LayerHandle<ClipRectLayer> _clipIntersectionsHandle =
       LayerHandle<ClipRectLayer>();
 
   @override
   void paint(PaintingContext context, Offset offset) {
     if (_firstNonPinnedCell == null &&
         _lastPinnedRow == null &&
-        _lastPinnedColumn == null) {
+        _lastPinnedColumn == null &&
+        _firstTrailingPinnedRow == null &&
+        _firstTrailingPinnedColumn == null) {
       assert(_lastNonPinnedCell == null);
       return;
     }
-
-    // Subclasses of RenderTwoDimensionalViewport will typically use
-    // firstChild to traverse children in a standard paint order that
-    // follows row or column major ordering. Here is slightly different
-    // as we break the cells up into 4 main paint passes to clip for overlap.
 
     final bool reversedH = axisDirectionIsReversed(horizontalAxisDirection);
     final bool reversedV = axisDirectionIsReversed(verticalAxisDirection);
@@ -1309,9 +1505,11 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         needsCompositing,
         offset,
         Rect.fromLTWH(
-          (reversedH ? 0.0 : _pinnedColumnsExtent) +
+          (reversedH
+                  ? _trailingPinnedColumnsExtent
+                  : _leadingPinnedColumnsExtent) +
               (reversedH ? -_hAlignmentOffset : _hAlignmentOffset),
-          (reversedV ? 0.0 : _pinnedRowsExtent) +
+          (reversedV ? _trailingPinnedRowsExtent : _leadingPinnedRowsExtent) +
               (reversedV ? -_vAlignmentOffset : _vAlignmentOffset),
           viewportDimension.width - _pinnedColumnsExtent,
           viewportDimension.height - _pinnedRowsExtent,
@@ -1332,20 +1530,18 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
 
     if (_lastPinnedColumn != null && _firstNonPinnedRow != null) {
-      // Paint all visible pinned column cells that do not intersect with pinned
-      // row cells.
+      // Paint all visible leading pinned column cells that do not intersect with
+      // pinned row cells.
       _clipPinnedColumnsHandle.layer = context.pushClipRect(
         needsCompositing,
         offset,
         Rect.fromLTWH(
           reversedH
-              ? viewportDimension.width -
-                    _pinnedColumnsExtent -
-                    _hAlignmentOffset
-              : _hAlignmentOffset,
-          (reversedV ? 0.0 : _pinnedRowsExtent) +
+              ? viewportDimension.width - _leadingPinnedColumnsExtent
+              : 0.0,
+          (reversedV ? _trailingPinnedRowsExtent : _leadingPinnedRowsExtent) +
               (reversedV ? -_vAlignmentOffset : _vAlignmentOffset),
-          _pinnedColumnsExtent,
+          _leadingPinnedColumnsExtent,
           viewportDimension.height - _pinnedRowsExtent,
         ),
         (PaintingContext context, Offset offset) {
@@ -1366,29 +1562,63 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       _clipPinnedColumnsHandle.layer = null;
     }
 
-    if (_lastPinnedRow != null && _firstNonPinnedColumn != null) {
-      // Paint all visible pinned row cells that do not intersect with pinned
-      // column cells.
-      _clipPinnedRowsHandle.layer = context.pushClipRect(
+    if (_firstTrailingPinnedColumn != null && _firstNonPinnedRow != null) {
+      // Paint all visible trailing pinned column cells that do not intersect
+      // with pinned row cells.
+      _clipTrailingPinnedColumnsHandle.layer = context.pushClipRect(
         needsCompositing,
         offset,
         Rect.fromLTWH(
-          (reversedH ? 0.0 : _pinnedColumnsExtent) +
-              (reversedH ? -_hAlignmentOffset : _hAlignmentOffset),
-          reversedV
-              ? viewportDimension.height - _pinnedRowsExtent - _vAlignmentOffset
-              : _vAlignmentOffset,
-          viewportDimension.width - _pinnedColumnsExtent,
-          _pinnedRowsExtent,
+          reversedH
+              ? 0.0
+              : viewportDimension.width - _trailingPinnedColumnsExtent,
+          (reversedV ? _trailingPinnedRowsExtent : _leadingPinnedRowsExtent) +
+              (reversedV ? -_vAlignmentOffset : _vAlignmentOffset),
+          _trailingPinnedColumnsExtent,
+          viewportDimension.height - _pinnedRowsExtent,
         ),
         (PaintingContext context, Offset offset) {
           _paintCells(
             context: context,
             offset: offset,
             leadingVicinity: TableVicinity(
-              column: _firstNonPinnedColumn!,
-              row: 0,
+              column: _firstTrailingPinnedColumn!,
+              row: _firstNonPinnedRow!,
             ),
+            trailingVicinity: TableVicinity(
+              column: delegate.columnCount! - 1,
+              row: _lastNonPinnedRow!,
+            ),
+          );
+        },
+        clipBehavior: clipBehavior,
+        oldLayer: _clipTrailingPinnedColumnsHandle.layer,
+      );
+    } else {
+      _clipTrailingPinnedColumnsHandle.layer = null;
+    }
+
+    if (_lastPinnedRow != null && _firstNonPinnedColumn != null) {
+      // Paint all visible leading pinned row cells that do not intersect with
+      // pinned column cells.
+      _clipPinnedRowsHandle.layer = context.pushClipRect(
+        needsCompositing,
+        offset,
+        Rect.fromLTWH(
+          (reversedH
+                  ? _trailingPinnedColumnsExtent
+                  : _leadingPinnedColumnsExtent) +
+              (reversedH ? -_hAlignmentOffset : _hAlignmentOffset),
+          reversedV ? viewportDimension.height - _leadingPinnedRowsExtent : 0.0,
+          viewportDimension.width - _pinnedColumnsExtent,
+          _leadingPinnedRowsExtent,
+        ),
+        (PaintingContext context, Offset offset) {
+          _paintCells(
+            context: context,
+            offset: offset,
+            leadingVicinity:
+                TableVicinity(column: _firstNonPinnedColumn!, row: 0),
             trailingVicinity: TableVicinity(
               column: _lastNonPinnedColumn!,
               row: _lastPinnedRow!,
@@ -1402,18 +1632,101 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       _clipPinnedRowsHandle.layer = null;
     }
 
-    if (_lastPinnedRow != null && _lastPinnedColumn != null) {
-      // Paint remaining visible pinned cells that represent the intersection of
-      // both pinned rows and columns.
-      _paintCells(
-        context: context,
-        offset: offset,
-        leadingVicinity: TableVicinity.zero,
-        trailingVicinity: TableVicinity(
-          column: _lastPinnedColumn!,
-          row: _lastPinnedRow!,
+    if (_firstTrailingPinnedRow != null && _firstNonPinnedColumn != null) {
+      // Paint all visible trailing pinned row cells that do not intersect with
+      // pinned column cells.
+      _clipTrailingPinnedRowsHandle.layer = context.pushClipRect(
+        needsCompositing,
+        offset,
+        Rect.fromLTWH(
+          (reversedH
+                  ? _trailingPinnedColumnsExtent
+                  : _leadingPinnedColumnsExtent) +
+              (reversedH ? -_hAlignmentOffset : _hAlignmentOffset),
+          reversedV
+              ? 0.0
+              : viewportDimension.height - _trailingPinnedRowsExtent,
+          viewportDimension.width - _pinnedColumnsExtent,
+          _trailingPinnedRowsExtent,
         ),
+        (PaintingContext context, Offset offset) {
+          _paintCells(
+            context: context,
+            offset: offset,
+            leadingVicinity: TableVicinity(
+              column: _firstNonPinnedColumn!,
+              row: _firstTrailingPinnedRow!,
+            ),
+            trailingVicinity: TableVicinity(
+              column: _lastNonPinnedColumn!,
+              row: delegate.rowCount! - 1,
+            ),
+          );
+        },
+        clipBehavior: clipBehavior,
+        oldLayer: _clipTrailingPinnedRowsHandle.layer,
       );
+    } else {
+      _clipTrailingPinnedRowsHandle.layer = null;
+    }
+
+    // Paint all intersections
+    if (_lastPinnedRow != null) {
+      if (_lastPinnedColumn != null) {
+        _paintCells(
+          context: context,
+          offset: offset,
+          leadingVicinity: TableVicinity.zero,
+          trailingVicinity: TableVicinity(
+            column: _lastPinnedColumn!,
+            row: _lastPinnedRow!,
+          ),
+        );
+      }
+      if (_firstTrailingPinnedColumn != null) {
+        _paintCells(
+          context: context,
+          offset: offset,
+          leadingVicinity: TableVicinity(
+            column: _firstTrailingPinnedColumn!,
+            row: 0,
+          ),
+          trailingVicinity: TableVicinity(
+            column: delegate.columnCount! - 1,
+            row: _lastPinnedRow!,
+          ),
+        );
+      }
+    }
+    if (_firstTrailingPinnedRow != null) {
+      if (_lastPinnedColumn != null) {
+        _paintCells(
+          context: context,
+          offset: offset,
+          leadingVicinity: TableVicinity(
+            column: 0,
+            row: _firstTrailingPinnedRow!,
+          ),
+          trailingVicinity: TableVicinity(
+            column: _lastPinnedColumn!,
+            row: delegate.rowCount! - 1,
+          ),
+        );
+      }
+      if (_firstTrailingPinnedColumn != null) {
+        _paintCells(
+          context: context,
+          offset: offset,
+          leadingVicinity: TableVicinity(
+            column: _firstTrailingPinnedColumn!,
+            row: _firstTrailingPinnedRow!,
+          ),
+          trailingVicinity: TableVicinity(
+            column: delegate.columnCount! - 1,
+            row: delegate.rowCount! - 1,
+          ),
+        );
+      }
     }
   }
 

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -1580,7 +1580,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         offset,
         Rect.fromLTWH(
           reversedH
-              ? viewportDimension.width - _leadingPinnedColumnsExtent - _hAlignmentOffset
+              ? viewportDimension.width -
+                    _leadingPinnedColumnsExtent -
+                    _hAlignmentOffset
               : _hAlignmentOffset,
           (reversedV ? _trailingPinnedRowsExtent : _leadingPinnedRowsExtent) +
               (reversedV ? -_vAlignmentOffset : _vAlignmentOffset),
@@ -1614,7 +1616,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         Rect.fromLTWH(
           reversedH
               ? _hAlignmentOffset
-              : viewportDimension.width - _trailingPinnedColumnsExtent - _hAlignmentOffset,
+              : viewportDimension.width -
+                    _trailingPinnedColumnsExtent -
+                    _hAlignmentOffset,
           (reversedV ? _trailingPinnedRowsExtent : _leadingPinnedRowsExtent) +
               (reversedV ? -_vAlignmentOffset : _vAlignmentOffset),
           _trailingPinnedColumnsExtent,
@@ -1653,7 +1657,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
                   : _leadingPinnedColumnsExtent) +
               (reversedH ? -_hAlignmentOffset : _hAlignmentOffset),
           reversedV
-              ? viewportDimension.height - _leadingPinnedRowsExtent - _vAlignmentOffset
+              ? viewportDimension.height -
+                    _leadingPinnedRowsExtent -
+                    _vAlignmentOffset
               : _vAlignmentOffset,
           viewportDimension.width - _pinnedColumnsExtent,
           _leadingPinnedRowsExtent,
@@ -1692,7 +1698,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
               (reversedH ? -_hAlignmentOffset : _hAlignmentOffset),
           reversedV
               ? _vAlignmentOffset
-              : viewportDimension.height - _trailingPinnedRowsExtent - _vAlignmentOffset,
+              : viewportDimension.height -
+                    _trailingPinnedRowsExtent -
+                    _vAlignmentOffset,
           viewportDimension.width - _pinnedColumnsExtent,
           _trailingPinnedRowsExtent,
         ),

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table_delegate.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table_delegate.dart
@@ -198,8 +198,14 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
        assert(trailingPinnedRowCount >= 0),
        assert(rowCount == null || rowCount >= 0),
        assert(columnCount == null || columnCount >= 0),
-       assert(columnCount == null || pinnedColumnCount + trailingPinnedColumnCount <= columnCount),
-       assert(rowCount == null || pinnedRowCount + trailingPinnedRowCount <= rowCount),
+       assert(
+         columnCount == null ||
+             pinnedColumnCount + trailingPinnedColumnCount <= columnCount,
+       ),
+       assert(
+         rowCount == null ||
+             pinnedRowCount + trailingPinnedRowCount <= rowCount,
+       ),
        _rowBuilder = rowBuilder,
        _columnBuilder = columnBuilder,
        _pinnedColumnCount = pinnedColumnCount,
@@ -219,7 +225,9 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
   int? get columnCount => maxXIndex == null ? null : maxXIndex! + 1;
 
   set columnCount(int? value) {
-    assert(value == null || pinnedColumnCount + trailingPinnedColumnCount <= value);
+    assert(
+      value == null || pinnedColumnCount + trailingPinnedColumnCount <= value,
+    );
     maxXIndex = value == null ? null : value - 1;
   }
 
@@ -238,7 +246,9 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
   int _pinnedColumnCount;
   set pinnedColumnCount(int value) {
     assert(value >= 0);
-    assert(columnCount == null || value + trailingPinnedColumnCount <= columnCount!);
+    assert(
+      columnCount == null || value + trailingPinnedColumnCount <= columnCount!,
+    );
     if (pinnedColumnCount == value) {
       return;
     }

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table_delegate.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table_delegate.dart
@@ -91,6 +91,27 @@ mixin TableCellDelegateMixin on TwoDimensionalChildDelegate {
   /// the delegate object, [notifyListeners] must be called.
   int get pinnedColumnCount => 0;
 
+  /// The number of columns that are permanently shown on the trailing vertical
+  /// edge of the viewport.
+  ///
+  /// If scrolling is enabled, other columns will scroll underneath the pinned
+  /// columns.
+  ///
+  /// Just like for regular columns, [buildColumn] method will be consulted for
+  /// additional information about the pinned column. The indices of trailing
+  /// pinned columns start at `columnCount - trailingPinnedColumnCount` and go
+  /// to `columnCount - 1`.
+  ///
+  /// [columnCount] must not be null if [trailingPinnedColumnCount] is greater
+  /// than zero.
+  ///
+  /// The integer returned by this getter must be smaller than (or equal to) the
+  /// integer returned by [columnCount].
+  ///
+  /// If the value returned by this getter changes throughout the lifetime of
+  /// the delegate object, [notifyListeners] must be called.
+  int get trailingPinnedColumnCount => 0;
+
   /// The number of rows that are permanently shown on the leading horizontal
   /// edge of the viewport.
   ///
@@ -107,6 +128,27 @@ mixin TableCellDelegateMixin on TwoDimensionalChildDelegate {
   /// If the value returned by this getter changes throughout the lifetime of
   /// the delegate object, [notifyListeners] must be called.
   int get pinnedRowCount => 0;
+
+  /// The number of rows that are permanently shown on the trailing horizontal
+  /// edge of the viewport.
+  ///
+  /// If scrolling is enabled, other rows will scroll underneath the pinned
+  /// rows.
+  ///
+  /// Just like for regular rows, [buildRow] will be consulted for
+  /// additional information about the pinned row. The indices of trailing
+  /// pinned rows start at `rowCount - trailingPinnedRowCount` and go to
+  /// `rowCount - 1`.
+  ///
+  /// [rowCount] must not be null if [trailingPinnedRowCount] is greater than
+  /// zero.
+  ///
+  /// The integer returned by this getter must be smaller than (or equal to) the
+  /// integer returned by [rowCount].
+  ///
+  /// If the value returned by this getter changes throughout the lifetime of
+  /// the delegate object, [notifyListeners] must be called.
+  int get trailingPinnedRowCount => 0;
 
   /// Builds the [TableSpan] that describes the column at the provided index.
   ///
@@ -144,20 +186,26 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
     int? rowCount,
     int pinnedColumnCount = 0,
     int pinnedRowCount = 0,
+    int trailingPinnedColumnCount = 0,
+    int trailingPinnedRowCount = 0,
     super.addAutomaticKeepAlives,
     required TableViewCellBuilder cellBuilder,
     required TableSpanBuilder columnBuilder,
     required TableSpanBuilder rowBuilder,
   }) : assert(pinnedColumnCount >= 0),
        assert(pinnedRowCount >= 0),
+       assert(trailingPinnedColumnCount >= 0),
+       assert(trailingPinnedRowCount >= 0),
        assert(rowCount == null || rowCount >= 0),
        assert(columnCount == null || columnCount >= 0),
-       assert(columnCount == null || pinnedColumnCount <= columnCount),
-       assert(rowCount == null || pinnedRowCount <= rowCount),
+       assert(columnCount == null || pinnedColumnCount + trailingPinnedColumnCount <= columnCount),
+       assert(rowCount == null || pinnedRowCount + trailingPinnedRowCount <= rowCount),
        _rowBuilder = rowBuilder,
        _columnBuilder = columnBuilder,
        _pinnedColumnCount = pinnedColumnCount,
        _pinnedRowCount = pinnedRowCount,
+       _trailingPinnedColumnCount = trailingPinnedColumnCount,
+       _trailingPinnedRowCount = trailingPinnedRowCount,
        super(
          builder: (BuildContext context, ChildVicinity vicinity) =>
              cellBuilder(context, vicinity as TableVicinity),
@@ -171,7 +219,7 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
   int? get columnCount => maxXIndex == null ? null : maxXIndex! + 1;
 
   set columnCount(int? value) {
-    assert(value == null || pinnedColumnCount <= value);
+    assert(value == null || pinnedColumnCount + trailingPinnedColumnCount <= value);
     maxXIndex = value == null ? null : value - 1;
   }
 
@@ -190,7 +238,7 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
   int _pinnedColumnCount;
   set pinnedColumnCount(int value) {
     assert(value >= 0);
-    assert(columnCount == null || value <= columnCount!);
+    assert(columnCount == null || value + trailingPinnedColumnCount <= columnCount!);
     if (pinnedColumnCount == value) {
       return;
     }
@@ -199,10 +247,23 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
   }
 
   @override
+  int get trailingPinnedColumnCount => _trailingPinnedColumnCount;
+  int _trailingPinnedColumnCount;
+  set trailingPinnedColumnCount(int value) {
+    assert(value >= 0);
+    assert(columnCount == null || pinnedColumnCount + value <= columnCount!);
+    if (trailingPinnedColumnCount == value) {
+      return;
+    }
+    _trailingPinnedColumnCount = value;
+    notifyListeners();
+  }
+
+  @override
   int? get rowCount => maxYIndex == null ? null : maxYIndex! + 1;
 
   set rowCount(int? value) {
-    assert(value == null || pinnedRowCount <= value);
+    assert(value == null || pinnedRowCount + trailingPinnedRowCount <= value);
     maxYIndex = value == null ? null : value - 1;
   }
 
@@ -221,11 +282,24 @@ class TableCellBuilderDelegate extends TwoDimensionalChildBuilderDelegate
   int _pinnedRowCount;
   set pinnedRowCount(int value) {
     assert(value >= 0);
-    assert(rowCount == null || value <= rowCount!);
+    assert(rowCount == null || value + trailingPinnedRowCount <= rowCount!);
     if (pinnedRowCount == value) {
       return;
     }
     _pinnedRowCount = value;
+    notifyListeners();
+  }
+
+  @override
+  int get trailingPinnedRowCount => _trailingPinnedRowCount;
+  int _trailingPinnedRowCount;
+  set trailingPinnedRowCount(int value) {
+    assert(value >= 0);
+    assert(rowCount == null || pinnedRowCount + value <= rowCount!);
+    if (trailingPinnedRowCount == value) {
+      return;
+    }
+    _trailingPinnedRowCount = value;
     notifyListeners();
   }
 }
@@ -246,16 +320,22 @@ class TableCellListDelegate extends TwoDimensionalChildListDelegate
   TableCellListDelegate({
     int pinnedColumnCount = 0,
     int pinnedRowCount = 0,
+    int trailingPinnedColumnCount = 0,
+    int trailingPinnedRowCount = 0,
     super.addAutomaticKeepAlives,
     required List<List<TableViewCell>> cells,
     required TableSpanBuilder columnBuilder,
     required TableSpanBuilder rowBuilder,
   }) : assert(pinnedColumnCount >= 0),
        assert(pinnedRowCount >= 0),
+       assert(trailingPinnedColumnCount >= 0),
+       assert(trailingPinnedRowCount >= 0),
        _columnBuilder = columnBuilder,
        _rowBuilder = rowBuilder,
        _pinnedColumnCount = pinnedColumnCount,
        _pinnedRowCount = pinnedRowCount,
+       _trailingPinnedColumnCount = trailingPinnedColumnCount,
+       _trailingPinnedRowCount = trailingPinnedRowCount,
        super(
          children: cells,
          // repaintBoundaries handled by TableViewCell
@@ -270,8 +350,8 @@ class TableCellListDelegate extends TwoDimensionalChildListDelegate
       children.map((List<Widget> array) => array.length).toSet().length == 1,
       'Each list of Widgets within cells must be of the same length.',
     );
-    assert(rowCount >= pinnedRowCount);
-    assert(columnCount >= pinnedColumnCount);
+    assert(columnCount >= pinnedColumnCount + trailingPinnedColumnCount);
+    assert(rowCount >= pinnedRowCount + trailingPinnedRowCount);
   }
 
   @override
@@ -296,11 +376,24 @@ class TableCellListDelegate extends TwoDimensionalChildListDelegate
   int _pinnedColumnCount;
   set pinnedColumnCount(int value) {
     assert(value >= 0);
-    assert(value <= columnCount);
+    assert(value + trailingPinnedColumnCount <= columnCount);
     if (pinnedColumnCount == value) {
       return;
     }
     _pinnedColumnCount = value;
+    notifyListeners();
+  }
+
+  @override
+  int get trailingPinnedColumnCount => _trailingPinnedColumnCount;
+  int _trailingPinnedColumnCount;
+  set trailingPinnedColumnCount(int value) {
+    assert(value >= 0);
+    assert(pinnedColumnCount + value <= columnCount);
+    if (trailingPinnedColumnCount == value) {
+      return;
+    }
+    _trailingPinnedColumnCount = value;
     notifyListeners();
   }
 
@@ -326,7 +419,7 @@ class TableCellListDelegate extends TwoDimensionalChildListDelegate
   int _pinnedRowCount;
   set pinnedRowCount(int value) {
     assert(value >= 0);
-    assert(value <= rowCount);
+    assert(value + trailingPinnedRowCount <= rowCount);
     if (pinnedRowCount == value) {
       return;
     }
@@ -335,13 +428,28 @@ class TableCellListDelegate extends TwoDimensionalChildListDelegate
   }
 
   @override
+  int get trailingPinnedRowCount => _trailingPinnedRowCount;
+  int _trailingPinnedRowCount;
+  set trailingPinnedRowCount(int value) {
+    assert(value >= 0);
+    assert(pinnedRowCount + value <= rowCount);
+    if (trailingPinnedRowCount == value) {
+      return;
+    }
+    _trailingPinnedRowCount = value;
+    notifyListeners();
+  }
+
+  @override
   bool shouldRebuild(covariant TableCellListDelegate oldDelegate) {
     return columnCount != oldDelegate.columnCount ||
         _columnBuilder != oldDelegate._columnBuilder ||
         pinnedColumnCount != oldDelegate.pinnedColumnCount ||
+        trailingPinnedColumnCount != oldDelegate.trailingPinnedColumnCount ||
         rowCount != oldDelegate.rowCount ||
         _rowBuilder != oldDelegate._rowBuilder ||
         pinnedRowCount != oldDelegate.pinnedRowCount ||
+        trailingPinnedRowCount != oldDelegate.trailingPinnedRowCount ||
         super.shouldRebuild(oldDelegate);
   }
 }

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.4.3
+version: 0.5.0
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.4.2
+version: 0.4.3
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/table_view/alignment_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/alignment_test.dart
@@ -605,7 +605,9 @@ void main() {
       );
     });
 
-    testWidgets('Alignment with trailing pinned columns', (WidgetTester tester) async {
+    testWidgets('Alignment with trailing pinned columns', (
+      WidgetTester tester,
+    ) async {
       const viewportWidth = 600.0;
 
       await tester.pumpWidget(
@@ -668,7 +670,9 @@ void main() {
       );
     });
 
-    testWidgets('Alignment with trailing pinned rows', (WidgetTester tester) async {
+    testWidgets('Alignment with trailing pinned rows', (
+      WidgetTester tester,
+    ) async {
       const viewportHeight = 600.0;
 
       await tester.pumpWidget(

--- a/packages/two_dimensional_scrollables/test/table_view/alignment_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/alignment_test.dart
@@ -604,5 +604,130 @@ void main() {
         const Offset(0.0, 150.0),
       );
     });
+
+    testWidgets('Alignment with trailing pinned columns', (WidgetTester tester) async {
+      const viewportWidth = 600.0;
+
+      await tester.pumpWidget(
+        WidgetsApp(
+          color: const Color(0xFFFFFFFF),
+          debugShowCheckedModeBanner: false,
+          builder: (context, child) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: viewportWidth,
+                height: 400,
+                child: TableView.builder(
+                  columnCount: 3,
+                  rowCount: 1,
+                  trailingPinnedColumnCount: 1,
+                  alignment: Alignment.topCenter,
+                  columnBuilder: (index) =>
+                      const TableSpan(extent: FixedTableSpanExtent(100)),
+                  rowBuilder: (index) =>
+                      const TableSpan(extent: FixedTableSpanExtent(100)),
+                  cellBuilder: (context, vicinity) {
+                    return TableViewCell(
+                      child: SizedBox(
+                        key: ValueKey<String>(
+                          'cell ${vicinity.column}:${vicinity.row}',
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset tableTopLeft = tester.getTopLeft(find.byType(TableView));
+      // Total width 300. Viewport 600. Offset 150.
+      // Columns 0 and 1 are unpinned. Column 2 is trailing pinned.
+      // If it sticks to table flow, it should be at 350.
+      // If it sticks to viewport edge, it should be at 500.
+      final Finder cell00 = find.byKey(const ValueKey<String>('cell 0:0'));
+      expect(
+        tester.getTopLeft(cell00) - tableTopLeft,
+        const Offset(200.0, 0.0),
+      );
+
+      final Finder cell10 = find.byKey(const ValueKey<String>('cell 1:0'));
+      expect(
+        tester.getTopLeft(cell10) - tableTopLeft,
+        const Offset(300.0, 0.0),
+      );
+
+      final Finder cell20 = find.byKey(const ValueKey<String>('cell 2:0'));
+      expect(
+        tester.getTopLeft(cell20) - tableTopLeft,
+        const Offset(500.0, 0.0),
+      );
+    });
+
+    testWidgets('Alignment with trailing pinned rows', (WidgetTester tester) async {
+      const viewportHeight = 600.0;
+
+      await tester.pumpWidget(
+        WidgetsApp(
+          color: const Color(0xFFFFFFFF),
+          debugShowCheckedModeBanner: false,
+          builder: (context, child) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 400,
+                height: viewportHeight,
+                child: TableView.builder(
+                  columnCount: 1,
+                  rowCount: 3,
+                  trailingPinnedRowCount: 1,
+                  alignment: Alignment.centerLeft,
+                  columnBuilder: (index) =>
+                      const TableSpan(extent: FixedTableSpanExtent(100)),
+                  rowBuilder: (index) =>
+                      const TableSpan(extent: FixedTableSpanExtent(100)),
+                  cellBuilder: (context, vicinity) {
+                    return TableViewCell(
+                      child: SizedBox(
+                        key: ValueKey<String>(
+                          'cell ${vicinity.column}:${vicinity.row}',
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset tableTopLeft = tester.getTopLeft(find.byType(TableView));
+      // Total height 300. Viewport 600. Offset 150.
+      // Rows 0 and 1 are unpinned. Row 2 is trailing pinned.
+      // If it sticks to table flow, it should be at 350.
+      final Finder cell00 = find.byKey(const ValueKey<String>('cell 0:0'));
+      expect(
+        tester.getTopLeft(cell00) - tableTopLeft,
+        const Offset(0.0, 200.0),
+      );
+
+      final Finder cell01 = find.byKey(const ValueKey<String>('cell 0:1'));
+      expect(
+        tester.getTopLeft(cell01) - tableTopLeft,
+        const Offset(0.0, 300.0),
+      );
+
+      final Finder cell02 = find.byKey(const ValueKey<String>('cell 0:2'));
+      expect(
+        tester.getTopLeft(cell02) - tableTopLeft,
+        const Offset(0.0, 500.0),
+      );
+    });
   });
 }

--- a/packages/two_dimensional_scrollables/test/table_view/table_delegate_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_delegate_test.dart
@@ -118,7 +118,7 @@ void main() {
           isA<AssertionError>().having(
             (AssertionError error) => error.toString(),
             'description',
-            contains('pinnedColumnCount <= columnCount'),
+            contains('pinnedColumnCount + trailingPinnedColumnCount <= columnCount'),
           ),
         ),
       );
@@ -138,7 +138,7 @@ void main() {
           isA<AssertionError>().having(
             (AssertionError error) => error.toString(),
             'description',
-            contains('pinnedRowCount <= rowCount'),
+            contains('pinnedRowCount + trailingPinnedRowCount <= rowCount'),
           ),
         ),
       );
@@ -499,26 +499,26 @@ void main() {
 
       expect(
         () {
-          delegate.pinnedColumnCount = 4;
+          delegate.pinnedColumnCount = 5;
         },
         throwsA(
           isA<AssertionError>().having(
             (AssertionError error) => error.toString(),
             'description',
-            contains('value <= columnCount'),
+            contains('value + trailingPinnedColumnCount <= columnCount'),
           ),
         ),
       );
 
       expect(
         () {
-          delegate.pinnedRowCount = 4;
+          delegate.pinnedRowCount = 5;
         },
         throwsA(
           isA<AssertionError>().having(
             (AssertionError error) => error.toString(),
             'description',
-            contains('value <= rowCount'),
+            contains('value + trailingPinnedRowCount <= rowCount'),
           ),
         ),
       );

--- a/packages/two_dimensional_scrollables/test/table_view/table_delegate_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_delegate_test.dart
@@ -118,7 +118,9 @@ void main() {
           isA<AssertionError>().having(
             (AssertionError error) => error.toString(),
             'description',
-            contains('pinnedColumnCount + trailingPinnedColumnCount <= columnCount'),
+            contains(
+              'pinnedColumnCount + trailingPinnedColumnCount <= columnCount',
+            ),
           ),
         ),
       );

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -4179,8 +4179,8 @@ void main() {
   testWidgets('Trailing pinned columns and rows - smoke test', (
     WidgetTester tester,
   ) async {
-    final ScrollController horizontalController = ScrollController();
-    final ScrollController verticalController = ScrollController();
+    final horizontalController = ScrollController();
+    final verticalController = ScrollController();
 
     Widget getTableView({
       int? columnCount = 10,
@@ -4223,8 +4223,6 @@ void main() {
             height: 400,
             width: 400,
             child: getTableView(
-              columnCount: 10,
-              rowCount: 10,
               trailingPinnedColumnCount: 1,
               trailingPinnedRowCount: 1,
             ),
@@ -4319,10 +4317,10 @@ void main() {
                   const TableSpan(extent: FixedTableSpanExtent(100)),
               cellBuilder: (BuildContext context, TableVicinity vicinity) {
                 if (vicinity.row >= 8 && vicinity.column == 0) {
-                  return TableViewCell(
+                  return const TableViewCell(
                     rowMergeStart: 8,
                     rowMergeSpan: 2,
-                    child: const Text('Merged R8-9 C0'),
+                    child: Text('Merged R8-9 C0'),
                   );
                 }
                 return TableViewCell(

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -4225,6 +4225,14 @@ void main() {
       expect(find.text('Cell 3,0'), findsNothing);
 
       // Scroll horizontally so that column 1 is entirely behind pinned column 0.
+      // Pinned column 0 is 0 to 100.
+      // Unpinned content starts at 100 (Column 1).
+      // Scroll 100 pixels.
+      // Content at 0 (start of column 1) moves to absolute 100 - 100 = 0.
+      // Content at 50 (end of column 1) moves to absolute 100 + (50 - 100) = 50.
+      // So column 1 (0 to 50) is entirely covered by pinned column 0.
+      // Column 2 (50 to 100) is also covered.
+      // Column 3 (100 to 150) is the first visible in unpinned area.
       horizontalController.jumpTo(100);
       await tester.pump();
 

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -4176,6 +4176,223 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Merged cells should not unmerge when the first cell is overlaid by a pinned column',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/174862
+      final horizontalController = ScrollController();
+      addTearDown(horizontalController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              height: 400,
+              child: TableView.builder(
+                cacheExtent: 0.0,
+                horizontalDetails: ScrollableDetails.horizontal(
+                  controller: horizontalController,
+                ),
+                pinnedColumnCount: 1,
+                columnCount: 10,
+                rowCount: 10,
+                columnBuilder: (int index) => TableSpan(
+                  extent: FixedTableSpanExtent(index == 0 ? 100 : 50),
+                ),
+                rowBuilder: (int index) =>
+                    const TableSpan(extent: FixedTableSpanExtent(50)),
+                cellBuilder: (BuildContext context, TableVicinity vicinity) {
+                  final isColumn1 = vicinity.column == 1;
+                  return TableViewCell(
+                    columnMergeStart: isColumn1 ? 1 : null,
+                    columnMergeSpan: isColumn1 ? 3 : null,
+                    child: Center(
+                      child: Text('Cell ${vicinity.column},${vicinity.row}'),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Initially, column 1 is visible next to pinned column 0.
+      expect(find.text('Cell 1,0'), findsOneWidget);
+      // Column 2 and 3 should be part of the merge, so they are not built.
+      expect(find.text('Cell 2,0'), findsNothing);
+      expect(find.text('Cell 3,0'), findsNothing);
+
+      // Scroll horizontally so that column 1 is entirely behind pinned column 0.
+      horizontalController.jumpTo(100);
+      await tester.pump();
+
+      // With the fix, column 1 is still built because it is under the pinned area.
+      // Since column 1 is built, its merge info is found and applied to columns 2 and 3.
+      expect(find.text('Cell 1,0'), findsOneWidget);
+      expect(find.text('Cell 2,0'), findsNothing);
+      expect(find.text('Cell 3,0'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Merged cells should not unmerge when the first cell is overlaid by a pinned row',
+    (WidgetTester tester) async {
+      final verticalController = ScrollController();
+      addTearDown(verticalController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              height: 400,
+              child: TableView.builder(
+                cacheExtent: 0.0,
+                verticalDetails: ScrollableDetails.vertical(
+                  controller: verticalController,
+                ),
+                pinnedRowCount: 1,
+                columnCount: 10,
+                rowCount: 10,
+                columnBuilder: (int index) =>
+                    const TableSpan(extent: FixedTableSpanExtent(50)),
+                rowBuilder: (int index) => TableSpan(
+                  extent: FixedTableSpanExtent(index == 0 ? 100 : 50),
+                ),
+                cellBuilder: (BuildContext context, TableVicinity vicinity) {
+                  // Merged cell spanning rows 1, 2, and 3.
+                  final isRow1 = vicinity.row == 1;
+                  return TableViewCell(
+                    rowMergeStart: isRow1 ? 1 : null,
+                    rowMergeSpan: isRow1 ? 3 : null,
+                    child: Center(
+                      child: Text('Cell ${vicinity.column},${vicinity.row}'),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Initially, row 1 is visible below pinned row 0.
+      expect(find.text('Cell 0,1'), findsOneWidget);
+      expect(find.text('Cell 0,2'), findsNothing);
+      expect(find.text('Cell 0,3'), findsNothing);
+
+      // Scroll vertically so that row 1 is entirely behind pinned row 0.
+      verticalController.jumpTo(100);
+      await tester.pump();
+
+      // Row 1 should still be built, maintaining the merge.
+      expect(find.text('Cell 0,1'), findsOneWidget);
+      expect(find.text('Cell 0,2'), findsNothing);
+      expect(find.text('Cell 0,3'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Table does not crash when focusing outside of the table while focused text field is not in the view',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/137112
+      final verticalController = ScrollController();
+      final horizontalController = ScrollController();
+      addTearDown(() {
+        verticalController.dispose();
+        horizontalController.dispose();
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                const TextField(key: Key('outside_textfield')),
+                Expanded(
+                  child: TableView.builder(
+                    verticalDetails: ScrollableDetails.vertical(
+                      controller: verticalController,
+                    ),
+                    horizontalDetails: ScrollableDetails.horizontal(
+                      controller: horizontalController,
+                    ),
+                    cellBuilder:
+                        (BuildContext context, TableVicinity vicinity) {
+                          return TableViewCell(
+                            child: Center(
+                              child: TextField(
+                                key: Key(
+                                  'cell_${vicinity.row}_${vicinity.column}',
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                    columnCount: 20,
+                    columnBuilder: (int index) {
+                      return const TableSpan(
+                        foregroundDecoration: TableSpanDecoration(
+                          border: TableSpanBorder(trailing: BorderSide()),
+                        ),
+                        extent: FixedTableSpanExtent(100),
+                      );
+                    },
+                    rowCount: 40,
+                    rowBuilder: (int index) {
+                      return TableSpan(
+                        backgroundDecoration: TableSpanDecoration(
+                          color: index.isEven ? Colors.purple[100] : null,
+                          border: const TableSpanBorder(
+                            trailing: BorderSide(width: 3),
+                          ),
+                        ),
+                        extent: const FixedTableSpanExtent(50),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // 1. Select a TextField in the table.
+      // Use the vicinity from the original crash report.
+      const vicinity = TableVicinity(row: 5, column: 6);
+      final Finder cellTextField = find.byKey(
+        Key('cell_${vicinity.row}_${vicinity.column}'),
+      );
+      // Bring it into view.
+      verticalController.jumpTo(250);
+      horizontalController.jumpTo(600);
+      await tester.pumpAndSettle();
+
+      await tester.tap(cellTextField);
+      await tester.pumpAndSettle();
+      expect(FocusManager.instance.primaryFocus, isNotNull);
+
+      // 2. Scroll until it disappears from the view, without unfocusing it.
+      verticalController.jumpTo(verticalController.offset + 1000);
+      await tester.pumpAndSettle();
+
+      // 3. Select another TextField outside of the table.
+      final Finder outsideTextField = find.byKey(
+        const Key('outside_textfield'),
+      );
+      await tester.tap(outsideTextField);
+      await tester.pumpAndSettle();
+
+      // 4. Scroll back and ensure the table does not crash.
+      verticalController.jumpTo(verticalController.offset - 1000);
+      await tester.pumpAndSettle();
+      expect(cellTextField, findsOneWidget);
+    },
+  );
+
   testWidgets('Trailing pinned columns and rows - smoke test', (
     WidgetTester tester,
   ) async {

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -4176,230 +4176,172 @@ void main() {
     },
   );
 
-  testWidgets(
-    'Merged cells should not unmerge when the first cell is overlaid by a pinned column',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/174862
-      final horizontalController = ScrollController();
-      addTearDown(horizontalController.dispose);
+  testWidgets('Trailing pinned columns and rows - smoke test', (
+    WidgetTester tester,
+  ) async {
+    final ScrollController horizontalController = ScrollController();
+    final ScrollController verticalController = ScrollController();
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              width: 400,
-              height: 400,
-              child: TableView.builder(
-                cacheExtent: 0.0,
-                horizontalDetails: ScrollableDetails.horizontal(
-                  controller: horizontalController,
-                ),
-                pinnedColumnCount: 1,
-                columnCount: 10,
-                rowCount: 10,
-                columnBuilder: (int index) => TableSpan(
-                  extent: FixedTableSpanExtent(index == 0 ? 100 : 50),
-                ),
-                rowBuilder: (int index) =>
-                    const TableSpan(extent: FixedTableSpanExtent(50)),
-                cellBuilder: (BuildContext context, TableVicinity vicinity) {
-                  final isColumn1 = vicinity.column == 1;
+    Widget getTableView({
+      int? columnCount = 10,
+      int? rowCount = 10,
+      int pinnedColumnCount = 0,
+      int pinnedRowCount = 0,
+      int trailingPinnedColumnCount = 0,
+      int trailingPinnedRowCount = 0,
+    }) {
+      return TableView.builder(
+        cacheExtent: 0.0,
+        columnCount: columnCount,
+        rowCount: rowCount,
+        pinnedColumnCount: pinnedColumnCount,
+        pinnedRowCount: pinnedRowCount,
+        trailingPinnedColumnCount: trailingPinnedColumnCount,
+        trailingPinnedRowCount: trailingPinnedRowCount,
+        horizontalDetails: ScrollableDetails.horizontal(
+          controller: horizontalController,
+        ),
+        verticalDetails: ScrollableDetails.vertical(
+          controller: verticalController,
+        ),
+        columnBuilder: (int index) =>
+            const TableSpan(extent: FixedTableSpanExtent(100)),
+        rowBuilder: (int index) =>
+            const TableSpan(extent: FixedTableSpanExtent(100)),
+        cellBuilder: (BuildContext context, TableVicinity vicinity) {
+          return TableViewCell(
+            child: Text('R${vicinity.row} C${vicinity.column}'),
+          );
+        },
+      );
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 400,
+            width: 400,
+            child: getTableView(
+              columnCount: 10,
+              rowCount: 10,
+              trailingPinnedColumnCount: 1,
+              trailingPinnedRowCount: 1,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Initial view: 0-2 rows/cols are visible (100 each), plus trailing pinned (Row 9, Column 9)
+    expect(find.text('R0 C0'), findsOneWidget);
+    expect(find.text('R9 C9'), findsOneWidget);
+    expect(find.text('R0 C9'), findsOneWidget);
+    expect(find.text('R9 C0'), findsOneWidget);
+
+    expect(tester.getRect(find.text('R0 C9')).left, 300);
+    expect(tester.getRect(find.text('R9 C0')).top, 300);
+
+    // Scroll
+    horizontalController.jumpTo(50);
+    verticalController.jumpTo(50);
+    await tester.pump();
+
+    expect(tester.getRect(find.text('R0 C0')).left, -50);
+    expect(tester.getRect(find.text('R0 C0')).top, -50);
+    expect(tester.getRect(find.text('R0 C9')).left, 300);
+    expect(tester.getRect(find.text('R9 C0')).top, 300);
+    expect(tester.getRect(find.text('R9 C9')).left, 300);
+    expect(tester.getRect(find.text('R9 C9')).top, 300);
+  });
+
+  testWidgets('Intersections of leading and trailing pinned', (
+    WidgetTester tester,
+  ) async {
+    const span = TableSpan(extent: FixedTableSpanExtent(100));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 400,
+            width: 400,
+            child: TableView.builder(
+              columnCount: 10,
+              rowCount: 10,
+              pinnedColumnCount: 1,
+              pinnedRowCount: 1,
+              trailingPinnedColumnCount: 1,
+              trailingPinnedRowCount: 1,
+              columnBuilder: (int index) => span,
+              rowBuilder: (int index) => span,
+              cellBuilder: (BuildContext context, TableVicinity vicinity) {
+                return TableViewCell(
+                  child: Text('R${vicinity.row} C${vicinity.column}'),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Leading-Leading intersection
+    expect(tester.getRect(find.text('R0 C0')).topLeft, Offset.zero);
+    // Leading-Trailing intersection (Row 0, Col 9)
+    expect(tester.getRect(find.text('R0 C9')).topLeft, const Offset(300, 0));
+    // Trailing-Leading intersection (Row 9, Col 0)
+    expect(tester.getRect(find.text('R9 C0')).topLeft, const Offset(0, 300));
+    // Trailing-Trailing intersection (Row 9, Col 9)
+    expect(tester.getRect(find.text('R9 C9')).topLeft, const Offset(300, 300));
+
+    // Non-pinned middle
+    expect(tester.getRect(find.text('R1 C1')).topLeft, const Offset(100, 100));
+  });
+
+  testWidgets('Trailing pinned - merged cells validation', (
+    WidgetTester tester,
+  ) async {
+    // Merged cell in trailing pinned row
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 400,
+            width: 400,
+            child: TableView.builder(
+              cacheExtent: 0.0,
+              columnCount: 10,
+              rowCount: 10,
+              trailingPinnedRowCount: 2,
+              columnBuilder: (int index) =>
+                  const TableSpan(extent: FixedTableSpanExtent(100)),
+              rowBuilder: (int index) =>
+                  const TableSpan(extent: FixedTableSpanExtent(100)),
+              cellBuilder: (BuildContext context, TableVicinity vicinity) {
+                if (vicinity.row >= 8 && vicinity.column == 0) {
                   return TableViewCell(
-                    columnMergeStart: isColumn1 ? 1 : null,
-                    columnMergeSpan: isColumn1 ? 3 : null,
-                    child: Center(
-                      child: Text('Cell ${vicinity.column},${vicinity.row}'),
-                    ),
+                    rowMergeStart: 8,
+                    rowMergeSpan: 2,
+                    child: const Text('Merged R8-9 C0'),
                   );
-                },
-              ),
+                }
+                return TableViewCell(
+                  child: Text('R${vicinity.row} C${vicinity.column}'),
+                );
+              },
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      // Initially, column 1 is visible next to pinned column 0.
-      expect(find.text('Cell 1,0'), findsOneWidget);
-      // Column 2 and 3 should be part of the merge, so they are not built.
-      expect(find.text('Cell 2,0'), findsNothing);
-      expect(find.text('Cell 3,0'), findsNothing);
-
-      // Scroll horizontally so that column 1 is entirely behind pinned column 0.
-      // Pinned column 0 is 0 to 100.
-      // Unpinned content starts at 100 (Column 1).
-      // Scroll 100 pixels.
-      // Content at 0 (start of column 1) moves to absolute 100 - 100 = 0.
-      // Content at 50 (end of column 1) moves to absolute 100 + (50 - 100) = 50.
-      // So column 1 (0 to 50) is entirely covered by pinned column 0.
-      // Column 2 (50 to 100) is also covered.
-      // Column 3 (100 to 150) is the first visible in unpinned area.
-      horizontalController.jumpTo(100);
-      await tester.pump();
-
-      // With the fix, column 1 is still built because it is under the pinned area.
-      // Since column 1 is built, its merge info is found and applied to columns 2 and 3.
-      expect(find.text('Cell 1,0'), findsOneWidget);
-      expect(find.text('Cell 2,0'), findsNothing);
-      expect(find.text('Cell 3,0'), findsNothing);
-    },
-  );
-
-  testWidgets(
-    'Merged cells should not unmerge when the first cell is overlaid by a pinned row',
-    (WidgetTester tester) async {
-      final verticalController = ScrollController();
-      addTearDown(verticalController.dispose);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              width: 400,
-              height: 400,
-              child: TableView.builder(
-                cacheExtent: 0.0,
-                verticalDetails: ScrollableDetails.vertical(
-                  controller: verticalController,
-                ),
-                pinnedRowCount: 1,
-                columnCount: 10,
-                rowCount: 10,
-                columnBuilder: (int index) =>
-                    const TableSpan(extent: FixedTableSpanExtent(50)),
-                rowBuilder: (int index) => TableSpan(
-                  extent: FixedTableSpanExtent(index == 0 ? 100 : 50),
-                ),
-                cellBuilder: (BuildContext context, TableVicinity vicinity) {
-                  // Merged cell spanning rows 1, 2, and 3.
-                  final isRow1 = vicinity.row == 1;
-                  return TableViewCell(
-                    rowMergeStart: isRow1 ? 1 : null,
-                    rowMergeSpan: isRow1 ? 3 : null,
-                    child: Center(
-                      child: Text('Cell ${vicinity.column},${vicinity.row}'),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
-        ),
-      );
-
-      // Initially, row 1 is visible below pinned row 0.
-      expect(find.text('Cell 0,1'), findsOneWidget);
-      expect(find.text('Cell 0,2'), findsNothing);
-      expect(find.text('Cell 0,3'), findsNothing);
-
-      // Scroll vertically so that row 1 is entirely behind pinned row 0.
-      verticalController.jumpTo(100);
-      await tester.pump();
-
-      // Row 1 should still be built, maintaining the merge.
-      expect(find.text('Cell 0,1'), findsOneWidget);
-      expect(find.text('Cell 0,2'), findsNothing);
-      expect(find.text('Cell 0,3'), findsNothing);
-    },
-  );
-
-  testWidgets(
-    'Table does not crash when focusing outside of the table while focused text field is not in the view',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/137112
-      final verticalController = ScrollController();
-      final horizontalController = ScrollController();
-      addTearDown(() {
-        verticalController.dispose();
-        horizontalController.dispose();
-      });
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Column(
-              children: [
-                const TextField(key: Key('outside_textfield')),
-                Expanded(
-                  child: TableView.builder(
-                    verticalDetails: ScrollableDetails.vertical(
-                      controller: verticalController,
-                    ),
-                    horizontalDetails: ScrollableDetails.horizontal(
-                      controller: horizontalController,
-                    ),
-                    cellBuilder:
-                        (BuildContext context, TableVicinity vicinity) {
-                          return TableViewCell(
-                            child: Center(
-                              child: TextField(
-                                key: Key(
-                                  'cell_${vicinity.row}_${vicinity.column}',
-                                ),
-                              ),
-                            ),
-                          );
-                        },
-                    columnCount: 20,
-                    columnBuilder: (int index) {
-                      return const TableSpan(
-                        foregroundDecoration: TableSpanDecoration(
-                          border: TableSpanBorder(trailing: BorderSide()),
-                        ),
-                        extent: FixedTableSpanExtent(100),
-                      );
-                    },
-                    rowCount: 40,
-                    rowBuilder: (int index) {
-                      return TableSpan(
-                        backgroundDecoration: TableSpanDecoration(
-                          color: index.isEven ? Colors.purple[100] : null,
-                          border: const TableSpanBorder(
-                            trailing: BorderSide(width: 3),
-                          ),
-                        ),
-                        extent: const FixedTableSpanExtent(50),
-                      );
-                    },
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-
-      // 1. Select a TextField in the table.
-      // Use the vicinity from the original crash report.
-      const vicinity = TableVicinity(row: 5, column: 6);
-      final Finder cellTextField = find.byKey(
-        Key('cell_${vicinity.row}_${vicinity.column}'),
-      );
-      // Bring it into view.
-      verticalController.jumpTo(250);
-      horizontalController.jumpTo(600);
-      await tester.pumpAndSettle();
-
-      await tester.tap(cellTextField);
-      await tester.pumpAndSettle();
-      expect(FocusManager.instance.primaryFocus, isNotNull);
-
-      // 2. Scroll until it disappears from the view, without unfocusing it.
-      verticalController.jumpTo(verticalController.offset + 1000);
-      await tester.pumpAndSettle();
-
-      // 3. Select another TextField outside of the table.
-      final Finder outsideTextField = find.byKey(
-        const Key('outside_textfield'),
-      );
-      await tester.tap(outsideTextField);
-      await tester.pumpAndSettle();
-
-      // 4. Scroll back and ensure the table does not crash.
-      verticalController.jumpTo(verticalController.offset - 1000);
-      await tester.pumpAndSettle();
-      expect(cellTextField, findsOneWidget);
-    },
-  );
+    // Merged cell should be at [0, 100] horizontally, and [200, 400] vertically
+    // because Row 8 & 9 are trailing pinned (bottom 200 pixels).
+    expect(find.text('Merged R8-9 C0'), findsOneWidget);
+    final Rect mergedRect = tester.getRect(find.text('Merged R8-9 C0'));
+    expect(mergedRect.top, 200);
+    expect(mergedRect.bottom, 400);
+  });
 }
 
 class _NullBuildContext implements BuildContext, TwoDimensionalChildManager {


### PR DESCRIPTION
This PR implements the requested feature to allow pinning rows and columns to the trailing edges of the TableView (bottom and right in LTR). Previously, only leading pinning was supported.

This implementation allows for use cases such as a "delete" button pinned to the right of every row, or a summary footer pinned to the bottom of the table.

   - Added trailingPinnedRowCount and trailingPinnedColumnCount to TableView.builder, TableView.list, and their associated delegates (TableCellBuilderDelegate, TableCellListDelegate).
   - Updated RenderTableViewport to calculate and track extents for trailing pinned spans. The indices for these spans are calculated from the end of the specified rowCount or columnCount.
   - Extended layoutChildSequence in RenderTableViewport to handle all 9 regions of the resulting grid (intersections of leading-pinned, regular, and trailing-pinned rows/columns).
   - Updated the paint method to correctly clip and layer trailing pinned areas, ensuring they stay at the viewport edges and that regular content scrolls underneath them correctly.
   - Adjusted maxScrollExtent calculations to account for both leading and trailing pinned extents, ensuring the scrollable area is correctly sized.
   - Updated the table alignment logic to correctly position the entire table (including pinned areas) when it is smaller than the viewport.

  Technical Details

   - Trailing pinned elements are logically positioned based on the viewport dimension minus their cumulative extent.
   - Merged cells are supported within trailing pinned areas, with safety assertions to ensure they do not span across pinned and unpinned boundaries.
   - The implementation maintains compatibility with existing leading pinning and supports various combinations of both.

Fixes flutter/flutter#133238
[Design Doc](https://docs.google.com/document/d/1TYqmQFot4TcwiddQdNW6YHeO0F_89nqTYOZOgrULJRw/edit?usp=sharing)

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
