### PR TITLE
[image_picker] Document maxDuration only applies to camera recording

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## NEXT
 
+* Documents that `maxDuration` on `pickVideo` and `pickMultiVideo` is only
+  honored when capturing from the camera; modern gallery pickers on iOS
+  (`PHPickerViewController`) and Android (`PickVisualMediaRequest` and
+  `Intent.ACTION_GET_CONTENT`) do not support filtering by duration.
 * Updates minimum supported SDK version to Flutter 3.35/Dart 3.9.
 * Updates README to reflect currently supported OS versions for the latest
   versions of the endorsed platform implementations.

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -270,8 +270,15 @@ class ImagePicker {
   /// The [source] argument controls where the video comes from. This can
   /// be either [ImageSource.camera] or [ImageSource.gallery].
   ///
-  /// The [maxDuration] argument specifies the maximum duration of the captured video. If no [maxDuration] is specified,
-  /// the maximum duration will be infinite.
+  /// The [maxDuration] argument specifies the maximum duration of the
+  /// captured video. If no [maxDuration] is specified, the maximum duration
+  /// will be infinite.
+  ///
+  /// [maxDuration] is only honored when [source] is [ImageSource.camera].
+  /// For gallery selection, the modern iOS picker (`PHPickerViewController`)
+  /// and the Android pickers (`PickVisualMediaRequest` and
+  /// `Intent.ACTION_GET_CONTENT`) do not support filtering by duration, so
+  /// this argument is ignored on those platforms.
   ///
   /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
   /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.
@@ -304,9 +311,15 @@ class ImagePicker {
   ///
   /// The videos come from the gallery.
   ///
-  /// The [maxDuration] argument specifies the maximum duration of the captured
-  /// videos. If no [maxDuration] is specified, the maximum duration will be
-  /// infinite. This value may be ignored by platforms that cannot support it.
+  /// The [maxDuration] argument specifies the maximum duration of the
+  /// selected videos. If no [maxDuration] is specified, the maximum duration
+  /// will be infinite.
+  ///
+  /// Most platform gallery pickers do not support filtering by duration, so
+  /// this argument is ignored on those platforms. Specifically, the modern
+  /// iOS picker (`PHPickerViewController`) and the Android pickers
+  /// (`PickVisualMediaRequest` and `Intent.ACTION_GET_CONTENT`) do not honor
+  /// it.
   ///
   /// The `limit` parameter modifies the maximum number of videos that can be
   /// selected. This value may be ignored by platforms that cannot support it.


### PR DESCRIPTION
Fixes flutter/flutter#83630.

## Summary

Updates the dartdoc on `ImagePicker.pickVideo` and `ImagePicker.pickMultiVideo` to clarify that the `maxDuration` argument only restricts video duration when capturing from the camera.

Per @stuartmorgan-g's [scoping comment on the issue](https://github.com/flutter/flutter/issues/83630#issuecomment-2007858693):

> The modern API on iOS (`PHPickerViewController`) does not provide an option to restrict by duration.
> The modern API on Android (`PickVisualMediaRequest`) does not provide an option to restrict by duration.
> The legacy API on Android (`Intent.ACTION_GET_CONTENT`) does not provide an option to restrict by duration.

The doc now states this explicitly so callers know not to rely on `maxDuration` for gallery selection.

## Changes

- `packages/image_picker/image_picker/lib/image_picker.dart` — expanded dartdoc on `pickVideo` and `pickMultiVideo` for `maxDuration`.
- `packages/image_picker/image_picker/CHANGELOG.md` — appended NEXT entry.

## Pre-launch checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Manual prose; no formatter changes.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`.
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pluginversioning].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt]. (Doc-only change.)

This is a doc-only change so no version bump in `pubspec.yaml` is needed; the entry lives under the existing `NEXT` section that already covers the next release.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#release-notes
[pluginversioning]: https://github.com/flutter/flutter/blob/main/docs/ecosystem/contributing/README.md#changing-federated-plugins
[following repository CHANGELOG style]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#changelog-style
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests