### PR TITLE
[two_dimensional_scrollables] Fix repainted trailing pinned cells

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Fixes an issue where trailing pinned spans were included in the regular layout pass, leading to unnecessary iterations.
+
 ## 0.5.1
 
 * Fixes an infinite loop of onExit/onEnter events when setState is called within onEnter in a TableSpan.

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -1025,7 +1025,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           !span.isPinned && span.trailingOffset >= _targetTrailingColumnPixel,
     );
     if (_firstNonPinnedColumn != null) {
-      _lastNonPinnedColumn ??= _columnMetrics.length - 1;
+      _lastNonPinnedColumn ??= _lastRegularColumnIndex;
     }
 
     if (_rowMetrics.isNotEmpty) {
@@ -1056,7 +1056,7 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
           !span.isPinned && span.trailingOffset >= _targetTrailingRowPixel,
     );
     if (_firstNonPinnedRow != null) {
-      _lastNonPinnedRow ??= _rowMetrics.length - 1;
+      _lastNonPinnedRow ??= _lastRegularRowIndex;
     }
   }
 

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -4631,6 +4631,84 @@ void main() {
     expect(mergedRect.top, 200);
     expect(mergedRect.bottom, 400);
   });
+
+  testWidgets('Trailing pinned spans are not included in regular layout pass', (
+    WidgetTester tester,
+  ) async {
+    // This test ensures that trailing pinned spans are not built or painted
+    // as part of the regular (non-pinned) range.
+    const spanExtent = 100.0;
+    final paintCounts = <TableVicinity, int>{};
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 400,
+            width: 400,
+            child: TableView.builder(
+              cacheExtent: 0.0,
+              columnCount: 6, // 2 regular (0,1), 4 trailing pinned (2,3,4,5)
+              rowCount: 6, // 2 regular, 4 trailing pinned
+              trailingPinnedColumnCount: 4,
+              trailingPinnedRowCount: 4,
+              columnBuilder: (int index) =>
+                  const TableSpan(extent: FixedTableSpanExtent(spanExtent)),
+              rowBuilder: (int index) =>
+                  const TableSpan(extent: FixedTableSpanExtent(spanExtent)),
+              cellBuilder: (context, vicinity) {
+                return TableViewCell(
+                  child: _PaintCounter(
+                    onPaint: () {
+                      paintCounts[vicinity] = (paintCounts[vicinity] ?? 0) + 1;
+                    },
+                    child: Text('x: ${vicinity.column} y: ${vicinity.row}'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    // Pinned cells should be painted exactly once.
+    // Before the fix, they would be painted once in the regular pass
+    // (if incorrectly included) and once in the pinned pass.
+    // Since they are visually clipped in the regular pass by pushClipRect,
+    // they would only be painted once anyway, BUT the fix ensures
+    // we don't even iterate over them in the regular pass.
+    expect(paintCounts[const TableVicinity(column: 5, row: 5)], 1);
+    expect(paintCounts[TableVicinity.zero], 1);
+    expect(paintCounts.length, 36);
+  });
+}
+
+class _PaintCounter extends SingleChildRenderObjectWidget {
+  const _PaintCounter({required this.onPaint, required super.child});
+  final VoidCallback onPaint;
+  @override
+  _RenderPaintCounter createRenderObject(BuildContext context) =>
+      _RenderPaintCounter(onPaint);
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderPaintCounter renderObject,
+  ) {
+    renderObject.onPaint = onPaint;
+  }
+}
+
+class _RenderPaintCounter extends RenderProxyBox {
+  _RenderPaintCounter(this.onPaint);
+  VoidCallback onPaint;
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    onPaint();
+    super.paint(context, offset);
+  }
 }
 
 class _NullBuildContext implements BuildContext, TwoDimensionalChildManager {


### PR DESCRIPTION
This PR fixes a performance bug in TableView where spans designated as trailing pinned were being incorrectly included in the range of "regular" (non-pinned) spans.

When the trailing pinned spans feature was introduced, these spans were appended to the end of the internal metrics maps. The logic in RenderTableViewport._updateFirstAndLastVisibleCell was defaulting the "last visible non-pinned index" to the very end of these maps (metrics.length - 1) whenever the binary search didn't find a clear boundary (e.g., when regular spans didn't fill the viewport).

This caused trailing pinned spans to be included in both the regular layout pass and the pinned layout pass. While visually hidden by clipping, this resulted in unnecessary iterations, building, and laying out of cells.

Updated _updateFirstAndLastVisibleCell in lib/src/table_view/table.dart to correctly cap the non-pinned range using the pre-calculated _lastRegularColumnIndex and _lastRegularRowIndex instead of the map length. This ensures the regular layout pass strictly terminates before reaching any trailing pinned spans.

Fixes https://github.com/flutter/flutter/issues/185842

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
