### PR TITLE
[video_player_android] Bump gradle plugin to 9.1.1

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.6
+
+* Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1.
+
 ## 2.9.5
 
 * Updates build files from Groovy to Kotlin.

--- a/packages/video_player/video_player_android/android/build.gradle.kts
+++ b/packages/video_player/video_player_android/android/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.13.1")
+        classpath("com.android.tools.build:gradle:9.1.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.9.5
+version: 2.9.6
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1 in packages/video_player/video_player_android.