### PR TITLE
[pigeon] fix: Apply correct ThrowError success callback

### DIFF
--- a/packages/pigeon/platform_tests/test_plugin/windows/test_plugin.cpp
+++ b/packages/pigeon/platform_tests/test_plugin/windows/test_plugin.cpp
@@ -746,8 +746,8 @@ void TestPlugin::CallFlutterThrowError(
     std::function<void(ErrorOr<std::optional<flutter::EncodableValue>> reply)>
         result) {
   flutter_api_->ThrowError(
-      [result](const std::optional<flutter::EncodableValue>& echo) {
-        result(echo);
+      [result](const flutter::EncodableValue* echo) {
+        result(echo ? std::make_optional(*echo) : std::nullopt);
       },
       [result](const FlutterError& error) { result(error); });
 }

--- a/packages/pigeon/platform_tests/test_plugin/windows/test_plugin.cpp
+++ b/packages/pigeon/platform_tests/test_plugin/windows/test_plugin.cpp
@@ -747,7 +747,7 @@ void TestPlugin::CallFlutterThrowError(
         result) {
   flutter_api_->ThrowError(
       [result](const flutter::EncodableValue* echo) {
-        result(echo ? std::make_optional(*echo) : std::nullopt);
+        result(echo ? std::optional<flutter::EncodableValue>(*echo) : std::nullopt);
       },
       [result](const FlutterError& error) { result(error); });
 }

--- a/packages/pigeon/platform_tests/test_plugin/windows/test_plugin.cpp
+++ b/packages/pigeon/platform_tests/test_plugin/windows/test_plugin.cpp
@@ -747,7 +747,8 @@ void TestPlugin::CallFlutterThrowError(
         result) {
   flutter_api_->ThrowError(
       [result](const flutter::EncodableValue* echo) {
-        result(echo ? std::optional<flutter::EncodableValue>(*echo) : std::nullopt);
+        result(echo ? std::optional<flutter::EncodableValue>(*echo)
+                    : std::nullopt);
       },
       [result](const FlutterError& error) { result(error); });
 }


### PR DESCRIPTION
Building in  Visual Studio 2026 gives the following error:

```
error C2664: 'void core_tests_pigeontest::FlutterIntegrationCoreApi::ThrowError(std::function<void (const flutter::EncodableValue *)> &&,std::function<void (const core_tests_pigeontest::FlutterError &)> &&)': cannot convert argument 1 from 'test_plugin::TestPlugin::CallFlutterThrowError::<lambda_1>' to 'std::function<void (const flutter::EncodableValue *)> &&'
```

This is likely due to https://stackoverflow.com/a/79894278/5164462 so the compiler does not allow unsuited call parameters.

Towards https://github.com/flutter/flutter/issues/185597

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
