### PR TITLE
[google_maps_flutter] Add MapColorScheme support to Android and iOS

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.17.2
+
+* Updates `colorScheme` doc comment to reflect Android and iOS support.
+
 ## 2.17.1
 
 * Updates README to link to implementation packages for platform-specific

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -402,10 +402,15 @@ class GoogleMap extends StatefulWidget {
   /// may result in unexpected behavior.
   final GoogleMapMarkerType markerType;
 
-  /// Color scheme for the cloud-style map. Web only.
+  /// Color scheme for the map.
   ///
-  /// The colorScheme option can only be set when the map is initialized;
-  /// setting this option after the map is created will have no effect.
+  /// On Android and iOS, the color scheme can be updated after the map is
+  /// created. On web, the value is applied only at map creation; later
+  /// changes have no effect.
+  ///
+  /// The map must use a cloud-based map style (via [mapId]) for the
+  /// color scheme to affect the base map tiles; otherwise the effect is
+  /// limited to map UI chrome.
   ///
   /// See https://developers.google.com/maps/documentation/javascript/mapcolorscheme for more details.
   final MapColorScheme? colorScheme;

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.17.1
+version: 2.17.2
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.20.0
+
+* Adds `colorScheme` support for cloud-based maps styling brightness.
+
 ## 2.19.12
 
 * Bumps the androidx group across 10 directories with 1 update.

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -577,6 +577,18 @@ class Convert {
     if (style != null) {
       sink.setMapStyle(style);
     }
+    final PlatformMapColorScheme colorScheme = config.getColorScheme();
+    if (colorScheme != null) {
+      sink.setMapColorScheme(toMapColorScheme(colorScheme));
+    }
+  }
+
+  static int toMapColorScheme(@NonNull PlatformMapColorScheme colorScheme) {
+    return switch (colorScheme) {
+      case LIGHT -> com.google.android.gms.maps.model.MapColorScheme.LIGHT;
+      case DARK -> com.google.android.gms.maps.model.MapColorScheme.DARK;
+      case FOLLOW_SYSTEM -> com.google.android.gms.maps.model.MapColorScheme.FOLLOW_SYSTEM;
+    };
   }
 
   /** Set the options in the given object to marker options sink. */

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
@@ -32,6 +32,7 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   private List<PlatformGroundOverlay> initialGroundOverlays;
   private Rect padding = new Rect(0, 0, 0, 0);
   private @Nullable String style;
+  private @Nullable Integer mapColorScheme;
 
   GoogleMapController build(
       int id,
@@ -59,6 +60,7 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
     controller.setInitialTileOverlays(initialTileOverlays);
     controller.setInitialGroundOverlays(initialGroundOverlays);
     controller.setMapStyle(style);
+    controller.setMapColorScheme(mapColorScheme);
     return controller;
   }
 
@@ -208,5 +210,10 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   @Override
   public void setMapStyle(@Nullable String style) {
     this.style = style;
+  }
+
+  @Override
+  public void setMapColorScheme(@Nullable Integer colorScheme) {
+    this.mapColorScheme = colorScheme;
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -111,6 +111,8 @@ class GoogleMapController
   private @Nullable List<PlatformGroundOverlay> initialGroundOverlays;
   // Null except between initialization and onMapReady.
   private @Nullable String initialMapStyle;
+  // Null except between initialization and onMapReady.
+  private @Nullable Integer initialMapColorScheme;
   private boolean lastSetStyleSucceeded;
   @VisibleForTesting List<Float> initialPadding;
 
@@ -244,6 +246,10 @@ class GoogleMapController
     if (initialMapStyle != null) {
       updateMapStyle(initialMapStyle);
       initialMapStyle = null;
+    }
+    if (initialMapColorScheme != null) {
+      googleMap.setMapColorScheme(initialMapColorScheme);
+      initialMapColorScheme = null;
     }
   }
 
@@ -850,6 +856,17 @@ class GoogleMapController
       initialMapStyle = style;
     } else {
       updateMapStyle(style);
+    }
+  }
+
+  public void setMapColorScheme(@Nullable Integer colorScheme) {
+    if (colorScheme == null) {
+      return;
+    }
+    if (googleMap == null) {
+      initialMapColorScheme = colorScheme;
+    } else {
+      googleMap.setMapColorScheme(colorScheme);
     }
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapOptionsSink.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapOptionsSink.java
@@ -64,4 +64,6 @@ interface GoogleMapOptionsSink {
   void setInitialGroundOverlays(@NonNull List<PlatformGroundOverlay> initialGroundOverlays);
 
   void setMapStyle(@Nullable String style);
+
+  void setMapColorScheme(@Nullable Integer colorScheme);
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/kotlin/io/flutter/plugins/googlemaps/Messages.kt
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/kotlin/io/flutter/plugins/googlemaps/Messages.kt
@@ -288,6 +288,19 @@ enum class PlatformMarkerType(val raw: Int) {
   }
 }
 
+/** Pigeon equivalent of MapColorScheme. */
+enum class PlatformMapColorScheme(val raw: Int) {
+  LIGHT(0),
+  DARK(1),
+  FOLLOW_SYSTEM(2);
+
+  companion object {
+    fun ofRaw(raw: Int): PlatformMapColorScheme? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
 /** Pigeon equivalent of [MapBitmapScaling]. */
 enum class PlatformMapBitmapScaling(val raw: Int) {
   AUTO(0),
@@ -2107,7 +2120,8 @@ data class PlatformMapConfiguration(
     val liteModeEnabled: Boolean? = null,
     val markerType: PlatformMarkerType,
     val mapId: String? = null,
-    val style: String? = null
+    val style: String? = null,
+    val colorScheme: PlatformMapColorScheme? = null
 ) {
   companion object {
     fun fromList(pigeonVar_list: List<Any?>): PlatformMapConfiguration {
@@ -2132,6 +2146,7 @@ data class PlatformMapConfiguration(
       val markerType = pigeonVar_list[18] as PlatformMarkerType
       val mapId = pigeonVar_list[19] as String?
       val style = pigeonVar_list[20] as String?
+      val colorScheme = pigeonVar_list[21] as PlatformMapColorScheme?
       return PlatformMapConfiguration(
           compassEnabled,
           cameraTargetBounds,
@@ -2153,7 +2168,8 @@ data class PlatformMapConfiguration(
           liteModeEnabled,
           markerType,
           mapId,
-          style)
+          style,
+          colorScheme)
     }
   }
 
@@ -2180,6 +2196,7 @@ data class PlatformMapConfiguration(
         markerType,
         mapId,
         style,
+        colorScheme,
     )
   }
 
@@ -2212,7 +2229,8 @@ data class PlatformMapConfiguration(
         MessagesPigeonUtils.deepEquals(this.liteModeEnabled, other.liteModeEnabled) &&
         MessagesPigeonUtils.deepEquals(this.markerType, other.markerType) &&
         MessagesPigeonUtils.deepEquals(this.mapId, other.mapId) &&
-        MessagesPigeonUtils.deepEquals(this.style, other.style)
+        MessagesPigeonUtils.deepEquals(this.style, other.style) &&
+        MessagesPigeonUtils.deepEquals(this.colorScheme, other.colorScheme)
   }
 
   override fun hashCode(): Int {
@@ -2238,6 +2256,7 @@ data class PlatformMapConfiguration(
     result = 31 * result + MessagesPigeonUtils.deepHash(this.markerType)
     result = 31 * result + MessagesPigeonUtils.deepHash(this.mapId)
     result = 31 * result + MessagesPigeonUtils.deepHash(this.style)
+    result = 31 * result + MessagesPigeonUtils.deepHash(this.colorScheme)
     return result
   }
 }
@@ -2810,148 +2829,151 @@ private open class MessagesPigeonCodec : StandardMessageCodec() {
         return (readValue(buffer) as Long?)?.let { PlatformMarkerType.ofRaw(it.toInt()) }
       }
       136.toByte() -> {
-        return (readValue(buffer) as Long?)?.let { PlatformMapBitmapScaling.ofRaw(it.toInt()) }
+        return (readValue(buffer) as Long?)?.let { PlatformMapColorScheme.ofRaw(it.toInt()) }
       }
       137.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraPosition.fromList(it) }
+        return (readValue(buffer) as Long?)?.let { PlatformMapBitmapScaling.ofRaw(it.toInt()) }
       }
       138.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraUpdate.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraPosition.fromList(it) }
       }
       139.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraUpdate.fromList(it) }
+      }
+      140.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           PlatformCameraUpdateNewCameraPosition.fromList(it)
         }
       }
-      140.toByte() -> {
+      141.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           PlatformCameraUpdateNewLatLng.fromList(it)
         }
       }
-      141.toByte() -> {
+      142.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           PlatformCameraUpdateNewLatLngBounds.fromList(it)
         }
       }
-      142.toByte() -> {
+      143.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           PlatformCameraUpdateNewLatLngZoom.fromList(it)
         }
       }
-      143.toByte() -> {
+      144.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraUpdateScrollBy.fromList(it) }
       }
-      144.toByte() -> {
+      145.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraUpdateZoomBy.fromList(it) }
       }
-      145.toByte() -> {
+      146.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraUpdateZoom.fromList(it) }
       }
-      146.toByte() -> {
+      147.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraUpdateZoomTo.fromList(it) }
       }
-      147.toByte() -> {
+      148.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformCircle.fromList(it) }
       }
-      148.toByte() -> {
+      149.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformHeatmap.fromList(it) }
       }
-      149.toByte() -> {
+      150.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformHeatmapGradient.fromList(it) }
       }
-      150.toByte() -> {
+      151.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformWeightedLatLng.fromList(it) }
       }
-      151.toByte() -> {
+      152.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformClusterManager.fromList(it) }
       }
-      152.toByte() -> {
+      153.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformDoublePair.fromList(it) }
       }
-      153.toByte() -> {
+      154.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformColor.fromList(it) }
       }
-      154.toByte() -> {
+      155.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformInfoWindow.fromList(it) }
       }
-      155.toByte() -> {
+      156.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformMarker.fromList(it) }
       }
-      156.toByte() -> {
+      157.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformPolygon.fromList(it) }
       }
-      157.toByte() -> {
+      158.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformPolyline.fromList(it) }
       }
-      158.toByte() -> {
+      159.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformCap.fromList(it) }
       }
-      159.toByte() -> {
+      160.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformPatternItem.fromList(it) }
       }
-      160.toByte() -> {
+      161.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformTile.fromList(it) }
       }
-      161.toByte() -> {
+      162.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformTileOverlay.fromList(it) }
       }
-      162.toByte() -> {
+      163.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformEdgeInsets.fromList(it) }
       }
-      163.toByte() -> {
+      164.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformLatLng.fromList(it) }
       }
-      164.toByte() -> {
+      165.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformLatLngBounds.fromList(it) }
       }
-      165.toByte() -> {
+      166.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformCluster.fromList(it) }
       }
-      166.toByte() -> {
+      167.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformGroundOverlay.fromList(it) }
       }
-      167.toByte() -> {
+      168.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformCameraTargetBounds.fromList(it) }
       }
-      168.toByte() -> {
+      169.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           PlatformMapViewCreationParams.fromList(it)
         }
       }
-      169.toByte() -> {
+      170.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformMapConfiguration.fromList(it) }
       }
-      170.toByte() -> {
+      171.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformPoint.fromList(it) }
       }
-      171.toByte() -> {
+      172.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformTileLayer.fromList(it) }
       }
-      172.toByte() -> {
+      173.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformZoomRange.fromList(it) }
       }
-      173.toByte() -> {
+      174.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformBitmap.fromList(it) }
       }
-      174.toByte() -> {
+      175.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformBitmapDefaultMarker.fromList(it) }
       }
-      175.toByte() -> {
+      176.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformBitmapBytes.fromList(it) }
       }
-      176.toByte() -> {
+      177.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformBitmapAsset.fromList(it) }
       }
-      177.toByte() -> {
+      178.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformBitmapAssetImage.fromList(it) }
       }
-      178.toByte() -> {
+      179.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformBitmapAssetMap.fromList(it) }
       }
-      179.toByte() -> {
+      180.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformBitmapBytesMap.fromList(it) }
       }
-      180.toByte() -> {
+      181.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { PlatformBitmapPinConfig.fromList(it) }
       }
       else -> super.readValueOfType(type, buffer)
@@ -2988,184 +3010,188 @@ private open class MessagesPigeonCodec : StandardMessageCodec() {
         stream.write(135)
         writeValue(stream, value.raw.toLong())
       }
