### PR TITLE
[two_dimensional_scrollables] Fixes TreeView crash when empty or last node collapsed

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Fixes a crash in `TreeView` when it shrinks to 0 rows or the last node is collapsed.
+
 ## 0.5.1
 
 * Fixes an infinite loop of onExit/onEnter events when setState is called within onEnter in a TableSpan.

--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.2
 
-* Fixes a crash in `TreeView` when it shrinks to 0 rows or the last node is collapsed.
+* Fixes a crash in `TreeView` when it collapses to 0 rows or the last node is collapsed.
 
 ## 0.5.1
 

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -1115,10 +1115,6 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         _firstTrailingPinnedRow == null &&
         _firstTrailingPinnedColumn == null) {
       assert(_lastNonPinnedCell == null);
-      // To satisfy older framework versions that require at least one vicinity
-      // to be laid out (even if no child is built).
-      // See also: https://github.com/flutter/flutter/pull/180563
-      buildOrObtainChildFor(TableVicinity.zero);
       return;
     }
 

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -1115,6 +1115,10 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
         _firstTrailingPinnedRow == null &&
         _firstTrailingPinnedColumn == null) {
       assert(_lastNonPinnedCell == null);
+      // To satisfy older framework versions that require at least one vicinity
+      // to be laid out (even if no child is built).
+      // See also: https://github.com/flutter/flutter/pull/180563
+      buildOrObtainChildFor(TableVicinity.zero);
       return;
     }
 

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
@@ -353,6 +353,8 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
       maxVerticalExtent,
     );
     if (!acceptedDimension) {
+      // If the scroll offset was corrected (e.g., clamped), we must
+      // re-calculate which rows are now visible.
       _updateFirstAndLastVisibleRow();
     }
   }
@@ -391,44 +393,57 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
       }
     }
 
+    // Ensure vertical scroll bounds are updated before layout. This allows
+    // any scroll corrections (e.g., clamping when the tree shrinks) to
+    // be applied immediately, ensuring the layout loop builds the rows
+    // that will actually be visible at the corrected offset.
     _updateVerticalScrollBounds();
 
-    if (_firstRow != null) {
-      assert(_lastRow != null);
-      _Span rowSpan;
-      double rowOffset =
-          -verticalOffset.pixels +
-          _rowMetrics[_firstRow!]!.leadingOffset +
-          _vAlignmentOffset;
-      for (int row = _firstRow!; row <= _lastRow!; row++) {
-        rowSpan = _rowMetrics[row]!;
-        final double rowHeight = rowSpan.extent;
-        if (_animationLeadingIndices.keys.contains(row)) {
-          rowOffset -= rowSpan.animationOffset;
-        }
-        rowOffset += rowSpan.configuration.padding.leading;
+    if (_firstRow == null) {
+      // If no rows are visible, we must still update horizontal bounds
+      // before returning to ensure the horizontal scroll controller
+      // has the latest information.
+      _updateHorizontalScrollBounds();
+      // Return early to avoid a framework crash in RenderTwoDimensionalViewport
+      // where it expects at least one child to be laid out if the layout
+      // pass completes.
+      return;
+    }
 
-        final vicinity = TreeVicinity(depth: _rowDepths[row]!, row: row);
-        final RenderBox child = buildOrObtainChildFor(vicinity)!;
-        final TwoDimensionalViewportParentData parentData = parentDataOf(child);
-        final childConstraints = BoxConstraints(
-          minHeight: rowHeight,
-          maxHeight: rowHeight,
-          // Width is allowed to be unbounded.
-        );
-        child.layout(childConstraints, parentUsesSize: true);
-        parentData.layoutOffset = Offset(
-          (_rowDepths[row]! * indentation) - horizontalOffset.pixels,
-          rowOffset,
-        );
-        rowOffset += rowHeight + rowSpan.configuration.padding.trailing;
-        _furthestHorizontalExtent = math.max(
-          parentData.layoutOffset!.dx +
-              horizontalOffset.pixels +
-              child.size.width,
-          _furthestHorizontalExtent,
-        );
+    assert(_lastRow != null);
+    _Span rowSpan;
+    double rowOffset =
+        -verticalOffset.pixels +
+        _rowMetrics[_firstRow!]!.leadingOffset +
+        _vAlignmentOffset;
+    for (int row = _firstRow!; row <= _lastRow!; row++) {
+      rowSpan = _rowMetrics[row]!;
+      final double rowHeight = rowSpan.extent;
+      if (_animationLeadingIndices.keys.contains(row)) {
+        rowOffset -= rowSpan.animationOffset;
       }
+      rowOffset += rowSpan.configuration.padding.leading;
+
+      final vicinity = TreeVicinity(depth: _rowDepths[row]!, row: row);
+      final RenderBox child = buildOrObtainChildFor(vicinity)!;
+      final TwoDimensionalViewportParentData parentData = parentDataOf(child);
+      final childConstraints = BoxConstraints(
+        minHeight: rowHeight,
+        maxHeight: rowHeight,
+        // Width is allowed to be unbounded.
+      );
+      child.layout(childConstraints, parentUsesSize: true);
+      parentData.layoutOffset = Offset(
+        (_rowDepths[row]! * indentation) - horizontalOffset.pixels,
+        rowOffset,
+      );
+      rowOffset += rowHeight + rowSpan.configuration.padding.trailing;
+      _furthestHorizontalExtent = math.max(
+        parentData.layoutOffset!.dx +
+            horizontalOffset.pixels +
+            child.size.width,
+        _furthestHorizontalExtent,
+      );
     }
     _updateHorizontalScrollBounds();
   }

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
@@ -404,6 +404,10 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
       // before returning to ensure the horizontal scroll controller
       // has the latest information.
       _updateHorizontalScrollBounds();
+      // To satisfy older framework versions that require at least one vicinity
+      // to be laid out (even if no child is built).
+      // See also: https://github.com/flutter/flutter/pull/180563
+      buildOrObtainChildFor(const TreeVicinity(depth: 0, row: 0));
       // Return early to avoid a framework crash in RenderTwoDimensionalViewport
       // where it expects at least one child to be laid out if the layout
       // pass completes.

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
@@ -346,13 +346,13 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
     );
     _horizontalOverflows = maxHorizontalExtent > 0.0;
 
-    final double verticalLeadingExtent = verticalOffset.pixels;
-    final double verticalTrailingExtent =
-        _rowMetrics[_lastRow!]!.trailingOffset - viewportDimension.height;
-    final double maxVerticalExtent = math.max(
-      0.0,
-      math.max(verticalLeadingExtent, verticalTrailingExtent),
-    );
+    final double maxVerticalExtent = _rowMetrics.isEmpty
+        ? 0.0
+        : math.max(
+            0.0,
+            _rowMetrics[_rowMetrics.length - 1]!.trailingOffset -
+                viewportDimension.height,
+          );
     _verticalOverflows = maxVerticalExtent > 0.0;
 
     final bool acceptedDimension =
@@ -389,43 +389,40 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
       }
     }
 
-    if (_firstRow == null) {
-      assert(_lastRow == null);
-      return;
-    }
-    assert(_firstRow != null && _lastRow != null);
+    if (_firstRow != null) {
+      assert(_lastRow != null);
+      _Span rowSpan;
+      double rowOffset =
+          -verticalOffset.pixels +
+          _rowMetrics[_firstRow!]!.leadingOffset +
+          _vAlignmentOffset;
+      for (int row = _firstRow!; row <= _lastRow!; row++) {
+        rowSpan = _rowMetrics[row]!;
+        final double rowHeight = rowSpan.extent;
+        if (_animationLeadingIndices.keys.contains(row)) {
+          rowOffset -= rowSpan.animationOffset;
+        }
+        rowOffset += rowSpan.configuration.padding.leading;
 
-    _Span rowSpan;
-    double rowOffset =
-        -verticalOffset.pixels +
-        _rowMetrics[_firstRow!]!.leadingOffset +
-        _vAlignmentOffset;
-    for (int row = _firstRow!; row <= _lastRow!; row++) {
-      rowSpan = _rowMetrics[row]!;
-      final double rowHeight = rowSpan.extent;
-      if (_animationLeadingIndices.keys.contains(row)) {
-        rowOffset -= rowSpan.animationOffset;
+        final vicinity = TreeVicinity(depth: _rowDepths[row]!, row: row);
+        final RenderBox child = buildOrObtainChildFor(vicinity)!;
+        final TwoDimensionalViewportParentData parentData = parentDataOf(child);
+        final childConstraints = BoxConstraints(
+          minHeight: rowHeight,
+          maxHeight: rowHeight,
+          // Width is allowed to be unbounded.
+        );
+        child.layout(childConstraints, parentUsesSize: true);
+        parentData.layoutOffset = Offset(
+          (_rowDepths[row]! * indentation) - horizontalOffset.pixels,
+          rowOffset,
+        );
+        rowOffset += rowHeight + rowSpan.configuration.padding.trailing;
+        _furthestHorizontalExtent = math.max(
+          parentData.layoutOffset!.dx + child.size.width,
+          _furthestHorizontalExtent,
+        );
       }
-      rowOffset += rowSpan.configuration.padding.leading;
-
-      final vicinity = TreeVicinity(depth: _rowDepths[row]!, row: row);
-      final RenderBox child = buildOrObtainChildFor(vicinity)!;
-      final TwoDimensionalViewportParentData parentData = parentDataOf(child);
-      final childConstraints = BoxConstraints(
-        minHeight: rowHeight,
-        maxHeight: rowHeight,
-        // Width is allowed to be unbounded.
-      );
-      child.layout(childConstraints, parentUsesSize: true);
-      parentData.layoutOffset = Offset(
-        (_rowDepths[row]! * indentation) - horizontalOffset.pixels,
-        rowOffset,
-      );
-      rowOffset += rowHeight + rowSpan.configuration.padding.trailing;
-      _furthestHorizontalExtent = math.max(
-        parentData.layoutOffset!.dx + child.size.width,
-        _furthestHorizontalExtent,
-      );
     }
     _updateScrollBounds();
   }

--- a/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
+++ b/packages/two_dimensional_scrollables/lib/src/tree_view/render_tree.dart
@@ -339,13 +339,7 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
     }
   }
 
-  void _updateScrollBounds() {
-    final double maxHorizontalExtent = math.max(
-      0.0,
-      _furthestHorizontalExtent - viewportDimension.width,
-    );
-    _horizontalOverflows = maxHorizontalExtent > 0.0;
-
+  void _updateVerticalScrollBounds() {
     final double maxVerticalExtent = _rowMetrics.isEmpty
         ? 0.0
         : math.max(
@@ -354,14 +348,22 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
                 viewportDimension.height,
           );
     _verticalOverflows = maxVerticalExtent > 0.0;
-
-    final bool acceptedDimension =
-        horizontalOffset.applyContentDimensions(0.0, maxHorizontalExtent) &&
-        verticalOffset.applyContentDimensions(0.0, maxVerticalExtent);
-
+    final bool acceptedDimension = verticalOffset.applyContentDimensions(
+      0.0,
+      maxVerticalExtent,
+    );
     if (!acceptedDimension) {
       _updateFirstAndLastVisibleRow();
     }
+  }
+
+  void _updateHorizontalScrollBounds() {
+    final double maxHorizontalExtent = math.max(
+      0.0,
+      _furthestHorizontalExtent - viewportDimension.width,
+    );
+    _horizontalOverflows = maxHorizontalExtent > 0.0;
+    horizontalOffset.applyContentDimensions(0.0, maxHorizontalExtent);
   }
 
   @override
@@ -388,6 +390,8 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
             2.0;
       }
     }
+
+    _updateVerticalScrollBounds();
 
     if (_firstRow != null) {
       assert(_lastRow != null);
@@ -419,12 +423,14 @@ class RenderTreeViewport extends RenderTwoDimensionalViewport {
         );
         rowOffset += rowHeight + rowSpan.configuration.padding.trailing;
         _furthestHorizontalExtent = math.max(
-          parentData.layoutOffset!.dx + child.size.width,
+          parentData.layoutOffset!.dx +
+              horizontalOffset.pixels +
+              child.size.width,
           _furthestHorizontalExtent,
         );
       }
     }
-    _updateScrollBounds();
+    _updateHorizontalScrollBounds();
   }
 
   // Maps the UniqueKey associated with animating node segments with the clip

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/tree_view/render_tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/render_tree_test.dart
@@ -682,7 +682,7 @@ void main() {
         await tester.pumpWidget(MaterialApp(home: treeView));
         await tester.pump();
         expect(verticalController.position.pixels, 0.0);
-        expect(verticalController.position.maxScrollExtent, 600.0);
+        expect(verticalController.position.maxScrollExtent, 2200.0);
 
         bool rowNeedsPaint(String row) {
           return find.text(row).evaluate().first.renderObject!.debugNeedsPaint;
@@ -865,6 +865,121 @@ void main() {
             ),
         );
       });
+    });
+
+    group('Scroll bounds', () {
+      testWidgets(
+        'shrinking to 0 rows updates scroll bounds and does not crash',
+        (WidgetTester tester) async {
+          var rows = 10;
+          late StateSetter setState;
+          final controller = ScrollController();
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: SizedBox(
+                  height: 400,
+                  width: 400,
+                  child: StatefulBuilder(
+                    builder: (BuildContext context, StateSetter setter) {
+                      setState = setter;
+                      return TreeView<String>(
+                        verticalDetails: ScrollableDetails.vertical(
+                          controller: controller,
+                        ),
+                        tree: List<TreeViewNode<String>>.generate(
+                          rows,
+                          (int index) => TreeViewNode<String>('Row $index'),
+                        ),
+                        treeRowBuilder: (TreeViewNode<String> node) =>
+                            const TreeRow(extent: FixedTreeRowExtent(64.0)),
+                        treeNodeBuilder:
+                            (
+                              BuildContext context,
+                              TreeViewNode<String> node,
+                              AnimationStyle toggleAnimationStyle,
+                            ) => Text(node.content),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.pump();
+          final double oldMax = controller.position.maxScrollExtent;
+          expect(oldMax, greaterThan(0));
+          controller.jumpTo(oldMax);
+          await tester.pump();
+          expect(controller.offset, oldMax);
+
+          // Shrink to 0 rows.
+          setState(() {
+            rows = 0;
+          });
+          // This should not crash and should update scroll bounds.
+          await tester.pump();
+
+          expect(controller.position.maxScrollExtent, 0.0);
+          expect(controller.offset, 0.0);
+        },
+      );
+
+      testWidgets(
+        'collapsing last node updates scroll bounds and does not crash',
+        (WidgetTester tester) async {
+          final treeController = TreeViewController();
+          final scrollController = ScrollController();
+
+          final treeNodes = <TreeViewNode<String>>[
+            TreeViewNode<String>(
+              'Root',
+              expanded: true,
+              children: <TreeViewNode<String>>[TreeViewNode<String>('Child')],
+            ),
+          ];
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: SizedBox(
+                  height: 100,
+                  width: 400,
+                  child: TreeView<String>(
+                    controller: treeController,
+                    verticalDetails: ScrollableDetails.vertical(
+                      controller: scrollController,
+                    ),
+                    tree: treeNodes,
+                    treeRowBuilder: (TreeViewNode<String> node) =>
+                        const TreeRow(extent: FixedTreeRowExtent(60.0)),
+                    treeNodeBuilder:
+                        (
+                          BuildContext context,
+                          TreeViewNode<String> node,
+                          AnimationStyle toggleAnimationStyle,
+                        ) => Text(node.content),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.pump();
+          // Root (60) + Child (60) = 120. Viewport is 100.
+          expect(scrollController.position.maxScrollExtent, 20.0);
+          scrollController.jumpTo(20.0);
+          await tester.pump();
+
+          // Collapse Root. Now only Root (60) is visible.
+          treeController.toggleNode(treeNodes[0]);
+          await tester.pumpAndSettle();
+
+          expect(scrollController.position.maxScrollExtent, 0.0);
+          expect(scrollController.offset, 0.0);
+        },
+      );
     });
   });
 }

--- a/packages/two_dimensional_scrollables/test/tree_view/render_tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/render_tree_test.dart
@@ -871,126 +871,124 @@ void main() {
 
     group('Scroll bounds', () {
       // Regression tests for https://github.com/flutter/flutter/issues/164981
-      testWidgets(
-        'shrinking to 0 rows updates scroll bounds and does not crash',
-        (WidgetTester tester) async {
+      testWidgets('shrinking to 0 rows updates scroll bounds and does not crash', (
+        WidgetTester tester,
+      ) async {
         // Setup a TreeView with 10 rows to ensure the content exceeds the viewport height.
-          var rows = 10;
-          late StateSetter setState;
-          final controller = ScrollController();
-          await tester.pumpWidget(
-            MaterialApp(
-              home: Scaffold(
-                body: SizedBox(
-                  height: 400,
-                  width: 400,
-                  child: StatefulBuilder(
-                    builder: (BuildContext context, StateSetter setter) {
-                      setState = setter;
-                      return TreeView<String>(
-                        verticalDetails: ScrollableDetails.vertical(
-                          controller: controller,
-                        ),
-                        tree: List<TreeViewNode<String>>.generate(
-                          rows,
-                          (int index) => TreeViewNode<String>('Row $index'),
-                        ),
-                        treeRowBuilder: (TreeViewNode<String> node) =>
-                            const TreeRow(extent: FixedTreeRowExtent(64.0)),
-                        treeNodeBuilder:
-                            (
-                              BuildContext context,
-                              TreeViewNode<String> node,
-                              AnimationStyle toggleAnimationStyle,
-                            ) => Text(node.content),
-                      );
-                    },
-                  ),
+        var rows = 10;
+        late StateSetter setState;
+        final controller = ScrollController();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 400,
+                width: 400,
+                child: StatefulBuilder(
+                  builder: (BuildContext context, StateSetter setter) {
+                    setState = setter;
+                    return TreeView<String>(
+                      verticalDetails: ScrollableDetails.vertical(
+                        controller: controller,
+                      ),
+                      tree: List<TreeViewNode<String>>.generate(
+                        rows,
+                        (int index) => TreeViewNode<String>('Row $index'),
+                      ),
+                      treeRowBuilder: (TreeViewNode<String> node) =>
+                          const TreeRow(extent: FixedTreeRowExtent(64.0)),
+                      treeNodeBuilder:
+                          (
+                            BuildContext context,
+                            TreeViewNode<String> node,
+                            AnimationStyle toggleAnimationStyle,
+                          ) => Text(node.content),
+                    );
+                  },
                 ),
               ),
             ),
-          );
+          ),
+        );
 
-          await tester.pump();
-          final double oldMax = controller.position.maxScrollExtent;
-          expect(oldMax, greaterThan(0));
-          
+        await tester.pump();
+        final double oldMax = controller.position.maxScrollExtent;
+        expect(oldMax, greaterThan(0));
+
         // Jump to the maximum scroll extent to test position correction.
-          controller.jumpTo(oldMax);
-          await tester.pump();
-          expect(controller.offset, oldMax);
+        controller.jumpTo(oldMax);
+        await tester.pump();
+        expect(controller.offset, oldMax);
 
-          // Shrink to 0 rows.
-          setState(() {
-            rows = 0;
-          });
-          // This should not crash and should update scroll bounds.
-          await tester.pump();
+        // Shrink to 0 rows.
+        setState(() {
+          rows = 0;
+        });
+        // This should not crash and should update scroll bounds.
+        await tester.pump();
 
         // Verify that the scroll bounds are updated to 0.0 and the offset is corrected to 0.0.
-          expect(controller.position.maxScrollExtent, 0.0);
-          expect(controller.offset, 0.0);
-        },
-      );
+        expect(controller.position.maxScrollExtent, 0.0);
+        expect(controller.offset, 0.0);
+      });
 
-      testWidgets(
-        'collapsing last node updates scroll bounds and does not crash',
-        (WidgetTester tester) async {
-          final treeController = TreeViewController();
-          final scrollController = ScrollController();
+      testWidgets('collapsing last node updates scroll bounds and does not crash', (
+        WidgetTester tester,
+      ) async {
+        final treeController = TreeViewController();
+        final scrollController = ScrollController();
 
         // Setup a TreeView with one expanded root node and one child node.
-          final treeNodes = <TreeViewNode<String>>[
-            TreeViewNode<String>(
-              'Root',
-              expanded: true,
-              children: <TreeViewNode<String>>[TreeViewNode<String>('Child')],
-            ),
-          ];
+        final treeNodes = <TreeViewNode<String>>[
+          TreeViewNode<String>(
+            'Root',
+            expanded: true,
+            children: <TreeViewNode<String>>[TreeViewNode<String>('Child')],
+          ),
+        ];
 
-          await tester.pumpWidget(
-            MaterialApp(
-              home: Scaffold(
-                body: SizedBox(
-                  height: 100,
-                  width: 400,
-                  child: TreeView<String>(
-                    controller: treeController,
-                    verticalDetails: ScrollableDetails.vertical(
-                      controller: scrollController,
-                    ),
-                    tree: treeNodes,
-                    treeRowBuilder: (TreeViewNode<String> node) =>
-                        const TreeRow(extent: FixedTreeRowExtent(60.0)),
-                    treeNodeBuilder:
-                        (
-                          BuildContext context,
-                          TreeViewNode<String> node,
-                          AnimationStyle toggleAnimationStyle,
-                        ) => Text(node.content),
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 100,
+                width: 400,
+                child: TreeView<String>(
+                  controller: treeController,
+                  verticalDetails: ScrollableDetails.vertical(
+                    controller: scrollController,
                   ),
+                  tree: treeNodes,
+                  treeRowBuilder: (TreeViewNode<String> node) =>
+                      const TreeRow(extent: FixedTreeRowExtent(60.0)),
+                  treeNodeBuilder:
+                      (
+                        BuildContext context,
+                        TreeViewNode<String> node,
+                        AnimationStyle toggleAnimationStyle,
+                      ) => Text(node.content),
                 ),
               ),
             ),
-          );
+          ),
+        );
 
-          await tester.pump();
+        await tester.pump();
         // Root (60) + Child (60) = 120. Viewport is 100. Max scroll extent is 20.
-          expect(scrollController.position.maxScrollExtent, 20.0);
-          
+        expect(scrollController.position.maxScrollExtent, 20.0);
+
         // Jump to the maximum scroll extent.
-          scrollController.jumpTo(20.0);
-          await tester.pump();
+        scrollController.jumpTo(20.0);
+        await tester.pump();
 
         // Collapse the Root node. Now only Root (60) is visible, fitting within the viewport (100).
-          treeController.toggleNode(treeNodes[0]);
-          await tester.pumpAndSettle();
+        treeController.toggleNode(treeNodes[0]);
+        await tester.pumpAndSettle();
 
         // Verify that the scroll bounds are updated to 0.0 and the offset is corrected to 0.0.
-          expect(scrollController.position.maxScrollExtent, 0.0);
-          expect(scrollController.offset, 0.0);
-        },
-      );
+        expect(scrollController.position.maxScrollExtent, 0.0);
+        expect(scrollController.offset, 0.0);
+      });
     });
   });
 }

--- a/packages/two_dimensional_scrollables/test/tree_view/render_tree_test.dart
+++ b/packages/two_dimensional_scrollables/test/tree_view/render_tree_test.dart
@@ -682,6 +682,8 @@ void main() {
         await tester.pumpWidget(MaterialApp(home: treeView));
         await tester.pump();
         expect(verticalController.position.pixels, 0.0);
+        // The total height accounts for all visible nodes (7 nodes * 400 = 2800).
+        // With a default viewport height of 600, the max scroll extent is 2200 (2800 - 600).
         expect(verticalController.position.maxScrollExtent, 2200.0);
 
         bool rowNeedsPaint(String row) {
@@ -868,9 +870,11 @@ void main() {
     });
 
     group('Scroll bounds', () {
+      // Regression tests for https://github.com/flutter/flutter/issues/164981
       testWidgets(
         'shrinking to 0 rows updates scroll bounds and does not crash',
         (WidgetTester tester) async {
+        // Setup a TreeView with 10 rows to ensure the content exceeds the viewport height.
           var rows = 10;
           late StateSetter setState;
           final controller = ScrollController();
@@ -910,6 +914,8 @@ void main() {
           await tester.pump();
           final double oldMax = controller.position.maxScrollExtent;
           expect(oldMax, greaterThan(0));
+          
+        // Jump to the maximum scroll extent to test position correction.
           controller.jumpTo(oldMax);
           await tester.pump();
           expect(controller.offset, oldMax);
@@ -921,6 +927,7 @@ void main() {
           // This should not crash and should update scroll bounds.
           await tester.pump();
 
+        // Verify that the scroll bounds are updated to 0.0 and the offset is corrected to 0.0.
           expect(controller.position.maxScrollExtent, 0.0);
           expect(controller.offset, 0.0);
         },
@@ -932,6 +939,7 @@ void main() {
           final treeController = TreeViewController();
           final scrollController = ScrollController();
 
+        // Setup a TreeView with one expanded root node and one child node.
           final treeNodes = <TreeViewNode<String>>[
             TreeViewNode<String>(
               'Root',
@@ -967,15 +975,18 @@ void main() {
           );
 
           await tester.pump();
-          // Root (60) + Child (60) = 120. Viewport is 100.
+        // Root (60) + Child (60) = 120. Viewport is 100. Max scroll extent is 20.
           expect(scrollController.position.maxScrollExtent, 20.0);
+          
+        // Jump to the maximum scroll extent.
           scrollController.jumpTo(20.0);
           await tester.pump();
 
-          // Collapse Root. Now only Root (60) is visible.
+        // Collapse the Root node. Now only Root (60) is visible, fitting within the viewport (100).
           treeController.toggleNode(treeNodes[0]);
           await tester.pumpAndSettle();
 
+        // Verify that the scroll bounds are updated to 0.0 and the offset is corrected to 0.0.
           expect(scrollController.position.maxScrollExtent, 0.0);
           expect(scrollController.offset, 0.0);
         },


### PR DESCRIPTION
This PR provides a robust fix for a crash in TreeView and resolves a regression introduced by a previous partial fix in PR #9103.

Previous attempts to fix the "empty tree" crash (shrinking to 0 rows) by moving _updateScrollBounds to the end of layout introduced a subtle inconsistency. When a node collapse triggered a scroll correction, the visible row range was recalculated after the layout loop had finished. This resulted in the paint phase attempting to access children that were never built, causing a null dereference (as seen in the Expand then collapse with offscreen nodes (top) test).

* _updateVerticalScrollBounds is now called before the child layout loop. This ensures that any vertical scroll corrections (e.g., clamping when content shrinks) happen first, so the layout loop builds exactly the rows that will be visible.
* Accurate Extent Calculation: Updated _updateScrollBounds to calculate the vertical scroll extent using the total height of all rows in _rowMetrics (via _rowMetrics.last.trailingOffset). This provides a consistent maxScrollExtent and correctly handles the "empty tree" state.
* Correct Horizontal Bounds: Updated the horizontal extent calculation to use absolute content-relative positions, ensuring correct scroll bounds when scrolling horizontally.

Fixes https://github.com/flutter/flutter/issues/164981

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
