### PR TITLE
[ci] Adds ci enable branch for batch release

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7,6 +7,7 @@
 #  * https://github.com/flutter/cocoon/blob/main/CI_YAML.md
 enabled_branches:
   - main
+  - release-go_router-\d+\.\d+\.\d+
 
 platform_properties:
   linux:

--- a/script/tool/lib/src/validators/repo_info_validator.dart
+++ b/script/tool/lib/src/validators/repo_info_validator.dart
@@ -277,6 +277,14 @@ class RepoInfoValidator {
       ),
     );
 
+    errors.addAll(
+      _validateCiYamlEnabledBranches(
+        packageName,
+        repoRoot: repoRoot,
+        isBatchRelease: isBatchRelease,
+      ),
+    );
+
     if (isBatchRelease &&
         (package.parsePubspec().version?.isPreRelease ?? false)) {
       errors.add(
@@ -409,6 +417,49 @@ class RepoInfoValidator {
       errors.add(
         'Unexpected trigger for release-$packageName-* in .github/workflows/$workflowName\n',
       );
+    }
+    return errors;
+  }
+
+  List<String> _validateCiYamlEnabledBranches(
+    String packageName, {
+    required Directory repoRoot,
+    required bool isBatchRelease,
+  }) {
+    final errors = <String>[];
+    final File ciYamlFile = repoRoot.childFile('.ci.yaml');
+    if (!ciYamlFile.existsSync()) {
+      if (isBatchRelease) {
+        printError(
+          '${_indentation}Missing .ci.yaml file at the repository root.\n'
+          '${_indentation}See https://github.com/flutter/flutter/blob/master/docs/ecosystem/release/README.md#batch-release',
+        );
+        errors.add('Missing .ci.yaml');
+      }
+      return errors;
+    }
+
+    final String content = ciYamlFile.readAsStringSync();
+    final yaml = loadYaml(content) as YamlMap;
+
+    final enabledBranches = yaml['enabled_branches'] as YamlList?;
+    final bool hasBranchPattern =
+        enabledBranches != null &&
+        enabledBranches.contains(r'release-' + packageName + r'-\d+\.\d+\.\d+');
+
+    if (isBatchRelease && !hasBranchPattern) {
+      printError(
+        '${_indentation}Missing release branch pattern release-$packageName-\\d+\\.\\d+\\.\\d+ '
+        'in enabled_branches in .ci.yaml\n'
+        '${_indentation}See https://github.com/flutter/flutter/blob/master/docs/ecosystem/release/README.md#batch-release',
+      );
+      errors.add('Unexpected branch handling in .ci.yaml');
+    } else if (!isBatchRelease && hasBranchPattern) {
+      printError(
+        '${_indentation}Unexpected release branch pattern release-$packageName-\\d+\\.\\d+\\.\\d+ '
+        'in enabled_branches in .ci.yaml',
+      );
+      errors.add('Unexpected branch handling in .ci.yaml');
     }
     return errors;
   }

--- a/script/tool/lib/src/validators/repo_info_validator.dart
+++ b/script/tool/lib/src/validators/repo_info_validator.dart
@@ -428,17 +428,6 @@ class RepoInfoValidator {
   }) {
     final errors = <String>[];
     final File ciYamlFile = repoRoot.childFile('.ci.yaml');
-    if (!ciYamlFile.existsSync()) {
-      if (isBatchRelease) {
-        printError(
-          '${_indentation}Missing .ci.yaml file at the repository root.\n'
-          '${_indentation}See https://github.com/flutter/flutter/blob/master/docs/ecosystem/release/README.md#batch-release',
-        );
-        errors.add('Missing .ci.yaml');
-      }
-      return errors;
-    }
-
     final String content = ciYamlFile.readAsStringSync();
     final yaml = loadYaml(content) as YamlMap;
 

--- a/script/tool/test/repo_package_info_check_command_test.dart
+++ b/script/tool/test/repo_package_info_check_command_test.dart
@@ -634,11 +634,21 @@ ${readmeTableEntry('a_package')}
       return package;
     }
 
-    void writeBatchConfig(RepositoryPackage package) {
+    void writeBatchConfig(
+      RepositoryPackage package, {
+      bool validCiYaml = true,
+    }) {
       package.ciConfigFile.writeAsStringSync('''
 release:
   batch: true
 ''');
+      if (validCiYaml) {
+        root.childFile('.ci.yaml').writeAsStringSync(r'''
+enabled_branches:
+  - main
+  - release-a_package-\d+\.\d+\.\d+
+''');
+      }
     }
 
     void writeWorkflowFiles({
@@ -948,5 +958,90 @@ jobs:
         containsAllInOrder(<Matcher>[contains('No issues found!')]),
       );
     });
+
+    test('fails if .ci.yaml file is missing for batch package', () async {
+      final RepositoryPackage package = setupReleaseStrategyTest();
+      writeBatchConfig(package, validCiYaml: false);
+      writeWorkflowFiles();
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+        runner,
+        <String>['repo-package-info-check'],
+        errorHandler: (Error e) {
+          commandError = e;
+        },
+      );
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        contains(contains('Missing .ci.yaml file at the repository root.')),
+      );
+    });
+
+    test(
+      'fails if branch pattern is missing in .ci.yaml enabled_branches for batch package',
+      () async {
+        final RepositoryPackage package = setupReleaseStrategyTest();
+        writeBatchConfig(package, validCiYaml: false);
+        writeWorkflowFiles();
+        root.childFile('.ci.yaml').writeAsStringSync('''
+enabled_branches:
+  - main
+''');
+
+        Error? commandError;
+        final List<String> output = await runCapturingPrint(
+          runner,
+          <String>['repo-package-info-check'],
+          errorHandler: (Error e) {
+            commandError = e;
+          },
+        );
+
+        expect(commandError, isA<ToolExit>());
+        expect(
+          output,
+          contains(
+            contains(
+              r'Missing release branch pattern release-a_package-\d+\.\d+\.\d+ in enabled_branches in .ci.yaml',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'fails if branch pattern is unexpectedly present in .ci.yaml for non-batch package',
+      () async {
+        setupReleaseStrategyTest();
+        writeWorkflowFiles();
+        root.childFile('.ci.yaml').writeAsStringSync(r'''
+enabled_branches:
+  - main
+  - release-a_package-\d+\.\d+\.\d+
+''');
+
+        Error? commandError;
+        final List<String> output = await runCapturingPrint(
+          runner,
+          <String>['repo-package-info-check'],
+          errorHandler: (Error e) {
+            commandError = e;
+          },
+        );
+
+        expect(commandError, isA<ToolExit>());
+        expect(
+          output,
+          contains(
+            contains(
+              r'Unexpected release branch pattern release-a_package-\d+\.\d+\.\d+ in enabled_branches in .ci.yaml',
+            ),
+          ),
+        );
+      },
+    );
   });
 }

--- a/script/tool/test/repo_package_info_check_command_test.dart
+++ b/script/tool/test/repo_package_info_check_command_test.dart
@@ -24,6 +24,11 @@ void main() {
         configureBaseCommandMocks();
     root = packagesDir.fileSystem.currentDirectory;
 
+    root.childFile('.ci.yaml').writeAsStringSync(r'''
+enabled_branches:
+  - main
+''');
+
     final command = RepoPackageInfoCheckCommand(packagesDir, gitDir: gitDir);
     runner = CommandRunner<void>(
       'dependabot_test',
@@ -956,27 +961,6 @@ jobs:
       expect(
         output,
         containsAllInOrder(<Matcher>[contains('No issues found!')]),
-      );
-    });
-
-    test('fails if .ci.yaml file is missing for batch package', () async {
-      final RepositoryPackage package = setupReleaseStrategyTest();
-      writeBatchConfig(package, validCiYaml: false);
-      writeWorkflowFiles();
-
-      Error? commandError;
-      final List<String> output = await runCapturingPrint(
-        runner,
-        <String>['repo-package-info-check'],
-        errorHandler: (Error e) {
-          commandError = e;
-        },
-      );
-
-      expect(commandError, isA<ToolExit>());
-      expect(
-        output,
-        contains(contains('Missing .ci.yaml file at the repository root.')),
       );
     });
 


### PR DESCRIPTION
as title

this is for the ci check in batch release pr https://github.com/flutter/packages/pull/11613/checks?check_run_id=73678550049

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
