### PR TITLE
[path_provider_linux] use soname for libgio

### DIFF
--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.2.2
 
+* Fixes getApplicationId() behavior on Linux when GLib development packages are not installed.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.2.1

--- a/packages/path_provider/path_provider_linux/lib/src/get_application_id_real.dart
+++ b/packages/path_provider/path_provider_linux/lib/src/get_application_id_real.dart
@@ -20,7 +20,7 @@ class GioUtils {
   /// Creates a default instance that uses the real libgio.
   GioUtils() {
     try {
-      _gio = DynamicLibrary.open('libgio-2.0.so');
+      _gio = DynamicLibrary.open('libgio-2.0.so.0');
     } on ArgumentError {
       _gio = null;
     }

--- a/packages/path_provider/path_provider_linux/lib/src/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/src/path_provider_linux.dart
@@ -70,9 +70,21 @@ class PathProviderLinux extends PathProviderPlatform {
   @override
   Future<String?> getApplicationCachePath() async {
     final directory = Directory(path.join(xdg.cacheHome.path, await _getId()));
-    if (!directory.existsSync()) {
-      await directory.create(recursive: true);
+    if (directory.existsSync()) {
+      return directory.path;
     }
+
+    // Unlike for the application support path, the plugin didn't intentionally
+    // use the executable name as a directory for cache path in the past.
+    // However, it *unintentionally* did use it depending on which packages are
+    // installed, so fall back to it anyway.
+    // See: https://github.com/flutter/flutter/issues/186834
+    final legacyDirectory = Directory(path.join(xdg.cacheHome.path, await _getExecutableName()));
+    if (legacyDirectory.existsSync()) {
+      return legacyDirectory.path;
+    }
+
+    await directory.create(recursive: true);
     return directory.path;
   }
 

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_linux
 description: Linux implementation of the path_provider plugin
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.2.1
+version: 2.2.2
 
 environment:
   sdk: ^3.10.0

--- a/packages/path_provider/path_provider_linux/test/path_provider_linux_test.dart
+++ b/packages/path_provider/path_provider_linux/test/path_provider_linux_test.dart
@@ -1,7 +1,9 @@
 // Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider_linux/path_provider_linux.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:xdg_directories/xdg_directories.dart' as xdg;
@@ -9,6 +11,24 @@ import 'package:xdg_directories/xdg_directories.dart' as xdg;
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PathProviderLinux.registerWith();
+
+  // These tests use the actual filesystem, since an injectable filesystem
+  // would add a runtime dependency to the package, so everything is contained
+  // to a temporary directory.
+  late Directory testRoot;
+  final fakeEnv = <String, String>{};
+
+  setUp(() async {
+    testRoot = Directory.systemTemp.createTempSync();
+    fakeEnv['XDG_CACHE_HOME'] = p.join(testRoot.path, 'application', 'cache', 'path');
+    fakeEnv['XDG_DATA_HOME'] = p.join(testRoot.path, 'application', 'support', 'path');
+    xdg.xdgEnvironmentOverride = (String key) => fakeEnv[key];
+  });
+
+  tearDown(() {
+    fakeEnv.clear();
+    testRoot.deleteSync(recursive: true);
+  });
 
   test('registered instance', () {
     expect(PathProviderPlatform.instance, isA<PathProviderLinux>());
@@ -38,7 +58,6 @@ void main() {
       executableName: 'path_provider_linux_test_binary',
       applicationId: 'com.example.Test',
     );
-    // Note this will fail if ${xdg.dataHome.path}/path_provider_linux_test_binary exists on the local filesystem.
     expect(await plugin.getApplicationSupportPath(), '${xdg.dataHome.path}/com.example.Test');
   });
 
@@ -52,6 +71,21 @@ void main() {
     );
   });
 
+  test(
+    'getApplicationSupportPath uses executable name fallback if subdir already exists',
+    () async {
+      final PathProviderPlatform plugin = PathProviderLinux.private(
+        executableName: 'path_provider_linux_test_binary',
+        applicationId: 'com.example.Test',
+      );
+      final executableNameDir = Directory(
+        p.join(xdg.dataHome.path, 'path_provider_linux_test_binary'),
+      );
+      await executableNameDir.create(recursive: true);
+      expect(await plugin.getApplicationSupportPath(), executableNameDir.path);
+    },
+  );
+
   test('getApplicationDocumentsPath', () async {
     final PathProviderPlatform plugin = PathProviderPlatform.instance;
     expect(await plugin.getApplicationDocumentsPath(), startsWith('/'));
@@ -60,11 +94,31 @@ void main() {
   test('getApplicationCachePath', () async {
     final PathProviderPlatform plugin = PathProviderLinux.private(
       executableName: 'path_provider_linux_test_binary',
+      applicationId: 'com.example.Test',
+    );
+    expect(await plugin.getApplicationCachePath(), '${xdg.cacheHome.path}/com.example.Test');
+  });
+
+  test('getApplicationCachePath uses executable name if no application Id', () async {
+    final PathProviderPlatform plugin = PathProviderLinux.private(
+      executableName: 'path_provider_linux_test_binary',
     );
     expect(
       await plugin.getApplicationCachePath(),
       '${xdg.cacheHome.path}/path_provider_linux_test_binary',
     );
+  });
+
+  test('getApplicationCachePath uses executable name fallback if subdir already exists', () async {
+    final PathProviderPlatform plugin = PathProviderLinux.private(
+      executableName: 'path_provider_linux_test_binary',
+      applicationId: 'com.example.Test',
+    );
+    final executableNameDir = Directory(
+      p.join(xdg.cacheHome.path, 'path_provider_linux_test_binary'),
+    );
+    await executableNameDir.create(recursive: true);
+    expect(await plugin.getApplicationCachePath(), executableNameDir.path);
   });
 
   test('getDownloadsPath', () async {


### PR DESCRIPTION
This was using the link name instead of the soname (see [1]) for dynamically loading libgio, resulting in a failed load if the relevant development package providing the link name symlink was not installed. The fallback behavior if the load fails is to use the executable name instead of the expected application ID, which means this would result in a different path being provided depending on whether the dev package is installed, even though the required library is actually present.

For example, on Ubuntu 22.04, with an executable named "testapp", with application ID set to "com.example.testapp":
- if `libglib2.0-dev` is installed, `getApplicationSupportPath()` returns `$XDG_DATA_HOME/com.example.testapp`
- if `libglib2.0-dev` is *not* installed, `getApplicationSupportPath()` returns `$XDG_DATA_HOME/testapp`

Change to use the soname instead, ensuring that the behavior is consistent whether or not the dev package that provides libgio is installed.

Also, replicate the fallback logic to use the appname for application cache path as well if an appname directory name exists, since it may have been unintentionally used prior to this change. Updated tests for the new behavior, and also changed to use a temporary test directory so that the test runner users' actual directories aren't used for the tests.

[1] https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html#AEN46

Fixes https://github.com/flutter/flutter/issues/186834

----

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
