### PR TITLE
[rfw] Fix fontWeight not applied in release mode

### DIFF
--- a/packages/rfw/CHANGELOG.md
+++ b/packages/rfw/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
+## 1.1.4
+
+* Fixes `fontWeight` not being applied in release mode for `Text` and `StrutStyle` widgets.
+
 ## 1.1.3
 
 * Fixes dartdoc comments that accidentally used HTML.

--- a/packages/rfw/lib/src/flutter/argument_decoders.dart
+++ b/packages/rfw/lib/src/flutter/argument_decoders.dart
@@ -632,6 +632,46 @@ class ArgumentDecoders {
     return null;
   }
 
+  /// Returns a [FontWeight] from the specified string or integer.
+  ///
+  /// This does not use [FontWeight.toString], which is not guaranteed to be
+  /// stable in release builds (since [FontWeight] is not a real Dart enum).
+  ///
+  /// Supported string values: `"w100"` through `"w900"`, `"normal"` (mapped to
+  /// [FontWeight.w400]), and `"bold"` (mapped to [FontWeight.w700]).
+  ///
+  /// Supported integer values: `100` through `900` in increments of 100.
+  static FontWeight? fontWeight(DataSource source, List<Object> key) {
+    final int? numeric = source.v<int>(key);
+    if (numeric != null) {
+      switch (numeric) {
+        case 100: return FontWeight.w100;
+        case 200: return FontWeight.w200;
+        case 300: return FontWeight.w300;
+        case 400: return FontWeight.w400;
+        case 500: return FontWeight.w500;
+        case 600: return FontWeight.w600;
+        case 700: return FontWeight.w700;
+        case 800: return FontWeight.w800;
+        case 900: return FontWeight.w900;
+      }
+    }
+    switch (source.v<String>(key)) {
+      case 'w100': return FontWeight.w100;
+      case 'w200': return FontWeight.w200;
+      case 'w300': return FontWeight.w300;
+      case 'w400':
+      case 'normal': return FontWeight.w400;
+      case 'w500': return FontWeight.w500;
+      case 'w600': return FontWeight.w600;
+      case 'w700':
+      case 'bold': return FontWeight.w700;
+      case 'w800': return FontWeight.w800;
+      case 'w900': return FontWeight.w900;
+    }
+    return null;
+  }
+
   /// Returns a [FontFeature] from the specified map.
   ///
   /// The `feature` key is used as the font feature name (defaulting to the
