### PR TITLE
[go_router] Add regression test for synchronous onEnter Block.then(router.go) (flutter#179370)

### DIFF
--- a/packages/go_router/test/on_enter_test.dart
+++ b/packages/go_router/test/on_enter_test.dart
@@ -898,6 +898,60 @@ void main() {
       expect(find.text('Start'), findsOneWidget);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/179370.
+    // A SYNCHRONOUS onEnter that returns `Block.then(() => router.go(...))`
+    // on the initial route must still run the `then` callback so the
+    // navigation redirect occurs. Previously the sync path resolved the
+    // SynchronousFuture inline, causing the deferred microtask to run
+    // before the Router had finished the initial navigation, which broke
+    // the redirect that the user added the `async` keyword to work around.
+    testWidgets(
+      'Synchronous onEnter Block.then(router.go) redirects from initial route',
+      (WidgetTester tester) async {
+        late GoRouter localRouter;
+        localRouter = GoRouter(
+          initialLocation: '/dashboard',
+          // Note: deliberately NOT marked `async`.
+          onEnter:
+              (
+                BuildContext context,
+                GoRouterState current,
+                GoRouterState next,
+                GoRouter goRouter,
+              ) {
+                // Mirrors the exact predicate from #179370: the user keys
+                // off `current.uri.path`, which on the initial parse equals
+                // `nextState.uri.path` because the router has no committed
+                // configuration yet.
+                if (current.uri.path == '/dashboard') {
+                  return Block.then(() => goRouter.go('/login'));
+                }
+                return const Allow();
+              },
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/dashboard',
+              builder: (_, __) =>
+                  const Scaffold(body: Center(child: Text('Dashboard'))),
+            ),
+            GoRoute(
+              path: '/login',
+              builder: (_, __) =>
+                  const Scaffold(body: Center(child: Text('Login'))),
+            ),
+          ],
+        );
+        router = localRouter;
+
+        await tester.pumpWidget(MaterialApp.router(routerConfig: localRouter));
+        await tester.pumpAndSettle();
+
+        expect(localRouter.state.uri.path, equals('/login'));
+        expect(find.text('Login'), findsOneWidget);
+        expect(find.text('Dashboard'), findsNothing);
+      },
+    );
+
     testWidgets('Should call onException when exceptions thrown in onEnter callback', (
       WidgetTester tester,
     ) async {

--- a/packages/go_router/test/on_enter_test.dart
+++ b/packages/go_router/test/on_enter_test.dart
@@ -908,8 +908,7 @@ void main() {
     testWidgets(
       'Synchronous onEnter Block.then(router.go) redirects from initial route',
       (WidgetTester tester) async {
-        late GoRouter localRouter;
-        localRouter = GoRouter(
+        router = GoRouter(
           initialLocation: '/dashboard',
           // Note: deliberately NOT marked `async`.
           onEnter:
@@ -941,12 +940,11 @@ void main() {
             ),
           ],
         );
-        router = localRouter;
 
-        await tester.pumpWidget(MaterialApp.router(routerConfig: localRouter));
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
         await tester.pumpAndSettle();
 
-        expect(localRouter.state.uri.path, equals('/login'));
+        expect(router.state.uri.path, equals('/login'));
         expect(find.text('Login'), findsOneWidget);
         expect(find.text('Dashboard'), findsNothing);
       },


### PR DESCRIPTION
Adds a regression test for flutter/flutter#179370. The user-visible symptom — a synchronous \`onEnter\` returning \`Block.then(() => router.go(...))\` failing to redirect on the initial route — was fixed in go_router 17.2.0 by #11136 (which replaced \`await Future<void>.sync(callback)\` with \`scheduleMicrotask(() async { await callback(); })\` in \`_OnEnterHandler.handleTopOnEnter\` to break the re-entrant parse cycle), but the linked issue is still open and there is no test that fails when that change is reverted.

The new test in \`packages/go_router/test/on_enter_test.dart\` mirrors the exact predicate the reporter used (\`current.uri.path == '/dashboard'\` on the initial parse, where \`currentState\` equals \`nextState\` because the router has no committed configuration yet) and asserts that the sync \`Block.then(router.go('/login'))\` redirect resolves to \`/login\`.

I verified the test is a real regression test by temporarily reverting parser.dart to the pre-#11136 implementation (\`await Future<void>.sync(callback)\`) and confirming this test fails with that change in place; with the current implementation it passes alongside the rest of \`on_enter_test.dart\` (32/32, all locally with stable Flutter SDK 3.41.7).

Fixes flutter/flutter#179370.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. \`[shared_preferences]\`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with \`///\`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

**Test-only change**, so no version bump / CHANGELOG entry per the published-package exemption. Happy to bump if the reviewer prefers.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests