### PR TITLE
[video_player] Add missing swift_version to podspec

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.6
+
+* Adds a Swift version to fix a potential build issue when using CocoaPods.
+
 ## 2.9.5
 
 * Converts portions of the native code to Swift for improved maintainability.

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation.podspec
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation.podspec
@@ -23,6 +23,7 @@ Downloaded by pub (not CocoaPods).
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.swift_version = '5.0'
   s.xcconfig = {
     'LIBRARY_SEARCH_PATHS' => '$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)/ $(SDKROOT)/usr/lib/swift',
     'LD_RUNPATH_SEARCH_PATHS' => '/usr/lib/swift',

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.9.5
+version: 2.9.6
 
 environment:
   sdk: ^3.10.0

--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -75,7 +75,9 @@ class PodspecCheckCommand extends PackageLoopingCommand {
     }
 
     if (await _hasIOSSwiftCode(package)) {
-      print('iOS Swift code found, checking for search paths settings...');
+      print(
+        'iOS Swift code found, checking for search paths settings and Swift version...',
+      );
       for (final podspec in podspecs) {
         if (_isPodspecMissingSearchPaths(podspec)) {
           const workaroundBlock = r'''
@@ -94,6 +96,20 @@ class PodspecCheckCommand extends PackageLoopingCommand {
             'needs to contain the following:\n\n'
             '$workaroundBlock\n'
             'For more details, see https://github.com/flutter/flutter/issues/118418.',
+          );
+          errors.add(podspec.basename);
+        }
+
+        if (_isPodspecMissingSwiftVersion(podspec)) {
+          final String path = getRelativePosixPath(
+            podspec,
+            from: package.directory,
+          );
+          printError(
+            '$path is missing Swift version configuration. Any iOS '
+            'plugin implementation that contains Swift implementation code '
+            'needs to contain a Swift version. For example:\n\n'
+            "s.swift_version = '5.0'",
           );
           errors.add(podspec.basename);
         }
@@ -124,6 +140,8 @@ class PodspecCheckCommand extends PackageLoopingCommand {
       return path.extension(filename) == '.podspec' &&
           filename != 'Flutter.podspec' &&
           filename != 'FlutterMacOS.podspec' &&
+          // Ignore build intermediates, such as transitive pod dependencies.
+          !entity.absolute.path.contains('/build/') &&
           !entity.path.contains('packages/pigeon/platform_tests/');
     }).toList();
 
@@ -177,6 +195,11 @@ class PodspecCheckCommand extends PackageLoopingCommand {
       if (relativePath.startsWith('example/')) {
         return false;
       }
+      // Ignore build intermediates.
+      if (relativePath.contains('/build/') ||
+          relativePath.startsWith('build/')) {
+        return false;
+      }
       // Ignore test code.
       if (relativePath.contains('/Tests/') ||
           relativePath.contains('/RunnerTests/') ||
@@ -225,5 +248,9 @@ class PodspecCheckCommand extends PackageLoopingCommand {
       dotAll: true,
     );
     return manifestBundling.hasMatch(podspec.readAsStringSync());
+  }
+
+  bool _isPodspecMissingSwiftVersion(File podspec) {
+    return !RegExp(r'swift_version\s*=').hasMatch(podspec.readAsStringSync());
   }
 }

--- a/script/tool/lib/src/podspec_check_command.dart
+++ b/script/tool/lib/src/podspec_check_command.dart
@@ -137,11 +137,15 @@ class PodspecCheckCommand extends PackageLoopingCommand {
       File entity,
     ) {
       final String filename = entity.basename;
+      final String relativePath = getRelativePosixPath(
+        entity,
+        from: package.directory,
+      );
       return path.extension(filename) == '.podspec' &&
           filename != 'Flutter.podspec' &&
           filename != 'FlutterMacOS.podspec' &&
           // Ignore build intermediates, such as transitive pod dependencies.
-          !entity.absolute.path.contains('/build/') &&
+          !relativePath.split('/').contains('build') &&
           !entity.path.contains('packages/pigeon/platform_tests/');
     }).toList();
 
@@ -196,8 +200,7 @@ class PodspecCheckCommand extends PackageLoopingCommand {
         return false;
       }
       // Ignore build intermediates.
-      if (relativePath.contains('/build/') ||
-          relativePath.startsWith('build/')) {
+      if (relativePath.split('/').contains('build')) {
         return false;
       }
       // Ignore test code.
@@ -251,6 +254,6 @@ class PodspecCheckCommand extends PackageLoopingCommand {
   }
 
   bool _isPodspecMissingSwiftVersion(File podspec) {
-    return !RegExp(r'swift_version\s*=').hasMatch(podspec.readAsStringSync());
+    return !RegExp(r'\bswift_version\s*=').hasMatch(podspec.readAsStringSync());
   }
 }

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -14,21 +14,22 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 import 'util.dart';
 
-/// Adds a fake podspec to [plugin]'s [platform] directory.
+/// Adds a fake podspec to [plugin]'s [subdirectory] directory.
 ///
 /// If [includeSwiftWorkaround] is set, the xcconfig additions to make Swift
 /// libraries work in apps that have no Swift will be included. If
 /// [scopeSwiftWorkaround] is set, it will be specific to the iOS configuration.
 void _writeFakePodspec(
   RepositoryPackage plugin,
-  String platform, {
+  String subdirectory, {
   bool includeSwiftWorkaround = false,
   bool scopeSwiftWorkaround = false,
   bool includePrivacyManifest = false,
+  bool includeSwiftVersion = true,
 }) {
   final String pluginName = plugin.directory.basename;
   final File file = plugin.directory
-      .childDirectory(platform)
+      .childDirectory(subdirectory)
       .childFile('$pluginName.podspec');
   final swiftWorkaround = includeSwiftWorkaround
       ? '''
@@ -43,6 +44,7 @@ void _writeFakePodspec(
   s.resource_bundles = {'$pluginName' => ['Resources/PrivacyInfo.xcprivacy']}
 '''
       : '';
+  final swiftVersion = includeSwiftVersion ? "s.swift_version = '5.0'" : '';
   file.createSync(recursive: true);
   file.writeAsStringSync('''
 #
@@ -66,7 +68,7 @@ Wraps NSUserDefaults, providing a persistent store for simple key-value pairs.
   s.osx.deployment_target = '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   $swiftWorkaround
-  s.swift_version = '5.0'
+  $swiftVersion
   $privacyManifest
 
 end
@@ -452,6 +454,54 @@ void main() {
       },
     );
 
+    test(
+      'ignores Swift files in the build directory when determining whether the plugin uses Swift',
+      () async {
+        final RepositoryPackage plugin = createFakePlugin(
+          'plugin1',
+          packagesDir,
+          extraFiles: <String>[
+            'ios/Classes/SomeObjC.h',
+            'ios/Classes/SomeObjC.m',
+            'build/SomeSwiftFile.swift',
+            'ios/build/AnotherSwiftFile.swift',
+          ],
+        );
+        _writeFakePodspec(plugin, 'ios');
+
+        final List<String> output = await runCapturingPrint(runner, <String>[
+          'podspec-check',
+        ]);
+
+        expect(
+          output,
+          containsAllInOrder(<Matcher>[contains('Ran for 1 package(s)')]),
+        );
+      },
+    );
+
+    test('does not check for search paths in build output', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin1',
+        packagesDir,
+        extraFiles: <String>[
+          'ios/Classes/SomeSwift.swift',
+          'ios/plugin1/Package.swift',
+        ],
+      );
+      _writeFakePodspec(plugin, 'ios', includeSwiftWorkaround: true);
+      _writeFakePodspec(plugin, 'ios/build/some_pod');
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'podspec-check',
+      ]);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[contains('Ran for 1 package(s)')]),
+      );
+    });
+
     test('passes if the search paths workaround is present', () async {
       final RepositoryPackage plugin = createFakePlugin(
         'plugin1',
@@ -627,6 +677,41 @@ void main() {
       expect(
         output,
         containsAllInOrder(<Matcher>[contains('Ran for 1 package(s)')]),
+      );
+    });
+
+    test('fails when a Swift plugin is missing a Swift version', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin1',
+        packagesDir,
+        platformSupport: <String, PlatformDetails>{
+          Platform.iOS: const PlatformDetails(PlatformSupport.inline),
+        },
+        extraFiles: <String>['ios/Classes/SomeSwift.swift'],
+      );
+      _writeFakePodspec(
+        plugin,
+        'ios',
+        includeSwiftVersion: false,
+        includeSwiftWorkaround: true,
+        includePrivacyManifest: true,
+      );
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+        runner,
+        <String>['podspec-check'],
+        errorHandler: (Error e) {
+          commandError = e;
+        },
+      );
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('missing Swift version configuration'),
+        ]),
       );
     });
   });


### PR DESCRIPTION
Adds a `swift_version` to the podspec of `video_player_avfoundation`, to fix a build error when building with CocoaPods in a project that doesn't itself have a Swift version set.

Updates the repo tooling `podspec-check` command to check for this, so that we don't forget it in future migrations.

Also fixes some missing ignores in `podspec-check` that caused false positives when running the check locally in a tree that has built plugins.

Fixes https://github.com/flutter/flutter/issues/186232

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
