### PR TITLE
Add example app for mustache_template package

### DIFF
--- a/script/configs/temp_exclude_excerpt.yaml
+++ b/script/configs/temp_exclude_excerpt.yaml
@@ -7,6 +7,5 @@
 # https://github.com/flutter/flutter/issues/102679
 - espresso
 - in_app_purchase/in_app_purchase
-- mustache_template
 - pointer_interceptor
 - quick_actions/quick_actions

--- a/third_party/packages/mustache_template/example/.gitignore
+++ b/third_party/packages/mustache_template/example/.gitignore
@@ -1,0 +1,44 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/third_party/packages/mustache_template/example/.metadata
+++ b/third_party/packages/mustache_template/example/.metadata
@@ -1,0 +1,45 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled.
+
+version:
+  revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+  channel: master
+
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+      base_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+    - platform: android
+      create_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+      base_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+    - platform: ios
+      create_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+      base_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+    - platform: linux
+      create_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+      base_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+    - platform: macos
+      create_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+      base_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+    - platform: web
+      create_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+      base_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+    - platform: windows
+      create_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+      base_revision: 822f6e3595d63f864ae2027ea37fd645b313b71b
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/third_party/packages/mustache_template/example/README.md
+++ b/third_party/packages/mustache_template/example/README.md
@@ -1,0 +1,13 @@
+# mustache_template_example
+
+Example app for the `mustache_template` package.
+
+This example demonstrates basic usage of the Mustache template library,
+including rendering templates with lists and conditional sections.
+
+## Running the example
+
+```sh
+cd example
+flutter run
+```

--- a/third_party/packages/mustache_template/example/analysis_options.yaml
+++ b/third_party/packages/mustache_template/example/analysis_options.yaml
@@ -1,0 +1,8 @@
+# Use the analysis options settings from the top level of the repo (not
+# the ones from above, which include the `public_member_api_docs` rule).
+
+include: ../../../analysis_options.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false

--- a/third_party/packages/mustache_template/example/lib/main.dart
+++ b/third_party/packages/mustache_template/example/lib/main.dart
@@ -1,0 +1,51 @@
+// Copyright 2024, the Flutter project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:mustache_template/mustache_template.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Mustache Template Demo',
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Mustache Template Demo'),
+        ),
+        body: Center(
+          child: Text(_renderTemplate()),
+        ),
+      ),
+    );
+  }
+
+  String _renderTemplate() {
+    // #docregion basic-usage
+    const source = '''
+    {{# names }}
+      <div>{{ lastname }}, {{ firstname }}</div>
+    {{/ names }}
+    {{^ names }}
+      <div>No names.</div>
+    {{/ names }}
+    ''';
+
+    final template = Template(source, name: 'example-template.html');
+
+    return template.renderString({
+      'names': [
+        {'firstname': 'Greg', 'lastname': 'Lowe'},
+        {'firstname': 'Bob', 'lastname': 'Johnson'},
+      ]
+    });
+    // #enddocregion basic-usage
+  }
+}

--- a/third_party/packages/mustache_template/example/lib/main.dart
+++ b/third_party/packages/mustache_template/example/lib/main.dart
@@ -30,15 +30,15 @@ class MyApp extends StatelessWidget {
   String _renderTemplate() {
     // #docregion basic-usage
     const source = '''
-    {{# names }}
-      <div>{{ lastname }}, {{ firstname }}</div>
-    {{/ names }}
-    {{^ names }}
-      <div>No names.</div>
-    {{/ names }}
-    ''';
+{{# names }}
+{{ lastname }}, {{ firstname }}
+{{/ names }}
+{{^ names }}
+No names.
+{{/ names }}
+''';
 
-    final template = Template(source, name: 'example-template.html');
+    final template = Template(source, name: 'example-template');
 
     return template.renderString({
       'names': [

--- a/third_party/packages/mustache_template/example/pubspec.yaml
+++ b/third_party/packages/mustache_template/example/pubspec.yaml
@@ -1,0 +1,18 @@
+name: mustache_template_example
+
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  mustache_template:
+    path: ../
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
Good day

This PR adds an example app for the mustache_template package to address issue #183936.

## Changes

- Added  directory with a minimal Flutter app demonstrating basic usage of the mustache_template package
- Removed mustache_template from  since it now has an example app with code excerpts

## Issue Context

The mustache_template package currently lacks an example app, which causes a score deduction on pub.dev. This fix addresses that by adding a proper example app with code excerpts that can be used in documentation generation.

## Testing

The example app follows the established pattern used by other packages in this repository (e.g., google_identity_services_web).

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof