### PR TITLE
[video_player] Fix washed-out HDR video playback on iOS

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.7
+
+* Forces tone-mapping to SDR on iOS to prevent washed-out HDR video playback.
+
 ## 2.9.6
 
 * Adds a Swift version to fix a potential build issue when using CocoaPods.

--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/TestClasses.swift
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/TestClasses.swift
@@ -200,6 +200,7 @@ final class StubFVPAVFactory: NSObject, FVPAVFactory {
   let player: AVPlayer
   let playerItem: FVPAVPlayerItem
   let pixelBufferSource: FVPPixelBufferSource?
+  private(set) var lastOutputSettings: [String: Any]?
   #if os(iOS)
     var audioSession: FVPAVAudioSession
   #endif
@@ -233,7 +234,8 @@ final class StubFVPAVFactory: NSObject, FVPAVFactory {
     return self.player
   }
 
-  func videoOutput(pixelBufferAttributes attributes: [String: Any]) -> FVPPixelBufferSource {
+  func videoOutput(outputSettings: [String: Any]) -> FVPPixelBufferSource {
+    lastOutputSettings = outputSettings
     return pixelBufferSource ?? TestPixelBufferSource()
   }
 

--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.swift
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.swift
@@ -755,6 +755,28 @@ private let hlsAudioTestURI =
     }
   }
 
+  @Test func videoOutputIsConfiguredWithBT709ColorProperties() throws {
+    let item = StubPlayerItem()
+    let stubAVFactory = StubFVPAVFactory(player: nil, playerItem: item, pixelBufferSource: nil)
+    let stubViewProvider = StubViewProvider()
+    let _ = FVPVideoPlayer(
+      playerItem: item, avFactory: stubAVFactory, viewProvider: stubViewProvider)
+
+    // BT.709 color properties are required so AVFoundation tone-maps HDR sources
+    // into the Flutter texture. Without them HDR samples arrive unconverted and
+    // render washed out. See flutter/flutter#91241.
+    let settings = try #require(stubAVFactory.lastOutputSettings)
+    let colorProperties = try #require(
+      settings[AVVideoColorPropertiesKey] as? [String: Any])
+    #expect(
+      colorProperties[AVVideoColorPrimariesKey] as? String == AVVideoColorPrimaries_ITU_R_709_2)
+    #expect(
+      colorProperties[AVVideoTransferFunctionKey] as? String
+        == AVVideoTransferFunction_ITU_R_709_2)
+    #expect(
+      colorProperties[AVVideoYCbCrMatrixKey] as? String == AVVideoYCbCrMatrix_ITU_R_709_2)
+  }
+
   // MARK: - Helper Methods
 
   /// Creates a plugin with the given dependencies, and default stubs for any that aren't provided,

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPAVFactory.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPAVFactory.m
@@ -84,10 +84,10 @@
 @end
 
 @implementation FVPDefaultAVPlayerItemVideoOutput
-- (instancetype)initWithPixelBufferAttributes:(NSDictionary<NSString *, id> *)attributes {
+- (instancetype)initWithOutputSettings:(NSDictionary<NSString *, id> *)outputSettings {
   self = [super init];
   if (self) {
-    _videoOutput = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:attributes];
+    _videoOutput = [[AVPlayerItemVideoOutput alloc] initWithOutputSettings:outputSettings];
   }
   return self;
 }
@@ -150,9 +150,9 @@
   return [AVPlayer playerWithPlayerItem:((FVPDefaultAVPlayerItem *)playerItem).playerItem];
 }
 
-- (NSObject<FVPPixelBufferSource> *)videoOutputWithPixelBufferAttributes:
-    (NSDictionary<NSString *, id> *)attributes {
-  return [[FVPDefaultAVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:attributes];
+- (NSObject<FVPPixelBufferSource> *)videoOutputWithOutputSettings:
+    (NSDictionary<NSString *, id> *)outputSettings {
+  return [[FVPDefaultAVPlayerItemVideoOutput alloc] initWithOutputSettings:outputSettings];
 }
 
 #if TARGET_OS_IOS

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m
@@ -138,12 +138,20 @@ static NSDictionary<NSString *, NSValue *> *FVPGetPlayerItemObservations(void) {
   _player = [avFactory playerWithPlayerItem:item];
   _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
 
-  // Configure output.
-  NSDictionary *pixBuffAttributes = @{
+  // Configure output. AVVideoColorPropertiesKey must be declared on the output settings (not on
+  // pixel buffer attributes, where AVFoundation silently ignores it) so that HDR sources are
+  // tone-mapped to BT.709 SDR for the Flutter texture.
+  // See https://github.com/flutter/flutter/issues/91241
+  NSDictionary *outputSettings = @{
+    AVVideoColorPropertiesKey : @{
+      AVVideoColorPrimariesKey : AVVideoColorPrimaries_ITU_R_709_2,
+      AVVideoTransferFunctionKey : AVVideoTransferFunction_ITU_R_709_2,
+      AVVideoYCbCrMatrixKey : AVVideoYCbCrMatrix_ITU_R_709_2,
+    },
     (id)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA),
-    (id)kCVPixelBufferIOSurfacePropertiesKey : @{}
+    (id)kCVPixelBufferIOSurfacePropertiesKey : @{},
   };
-  _pixelBufferSource = [avFactory videoOutputWithPixelBufferAttributes:pixBuffAttributes];
+  _pixelBufferSource = [avFactory videoOutputWithOutputSettings:outputSettings];
 
   [asset loadValuesAsynchronouslyForKeys:@[ @"tracks" ] completionHandler:assetCompletionHandler];
 

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/include/video_player_avfoundation_objc/FVPAVFactory.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/include/video_player_avfoundation_objc/FVPAVFactory.h
@@ -94,10 +94,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// Creates and returns an AVPlayer instance with the specified player item.
 - (AVPlayer *)playerWithPlayerItem:(NSObject<FVPAVPlayerItem> *)playerItem;
 
-/// Creates and returns a wrapped AVPlayerItemVideoOutput instance with the specified pixel buffer
-/// attributes.
-- (NSObject<FVPPixelBufferSource> *)videoOutputWithPixelBufferAttributes:
-    (NSDictionary<NSString *, id> *)attributes;
+/// Creates and returns a wrapped AVPlayerItemVideoOutput instance with the specified output
+/// settings. The dictionary may contain both video output keys (e.g. AVVideoColorPropertiesKey)
+/// and CVPixelBuffer attribute keys (e.g. kCVPixelBufferPixelFormatTypeKey), as accepted by
+/// -[AVPlayerItemVideoOutput initWithOutputSettings:].
+- (NSObject<FVPPixelBufferSource> *)videoOutputWithOutputSettings:
+    (NSDictionary<NSString *, id> *)outputSettings NS_SWIFT_NAME(videoOutput(outputSettings:));
 
 #if TARGET_OS_IOS
 /// Returns the AVAudioSession shared instance, wrapped in the protocol.

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.9.6
+version: 2.9.7
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Declares BT.709 color properties on `AVPlayerItemVideoOutput` so AVFoundation tone-maps HDR sources (HLG, PQ, Dolby Vision) into the Flutter texture on the way into the pixel buffer.

Previously the output was constructed with only pixel buffer attributes, so HDR BT.2020 samples reached the Flutter texture unconverted, were sampled as sRGB, and produced washed-out highlights, raised blacks, and desaturated midtones. SDR (BT.709) sources are unaffected (BT.709 → BT.709 is a no-op).

The canonical fix per Apple is to construct the output with `-initWithOutputSettings:` and pass `AVVideoColorPropertiesKey` with a BT.709 triplet. `AVVideoColorPropertiesKey` placed under `pixelBufferAttributes` is silently ignored — this is the trap that has kept the underlying issue open for years.

Internal factory method renamed from `videoOutputWithPixelBufferAttributes:` to `videoOutputWithOutputSettings:` to reflect that the dictionary is now output settings (which may still include pixel buffer attribute keys).

References:
- WWDC22 "Display HDR video in EDR with AVFoundation and Metal"
- Apple Developer Forum thread 686044

## Fixes

- fixes flutter/flutter#91241
- fixes flutter/flutter#143080 (closed as duplicate of #91241)

## Tested on

Manual validation against an iPhone camera roll containing HLG and Dolby Vision clips, played inside a Flutter app using `video_player`. Before: preview washed out, highlights clipped grey, blacks raised. After: preview matches Photos.app for the same source clip. SDR BT.709 content renders identically to before.

A unit test (`videoOutputIsConfiguredWithBT709ColorProperties`) was added to assert the BT.709 triplet is present in the `outputSettings` dictionary passed to the factory — this locks in the fix against silent regression (since the old `pixelBufferAttributes`-only path produced no test failure and no runtime error, just visually wrong output).

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
