### PR TITLE
[image_picker_android] Bump gradle plugin to 9.1.1

### DIFF
--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.14
+
+* Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1.
+
 ## 0.8.13+16
 
 * Bumps androidx.core:core from 1.17.0 to 1.18.0.

--- a/packages/image_picker/image_picker_android/android/build.gradle.kts
+++ b/packages/image_picker/image_picker_android/android/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.13.1")
+        classpath("com.android.tools.build:gradle:9.1.1")
     }
 }
 

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.13+16
+version: 0.8.14
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1 in packages/image_picker/image_picker_android.