@@ -1276,7 +1316,7 @@ class ArgumentDecoders {
   /// following keys: 'fontFamily` (string), `fontFamilyFallback` ([list] of
   /// [string]), `fontSize` (double), `height` (double), `leadingDistribution`
   /// ([enumValue] of [TextLeadingDistribution]), `leading` (double),
-  /// `fontWeight` ([enumValue] of [FontWeight]), `fontStyle` ([enumValue] of
+  /// `fontWeight` ([fontWeight]), `fontStyle` ([enumValue] of
   /// [FontStyle]), `forceStrutHeight` (boolean).
   static StrutStyle? strutStyle(DataSource source, List<Object> key) {
     if (!source.isMap(key)) {
@@ -1289,7 +1329,7 @@ class ArgumentDecoders {
       height: source.v<double>([...key, 'height']),
       leadingDistribution: enumValue<TextLeadingDistribution>(TextLeadingDistribution.values, source, [...key, 'leadingDistribution']),
       leading: source.v<double>([...key, 'leading']),
-      fontWeight: enumValue<FontWeight>(FontWeight.values, source, [...key, 'fontWeight']),
+      fontWeight: fontWeight(source, [...key, 'fontWeight']),
       fontStyle: enumValue<FontStyle>(FontStyle.values, source, [...key, 'fontStyle']),
       forceStrutHeight: source.v<bool>([...key, 'forceStrutHeight']),
     );
@@ -1350,7 +1390,7 @@ class ArgumentDecoders {
   ///
   /// Otherwise (even if it has no keys), the [TextStyle] is created from the
   /// following keys: `color` ([color]), `backgroundColor` ([color]), `fontSize`
-  /// (double), `fontWeight` ([enumValue] of [FontWeight]), `fontStyle`
+  /// (double), `fontWeight` ([fontWeight]), `fontStyle`
   /// ([enumValue] of [FontStyle]), `letterSpacing` (double), `wordSpacing`
   /// (double), `textBaseline` ([enumValue] of [TextBaseline]), `height`
   /// (double), `leadingDistribution` ([enumValue] of
@@ -1369,7 +1409,7 @@ class ArgumentDecoders {
       color: color(source, [...key, 'color']),
       backgroundColor: color(source, [...key, 'backgroundColor']),
       fontSize: source.v<double>([...key, 'fontSize']),
-      fontWeight: enumValue<FontWeight>(FontWeight.values, source, [...key, 'fontWeight']),
+      fontWeight: fontWeight(source, [...key, 'fontWeight']),
       fontStyle: enumValue<FontStyle>(FontStyle.values, source, [...key, 'fontStyle']),
       letterSpacing: source.v<double>([...key, 'letterSpacing']),
       wordSpacing: source.v<double>([...key, 'wordSpacing']),

--- a/packages/rfw/pubspec.yaml
+++ b/packages/rfw/pubspec.yaml
@@ -2,7 +2,7 @@ name: rfw
 description: "Remote Flutter widgets: a library for rendering declarative widget description files at runtime."
 repository: https://github.com/flutter/packages/tree/main/packages/rfw
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+rfw%22
-version: 1.1.3
+version: 1.1.4
 
 environment:
   sdk: ^3.10.0

--- a/packages/rfw/test/argument_decoders_test.dart
+++ b/packages/rfw/test/argument_decoders_test.dart
@@ -551,4 +551,111 @@ void main() {
 
     expect(eventLog, isEmpty);
   }, skip: kIsWeb || !isMainChannel); // https://github.com/flutter/flutter/pull/129851
+
+  testWidgets('fontWeight decoder', (WidgetTester tester) async {
+    final runtime = Runtime()
+      ..update(const LibraryName(<String>['core']), createCoreWidgets())
+      ..update(const LibraryName(<String>['test']), parseLibraryFile('import core; widget root = SizedBox();'));
+    addTearDown(runtime.dispose);
+    await tester.pumpWidget(
+      RemoteWidget(
+        runtime: runtime,
+        data: DynamicContent(),
+        widget: const FullyQualifiedWidgetName(LibraryName(<String>['test']), 'root'),
+        onEvent: (String name, DynamicMap arguments) { },
+      ),
+    );
+
+    // String values w100–w900 in textStyle.
+    for (final (String name, FontWeight weight) in <(String, FontWeight)>[
+      ('w100', FontWeight.w100), ('w200', FontWeight.w200), ('w300', FontWeight.w300),
+      ('w400', FontWeight.w400), ('w500', FontWeight.w500), ('w600', FontWeight.w600),
+      ('w700', FontWeight.w700), ('w800', FontWeight.w800), ('w900', FontWeight.w900),
+      ('normal', FontWeight.w400), ('bold', FontWeight.w700),
+    ]) {
+      runtime.update(const LibraryName(<String>['test']), parseLibraryFile('''
+        import core;
+        widget root = Directionality(
+          textDirection: "ltr",
+          child: Text(text: "hello", style: { fontWeight: "$name", fontSize: 16.0 }),
+        );
+      '''));
+      await tester.pump();
+      expect(tester.widget<Text>(find.byType(Text)).style?.fontWeight, weight, reason: 'string "$name"');
+    }
+
+    // Integer values 100–900 in textStyle.
+    for (final (int value, FontWeight weight) in <(int, FontWeight)>[
+      (100, FontWeight.w100), (200, FontWeight.w200), (300, FontWeight.w300),
+      (400, FontWeight.w400), (500, FontWeight.w500), (600, FontWeight.w600),
+      (700, FontWeight.w700), (800, FontWeight.w800), (900, FontWeight.w900),
+    ]) {
+      runtime.update(const LibraryName(<String>['test']), parseLibraryFile('''
+        import core;
+        widget root = Directionality(
+          textDirection: "ltr",
+          child: Text(text: "hello", style: { fontWeight: $value, fontSize: 16.0 }),
+        );
+      '''));
+      await tester.pump();
+      expect(tester.widget<Text>(find.byType(Text)).style?.fontWeight, weight, reason: 'int $value');
+    }
+
+    // Unknown string returns null.
+    runtime.update(const LibraryName(<String>['test']), parseLibraryFile('''
+      import core;
+      widget root = Directionality(
+        textDirection: "ltr",
+        child: Text(text: "hello", style: { fontWeight: "heavy", fontSize: 16.0 }),
+      );
+    '''));
+    await tester.pump();
+    expect(tester.widget<Text>(find.byType(Text)).style?.fontWeight, isNull);
+
+    // Missing key returns null.
+    runtime.update(const LibraryName(<String>['test']), parseLibraryFile('''
+      import core;
+      widget root = Directionality(
+        textDirection: "ltr",
+        child: Text(text: "hello", style: { fontSize: 16.0 }),
+      );
+    '''));
+    await tester.pump();
+    expect(tester.widget<Text>(find.byType(Text)).style?.fontWeight, isNull);
+
+    // String values w100–w900 in strutStyle.
+    for (final (String name, FontWeight weight) in <(String, FontWeight)>[
+      ('w100', FontWeight.w100), ('w200', FontWeight.w200), ('w300', FontWeight.w300),
+      ('w400', FontWeight.w400), ('w500', FontWeight.w500), ('w600', FontWeight.w600),
+      ('w700', FontWeight.w700), ('w800', FontWeight.w800), ('w900', FontWeight.w900),
+      ('normal', FontWeight.w400), ('bold', FontWeight.w700),
+    ]) {
+      runtime.update(const LibraryName(<String>['test']), parseLibraryFile('''
+        import core;
+        widget root = Directionality(
+          textDirection: "ltr",
+          child: Text(text: "hello", strutStyle: { fontWeight: "$name", fontSize: 16.0 }),
+        );
+      '''));
+      await tester.pump();
+      expect(tester.widget<Text>(find.byType(Text)).strutStyle?.fontWeight, weight, reason: 'strutStyle string "$name"');
+    }
+
+    // Integer values 100–900 in strutStyle.
+    for (final (int value, FontWeight weight) in <(int, FontWeight)>[
+      (100, FontWeight.w100), (200, FontWeight.w200), (300, FontWeight.w300),
+      (400, FontWeight.w400), (500, FontWeight.w500), (600, FontWeight.w600),
+      (700, FontWeight.w700), (800, FontWeight.w800), (900, FontWeight.w900),
+    ]) {
+      runtime.update(const LibraryName(<String>['test']), parseLibraryFile('''
+        import core;
+        widget root = Directionality(
+          textDirection: "ltr",
+          child: Text(text: "hello", strutStyle: { fontWeight: $value, fontSize: 16.0 }),
+        );
+      '''));
+      await tester.pump();
+      expect(tester.widget<Text>(find.byType(Text)).strutStyle?.fontWeight, weight, reason: 'strutStyle int $value');
+    }
+  });
 }


### PR DESCRIPTION
Fixes the `fontWeight` property of RFW `TextStyle` (and `StrutStyle`) not being applied in release mode for `Text` widgets.

Fixes flutter/flutter#180223

## Root cause

`ArgumentDecoders.textStyle` (and `strutStyle`) decoded `fontWeight` using `enumValue(FontWeight.values, ...)`, which matched the input string against `FontWeight.value.toString().split('.').last`. `FontWeight` is not a real Dart `enum`; it is a hand-crafted class with `static const` members. In AOT/release builds, `toString()` for such classes is not guaranteed to return the same human-readable name (tree-shaking can strip debug labels), so all matches silently fail and `null` is returned, causing Flutter to fall back to the default weight (`w400`).

## Fix

Added a new `ArgumentDecoders.fontWeight` static method that maps strings (`"w100"`–`"w900"`, `"normal"`, `"bold"`) and integers (`100`–`900`) to the correct `FontWeight` constant using an explicit `switch`, without relying on `toString()`. Updated both `textStyle` and `strutStyle` to use this new decoder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/packages/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines) and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md) page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides](https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style) and ran [the auto-formatter](https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes](https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview) in the description above.
- [x] I followed the [version and CHANGELOG instructions](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates), using [semantic versioning](https://dart.dev/tools/pub/versioning#semantic-versions) and the [repository CHANGELOG style](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style).
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.