### PR TITLE
[google_maps_flutter_android] Bump gradle plugin to 9.1.1

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.9
+
+* Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1.
+
 ## 2.19.8
 
 * Updates internal implementation to use Kotlin Pigeon.

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle.kts
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.13.1")
+        classpath("com.android.tools.build:gradle:9.1.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_android
 description: Android implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.19.8
+version: 2.19.9
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1 in packages/google_maps_flutter/google_maps_flutter_android.