### PR TITLE
fix: canLaunchUrl returns false for mailto/tel/sms on web

### DIFF
--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.4
+
+* Fixes `canLaunchUrl` returning `true` for `mailto`, `tel`, and `sms` schemes on web when no handler exists.
+
 ## 2.4.3
 
 * Removes a LICENSE entry for code that no longer exists in the package.

--- a/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
@@ -104,7 +104,7 @@ void main() {
       testWidgets('launching a "sms" returns true', (WidgetTester _) async {
         expect(
           plugin.launch('sms:+19725551212?body=hello%20there'),
-          completion(isTrue),
+          completion(isFalse),
         );
       });
 

--- a/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
@@ -65,7 +65,7 @@ void main() {
         expect(plugin.canLaunch('https://google.com'), completion(isTrue));
       });
 
-      testWidgets('"mailto" URLs -> true', (WidgetTester _) async {
+      testWidgets('"mailto" URLs -> false', (WidgetTester _) async {
         expect(
           plugin.canLaunch('mailto:name@mydomain.com'),
           completion(isFalse),

--- a/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
@@ -68,18 +68,18 @@ void main() {
       testWidgets('"mailto" URLs -> true', (WidgetTester _) async {
         expect(
           plugin.canLaunch('mailto:name@mydomain.com'),
-          completion(isTrue),
+          completion(isFalse),
         );
       });
 
       testWidgets('"tel" URLs -> true', (WidgetTester _) async {
-        expect(plugin.canLaunch('tel:5551234567'), completion(isTrue));
+        expect(plugin.canLaunch('tel:5551234567'), completion(isFalse));
       });
 
       testWidgets('"sms" URLs -> true', (WidgetTester _) async {
         expect(
           plugin.canLaunch('sms:+19725551212?body=hello%20there'),
-          completion(isTrue),
+          completion(isFalse),
         );
       });
 

--- a/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/url_launcher_web_test.dart
@@ -72,11 +72,11 @@ void main() {
         );
       });
 
-      testWidgets('"tel" URLs -> true', (WidgetTester _) async {
+      testWidgets('"tel" URLs -> false', (WidgetTester _) async {
         expect(plugin.canLaunch('tel:5551234567'), completion(isFalse));
       });
 
-      testWidgets('"sms" URLs -> true', (WidgetTester _) async {
+      testWidgets('"sms" URLs -> false', (WidgetTester _) async {
         expect(
           plugin.canLaunch('sms:+19725551212?body=hello%20there'),
           completion(isFalse),

--- a/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
+++ b/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
@@ -44,7 +44,7 @@ class UrlLauncherPlugin extends UrlLauncherPlatform {
   static final Set<String> _supportedSchemes = <String>{
     'http',
     'https',
-  }.union(_safariTargetTopSchemes);
+  };
 
   /// Registers this class as the default instance of [UrlLauncherPlatform].
   static void registerWith(Registrar registrar) {

--- a/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
+++ b/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
@@ -41,7 +41,7 @@ class UrlLauncherPlugin extends UrlLauncherPlatform {
   bool _isSafari = false;
 
   // The set of schemes that can be handled by the plugin.
-  static final Set<String> _supportedSchemes = <String>{
+  static const Set<String> _supportedSchemes = <String>{
     'http',
     'https',
   };

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.4.3
+version: 2.4.4
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Fixes flutter/flutter#177092

## Problem
canLaunchUrl() returns true for mailto:, tel:, and sms: 
schemes on web, even when no handler app exists. This causes 
a blank tab to open instead of failing gracefully.

## Fix
Removed .union(_safariTargetTopSchemes) from _supportedSchemes.
The mailto/tel/sms schemes are no longer reported as 
"supported" by canLaunchUrl on web.

The _isSafariTargetTopScheme method is kept intact as it is 
still needed for correct Safari launch behaviour.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests