### PR TITLE
[pigeon] Bump gradle plugin to 9.1.1 in test_plugin

### DIFF
--- a/packages/pigeon/platform_tests/test_plugin/android/build.gradle.kts
+++ b/packages/pigeon/platform_tests/test_plugin/android/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.13.1")
+        classpath("com.android.tools.build:gradle:9.1.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.13.1 to 9.1.1 in packages/pigeon/platform_tests/test_plugin.