### PR TITLE
[go_router] docs: Document regex constraints on path parameters (flutter#177766)

### DIFF
--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -361,6 +361,15 @@ class GoRoute extends RouteBase {
   /// `/family/456` and etc. The parameter values are stored in [GoRouterState]
   /// that are passed into [pageBuilder] and [builder].
   ///
+  /// A path parameter may optionally be constrained to a regular expression
+  /// by appending the expression in parentheses after the parameter name:
+  /// `:paramName(regex)`. The parameter only matches if the corresponding path
+  /// segment also matches the regular expression — segments that fail the
+  /// pattern fall through to other route candidates. For example,
+  /// `/users/:id(\d+)` matches `/users/42` but not `/users/alice`. The
+  /// expression must not introduce its own capturing groups; everything
+  /// between the parentheses is interpreted as a Dart [RegExp] body.
+  ///
   /// The query parameter are also capture during the route parsing and stored
   /// in [GoRouterState].
   ///

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -367,8 +367,8 @@ class GoRoute extends RouteBase {
   /// segment also matches the regular expression — segments that fail the
   /// pattern fall through to other route candidates. For example,
   /// `/users/:id(\d+)` matches `/users/42` but not `/users/alice`. The
-  /// expression must not introduce its own capturing groups; everything
-  /// between the parentheses is interpreted as a Dart [RegExp] body.
+  /// expression must not contain nested parentheses; everything between the
+  /// outer parentheses is interpreted as a Dart [RegExp] body.
   ///
   /// The query parameter are also capture during the route parsing and stored
   /// in [GoRouterState].


### PR DESCRIPTION
Documents the regex-constraint syntax that `GoRoute.path` already supports via `_parameterRegExp` in `path_utils.dart`, but that was previously undocumented. Adds a paragraph to the `GoRoute.path` dartdoc describing the `:paramName(regex)` form, matching semantics ("segments that fail the pattern fall through to other route candidates"), an example (`/users/:id(\d+)` matches `/users/42` but not `/users/alice`), and the constraint that the expression must not contain nested parentheses (parser limitation per `[^\\()]+` in `_parameterRegExp`).

Fixes flutter/flutter#177766.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with \`///\`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

**Documentation-only change**, so I am claiming the test exemption for "Code with no logical impact (such as changes to documentation)" per the [test exemption] policy. No version bump or CHANGELOG entry was made because no behavior changes; happy to add one if the reviewer prefers.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests