### PR TITLE
spm support via google_maps_flutter_ios_sdk9

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   flutter:
     sdk: flutter
   google_maps_flutter_android: ^2.19.1
-  google_maps_flutter_ios: ^2.18.0
   google_maps_flutter_platform_interface: ^2.15.0
   google_maps_flutter_web: ^0.6.2
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ flutter:
       android:
         default_package: google_maps_flutter_android
       ios:
-        default_package: google_maps_flutter_ios
+        default_package: google_maps_flutter_ios_sdk9
       web:
         default_package: google_maps_flutter_web
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter:
     sdk: flutter
   google_maps_flutter_android: ^2.19.1
+  google_maps_flutter_ios_sdk9: ^2.18.1
   google_maps_flutter_platform_interface: ^2.15.0
   google_maps_flutter_web: ^0.6.2
 


### PR DESCRIPTION
change depdendency to google_maps_flutter_ios_sdk9 to support swift package manager.
requires ios15. 