### PR TITLE
[google_maps_flutter] Fix markers NPOT sampling issue for IOS

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.18.2
+
+* Fixes incorrect or swapped custom marker icons on iOS when decoded bitmaps or target sizes
+  are not power-of-two (for example 410×512). Icons are now drawn into a transparent
+  power-of-two bitmap whose pixel size is the next power of two of the requested physical
+  size, which avoids texture-atlas / caching issues in the Google Maps SDK while keeping
+  the visible artwork in the top-left `width`×`height` region.
+
 ## 2.18.1
 
 * Removes conditional header logic that broke add-to-app builds.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/ExtractIconFromDataTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/ExtractIconFromDataTests.m
@@ -88,13 +88,13 @@
   XCTAssertNotNil(resultImage);
   XCTAssertEqual(testImage.scale, 1.0);
 
-  // As image has same aspect ratio as the original image,
-  // only image scale has been changed to match the target size.
-  CGFloat targetScale = testImage.scale * (testImage.size.width / width);
-  const CGFloat accuracy = 0.001;
-  XCTAssertEqualWithAccuracy(resultImage.scale, targetScale, accuracy);
-  XCTAssertEqual(resultImage.size.width, width);
-  XCTAssertEqual(resultImage.size.height, width);
+  // Target physical size 45×45 @3x; padded to 64×64 POT for the Maps SDK texture path.
+  const NSUInteger pot = 64u;
+  XCTAssertEqual((NSUInteger)CGImageGetWidth(resultImage.CGImage), pot);
+  XCTAssertEqual((NSUInteger)CGImageGetHeight(resultImage.CGImage), pot);
+  XCTAssertEqualWithAccuracy(resultImage.scale, screenScale, 0.001);
+  XCTAssertEqualWithAccuracy(resultImage.size.width, (CGFloat)pot / screenScale, 0.001);
+  XCTAssertEqualWithAccuracy(resultImage.size.height, (CGFloat)pot / screenScale, 0.001);
 }
 
 - (void)testExtractIconFromDataAssetAutoAndSizeWithDifferentAspectRatio {
@@ -120,8 +120,11 @@
       FGMIconFromBitmap([FGMPlatformBitmap makeWithBitmap:bitmap], assetProvider, screenScale);
   XCTAssertNotNil(resultImage);
   XCTAssertEqual(resultImage.scale, screenScale);
-  XCTAssertEqual(resultImage.size.width, width);
-  XCTAssertEqual(resultImage.size.height, height);
+  // Physical 45×135 → POT canvas 64×256.
+  XCTAssertEqual((NSUInteger)CGImageGetWidth(resultImage.CGImage), 64u);
+  XCTAssertEqual((NSUInteger)CGImageGetHeight(resultImage.CGImage), 256u);
+  XCTAssertEqualWithAccuracy(resultImage.size.width, 64.0 / screenScale, 0.001);
+  XCTAssertEqualWithAccuracy(resultImage.size.height, 256.0 / screenScale, 0.001);
 }
 
 - (void)testExtractIconFromDataAssetNoScaling {
@@ -220,13 +223,12 @@
   XCTAssertNotNil(resultImage);
   XCTAssertEqual(testImage.scale, 1.0);
 
-  // As image has same aspect ratio as the original image,
-  // only image scale has been changed to match the target size.
-  CGFloat targetScale = testImage.scale * (testImage.size.width / width);
-  const CGFloat accuracy = 0.001;
-  XCTAssertEqualWithAccuracy(resultImage.scale, targetScale, accuracy);
-  XCTAssertEqual(resultImage.size.width, width);
-  XCTAssertEqual(resultImage.size.height, height);
+  const NSUInteger pot = 64u;
+  XCTAssertEqual((NSUInteger)CGImageGetWidth(resultImage.CGImage), pot);
+  XCTAssertEqual((NSUInteger)CGImageGetHeight(resultImage.CGImage), pot);
+  XCTAssertEqualWithAccuracy(resultImage.scale, screenScale, 0.001);
+  XCTAssertEqualWithAccuracy(resultImage.size.width, (CGFloat)pot / screenScale, 0.001);
+  XCTAssertEqualWithAccuracy(resultImage.size.height, (CGFloat)pot / screenScale, 0.001);
 }
 
 - (void)testExtractIconFromDataBytesAutoAndSizeWithDifferentAspectRatio {
@@ -250,8 +252,50 @@
                                            [[TestAssetProvider alloc] init], screenScale);
   XCTAssertNotNil(resultImage);
   XCTAssertEqual(resultImage.scale, screenScale);
