### PR TITLE
[shared_preferences_android] Bump gradle plugin to 9.1.1

### DIFF
--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.24
+
+* Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1.
+
 ## 2.4.23
 
 * Fixes dartdoc comments that accidentally used HTML.

--- a/packages/shared_preferences/shared_preferences_android/android/build.gradle.kts
+++ b/packages/shared_preferences/shared_preferences_android/android/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.13.1")
+        classpath("com.android.tools.build:gradle:9.1.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.4.23
+version: 2.4.24
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1 in packages/shared_preferences/shared_preferences_android.