-      is PlatformMapBitmapScaling -> {
+      is PlatformMapColorScheme -> {
         stream.write(136)
         writeValue(stream, value.raw.toLong())
       }
-      is PlatformCameraPosition -> {
+      is PlatformMapBitmapScaling -> {
         stream.write(137)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw.toLong())
       }
-      is PlatformCameraUpdate -> {
+      is PlatformCameraPosition -> {
         stream.write(138)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraUpdateNewCameraPosition -> {
+      is PlatformCameraUpdate -> {
         stream.write(139)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraUpdateNewLatLng -> {
+      is PlatformCameraUpdateNewCameraPosition -> {
         stream.write(140)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraUpdateNewLatLngBounds -> {
+      is PlatformCameraUpdateNewLatLng -> {
         stream.write(141)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraUpdateNewLatLngZoom -> {
+      is PlatformCameraUpdateNewLatLngBounds -> {
         stream.write(142)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraUpdateScrollBy -> {
+      is PlatformCameraUpdateNewLatLngZoom -> {
         stream.write(143)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraUpdateZoomBy -> {
+      is PlatformCameraUpdateScrollBy -> {
         stream.write(144)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraUpdateZoom -> {
+      is PlatformCameraUpdateZoomBy -> {
         stream.write(145)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraUpdateZoomTo -> {
+      is PlatformCameraUpdateZoom -> {
         stream.write(146)
         writeValue(stream, value.toList())
       }
-      is PlatformCircle -> {
+      is PlatformCameraUpdateZoomTo -> {
         stream.write(147)
         writeValue(stream, value.toList())
       }
-      is PlatformHeatmap -> {
+      is PlatformCircle -> {
         stream.write(148)
         writeValue(stream, value.toList())
       }
-      is PlatformHeatmapGradient -> {
+      is PlatformHeatmap -> {
         stream.write(149)
         writeValue(stream, value.toList())
       }
-      is PlatformWeightedLatLng -> {
+      is PlatformHeatmapGradient -> {
         stream.write(150)
         writeValue(stream, value.toList())
       }
-      is PlatformClusterManager -> {
+      is PlatformWeightedLatLng -> {
         stream.write(151)
         writeValue(stream, value.toList())
       }
-      is PlatformDoublePair -> {
+      is PlatformClusterManager -> {
         stream.write(152)
         writeValue(stream, value.toList())
       }
-      is PlatformColor -> {
+      is PlatformDoublePair -> {
         stream.write(153)
         writeValue(stream, value.toList())
       }
-      is PlatformInfoWindow -> {
+      is PlatformColor -> {
         stream.write(154)
         writeValue(stream, value.toList())
       }
-      is PlatformMarker -> {
+      is PlatformInfoWindow -> {
         stream.write(155)
         writeValue(stream, value.toList())
       }
-      is PlatformPolygon -> {
+      is PlatformMarker -> {
         stream.write(156)
         writeValue(stream, value.toList())
       }
-      is PlatformPolyline -> {
+      is PlatformPolygon -> {
         stream.write(157)
         writeValue(stream, value.toList())
       }
-      is PlatformCap -> {
+      is PlatformPolyline -> {
         stream.write(158)
         writeValue(stream, value.toList())
       }
-      is PlatformPatternItem -> {
+      is PlatformCap -> {
         stream.write(159)
         writeValue(stream, value.toList())
       }
-      is PlatformTile -> {
+      is PlatformPatternItem -> {
         stream.write(160)
         writeValue(stream, value.toList())
       }
-      is PlatformTileOverlay -> {
+      is PlatformTile -> {
         stream.write(161)
         writeValue(stream, value.toList())
       }
-      is PlatformEdgeInsets -> {
+      is PlatformTileOverlay -> {
         stream.write(162)
         writeValue(stream, value.toList())
       }
-      is PlatformLatLng -> {
+      is PlatformEdgeInsets -> {
         stream.write(163)
         writeValue(stream, value.toList())
       }
-      is PlatformLatLngBounds -> {
+      is PlatformLatLng -> {
         stream.write(164)
         writeValue(stream, value.toList())
       }
-      is PlatformCluster -> {
+      is PlatformLatLngBounds -> {
         stream.write(165)
         writeValue(stream, value.toList())
       }
-      is PlatformGroundOverlay -> {
+      is PlatformCluster -> {
         stream.write(166)
         writeValue(stream, value.toList())
       }
-      is PlatformCameraTargetBounds -> {
+      is PlatformGroundOverlay -> {
         stream.write(167)
         writeValue(stream, value.toList())
       }
-      is PlatformMapViewCreationParams -> {
+      is PlatformCameraTargetBounds -> {
         stream.write(168)
         writeValue(stream, value.toList())
       }
-      is PlatformMapConfiguration -> {
+      is PlatformMapViewCreationParams -> {
         stream.write(169)
         writeValue(stream, value.toList())
       }
-      is PlatformPoint -> {
+      is PlatformMapConfiguration -> {
         stream.write(170)
         writeValue(stream, value.toList())
       }
-      is PlatformTileLayer -> {
+      is PlatformPoint -> {
         stream.write(171)
         writeValue(stream, value.toList())
       }
-      is PlatformZoomRange -> {
+      is PlatformTileLayer -> {
         stream.write(172)
         writeValue(stream, value.toList())
       }
-      is PlatformBitmap -> {
+      is PlatformZoomRange -> {
         stream.write(173)
         writeValue(stream, value.toList())
       }
-      is PlatformBitmapDefaultMarker -> {
+      is PlatformBitmap -> {
         stream.write(174)
         writeValue(stream, value.toList())
       }
-      is PlatformBitmapBytes -> {
+      is PlatformBitmapDefaultMarker -> {
         stream.write(175)
         writeValue(stream, value.toList())
       }
-      is PlatformBitmapAsset -> {
+      is PlatformBitmapBytes -> {
         stream.write(176)
         writeValue(stream, value.toList())
       }
-      is PlatformBitmapAssetImage -> {
+      is PlatformBitmapAsset -> {
         stream.write(177)
         writeValue(stream, value.toList())
       }
-      is PlatformBitmapAssetMap -> {
+      is PlatformBitmapAssetImage -> {
         stream.write(178)
         writeValue(stream, value.toList())
       }
-      is PlatformBitmapBytesMap -> {
+      is PlatformBitmapAssetMap -> {
         stream.write(179)
         writeValue(stream, value.toList())
       }
-      is PlatformBitmapPinConfig -> {
+      is PlatformBitmapBytesMap -> {
         stream.write(180)
+        writeValue(stream, value.toList())
+      }
+      is PlatformBitmapPinConfig -> {
+        stream.write(181)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/test/java/io/flutter/plugins/googlemaps/ConvertTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/test/java/io/flutter/plugins/googlemaps/ConvertTest.java
@@ -522,6 +522,28 @@ public class ConvertTest {
   }
 
   @Test
+  public void toMapColorScheme_mapsAllPlatformValues() {
+    for (PlatformMapColorScheme value : PlatformMapColorScheme.values()) {
+      final int expected =
+          switch (value) {
+            case LIGHT -> com.google.android.gms.maps.model.MapColorScheme.LIGHT;
+            case DARK -> com.google.android.gms.maps.model.MapColorScheme.DARK;
+            case FOLLOW_SYSTEM -> com.google.android.gms.maps.model.MapColorScheme.FOLLOW_SYSTEM;
+          };
+      Assert.assertEquals(expected, Convert.toMapColorScheme(value));
+    }
+  }
+
+  @Test
+  public void interpretMapConfiguration_handlesColorScheme() {
+    final PlatformMapConfiguration config =
+        getMinimalConfigurationBuilder().setColorScheme(PlatformMapColorScheme.DARK).build();
+    Convert.interpretMapConfiguration(config, optionsSink);
+    verify(optionsSink, times(1))
+        .setMapColorScheme(com.google.android.gms.maps.model.MapColorScheme.DARK);
+  }
+
+  @Test
   public void interpretMapConfiguration_handlesUnboundedCameraTargetBounds() {
     final PlatformMapConfiguration config =
         getMinimalConfigurationBuilder()
@@ -859,6 +881,7 @@ public class ConvertTest {
     private @Nullable PlatformMarkerType markerType;
     private @Nullable String mapId;
     private @Nullable String style;
+    private @Nullable PlatformMapColorScheme colorScheme;
 
     public @NonNull PlatformMapConfigurationBuilder setCompassEnabled(@Nullable Boolean setterArg) {
       this.compassEnabled = setterArg;
@@ -982,6 +1005,12 @@ public class ConvertTest {
       return this;
     }
 
+    public @NonNull PlatformMapConfigurationBuilder setColorScheme(
+        @Nullable PlatformMapColorScheme setterArg) {
+      this.colorScheme = setterArg;
+      return this;
+    }
+
     public @NonNull PlatformMapConfiguration build() {
       return new PlatformMapConfiguration(
           compassEnabled,
@@ -1004,7 +1033,8 @@ public class ConvertTest {
           liteModeEnabled,
           Objects.requireNonNull(markerType),
           mapId,
-          style);
+          style,
+          colorScheme);
     }
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -1242,6 +1242,26 @@ PlatformMarkerType _platformMarkerTypeFromMarkerType(MarkerType markerType) {
   };
 }
 
+PlatformMapColorScheme? _platformMapColorSchemeFromMapColorScheme(MapColorScheme? colorScheme) {
+  if (colorScheme == null) {
+    return null;
+  }
+  switch (colorScheme) {
+    case MapColorScheme.light:
+      return PlatformMapColorScheme.light;
+    case MapColorScheme.dark:
+      return PlatformMapColorScheme.dark;
+    case MapColorScheme.followSystem:
+      return PlatformMapColorScheme.followSystem;
+    // The enum comes from a different package, which could get a new value at
+    // any time, so provide a fallback that ensures this won't break when used
+    // with a version that contains new values.
+    // ignore: no_default_cases, unreachable_switch_default
+    default:
+      throw UnimplementedError('MapColorScheme "$colorScheme" has not been implemented');
+  }
+}
+
 PlatformMapConfiguration _platformMapConfigurationFromMapConfiguration(MapConfiguration config) {
   return PlatformMapConfiguration(
     compassEnabled: config.compassEnabled,
@@ -1267,6 +1287,7 @@ PlatformMapConfiguration _platformMapConfigurationFromMapConfiguration(MapConfig
     markerType: _platformMarkerTypeFromMarkerType(config.markerType ?? MarkerType.marker),
     mapId: config.mapId,
     style: config.style,
+    colorScheme: _platformMapColorSchemeFromMapColorScheme(config.colorScheme),
   );
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/messages.g.dart
@@ -132,6 +132,9 @@ enum PlatformPatternItemType { dot, dash, gap }
 
 enum PlatformMarkerType { marker, advancedMarker }
 
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
+
 /// Pigeon equivalent of [MapBitmapScaling].
 enum PlatformMapBitmapScaling { auto, none }
 
@@ -1930,6 +1933,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     this.mapId,
     this.style,
+    this.colorScheme,
   });
 
   bool? compassEnabled;
@@ -1974,6 +1978,8 @@ class PlatformMapConfiguration {
 
   String? style;
 
+  PlatformMapColorScheme? colorScheme;
+
   List<Object?> _toList() {
     return <Object?>[
       compassEnabled,
@@ -1997,6 +2003,7 @@ class PlatformMapConfiguration {
       markerType,
       mapId,
       style,
+      colorScheme,
     ];
   }
 
@@ -2028,6 +2035,7 @@ class PlatformMapConfiguration {
       markerType: result[18]! as PlatformMarkerType,
       mapId: result[19] as String?,
       style: result[20] as String?,
+      colorScheme: result[21] as PlatformMapColorScheme?,
     );
   }
 
@@ -2060,7 +2068,8 @@ class PlatformMapConfiguration {
         _deepEquals(liteModeEnabled, other.liteModeEnabled) &&
         _deepEquals(markerType, other.markerType) &&
         _deepEquals(mapId, other.mapId) &&
-        _deepEquals(style, other.style);
+        _deepEquals(style, other.style) &&
+        _deepEquals(colorScheme, other.colorScheme);
   }
 
   @override
@@ -2631,140 +2640,143 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PlatformMarkerType) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    } else if (value is PlatformMapBitmapScaling) {
+    } else if (value is PlatformMapColorScheme) {
       buffer.putUint8(136);
       writeValue(buffer, value.index);
-    } else if (value is PlatformCameraPosition) {
+    } else if (value is PlatformMapBitmapScaling) {
       buffer.putUint8(137);
-      writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdate) {
+      writeValue(buffer, value.index);
+    } else if (value is PlatformCameraPosition) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewCameraPosition) {
+    } else if (value is PlatformCameraUpdate) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLng) {
+    } else if (value is PlatformCameraUpdateNewCameraPosition) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
+    } else if (value is PlatformCameraUpdateNewLatLng) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
+    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateScrollBy) {
+    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomBy) {
+    } else if (value is PlatformCameraUpdateScrollBy) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoom) {
+    } else if (value is PlatformCameraUpdateZoomBy) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomTo) {
+    } else if (value is PlatformCameraUpdateZoom) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCircle) {
+    } else if (value is PlatformCameraUpdateZoomTo) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmap) {
+    } else if (value is PlatformCircle) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmapGradient) {
+    } else if (value is PlatformHeatmap) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformWeightedLatLng) {
+    } else if (value is PlatformHeatmapGradient) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformClusterManager) {
+    } else if (value is PlatformWeightedLatLng) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformDoublePair) {
+    } else if (value is PlatformClusterManager) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformColor) {
+    } else if (value is PlatformDoublePair) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformInfoWindow) {
+    } else if (value is PlatformColor) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMarker) {
+    } else if (value is PlatformInfoWindow) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolygon) {
+    } else if (value is PlatformMarker) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolyline) {
+    } else if (value is PlatformPolygon) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCap) {
+    } else if (value is PlatformPolyline) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPatternItem) {
+    } else if (value is PlatformCap) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTile) {
+    } else if (value is PlatformPatternItem) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileOverlay) {
+    } else if (value is PlatformTile) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformEdgeInsets) {
+    } else if (value is PlatformTileOverlay) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLng) {
+    } else if (value is PlatformEdgeInsets) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLngBounds) {
+    } else if (value is PlatformLatLng) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCluster) {
+    } else if (value is PlatformLatLngBounds) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformGroundOverlay) {
+    } else if (value is PlatformCluster) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraTargetBounds) {
+    } else if (value is PlatformGroundOverlay) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapViewCreationParams) {
+    } else if (value is PlatformCameraTargetBounds) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapConfiguration) {
+    } else if (value is PlatformMapViewCreationParams) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPoint) {
+    } else if (value is PlatformMapConfiguration) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileLayer) {
+    } else if (value is PlatformPoint) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformZoomRange) {
+    } else if (value is PlatformTileLayer) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmap) {
+    } else if (value is PlatformZoomRange) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapDefaultMarker) {
+    } else if (value is PlatformBitmap) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytes) {
+    } else if (value is PlatformBitmapDefaultMarker) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAsset) {
+    } else if (value is PlatformBitmapBytes) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetImage) {
+    } else if (value is PlatformBitmapAsset) {
       buffer.putUint8(177);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetMap) {
+    } else if (value is PlatformBitmapAssetImage) {
       buffer.putUint8(178);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytesMap) {
+    } else if (value is PlatformBitmapAssetMap) {
       buffer.putUint8(179);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapPinConfig) {
+    } else if (value is PlatformBitmapBytesMap) {
       buffer.putUint8(180);
+      writeValue(buffer, value.encode());
+    } else if (value is PlatformBitmapPinConfig) {
+      buffer.putUint8(181);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -2797,94 +2809,97 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PlatformMarkerType.values[value];
       case 136:
         final value = readValue(buffer) as int?;
-        return value == null ? null : PlatformMapBitmapScaling.values[value];
+        return value == null ? null : PlatformMapColorScheme.values[value];
       case 137:
-        return PlatformCameraPosition.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : PlatformMapBitmapScaling.values[value];
       case 138:
-        return PlatformCameraUpdate.decode(readValue(buffer)!);
+        return PlatformCameraPosition.decode(readValue(buffer)!);
       case 139:
-        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
+        return PlatformCameraUpdate.decode(readValue(buffer)!);
       case 140:
-        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
       case 141:
-        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
       case 142:
-        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
       case 143:
-        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
       case 144:
-        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
       case 145:
-        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
       case 146:
-        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
       case 147:
-        return PlatformCircle.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
       case 148:
-        return PlatformHeatmap.decode(readValue(buffer)!);
+        return PlatformCircle.decode(readValue(buffer)!);
       case 149:
-        return PlatformHeatmapGradient.decode(readValue(buffer)!);
+        return PlatformHeatmap.decode(readValue(buffer)!);
       case 150:
-        return PlatformWeightedLatLng.decode(readValue(buffer)!);
+        return PlatformHeatmapGradient.decode(readValue(buffer)!);
       case 151:
-        return PlatformClusterManager.decode(readValue(buffer)!);
+        return PlatformWeightedLatLng.decode(readValue(buffer)!);
       case 152:
-        return PlatformDoublePair.decode(readValue(buffer)!);
+        return PlatformClusterManager.decode(readValue(buffer)!);
       case 153:
-        return PlatformColor.decode(readValue(buffer)!);
+        return PlatformDoublePair.decode(readValue(buffer)!);
       case 154:
-        return PlatformInfoWindow.decode(readValue(buffer)!);
+        return PlatformColor.decode(readValue(buffer)!);
       case 155:
-        return PlatformMarker.decode(readValue(buffer)!);
+        return PlatformInfoWindow.decode(readValue(buffer)!);
       case 156:
-        return PlatformPolygon.decode(readValue(buffer)!);
+        return PlatformMarker.decode(readValue(buffer)!);
       case 157:
-        return PlatformPolyline.decode(readValue(buffer)!);
+        return PlatformPolygon.decode(readValue(buffer)!);
       case 158:
-        return PlatformCap.decode(readValue(buffer)!);
+        return PlatformPolyline.decode(readValue(buffer)!);
       case 159:
-        return PlatformPatternItem.decode(readValue(buffer)!);
+        return PlatformCap.decode(readValue(buffer)!);
       case 160:
-        return PlatformTile.decode(readValue(buffer)!);
+        return PlatformPatternItem.decode(readValue(buffer)!);
       case 161:
-        return PlatformTileOverlay.decode(readValue(buffer)!);
+        return PlatformTile.decode(readValue(buffer)!);
       case 162:
-        return PlatformEdgeInsets.decode(readValue(buffer)!);
+        return PlatformTileOverlay.decode(readValue(buffer)!);
       case 163:
-        return PlatformLatLng.decode(readValue(buffer)!);
+        return PlatformEdgeInsets.decode(readValue(buffer)!);
       case 164:
-        return PlatformLatLngBounds.decode(readValue(buffer)!);
+        return PlatformLatLng.decode(readValue(buffer)!);
       case 165:
-        return PlatformCluster.decode(readValue(buffer)!);
+        return PlatformLatLngBounds.decode(readValue(buffer)!);
       case 166:
-        return PlatformGroundOverlay.decode(readValue(buffer)!);
+        return PlatformCluster.decode(readValue(buffer)!);
       case 167:
-        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
+        return PlatformGroundOverlay.decode(readValue(buffer)!);
       case 168:
-        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
+        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
       case 169:
-        return PlatformMapConfiguration.decode(readValue(buffer)!);
+        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
       case 170:
-        return PlatformPoint.decode(readValue(buffer)!);
+        return PlatformMapConfiguration.decode(readValue(buffer)!);
       case 171:
-        return PlatformTileLayer.decode(readValue(buffer)!);
+        return PlatformPoint.decode(readValue(buffer)!);
       case 172:
-        return PlatformZoomRange.decode(readValue(buffer)!);
+        return PlatformTileLayer.decode(readValue(buffer)!);
       case 173:
-        return PlatformBitmap.decode(readValue(buffer)!);
+        return PlatformZoomRange.decode(readValue(buffer)!);
       case 174:
-        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
+        return PlatformBitmap.decode(readValue(buffer)!);
       case 175:
-        return PlatformBitmapBytes.decode(readValue(buffer)!);
+        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
       case 176:
-        return PlatformBitmapAsset.decode(readValue(buffer)!);
+        return PlatformBitmapBytes.decode(readValue(buffer)!);
       case 177:
-        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
+        return PlatformBitmapAsset.decode(readValue(buffer)!);
       case 178:
-        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
       case 179:
-        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
       case 180:
+        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+      case 181:
         return PlatformBitmapPinConfig.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_maps_flutter/google_maps_flutter_android/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pigeons/messages.dart
@@ -483,6 +483,9 @@ class PlatformMapViewCreationParams {
 
 enum PlatformMarkerType { marker, advancedMarker }
 
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
+
 /// Pigeon equivalent of MapConfiguration.
 class PlatformMapConfiguration {
   PlatformMapConfiguration({
@@ -507,6 +510,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     required this.mapId,
     required this.style,
+    required this.colorScheme,
   });
 
   final bool? compassEnabled;
@@ -530,6 +534,7 @@ class PlatformMapConfiguration {
   final PlatformMarkerType markerType;
   final String? mapId;
   final String? style;
+  final PlatformMapColorScheme? colorScheme;
 }
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_android
 description: Android implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.19.12
+version: 2.20.0
 
 environment:
   sdk: ^3.12.0
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
-  google_maps_flutter_platform_interface: ^2.13.0
+  google_maps_flutter_platform_interface: ^2.15.0
   meta: ^1.10.0
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
@@ -1413,4 +1413,42 @@ void main() {
       PlatformMarkerType.marker,
     );
   });
+
+  test('colorScheme is passed to platform view', () async {
+    final maps = GoogleMapsFlutterAndroid();
+    final Widget widget = maps.buildViewWithConfiguration(
+      1,
+      (int _) {},
+      widgetConfiguration: const MapWidgetConfiguration(
+        initialCameraPosition: CameraPosition(target: LatLng(0, 0), zoom: 1),
+        textDirection: TextDirection.ltr,
+      ),
+      mapConfiguration: const MapConfiguration(colorScheme: MapColorScheme.dark),
+    );
+
+    expect(widget, isA<AndroidView>());
+    final dynamic creationParams = (widget as AndroidView).creationParams;
+    expect(creationParams, isA<PlatformMapViewCreationParams>());
+    expect(
+      (creationParams as PlatformMapViewCreationParams).mapConfiguration.colorScheme,
+      PlatformMapColorScheme.dark,
+    );
+  });
+
+  test('colorScheme defaults to null if unset', () async {
+    final maps = GoogleMapsFlutterAndroid();
+    final Widget widget = maps.buildViewWithConfiguration(
+      1,
+      (int _) {},
+      widgetConfiguration: const MapWidgetConfiguration(
+        initialCameraPosition: CameraPosition(target: LatLng(0, 0), zoom: 1),
+        textDirection: TextDirection.ltr,
+      ),
+    );
+
+    expect(widget, isA<AndroidView>());
+    final dynamic creationParams = (widget as AndroidView).creationParams;
+    expect(creationParams, isA<PlatformMapViewCreationParams>());
+    expect((creationParams as PlatformMapViewCreationParams).mapConfiguration.colorScheme, isNull);
+  });
 }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds `colorScheme` support for cloud-based maps styling brightness.
+
 ## 2.18.4
 
 * Fixes a potential compilation issue in tile downscaling.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.m
@@ -222,6 +222,56 @@
   XCTAssertEqual(cameraPosition.zoom, initialCameraPosition.zoom);
 }
 
+- (void)testSetMapColorScheme {
+  CGRect frame = CGRectMake(0, 0, 100, 100);
+  GMSMapViewOptions *options = [[GMSMapViewOptions alloc] init];
+  options.frame = frame;
+  options.camera = [[GMSCameraPosition alloc] initWithLatitude:0 longitude:0 zoom:0];
+  PartiallyMockedMapView *mapView = [[PartiallyMockedMapView alloc] initWithOptions:options];
+  FGMGoogleMapController *controller =
+      [[FGMGoogleMapController alloc] initWithMapView:mapView
+                                       viewIdentifier:0
+                                   creationParameters:[self emptyCreationParameters]
+                                        assetProvider:[[TestAssetProvider alloc] init]
+                                      binaryMessenger:[[StubBinaryMessenger alloc] init]];
+  FlutterError *error = nil;
+
+  // Light. Start from a different style so the assertion confirms a real change.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *lightConfig = [self emptyCreationParameters].mapConfiguration;
+  lightConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeLight];
+  [controller.callHandler updateWithMapConfiguration:lightConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleLight);
+
+  // Dark.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+  FGMPlatformMapConfiguration *darkConfig = [self emptyCreationParameters].mapConfiguration;
+  darkConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeDark];
+  [controller.callHandler updateWithMapConfiguration:darkConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+
+  // followSystem maps to "unspecified", letting the system drive appearance.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *followConfig = [self emptyCreationParameters].mapConfiguration;
+  followConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeFollowSystem];
+  [controller.callHandler updateWithMapConfiguration:followConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleUnspecified);
+
+  // A configuration with no color scheme must not change the interface style.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *noSchemeConfig = [self emptyCreationParameters].mapConfiguration;
+  noSchemeConfig.colorScheme = nil;
+  [controller.callHandler updateWithMapConfiguration:noSchemeConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+}
+
 /// Creates an empty creation paramaters object for tests where the values don't matter, just that
 /// there's a valid object to pass in.
 - (FGMPlatformMapViewCreationParams *)emptyCreationParameters {
@@ -250,7 +300,8 @@
                                                buildingsEnabled:nil
                                                      markerType:FGMPlatformMarkerTypeMarker
                                                           mapId:nil
-                                                          style:nil]
+                                                          style:nil
+                                                    colorScheme:nil]
                      initialCircles:@[]
                      initialMarkers:@[]
                     initialPolygons:@[]

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
@@ -478,6 +478,20 @@
   self.mapView.settings.myLocationButton = enabled;
 }
 
+- (void)setColorScheme:(FGMPlatformMapColorScheme)colorScheme {
+  switch (colorScheme) {
+    case FGMPlatformMapColorSchemeLight:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+      break;
+    case FGMPlatformMapColorSchemeDark:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+      break;
+    case FGMPlatformMapColorSchemeFollowSystem:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+      break;
+  }
+}
+
 /// Sets the map style, returing any error string as well as storing that error in `mapStyle` for
 /// later access.
 - (NSString *)setMapStyle:(NSString *)mapStyle {
@@ -636,6 +650,10 @@
   NSString *style = config.style;
   if (style) {
     [self setMapStyle:style];
+  }
+  FGMPlatformMapColorSchemeBox *colorScheme = config.colorScheme;
+  if (colorScheme) {
+    [self setColorScheme:colorScheme.value];
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
@@ -46,7 +46,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 }
 @end
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 @implementation FGMPlatformMarkerCollisionBehaviorBox
 - (instancetype)initWithValue:(FGMPlatformMarkerCollisionBehavior)value {
   self = [super init];
@@ -81,6 +81,17 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 
 @implementation FGMPlatformMarkerTypeBox
 - (instancetype)initWithValue:(FGMPlatformMarkerType)value {
+  self = [super init];
+  if (self) {
+    _value = value;
+  }
+  return self;
+}
+@end
+
+/// Pigeon equivalent of MapColorScheme.
+@implementation FGMPlatformMapColorSchemeBox
+- (instancetype)initWithValue:(FGMPlatformMapColorScheme)value {
   self = [super init];
   if (self) {
     _value = value;
@@ -1356,7 +1367,8 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
                       buildingsEnabled:(nullable NSNumber *)buildingsEnabled
                             markerType:(FGMPlatformMarkerType)markerType
                                  mapId:(nullable NSString *)mapId
-                                 style:(nullable NSString *)style {
+                                 style:(nullable NSString *)style
+                           colorScheme:(nullable FGMPlatformMapColorSchemeBox *)colorScheme {
   FGMPlatformMapConfiguration *pigeonResult = [[FGMPlatformMapConfiguration alloc] init];
   pigeonResult.compassEnabled = compassEnabled;
   pigeonResult.cameraTargetBounds = cameraTargetBounds;
@@ -1376,6 +1388,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.markerType = markerType;
   pigeonResult.mapId = mapId;
   pigeonResult.style = style;
+  pigeonResult.colorScheme = colorScheme;
   return pigeonResult;
 }
 + (FGMPlatformMapConfiguration *)fromList:(NSArray<id> *)list {
@@ -1399,6 +1412,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.markerType = boxedFGMPlatformMarkerType.value;
   pigeonResult.mapId = GetNullableObjectAtIndex(list, 16);
   pigeonResult.style = GetNullableObjectAtIndex(list, 17);
+  pigeonResult.colorScheme = GetNullableObjectAtIndex(list, 18);
   return pigeonResult;
 }
 + (nullable FGMPlatformMapConfiguration *)nullableFromList:(NSArray<id> *)list {
@@ -1424,6 +1438,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     [[FGMPlatformMarkerTypeBox alloc] initWithValue:self.markerType],
     self.mapId ?: [NSNull null],
     self.style ?: [NSNull null],
+    self.colorScheme ?: [NSNull null],
   ];
 }
 @end
@@ -1839,95 +1854,101 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     }
     case 134: {
       NSNumber *enumAsNumber = [self readValue];
+      return enumAsNumber == nil
+                 ? nil
+                 : [[FGMPlatformMapColorSchemeBox alloc] initWithValue:[enumAsNumber integerValue]];
+    }
+    case 135: {
+      NSNumber *enumAsNumber = [self readValue];
       return enumAsNumber == nil ? nil
                                  : [[FGMPlatformMapBitmapScalingBox alloc]
                                        initWithValue:[enumAsNumber integerValue]];
     }
-    case 135:
-      return [FGMPlatformCameraPosition fromList:[self readValue]];
     case 136:
-      return [FGMPlatformCameraUpdate fromList:[self readValue]];
+      return [FGMPlatformCameraPosition fromList:[self readValue]];
     case 137:
-      return [FGMPlatformCameraUpdateNewCameraPosition fromList:[self readValue]];
+      return [FGMPlatformCameraUpdate fromList:[self readValue]];
     case 138:
-      return [FGMPlatformCameraUpdateNewLatLng fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewCameraPosition fromList:[self readValue]];
     case 139:
-      return [FGMPlatformCameraUpdateNewLatLngBounds fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLng fromList:[self readValue]];
     case 140:
-      return [FGMPlatformCameraUpdateNewLatLngZoom fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLngBounds fromList:[self readValue]];
     case 141:
-      return [FGMPlatformCameraUpdateScrollBy fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLngZoom fromList:[self readValue]];
     case 142:
-      return [FGMPlatformCameraUpdateZoomBy fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateScrollBy fromList:[self readValue]];
     case 143:
-      return [FGMPlatformCameraUpdateZoom fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoomBy fromList:[self readValue]];
     case 144:
-      return [FGMPlatformCameraUpdateZoomTo fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoom fromList:[self readValue]];
     case 145:
-      return [FGMPlatformCircle fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoomTo fromList:[self readValue]];
     case 146:
-      return [FGMPlatformHeatmap fromList:[self readValue]];
+      return [FGMPlatformCircle fromList:[self readValue]];
     case 147:
-      return [FGMPlatformHeatmapGradient fromList:[self readValue]];
+      return [FGMPlatformHeatmap fromList:[self readValue]];
     case 148:
-      return [FGMPlatformWeightedLatLng fromList:[self readValue]];
+      return [FGMPlatformHeatmapGradient fromList:[self readValue]];
     case 149:
-      return [FGMPlatformInfoWindow fromList:[self readValue]];
+      return [FGMPlatformWeightedLatLng fromList:[self readValue]];
     case 150:
-      return [FGMPlatformCluster fromList:[self readValue]];
+      return [FGMPlatformInfoWindow fromList:[self readValue]];
     case 151:
-      return [FGMPlatformClusterManager fromList:[self readValue]];
+      return [FGMPlatformCluster fromList:[self readValue]];
     case 152:
-      return [FGMPlatformMarker fromList:[self readValue]];
+      return [FGMPlatformClusterManager fromList:[self readValue]];
     case 153:
-      return [FGMPlatformPolygon fromList:[self readValue]];
+      return [FGMPlatformMarker fromList:[self readValue]];
     case 154:
-      return [FGMPlatformPolyline fromList:[self readValue]];
+      return [FGMPlatformPolygon fromList:[self readValue]];
     case 155:
-      return [FGMPlatformPatternItem fromList:[self readValue]];
+      return [FGMPlatformPolyline fromList:[self readValue]];
     case 156:
-      return [FGMPlatformTile fromList:[self readValue]];
+      return [FGMPlatformPatternItem fromList:[self readValue]];
     case 157:
-      return [FGMPlatformTileOverlay fromList:[self readValue]];
+      return [FGMPlatformTile fromList:[self readValue]];
     case 158:
-      return [FGMPlatformEdgeInsets fromList:[self readValue]];
+      return [FGMPlatformTileOverlay fromList:[self readValue]];
     case 159:
-      return [FGMPlatformLatLng fromList:[self readValue]];
+      return [FGMPlatformEdgeInsets fromList:[self readValue]];
     case 160:
-      return [FGMPlatformLatLngBounds fromList:[self readValue]];
+      return [FGMPlatformLatLng fromList:[self readValue]];
     case 161:
-      return [FGMPlatformCameraTargetBounds fromList:[self readValue]];
+      return [FGMPlatformLatLngBounds fromList:[self readValue]];
     case 162:
-      return [FGMPlatformGroundOverlay fromList:[self readValue]];
+      return [FGMPlatformCameraTargetBounds fromList:[self readValue]];
     case 163:
-      return [FGMPlatformMapViewCreationParams fromList:[self readValue]];
+      return [FGMPlatformGroundOverlay fromList:[self readValue]];
     case 164:
-      return [FGMPlatformMapConfiguration fromList:[self readValue]];
+      return [FGMPlatformMapViewCreationParams fromList:[self readValue]];
     case 165:
-      return [FGMPlatformPoint fromList:[self readValue]];
+      return [FGMPlatformMapConfiguration fromList:[self readValue]];
     case 166:
-      return [FGMPlatformSize fromList:[self readValue]];
+      return [FGMPlatformPoint fromList:[self readValue]];
     case 167:
-      return [FGMPlatformColor fromList:[self readValue]];
+      return [FGMPlatformSize fromList:[self readValue]];
     case 168:
-      return [FGMPlatformTileLayer fromList:[self readValue]];
+      return [FGMPlatformColor fromList:[self readValue]];
     case 169:
-      return [FGMPlatformZoomRange fromList:[self readValue]];
+      return [FGMPlatformTileLayer fromList:[self readValue]];
     case 170:
-      return [FGMPlatformBitmap fromList:[self readValue]];
+      return [FGMPlatformZoomRange fromList:[self readValue]];
     case 171:
-      return [FGMPlatformBitmapDefaultMarker fromList:[self readValue]];
+      return [FGMPlatformBitmap fromList:[self readValue]];
     case 172:
-      return [FGMPlatformBitmapBytes fromList:[self readValue]];
+      return [FGMPlatformBitmapDefaultMarker fromList:[self readValue]];
     case 173:
-      return [FGMPlatformBitmapAsset fromList:[self readValue]];
+      return [FGMPlatformBitmapBytes fromList:[self readValue]];
     case 174:
-      return [FGMPlatformBitmapAssetImage fromList:[self readValue]];
+      return [FGMPlatformBitmapAsset fromList:[self readValue]];
     case 175:
-      return [FGMPlatformBitmapAssetMap fromList:[self readValue]];
+      return [FGMPlatformBitmapAssetImage fromList:[self readValue]];
     case 176:
-      return [FGMPlatformBitmapBytesMap fromList:[self readValue]];
+      return [FGMPlatformBitmapAssetMap fromList:[self readValue]];
     case 177:
+      return [FGMPlatformBitmapBytesMap fromList:[self readValue]];
+    case 178:
       return [FGMPlatformBitmapPinConfig fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
@@ -1959,138 +1980,142 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     FGMPlatformMarkerTypeBox *box = (FGMPlatformMarkerTypeBox *)value;
     [self writeByte:133];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[FGMPlatformMapBitmapScalingBox class]]) {
-    FGMPlatformMapBitmapScalingBox *box = (FGMPlatformMapBitmapScalingBox *)value;
+  } else if ([value isKindOfClass:[FGMPlatformMapColorSchemeBox class]]) {
+    FGMPlatformMapColorSchemeBox *box = (FGMPlatformMapColorSchemeBox *)value;
     [self writeByte:134];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[FGMPlatformCameraPosition class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapBitmapScalingBox class]]) {
+    FGMPlatformMapBitmapScalingBox *box = (FGMPlatformMapBitmapScalingBox *)value;
     [self writeByte:135];
-    [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdate class]]) {
+    [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
+  } else if ([value isKindOfClass:[FGMPlatformCameraPosition class]]) {
     [self writeByte:136];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewCameraPosition class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdate class]]) {
     [self writeByte:137];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewCameraPosition class]]) {
     [self writeByte:138];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLng class]]) {
     [self writeByte:139];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngZoom class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngBounds class]]) {
     [self writeByte:140];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateScrollBy class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngZoom class]]) {
     [self writeByte:141];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomBy class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateScrollBy class]]) {
     [self writeByte:142];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoom class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomBy class]]) {
     [self writeByte:143];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomTo class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoom class]]) {
     [self writeByte:144];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCircle class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomTo class]]) {
     [self writeByte:145];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformHeatmap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCircle class]]) {
     [self writeByte:146];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformHeatmapGradient class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformHeatmap class]]) {
     [self writeByte:147];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformWeightedLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformHeatmapGradient class]]) {
     [self writeByte:148];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformInfoWindow class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformWeightedLatLng class]]) {
     [self writeByte:149];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCluster class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformInfoWindow class]]) {
     [self writeByte:150];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformClusterManager class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCluster class]]) {
     [self writeByte:151];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMarker class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformClusterManager class]]) {
     [self writeByte:152];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPolygon class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMarker class]]) {
     [self writeByte:153];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPolyline class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPolygon class]]) {
     [self writeByte:154];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPatternItem class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPolyline class]]) {
     [self writeByte:155];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTile class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPatternItem class]]) {
     [self writeByte:156];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTileOverlay class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTile class]]) {
     [self writeByte:157];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformEdgeInsets class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTileOverlay class]]) {
     [self writeByte:158];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformEdgeInsets class]]) {
     [self writeByte:159];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformLatLngBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformLatLng class]]) {
     [self writeByte:160];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraTargetBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformLatLngBounds class]]) {
     [self writeByte:161];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformGroundOverlay class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraTargetBounds class]]) {
     [self writeByte:162];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMapViewCreationParams class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformGroundOverlay class]]) {
     [self writeByte:163];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMapConfiguration class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapViewCreationParams class]]) {
     [self writeByte:164];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPoint class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapConfiguration class]]) {
     [self writeByte:165];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformSize class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPoint class]]) {
     [self writeByte:166];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformColor class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformSize class]]) {
     [self writeByte:167];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTileLayer class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformColor class]]) {
     [self writeByte:168];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformZoomRange class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTileLayer class]]) {
     [self writeByte:169];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformZoomRange class]]) {
     [self writeByte:170];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapDefaultMarker class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmap class]]) {
     [self writeByte:171];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapBytes class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapDefaultMarker class]]) {
     [self writeByte:172];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAsset class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapBytes class]]) {
     [self writeByte:173];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetImage class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAsset class]]) {
     [self writeByte:174];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetMap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetImage class]]) {
     [self writeByte:175];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapBytesMap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetMap class]]) {
     [self writeByte:176];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapPinConfig class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapBytesMap class]]) {
     [self writeByte:177];
+    [self writeValue:[value toList]];
+  } else if ([value isKindOfClass:[FGMPlatformBitmapPinConfig class]]) {
+    [self writeByte:178];
     [self writeValue:[value toList]];
   } else {
     [super writeValue:value];

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapType) {
 - (instancetype)initWithValue:(FGMPlatformMapType)value;
 @end
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 typedef NS_ENUM(NSUInteger, FGMPlatformMarkerCollisionBehavior) {
   FGMPlatformMarkerCollisionBehaviorRequiredDisplay = 0,
   FGMPlatformMarkerCollisionBehaviorOptionalAndHidesLowerPriority = 1,
@@ -76,6 +76,19 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMarkerType) {
 @interface FGMPlatformMarkerTypeBox : NSObject
 @property(nonatomic, assign) FGMPlatformMarkerType value;
 - (instancetype)initWithValue:(FGMPlatformMarkerType)value;
+@end
+
+/// Pigeon equivalent of MapColorScheme.
+typedef NS_ENUM(NSUInteger, FGMPlatformMapColorScheme) {
+  FGMPlatformMapColorSchemeLight = 0,
+  FGMPlatformMapColorSchemeDark = 1,
+  FGMPlatformMapColorSchemeFollowSystem = 2,
+};
+
+/// Wrapper for FGMPlatformMapColorScheme to allow for nullability.
+@interface FGMPlatformMapColorSchemeBox : NSObject
+@property(nonatomic, assign) FGMPlatformMapColorScheme value;
+- (instancetype)initWithValue:(FGMPlatformMapColorScheme)value;
 @end
 
 /// Pigeon equivalent of [MapBitmapScaling].
@@ -573,7 +586,8 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapBitmapScaling) {
                       buildingsEnabled:(nullable NSNumber *)buildingsEnabled
                             markerType:(FGMPlatformMarkerType)markerType
                                  mapId:(nullable NSString *)mapId
-                                 style:(nullable NSString *)style;
+                                 style:(nullable NSString *)style
+                           colorScheme:(nullable FGMPlatformMapColorSchemeBox *)colorScheme;
 @property(nonatomic, strong, nullable) NSNumber *compassEnabled;
 @property(nonatomic, strong, nullable) FGMPlatformCameraTargetBounds *cameraTargetBounds;
 @property(nonatomic, strong, nullable) FGMPlatformMapTypeBox *mapType;
@@ -592,6 +606,7 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapBitmapScaling) {
 @property(nonatomic, assign) FGMPlatformMarkerType markerType;
 @property(nonatomic, copy, nullable) NSString *mapId;
 @property(nonatomic, copy, nullable) NSString *style;
+@property(nonatomic, strong, nullable) FGMPlatformMapColorSchemeBox *colorScheme;
 @end
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
@@ -1162,6 +1162,7 @@ PlatformMapConfiguration _platformMapConfigurationFromMapConfiguration(MapConfig
     markerType: _platformMarkerTypeFromMarkerType(config.markerType ?? MarkerType.marker),
     mapId: config.mapId,
     style: config.style,
+    colorScheme: _platformMapColorSchemeFromMapColorScheme(config.colorScheme),
   );
 }
 
@@ -1180,6 +1181,26 @@ PlatformMarkerType _platformMarkerTypeFromMarkerType(MarkerType markerType) {
   // switch as needing an update.
   // ignore: dead_code
   throw UnimplementedError('MarkerType "$markerType" has not been implemented');
+}
+
+PlatformMapColorScheme? _platformMapColorSchemeFromMapColorScheme(MapColorScheme? colorScheme) {
+  if (colorScheme == null) {
+    return null;
+  }
+  switch (colorScheme) {
+    case MapColorScheme.light:
+      return PlatformMapColorScheme.light;
+    case MapColorScheme.dark:
+      return PlatformMapColorScheme.dark;
+    case MapColorScheme.followSystem:
+      return PlatformMapColorScheme.followSystem;
+    // The enum comes from a different package, which could get a new value at
+    // any time, so provide a fallback that ensures this won't break when used
+    // with a version that contains new values.
+    // ignore: no_default_cases, unreachable_switch_default
+    default:
+      throw UnimplementedError('MapColorScheme "$colorScheme" has not been implemented');
+  }
 }
 
 // For supporting the deprecated updateMapOptions API.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/messages.g.dart
@@ -47,7 +47,7 @@ bool _deepEquals(Object? a, Object? b) {
 /// Pigeon equivalent of MapType
 enum PlatformMapType { none, normal, satellite, terrain, hybrid }
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 enum PlatformMarkerCollisionBehavior {
   requiredDisplay,
   optionalAndHidesLowerPriority,
@@ -61,6 +61,9 @@ enum PlatformJointType { mitered, bevel, round }
 enum PlatformPatternItemType { dot, dash, gap }
 
 enum PlatformMarkerType { marker, advancedMarker }
+
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
 
 /// Pigeon equivalent of [MapBitmapScaling].
 enum PlatformMapBitmapScaling { auto, none }
@@ -1641,6 +1644,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     this.mapId,
     this.style,
+    this.colorScheme,
   });
 
   bool? compassEnabled;
@@ -1679,6 +1683,8 @@ class PlatformMapConfiguration {
 
   String? style;
 
+  PlatformMapColorScheme? colorScheme;
+
   List<Object?> _toList() {
     return <Object?>[
       compassEnabled,
@@ -1699,6 +1705,7 @@ class PlatformMapConfiguration {
       markerType,
       mapId,
       style,
+      colorScheme,
     ];
   }
 
@@ -1727,6 +1734,7 @@ class PlatformMapConfiguration {
       markerType: result[15]! as PlatformMarkerType,
       mapId: result[16] as String?,
       style: result[17] as String?,
+      colorScheme: result[18] as PlatformMapColorScheme?,
     );
   }
 
@@ -2362,137 +2370,140 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PlatformMarkerType) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is PlatformMapBitmapScaling) {
+    } else if (value is PlatformMapColorScheme) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    } else if (value is PlatformCameraPosition) {
+    } else if (value is PlatformMapBitmapScaling) {
       buffer.putUint8(135);
-      writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdate) {
+      writeValue(buffer, value.index);
+    } else if (value is PlatformCameraPosition) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewCameraPosition) {
+    } else if (value is PlatformCameraUpdate) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLng) {
+    } else if (value is PlatformCameraUpdateNewCameraPosition) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
+    } else if (value is PlatformCameraUpdateNewLatLng) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
+    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateScrollBy) {
+    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomBy) {
+    } else if (value is PlatformCameraUpdateScrollBy) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoom) {
+    } else if (value is PlatformCameraUpdateZoomBy) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomTo) {
+    } else if (value is PlatformCameraUpdateZoom) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCircle) {
+    } else if (value is PlatformCameraUpdateZoomTo) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmap) {
+    } else if (value is PlatformCircle) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmapGradient) {
+    } else if (value is PlatformHeatmap) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformWeightedLatLng) {
+    } else if (value is PlatformHeatmapGradient) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformInfoWindow) {
+    } else if (value is PlatformWeightedLatLng) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCluster) {
+    } else if (value is PlatformInfoWindow) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformClusterManager) {
+    } else if (value is PlatformCluster) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMarker) {
+    } else if (value is PlatformClusterManager) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolygon) {
+    } else if (value is PlatformMarker) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolyline) {
+    } else if (value is PlatformPolygon) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPatternItem) {
+    } else if (value is PlatformPolyline) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTile) {
+    } else if (value is PlatformPatternItem) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileOverlay) {
+    } else if (value is PlatformTile) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformEdgeInsets) {
+    } else if (value is PlatformTileOverlay) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLng) {
+    } else if (value is PlatformEdgeInsets) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLngBounds) {
+    } else if (value is PlatformLatLng) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraTargetBounds) {
+    } else if (value is PlatformLatLngBounds) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformGroundOverlay) {
+    } else if (value is PlatformCameraTargetBounds) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapViewCreationParams) {
+    } else if (value is PlatformGroundOverlay) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapConfiguration) {
+    } else if (value is PlatformMapViewCreationParams) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPoint) {
+    } else if (value is PlatformMapConfiguration) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformSize) {
+    } else if (value is PlatformPoint) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformColor) {
+    } else if (value is PlatformSize) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileLayer) {
+    } else if (value is PlatformColor) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformZoomRange) {
+    } else if (value is PlatformTileLayer) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmap) {
+    } else if (value is PlatformZoomRange) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapDefaultMarker) {
+    } else if (value is PlatformBitmap) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytes) {
+    } else if (value is PlatformBitmapDefaultMarker) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAsset) {
+    } else if (value is PlatformBitmapBytes) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetImage) {
+    } else if (value is PlatformBitmapAsset) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetMap) {
+    } else if (value is PlatformBitmapAssetImage) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytesMap) {
+    } else if (value is PlatformBitmapAssetMap) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapPinConfig) {
+    } else if (value is PlatformBitmapBytesMap) {
       buffer.putUint8(177);
+      writeValue(buffer, value.encode());
+    } else if (value is PlatformBitmapPinConfig) {
+      buffer.putUint8(178);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -2519,92 +2530,95 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PlatformMarkerType.values[value];
       case 134:
         final value = readValue(buffer) as int?;
-        return value == null ? null : PlatformMapBitmapScaling.values[value];
+        return value == null ? null : PlatformMapColorScheme.values[value];
       case 135:
-        return PlatformCameraPosition.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : PlatformMapBitmapScaling.values[value];
       case 136:
-        return PlatformCameraUpdate.decode(readValue(buffer)!);
+        return PlatformCameraPosition.decode(readValue(buffer)!);
       case 137:
-        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
+        return PlatformCameraUpdate.decode(readValue(buffer)!);
       case 138:
-        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
       case 139:
-        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
       case 140:
-        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
       case 141:
-        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
       case 142:
-        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
       case 143:
-        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
       case 144:
-        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
       case 145:
-        return PlatformCircle.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
       case 146:
-        return PlatformHeatmap.decode(readValue(buffer)!);
+        return PlatformCircle.decode(readValue(buffer)!);
       case 147:
-        return PlatformHeatmapGradient.decode(readValue(buffer)!);
+        return PlatformHeatmap.decode(readValue(buffer)!);
       case 148:
-        return PlatformWeightedLatLng.decode(readValue(buffer)!);
+        return PlatformHeatmapGradient.decode(readValue(buffer)!);
       case 149:
-        return PlatformInfoWindow.decode(readValue(buffer)!);
+        return PlatformWeightedLatLng.decode(readValue(buffer)!);
       case 150:
-        return PlatformCluster.decode(readValue(buffer)!);
+        return PlatformInfoWindow.decode(readValue(buffer)!);
       case 151:
-        return PlatformClusterManager.decode(readValue(buffer)!);
+        return PlatformCluster.decode(readValue(buffer)!);
       case 152:
-        return PlatformMarker.decode(readValue(buffer)!);
+        return PlatformClusterManager.decode(readValue(buffer)!);
       case 153:
-        return PlatformPolygon.decode(readValue(buffer)!);
+        return PlatformMarker.decode(readValue(buffer)!);
       case 154:
-        return PlatformPolyline.decode(readValue(buffer)!);
+        return PlatformPolygon.decode(readValue(buffer)!);
       case 155:
-        return PlatformPatternItem.decode(readValue(buffer)!);
+        return PlatformPolyline.decode(readValue(buffer)!);
       case 156:
-        return PlatformTile.decode(readValue(buffer)!);
+        return PlatformPatternItem.decode(readValue(buffer)!);
       case 157:
-        return PlatformTileOverlay.decode(readValue(buffer)!);
+        return PlatformTile.decode(readValue(buffer)!);
       case 158:
-        return PlatformEdgeInsets.decode(readValue(buffer)!);
+        return PlatformTileOverlay.decode(readValue(buffer)!);
       case 159:
-        return PlatformLatLng.decode(readValue(buffer)!);
+        return PlatformEdgeInsets.decode(readValue(buffer)!);
       case 160:
-        return PlatformLatLngBounds.decode(readValue(buffer)!);
+        return PlatformLatLng.decode(readValue(buffer)!);
       case 161:
-        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
+        return PlatformLatLngBounds.decode(readValue(buffer)!);
       case 162:
-        return PlatformGroundOverlay.decode(readValue(buffer)!);
+        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
       case 163:
-        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
+        return PlatformGroundOverlay.decode(readValue(buffer)!);
       case 164:
-        return PlatformMapConfiguration.decode(readValue(buffer)!);
+        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
       case 165:
-        return PlatformPoint.decode(readValue(buffer)!);
+        return PlatformMapConfiguration.decode(readValue(buffer)!);
       case 166:
-        return PlatformSize.decode(readValue(buffer)!);
+        return PlatformPoint.decode(readValue(buffer)!);
       case 167:
-        return PlatformColor.decode(readValue(buffer)!);
+        return PlatformSize.decode(readValue(buffer)!);
       case 168:
-        return PlatformTileLayer.decode(readValue(buffer)!);
+        return PlatformColor.decode(readValue(buffer)!);
       case 169:
-        return PlatformZoomRange.decode(readValue(buffer)!);
+        return PlatformTileLayer.decode(readValue(buffer)!);
       case 170:
-        return PlatformBitmap.decode(readValue(buffer)!);
+        return PlatformZoomRange.decode(readValue(buffer)!);
       case 171:
-        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
+        return PlatformBitmap.decode(readValue(buffer)!);
       case 172:
-        return PlatformBitmapBytes.decode(readValue(buffer)!);
+        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
       case 173:
-        return PlatformBitmapAsset.decode(readValue(buffer)!);
+        return PlatformBitmapBytes.decode(readValue(buffer)!);
       case 174:
-        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
+        return PlatformBitmapAsset.decode(readValue(buffer)!);
       case 175:
-        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
       case 176:
-        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
       case 177:
+        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+      case 178:
         return PlatformBitmapPinConfig.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pigeons/messages.dart
@@ -449,6 +449,9 @@ class PlatformMapViewCreationParams {
 
 enum PlatformMarkerType { marker, advancedMarker }
 
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
+
 /// Pigeon equivalent of MapConfiguration.
 class PlatformMapConfiguration {
   PlatformMapConfiguration({
@@ -470,6 +473,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     required this.mapId,
     required this.style,
+    required this.colorScheme,
   });
 
   final bool? compassEnabled;
@@ -490,6 +494,7 @@ class PlatformMapConfiguration {
   final PlatformMarkerType markerType;
   final String? mapId;
   final String? style;
+  final PlatformMapColorScheme? colorScheme;
 }
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.4
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.15.0
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
@@ -1311,6 +1311,109 @@ void main() {
       );
     });
   });
