### PR TITLE
[google_maps_flutter] Replace use of zIndex in examples and tests

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_advanced_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_advanced_marker.dart
@@ -247,10 +247,10 @@ class _PlaceAdvancedMarkerBodyState extends State<_PlaceAdvancedMarkerBody> {
 
   Future<void> _changeZIndex(MarkerId markerId) async {
     final AdvancedMarker marker = markers[markerId]!;
-    final double current = marker.zIndex;
+    final int current = marker.zIndexInt;
     setState(() {
       markers[markerId] = marker.copyWith(
-        zIndexParam: current == 12.0 ? 0.0 : current + 1.0,
+        zIndexIntParam: current == 12 ? 0 : current + 1,
       );
     });
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_test.dart
@@ -2488,7 +2488,7 @@ AdvancedMarker _copyAdvancedMarkerWithClusterManagerId(
     position: marker.position,
     rotation: marker.rotation,
     visible: marker.visible,
-    zIndex: marker.zIndex.toInt(),
+    zIndex: marker.zIndexInt,
     onTap: marker.onTap,
     onDragStart: marker.onDragStart,
     onDrag: marker.onDrag,

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/place_advanced_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/place_advanced_marker.dart
@@ -247,10 +247,10 @@ class _PlaceAdvancedMarkerBodyState extends State<_PlaceAdvancedMarkerBody> {
 
   Future<void> _changeZIndex(MarkerId markerId) async {
     final AdvancedMarker marker = markers[markerId]!;
-    final double current = marker.zIndex;
+    final int current = marker.zIndexInt;
     setState(() {
       markers[markerId] = marker.copyWith(
-        zIndexParam: current == 12.0 ? 0.0 : current + 1.0,
+        zIndexIntParam: current == 12 ? 0 : current + 1,
       );
     });
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
@@ -662,7 +662,7 @@ void main() {
       expect(firstChanged.position.longitude, object2new.position.longitude);
       expect(firstChanged.rotation, object2new.rotation);
       expect(firstChanged.visible, object2new.visible);
-      expect(firstChanged.zIndex, object2new.zIndex);
+      expect(firstChanged.zIndex, object2new.zIndexInt);
       expect(firstChanged.markerId, object2new.markerId.value);
       expect(firstChanged.clusterManagerId, object2new.clusterManagerId?.value);
       expect(
@@ -694,7 +694,7 @@ void main() {
       expect(firstAdded.position.longitude, object3.position.longitude);
       expect(firstAdded.rotation, object3.rotation);
       expect(firstAdded.visible, object3.visible);
-      expect(firstAdded.zIndex, object3.zIndex);
+      expect(firstAdded.zIndex, object3.zIndexInt);
       expect(firstAdded.markerId, object3.markerId.value);
       expect(firstAdded.clusterManagerId, object3.clusterManagerId?.value);
       expect(

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/integration_test/google_maps_test.dart
@@ -2274,7 +2274,7 @@ AdvancedMarker _copyAdvancedMarkerWithClusterManagerId(
     position: marker.position,
     rotation: marker.rotation,
     visible: marker.visible,
-    zIndex: marker.zIndex.toInt(),
+    zIndex: marker.zIndexInt,
     onTap: marker.onTap,
     onDragStart: marker.onDragStart,
     onDrag: marker.onDrag,

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/place_advanced_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/place_advanced_marker.dart
@@ -264,10 +264,10 @@ class _PlaceAdvancedMarkerBodyState extends State<_PlaceAdvancedMarkerBody> {
 
   Future<void> _changeZIndex(MarkerId markerId) async {
     final AdvancedMarker marker = markers[markerId]!;
-    final double current = marker.zIndex;
+    final int current = marker.zIndexInt;
     setState(() {
       markers[markerId] = marker.copyWith(
-        zIndexParam: current == 12.0 ? 0.0 : current + 1.0,
+        zIndexIntParam: current == 12 ? 0 : current + 1,
       );
     });
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
@@ -600,7 +600,7 @@ void main() {
       expect(firstChanged.position.longitude, object2new.position.longitude);
       expect(firstChanged.rotation, object2new.rotation);
       expect(firstChanged.visible, object2new.visible);
-      expect(firstChanged.zIndex, object2new.zIndex);
+      expect(firstChanged.zIndex, object2new.zIndexInt);
       expect(firstChanged.markerId, object2new.markerId.value);
       expect(firstChanged.clusterManagerId, object2new.clusterManagerId?.value);
       expect(
@@ -634,7 +634,7 @@ void main() {
       expect(firstAdded.position.longitude, object3.position.longitude);
       expect(firstAdded.rotation, object3.rotation);
       expect(firstAdded.visible, object3.visible);
-      expect(firstAdded.zIndex, object3.zIndex);
+      expect(firstAdded.zIndex, object3.zIndexInt);
       expect(firstAdded.markerId, object3.markerId.value);
       expect(firstAdded.clusterManagerId, object3.clusterManagerId?.value);
       expect(

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/integration_test/google_maps_test.dart
@@ -2274,7 +2274,7 @@ AdvancedMarker _copyAdvancedMarkerWithClusterManagerId(
     position: marker.position,
     rotation: marker.rotation,
     visible: marker.visible,
-    zIndex: marker.zIndex.toInt(),
+    zIndex: marker.zIndexInt,
     onTap: marker.onTap,
     onDragStart: marker.onDragStart,
     onDrag: marker.onDrag,

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/lib/place_advanced_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/lib/place_advanced_marker.dart
@@ -264,10 +264,10 @@ class _PlaceAdvancedMarkerBodyState extends State<_PlaceAdvancedMarkerBody> {
 
   Future<void> _changeZIndex(MarkerId markerId) async {
     final AdvancedMarker marker = markers[markerId]!;
-    final double current = marker.zIndex;
+    final int current = marker.zIndexInt;
     setState(() {
       markers[markerId] = marker.copyWith(
-        zIndexParam: current == 12.0 ? 0.0 : current + 1.0,
+        zIndexIntParam: current == 12 ? 0 : current + 1,
       );
     });
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/test/google_maps_flutter_ios_test.dart
@@ -600,7 +600,7 @@ void main() {
       expect(firstChanged.position.longitude, object2new.position.longitude);
       expect(firstChanged.rotation, object2new.rotation);
       expect(firstChanged.visible, object2new.visible);
-      expect(firstChanged.zIndex, object2new.zIndex);
+      expect(firstChanged.zIndex, object2new.zIndexInt);
       expect(firstChanged.markerId, object2new.markerId.value);
       expect(firstChanged.clusterManagerId, object2new.clusterManagerId?.value);
       expect(
@@ -634,7 +634,7 @@ void main() {
       expect(firstAdded.position.longitude, object3.position.longitude);
       expect(firstAdded.rotation, object3.rotation);
       expect(firstAdded.visible, object3.visible);
-      expect(firstAdded.zIndex, object3.zIndex);
+      expect(firstAdded.zIndex, object3.zIndexInt);
       expect(firstAdded.markerId, object3.markerId.value);
       expect(firstAdded.clusterManagerId, object3.clusterManagerId?.value);
       expect(

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/integration_test/google_maps_test.dart
@@ -2274,7 +2274,7 @@ AdvancedMarker _copyAdvancedMarkerWithClusterManagerId(
     position: marker.position,
     rotation: marker.rotation,
     visible: marker.visible,
-    zIndex: marker.zIndex.toInt(),
+    zIndex: marker.zIndexInt,
     onTap: marker.onTap,
     onDragStart: marker.onDragStart,
     onDrag: marker.onDrag,

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/lib/place_advanced_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/lib/place_advanced_marker.dart
@@ -264,10 +264,10 @@ class _PlaceAdvancedMarkerBodyState extends State<_PlaceAdvancedMarkerBody> {
 
   Future<void> _changeZIndex(MarkerId markerId) async {
     final AdvancedMarker marker = markers[markerId]!;
-    final double current = marker.zIndex;
+    final int current = marker.zIndexInt;
     setState(() {
       markers[markerId] = marker.copyWith(
-        zIndexParam: current == 12.0 ? 0.0 : current + 1.0,
+        zIndexIntParam: current == 12 ? 0 : current + 1,
       );
     });
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/test/google_maps_flutter_ios_test.dart
@@ -600,7 +600,7 @@ void main() {
       expect(firstChanged.position.longitude, object2new.position.longitude);
       expect(firstChanged.rotation, object2new.rotation);
       expect(firstChanged.visible, object2new.visible);
-      expect(firstChanged.zIndex, object2new.zIndex);
+      expect(firstChanged.zIndex, object2new.zIndexInt);
       expect(firstChanged.markerId, object2new.markerId.value);
       expect(firstChanged.clusterManagerId, object2new.clusterManagerId?.value);
       expect(
@@ -634,7 +634,7 @@ void main() {
       expect(firstAdded.position.longitude, object3.position.longitude);
       expect(firstAdded.rotation, object3.rotation);
       expect(firstAdded.visible, object3.visible);
-      expect(firstAdded.zIndex, object3.zIndex);
+      expect(firstAdded.zIndex, object3.zIndexInt);
       expect(firstAdded.markerId, object3.markerId.value);
       expect(firstAdded.clusterManagerId, object3.clusterManagerId?.value);
       expect(

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/integration_test/google_maps_test.dart
@@ -2274,7 +2274,7 @@ AdvancedMarker _copyAdvancedMarkerWithClusterManagerId(
     position: marker.position,
     rotation: marker.rotation,
     visible: marker.visible,
-    zIndex: marker.zIndex.toInt(),
+    zIndex: marker.zIndexInt,
     onTap: marker.onTap,
     onDragStart: marker.onDragStart,
     onDrag: marker.onDrag,

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/lib/place_advanced_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/lib/place_advanced_marker.dart
@@ -264,10 +264,10 @@ class _PlaceAdvancedMarkerBodyState extends State<_PlaceAdvancedMarkerBody> {
 
   Future<void> _changeZIndex(MarkerId markerId) async {
     final AdvancedMarker marker = markers[markerId]!;
-    final double current = marker.zIndex;
+    final int current = marker.zIndexInt;
     setState(() {
       markers[markerId] = marker.copyWith(
-        zIndexParam: current == 12.0 ? 0.0 : current + 1.0,
+        zIndexIntParam: current == 12 ? 0 : current + 1,
       );
     });
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/test/google_maps_flutter_ios_test.dart
@@ -600,7 +600,7 @@ void main() {
       expect(firstChanged.position.longitude, object2new.position.longitude);
       expect(firstChanged.rotation, object2new.rotation);
       expect(firstChanged.visible, object2new.visible);
-      expect(firstChanged.zIndex, object2new.zIndex);
+      expect(firstChanged.zIndex, object2new.zIndexInt);
       expect(firstChanged.markerId, object2new.markerId.value);
       expect(firstChanged.clusterManagerId, object2new.clusterManagerId?.value);
       expect(
@@ -634,7 +634,7 @@ void main() {
       expect(firstAdded.position.longitude, object3.position.longitude);
       expect(firstAdded.rotation, object3.rotation);
       expect(firstAdded.visible, object3.visible);
-      expect(firstAdded.zIndex, object3.zIndex);
+      expect(firstAdded.zIndex, object3.zIndexInt);
       expect(firstAdded.markerId, object3.markerId.value);
       expect(firstAdded.clusterManagerId, object3.clusterManagerId?.value);
       expect(


### PR DESCRIPTION
Replaces uses of the deprecated `zIndex` in examples and tests with the preferred `zIndexInt`.

This doesn't change the production use of `zIndex` in google_maps_flutter_web, as that could change behavior, so should stay for now.