-  XCTAssertEqual(resultImage.size.width, width);
-  XCTAssertEqual(resultImage.size.height, height);
+  XCTAssertEqual((NSUInteger)CGImageGetWidth(resultImage.CGImage), 64u);
+  XCTAssertEqual((NSUInteger)CGImageGetHeight(resultImage.CGImage), 256u);
+  XCTAssertEqualWithAccuracy(resultImage.size.width, 64.0 / screenScale, 0.001);
+  XCTAssertEqualWithAccuracy(resultImage.size.height, 256.0 / screenScale, 0.001);
+}
+
+/// Regression for tall NPOT sources (e.g. 410×512): output is a POT texture; artwork stays in the
+/// top-left physical pixel rectangle (transparent padding elsewhere).
+- (void)testExtractIconFromDataBytesTallNpotSourceUsesPaddedPowerOfTwoCanvas {
+  const CGFloat imageWidth = 200.0;
+  const CGFloat imageHeight = 233.0;
+  CGSize imageSize = CGSizeMake(imageWidth, imageHeight);
+  UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+  format.scale = 1.0;
+  format.opaque = YES;
+  UIGraphicsImageRenderer *renderer =
+      [[UIGraphicsImageRenderer alloc] initWithSize:imageSize format:format];
+  UIImage *testImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull context) {
+    [[UIColor redColor] setFill];
+    [context fillRect:CGRectMake(0, 0, imageWidth, imageHeight)];
+  }];
+  NSData *pngData = UIImagePNGRepresentation(testImage);
+  XCTAssertNotNil(pngData);
+
+  FlutterStandardTypedData *typedData = [FlutterStandardTypedData typedDataWithBytes:pngData];
+  FGMPlatformBitmapBytesMap *bitmap =
+      [FGMPlatformBitmapBytesMap makeWithByteData:typedData
+                                    bitmapScaling:FGMPlatformMapBitmapScalingAuto
+                                  imagePixelRatio:1
+                                            width:@(20.0)
+                                           height:@(23.0)];
+
+  CGFloat screenScale = 1.0;
+
+  UIImage *resultImage = FGMIconFromBitmap([FGMPlatformBitmap makeWithBitmap:bitmap],
+                                           [[TestAssetProvider alloc] init], screenScale);
+
+  XCTAssertNotNil(resultImage);
+  // Physical 20×23 → next POT 32×32.
+  XCTAssertEqual((NSUInteger)CGImageGetWidth(resultImage.CGImage), 32u);
+  XCTAssertEqual((NSUInteger)CGImageGetHeight(resultImage.CGImage), 32u);
+  XCTAssertEqualWithAccuracy(resultImage.scale, screenScale, 0.001);
+  XCTAssertEqualWithAccuracy(resultImage.size.width, 32.0, 0.001);
+  XCTAssertEqualWithAccuracy(resultImage.size.height, 32.0, 0.001);
 }
 
 - (void)testExtractIconFromDataBytesNoScaling {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMImageUtils.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMImageUtils.m
@@ -185,45 +185,56 @@ UIImage *scaledImageWithScale(UIImage *image, CGFloat scale) {
   return image;
 }
 
+static NSUInteger FGMNextPowerOfTwo(NSUInteger v) {
+  if (v == 0) return 1;
+  v--;
+  v |= v >> 1;
+  v |= v >> 2;
+  v |= v >> 4;
+  v |= v >> 8;
+  v |= v >> 16;
+#if defined(__LP64__) && __LP64__
+  v |= v >> 32;
+#endif
+  return v + 1;
+}
+
 UIImage *scaledImageWithSize(UIImage *image, CGSize size) {
-  CGFloat originalPixelWidth = image.size.width * image.scale;
-  CGFloat originalPixelHeight = image.size.height * image.scale;
-
-  // Return original image if either original image size or target size is so small that
-  // image cannot be resized or displayed.
-  if (originalPixelWidth <= 0 || originalPixelHeight <= 0 || size.width <= 0 || size.height <= 0) {
+  if (!image || size.width <= 0 || size.height <= 0) {
     return image;
   }
 
-  // Check if the image's size, accounting for scale, matches the target size.
-  if (fabs(originalPixelWidth - size.width) <= DBL_EPSILON &&
-      fabs(originalPixelHeight - size.height) <= DBL_EPSILON) {
-    // No need for resizing, return the original image
+  NSUInteger physicalW = (NSUInteger)round(size.width);
+  NSUInteger physicalH = (NSUInteger)round(size.height);
+  NSUInteger potW = FGMNextPowerOfTwo(physicalW);
+  NSUInteger potH = FGMNextPowerOfTwo(physicalH);
+
+  CGImageRef existingCGImage = image.CGImage;
+  BOOL alreadyPOT = existingCGImage && (NSUInteger)round(image.size.width * image.scale) == potW &&
+                    (NSUInteger)round(image.size.height * image.scale) == potH;
+  if (alreadyPOT) {
+    return [UIImage imageWithCGImage:existingCGImage
+                               scale:image.scale
+                         orientation:image.imageOrientation];
+  }
+
+  UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+  format.scale = 1.0;
+  format.opaque = NO;
+
+  CGSize potSize = CGSizeMake((CGFloat)potW, (CGFloat)potH);
+  UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:potSize
+                                                                             format:format];
+  UIImage *potImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
+    [image drawInRect:CGRectMake(0, 0, (CGFloat)physicalW, (CGFloat)physicalH)];
+  }];
+
+  CGImageRef potCGImage = potImage.CGImage;
+  if (!potCGImage) {
     return image;
   }
 
-  // Check if the aspect ratios are approximately equal.
-  CGSize originalPixelSize = CGSizeMake(originalPixelWidth, originalPixelHeight);
-  if (FGMIsScalableWithScaleFactorFromSize(originalPixelSize, size)) {
-    // Scaled image has close to same aspect ratio,
-    // updating image scale instead of resizing image.
-    CGFloat factor = originalPixelWidth / size.width;
-    return scaledImageWithScale(image, image.scale * factor);
-  } else {
-    // Aspect ratios differ significantly, resize the image.
-    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
-    format.scale = 1.0;
-    format.opaque = NO;
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size
-                                                                               format:format];
-    UIImage *newImage =
-        [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull context) {
-          [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
-        }];
-
-    // Return image with proper scaling.
-    return scaledImageWithScale(newImage, image.scale);
-  }
+  return [UIImage imageWithCGImage:potCGImage scale:image.scale orientation:image.imageOrientation];
 }
 
 UIImage *scaledImageWithWidthHeight(UIImage *image, NSNumber *width, NSNumber *height,

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.1
+version: 2.18.2
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
This PR fixes bug explained in [this issue](https://github.com/flutter/flutter/issues/185742#issuecomment-4451273324)

- Fixes incorrect or swapped custom marker icons on iOS when decoded bitmaps or target sizes
  are not power-of-two
  
Expected behavior: 
<img width="481" height="914" alt="Screenshot 2026-05-14 at 12 45 30" src="https://github.com/user-attachments/assets/a5b49c89-fca9-499c-9c18-ec2c47294c16" />

Actual behavior (before PR):
<img width="436" height="940" alt="image" src="https://github.com/user-attachments/assets/2fa3649f-c682-4d12-a672-d3c944ebcdaa" />


## Pre-Review Checklist

- [✅] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✅] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [✅] I read the [Tree Hygiene] page, which explains my responsibilities.
- [✅] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [✅] I signed the [CLA].
- [✅] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [✅] I [linked to at least one issue that this PR fixes] in the description above.
- [✅] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [✅] I updated/added any relevant documentation (doc comments with `///`).
- [✅] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [✅] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
