### PR TITLE
[vector_graphics] Fix uncaught StateError in useHtmlRenderObject on CanvasKit / iOS Safari

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+* Fixes uncaught `StateError` and `NoSuchMethodError` from `useHtmlRenderObject()` on CanvasKit / iOS Safari so SVG widgets fall back to the HTML render object.
+
 ## 1.2.0
 
 * Adds `imageBuilder` property to `VectorGraphic` for wrapping the loaded vector graphic widget.

--- a/packages/vector_graphics/lib/src/render_object_selection.dart
+++ b/packages/vector_graphics/lib/src/render_object_selection.dart
@@ -28,6 +28,18 @@ bool useHtmlRenderObject() {
     image = picture.toImageSync(1, 1);
     _cachedUseHtmlRenderObject = false;
   } on UnsupportedError catch (_) {
+    // The original HTML renderer does not implement toImageSync.
+    _cachedUseHtmlRenderObject = true;
+  } on StateError catch (_) {
+    // CanvasKit on Mobile Safari (iOS 18.7) throws "Unable to convert
+    // read pixels from SkImage" when readPixels fails at runtime.
+    // See https://github.com/flutter/flutter/issues/186333.
+    _cachedUseHtmlRenderObject = true;
+  } on NoSuchMethodError catch (_) {
+    // Same renderer/browser combination as the StateError case also
+    // surfaces a "Null check operator used on a null value" thrown
+    // from canvaskit.js wasm internals via Surface.createOrUpdateSurface.
+    // See https://github.com/flutter/flutter/issues/186333.
     _cachedUseHtmlRenderObject = true;
   } finally {
     image?.dispose();

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -2,7 +2,7 @@ name: vector_graphics
 description: A vector graphics rendering package for Flutter using a binary encoding.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-version: 1.2.0
+version: 1.2.1
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
## Description

`useHtmlRenderObject()` only caught `UnsupportedError` when probing
`toImageSync`. CanvasKit on Mobile Safari (iOS 18.7) throws a `StateError`
("Unable to convert read pixels from SkImage") instead, which escapes the
`try/catch` and crashes the widget subtree.

This change treats both `UnsupportedError` and `StateError` as
"use the HTML render object" — the function only exists to probe and
pick a fallback.

## Related Issues

Fixes flutter/flutter#186333

## Tests

The failure mode is only triggered by specific CanvasKit / Mobile Safari
combinations (observed on iOS 18.7) and cannot be reproduced deterministically
in a unit test against the host's renderer. Validated against production
telemetry on iOS 18.7 Safari, where this exception is currently uncaught and
reaches users.

All existing `vector_graphics` and `vector_graphics_compiler` tests still
pass after the change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets.
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making. — see Tests above.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
