### PR TITLE
[two_dimensional_scrollables] Fix mouse event loop when calling setState in TableSpan.onEnter

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Fixes an infinite loop of onExit/onEnter events when setState is called within onEnter in a TableSpan.
+
 ## 0.5.0
 
 * Adds support for trailing pinned columns and rows in TableView.

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -699,13 +699,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         // If we are starting from 0, we should dispose of any metrics that are
         // no longer in use. This happens when the number of columns is reduced.
         if (!appendColumns) {
-          _columnMetrics.removeWhere((int key, _Span span) {
-            if (key >= column) {
-              span.dispose();
-              return true;
-            }
-            return false;
-          });
+          _disposeTrailingSpans(_columnMetrics, column);
         }
         final bool acceptedDimension = _updateHorizontalScrollBounds();
         if (!acceptedDimension) {
@@ -746,15 +740,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
 
     if (!appendColumns) {
-      // If we are not appending, we should dispose of any metrics that are
-      // no longer in use. This happens when the number of columns is reduced.
-      _columnMetrics.removeWhere((int key, _Span span) {
-        if (key >= column) {
-          span.dispose();
-          return true;
-        }
-        return false;
-      });
+      _disposeTrailingSpans(_columnMetrics, column);
     }
 
     assert(_columnMetrics.length >= delegate.pinnedColumnCount);
@@ -842,13 +828,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         // If we are starting from 0, we should dispose of any metrics that are
         // no longer in use. This happens when the number of rows is reduced.
         if (!appendRows) {
-          _rowMetrics.removeWhere((int key, _Span span) {
-            if (key >= row) {
-              span.dispose();
-              return true;
-            }
-            return false;
-          });
+          _disposeTrailingSpans(_rowMetrics, row);
         }
         final bool acceptedDimension = _updateVerticalScrollBounds();
         if (!acceptedDimension) {
@@ -889,15 +869,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
     }
 
     if (!appendRows) {
-      // If we are not appending, we should dispose of any metrics that are
-      // no longer in use. This happens when the number of rows is reduced.
-      _rowMetrics.removeWhere((int key, _Span span) {
-        if (key >= row) {
-          span.dispose();
-          return true;
-        }
-        return false;
-      });
+      _disposeTrailingSpans(_rowMetrics, row);
     }
 
     assert(_rowMetrics.length >= delegate.pinnedRowCount);
@@ -921,6 +893,16 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
             ? _rowNullTerminatedIndex! - 1
             : null
       : delegate.rowCount! - delegate.trailingPinnedRowCount - 1;
+
+  void _disposeTrailingSpans(Map<int, _Span> metrics, int startIndex) {
+    metrics.removeWhere((int key, _Span span) {
+      if (key >= startIndex) {
+        span.dispose();
+        return true;
+      }
+      return false;
+    });
+  }
 
   void _updateScrollBounds() {
     final bool acceptedDimension =

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -687,18 +687,31 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
                 : startOfTrailingPinnedColumn)
           : startOfRegularColumn;
       _Span? span = _columnMetrics.remove(column);
-      final TableSpan? configuration =
-          span?.configuration ?? delegate.buildColumn(column);
+      final TableSpan? configuration = (needsDelegateRebuild || span == null)
+          ? delegate.buildColumn(column)
+          : span.configuration;
       if (configuration == null) {
         // We have reached the end of columns based on a null termination. This
         // This happens when a column count has not been specified.
         assert(_columnsAreInfinite);
         _lastNonPinnedColumn ??= column - 1;
         _columnNullTerminatedIndex = column;
+        // If we are starting from 0, we should dispose of any metrics that are
+        // no longer in use. This happens when the number of columns is reduced.
+        if (!appendColumns) {
+          _columnMetrics.removeWhere((int key, _Span span) {
+            if (key >= column) {
+              span.dispose();
+              return true;
+            }
+            return false;
+          });
+        }
         final bool acceptedDimension = _updateHorizontalScrollBounds();
         if (!acceptedDimension) {
           _updateFirstAndLastVisibleCell();
         }
+        span?.dispose();
         break;
       }
       span ??= _Span();
@@ -730,6 +743,18 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         startOfTrailingPinnedColumn = span.trailingOffset;
       }
       column++;
+    }
+
+    if (!appendColumns) {
+      // If we are not appending, we should dispose of any metrics that are
+      // no longer in use. This happens when the number of columns is reduced.
+      _columnMetrics.removeWhere((int key, _Span span) {
+        if (key >= column) {
+          span.dispose();
+          return true;
+        }
+        return false;
+      });
     }
 
     assert(_columnMetrics.length >= delegate.pinnedColumnCount);
@@ -804,8 +829,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
                 : startOfTrailingPinnedRow)
           : startOfRegularRow;
       _Span? span = _rowMetrics.remove(row);
-      final TableSpan? configuration =
-          span?.configuration ?? delegate.buildRow(row);
+      final TableSpan? configuration = (needsDelegateRebuild || span == null)
+          ? delegate.buildRow(row)
+          : span.configuration;
       if (configuration == null) {
         // We have reached the end of rows based on a null termination. This
         // This happens when a row count has not been specified, but we have
@@ -813,10 +839,22 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         assert(_rowsAreInfinite);
         _lastNonPinnedRow ??= row - 1;
         _rowNullTerminatedIndex = row;
+        // If we are starting from 0, we should dispose of any metrics that are
+        // no longer in use. This happens when the number of rows is reduced.
+        if (!appendRows) {
+          _rowMetrics.removeWhere((int key, _Span span) {
+            if (key >= row) {
+              span.dispose();
+              return true;
+            }
+            return false;
+          });
+        }
         final bool acceptedDimension = _updateVerticalScrollBounds();
         if (!acceptedDimension) {
           _updateFirstAndLastVisibleCell();
         }
+        span?.dispose();
         break;
       }
       span ??= _Span();
@@ -848,6 +886,18 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         startOfTrailingPinnedRow = span.trailingOffset;
       }
       row++;
+    }
+
+    if (!appendRows) {
+      // If we are not appending, we should dispose of any metrics that are
+      // no longer in use. This happens when the number of rows is reduced.
+      _rowMetrics.removeWhere((int key, _Span span) {
+        if (key >= row) {
+          span.dispose();
+          return true;
+        }
+        return false;
+      });
     }
 
     assert(_rowMetrics.length >= delegate.pinnedRowCount);
@@ -1041,14 +1091,6 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
 
     if (needsDelegateRebuild || didResize) {
       // Recomputes the table metrics, invalidates any cached information.
-      for (final _Span span in _columnMetrics.values) {
-        span.dispose();
-      }
-      _columnMetrics.clear();
-      for (final _Span span in _rowMetrics.values) {
-        span.dispose();
-      }
-      _rowMetrics.clear();
       _updateColumnMetrics();
       _updateRowMetrics();
       _updateScrollBounds();

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -3634,8 +3634,9 @@ void main() {
     });
 
     testWidgets(
-      'Calling setState within onEnter does not cause a loop of onExit/onEnter - Regression test for https://github.com/flutter/flutter/issues/147614',
+      'Calling setState within onEnter does not cause a loop of onExit/onEnter',
       (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/147614
         var enterCounter = 0;
         var exitCounter = 0;
 

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -3630,7 +3630,72 @@ void main() {
         RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
         SystemMouseCursors.basic,
       );
+      await gesture.removePointer();
     });
+
+    testWidgets(
+      'Calling setState within onEnter does not cause a loop of onExit/onEnter - Regression test for https://github.com/flutter/flutter/issues/147614',
+      (WidgetTester tester) async {
+        var enterCounter = 0;
+        var exitCounter = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return TableView.builder(
+                    columnCount: 1,
+                    rowCount: 1,
+                    columnBuilder: (int index) =>
+                        const TableSpan(extent: FixedTableSpanExtent(100)),
+                    rowBuilder: (int index) => TableSpan(
+                      extent: const FixedTableSpanExtent(100),
+                      onEnter: (_) {
+                        enterCounter++;
+                        setState(() {});
+                      },
+                      onExit: (_) {
+                        exitCounter++;
+                      },
+                    ),
+                    cellBuilder:
+                        (BuildContext context, TableVicinity vicinity) {
+                          return const TableViewCell(
+                            child: SizedBox.square(dimension: 100),
+                          );
+                        },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Initial state
+        expect(enterCounter, 0);
+        expect(exitCounter, 0);
+
+        // Move mouse to the center of the first row (0,0)
+        final TestGesture gesture = await tester.createGesture(
+          kind: PointerDeviceKind.mouse,
+        );
+        await gesture.addPointer(location: const Offset(50, 50));
+        await tester.pump();
+
+        // Should have entered once
+        expect(enterCounter, 1);
+        expect(exitCounter, 0);
+
+        // Pump again to see if it triggers again
+        await tester.pump();
+
+        expect(exitCounter, 0, reason: 'Should not have exited');
+        expect(enterCounter, 1, reason: 'Should not have re-entered');
+
+        await gesture.removePointer();
+      },
+    );
 
     group('Merged pinned cells layout', () {
       // Regression tests for https://github.com/flutter/flutter/issues/143526


### PR DESCRIPTION
This PR addresses a bug in TableView where calling setState (or any action that triggers a delegate rebuild) inside a TableSpan.onEnter callback would cause an infinite loop of onExit and onEnter events.

The RenderTableViewport was clearing its cached _columnMetrics and _rowMetrics (_Span objects) on every delegate rebuild. Since _Span implements MouseTrackerAnnotation, and the MouseTracker identifies regions by object identity, re-creating these objects every frame caused the MouseTracker to:
   1. Trigger onExit for the old _Span object.
   2. Trigger onEnter for the new _Span object.

If onEnter contained a setState call, this cycle would repeat indefinitely.

Fixes https://github.com/flutter/flutter/issues/147614

  Fix:
   - Refactored _updateRowMetrics and _updateColumnMetrics to reuse existing _Span objects when
     available.
   - Updated _Span.update to only refresh the internal configuration and layout metrics while
     maintaining the same object instance.
   - Modified layoutChildSequence to avoid clearing the metrics maps, instead allowing the update
     methods to handle stale entries.
   - Added logic to properly dispose and remove spans when the row or column count is reduced.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