+
+  group('colorScheme in creationParams', () {
+    Future<PlatformMapColorScheme?> getColorSchemeFromCreationParams(
+      WidgetTester tester,
+      MapColorScheme? colorScheme,
+    ) async {
+      final passedColorSchemeCompleter = Completer<PlatformMapColorScheme?>();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform_views,
+        (MethodCall methodCall) {
+          if (methodCall.method == 'create') {
+            final args = Map<String, dynamic>.from(methodCall.arguments as Map<dynamic, dynamic>);
+            if (args.containsKey('params')) {
+              final paramsUint8List = args['params'] as Uint8List;
+              final byteData = ByteData.sublistView(paramsUint8List);
+              final creationParams =
+                  MapsApi.pigeonChannelCodec.decodeMessage(byteData)
+                      as PlatformMapViewCreationParams?;
+              if (creationParams != null && !passedColorSchemeCompleter.isCompleted) {
+                passedColorSchemeCompleter.complete(creationParams.mapConfiguration.colorScheme);
+              }
+            }
+          }
+          return null;
+        },
+      );
+
+      final maps = GoogleMapsFlutterIOS();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: maps.buildViewWithConfiguration(
+            1,
+            (int _) {},
+            widgetConfiguration: const MapWidgetConfiguration(
+              initialCameraPosition: CameraPosition(target: LatLng(0, 0), zoom: 1),
+              textDirection: TextDirection.ltr,
+            ),
+            mapConfiguration: MapConfiguration(colorScheme: colorScheme),
+          ),
+        ),
+      );
+
+      return passedColorSchemeCompleter.future;
+    }
+
+    testWidgets('passes light when MapColorScheme.light is set', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.light,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.light,
+        reason: 'Should pass light on PlatformView creation when MapColorScheme.light is set',
+      );
+    });
+
+    testWidgets('passes dark when MapColorScheme.dark is set', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.dark,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.dark,
+        reason: 'Should pass dark on PlatformView creation when MapColorScheme.dark is set',
+      );
+    });
+
+    testWidgets('passes followSystem when MapColorScheme.followSystem is set', (
+      WidgetTester tester,
+    ) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.followSystem,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.followSystem,
+        reason:
+            'Should pass followSystem on PlatformView creation when MapColorScheme.followSystem is set',
+      );
+    });
+
+    testWidgets('passes null when colorScheme is null', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        null,
+      );
+
+      expect(
+        passedColorScheme,
+        isNull,
+        reason: 'Should default to null on PlatformView creation when colorScheme is null',
+      );
+    });
+  });
 }
 
 void _expectColorsEqual(PlatformColor actual, Color expected) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds `colorScheme` support for cloud-based maps styling brightness.
+
 ## 2.18.5
 
 * Fixes a potential compilation issue in tile downscaling.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerTests/GoogleMapsTests.m
@@ -222,6 +222,56 @@
   XCTAssertEqual(cameraPosition.zoom, initialCameraPosition.zoom);
 }
 
+- (void)testSetMapColorScheme {
+  CGRect frame = CGRectMake(0, 0, 100, 100);
+  GMSMapViewOptions *options = [[GMSMapViewOptions alloc] init];
+  options.frame = frame;
+  options.camera = [[GMSCameraPosition alloc] initWithLatitude:0 longitude:0 zoom:0];
+  PartiallyMockedMapView *mapView = [[PartiallyMockedMapView alloc] initWithOptions:options];
+  FGMGoogleMapController *controller =
+      [[FGMGoogleMapController alloc] initWithMapView:mapView
+                                       viewIdentifier:0
+                                   creationParameters:[self emptyCreationParameters]
+                                        assetProvider:[[TestAssetProvider alloc] init]
+                                      binaryMessenger:[[StubBinaryMessenger alloc] init]];
+  FlutterError *error = nil;
+
+  // Light. Start from a different style so the assertion confirms a real change.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *lightConfig = [self emptyCreationParameters].mapConfiguration;
+  lightConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeLight];
+  [controller.callHandler updateWithMapConfiguration:lightConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleLight);
+
+  // Dark.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+  FGMPlatformMapConfiguration *darkConfig = [self emptyCreationParameters].mapConfiguration;
+  darkConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeDark];
+  [controller.callHandler updateWithMapConfiguration:darkConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+
+  // followSystem maps to "unspecified", letting the system drive appearance.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *followConfig = [self emptyCreationParameters].mapConfiguration;
+  followConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeFollowSystem];
+  [controller.callHandler updateWithMapConfiguration:followConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleUnspecified);
+
+  // A configuration with no color scheme must not change the interface style.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *noSchemeConfig = [self emptyCreationParameters].mapConfiguration;
+  noSchemeConfig.colorScheme = nil;
+  [controller.callHandler updateWithMapConfiguration:noSchemeConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+}
+
 /// Creates an empty creation paramaters object for tests where the values don't matter, just that
 /// there's a valid object to pass in.
 - (FGMPlatformMapViewCreationParams *)emptyCreationParameters {
@@ -250,7 +300,8 @@
                                                buildingsEnabled:nil
                                                      markerType:FGMPlatformMarkerTypeMarker
                                                           mapId:nil
-                                                          style:nil]
+                                                          style:nil
+                                                    colorScheme:nil]
                      initialCircles:@[]
                      initialMarkers:@[]
                     initialPolygons:@[]

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMGoogleMapController.m
@@ -478,6 +478,20 @@
   self.mapView.settings.myLocationButton = enabled;
 }
 
+- (void)setColorScheme:(FGMPlatformMapColorScheme)colorScheme {
+  switch (colorScheme) {
+    case FGMPlatformMapColorSchemeLight:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+      break;
+    case FGMPlatformMapColorSchemeDark:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+      break;
+    case FGMPlatformMapColorSchemeFollowSystem:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+      break;
+  }
+}
+
 /// Sets the map style, returing any error string as well as storing that error in `mapStyle` for
 /// later access.
 - (NSString *)setMapStyle:(NSString *)mapStyle {
@@ -636,6 +650,10 @@
   NSString *style = config.style;
   if (style) {
     [self setMapStyle:style];
+  }
+  FGMPlatformMapColorSchemeBox *colorScheme = config.colorScheme;
+  if (colorScheme) {
+    [self setColorScheme:colorScheme.value];
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.m
@@ -46,7 +46,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 }
 @end
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 @implementation FGMPlatformMarkerCollisionBehaviorBox
 - (instancetype)initWithValue:(FGMPlatformMarkerCollisionBehavior)value {
   self = [super init];
@@ -81,6 +81,17 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 
 @implementation FGMPlatformMarkerTypeBox
 - (instancetype)initWithValue:(FGMPlatformMarkerType)value {
+  self = [super init];
+  if (self) {
+    _value = value;
+  }
+  return self;
+}
+@end
+
+/// Pigeon equivalent of MapColorScheme.
+@implementation FGMPlatformMapColorSchemeBox
+- (instancetype)initWithValue:(FGMPlatformMapColorScheme)value {
   self = [super init];
   if (self) {
     _value = value;
@@ -1356,7 +1367,8 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
                       buildingsEnabled:(nullable NSNumber *)buildingsEnabled
                             markerType:(FGMPlatformMarkerType)markerType
                                  mapId:(nullable NSString *)mapId
-                                 style:(nullable NSString *)style {
+                                 style:(nullable NSString *)style
+                           colorScheme:(nullable FGMPlatformMapColorSchemeBox *)colorScheme {
   FGMPlatformMapConfiguration *pigeonResult = [[FGMPlatformMapConfiguration alloc] init];
   pigeonResult.compassEnabled = compassEnabled;
   pigeonResult.cameraTargetBounds = cameraTargetBounds;
@@ -1376,6 +1388,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.markerType = markerType;
   pigeonResult.mapId = mapId;
   pigeonResult.style = style;
+  pigeonResult.colorScheme = colorScheme;
   return pigeonResult;
 }
 + (FGMPlatformMapConfiguration *)fromList:(NSArray<id> *)list {
@@ -1399,6 +1412,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.markerType = boxedFGMPlatformMarkerType.value;
   pigeonResult.mapId = GetNullableObjectAtIndex(list, 16);
   pigeonResult.style = GetNullableObjectAtIndex(list, 17);
+  pigeonResult.colorScheme = GetNullableObjectAtIndex(list, 18);
   return pigeonResult;
 }
 + (nullable FGMPlatformMapConfiguration *)nullableFromList:(NSArray<id> *)list {
@@ -1424,6 +1438,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     [[FGMPlatformMarkerTypeBox alloc] initWithValue:self.markerType],
     self.mapId ?: [NSNull null],
     self.style ?: [NSNull null],
+    self.colorScheme ?: [NSNull null],
   ];
 }
 @end
@@ -1839,95 +1854,101 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     }
     case 134: {
       NSNumber *enumAsNumber = [self readValue];
+      return enumAsNumber == nil
+                 ? nil
+                 : [[FGMPlatformMapColorSchemeBox alloc] initWithValue:[enumAsNumber integerValue]];
+    }
+    case 135: {
+      NSNumber *enumAsNumber = [self readValue];
       return enumAsNumber == nil ? nil
                                  : [[FGMPlatformMapBitmapScalingBox alloc]
                                        initWithValue:[enumAsNumber integerValue]];
     }
-    case 135:
-      return [FGMPlatformCameraPosition fromList:[self readValue]];
     case 136:
-      return [FGMPlatformCameraUpdate fromList:[self readValue]];
+      return [FGMPlatformCameraPosition fromList:[self readValue]];
     case 137:
-      return [FGMPlatformCameraUpdateNewCameraPosition fromList:[self readValue]];
+      return [FGMPlatformCameraUpdate fromList:[self readValue]];
     case 138:
-      return [FGMPlatformCameraUpdateNewLatLng fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewCameraPosition fromList:[self readValue]];
     case 139:
-      return [FGMPlatformCameraUpdateNewLatLngBounds fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLng fromList:[self readValue]];
     case 140:
-      return [FGMPlatformCameraUpdateNewLatLngZoom fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLngBounds fromList:[self readValue]];
     case 141:
-      return [FGMPlatformCameraUpdateScrollBy fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLngZoom fromList:[self readValue]];
     case 142:
-      return [FGMPlatformCameraUpdateZoomBy fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateScrollBy fromList:[self readValue]];
     case 143:
-      return [FGMPlatformCameraUpdateZoom fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoomBy fromList:[self readValue]];
     case 144:
-      return [FGMPlatformCameraUpdateZoomTo fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoom fromList:[self readValue]];
     case 145:
-      return [FGMPlatformCircle fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoomTo fromList:[self readValue]];
     case 146:
-      return [FGMPlatformHeatmap fromList:[self readValue]];
+      return [FGMPlatformCircle fromList:[self readValue]];
     case 147:
-      return [FGMPlatformHeatmapGradient fromList:[self readValue]];
+      return [FGMPlatformHeatmap fromList:[self readValue]];
     case 148:
-      return [FGMPlatformWeightedLatLng fromList:[self readValue]];
+      return [FGMPlatformHeatmapGradient fromList:[self readValue]];
     case 149:
-      return [FGMPlatformInfoWindow fromList:[self readValue]];
+      return [FGMPlatformWeightedLatLng fromList:[self readValue]];
     case 150:
-      return [FGMPlatformCluster fromList:[self readValue]];
+      return [FGMPlatformInfoWindow fromList:[self readValue]];
     case 151:
-      return [FGMPlatformClusterManager fromList:[self readValue]];
+      return [FGMPlatformCluster fromList:[self readValue]];
     case 152:
-      return [FGMPlatformMarker fromList:[self readValue]];
+      return [FGMPlatformClusterManager fromList:[self readValue]];
     case 153:
-      return [FGMPlatformPolygon fromList:[self readValue]];
+      return [FGMPlatformMarker fromList:[self readValue]];
     case 154:
-      return [FGMPlatformPolyline fromList:[self readValue]];
+      return [FGMPlatformPolygon fromList:[self readValue]];
     case 155:
-      return [FGMPlatformPatternItem fromList:[self readValue]];
+      return [FGMPlatformPolyline fromList:[self readValue]];
     case 156:
-      return [FGMPlatformTile fromList:[self readValue]];
+      return [FGMPlatformPatternItem fromList:[self readValue]];
     case 157:
-      return [FGMPlatformTileOverlay fromList:[self readValue]];
+      return [FGMPlatformTile fromList:[self readValue]];
     case 158:
-      return [FGMPlatformEdgeInsets fromList:[self readValue]];
+      return [FGMPlatformTileOverlay fromList:[self readValue]];
     case 159:
-      return [FGMPlatformLatLng fromList:[self readValue]];
+      return [FGMPlatformEdgeInsets fromList:[self readValue]];
     case 160:
-      return [FGMPlatformLatLngBounds fromList:[self readValue]];
+      return [FGMPlatformLatLng fromList:[self readValue]];
     case 161:
-      return [FGMPlatformCameraTargetBounds fromList:[self readValue]];
+      return [FGMPlatformLatLngBounds fromList:[self readValue]];
     case 162:
-      return [FGMPlatformGroundOverlay fromList:[self readValue]];
+      return [FGMPlatformCameraTargetBounds fromList:[self readValue]];
     case 163:
-      return [FGMPlatformMapViewCreationParams fromList:[self readValue]];
+      return [FGMPlatformGroundOverlay fromList:[self readValue]];
     case 164:
-      return [FGMPlatformMapConfiguration fromList:[self readValue]];
+      return [FGMPlatformMapViewCreationParams fromList:[self readValue]];
     case 165:
-      return [FGMPlatformPoint fromList:[self readValue]];
+      return [FGMPlatformMapConfiguration fromList:[self readValue]];
     case 166:
-      return [FGMPlatformSize fromList:[self readValue]];
+      return [FGMPlatformPoint fromList:[self readValue]];
     case 167:
-      return [FGMPlatformColor fromList:[self readValue]];
+      return [FGMPlatformSize fromList:[self readValue]];
     case 168:
-      return [FGMPlatformTileLayer fromList:[self readValue]];
+      return [FGMPlatformColor fromList:[self readValue]];
     case 169:
-      return [FGMPlatformZoomRange fromList:[self readValue]];
+      return [FGMPlatformTileLayer fromList:[self readValue]];
     case 170:
-      return [FGMPlatformBitmap fromList:[self readValue]];
+      return [FGMPlatformZoomRange fromList:[self readValue]];
     case 171:
-      return [FGMPlatformBitmapDefaultMarker fromList:[self readValue]];
+      return [FGMPlatformBitmap fromList:[self readValue]];
     case 172:
-      return [FGMPlatformBitmapBytes fromList:[self readValue]];
+      return [FGMPlatformBitmapDefaultMarker fromList:[self readValue]];
     case 173:
-      return [FGMPlatformBitmapAsset fromList:[self readValue]];
+      return [FGMPlatformBitmapBytes fromList:[self readValue]];
     case 174:
-      return [FGMPlatformBitmapAssetImage fromList:[self readValue]];
+      return [FGMPlatformBitmapAsset fromList:[self readValue]];
     case 175:
-      return [FGMPlatformBitmapAssetMap fromList:[self readValue]];
+      return [FGMPlatformBitmapAssetImage fromList:[self readValue]];
     case 176:
-      return [FGMPlatformBitmapBytesMap fromList:[self readValue]];
+      return [FGMPlatformBitmapAssetMap fromList:[self readValue]];
     case 177:
+      return [FGMPlatformBitmapBytesMap fromList:[self readValue]];
+    case 178:
       return [FGMPlatformBitmapPinConfig fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
@@ -1959,138 +1980,142 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     FGMPlatformMarkerTypeBox *box = (FGMPlatformMarkerTypeBox *)value;
     [self writeByte:133];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[FGMPlatformMapBitmapScalingBox class]]) {
-    FGMPlatformMapBitmapScalingBox *box = (FGMPlatformMapBitmapScalingBox *)value;
+  } else if ([value isKindOfClass:[FGMPlatformMapColorSchemeBox class]]) {
+    FGMPlatformMapColorSchemeBox *box = (FGMPlatformMapColorSchemeBox *)value;
     [self writeByte:134];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[FGMPlatformCameraPosition class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapBitmapScalingBox class]]) {
+    FGMPlatformMapBitmapScalingBox *box = (FGMPlatformMapBitmapScalingBox *)value;
     [self writeByte:135];
-    [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdate class]]) {
+    [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
+  } else if ([value isKindOfClass:[FGMPlatformCameraPosition class]]) {
     [self writeByte:136];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewCameraPosition class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdate class]]) {
     [self writeByte:137];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewCameraPosition class]]) {
     [self writeByte:138];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLng class]]) {
     [self writeByte:139];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngZoom class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngBounds class]]) {
     [self writeByte:140];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateScrollBy class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngZoom class]]) {
     [self writeByte:141];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomBy class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateScrollBy class]]) {
     [self writeByte:142];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoom class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomBy class]]) {
     [self writeByte:143];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomTo class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoom class]]) {
     [self writeByte:144];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCircle class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomTo class]]) {
     [self writeByte:145];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformHeatmap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCircle class]]) {
     [self writeByte:146];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformHeatmapGradient class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformHeatmap class]]) {
     [self writeByte:147];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformWeightedLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformHeatmapGradient class]]) {
     [self writeByte:148];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformInfoWindow class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformWeightedLatLng class]]) {
     [self writeByte:149];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCluster class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformInfoWindow class]]) {
     [self writeByte:150];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformClusterManager class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCluster class]]) {
     [self writeByte:151];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMarker class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformClusterManager class]]) {
     [self writeByte:152];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPolygon class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMarker class]]) {
     [self writeByte:153];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPolyline class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPolygon class]]) {
     [self writeByte:154];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPatternItem class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPolyline class]]) {
     [self writeByte:155];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTile class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPatternItem class]]) {
     [self writeByte:156];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTileOverlay class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTile class]]) {
     [self writeByte:157];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformEdgeInsets class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTileOverlay class]]) {
     [self writeByte:158];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformEdgeInsets class]]) {
     [self writeByte:159];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformLatLngBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformLatLng class]]) {
     [self writeByte:160];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraTargetBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformLatLngBounds class]]) {
     [self writeByte:161];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformGroundOverlay class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraTargetBounds class]]) {
     [self writeByte:162];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMapViewCreationParams class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformGroundOverlay class]]) {
     [self writeByte:163];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMapConfiguration class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapViewCreationParams class]]) {
     [self writeByte:164];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPoint class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapConfiguration class]]) {
     [self writeByte:165];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformSize class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPoint class]]) {
     [self writeByte:166];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformColor class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformSize class]]) {
     [self writeByte:167];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTileLayer class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformColor class]]) {
     [self writeByte:168];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformZoomRange class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTileLayer class]]) {
     [self writeByte:169];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformZoomRange class]]) {
     [self writeByte:170];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapDefaultMarker class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmap class]]) {
     [self writeByte:171];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapBytes class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapDefaultMarker class]]) {
     [self writeByte:172];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAsset class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapBytes class]]) {
     [self writeByte:173];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetImage class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAsset class]]) {
     [self writeByte:174];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetMap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetImage class]]) {
     [self writeByte:175];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapBytesMap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetMap class]]) {
     [self writeByte:176];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapPinConfig class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapBytesMap class]]) {
     [self writeByte:177];
+    [self writeValue:[value toList]];
+  } else if ([value isKindOfClass:[FGMPlatformBitmapPinConfig class]]) {
+    [self writeByte:178];
     [self writeValue:[value toList]];
   } else {
     [super writeValue:value];

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapType) {
 - (instancetype)initWithValue:(FGMPlatformMapType)value;
 @end
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 typedef NS_ENUM(NSUInteger, FGMPlatformMarkerCollisionBehavior) {
   FGMPlatformMarkerCollisionBehaviorRequiredDisplay = 0,
   FGMPlatformMarkerCollisionBehaviorOptionalAndHidesLowerPriority = 1,
@@ -76,6 +76,19 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMarkerType) {
 @interface FGMPlatformMarkerTypeBox : NSObject
 @property(nonatomic, assign) FGMPlatformMarkerType value;
 - (instancetype)initWithValue:(FGMPlatformMarkerType)value;
+@end
+
+/// Pigeon equivalent of MapColorScheme.
+typedef NS_ENUM(NSUInteger, FGMPlatformMapColorScheme) {
+  FGMPlatformMapColorSchemeLight = 0,
+  FGMPlatformMapColorSchemeDark = 1,
+  FGMPlatformMapColorSchemeFollowSystem = 2,
+};
+
+/// Wrapper for FGMPlatformMapColorScheme to allow for nullability.
+@interface FGMPlatformMapColorSchemeBox : NSObject
+@property(nonatomic, assign) FGMPlatformMapColorScheme value;
+- (instancetype)initWithValue:(FGMPlatformMapColorScheme)value;
 @end
 
 /// Pigeon equivalent of [MapBitmapScaling].
@@ -573,7 +586,8 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapBitmapScaling) {
                       buildingsEnabled:(nullable NSNumber *)buildingsEnabled
                             markerType:(FGMPlatformMarkerType)markerType
                                  mapId:(nullable NSString *)mapId
-                                 style:(nullable NSString *)style;
+                                 style:(nullable NSString *)style
+                           colorScheme:(nullable FGMPlatformMapColorSchemeBox *)colorScheme;
 @property(nonatomic, strong, nullable) NSNumber *compassEnabled;
 @property(nonatomic, strong, nullable) FGMPlatformCameraTargetBounds *cameraTargetBounds;
 @property(nonatomic, strong, nullable) FGMPlatformMapTypeBox *mapType;
@@ -592,6 +606,7 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapBitmapScaling) {
 @property(nonatomic, assign) FGMPlatformMarkerType markerType;
 @property(nonatomic, copy, nullable) NSString *mapId;
 @property(nonatomic, copy, nullable) NSString *style;
+@property(nonatomic, strong, nullable) FGMPlatformMapColorSchemeBox *colorScheme;
 @end
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/google_maps_flutter_ios.dart
@@ -1162,6 +1162,7 @@ PlatformMapConfiguration _platformMapConfigurationFromMapConfiguration(MapConfig
     markerType: _platformMarkerTypeFromMarkerType(config.markerType ?? MarkerType.marker),
     mapId: config.mapId,
     style: config.style,
+    colorScheme: _platformMapColorSchemeFromMapColorScheme(config.colorScheme),
   );
 }
 
@@ -1180,6 +1181,26 @@ PlatformMarkerType _platformMarkerTypeFromMarkerType(MarkerType markerType) {
   // switch as needing an update.
   // ignore: dead_code
   throw UnimplementedError('MarkerType "$markerType" has not been implemented');
+}
+
+PlatformMapColorScheme? _platformMapColorSchemeFromMapColorScheme(MapColorScheme? colorScheme) {
+  if (colorScheme == null) {
+    return null;
+  }
+  switch (colorScheme) {
+    case MapColorScheme.light:
+      return PlatformMapColorScheme.light;
+    case MapColorScheme.dark:
+      return PlatformMapColorScheme.dark;
+    case MapColorScheme.followSystem:
+      return PlatformMapColorScheme.followSystem;
+    // The enum comes from a different package, which could get a new value at
+    // any time, so provide a fallback that ensures this won't break when used
+    // with a version that contains new values.
+    // ignore: no_default_cases, unreachable_switch_default
+    default:
+      throw UnimplementedError('MapColorScheme "$colorScheme" has not been implemented');
+  }
 }
 
 // For supporting the deprecated updateMapOptions API.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/messages.g.dart
@@ -47,7 +47,7 @@ bool _deepEquals(Object? a, Object? b) {
 /// Pigeon equivalent of MapType
 enum PlatformMapType { none, normal, satellite, terrain, hybrid }
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 enum PlatformMarkerCollisionBehavior {
   requiredDisplay,
   optionalAndHidesLowerPriority,
@@ -61,6 +61,9 @@ enum PlatformJointType { mitered, bevel, round }
 enum PlatformPatternItemType { dot, dash, gap }
 
 enum PlatformMarkerType { marker, advancedMarker }
+
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
 
 /// Pigeon equivalent of [MapBitmapScaling].
 enum PlatformMapBitmapScaling { auto, none }
@@ -1641,6 +1644,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     this.mapId,
     this.style,
+    this.colorScheme,
   });
 
   bool? compassEnabled;
@@ -1679,6 +1683,8 @@ class PlatformMapConfiguration {
 
   String? style;
 
+  PlatformMapColorScheme? colorScheme;
+
   List<Object?> _toList() {
     return <Object?>[
       compassEnabled,
@@ -1699,6 +1705,7 @@ class PlatformMapConfiguration {
       markerType,
       mapId,
       style,
+      colorScheme,
     ];
   }
 
@@ -1727,6 +1734,7 @@ class PlatformMapConfiguration {
       markerType: result[15]! as PlatformMarkerType,
       mapId: result[16] as String?,
       style: result[17] as String?,
+      colorScheme: result[18] as PlatformMapColorScheme?,
     );
   }
 
@@ -2362,137 +2370,140 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PlatformMarkerType) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is PlatformMapBitmapScaling) {
+    } else if (value is PlatformMapColorScheme) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    } else if (value is PlatformCameraPosition) {
+    } else if (value is PlatformMapBitmapScaling) {
       buffer.putUint8(135);
-      writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdate) {
+      writeValue(buffer, value.index);
+    } else if (value is PlatformCameraPosition) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewCameraPosition) {
+    } else if (value is PlatformCameraUpdate) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLng) {
+    } else if (value is PlatformCameraUpdateNewCameraPosition) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
+    } else if (value is PlatformCameraUpdateNewLatLng) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
+    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateScrollBy) {
+    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomBy) {
+    } else if (value is PlatformCameraUpdateScrollBy) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoom) {
+    } else if (value is PlatformCameraUpdateZoomBy) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomTo) {
+    } else if (value is PlatformCameraUpdateZoom) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCircle) {
+    } else if (value is PlatformCameraUpdateZoomTo) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmap) {
+    } else if (value is PlatformCircle) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmapGradient) {
+    } else if (value is PlatformHeatmap) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformWeightedLatLng) {
+    } else if (value is PlatformHeatmapGradient) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformInfoWindow) {
+    } else if (value is PlatformWeightedLatLng) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCluster) {
+    } else if (value is PlatformInfoWindow) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformClusterManager) {
+    } else if (value is PlatformCluster) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMarker) {
+    } else if (value is PlatformClusterManager) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolygon) {
+    } else if (value is PlatformMarker) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolyline) {
+    } else if (value is PlatformPolygon) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPatternItem) {
+    } else if (value is PlatformPolyline) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTile) {
+    } else if (value is PlatformPatternItem) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileOverlay) {
+    } else if (value is PlatformTile) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformEdgeInsets) {
+    } else if (value is PlatformTileOverlay) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLng) {
+    } else if (value is PlatformEdgeInsets) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLngBounds) {
+    } else if (value is PlatformLatLng) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraTargetBounds) {
+    } else if (value is PlatformLatLngBounds) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformGroundOverlay) {
+    } else if (value is PlatformCameraTargetBounds) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapViewCreationParams) {
+    } else if (value is PlatformGroundOverlay) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapConfiguration) {
+    } else if (value is PlatformMapViewCreationParams) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPoint) {
+    } else if (value is PlatformMapConfiguration) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformSize) {
+    } else if (value is PlatformPoint) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformColor) {
+    } else if (value is PlatformSize) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileLayer) {
+    } else if (value is PlatformColor) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformZoomRange) {
+    } else if (value is PlatformTileLayer) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmap) {
+    } else if (value is PlatformZoomRange) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapDefaultMarker) {
+    } else if (value is PlatformBitmap) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytes) {
+    } else if (value is PlatformBitmapDefaultMarker) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAsset) {
+    } else if (value is PlatformBitmapBytes) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetImage) {
+    } else if (value is PlatformBitmapAsset) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetMap) {
+    } else if (value is PlatformBitmapAssetImage) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytesMap) {
+    } else if (value is PlatformBitmapAssetMap) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapPinConfig) {
+    } else if (value is PlatformBitmapBytesMap) {
       buffer.putUint8(177);
+      writeValue(buffer, value.encode());
+    } else if (value is PlatformBitmapPinConfig) {
+      buffer.putUint8(178);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -2519,92 +2530,95 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PlatformMarkerType.values[value];
       case 134:
         final value = readValue(buffer) as int?;
-        return value == null ? null : PlatformMapBitmapScaling.values[value];
+        return value == null ? null : PlatformMapColorScheme.values[value];
       case 135:
-        return PlatformCameraPosition.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : PlatformMapBitmapScaling.values[value];
       case 136:
-        return PlatformCameraUpdate.decode(readValue(buffer)!);
+        return PlatformCameraPosition.decode(readValue(buffer)!);
       case 137:
-        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
+        return PlatformCameraUpdate.decode(readValue(buffer)!);
       case 138:
-        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
       case 139:
-        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
       case 140:
-        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
       case 141:
-        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
       case 142:
-        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
       case 143:
-        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
       case 144:
-        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
       case 145:
-        return PlatformCircle.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
       case 146:
-        return PlatformHeatmap.decode(readValue(buffer)!);
+        return PlatformCircle.decode(readValue(buffer)!);
       case 147:
-        return PlatformHeatmapGradient.decode(readValue(buffer)!);
+        return PlatformHeatmap.decode(readValue(buffer)!);
       case 148:
-        return PlatformWeightedLatLng.decode(readValue(buffer)!);
+        return PlatformHeatmapGradient.decode(readValue(buffer)!);
       case 149:
-        return PlatformInfoWindow.decode(readValue(buffer)!);
+        return PlatformWeightedLatLng.decode(readValue(buffer)!);
       case 150:
-        return PlatformCluster.decode(readValue(buffer)!);
+        return PlatformInfoWindow.decode(readValue(buffer)!);
       case 151:
-        return PlatformClusterManager.decode(readValue(buffer)!);
+        return PlatformCluster.decode(readValue(buffer)!);
       case 152:
-        return PlatformMarker.decode(readValue(buffer)!);
+        return PlatformClusterManager.decode(readValue(buffer)!);
       case 153:
-        return PlatformPolygon.decode(readValue(buffer)!);
+        return PlatformMarker.decode(readValue(buffer)!);
       case 154:
-        return PlatformPolyline.decode(readValue(buffer)!);
+        return PlatformPolygon.decode(readValue(buffer)!);
       case 155:
-        return PlatformPatternItem.decode(readValue(buffer)!);
+        return PlatformPolyline.decode(readValue(buffer)!);
       case 156:
-        return PlatformTile.decode(readValue(buffer)!);
+        return PlatformPatternItem.decode(readValue(buffer)!);
       case 157:
-        return PlatformTileOverlay.decode(readValue(buffer)!);
+        return PlatformTile.decode(readValue(buffer)!);
       case 158:
-        return PlatformEdgeInsets.decode(readValue(buffer)!);
+        return PlatformTileOverlay.decode(readValue(buffer)!);
       case 159:
-        return PlatformLatLng.decode(readValue(buffer)!);
+        return PlatformEdgeInsets.decode(readValue(buffer)!);
       case 160:
-        return PlatformLatLngBounds.decode(readValue(buffer)!);
+        return PlatformLatLng.decode(readValue(buffer)!);
       case 161:
-        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
+        return PlatformLatLngBounds.decode(readValue(buffer)!);
       case 162:
-        return PlatformGroundOverlay.decode(readValue(buffer)!);
+        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
       case 163:
-        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
+        return PlatformGroundOverlay.decode(readValue(buffer)!);
       case 164:
-        return PlatformMapConfiguration.decode(readValue(buffer)!);
+        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
       case 165:
-        return PlatformPoint.decode(readValue(buffer)!);
+        return PlatformMapConfiguration.decode(readValue(buffer)!);
       case 166:
-        return PlatformSize.decode(readValue(buffer)!);
+        return PlatformPoint.decode(readValue(buffer)!);
       case 167:
-        return PlatformColor.decode(readValue(buffer)!);
+        return PlatformSize.decode(readValue(buffer)!);
       case 168:
-        return PlatformTileLayer.decode(readValue(buffer)!);
+        return PlatformColor.decode(readValue(buffer)!);
       case 169:
-        return PlatformZoomRange.decode(readValue(buffer)!);
+        return PlatformTileLayer.decode(readValue(buffer)!);
       case 170:
-        return PlatformBitmap.decode(readValue(buffer)!);
+        return PlatformZoomRange.decode(readValue(buffer)!);
       case 171:
-        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
+        return PlatformBitmap.decode(readValue(buffer)!);
       case 172:
-        return PlatformBitmapBytes.decode(readValue(buffer)!);
+        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
       case 173:
-        return PlatformBitmapAsset.decode(readValue(buffer)!);
+        return PlatformBitmapBytes.decode(readValue(buffer)!);
       case 174:
-        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
+        return PlatformBitmapAsset.decode(readValue(buffer)!);
       case 175:
-        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
       case 176:
-        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
       case 177:
+        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+      case 178:
         return PlatformBitmapPinConfig.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pigeons/messages.dart
@@ -449,6 +449,9 @@ class PlatformMapViewCreationParams {
 
 enum PlatformMarkerType { marker, advancedMarker }
 
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
+
 /// Pigeon equivalent of MapConfiguration.
 class PlatformMapConfiguration {
   PlatformMapConfiguration({
@@ -470,6 +473,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     required this.mapId,
     required this.style,
+    required this.colorScheme,
   });
 
   final bool? compassEnabled;
@@ -490,6 +494,7 @@ class PlatformMapConfiguration {
   final PlatformMarkerType markerType;
   final String? mapId;
   final String? style;
+  final PlatformMapColorScheme? colorScheme;
 }
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios_sdk10
 description: iOS implementation of the google_maps_flutter plugin using Google Maps SDK 10.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios_sdk10
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.5
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.15.0
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/test/google_maps_flutter_ios_test.dart
@@ -1311,6 +1311,109 @@ void main() {
       );
     });
   });
+
+  group('colorScheme in creationParams', () {
+    Future<PlatformMapColorScheme?> getColorSchemeFromCreationParams(
+      WidgetTester tester,
+      MapColorScheme? colorScheme,
+    ) async {
+      final passedColorSchemeCompleter = Completer<PlatformMapColorScheme?>();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform_views,
+        (MethodCall methodCall) {
+          if (methodCall.method == 'create') {
+            final args = Map<String, dynamic>.from(methodCall.arguments as Map<dynamic, dynamic>);
+            if (args.containsKey('params')) {
+              final paramsUint8List = args['params'] as Uint8List;
+              final byteData = ByteData.sublistView(paramsUint8List);
+              final creationParams =
+                  MapsApi.pigeonChannelCodec.decodeMessage(byteData)
+                      as PlatformMapViewCreationParams?;
+              if (creationParams != null && !passedColorSchemeCompleter.isCompleted) {
+                passedColorSchemeCompleter.complete(creationParams.mapConfiguration.colorScheme);
+              }
+            }
+          }
+          return null;
+        },
+      );
+
+      final maps = GoogleMapsFlutterIOS();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: maps.buildViewWithConfiguration(
+            1,
+            (int _) {},
+            widgetConfiguration: const MapWidgetConfiguration(
+              initialCameraPosition: CameraPosition(target: LatLng(0, 0), zoom: 1),
+              textDirection: TextDirection.ltr,
+            ),
+            mapConfiguration: MapConfiguration(colorScheme: colorScheme),
+          ),
+        ),
+      );
+
+      return passedColorSchemeCompleter.future;
+    }
+
+    testWidgets('passes light when MapColorScheme.light is set', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.light,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.light,
+        reason: 'Should pass light on PlatformView creation when MapColorScheme.light is set',
+      );
+    });
+
+    testWidgets('passes dark when MapColorScheme.dark is set', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.dark,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.dark,
+        reason: 'Should pass dark on PlatformView creation when MapColorScheme.dark is set',
+      );
+    });
+
+    testWidgets('passes followSystem when MapColorScheme.followSystem is set', (
+      WidgetTester tester,
+    ) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.followSystem,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.followSystem,
+        reason:
+            'Should pass followSystem on PlatformView creation when MapColorScheme.followSystem is set',
+      );
+    });
+
+    testWidgets('passes null when colorScheme is null', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        null,
+      );
+
+      expect(
+        passedColorScheme,
+        isNull,
+        reason: 'Should default to null on PlatformView creation when colorScheme is null',
+      );
+    });
+  });
 }
 
 void _expectColorsEqual(PlatformColor actual, Color expected) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds `colorScheme` support for cloud-based maps styling brightness.
+
 ## 2.18.6
 
 * Fixes a potential compilation issue in tile downscaling.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerTests/GoogleMapsTests.m
@@ -222,6 +222,56 @@
   XCTAssertEqual(cameraPosition.zoom, initialCameraPosition.zoom);
 }
 
+- (void)testSetMapColorScheme {
+  CGRect frame = CGRectMake(0, 0, 100, 100);
+  GMSMapViewOptions *options = [[GMSMapViewOptions alloc] init];
+  options.frame = frame;
+  options.camera = [[GMSCameraPosition alloc] initWithLatitude:0 longitude:0 zoom:0];
+  PartiallyMockedMapView *mapView = [[PartiallyMockedMapView alloc] initWithOptions:options];
+  FGMGoogleMapController *controller =
+      [[FGMGoogleMapController alloc] initWithMapView:mapView
+                                       viewIdentifier:0
+                                   creationParameters:[self emptyCreationParameters]
+                                        assetProvider:[[TestAssetProvider alloc] init]
+                                      binaryMessenger:[[StubBinaryMessenger alloc] init]];
+  FlutterError *error = nil;
+
+  // Light. Start from a different style so the assertion confirms a real change.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *lightConfig = [self emptyCreationParameters].mapConfiguration;
+  lightConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeLight];
+  [controller.callHandler updateWithMapConfiguration:lightConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleLight);
+
+  // Dark.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+  FGMPlatformMapConfiguration *darkConfig = [self emptyCreationParameters].mapConfiguration;
+  darkConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeDark];
+  [controller.callHandler updateWithMapConfiguration:darkConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+
+  // followSystem maps to "unspecified", letting the system drive appearance.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *followConfig = [self emptyCreationParameters].mapConfiguration;
+  followConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeFollowSystem];
+  [controller.callHandler updateWithMapConfiguration:followConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleUnspecified);
+
+  // A configuration with no color scheme must not change the interface style.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *noSchemeConfig = [self emptyCreationParameters].mapConfiguration;
+  noSchemeConfig.colorScheme = nil;
+  [controller.callHandler updateWithMapConfiguration:noSchemeConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+}
+
 /// Creates an empty creation paramaters object for tests where the values don't matter, just that
 /// there's a valid object to pass in.
 - (FGMPlatformMapViewCreationParams *)emptyCreationParameters {
@@ -250,7 +300,8 @@
                                                buildingsEnabled:nil
                                                      markerType:FGMPlatformMarkerTypeMarker
                                                           mapId:nil
-                                                          style:nil]
+                                                          style:nil
+                                                    colorScheme:nil]
                      initialCircles:@[]
                      initialMarkers:@[]
                     initialPolygons:@[]

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMGoogleMapController.m
@@ -478,6 +478,20 @@
   self.mapView.settings.myLocationButton = enabled;
 }
 
+- (void)setColorScheme:(FGMPlatformMapColorScheme)colorScheme {
+  switch (colorScheme) {
+    case FGMPlatformMapColorSchemeLight:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+      break;
+    case FGMPlatformMapColorSchemeDark:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+      break;
+    case FGMPlatformMapColorSchemeFollowSystem:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+      break;
+  }
+}
+
 /// Sets the map style, returing any error string as well as storing that error in `mapStyle` for
 /// later access.
 - (NSString *)setMapStyle:(NSString *)mapStyle {
@@ -636,6 +650,10 @@
   NSString *style = config.style;
   if (style) {
     [self setMapStyle:style];
+  }
+  FGMPlatformMapColorSchemeBox *colorScheme = config.colorScheme;
+  if (colorScheme) {
+    [self setColorScheme:colorScheme.value];
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.m
@@ -46,7 +46,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 }
 @end
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 @implementation FGMPlatformMarkerCollisionBehaviorBox
 - (instancetype)initWithValue:(FGMPlatformMarkerCollisionBehavior)value {
   self = [super init];
@@ -81,6 +81,17 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 
 @implementation FGMPlatformMarkerTypeBox
 - (instancetype)initWithValue:(FGMPlatformMarkerType)value {
+  self = [super init];
+  if (self) {
+    _value = value;
+  }
+  return self;
+}
+@end
+
+/// Pigeon equivalent of MapColorScheme.
+@implementation FGMPlatformMapColorSchemeBox
+- (instancetype)initWithValue:(FGMPlatformMapColorScheme)value {
   self = [super init];
   if (self) {
     _value = value;
@@ -1356,7 +1367,8 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
                       buildingsEnabled:(nullable NSNumber *)buildingsEnabled
                             markerType:(FGMPlatformMarkerType)markerType
                                  mapId:(nullable NSString *)mapId
-                                 style:(nullable NSString *)style {
+                                 style:(nullable NSString *)style
+                           colorScheme:(nullable FGMPlatformMapColorSchemeBox *)colorScheme {
   FGMPlatformMapConfiguration *pigeonResult = [[FGMPlatformMapConfiguration alloc] init];
   pigeonResult.compassEnabled = compassEnabled;
   pigeonResult.cameraTargetBounds = cameraTargetBounds;
@@ -1376,6 +1388,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.markerType = markerType;
   pigeonResult.mapId = mapId;
   pigeonResult.style = style;
+  pigeonResult.colorScheme = colorScheme;
   return pigeonResult;
 }
 + (FGMPlatformMapConfiguration *)fromList:(NSArray<id> *)list {
@@ -1399,6 +1412,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.markerType = boxedFGMPlatformMarkerType.value;
   pigeonResult.mapId = GetNullableObjectAtIndex(list, 16);
   pigeonResult.style = GetNullableObjectAtIndex(list, 17);
+  pigeonResult.colorScheme = GetNullableObjectAtIndex(list, 18);
   return pigeonResult;
 }
 + (nullable FGMPlatformMapConfiguration *)nullableFromList:(NSArray<id> *)list {
@@ -1424,6 +1438,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     [[FGMPlatformMarkerTypeBox alloc] initWithValue:self.markerType],
     self.mapId ?: [NSNull null],
     self.style ?: [NSNull null],
+    self.colorScheme ?: [NSNull null],
   ];
 }
 @end
@@ -1839,95 +1854,101 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     }
     case 134: {
       NSNumber *enumAsNumber = [self readValue];
+      return enumAsNumber == nil
+                 ? nil
+                 : [[FGMPlatformMapColorSchemeBox alloc] initWithValue:[enumAsNumber integerValue]];
+    }
+    case 135: {
+      NSNumber *enumAsNumber = [self readValue];
       return enumAsNumber == nil ? nil
                                  : [[FGMPlatformMapBitmapScalingBox alloc]
                                        initWithValue:[enumAsNumber integerValue]];
     }
-    case 135:
-      return [FGMPlatformCameraPosition fromList:[self readValue]];
     case 136:
-      return [FGMPlatformCameraUpdate fromList:[self readValue]];
+      return [FGMPlatformCameraPosition fromList:[self readValue]];
     case 137:
-      return [FGMPlatformCameraUpdateNewCameraPosition fromList:[self readValue]];
+      return [FGMPlatformCameraUpdate fromList:[self readValue]];
     case 138:
-      return [FGMPlatformCameraUpdateNewLatLng fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewCameraPosition fromList:[self readValue]];
     case 139:
-      return [FGMPlatformCameraUpdateNewLatLngBounds fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLng fromList:[self readValue]];
     case 140:
-      return [FGMPlatformCameraUpdateNewLatLngZoom fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLngBounds fromList:[self readValue]];
     case 141:
-      return [FGMPlatformCameraUpdateScrollBy fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLngZoom fromList:[self readValue]];
     case 142:
-      return [FGMPlatformCameraUpdateZoomBy fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateScrollBy fromList:[self readValue]];
     case 143:
-      return [FGMPlatformCameraUpdateZoom fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoomBy fromList:[self readValue]];
     case 144:
-      return [FGMPlatformCameraUpdateZoomTo fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoom fromList:[self readValue]];
     case 145:
-      return [FGMPlatformCircle fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoomTo fromList:[self readValue]];
     case 146:
-      return [FGMPlatformHeatmap fromList:[self readValue]];
+      return [FGMPlatformCircle fromList:[self readValue]];
     case 147:
-      return [FGMPlatformHeatmapGradient fromList:[self readValue]];
+      return [FGMPlatformHeatmap fromList:[self readValue]];
     case 148:
-      return [FGMPlatformWeightedLatLng fromList:[self readValue]];
+      return [FGMPlatformHeatmapGradient fromList:[self readValue]];
     case 149:
-      return [FGMPlatformInfoWindow fromList:[self readValue]];
+      return [FGMPlatformWeightedLatLng fromList:[self readValue]];
     case 150:
-      return [FGMPlatformCluster fromList:[self readValue]];
+      return [FGMPlatformInfoWindow fromList:[self readValue]];
     case 151:
-      return [FGMPlatformClusterManager fromList:[self readValue]];
+      return [FGMPlatformCluster fromList:[self readValue]];
     case 152:
-      return [FGMPlatformMarker fromList:[self readValue]];
+      return [FGMPlatformClusterManager fromList:[self readValue]];
     case 153:
-      return [FGMPlatformPolygon fromList:[self readValue]];
+      return [FGMPlatformMarker fromList:[self readValue]];
     case 154:
-      return [FGMPlatformPolyline fromList:[self readValue]];
+      return [FGMPlatformPolygon fromList:[self readValue]];
     case 155:
-      return [FGMPlatformPatternItem fromList:[self readValue]];
+      return [FGMPlatformPolyline fromList:[self readValue]];
     case 156:
-      return [FGMPlatformTile fromList:[self readValue]];
+      return [FGMPlatformPatternItem fromList:[self readValue]];
     case 157:
-      return [FGMPlatformTileOverlay fromList:[self readValue]];
+      return [FGMPlatformTile fromList:[self readValue]];
     case 158:
-      return [FGMPlatformEdgeInsets fromList:[self readValue]];
+      return [FGMPlatformTileOverlay fromList:[self readValue]];
     case 159:
-      return [FGMPlatformLatLng fromList:[self readValue]];
+      return [FGMPlatformEdgeInsets fromList:[self readValue]];
     case 160:
-      return [FGMPlatformLatLngBounds fromList:[self readValue]];
+      return [FGMPlatformLatLng fromList:[self readValue]];
     case 161:
-      return [FGMPlatformCameraTargetBounds fromList:[self readValue]];
+      return [FGMPlatformLatLngBounds fromList:[self readValue]];
     case 162:
-      return [FGMPlatformGroundOverlay fromList:[self readValue]];
+      return [FGMPlatformCameraTargetBounds fromList:[self readValue]];
     case 163:
-      return [FGMPlatformMapViewCreationParams fromList:[self readValue]];
+      return [FGMPlatformGroundOverlay fromList:[self readValue]];
     case 164:
-      return [FGMPlatformMapConfiguration fromList:[self readValue]];
+      return [FGMPlatformMapViewCreationParams fromList:[self readValue]];
     case 165:
-      return [FGMPlatformPoint fromList:[self readValue]];
+      return [FGMPlatformMapConfiguration fromList:[self readValue]];
     case 166:
-      return [FGMPlatformSize fromList:[self readValue]];
+      return [FGMPlatformPoint fromList:[self readValue]];
     case 167:
-      return [FGMPlatformColor fromList:[self readValue]];
+      return [FGMPlatformSize fromList:[self readValue]];
     case 168:
-      return [FGMPlatformTileLayer fromList:[self readValue]];
+      return [FGMPlatformColor fromList:[self readValue]];
     case 169:
-      return [FGMPlatformZoomRange fromList:[self readValue]];
+      return [FGMPlatformTileLayer fromList:[self readValue]];
     case 170:
-      return [FGMPlatformBitmap fromList:[self readValue]];
+      return [FGMPlatformZoomRange fromList:[self readValue]];
     case 171:
-      return [FGMPlatformBitmapDefaultMarker fromList:[self readValue]];
+      return [FGMPlatformBitmap fromList:[self readValue]];
     case 172:
-      return [FGMPlatformBitmapBytes fromList:[self readValue]];
+      return [FGMPlatformBitmapDefaultMarker fromList:[self readValue]];
     case 173:
-      return [FGMPlatformBitmapAsset fromList:[self readValue]];
+      return [FGMPlatformBitmapBytes fromList:[self readValue]];
     case 174:
-      return [FGMPlatformBitmapAssetImage fromList:[self readValue]];
+      return [FGMPlatformBitmapAsset fromList:[self readValue]];
     case 175:
-      return [FGMPlatformBitmapAssetMap fromList:[self readValue]];
+      return [FGMPlatformBitmapAssetImage fromList:[self readValue]];
     case 176:
-      return [FGMPlatformBitmapBytesMap fromList:[self readValue]];
+      return [FGMPlatformBitmapAssetMap fromList:[self readValue]];
     case 177:
+      return [FGMPlatformBitmapBytesMap fromList:[self readValue]];
+    case 178:
       return [FGMPlatformBitmapPinConfig fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
@@ -1959,138 +1980,142 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     FGMPlatformMarkerTypeBox *box = (FGMPlatformMarkerTypeBox *)value;
     [self writeByte:133];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[FGMPlatformMapBitmapScalingBox class]]) {
-    FGMPlatformMapBitmapScalingBox *box = (FGMPlatformMapBitmapScalingBox *)value;
+  } else if ([value isKindOfClass:[FGMPlatformMapColorSchemeBox class]]) {
+    FGMPlatformMapColorSchemeBox *box = (FGMPlatformMapColorSchemeBox *)value;
     [self writeByte:134];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[FGMPlatformCameraPosition class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapBitmapScalingBox class]]) {
+    FGMPlatformMapBitmapScalingBox *box = (FGMPlatformMapBitmapScalingBox *)value;
     [self writeByte:135];
-    [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdate class]]) {
+    [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
+  } else if ([value isKindOfClass:[FGMPlatformCameraPosition class]]) {
     [self writeByte:136];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewCameraPosition class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdate class]]) {
     [self writeByte:137];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewCameraPosition class]]) {
     [self writeByte:138];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLng class]]) {
     [self writeByte:139];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngZoom class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngBounds class]]) {
     [self writeByte:140];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateScrollBy class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngZoom class]]) {
     [self writeByte:141];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomBy class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateScrollBy class]]) {
     [self writeByte:142];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoom class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomBy class]]) {
     [self writeByte:143];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomTo class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoom class]]) {
     [self writeByte:144];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCircle class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomTo class]]) {
     [self writeByte:145];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformHeatmap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCircle class]]) {
     [self writeByte:146];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformHeatmapGradient class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformHeatmap class]]) {
     [self writeByte:147];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformWeightedLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformHeatmapGradient class]]) {
     [self writeByte:148];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformInfoWindow class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformWeightedLatLng class]]) {
     [self writeByte:149];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCluster class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformInfoWindow class]]) {
     [self writeByte:150];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformClusterManager class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCluster class]]) {
     [self writeByte:151];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMarker class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformClusterManager class]]) {
     [self writeByte:152];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPolygon class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMarker class]]) {
     [self writeByte:153];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPolyline class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPolygon class]]) {
     [self writeByte:154];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPatternItem class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPolyline class]]) {
     [self writeByte:155];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTile class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPatternItem class]]) {
     [self writeByte:156];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTileOverlay class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTile class]]) {
     [self writeByte:157];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformEdgeInsets class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTileOverlay class]]) {
     [self writeByte:158];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformEdgeInsets class]]) {
     [self writeByte:159];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformLatLngBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformLatLng class]]) {
     [self writeByte:160];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraTargetBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformLatLngBounds class]]) {
     [self writeByte:161];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformGroundOverlay class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraTargetBounds class]]) {
     [self writeByte:162];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMapViewCreationParams class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformGroundOverlay class]]) {
     [self writeByte:163];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMapConfiguration class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapViewCreationParams class]]) {
     [self writeByte:164];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPoint class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapConfiguration class]]) {
     [self writeByte:165];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformSize class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPoint class]]) {
     [self writeByte:166];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformColor class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformSize class]]) {
     [self writeByte:167];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTileLayer class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformColor class]]) {
     [self writeByte:168];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformZoomRange class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTileLayer class]]) {
     [self writeByte:169];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformZoomRange class]]) {
     [self writeByte:170];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapDefaultMarker class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmap class]]) {
     [self writeByte:171];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapBytes class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapDefaultMarker class]]) {
     [self writeByte:172];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAsset class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapBytes class]]) {
     [self writeByte:173];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetImage class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAsset class]]) {
     [self writeByte:174];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetMap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetImage class]]) {
     [self writeByte:175];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapBytesMap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetMap class]]) {
     [self writeByte:176];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapPinConfig class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapBytesMap class]]) {
     [self writeByte:177];
+    [self writeValue:[value toList]];
+  } else if ([value isKindOfClass:[FGMPlatformBitmapPinConfig class]]) {
+    [self writeByte:178];
     [self writeValue:[value toList]];
   } else {
     [super writeValue:value];

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapType) {
 - (instancetype)initWithValue:(FGMPlatformMapType)value;
 @end
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 typedef NS_ENUM(NSUInteger, FGMPlatformMarkerCollisionBehavior) {
   FGMPlatformMarkerCollisionBehaviorRequiredDisplay = 0,
   FGMPlatformMarkerCollisionBehaviorOptionalAndHidesLowerPriority = 1,
@@ -76,6 +76,19 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMarkerType) {
 @interface FGMPlatformMarkerTypeBox : NSObject
 @property(nonatomic, assign) FGMPlatformMarkerType value;
 - (instancetype)initWithValue:(FGMPlatformMarkerType)value;
+@end
+
+/// Pigeon equivalent of MapColorScheme.
+typedef NS_ENUM(NSUInteger, FGMPlatformMapColorScheme) {
+  FGMPlatformMapColorSchemeLight = 0,
+  FGMPlatformMapColorSchemeDark = 1,
+  FGMPlatformMapColorSchemeFollowSystem = 2,
+};
+
+/// Wrapper for FGMPlatformMapColorScheme to allow for nullability.
+@interface FGMPlatformMapColorSchemeBox : NSObject
+@property(nonatomic, assign) FGMPlatformMapColorScheme value;
+- (instancetype)initWithValue:(FGMPlatformMapColorScheme)value;
 @end
 
 /// Pigeon equivalent of [MapBitmapScaling].
@@ -573,7 +586,8 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapBitmapScaling) {
                       buildingsEnabled:(nullable NSNumber *)buildingsEnabled
                             markerType:(FGMPlatformMarkerType)markerType
                                  mapId:(nullable NSString *)mapId
-                                 style:(nullable NSString *)style;
+                                 style:(nullable NSString *)style
+                           colorScheme:(nullable FGMPlatformMapColorSchemeBox *)colorScheme;
 @property(nonatomic, strong, nullable) NSNumber *compassEnabled;
 @property(nonatomic, strong, nullable) FGMPlatformCameraTargetBounds *cameraTargetBounds;
 @property(nonatomic, strong, nullable) FGMPlatformMapTypeBox *mapType;
@@ -592,6 +606,7 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapBitmapScaling) {
 @property(nonatomic, assign) FGMPlatformMarkerType markerType;
 @property(nonatomic, copy, nullable) NSString *mapId;
 @property(nonatomic, copy, nullable) NSString *style;
+@property(nonatomic, strong, nullable) FGMPlatformMapColorSchemeBox *colorScheme;
 @end
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/google_maps_flutter_ios.dart
@@ -1162,6 +1162,7 @@ PlatformMapConfiguration _platformMapConfigurationFromMapConfiguration(MapConfig
     markerType: _platformMarkerTypeFromMarkerType(config.markerType ?? MarkerType.marker),
     mapId: config.mapId,
     style: config.style,
+    colorScheme: _platformMapColorSchemeFromMapColorScheme(config.colorScheme),
   );
 }
 
@@ -1180,6 +1181,26 @@ PlatformMarkerType _platformMarkerTypeFromMarkerType(MarkerType markerType) {
   // switch as needing an update.
   // ignore: dead_code
   throw UnimplementedError('MarkerType "$markerType" has not been implemented');
+}
+
+PlatformMapColorScheme? _platformMapColorSchemeFromMapColorScheme(MapColorScheme? colorScheme) {
+  if (colorScheme == null) {
+    return null;
+  }
+  switch (colorScheme) {
+    case MapColorScheme.light:
+      return PlatformMapColorScheme.light;
+    case MapColorScheme.dark:
+      return PlatformMapColorScheme.dark;
+    case MapColorScheme.followSystem:
+      return PlatformMapColorScheme.followSystem;
+    // The enum comes from a different package, which could get a new value at
+    // any time, so provide a fallback that ensures this won't break when used
+    // with a version that contains new values.
+    // ignore: no_default_cases, unreachable_switch_default
+    default:
+      throw UnimplementedError('MapColorScheme "$colorScheme" has not been implemented');
+  }
 }
 
 // For supporting the deprecated updateMapOptions API.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/messages.g.dart
@@ -47,7 +47,7 @@ bool _deepEquals(Object? a, Object? b) {
 /// Pigeon equivalent of MapType
 enum PlatformMapType { none, normal, satellite, terrain, hybrid }
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 enum PlatformMarkerCollisionBehavior {
   requiredDisplay,
   optionalAndHidesLowerPriority,
@@ -61,6 +61,9 @@ enum PlatformJointType { mitered, bevel, round }
 enum PlatformPatternItemType { dot, dash, gap }
 
 enum PlatformMarkerType { marker, advancedMarker }
+
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
 
 /// Pigeon equivalent of [MapBitmapScaling].
 enum PlatformMapBitmapScaling { auto, none }
@@ -1641,6 +1644,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     this.mapId,
     this.style,
+    this.colorScheme,
   });
 
   bool? compassEnabled;
@@ -1679,6 +1683,8 @@ class PlatformMapConfiguration {
 
   String? style;
 
+  PlatformMapColorScheme? colorScheme;
+
   List<Object?> _toList() {
     return <Object?>[
       compassEnabled,
@@ -1699,6 +1705,7 @@ class PlatformMapConfiguration {
       markerType,
       mapId,
       style,
+      colorScheme,
     ];
   }
 
@@ -1727,6 +1734,7 @@ class PlatformMapConfiguration {
       markerType: result[15]! as PlatformMarkerType,
       mapId: result[16] as String?,
       style: result[17] as String?,
+      colorScheme: result[18] as PlatformMapColorScheme?,
     );
   }
 
@@ -2362,137 +2370,140 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PlatformMarkerType) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is PlatformMapBitmapScaling) {
+    } else if (value is PlatformMapColorScheme) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    } else if (value is PlatformCameraPosition) {
+    } else if (value is PlatformMapBitmapScaling) {
       buffer.putUint8(135);
-      writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdate) {
+      writeValue(buffer, value.index);
+    } else if (value is PlatformCameraPosition) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewCameraPosition) {
+    } else if (value is PlatformCameraUpdate) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLng) {
+    } else if (value is PlatformCameraUpdateNewCameraPosition) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
+    } else if (value is PlatformCameraUpdateNewLatLng) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
+    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateScrollBy) {
+    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomBy) {
+    } else if (value is PlatformCameraUpdateScrollBy) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoom) {
+    } else if (value is PlatformCameraUpdateZoomBy) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomTo) {
+    } else if (value is PlatformCameraUpdateZoom) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCircle) {
+    } else if (value is PlatformCameraUpdateZoomTo) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmap) {
+    } else if (value is PlatformCircle) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmapGradient) {
+    } else if (value is PlatformHeatmap) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformWeightedLatLng) {
+    } else if (value is PlatformHeatmapGradient) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformInfoWindow) {
+    } else if (value is PlatformWeightedLatLng) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCluster) {
+    } else if (value is PlatformInfoWindow) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformClusterManager) {
+    } else if (value is PlatformCluster) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMarker) {
+    } else if (value is PlatformClusterManager) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolygon) {
+    } else if (value is PlatformMarker) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolyline) {
+    } else if (value is PlatformPolygon) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPatternItem) {
+    } else if (value is PlatformPolyline) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTile) {
+    } else if (value is PlatformPatternItem) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileOverlay) {
+    } else if (value is PlatformTile) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformEdgeInsets) {
+    } else if (value is PlatformTileOverlay) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLng) {
+    } else if (value is PlatformEdgeInsets) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLngBounds) {
+    } else if (value is PlatformLatLng) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraTargetBounds) {
+    } else if (value is PlatformLatLngBounds) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformGroundOverlay) {
+    } else if (value is PlatformCameraTargetBounds) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapViewCreationParams) {
+    } else if (value is PlatformGroundOverlay) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapConfiguration) {
+    } else if (value is PlatformMapViewCreationParams) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPoint) {
+    } else if (value is PlatformMapConfiguration) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformSize) {
+    } else if (value is PlatformPoint) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformColor) {
+    } else if (value is PlatformSize) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileLayer) {
+    } else if (value is PlatformColor) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformZoomRange) {
+    } else if (value is PlatformTileLayer) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmap) {
+    } else if (value is PlatformZoomRange) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapDefaultMarker) {
+    } else if (value is PlatformBitmap) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytes) {
+    } else if (value is PlatformBitmapDefaultMarker) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAsset) {
+    } else if (value is PlatformBitmapBytes) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetImage) {
+    } else if (value is PlatformBitmapAsset) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetMap) {
+    } else if (value is PlatformBitmapAssetImage) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytesMap) {
+    } else if (value is PlatformBitmapAssetMap) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapPinConfig) {
+    } else if (value is PlatformBitmapBytesMap) {
       buffer.putUint8(177);
+      writeValue(buffer, value.encode());
+    } else if (value is PlatformBitmapPinConfig) {
+      buffer.putUint8(178);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -2519,92 +2530,95 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PlatformMarkerType.values[value];
       case 134:
         final value = readValue(buffer) as int?;
-        return value == null ? null : PlatformMapBitmapScaling.values[value];
+        return value == null ? null : PlatformMapColorScheme.values[value];
       case 135:
-        return PlatformCameraPosition.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : PlatformMapBitmapScaling.values[value];
       case 136:
-        return PlatformCameraUpdate.decode(readValue(buffer)!);
+        return PlatformCameraPosition.decode(readValue(buffer)!);
       case 137:
-        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
+        return PlatformCameraUpdate.decode(readValue(buffer)!);
       case 138:
-        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
       case 139:
-        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
       case 140:
-        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
       case 141:
-        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
       case 142:
-        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
       case 143:
-        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
       case 144:
-        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
       case 145:
-        return PlatformCircle.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
       case 146:
-        return PlatformHeatmap.decode(readValue(buffer)!);
+        return PlatformCircle.decode(readValue(buffer)!);
       case 147:
-        return PlatformHeatmapGradient.decode(readValue(buffer)!);
+        return PlatformHeatmap.decode(readValue(buffer)!);
       case 148:
-        return PlatformWeightedLatLng.decode(readValue(buffer)!);
+        return PlatformHeatmapGradient.decode(readValue(buffer)!);
       case 149:
-        return PlatformInfoWindow.decode(readValue(buffer)!);
+        return PlatformWeightedLatLng.decode(readValue(buffer)!);
       case 150:
-        return PlatformCluster.decode(readValue(buffer)!);
+        return PlatformInfoWindow.decode(readValue(buffer)!);
       case 151:
-        return PlatformClusterManager.decode(readValue(buffer)!);
+        return PlatformCluster.decode(readValue(buffer)!);
       case 152:
-        return PlatformMarker.decode(readValue(buffer)!);
+        return PlatformClusterManager.decode(readValue(buffer)!);
       case 153:
-        return PlatformPolygon.decode(readValue(buffer)!);
+        return PlatformMarker.decode(readValue(buffer)!);
       case 154:
-        return PlatformPolyline.decode(readValue(buffer)!);
+        return PlatformPolygon.decode(readValue(buffer)!);
       case 155:
-        return PlatformPatternItem.decode(readValue(buffer)!);
+        return PlatformPolyline.decode(readValue(buffer)!);
       case 156:
-        return PlatformTile.decode(readValue(buffer)!);
+        return PlatformPatternItem.decode(readValue(buffer)!);
       case 157:
-        return PlatformTileOverlay.decode(readValue(buffer)!);
+        return PlatformTile.decode(readValue(buffer)!);
       case 158:
-        return PlatformEdgeInsets.decode(readValue(buffer)!);
+        return PlatformTileOverlay.decode(readValue(buffer)!);
       case 159:
-        return PlatformLatLng.decode(readValue(buffer)!);
+        return PlatformEdgeInsets.decode(readValue(buffer)!);
       case 160:
-        return PlatformLatLngBounds.decode(readValue(buffer)!);
+        return PlatformLatLng.decode(readValue(buffer)!);
       case 161:
-        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
+        return PlatformLatLngBounds.decode(readValue(buffer)!);
       case 162:
-        return PlatformGroundOverlay.decode(readValue(buffer)!);
+        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
       case 163:
-        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
+        return PlatformGroundOverlay.decode(readValue(buffer)!);
       case 164:
-        return PlatformMapConfiguration.decode(readValue(buffer)!);
+        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
       case 165:
-        return PlatformPoint.decode(readValue(buffer)!);
+        return PlatformMapConfiguration.decode(readValue(buffer)!);
       case 166:
-        return PlatformSize.decode(readValue(buffer)!);
+        return PlatformPoint.decode(readValue(buffer)!);
       case 167:
-        return PlatformColor.decode(readValue(buffer)!);
+        return PlatformSize.decode(readValue(buffer)!);
       case 168:
-        return PlatformTileLayer.decode(readValue(buffer)!);
+        return PlatformColor.decode(readValue(buffer)!);
       case 169:
-        return PlatformZoomRange.decode(readValue(buffer)!);
+        return PlatformTileLayer.decode(readValue(buffer)!);
       case 170:
-        return PlatformBitmap.decode(readValue(buffer)!);
+        return PlatformZoomRange.decode(readValue(buffer)!);
       case 171:
-        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
+        return PlatformBitmap.decode(readValue(buffer)!);
       case 172:
-        return PlatformBitmapBytes.decode(readValue(buffer)!);
+        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
       case 173:
-        return PlatformBitmapAsset.decode(readValue(buffer)!);
+        return PlatformBitmapBytes.decode(readValue(buffer)!);
       case 174:
-        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
+        return PlatformBitmapAsset.decode(readValue(buffer)!);
       case 175:
-        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
       case 176:
-        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
       case 177:
+        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+      case 178:
         return PlatformBitmapPinConfig.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pigeons/messages.dart
@@ -449,6 +449,9 @@ class PlatformMapViewCreationParams {
 
 enum PlatformMarkerType { marker, advancedMarker }
 
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
+
 /// Pigeon equivalent of MapConfiguration.
 class PlatformMapConfiguration {
   PlatformMapConfiguration({
@@ -470,6 +473,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     required this.mapId,
     required this.style,
+    required this.colorScheme,
   });
 
   final bool? compassEnabled;
@@ -490,6 +494,7 @@ class PlatformMapConfiguration {
   final PlatformMarkerType markerType;
   final String? mapId;
   final String? style;
+  final PlatformMapColorScheme? colorScheme;
 }
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios_sdk9
 description: iOS implementation of the google_maps_flutter plugin using Google Maps SDK 9.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios_sdk9
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.6
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.15.0
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/test/google_maps_flutter_ios_test.dart
@@ -1311,6 +1311,109 @@ void main() {
       );
     });
   });
