### PR TITLE
[animations] Trying out go_router support for OpenContainer

### DIFF
--- a/packages/animations/CHANGELOG.md
+++ b/packages/animations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+* Added OpenContainerPage and onOpen hook to OpenContainer for go_router compatibility.
+
 ## 2.2.0
 
 * Adds support for custom `closedShadows` and `openShadows` to `OpenContainer`.

--- a/packages/animations/README.md
+++ b/packages/animations/README.md
@@ -72,3 +72,31 @@ _Examples of the fade pattern:_
 2.  _A menu_
 3.  _A snackbar_
 4.  _A FAB_
+
+## Usage with Declarative Routers (e.g. go_router)
+
+The `OpenContainer` widget can be integrated with declarative routers like `go_router` to ensure that the browser URL updates when the container opens, while still preserving the container transform animation.
+
+To do this, use the `onOpen` hook to trigger the navigation and `OpenContainerPage` in your route definition. Both must share the same `transitionTag`.
+
+```dart
+// In your list page:
+OpenContainer(
+  transitionTag: 'item-${item.id}',
+  onOpen: () => context.push('/details/${item.id}'),
+  closedBuilder: (context, action) => MyListTile(onTap: action),
+  openBuilder: (context, action) => MyDetailsPage(id: item.id),
+)
+
+// In your router configuration:
+GoRoute(
+  path: '/details/:id',
+  pageBuilder: (context, state) {
+    final String id = state.pathParameters['id']!;
+    return OpenContainerPage(
+      transitionTag: 'item-$id',
+      openBuilder: (context, action) => MyDetailsPage(id: id),
+    );
+  },
+)
+```

--- a/packages/animations/example/lib/go_router_example.dart
+++ b/packages/animations/example/lib/go_router_example.dart
@@ -1,0 +1,118 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:animations/animations.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  runApp(const GoRouterExampleApp());
+}
+
+/// An example of integrating package:animations with package:go_router.
+class GoRouterExampleApp extends StatelessWidget {
+  /// Creates a [GoRouterExampleApp].
+  const GoRouterExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'OpenContainer go_router Example',
+      routerConfig: _router,
+    );
+  }
+}
+
+final GoRouter _router = GoRouter(
+  routes: <RouteBase>[
+    GoRoute(
+      path: '/',
+      builder: (BuildContext context, GoRouterState state) {
+        return const HomeScreen();
+      },
+      routes: <RouteBase>[
+        GoRoute(
+          path: 'details/:id',
+          pageBuilder: (BuildContext context, GoRouterState state) {
+            final String id = state.pathParameters['id']!;
+            return OpenContainerPage<void>(
+              transitionTag: 'item-$id',
+              openBuilder: (BuildContext context, VoidCallback closeContainer) {
+                return DetailsScreen(id: id);
+              },
+            );
+          },
+        ),
+      ],
+    ),
+  ],
+);
+
+/// The home screen of the go_router example.
+class HomeScreen extends StatelessWidget {
+  /// Creates a [HomeScreen].
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('OpenContainer go_router Example')),
+      body: ListView.builder(
+        itemCount: 20,
+        itemBuilder: (BuildContext context, int index) {
+          final id = index.toString();
+          return OpenContainer(
+            transitionTag: 'item-$id',
+            onOpen: () {
+              context.go('/details/$id');
+              return Future<void>.value();
+            },
+            closedBuilder: (BuildContext context, VoidCallback openContainer) {
+              return ListTile(
+                onTap: openContainer,
+                title: Text('Item $id'),
+                subtitle: const Text('Tap to open with container transform'),
+              );
+            },
+            openBuilder: (BuildContext context, VoidCallback closeContainer) {
+              return DetailsScreen(id: id);
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// The details screen of the go_router example.
+class DetailsScreen extends StatelessWidget {
+  /// Creates a [DetailsScreen].
+  const DetailsScreen({super.key, required this.id});
+
+  /// The ID of the item to display.
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Details of Item $id')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              'Details for Item $id',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => context.pop(),
+              child: const Text('Go Back'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/animations/example/lib/main.dart
+++ b/packages/animations/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/scheduler.dart';
 import 'container_transition.dart';
 import 'fade_scale_transition.dart';
 import 'fade_through_transition.dart';
+import 'go_router_example.dart';
 import 'shared_axis_transition.dart';
 
 void main() {
@@ -89,6 +90,19 @@ class _TransitionsHomePageState extends State<_TransitionsHomePage> {
                       MaterialPageRoute<void>(
                         builder: (BuildContext context) {
                           return const FadeScaleTransitionDemo();
+                        },
+                      ),
+                    );
+                  },
+                ),
+                _TransitionListTile(
+                  title: 'go_router integration',
+                  subtitle: 'OpenContainerPage',
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (BuildContext context) {
+                          return const GoRouterExampleApp();
                         },
                       ),
                     );

--- a/packages/animations/example/pubspec.yaml
+++ b/packages/animations/example/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
+  go_router: ^14.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/animations/lib/src/open_container.dart
+++ b/packages/animations/lib/src/open_container.dart
@@ -139,6 +139,8 @@ class OpenContainer<T extends Object?> extends StatefulWidget {
     this.clipBehavior = Clip.antiAlias,
     this.closedShadows,
     this.openShadows,
+    this.transitionTag,
+    this.onOpen,
   });
 
   /// Background color of the container while it is closed.
@@ -311,8 +313,168 @@ class OpenContainer<T extends Object?> extends StatefulWidget {
   /// If this is provided, [openElevation] will be ignored.
   final List<BoxShadow>? openShadows;
 
+  /// An optional tag to identify this [OpenContainer].
+  ///
+  /// This tag can be used by an [OpenContainerPage] to find this container
+  /// and perform the container transform animation when the page is pushed
+  /// declaratively (e.g. via `go_router`).
+  final Object? transitionTag;
+
+  /// An optional callback to trigger the opening of the container.
+  ///
+  /// If this is provided, it will be called instead of the default
+  /// [Navigator.push] when the container is tapped or when
+  /// [OpenContainerState.openContainer] is called.
+  ///
+  /// This is useful for integrating with declarative routers like `go_router`.
+  /// For example:
+  ///
+  /// ```dart
+  /// OpenContainer(
+  ///   onOpen: () => context.push('/details'),
+  ///   // ...
+  /// )
+  /// ```
+  final Future<T?> Function()? onOpen;
+
   @override
   State<OpenContainer<T?>> createState() => OpenContainerState<T>();
+}
+
+/// A page that shows the container transform animation.
+///
+/// This is used for integrating with declarative routers like `go_router`.
+/// It uses the [transitionTag] to find the source [OpenContainer] and perform
+/// the container transform animation.
+///
+/// If the source [OpenContainer] is not found (e.g. direct URL navigation),
+/// it will perform a simple fade-in transition using the provided properties.
+class OpenContainerPage<T> extends Page<T> {
+  /// Creates an [OpenContainerPage].
+  const OpenContainerPage({
+    this.closedColor = Colors.white,
+    this.openColor = Colors.white,
+    this.middleColor,
+    this.closedElevation = 1.0,
+    this.openElevation = 4.0,
+    this.closedShape = const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(4.0)),
+    ),
+    this.openShape = const RoundedRectangleBorder(),
+    required this.openBuilder,
+    this.transitionDuration = const Duration(milliseconds: 300),
+    this.transitionType = ContainerTransitionType.fade,
+    this.useRootNavigator = false,
+    this.closedShadows,
+    this.openShadows,
+    this.transitionTag,
+    super.key,
+    super.name,
+    super.arguments,
+    super.restorationId,
+  });
+
+  /// Background color of the container while it is closed.
+  final Color closedColor;
+
+  /// Background color of the container while it is open.
+  final Color openColor;
+
+  /// The color to use for the background color during the transition.
+  final Color? middleColor;
+
+  /// Elevation of the container while it is closed.
+  final double closedElevation;
+
+  /// Elevation of the container while it is open.
+  final double openElevation;
+
+  /// Shape of the container while it is closed.
+  final ShapeBorder closedShape;
+
+  /// Shape of the container while it is open.
+  final ShapeBorder openShape;
+
+  /// Called to obtain the child for the container in the open state.
+  final OpenContainerBuilder<T> openBuilder;
+
+  /// The time it will take to animate the transition.
+  final Duration transitionDuration;
+
+  /// The type of fade transition that the container will use.
+  final ContainerTransitionType transitionType;
+
+  /// Whether to use the root navigator.
+  final bool useRootNavigator;
+
+  /// Custom shadows of the container while it is closed.
+  final List<BoxShadow>? closedShadows;
+
+  /// Custom shadows of the container while it is open.
+  final List<BoxShadow>? openShadows;
+
+  /// The tag of the source [OpenContainer].
+  final Object? transitionTag;
+
+  @override
+  Route<T> createRoute(BuildContext context) {
+    OpenContainerState<dynamic>? state;
+    if (transitionTag != null) {
+      state = OpenContainerRegistry.instance.get(transitionTag!);
+    }
+
+    return OpenContainerRoute<T>(
+      closedColor: state?.widget.closedColor ?? closedColor,
+      openColor: state?.widget.openColor ?? openColor,
+      middleColor: state?.widget.middleColor ??
+          middleColor ??
+          Theme.of(context).canvasColor,
+      closedElevation: state?.widget.closedElevation ?? closedElevation,
+      openElevation: state?.widget.openElevation ?? openElevation,
+      closedShape: state?.widget.closedShape ?? closedShape,
+      openShape: state?.widget.openShape ?? openShape,
+      closedBuilder: state?.widget.closedBuilder,
+      openBuilder: openBuilder,
+      hideableKey: state?.hideableKey,
+      closedBuilderKey: state?.closedBuilderKey,
+      transitionDuration:
+          state?.widget.transitionDuration ?? transitionDuration,
+      transitionType: state?.widget.transitionType ?? transitionType,
+      useRootNavigator: state?.widget.useRootNavigator ?? useRootNavigator,
+      routeSettings: this,
+      closedShadows: state?.widget.closedShadows ?? closedShadows,
+      openShadows: state?.widget.openShadows ?? openShadows,
+    );
+  }
+}
+
+/// A registry that tracks active [OpenContainerState] instances by their
+/// [OpenContainer.transitionTag].
+///
+/// This is used by [OpenContainerPage] to coordinate the container transform
+/// animation between the source [OpenContainer] and the destination page.
+class OpenContainerRegistry {
+  OpenContainerRegistry._();
+
+  static final OpenContainerRegistry _instance = OpenContainerRegistry._();
+
+  /// Returns the singleton instance of the registry.
+  static OpenContainerRegistry get instance => _instance;
+
+  final Map<Object, OpenContainerState<dynamic>> _states = <Object, OpenContainerState<dynamic>>{};
+
+  /// Registers an [OpenContainerState] with the given [tag].
+  void register(Object tag, OpenContainerState<dynamic> state) {
+    _states[tag] = state;
+  }
+
+  /// Unregisters the [OpenContainerState] associated with the given [tag].
+  void unregister(Object tag) {
+    _states.remove(tag);
+  }
+
+  /// Returns the [OpenContainerState] associated with the given [tag], if any.
+  OpenContainerState<dynamic>? get(Object tag) => _states[tag];
 }
 
 /// State for a [OpenContainer].
@@ -323,21 +485,58 @@ class OpenContainer<T extends Object?> extends StatefulWidget {
 ///    if [OpenContainer.tappable] is true.
 @optionalTypeArgs
 class OpenContainerState<T> extends State<OpenContainer<T?>> {
-  // Key used in [_OpenContainerRoute] to hide the widget returned by
-  // [OpenContainer.openBuilder] in the source route while the container is
-  // opening/open. A copy of that widget is included in the
-  // [_OpenContainerRoute] where it fades out. To avoid issues with double
-  // shadows and transparency, we hide it in the source route.
-  final GlobalKey<_HideableState> _hideableKey = GlobalKey<_HideableState>();
+  /// Key used in [OpenContainerRoute] to hide the widget returned by
+  /// [OpenContainer.openBuilder] in the source route while the container is
+  /// opening/open. A copy of that widget is included in the
+  /// [OpenContainerRoute] where it fades out. To avoid issues with double
+  /// shadows and transparency, we hide it in the source route.
+  final GlobalKey<HideableState> hideableKey = GlobalKey<HideableState>();
 
-  // Key used to steal the state of the widget returned by
-  // [OpenContainer.openBuilder] from the source route and attach it to the
-  // same widget included in the [_OpenContainerRoute] where it fades out.
-  final GlobalKey _closedBuilderKey = GlobalKey();
+  /// Key used to steal the state of the widget returned by
+  /// [OpenContainer.openBuilder] from the source route and attach it to the
+  /// same widget included in the [OpenContainerRoute] where it fades out.
+  final GlobalKey closedBuilderKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.transitionTag != null) {
+      OpenContainerRegistry.instance.register(widget.transitionTag!, this);
+    }
+  }
+
+  @override
+  void didUpdateWidget(OpenContainer<T?> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.transitionTag != widget.transitionTag) {
+      if (oldWidget.transitionTag != null) {
+        OpenContainerRegistry.instance.unregister(oldWidget.transitionTag!);
+      }
+      if (widget.transitionTag != null) {
+        OpenContainerRegistry.instance.register(widget.transitionTag!, this);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    if (widget.transitionTag != null) {
+      OpenContainerRegistry.instance.unregister(widget.transitionTag!);
+    }
+    super.dispose();
+  }
 
   /// Open the container using the given middle color and specific route,
   /// then call `onClosed` with the returned data after popped.
   Future<void> openContainer() async {
+    if (widget.onOpen != null) {
+      final T? data = await widget.onOpen!();
+      if (widget.onClosed != null) {
+        widget.onClosed!(data);
+      }
+      return;
+    }
+
     final Color middleColor =
         widget.middleColor ?? Theme.of(context).canvasColor;
     final T? data =
@@ -345,7 +544,7 @@ class OpenContainerState<T> extends State<OpenContainer<T?>> {
           context,
           rootNavigator: widget.useRootNavigator,
         ).push(
-          _OpenContainerRoute<T>(
+          OpenContainerRoute<T>(
             closedColor: widget.closedColor,
             openColor: widget.openColor,
             middleColor: middleColor,
@@ -355,8 +554,8 @@ class OpenContainerState<T> extends State<OpenContainer<T?>> {
             openShape: widget.openShape,
             closedBuilder: widget.closedBuilder,
             openBuilder: widget.openBuilder,
-            hideableKey: _hideableKey,
-            closedBuilderKey: _closedBuilderKey,
+            hideableKey: hideableKey,
+            closedBuilderKey: closedBuilderKey,
             transitionDuration: widget.transitionDuration,
             transitionType: widget.transitionType,
             useRootNavigator: widget.useRootNavigator,
@@ -378,15 +577,15 @@ class OpenContainerState<T> extends State<OpenContainer<T?>> {
       elevation: widget.closedShadows == null ? widget.closedElevation : 0.0,
       shape: widget.closedShape,
       child: Builder(
-        key: _closedBuilderKey,
+        key: closedBuilderKey,
         builder: (BuildContext context) {
           return widget.closedBuilder(context, openContainer);
         },
       ),
     );
 
-    return _Hideable(
-      key: _hideableKey,
+    return Hideable(
+      key: hideableKey,
       child: GestureDetector(
         onTap: widget.tappable ? openContainer : null,
         child: widget.closedShadows == null
@@ -414,16 +613,19 @@ class OpenContainerState<T> extends State<OpenContainer<T?>> {
 ///  * It is not included in the tree. Instead a [SizedBox] of dimensions
 ///    specified by `placeholderSize` is included in the tree. (The value of
 ///    `isVisible` is ignored).
-class _Hideable extends StatefulWidget {
-  const _Hideable({super.key, required this.child});
+class Hideable extends StatefulWidget {
+  /// Creates a [Hideable].
+  const Hideable({super.key, required this.child});
 
+  /// The widget below this widget in the tree.
   final Widget child;
 
   @override
-  State<_Hideable> createState() => _HideableState();
+  State<Hideable> createState() => HideableState();
 }
 
-class _HideableState extends State<_Hideable> {
+/// State for [Hideable].
+class HideableState extends State<Hideable> {
   /// When non-null the child is replaced by a [SizedBox] of the set size.
   Size? get placeholderSize => _placeholderSize;
   Size? _placeholderSize;
@@ -471,8 +673,10 @@ class _HideableState extends State<_Hideable> {
   }
 }
 
-class _OpenContainerRoute<T> extends ModalRoute<T> {
-  _OpenContainerRoute({
+/// A route that shows the container transform animation.
+class OpenContainerRoute<T> extends ModalRoute<T> {
+  /// Creates an [OpenContainerRoute].
+  OpenContainerRoute({
     required this.closedColor,
     required this.openColor,
     required this.middleColor,
@@ -480,13 +684,13 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     required this.openElevation,
     required ShapeBorder closedShape,
     required this.openShape,
-    required this.closedBuilder,
+    this.closedBuilder,
     required this.openBuilder,
-    required this.hideableKey,
-    required this.closedBuilderKey,
+    this.hideableKey,
+    this.closedBuilderKey,
     required this.transitionDuration,
     required this.transitionType,
-    required this.useRootNavigator,
+    this.useRootNavigator = false,
     required RouteSettings? routeSettings,
     required this.closedShadows,
     required this.openShadows,
@@ -506,7 +710,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
        _openOpacityTween = _getOpenOpacityTween(transitionType),
        super(settings: routeSettings);
 
-  static _FlippableTweenSequence<Color?> _getColorTween({
+  static FlippableTweenSequence<Color?> _getColorTween({
     required ContainerTransitionType transitionType,
     required Color closedColor,
     required Color openColor,
@@ -514,7 +718,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
   }) {
     switch (transitionType) {
       case ContainerTransitionType.fade:
-        return _FlippableTweenSequence<Color?>(<TweenSequenceItem<Color?>>[
+        return FlippableTweenSequence<Color?>(<TweenSequenceItem<Color?>>[
           TweenSequenceItem<Color>(
             tween: ConstantTween<Color>(closedColor),
             weight: 1 / 5,
@@ -529,7 +733,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
           ),
         ]);
       case ContainerTransitionType.fadeThrough:
-        return _FlippableTweenSequence<Color?>(<TweenSequenceItem<Color?>>[
+        return FlippableTweenSequence<Color?>(<TweenSequenceItem<Color?>>[
           TweenSequenceItem<Color?>(
             tween: ColorTween(begin: closedColor, end: middleColor),
             weight: 1 / 5,
@@ -542,19 +746,19 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     }
   }
 
-  static _FlippableTweenSequence<double> _getClosedOpacityTween(
+  static FlippableTweenSequence<double> _getClosedOpacityTween(
     ContainerTransitionType transitionType,
   ) {
     switch (transitionType) {
       case ContainerTransitionType.fade:
-        return _FlippableTweenSequence<double>(<TweenSequenceItem<double>>[
+        return FlippableTweenSequence<double>(<TweenSequenceItem<double>>[
           TweenSequenceItem<double>(
             tween: ConstantTween<double>(1.0),
             weight: 1,
           ),
         ]);
       case ContainerTransitionType.fadeThrough:
-        return _FlippableTweenSequence<double>(<TweenSequenceItem<double>>[
+        return FlippableTweenSequence<double>(<TweenSequenceItem<double>>[
           TweenSequenceItem<double>(
             tween: Tween<double>(begin: 1.0, end: 0.0),
             weight: 1 / 5,
@@ -567,12 +771,12 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     }
   }
 
-  static _FlippableTweenSequence<double> _getOpenOpacityTween(
+  static FlippableTweenSequence<double> _getOpenOpacityTween(
     ContainerTransitionType transitionType,
   ) {
     switch (transitionType) {
       case ContainerTransitionType.fade:
-        return _FlippableTweenSequence<double>(<TweenSequenceItem<double>>[
+        return FlippableTweenSequence<double>(<TweenSequenceItem<double>>[
           TweenSequenceItem<double>(
             tween: ConstantTween<double>(0.0),
             weight: 1 / 5,
@@ -587,7 +791,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
           ),
         ]);
       case ContainerTransitionType.fadeThrough:
-        return _FlippableTweenSequence<double>(<TweenSequenceItem<double>>[
+        return FlippableTweenSequence<double>(<TweenSequenceItem<double>>[
           TweenSequenceItem<double>(
             tween: ConstantTween<double>(0.0),
             weight: 1 / 5,
@@ -600,34 +804,54 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     }
   }
 
+  /// Background color of the container while it is closed.
   final Color closedColor;
+
+  /// Background color of the container while it is open.
   final Color openColor;
+
+  /// The color to use for the background color during the transition.
   final Color middleColor;
+
+  /// Elevation of the container while it is open.
   final double openElevation;
+
+  /// Shape of the container while it is open.
   final ShapeBorder openShape;
-  final CloseContainerBuilder closedBuilder;
+
+  /// Called to obtain the child for the container in the closed state.
+  final CloseContainerBuilder? closedBuilder;
+
+  /// Called to obtain the child for the container in the open state.
   final OpenContainerBuilder<T> openBuilder;
+
+  /// Custom shadows of the container while it is closed.
   final List<BoxShadow>? closedShadows;
+
+  /// Custom shadows of the container while it is open.
   final List<BoxShadow>? openShadows;
 
-  // See [_OpenContainerState._hideableKey].
-  final GlobalKey<_HideableState> hideableKey;
+  /// See [OpenContainerState.hideableKey].
+  final GlobalKey<HideableState>? hideableKey;
 
-  // See [_OpenContainerState._closedBuilderKey].
-  final GlobalKey closedBuilderKey;
+  /// See [OpenContainerState.closedBuilderKey].
+  final GlobalKey? closedBuilderKey;
 
   @override
   final Duration transitionDuration;
+
+  /// The type of fade transition that the container will use.
   final ContainerTransitionType transitionType;
 
+  /// Whether to use the root navigator.
   final bool useRootNavigator;
 
   final Tween<double> _elevationTween;
   final Animatable<List<BoxShadow>?> _shadowsTween;
   final ShapeBorderTween _shapeTween;
-  final _FlippableTweenSequence<double> _closedOpacityTween;
-  final _FlippableTweenSequence<double> _openOpacityTween;
-  final _FlippableTweenSequence<Color?> _colorTween;
+  final FlippableTweenSequence<double> _closedOpacityTween;
+  final FlippableTweenSequence<double> _openOpacityTween;
+  final FlippableTweenSequence<Color?> _colorTween;
 
   static final TweenSequence<Color?> _scrimFadeInTween =
       TweenSequence<Color?>(<TweenSequenceItem<Color?>>[
@@ -662,15 +886,17 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     if (begin == null && end == null) {
       return ConstantTween<List<BoxShadow>?>(null);
     }
-    return _ShadowsTween(begin: begin, end: end);
+    return ShadowsTween(begin: begin, end: end);
   }
 
   AnimationStatus? _lastAnimationStatus;
   AnimationStatus? _currentAnimationStatus;
 
+  bool get _isCoordinated => hideableKey != null && closedBuilderKey != null && closedBuilder != null;
+
   @override
   TickerFuture didPush() {
-    _takeMeasurements(navigatorContext: hideableKey.currentContext!);
+    _takeMeasurements();
 
     animation!.addStatusListener((AnimationStatus status) {
       _lastAnimationStatus = _currentAnimationStatus;
@@ -691,16 +917,15 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
 
   @override
   bool didPop(T? result) {
-    _takeMeasurements(
-      navigatorContext: subtreeContext!,
-      delayForSourceRoute: true,
-    );
+    if (_isCoordinated) {
+      _takeMeasurements(delayForSourceRoute: true);
+    }
     return super.didPop(result);
   }
 
   @override
   void dispose() {
-    if (hideableKey.currentState?.isVisible == false) {
+    if (_isCoordinated && hideableKey!.currentState?.isVisible == false) {
       // This route may be disposed without dismissing its animation if it is
       // removed by the navigator.
       SchedulerBinding.instance.addPostFrameCallback(
@@ -711,39 +936,34 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
   }
 
   void _toggleHideable({required bool hide}) {
-    if (hideableKey.currentState != null) {
-      hideableKey.currentState!
+    if (_isCoordinated && hideableKey!.currentState != null) {
+      hideableKey!.currentState!
         ..placeholderSize = null
         ..isVisible = !hide;
     }
   }
 
   void _takeMeasurements({
-    required BuildContext navigatorContext,
     bool delayForSourceRoute = false,
   }) {
-    final navigator =
-        Navigator.of(
-              navigatorContext,
-              rootNavigator: useRootNavigator,
-            ).context.findRenderObject()!
-            as RenderBox;
-    final Size navSize = _getSize(navigator);
+    final navigatorBox =
+        navigator!.context.findRenderObject()! as RenderBox;
+    final Size navSize = _getSize(navigatorBox);
     _rectTween.end = Offset.zero & navSize;
 
     void takeMeasurementsInSourceRoute([Duration? _]) {
-      if (!navigator.attached || hideableKey.currentContext == null) {
+      if (!navigatorBox.attached || hideableKey?.currentContext == null) {
         return;
       }
-      _rectTween.begin = _getRect(hideableKey, navigator);
-      hideableKey.currentState!.placeholderSize = _rectTween.begin!.size;
+      _rectTween.begin = _getRect(hideableKey!, navigatorBox);
+      hideableKey!.currentState!.placeholderSize = _rectTween.begin!.size;
     }
 
     if (delayForSourceRoute) {
       SchedulerBinding.instance.addPostFrameCallback(
         takeMeasurementsInSourceRoute,
       );
-    } else {
+    } else if (_isCoordinated) {
       takeMeasurementsInSourceRoute();
     }
   }
@@ -793,6 +1013,7 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
     return wasInProgress && isInProgress;
   }
 
+  /// Closes the container.
   void closeContainer({T? returnValue}) {
     Navigator.of(subtreeContext!).pop(returnValue);
   }
@@ -871,7 +1092,9 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
           assert(openOpacityTween != null);
           assert(scrimTween != null);
 
-          final Rect rect = _rectTween.evaluate(curvedAnimation)!;
+          final Rect? rect = _rectTween.begin == null
+              ? _rectTween.end
+              : _rectTween.evaluate(curvedAnimation);
           final Widget material = Material(
             clipBehavior: Clip.antiAlias,
             animationDuration: Duration.zero,
@@ -882,27 +1105,28 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
               fit: StackFit.passthrough,
               children: <Widget>[
                 // Closed child fading out.
-                FittedBox(
-                  fit: BoxFit.fitWidth,
-                  alignment: Alignment.topLeft,
-                  child: SizedBox(
-                    width: _rectTween.begin!.width,
-                    height: _rectTween.begin!.height,
-                    child: (hideableKey.currentState?.isInTree ?? false)
-                        ? null
-                        : FadeTransition(
-                            opacity: closedOpacityTween!.animate(animation),
-                            child: Builder(
-                              key: closedBuilderKey,
-                              builder: (BuildContext context) {
-                                // Use dummy "open container" callback
-                                // since we are in the process of opening.
-                                return closedBuilder(context, () {});
-                              },
+                if (_isCoordinated)
+                  FittedBox(
+                    fit: BoxFit.fitWidth,
+                    alignment: Alignment.topLeft,
+                    child: SizedBox(
+                      width: _rectTween.begin!.width,
+                      height: _rectTween.begin!.height,
+                      child: (hideableKey!.currentState?.isInTree ?? false)
+                          ? null
+                          : FadeTransition(
+                              opacity: closedOpacityTween!.animate(animation),
+                              child: Builder(
+                                key: closedBuilderKey,
+                                builder: (BuildContext context) {
+                                  // Use dummy "open container" callback
+                                  // since we are in the process of opening.
+                                  return closedBuilder!(context, () {});
+                                },
+                              ),
                             ),
-                          ),
+                    ),
                   ),
-                ),
 
                 // Open child fading in.
                 FittedBox(
@@ -936,10 +1160,10 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
               child: Align(
                 alignment: Alignment.topLeft,
                 child: Transform.translate(
-                  offset: Offset(rect.left, rect.top),
+                  offset: rect == null ? Offset.zero : Offset(rect.left, rect.top),
                   child: SizedBox(
-                    width: rect.width,
-                    height: rect.height,
+                    width: rect?.width ?? 0.0,
+                    height: rect?.height ?? 0.0,
                     child: currentShadows == null
                         ? material
                         : DecoratedBox(
@@ -975,13 +1199,16 @@ class _OpenContainerRoute<T> extends ModalRoute<T> {
   String? get barrierLabel => null;
 }
 
-class _FlippableTweenSequence<T> extends TweenSequence<T> {
-  _FlippableTweenSequence(this._items) : super(_items);
+/// A [TweenSequence] that can be flipped.
+class FlippableTweenSequence<T> extends TweenSequence<T> {
+  /// Creates a [FlippableTweenSequence].
+  FlippableTweenSequence(this._items) : super(_items);
 
   final List<TweenSequenceItem<T>> _items;
-  _FlippableTweenSequence<T>? _flipped;
+  FlippableTweenSequence<T>? _flipped;
 
-  _FlippableTweenSequence<T>? get flipped {
+  /// Returns a flipped version of this [TweenSequence].
+  FlippableTweenSequence<T>? get flipped {
     if (_flipped == null) {
       final newItems = <TweenSequenceItem<T>>[];
       for (var i = 0; i < _items.length; i++) {
@@ -992,14 +1219,16 @@ class _FlippableTweenSequence<T> extends TweenSequence<T> {
           ),
         );
       }
-      _flipped = _FlippableTweenSequence<T>(newItems);
+      _flipped = FlippableTweenSequence<T>(newItems);
     }
     return _flipped;
   }
 }
 
-class _ShadowsTween extends Tween<List<BoxShadow>?> {
-  _ShadowsTween({super.begin, super.end});
+/// A [Tween] that interpolates between two lists of [BoxShadow]s.
+class ShadowsTween extends Tween<List<BoxShadow>?> {
+  /// Creates a [ShadowsTween].
+  ShadowsTween({super.begin, super.end});
 
   @override
   List<BoxShadow>? lerp(double t) {

--- a/packages/animations/pubspec.yaml
+++ b/packages/animations/pubspec.yaml
@@ -2,7 +2,7 @@ name: animations
 description: Fancy pre-built animations that can easily be integrated into any Flutter application.
 repository: https://github.com/flutter/packages/tree/main/packages/animations
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+animations%22
-version: 2.2.0
+version: 2.3.0
 
 environment:
   sdk: ^3.9.0

--- a/packages/animations/test/open_container_declarative_test.dart
+++ b/packages/animations/test/open_container_declarative_test.dart
@@ -1,0 +1,142 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:animations/animations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('OpenContainer can be opened via onOpen hook', (WidgetTester tester) async {
+    var onOpenCalled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OpenContainer(
+            onOpen: () {
+              onOpenCalled = true;
+              return Future<void>.value();
+            },
+            closedBuilder: (BuildContext context, VoidCallback openContainer) {
+              return ElevatedButton(
+                onPressed: openContainer,
+                child: const Text('Open'),
+              );
+            },
+            openBuilder: (BuildContext context, VoidCallback closeContainer) {
+              return const Text('Opened');
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(onOpenCalled, isFalse);
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+    expect(onOpenCalled, isTrue);
+  });
+
+  testWidgets('OpenContainer registers itself in OpenContainerRegistry', (WidgetTester tester) async {
+    const tag = 'test-tag';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OpenContainer(
+            transitionTag: tag,
+            closedBuilder: (BuildContext context, VoidCallback openContainer) {
+              return const Text('Closed');
+            },
+            openBuilder: (BuildContext context, VoidCallback closeContainer) {
+              return const Text('Opened');
+            },
+          ),
+        ),
+      ),
+    );
+
+    final OpenContainerState<dynamic>? state = OpenContainerRegistry.instance.get(tag);
+    expect(state, isNotNull);
+    expect(state!.widget.transitionTag, tag);
+
+    await tester.pumpWidget(Container());
+    expect(OpenContainerRegistry.instance.get(tag), isNull);
+  });
+
+  testWidgets('OpenContainerPage performs coordinated transition', (WidgetTester tester) async {
+    const tag = 'coordinated-tag';
+    final navKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navKey,
+        home: Scaffold(
+          body: OpenContainer(
+            transitionTag: tag,
+            closedBuilder: (BuildContext context, VoidCallback openContainer) {
+              return const SizedBox(
+                width: 100,
+                height: 100,
+                child: Text('Closed Content'),
+              );
+            },
+            openBuilder: (BuildContext context, VoidCallback closeContainer) {
+              return const Text('Opened Content');
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Closed Content'), findsOneWidget);
+    expect(find.text('Opened Content'), findsNothing);
+
+    navKey.currentState!.push(
+      OpenContainerPage<void>(
+        transitionTag: tag,
+        openBuilder: (BuildContext context, VoidCallback closeContainer) {
+          return const Scaffold(body: Text('Opened Content'));
+        },
+      ).createRoute(tester.element(find.byType(OpenContainer))),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+
+    // During transition, both should be present (though one might be fading out)
+    expect(find.text('Closed Content'), findsOneWidget);
+    expect(find.text('Opened Content'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+    expect(find.text('Closed Content'), findsNothing);
+    expect(find.text('Opened Content'), findsOneWidget);
+  });
+
+  testWidgets('OpenContainerPage falls back to fade when tag not found', (WidgetTester tester) async {
+    final navKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navKey,
+        home: const Scaffold(
+          body: Text('Home'),
+        ),
+      ),
+    );
+
+    navKey.currentState!.push(
+      OpenContainerPage<void>(
+        transitionTag: 'non-existent',
+        openBuilder: (BuildContext context, VoidCallback closeContainer) {
+          return const Scaffold(body: Text('Opened Content'));
+        },
+      ).createRoute(tester.element(find.text('Home'))),
+    );
+
+    await tester.pump();
+    // It should just work without crashing
+    expect(find.text('Opened Content'), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.text('Opened Content'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
[Design Doc](https://docs.google.com/document/d/10U2hDOE_aN9sIrzz_ISKIF6mt8oX5oiEyDD4wIgbjYM/edit?usp=sharing)

This PR fixes [flutter/flutter#121929](https://github.com/flutter/flutter/issues/121929) by making the `OpenContainer` widget compatible with declarative routers like `go_router`.

## Problem
`OpenContainer` previously hardcoded an imperative `Navigator.push` call. When used with declarative routers on the web, this prevented the browser URL from updating when the container opened. Manually triggering a router navigation would lose the signature "morphing" animation because the destination page had no metadata about the source widget's position/size.

## Solution
I have introduced a coordination mechanism that allows the source widget and the destination page to share animation metadata while letting the Router own the navigation state.

### Key Changes
1.  A new `Page` class that can be used in `Router` route definitions.
2.  Added to `OpenContainer` to allow overriding the default imperative push with a declarative navigation call (e.g., `context.go()`).
3.  A shared identifier (similar to `Hero.tag`) used to link the source `OpenContainer` with the destination `OpenContainerPage`.
4.  An internal registry that coordinates the "morphing" measurements between the source and destination.
5.  Updated `OpenContainerRoute` to handle cases where the source widget is not present (e.g., direct URL deep-linking) by falling back to a smooth fade transition.
6.  Made `OpenContainerRoute` and `Hideable` public to support these new declarative workflows.

## Usage Example
```dart
// List Page
OpenContainer(
  transitionTag: 'item-$id',
  onOpen: () => context.go('/details/$id'),
  closedBuilder: (context, action) => ListTile(onTap: action, ...),
  openBuilder: (context, action) => DetailsPage(id: id),
)

// Router Config
GoRoute(
  path: '/details/:id',
  pageBuilder: (context, state) => OpenContainerPage(
    transitionTag: 'item-${state.pathParameters['id']}',
    openBuilder: (context, action) => DetailsPage(id: id),
  ),
)
```

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
