### PR TITLE
[google_fonts] Extract the config class to its own file in prevision of a GoogleFontsLite version

### DIFF
--- a/packages/google_fonts/CHANGELOG.md
+++ b/packages/google_fonts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.2.0
+
+- Extract the class `Config` to its own file and rename it `GoogleFontsConfig`. The `Config` name will be deprecated in a future release.
+
 ## 8.1.0
 
 - Adds the ability to supply a custom HTTP client to `GoogleFonts.config`.

--- a/packages/google_fonts/generator/google_fonts.tmpl
+++ b/packages/google_fonts/generator/google_fonts.tmpl
@@ -9,27 +9,12 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 
 import 'google_fonts_base.dart';
+import 'google_fonts_config.dart';
 {{#allParts}}
 import '{{partFilePath}}';
 {{/allParts}}
-
-/// A collection of properties used to specify custom behavior of the
-/// GoogleFonts library.
-class Config {
-  /// Whether or not the GoogleFonts library can make requests to
-  /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
-  bool allowRuntimeFetching = true;
-
-  /// The HTTP client used to fetch fonts.
-  ///
-  /// If this is null, a shared default [http.Client] will be used.
-  ///
-  /// If you supply a client, you are responsible for closing it.
-  http.Client? httpClient;
-}
 
 /// Provides configuration, and static methods to obtain [TextStyle]s and [TextTheme]s.
 ///
@@ -49,7 +34,7 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
-  static final Config config = Config();
+  static final GoogleFontsConfig config = GoogleFontsConfig();
 
   /// Returns a [Future] which resolves when requested fonts have finished
   /// loading and are ready to be rendered on screen.

--- a/packages/google_fonts/lib/google_fonts.dart
+++ b/packages/google_fonts/lib/google_fonts.dart
@@ -3,3 +3,4 @@
 // found in the LICENSE file.
 
 export 'src/google_fonts_all_parts.dart';
+export 'src/google_fonts_config.dart';

--- a/packages/google_fonts/lib/src/google_fonts_all_parts.dart
+++ b/packages/google_fonts/lib/src/google_fonts_all_parts.dart
@@ -9,9 +9,9 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 
 import 'google_fonts_base.dart';
+import 'google_fonts_config.dart';
 import 'google_fonts_parts/part_a.dart';
 import 'google_fonts_parts/part_b.dart';
 import 'google_fonts_parts/part_c.dart';
@@ -39,21 +39,6 @@ import 'google_fonts_parts/part_x.dart';
 import 'google_fonts_parts/part_y.dart';
 import 'google_fonts_parts/part_z.dart';
 
-/// A collection of properties used to specify custom behavior of the
-/// GoogleFonts library.
-class Config {
-  /// Whether or not the GoogleFonts library can make requests to
-  /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
-  bool allowRuntimeFetching = true;
-
-  /// The HTTP client used to fetch fonts.
-  ///
-  /// If this is null, a shared default [http.Client] will be used.
-  ///
-  /// If you supply a client, you are responsible for closing it.
-  http.Client? httpClient;
-}
-
 /// Provides configuration, and static methods to obtain [TextStyle]s and [TextTheme]s.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=8Vzv2CdbEY0}
@@ -72,7 +57,7 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
-  static final Config config = Config();
+  static final GoogleFontsConfig config = GoogleFontsConfig();
 
   /// Returns a [Future] which resolves when requested fonts have finished
   /// loading and are ready to be rendered on screen.

--- a/packages/google_fonts/lib/src/google_fonts_config.dart
+++ b/packages/google_fonts/lib/src/google_fonts_config.dart
@@ -18,3 +18,6 @@ class GoogleFontsConfig {
   /// If you supply a client, you are responsible for closing it.
   http.Client? httpClient;
 }
+
+@Deprecated('Use GoogleFontsConfig instead')
+typedef Config = GoogleFontsConfig;

--- a/packages/google_fonts/lib/src/google_fonts_config.dart
+++ b/packages/google_fonts/lib/src/google_fonts_config.dart
@@ -1,0 +1,16 @@
+import 'package:http/http.dart' as http;
+
+/// A collection of properties used to specify custom behavior of the
+/// GoogleFonts library.
+class GoogleFontsConfig {
+  /// Whether or not the GoogleFonts library can make requests to
+  /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
+  bool allowRuntimeFetching = true;
+
+  /// The HTTP client used to fetch fonts.
+  ///
+  /// If this is null, a shared default [http.Client] will be used.
+  ///
+  /// If you supply a client, you are responsible for closing it.
+  http.Client? httpClient;
+}

--- a/packages/google_fonts/lib/src/google_fonts_config.dart
+++ b/packages/google_fonts/lib/src/google_fonts_config.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:http/http.dart' as http;
 
 /// A collection of properties used to specify custom behavior of the

--- a/packages/google_fonts/pubspec.yaml
+++ b/packages/google_fonts/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_fonts
 description: A Flutter package to use fonts from fonts.google.com. Supports HTTP fetching, caching, and asset bundling.
 repository: https://github.com/flutter/packages/tree/main/packages/google_fonts
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_fonts%22
-version: 8.1.0
+version: 8.2.0
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
See https://github.com/flutter/packages/pull/11433 and the comment https://github.com/flutter/packages/pull/11433#pullrequestreview-4184165033