### PR TITLE
[in_app_purchase] Fix broken dartdoc references in completePurchase

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 3.2.4
 
 * Fixes broken dartdoc references in `completePurchase` to point to
   `InAppPurchaseException` and `InAppPurchaseException.code` instead of the

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## NEXT
 
+* Fixes broken dartdoc references in `completePurchase` to point to
+  `InAppPurchaseException` and `InAppPurchaseException.code` instead of the
+  non-existent `PurchaseException` and `PurchaseException.errorCode`.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 * Updates README to reflect currently supported OS versions for the latest
   versions of the endorsed platform implementations.

--- a/packages/in_app_purchase/in_app_purchase/lib/in_app_purchase.dart
+++ b/packages/in_app_purchase/in_app_purchase/lib/in_app_purchase.dart
@@ -173,15 +173,15 @@ class InAppPurchase implements InAppPurchasePlatformAdditionProvider {
   /// For convenience, [PurchaseDetails.pendingCompletePurchase] indicates if a
   /// purchase is pending for completion.
   ///
-  /// The method will throw a [PurchaseException] when the purchase could not be
-  /// finished. Depending on the [PurchaseException.errorCode] the developer
-  /// should try to complete the purchase via this method again, or retry the
-  /// [completePurchase] method at a later time. If the
-  /// [PurchaseException.errorCode] indicates you should not retry there might
+  /// The method will throw an [InAppPurchaseException] when the purchase
+  /// could not be finished. Depending on the [InAppPurchaseException.code] the
+  /// developer should try to complete the purchase via this method again, or
+  /// retry the [completePurchase] method at a later time. If the
+  /// [InAppPurchaseException.code] indicates you should not retry there might
   /// be some issue with the app's code or the configuration of the app in the
   /// respective store. The developer is responsible to fix this issue. The
-  /// [PurchaseException.message] field might provide more information on what
-  /// went wrong.
+  /// [InAppPurchaseException.message] field might provide more information on
+  /// what went wrong.
   Future<void> completePurchase(PurchaseDetails purchase) =>
       InAppPurchasePlatform.instance.completePurchase(purchase);
 

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.2.3
+version: 3.2.4
 
 environment:
   sdk: ^3.10.0

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## NEXT
 
+* Fixes broken dartdoc references in `completePurchase` to point to
+  `InAppPurchaseException` and `InAppPurchaseException.code` instead of the
+  non-existent `PurchaseException` and `PurchaseException.errorCode`.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 1.4.0

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 1.4.1
 
 * Fixes broken dartdoc references in `completePurchase` to point to
   `InAppPurchaseException` and `InAppPurchaseException.code` instead of the

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/in_app_purchase_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/in_app_purchase_platform.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import 'errors/errors.dart';
 import 'types/types.dart';
 
 /// The interface that implementations of in_app_purchase must implement.
@@ -161,15 +162,15 @@ abstract class InAppPurchasePlatform extends PlatformInterface {
   /// For convenience, [PurchaseDetails.pendingCompletePurchase] indicates if a
   /// purchase is pending for completion.
   ///
-  /// The method will throw a [PurchaseException] when the purchase could not be
-  /// finished. Depending on the [PurchaseException.errorCode] the developer
-  /// should try to complete the purchase via this method again, or retry the
-  /// [completePurchase] method at a later time. If the
-  /// [PurchaseException.errorCode] indicates you should not retry there might
+  /// The method will throw an [InAppPurchaseException] when the purchase
+  /// could not be finished. Depending on the [InAppPurchaseException.code] the
+  /// developer should try to complete the purchase via this method again, or
+  /// retry the [completePurchase] method at a later time. If the
+  /// [InAppPurchaseException.code] indicates you should not retry there might
   /// be some issue with the app's code or the configuration of the app in the
   /// respective store. The developer is responsible to fix this issue. The
-  /// [PurchaseException.message] field might provide more information on what
-  /// went wrong.
+  /// [InAppPurchaseException.message] field might provide more information on
+  /// what went wrong.
   Future<void> completePurchase(PurchaseDetails purchase) =>
       throw UnimplementedError('completePurchase() has not been implemented.');
 

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/in_app_purcha
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.4.0
+version: 1.4.1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
The dartdoc on `InAppPurchase.completePurchase` and `InAppPurchasePlatform.completePurchase` referenced a `PurchaseException` class and a `PurchaseException.errorCode` field, neither of which exists in this package. The actual class thrown by `completePurchase` is `InAppPurchaseException` and its error code field is named `code`. Because of the typo the dartdoc links rendered as broken on pub.dev and api.flutter.dev.

This PR rewrites the doc comment in both files to point at `InAppPurchaseException`, `InAppPurchaseException.code`, and `InAppPurchaseException.message` so the references resolve. The platform interface file also gains an `errors/errors.dart` import so the class is in scope for the dartdoc link. No runtime behavior changes.

Fixes flutter/flutter#118626

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1]. Test-exempt: this PR only corrects documentation text, with no behavioral changes.
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