+
+  group('colorScheme in creationParams', () {
+    Future<PlatformMapColorScheme?> getColorSchemeFromCreationParams(
+      WidgetTester tester,
+      MapColorScheme? colorScheme,
+    ) async {
+      final passedColorSchemeCompleter = Completer<PlatformMapColorScheme?>();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform_views,
+        (MethodCall methodCall) {
+          if (methodCall.method == 'create') {
+            final args = Map<String, dynamic>.from(methodCall.arguments as Map<dynamic, dynamic>);
+            if (args.containsKey('params')) {
+              final paramsUint8List = args['params'] as Uint8List;
+              final byteData = ByteData.sublistView(paramsUint8List);
+              final creationParams =
+                  MapsApi.pigeonChannelCodec.decodeMessage(byteData)
+                      as PlatformMapViewCreationParams?;
+              if (creationParams != null && !passedColorSchemeCompleter.isCompleted) {
+                passedColorSchemeCompleter.complete(creationParams.mapConfiguration.colorScheme);
+              }
+            }
+          }
+          return null;
+        },
+      );
+
+      final maps = GoogleMapsFlutterIOS();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: maps.buildViewWithConfiguration(
+            1,
+            (int _) {},
+            widgetConfiguration: const MapWidgetConfiguration(
+              initialCameraPosition: CameraPosition(target: LatLng(0, 0), zoom: 1),
+              textDirection: TextDirection.ltr,
+            ),
+            mapConfiguration: MapConfiguration(colorScheme: colorScheme),
+          ),
+        ),
+      );
+
+      return passedColorSchemeCompleter.future;
+    }
+
+    testWidgets('passes light when MapColorScheme.light is set', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.light,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.light,
+        reason: 'Should pass light on PlatformView creation when MapColorScheme.light is set',
+      );
+    });
+
+    testWidgets('passes dark when MapColorScheme.dark is set', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.dark,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.dark,
+        reason: 'Should pass dark on PlatformView creation when MapColorScheme.dark is set',
+      );
+    });
+
+    testWidgets('passes followSystem when MapColorScheme.followSystem is set', (
+      WidgetTester tester,
+    ) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.followSystem,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.followSystem,
+        reason:
+            'Should pass followSystem on PlatformView creation when MapColorScheme.followSystem is set',
+      );
+    });
+
+    testWidgets('passes null when colorScheme is null', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        null,
+      );
+
+      expect(
+        passedColorScheme,
+        isNull,
+        reason: 'Should default to null on PlatformView creation when colorScheme is null',
+      );
+    });
+  });
 }
 
 void _expectColorsEqual(PlatformColor actual, Color expected) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerTests/GoogleMapsTests.m
@@ -222,6 +222,56 @@
   XCTAssertEqual(cameraPosition.zoom, initialCameraPosition.zoom);
 }
 
+- (void)testSetMapColorScheme {
+  CGRect frame = CGRectMake(0, 0, 100, 100);
+  GMSMapViewOptions *options = [[GMSMapViewOptions alloc] init];
+  options.frame = frame;
+  options.camera = [[GMSCameraPosition alloc] initWithLatitude:0 longitude:0 zoom:0];
+  PartiallyMockedMapView *mapView = [[PartiallyMockedMapView alloc] initWithOptions:options];
+  FGMGoogleMapController *controller =
+      [[FGMGoogleMapController alloc] initWithMapView:mapView
+                                       viewIdentifier:0
+                                   creationParameters:[self emptyCreationParameters]
+                                        assetProvider:[[TestAssetProvider alloc] init]
+                                      binaryMessenger:[[StubBinaryMessenger alloc] init]];
+  FlutterError *error = nil;
+
+  // Light. Start from a different style so the assertion confirms a real change.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *lightConfig = [self emptyCreationParameters].mapConfiguration;
+  lightConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeLight];
+  [controller.callHandler updateWithMapConfiguration:lightConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleLight);
+
+  // Dark.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+  FGMPlatformMapConfiguration *darkConfig = [self emptyCreationParameters].mapConfiguration;
+  darkConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeDark];
+  [controller.callHandler updateWithMapConfiguration:darkConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+
+  // followSystem maps to "unspecified", letting the system drive appearance.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *followConfig = [self emptyCreationParameters].mapConfiguration;
+  followConfig.colorScheme =
+      [[FGMPlatformMapColorSchemeBox alloc] initWithValue:FGMPlatformMapColorSchemeFollowSystem];
+  [controller.callHandler updateWithMapConfiguration:followConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleUnspecified);
+
+  // A configuration with no color scheme must not change the interface style.
+  mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  FGMPlatformMapConfiguration *noSchemeConfig = [self emptyCreationParameters].mapConfiguration;
+  noSchemeConfig.colorScheme = nil;
+  [controller.callHandler updateWithMapConfiguration:noSchemeConfig error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(mapView.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+}
+
 /// Creates an empty creation paramaters object for tests where the values don't matter, just that
 /// there's a valid object to pass in.
 - (FGMPlatformMapViewCreationParams *)emptyCreationParameters {
@@ -250,7 +300,8 @@
                                                buildingsEnabled:nil
                                                      markerType:FGMPlatformMarkerTypeMarker
                                                           mapId:nil
-                                                          style:nil]
+                                                          style:nil
+                                                    colorScheme:nil]
                      initialCircles:@[]
                      initialMarkers:@[]
                     initialPolygons:@[]

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
@@ -478,6 +478,20 @@
   self.mapView.settings.myLocationButton = enabled;
 }
 
