### PR TITLE
[google_maps_flutter] Fix styles on web

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2+1
+
+* Fixes a bug that prevented non-cloud styles from being applied.
+
 ## 0.6.2
 
 * Adds `colorScheme` support for controlling cloud-based map brightness.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/cloud_map_styles_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/cloud_map_styles_test.dart
@@ -26,7 +26,7 @@ void main() {
     textDirection: TextDirection.ltr,
   );
 
-  testWidgets('cloudMapId present => mapId set & styles omitted', (
+  testWidgets('cloud mapId present => mapId set & styles omitted', (
     WidgetTester tester,
   ) async {
     const testMapConfig = MapConfiguration(mapId: 'test-cloud-map-id');
@@ -46,7 +46,7 @@ void main() {
       mapId: 1, // Internal controller ID
       streamController: stream,
       widgetConfiguration: cfg(),
-      mapConfiguration: testMapConfig, // cloudMapId is set here
+      mapConfiguration: testMapConfig, // Cloud mapId is set here
     );
 
     controller.debugSetOverrides(
@@ -70,13 +70,13 @@ void main() {
     expect(
       captured!.styles == null || captured!.styles!.isEmpty,
       isTrue,
-      reason: 'When cloudMapId is set, styles must not be applied.',
+      reason: 'When cloud mapId is set, styles must not be applied.',
     );
 
     controller.dispose();
   });
 
-  testWidgets('no cloudMapId => styles applied', (WidgetTester tester) async {
+  testWidgets('no cloud mapId => styles applied', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(textDirection: TextDirection.ltr, child: SizedBox()),
     );
@@ -113,13 +113,65 @@ void main() {
     expect(
       captured!.mapId,
       anyOf(isNull, isEmpty),
-      reason: 'mapId should be empty/null when no Cloud Map is used.',
+      reason: 'mapId should be empty/null when no cloud mapId is used.',
     );
     expect(captured!.styles, isNotNull);
     expect(
       captured!.styles,
       isNotEmpty,
-      reason: 'When cloudMapId is null, styles should be applied.',
+      reason: 'When cloud mapId is null, styles should be applied.',
+    );
+
+    controller.dispose();
+  });
+
+  testWidgets('empty cloud mapId is treated as no mapId', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const Directionality(textDirection: TextDirection.ltr, child: SizedBox()),
+    );
+
+    final stream = StreamController<MapEvent<Object?>>();
+    addTearDown(() {
+      // Stream is closed by controller.dispose()
+    });
+
+    gmaps.MapOptions? captured;
+    final controller = GoogleMapController(
+      mapId: 2, // Internal controller ID
+      streamController: stream,
+      widgetConfiguration: cfg(),
+      mapConfiguration: const MapConfiguration(mapId: ''),
+    );
+
+    controller.debugSetOverrides(
+      setOptions: (gmaps.MapOptions options) {
+        captured = options;
+      },
+    );
+
+    final styles = <gmaps.MapTypeStyle>[
+      gmaps.MapTypeStyle()
+        ..featureType = 'poi'
+        ..elementType = 'labels',
+    ];
+
+    controller.updateStyles(styles);
+
+    await tester.pump();
+
+    expect(captured, isNotNull);
+    expect(
+      captured!.mapId,
+      anyOf(isNull, isEmpty),
+      reason: 'mapId should be empty/null when no cloud mapId is used.',
+    );
+    expect(captured!.styles, isNotNull);
+    expect(
+      captured!.styles,
+      isNotEmpty,
+      reason: 'When cloud mapId is empty, styles should be applied.',
     );
 
     controller.dispose();

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -124,12 +124,17 @@ gmaps.MapOptions _configurationAndStyleToGmapsOptions(
   options.fullscreenControl = false;
   options.streetViewControl = false;
 
+  // Treat an empty mapId as null, as the app-facing package may pass it either
+  // way.
+  final String? mapId = configuration.mapId?.isEmpty ?? true
+      ? null
+      : configuration.mapId;
   // If using cloud map, do not set options.styles
-  if (configuration.mapId == null) {
+  if (mapId == null) {
     options.styles = styles;
   }
 
-  options.mapId = configuration.mapId;
+  options.mapId = mapId;
 
   final gmaps.ColorScheme? jsColorScheme = _gmapTypeColorSchemeForPluginColor(
     configuration.colorScheme,

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -126,9 +126,7 @@ gmaps.MapOptions _configurationAndStyleToGmapsOptions(
 
   // Treat an empty mapId as null, as the app-facing package may pass it either
   // way.
-  final String? mapId = configuration.mapId?.isEmpty ?? true
-      ? null
-      : configuration.mapId;
+  final String? mapId = configuration.mapId == '' ? null : configuration.mapId;
   // If using cloud map, do not set options.styles
   if (mapId == null) {
     options.styles = styles;

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.6.2
+version: 0.6.2+1
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Fixes a regression from https://github.com/flutter/packages/pull/7882 that caused non-cloud map styling not be applied on web, since the app-facing package changed to sending '' rather than null when a cloud mapId wasn't provided, and the web implementation didn't handle that case.

Fixes https://github.com/flutter/flutter/issues/185171

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
