### PR TITLE
[file_selector] Update Windows example for deprecations

### DIFF
--- a/packages/file_selector/file_selector_windows/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/get_directory_page.dart
@@ -14,7 +14,9 @@ class GetDirectoryPage extends StatelessWidget {
   Future<void> _getDirectoryPath(BuildContext context) async {
     const confirmButtonText = 'Choose';
     final String? directoryPath = await FileSelectorPlatform.instance
-        .getDirectoryPath(confirmButtonText: confirmButtonText);
+        .getDirectoryPathWithOptions(
+          const FileDialogOptions(confirmButtonText: confirmButtonText),
+        );
     if (directoryPath == null) {
       // Operation was canceled by the user.
       return;

--- a/packages/file_selector/file_selector_windows/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/get_multiple_directories_page.dart
@@ -14,7 +14,9 @@ class GetMultipleDirectoriesPage extends StatelessWidget {
   Future<void> _getDirectoryPaths(BuildContext context) async {
     const confirmButtonText = 'Choose';
     final List<String?> directoriesPaths = await FileSelectorPlatform.instance
-        .getDirectoryPaths(confirmButtonText: confirmButtonText);
+        .getDirectoryPathsWithOptions(
+          const FileDialogOptions(confirmButtonText: confirmButtonText),
+        );
     if (directoriesPaths.isEmpty) {
       // Operation was canceled by the user.
       return;

--- a/packages/file_selector/file_selector_windows/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.35.0"
 
 dependencies:
-  file_selector_platform_interface: ^2.6.0
+  file_selector_platform_interface: ^2.7.0
   file_selector_windows:
     # When depending on this package from a real application you should use:
     #   file_selector_windows: ^x.y.z


### PR DESCRIPTION
The `file_selector_windows` example was using some methods that have been deprecated in favor of param-object versions. This updates to use those new versions.