+- (void)setColorScheme:(FGMPlatformMapColorScheme)colorScheme {
+  switch (colorScheme) {
+    case FGMPlatformMapColorSchemeLight:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+      break;
+    case FGMPlatformMapColorSchemeDark:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+      break;
+    case FGMPlatformMapColorSchemeFollowSystem:
+      self.mapView.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+      break;
+  }
+}
+
 /// Sets the map style, returing any error string as well as storing that error in `mapStyle` for
 /// later access.
 - (NSString *)setMapStyle:(NSString *)mapStyle {
@@ -636,6 +650,10 @@
   NSString *style = config.style;
   if (style) {
     [self setMapStyle:style];
+  }
+  FGMPlatformMapColorSchemeBox *colorScheme = config.colorScheme;
+  if (colorScheme) {
+    [self setColorScheme:colorScheme.value];
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
@@ -46,7 +46,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 }
 @end
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 @implementation FGMPlatformMarkerCollisionBehaviorBox
 - (instancetype)initWithValue:(FGMPlatformMarkerCollisionBehavior)value {
   self = [super init];
@@ -81,6 +81,17 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 
 @implementation FGMPlatformMarkerTypeBox
 - (instancetype)initWithValue:(FGMPlatformMarkerType)value {
+  self = [super init];
+  if (self) {
+    _value = value;
+  }
+  return self;
+}
+@end
+
+/// Pigeon equivalent of MapColorScheme.
+@implementation FGMPlatformMapColorSchemeBox
+- (instancetype)initWithValue:(FGMPlatformMapColorScheme)value {
   self = [super init];
   if (self) {
     _value = value;
@@ -1356,7 +1367,8 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
                       buildingsEnabled:(nullable NSNumber *)buildingsEnabled
                             markerType:(FGMPlatformMarkerType)markerType
                                  mapId:(nullable NSString *)mapId
-                                 style:(nullable NSString *)style {
+                                 style:(nullable NSString *)style
+                           colorScheme:(nullable FGMPlatformMapColorSchemeBox *)colorScheme {
   FGMPlatformMapConfiguration *pigeonResult = [[FGMPlatformMapConfiguration alloc] init];
   pigeonResult.compassEnabled = compassEnabled;
   pigeonResult.cameraTargetBounds = cameraTargetBounds;
@@ -1376,6 +1388,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.markerType = markerType;
   pigeonResult.mapId = mapId;
   pigeonResult.style = style;
+  pigeonResult.colorScheme = colorScheme;
   return pigeonResult;
 }
 + (FGMPlatformMapConfiguration *)fromList:(NSArray<id> *)list {
@@ -1399,6 +1412,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.markerType = boxedFGMPlatformMarkerType.value;
   pigeonResult.mapId = GetNullableObjectAtIndex(list, 16);
   pigeonResult.style = GetNullableObjectAtIndex(list, 17);
+  pigeonResult.colorScheme = GetNullableObjectAtIndex(list, 18);
   return pigeonResult;
 }
 + (nullable FGMPlatformMapConfiguration *)nullableFromList:(NSArray<id> *)list {
@@ -1424,6 +1438,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     [[FGMPlatformMarkerTypeBox alloc] initWithValue:self.markerType],
     self.mapId ?: [NSNull null],
     self.style ?: [NSNull null],
+    self.colorScheme ?: [NSNull null],
   ];
 }
 @end
@@ -1839,95 +1854,101 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     }
     case 134: {
       NSNumber *enumAsNumber = [self readValue];
+      return enumAsNumber == nil
+                 ? nil
+                 : [[FGMPlatformMapColorSchemeBox alloc] initWithValue:[enumAsNumber integerValue]];
+    }
+    case 135: {
+      NSNumber *enumAsNumber = [self readValue];
       return enumAsNumber == nil ? nil
                                  : [[FGMPlatformMapBitmapScalingBox alloc]
                                        initWithValue:[enumAsNumber integerValue]];
     }
-    case 135:
-      return [FGMPlatformCameraPosition fromList:[self readValue]];
     case 136:
-      return [FGMPlatformCameraUpdate fromList:[self readValue]];
+      return [FGMPlatformCameraPosition fromList:[self readValue]];
     case 137:
-      return [FGMPlatformCameraUpdateNewCameraPosition fromList:[self readValue]];
+      return [FGMPlatformCameraUpdate fromList:[self readValue]];
     case 138:
-      return [FGMPlatformCameraUpdateNewLatLng fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewCameraPosition fromList:[self readValue]];
     case 139:
-      return [FGMPlatformCameraUpdateNewLatLngBounds fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLng fromList:[self readValue]];
     case 140:
-      return [FGMPlatformCameraUpdateNewLatLngZoom fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLngBounds fromList:[self readValue]];
     case 141:
-      return [FGMPlatformCameraUpdateScrollBy fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateNewLatLngZoom fromList:[self readValue]];
     case 142:
-      return [FGMPlatformCameraUpdateZoomBy fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateScrollBy fromList:[self readValue]];
     case 143:
-      return [FGMPlatformCameraUpdateZoom fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoomBy fromList:[self readValue]];
     case 144:
-      return [FGMPlatformCameraUpdateZoomTo fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoom fromList:[self readValue]];
     case 145:
-      return [FGMPlatformCircle fromList:[self readValue]];
+      return [FGMPlatformCameraUpdateZoomTo fromList:[self readValue]];
     case 146:
-      return [FGMPlatformHeatmap fromList:[self readValue]];
+      return [FGMPlatformCircle fromList:[self readValue]];
     case 147:
-      return [FGMPlatformHeatmapGradient fromList:[self readValue]];
+      return [FGMPlatformHeatmap fromList:[self readValue]];
     case 148:
-      return [FGMPlatformWeightedLatLng fromList:[self readValue]];
+      return [FGMPlatformHeatmapGradient fromList:[self readValue]];
     case 149:
-      return [FGMPlatformInfoWindow fromList:[self readValue]];
+      return [FGMPlatformWeightedLatLng fromList:[self readValue]];
     case 150:
-      return [FGMPlatformCluster fromList:[self readValue]];
+      return [FGMPlatformInfoWindow fromList:[self readValue]];
     case 151:
-      return [FGMPlatformClusterManager fromList:[self readValue]];
+      return [FGMPlatformCluster fromList:[self readValue]];
     case 152:
-      return [FGMPlatformMarker fromList:[self readValue]];
+      return [FGMPlatformClusterManager fromList:[self readValue]];
     case 153:
-      return [FGMPlatformPolygon fromList:[self readValue]];
+      return [FGMPlatformMarker fromList:[self readValue]];
     case 154:
-      return [FGMPlatformPolyline fromList:[self readValue]];
+      return [FGMPlatformPolygon fromList:[self readValue]];
     case 155:
-      return [FGMPlatformPatternItem fromList:[self readValue]];
+      return [FGMPlatformPolyline fromList:[self readValue]];
     case 156:
-      return [FGMPlatformTile fromList:[self readValue]];
+      return [FGMPlatformPatternItem fromList:[self readValue]];
     case 157:
-      return [FGMPlatformTileOverlay fromList:[self readValue]];
+      return [FGMPlatformTile fromList:[self readValue]];
     case 158:
-      return [FGMPlatformEdgeInsets fromList:[self readValue]];
+      return [FGMPlatformTileOverlay fromList:[self readValue]];
     case 159:
-      return [FGMPlatformLatLng fromList:[self readValue]];
+      return [FGMPlatformEdgeInsets fromList:[self readValue]];
     case 160:
-      return [FGMPlatformLatLngBounds fromList:[self readValue]];
+      return [FGMPlatformLatLng fromList:[self readValue]];
     case 161:
-      return [FGMPlatformCameraTargetBounds fromList:[self readValue]];
+      return [FGMPlatformLatLngBounds fromList:[self readValue]];
     case 162:
-      return [FGMPlatformGroundOverlay fromList:[self readValue]];
+      return [FGMPlatformCameraTargetBounds fromList:[self readValue]];
     case 163:
-      return [FGMPlatformMapViewCreationParams fromList:[self readValue]];
+      return [FGMPlatformGroundOverlay fromList:[self readValue]];
     case 164:
-      return [FGMPlatformMapConfiguration fromList:[self readValue]];
+      return [FGMPlatformMapViewCreationParams fromList:[self readValue]];
     case 165:
-      return [FGMPlatformPoint fromList:[self readValue]];
+      return [FGMPlatformMapConfiguration fromList:[self readValue]];
     case 166:
-      return [FGMPlatformSize fromList:[self readValue]];
+      return [FGMPlatformPoint fromList:[self readValue]];
     case 167:
-      return [FGMPlatformColor fromList:[self readValue]];
+      return [FGMPlatformSize fromList:[self readValue]];
     case 168:
-      return [FGMPlatformTileLayer fromList:[self readValue]];
+      return [FGMPlatformColor fromList:[self readValue]];
     case 169:
-      return [FGMPlatformZoomRange fromList:[self readValue]];
+      return [FGMPlatformTileLayer fromList:[self readValue]];
     case 170:
-      return [FGMPlatformBitmap fromList:[self readValue]];
+      return [FGMPlatformZoomRange fromList:[self readValue]];
     case 171:
-      return [FGMPlatformBitmapDefaultMarker fromList:[self readValue]];
+      return [FGMPlatformBitmap fromList:[self readValue]];
     case 172:
-      return [FGMPlatformBitmapBytes fromList:[self readValue]];
+      return [FGMPlatformBitmapDefaultMarker fromList:[self readValue]];
     case 173:
-      return [FGMPlatformBitmapAsset fromList:[self readValue]];
+      return [FGMPlatformBitmapBytes fromList:[self readValue]];
     case 174:
-      return [FGMPlatformBitmapAssetImage fromList:[self readValue]];
+      return [FGMPlatformBitmapAsset fromList:[self readValue]];
     case 175:
-      return [FGMPlatformBitmapAssetMap fromList:[self readValue]];
+      return [FGMPlatformBitmapAssetImage fromList:[self readValue]];
     case 176:
-      return [FGMPlatformBitmapBytesMap fromList:[self readValue]];
+      return [FGMPlatformBitmapAssetMap fromList:[self readValue]];
     case 177:
+      return [FGMPlatformBitmapBytesMap fromList:[self readValue]];
+    case 178:
       return [FGMPlatformBitmapPinConfig fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
@@ -1959,138 +1980,142 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     FGMPlatformMarkerTypeBox *box = (FGMPlatformMarkerTypeBox *)value;
     [self writeByte:133];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[FGMPlatformMapBitmapScalingBox class]]) {
-    FGMPlatformMapBitmapScalingBox *box = (FGMPlatformMapBitmapScalingBox *)value;
+  } else if ([value isKindOfClass:[FGMPlatformMapColorSchemeBox class]]) {
+    FGMPlatformMapColorSchemeBox *box = (FGMPlatformMapColorSchemeBox *)value;
     [self writeByte:134];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[FGMPlatformCameraPosition class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapBitmapScalingBox class]]) {
+    FGMPlatformMapBitmapScalingBox *box = (FGMPlatformMapBitmapScalingBox *)value;
     [self writeByte:135];
-    [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdate class]]) {
+    [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
+  } else if ([value isKindOfClass:[FGMPlatformCameraPosition class]]) {
     [self writeByte:136];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewCameraPosition class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdate class]]) {
     [self writeByte:137];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewCameraPosition class]]) {
     [self writeByte:138];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLng class]]) {
     [self writeByte:139];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngZoom class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngBounds class]]) {
     [self writeByte:140];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateScrollBy class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateNewLatLngZoom class]]) {
     [self writeByte:141];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomBy class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateScrollBy class]]) {
     [self writeByte:142];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoom class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomBy class]]) {
     [self writeByte:143];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomTo class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoom class]]) {
     [self writeByte:144];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCircle class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraUpdateZoomTo class]]) {
     [self writeByte:145];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformHeatmap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCircle class]]) {
     [self writeByte:146];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformHeatmapGradient class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformHeatmap class]]) {
     [self writeByte:147];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformWeightedLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformHeatmapGradient class]]) {
     [self writeByte:148];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformInfoWindow class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformWeightedLatLng class]]) {
     [self writeByte:149];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCluster class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformInfoWindow class]]) {
     [self writeByte:150];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformClusterManager class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCluster class]]) {
     [self writeByte:151];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMarker class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformClusterManager class]]) {
     [self writeByte:152];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPolygon class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMarker class]]) {
     [self writeByte:153];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPolyline class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPolygon class]]) {
     [self writeByte:154];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPatternItem class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPolyline class]]) {
     [self writeByte:155];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTile class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPatternItem class]]) {
     [self writeByte:156];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTileOverlay class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTile class]]) {
     [self writeByte:157];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformEdgeInsets class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTileOverlay class]]) {
     [self writeByte:158];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformLatLng class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformEdgeInsets class]]) {
     [self writeByte:159];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformLatLngBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformLatLng class]]) {
     [self writeByte:160];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformCameraTargetBounds class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformLatLngBounds class]]) {
     [self writeByte:161];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformGroundOverlay class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformCameraTargetBounds class]]) {
     [self writeByte:162];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMapViewCreationParams class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformGroundOverlay class]]) {
     [self writeByte:163];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformMapConfiguration class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapViewCreationParams class]]) {
     [self writeByte:164];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformPoint class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformMapConfiguration class]]) {
     [self writeByte:165];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformSize class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformPoint class]]) {
     [self writeByte:166];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformColor class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformSize class]]) {
     [self writeByte:167];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformTileLayer class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformColor class]]) {
     [self writeByte:168];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformZoomRange class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformTileLayer class]]) {
     [self writeByte:169];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformZoomRange class]]) {
     [self writeByte:170];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapDefaultMarker class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmap class]]) {
     [self writeByte:171];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapBytes class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapDefaultMarker class]]) {
     [self writeByte:172];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAsset class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapBytes class]]) {
     [self writeByte:173];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetImage class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAsset class]]) {
     [self writeByte:174];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetMap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetImage class]]) {
     [self writeByte:175];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapBytesMap class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapAssetMap class]]) {
     [self writeByte:176];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[FGMPlatformBitmapPinConfig class]]) {
+  } else if ([value isKindOfClass:[FGMPlatformBitmapBytesMap class]]) {
     [self writeByte:177];
+    [self writeValue:[value toList]];
+  } else if ([value isKindOfClass:[FGMPlatformBitmapPinConfig class]]) {
+    [self writeByte:178];
     [self writeValue:[value toList]];
   } else {
     [super writeValue:value];

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapType) {
 - (instancetype)initWithValue:(FGMPlatformMapType)value;
 @end
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 typedef NS_ENUM(NSUInteger, FGMPlatformMarkerCollisionBehavior) {
   FGMPlatformMarkerCollisionBehaviorRequiredDisplay = 0,
   FGMPlatformMarkerCollisionBehaviorOptionalAndHidesLowerPriority = 1,
@@ -76,6 +76,19 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMarkerType) {
 @interface FGMPlatformMarkerTypeBox : NSObject
 @property(nonatomic, assign) FGMPlatformMarkerType value;
 - (instancetype)initWithValue:(FGMPlatformMarkerType)value;
+@end
+
+/// Pigeon equivalent of MapColorScheme.
+typedef NS_ENUM(NSUInteger, FGMPlatformMapColorScheme) {
+  FGMPlatformMapColorSchemeLight = 0,
+  FGMPlatformMapColorSchemeDark = 1,
+  FGMPlatformMapColorSchemeFollowSystem = 2,
+};
+
+/// Wrapper for FGMPlatformMapColorScheme to allow for nullability.
+@interface FGMPlatformMapColorSchemeBox : NSObject
+@property(nonatomic, assign) FGMPlatformMapColorScheme value;
+- (instancetype)initWithValue:(FGMPlatformMapColorScheme)value;
 @end
 
 /// Pigeon equivalent of [MapBitmapScaling].
@@ -573,7 +586,8 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapBitmapScaling) {
                       buildingsEnabled:(nullable NSNumber *)buildingsEnabled
                             markerType:(FGMPlatformMarkerType)markerType
                                  mapId:(nullable NSString *)mapId
-                                 style:(nullable NSString *)style;
+                                 style:(nullable NSString *)style
+                           colorScheme:(nullable FGMPlatformMapColorSchemeBox *)colorScheme;
 @property(nonatomic, strong, nullable) NSNumber *compassEnabled;
 @property(nonatomic, strong, nullable) FGMPlatformCameraTargetBounds *cameraTargetBounds;
 @property(nonatomic, strong, nullable) FGMPlatformMapTypeBox *mapType;
@@ -592,6 +606,7 @@ typedef NS_ENUM(NSUInteger, FGMPlatformMapBitmapScaling) {
 @property(nonatomic, assign) FGMPlatformMarkerType markerType;
 @property(nonatomic, copy, nullable) NSString *mapId;
 @property(nonatomic, copy, nullable) NSString *style;
+@property(nonatomic, strong, nullable) FGMPlatformMapColorSchemeBox *colorScheme;
 @end
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/google_maps_flutter_ios.dart
@@ -1162,6 +1162,7 @@ PlatformMapConfiguration _platformMapConfigurationFromMapConfiguration(MapConfig
     markerType: _platformMarkerTypeFromMarkerType(config.markerType ?? MarkerType.marker),
     mapId: config.mapId,
     style: config.style,
+    colorScheme: _platformMapColorSchemeFromMapColorScheme(config.colorScheme),
   );
 }
 
@@ -1180,6 +1181,26 @@ PlatformMarkerType _platformMarkerTypeFromMarkerType(MarkerType markerType) {
   // switch as needing an update.
   // ignore: dead_code
   throw UnimplementedError('MarkerType "$markerType" has not been implemented');
+}
+
+PlatformMapColorScheme? _platformMapColorSchemeFromMapColorScheme(MapColorScheme? colorScheme) {
+  if (colorScheme == null) {
+    return null;
+  }
+  switch (colorScheme) {
+    case MapColorScheme.light:
+      return PlatformMapColorScheme.light;
+    case MapColorScheme.dark:
+      return PlatformMapColorScheme.dark;
+    case MapColorScheme.followSystem:
+      return PlatformMapColorScheme.followSystem;
+    // The enum comes from a different package, which could get a new value at
+    // any time, so provide a fallback that ensures this won't break when used
+    // with a version that contains new values.
+    // ignore: no_default_cases, unreachable_switch_default
+    default:
+      throw UnimplementedError('MapColorScheme "$colorScheme" has not been implemented');
+  }
 }
 
 // For supporting the deprecated updateMapOptions API.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/messages.g.dart
@@ -47,7 +47,7 @@ bool _deepEquals(Object? a, Object? b) {
 /// Pigeon equivalent of MapType
 enum PlatformMapType { none, normal, satellite, terrain, hybrid }
 
-/// Pigeon equivalent of MarkerCollisionBehavior.
+/// Pigeon equivalent of the MarkerCollisionBehavior enum.
 enum PlatformMarkerCollisionBehavior {
   requiredDisplay,
   optionalAndHidesLowerPriority,
@@ -61,6 +61,9 @@ enum PlatformJointType { mitered, bevel, round }
 enum PlatformPatternItemType { dot, dash, gap }
 
 enum PlatformMarkerType { marker, advancedMarker }
+
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
 
 /// Pigeon equivalent of [MapBitmapScaling].
 enum PlatformMapBitmapScaling { auto, none }
@@ -1641,6 +1644,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     this.mapId,
     this.style,
+    this.colorScheme,
   });
 
   bool? compassEnabled;
@@ -1679,6 +1683,8 @@ class PlatformMapConfiguration {
 
   String? style;
 
+  PlatformMapColorScheme? colorScheme;
+
   List<Object?> _toList() {
     return <Object?>[
       compassEnabled,
@@ -1699,6 +1705,7 @@ class PlatformMapConfiguration {
       markerType,
       mapId,
       style,
+      colorScheme,
     ];
   }
 
@@ -1727,6 +1734,7 @@ class PlatformMapConfiguration {
       markerType: result[15]! as PlatformMarkerType,
       mapId: result[16] as String?,
       style: result[17] as String?,
+      colorScheme: result[18] as PlatformMapColorScheme?,
     );
   }
 
@@ -2362,137 +2370,140 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PlatformMarkerType) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is PlatformMapBitmapScaling) {
+    } else if (value is PlatformMapColorScheme) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    } else if (value is PlatformCameraPosition) {
+    } else if (value is PlatformMapBitmapScaling) {
       buffer.putUint8(135);
-      writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdate) {
+      writeValue(buffer, value.index);
+    } else if (value is PlatformCameraPosition) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewCameraPosition) {
+    } else if (value is PlatformCameraUpdate) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLng) {
+    } else if (value is PlatformCameraUpdateNewCameraPosition) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
+    } else if (value is PlatformCameraUpdateNewLatLng) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
+    } else if (value is PlatformCameraUpdateNewLatLngBounds) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateScrollBy) {
+    } else if (value is PlatformCameraUpdateNewLatLngZoom) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomBy) {
+    } else if (value is PlatformCameraUpdateScrollBy) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoom) {
+    } else if (value is PlatformCameraUpdateZoomBy) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraUpdateZoomTo) {
+    } else if (value is PlatformCameraUpdateZoom) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCircle) {
+    } else if (value is PlatformCameraUpdateZoomTo) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmap) {
+    } else if (value is PlatformCircle) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformHeatmapGradient) {
+    } else if (value is PlatformHeatmap) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformWeightedLatLng) {
+    } else if (value is PlatformHeatmapGradient) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformInfoWindow) {
+    } else if (value is PlatformWeightedLatLng) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCluster) {
+    } else if (value is PlatformInfoWindow) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformClusterManager) {
+    } else if (value is PlatformCluster) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMarker) {
+    } else if (value is PlatformClusterManager) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolygon) {
+    } else if (value is PlatformMarker) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPolyline) {
+    } else if (value is PlatformPolygon) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPatternItem) {
+    } else if (value is PlatformPolyline) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTile) {
+    } else if (value is PlatformPatternItem) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileOverlay) {
+    } else if (value is PlatformTile) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformEdgeInsets) {
+    } else if (value is PlatformTileOverlay) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLng) {
+    } else if (value is PlatformEdgeInsets) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformLatLngBounds) {
+    } else if (value is PlatformLatLng) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformCameraTargetBounds) {
+    } else if (value is PlatformLatLngBounds) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformGroundOverlay) {
+    } else if (value is PlatformCameraTargetBounds) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapViewCreationParams) {
+    } else if (value is PlatformGroundOverlay) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformMapConfiguration) {
+    } else if (value is PlatformMapViewCreationParams) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformPoint) {
+    } else if (value is PlatformMapConfiguration) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformSize) {
+    } else if (value is PlatformPoint) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformColor) {
+    } else if (value is PlatformSize) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformTileLayer) {
+    } else if (value is PlatformColor) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformZoomRange) {
+    } else if (value is PlatformTileLayer) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmap) {
+    } else if (value is PlatformZoomRange) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapDefaultMarker) {
+    } else if (value is PlatformBitmap) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytes) {
+    } else if (value is PlatformBitmapDefaultMarker) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAsset) {
+    } else if (value is PlatformBitmapBytes) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetImage) {
+    } else if (value is PlatformBitmapAsset) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapAssetMap) {
+    } else if (value is PlatformBitmapAssetImage) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapBytesMap) {
+    } else if (value is PlatformBitmapAssetMap) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is PlatformBitmapPinConfig) {
+    } else if (value is PlatformBitmapBytesMap) {
       buffer.putUint8(177);
+      writeValue(buffer, value.encode());
+    } else if (value is PlatformBitmapPinConfig) {
+      buffer.putUint8(178);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -2519,92 +2530,95 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PlatformMarkerType.values[value];
       case 134:
         final value = readValue(buffer) as int?;
-        return value == null ? null : PlatformMapBitmapScaling.values[value];
+        return value == null ? null : PlatformMapColorScheme.values[value];
       case 135:
-        return PlatformCameraPosition.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : PlatformMapBitmapScaling.values[value];
       case 136:
-        return PlatformCameraUpdate.decode(readValue(buffer)!);
+        return PlatformCameraPosition.decode(readValue(buffer)!);
       case 137:
-        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
+        return PlatformCameraUpdate.decode(readValue(buffer)!);
       case 138:
-        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewCameraPosition.decode(readValue(buffer)!);
       case 139:
-        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLng.decode(readValue(buffer)!);
       case 140:
-        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngBounds.decode(readValue(buffer)!);
       case 141:
-        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateNewLatLngZoom.decode(readValue(buffer)!);
       case 142:
-        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
+        return PlatformCameraUpdateScrollBy.decode(readValue(buffer)!);
       case 143:
-        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomBy.decode(readValue(buffer)!);
       case 144:
-        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoom.decode(readValue(buffer)!);
       case 145:
-        return PlatformCircle.decode(readValue(buffer)!);
+        return PlatformCameraUpdateZoomTo.decode(readValue(buffer)!);
       case 146:
-        return PlatformHeatmap.decode(readValue(buffer)!);
+        return PlatformCircle.decode(readValue(buffer)!);
       case 147:
-        return PlatformHeatmapGradient.decode(readValue(buffer)!);
+        return PlatformHeatmap.decode(readValue(buffer)!);
       case 148:
-        return PlatformWeightedLatLng.decode(readValue(buffer)!);
+        return PlatformHeatmapGradient.decode(readValue(buffer)!);
       case 149:
-        return PlatformInfoWindow.decode(readValue(buffer)!);
+        return PlatformWeightedLatLng.decode(readValue(buffer)!);
       case 150:
-        return PlatformCluster.decode(readValue(buffer)!);
+        return PlatformInfoWindow.decode(readValue(buffer)!);
       case 151:
-        return PlatformClusterManager.decode(readValue(buffer)!);
+        return PlatformCluster.decode(readValue(buffer)!);
       case 152:
-        return PlatformMarker.decode(readValue(buffer)!);
+        return PlatformClusterManager.decode(readValue(buffer)!);
       case 153:
-        return PlatformPolygon.decode(readValue(buffer)!);
+        return PlatformMarker.decode(readValue(buffer)!);
       case 154:
-        return PlatformPolyline.decode(readValue(buffer)!);
+        return PlatformPolygon.decode(readValue(buffer)!);
       case 155:
-        return PlatformPatternItem.decode(readValue(buffer)!);
+        return PlatformPolyline.decode(readValue(buffer)!);
       case 156:
-        return PlatformTile.decode(readValue(buffer)!);
+        return PlatformPatternItem.decode(readValue(buffer)!);
       case 157:
-        return PlatformTileOverlay.decode(readValue(buffer)!);
+        return PlatformTile.decode(readValue(buffer)!);
       case 158:
-        return PlatformEdgeInsets.decode(readValue(buffer)!);
+        return PlatformTileOverlay.decode(readValue(buffer)!);
       case 159:
-        return PlatformLatLng.decode(readValue(buffer)!);
+        return PlatformEdgeInsets.decode(readValue(buffer)!);
       case 160:
-        return PlatformLatLngBounds.decode(readValue(buffer)!);
+        return PlatformLatLng.decode(readValue(buffer)!);
       case 161:
-        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
+        return PlatformLatLngBounds.decode(readValue(buffer)!);
       case 162:
-        return PlatformGroundOverlay.decode(readValue(buffer)!);
+        return PlatformCameraTargetBounds.decode(readValue(buffer)!);
       case 163:
-        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
+        return PlatformGroundOverlay.decode(readValue(buffer)!);
       case 164:
-        return PlatformMapConfiguration.decode(readValue(buffer)!);
+        return PlatformMapViewCreationParams.decode(readValue(buffer)!);
       case 165:
-        return PlatformPoint.decode(readValue(buffer)!);
+        return PlatformMapConfiguration.decode(readValue(buffer)!);
       case 166:
-        return PlatformSize.decode(readValue(buffer)!);
+        return PlatformPoint.decode(readValue(buffer)!);
       case 167:
-        return PlatformColor.decode(readValue(buffer)!);
+        return PlatformSize.decode(readValue(buffer)!);
       case 168:
-        return PlatformTileLayer.decode(readValue(buffer)!);
+        return PlatformColor.decode(readValue(buffer)!);
       case 169:
-        return PlatformZoomRange.decode(readValue(buffer)!);
+        return PlatformTileLayer.decode(readValue(buffer)!);
       case 170:
-        return PlatformBitmap.decode(readValue(buffer)!);
+        return PlatformZoomRange.decode(readValue(buffer)!);
       case 171:
-        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
+        return PlatformBitmap.decode(readValue(buffer)!);
       case 172:
-        return PlatformBitmapBytes.decode(readValue(buffer)!);
+        return PlatformBitmapDefaultMarker.decode(readValue(buffer)!);
       case 173:
-        return PlatformBitmapAsset.decode(readValue(buffer)!);
+        return PlatformBitmapBytes.decode(readValue(buffer)!);
       case 174:
-        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
+        return PlatformBitmapAsset.decode(readValue(buffer)!);
       case 175:
-        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetImage.decode(readValue(buffer)!);
       case 176:
-        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+        return PlatformBitmapAssetMap.decode(readValue(buffer)!);
       case 177:
+        return PlatformBitmapBytesMap.decode(readValue(buffer)!);
+      case 178:
         return PlatformBitmapPinConfig.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/pigeons/messages.dart
@@ -449,6 +449,9 @@ class PlatformMapViewCreationParams {
 
 enum PlatformMarkerType { marker, advancedMarker }
 
+/// Pigeon equivalent of MapColorScheme.
+enum PlatformMapColorScheme { light, dark, followSystem }
+
 /// Pigeon equivalent of MapConfiguration.
 class PlatformMapConfiguration {
   PlatformMapConfiguration({
@@ -470,6 +473,7 @@ class PlatformMapConfiguration {
     required this.markerType,
     required this.mapId,
     required this.style,
+    required this.colorScheme,
   });
 
   final bool? compassEnabled;
@@ -490,6 +494,7 @@ class PlatformMapConfiguration {
   final PlatformMarkerType markerType;
   final String? mapId;
   final String? style;
+  final PlatformMapColorScheme? colorScheme;
 }
 
 /// Pigeon representation of an x,y coordinate.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/test/google_maps_flutter_ios_test.dart
@@ -1311,6 +1311,109 @@ void main() {
       );
     });
   });
+
+  group('colorScheme in creationParams', () {
+    Future<PlatformMapColorScheme?> getColorSchemeFromCreationParams(
+      WidgetTester tester,
+      MapColorScheme? colorScheme,
+    ) async {
+      final passedColorSchemeCompleter = Completer<PlatformMapColorScheme?>();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform_views,
+        (MethodCall methodCall) {
+          if (methodCall.method == 'create') {
+            final args = Map<String, dynamic>.from(methodCall.arguments as Map<dynamic, dynamic>);
+            if (args.containsKey('params')) {
+              final paramsUint8List = args['params'] as Uint8List;
+              final byteData = ByteData.sublistView(paramsUint8List);
+              final creationParams =
+                  MapsApi.pigeonChannelCodec.decodeMessage(byteData)
+                      as PlatformMapViewCreationParams?;
+              if (creationParams != null && !passedColorSchemeCompleter.isCompleted) {
+                passedColorSchemeCompleter.complete(creationParams.mapConfiguration.colorScheme);
+              }
+            }
+          }
+          return null;
+        },
+      );
+
+      final maps = GoogleMapsFlutterIOS();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: maps.buildViewWithConfiguration(
+            1,
+            (int _) {},
+            widgetConfiguration: const MapWidgetConfiguration(
+              initialCameraPosition: CameraPosition(target: LatLng(0, 0), zoom: 1),
+              textDirection: TextDirection.ltr,
+            ),
+            mapConfiguration: MapConfiguration(colorScheme: colorScheme),
+          ),
+        ),
+      );
+
+      return passedColorSchemeCompleter.future;
+    }
+
+    testWidgets('passes light when MapColorScheme.light is set', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.light,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.light,
+        reason: 'Should pass light on PlatformView creation when MapColorScheme.light is set',
+      );
+    });
+
+    testWidgets('passes dark when MapColorScheme.dark is set', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.dark,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.dark,
+        reason: 'Should pass dark on PlatformView creation when MapColorScheme.dark is set',
+      );
+    });
+
+    testWidgets('passes followSystem when MapColorScheme.followSystem is set', (
+      WidgetTester tester,
+    ) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        MapColorScheme.followSystem,
+      );
+
+      expect(
+        passedColorScheme,
+        PlatformMapColorScheme.followSystem,
+        reason:
+            'Should pass followSystem on PlatformView creation when MapColorScheme.followSystem is set',
+      );
+    });
+
+    testWidgets('passes null when colorScheme is null', (WidgetTester tester) async {
+      final PlatformMapColorScheme? passedColorScheme = await getColorSchemeFromCreationParams(
+        tester,
+        null,
+      );
+
+      expect(
+        passedColorScheme,
+        isNull,
+        reason: 'Should default to null on PlatformView creation when colorScheme is null',
+      );
+    });
+  });
 }
 
 void _expectColorsEqual(PlatformColor actual, Color expected) {

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.15.1
 
+* Updates `colorScheme` doc comment to reflect Android and iOS support.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.15.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
@@ -143,7 +143,10 @@ class MapConfiguration {
   /// used.
   final MarkerType? markerType;
 
-  /// Preferred color scheme for the cloud-styled map. Web only.
+  /// Preferred color scheme for the map.
+  ///
+  /// The map must use a cloud-based map style (via [mapId]) for the color
+  /// scheme to affect the base map tiles.
   ///
   /// See https://developers.google.com/maps/documentation/javascript/mapcolorscheme for more details.
   final MapColorScheme? colorScheme;

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.15.0
+version: 2.15.1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Description

Wires up `MapColorScheme` (light/dark/followSystem) to native APIs on Android and iOS. The platform interface and app-facing `google_maps_flutter` package already exposed this parameter (added in 2.16.0 for web), but the Android and iOS plugins silently ignored it.

- **Android**: `GoogleMap.setMapColorScheme()` is invoked with the matching `MapColorScheme` constant. Both creation-time and runtime updates (via `interpretMapConfiguration`) are supported.
- **iOS**: `GMSMapView.overrideUserInterfaceStyle` is set to `UIUserInterfaceStyleLight` / `Dark` / `Unspecified` — the documented API per the Google Maps SDK for iOS.

The change is mirrored across `google_maps_flutter_ios`, `google_maps_flutter_ios_sdk9`, `google_maps_flutter_ios_sdk10`, and `google_maps_flutter_ios_shared_code` via `dart tool/sync_shared_files.dart`.

The `colorScheme` doc comment in `google_maps_flutter` and `google_maps_flutter_platform_interface` is updated to reflect the new platform support (previously documented as "Web only").

Tests added:
- **Android**: `Convert.toMapColorScheme` JUnit tests for all three enum values; `interpretMapConfiguration_handlesColorScheme` dispatcher test mirroring `_handlesStyle`; Dart-side creation-params test asserting `colorScheme` flows through to the platform view.
- **iOS**: Parametrized Dart-side creation-params tests covering `light`, `dark`, `followSystem`, and `null`; matching tests propagated to sdk9 and sdk10 via the shared-code sync.

Fixes flutter/flutter#186737

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests