### PR TITLE
[quick_actions_android] Bump gradle plugin to 9.1.1

### DIFF
--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.30
+
+* Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1.
+
 ## 1.0.29
 
 * Simplifies thread handling in message responses.

--- a/packages/quick_actions/quick_actions_android/android/build.gradle.kts
+++ b/packages/quick_actions/quick_actions_android/android/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.13.1")
+        classpath("com.android.tools.build:gradle:9.1.1")
     }
 }
 

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_android
 description: An implementation for the Android platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/quick_actions/quick_actions_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 1.0.29
+version: 1.0.30
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1 in packages/quick_actions/quick_actions_android.