### PR TITLE
build(android): support AGP 9 built-in Kotlin

### DIFF
--- a/packages/local_auth/local_auth_android/android/build.gradle.kts
+++ b/packages/local_auth/local_auth_android/android/build.gradle.kts
@@ -25,7 +25,6 @@ rootProject.allprojects {
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
 }
 
 kotlin {

--- a/packages/shared_preferences/shared_preferences_android/android/build.gradle.kts
+++ b/packages/shared_preferences/shared_preferences_android/android/build.gradle.kts
@@ -31,7 +31,6 @@ tasks.withType<JavaCompile>().configureEach {
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
 }
 
 kotlin {


### PR DESCRIPTION
## Draft status

This is an AGP 9 built-in Kotlin migration draft. It removes explicit `kotlin-android` application from Android plugin Gradle files that already use Kotlin DSL/build configuration compatible with built-in Kotlin.

Do not treat this as merge-ready unless this repository is ready to rely on AGP 9 built-in Kotlin. If AGP 8 compatibility is still required, this should be revised to the maintainer-preferred compatibility shape instead of removing the Kotlin Gradle plugin.

## Scope

- local_auth_android
- shared_preferences_android

No Dart APIs, Android manifests, SDK versions, or runtime code are changed.

## Verification

- `rg "kotlin-android|org.jetbrains.kotlin.android|kotlinOptions"` on touched Android Gradle files returns no matches.
- `git diff --check`
- Consuming app validation with AGP 9: `flutter pub get`, `flutter build apk --debug`, `./gradlew -q :app:checkKotlinGradlePluginConfigurationErrors`, `flutter analyze --no-fatal-infos`.
