### PR TITLE
[in_app_purchase_android] Bump gradle plugin to 9.1.1

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1.
+
 ## 0.4.0+10
 
 * Fixes dartdoc comments that accidentally used HTML.

--- a/packages/in_app_purchase/in_app_purchase_android/android/build.gradle.kts
+++ b/packages/in_app_purchase/in_app_purchase_android/android/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.13.1")
+        classpath("com.android.tools.build:gradle:9.1.1")
     }
 }
 

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.4.0+10
+version: 0.4.1
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1 in packages/in_app_purchase/in_app_purchase_android.