### PR TITLE
[google_maps_flutter_android] Reindex clustered markers in spatial index on position change

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/ClusterManagersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/ClusterManagersController.java
@@ -199,6 +199,36 @@ class ClusterManagersController
     }
   }
 
+  /**
+   * Reindexes a single item in the ClusterManager's spatial index.
+   *
+   * <p>When a clustered marker's position changes in-place, the algorithm's QuadTree retains the
+   * stale coordinates. This method forces a remove + add cycle so the QuadTree stores the updated
+   * position, then re-clusters.
+   */
+  public void reindexItem(@NonNull String clusterManagerId, @NonNull MarkerBuilder item) {
+    ClusterManager<MarkerBuilder> clusterManager = clusterManagerIdToManager.get(clusterManagerId);
+    if (clusterManager != null) {
+      clusterManager.removeItem(item);
+      clusterManager.addItem(item);
+      clusterManager.cluster();
+    }
+  }
+
+  /**
+   * Batch-reindexes multiple items in the ClusterManager's spatial index. Only calls {@code
+   * cluster()} once at the end for efficiency.
+   */
+  public void reindexItems(
+      @NonNull String clusterManagerId, @NonNull List<MarkerBuilder> items) {
+    ClusterManager<MarkerBuilder> clusterManager = clusterManagerIdToManager.get(clusterManagerId);
+    if (clusterManager != null) {
+      clusterManager.removeItems(items);
+      clusterManager.addItems(items);
+      clusterManager.cluster();
+    }
+  }
+
   /** Called when ClusterRenderer has rendered new visible marker to the map. */
   void onClusterItemRendered(@NonNull MarkerBuilder item, @NonNull Marker marker) {
     // If map is being disposed, clusterItemRenderedListener might have been cleared and

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/ClusterManagersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/ClusterManagersController.java
@@ -5,6 +5,9 @@
 package io.flutter.plugins.googlemaps;
 
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -53,6 +56,25 @@ class ClusterManagersController
   @Nullable
   private ClusterManagersController.OnClusterItemRendered<MarkerBuilder>
       clusterItemRenderedListener;
+
+  // ─── Throttle de re-clustering para updates de posição em alta frequência ──
+  //
+  // Marcadores animados (motoristas) emitem updates de posição a ~15fps. A
+  // posição do marcador VISÍVEL já é atualizada direto pelo `MarkerController`
+  // (ver `MarkersController.changeMarkers`); aqui só precisamos manter o índice
+  // espacial em sincronia e re-agregar. Rodar `cluster()` por tick re-executa o
+  // algoritmo da frota inteira (raster sustentado).
+  //
+  // NÃO usamos debounce (esperar a movimentação pausar): a frota se move em
+  // tempo real, então uma pausa raramente acontece e o agrupamento/contagem
+  // ficaria desatualizado. Usamos THROTTLE: garante um `cluster()` no máximo a
+  // cada [CLUSTER_THROTTLE_MS] mesmo em movimento contínuo — contagem fresca
+  // (~3x/s) e custo cortado de ~15 para ~3 reclusters/s. O `onCameraIdle`
+  // natural continua reclusterizando normalmente.
+  private final Handler clusterThrottleHandler = new Handler(Looper.getMainLooper());
+  private final HashMap<String, Runnable> pendingClusterRunnables = new HashMap<>();
+  private final HashMap<String, Long> lastClusterAtMs = new HashMap<>();
+  private static final long CLUSTER_THROTTLE_MS = 300;
 
   ClusterManagersController(
       @NonNull MapsCallbackApi flutterApi,
@@ -156,6 +178,11 @@ class ClusterManagersController
     if (clusterManager == null) {
       return;
     }
+    final Runnable pending = pendingClusterRunnables.remove(clusterManagerId);
+    if (pending != null) {
+      clusterThrottleHandler.removeCallbacks(pending);
+    }
+    lastClusterAtMs.remove(clusterManagerId);
     initListenersForClusterManager(clusterManager, null, null, null);
     clusterManager.clearItems();
     clusterManager.cluster();
@@ -178,6 +205,59 @@ class ClusterManagersController
       clusterManager.addItems(items);
       clusterManager.cluster();
     }
+  }
+
+  /**
+   * Adds items to the ClusterManager's spatial index WITHOUT triggering an
+   * immediate {@code cluster()}.
+   *
+   * <p>For high-frequency position updates of animated markers, the visible
+   * marker is already moved directly by its {@code MarkerController}; only the
+   * algorithm's spatial index needs to stay in sync here. Pair this with
+   * {@link #scheduleClusterThrottled} so re-aggregation runs at most once per
+   * throttle interval instead of once per animation frame.
+   */
+  public void addItemsSilently(String clusterManagerId, @NonNull List<MarkerBuilder> items) {
+    ClusterManager<MarkerBuilder> clusterManager = clusterManagerIdToManager.get(clusterManagerId);
+    if (clusterManager != null) {
+      clusterManager.addItems(items);
+    }
+  }
+
+  /**
+   * Schedules a throttled {@code cluster()} for the given cluster manager.
+   *
+   * <p>Guarantees re-aggregation runs at most once per {@link #CLUSTER_THROTTLE_MS}
+   * even while markers keep moving continuously. The first call after an idle
+   * period clusters almost immediately (responsive); subsequent calls during
+   * continuous movement are capped to the throttle interval. This keeps cluster
+   * grouping/counts fresh without paying the per-frame clustering cost.
+   */
+  public void scheduleClusterThrottled(@NonNull String clusterManagerId) {
+    final ClusterManager<MarkerBuilder> clusterManager =
+        clusterManagerIdToManager.get(clusterManagerId);
+    if (clusterManager == null) {
+      return;
+    }
+    // A run is already queued; it will reconcile the latest positions.
+    if (pendingClusterRunnables.containsKey(clusterManagerId)) {
+      return;
+    }
+    final long now = SystemClock.uptimeMillis();
+    final Long last = lastClusterAtMs.get(clusterManagerId);
+    final long elapsed = (last == null) ? CLUSTER_THROTTLE_MS : (now - last);
+    final long delay = Math.max(0, CLUSTER_THROTTLE_MS - elapsed);
+    final Runnable runnable =
+        () -> {
+          pendingClusterRunnables.remove(clusterManagerId);
+          // O manager pode ter sido removido enquanto o callback estava pendente.
+          if (clusterManagerIdToManager.containsValue(clusterManager)) {
+            lastClusterAtMs.put(clusterManagerId, SystemClock.uptimeMillis());
+            clusterManager.cluster();
+          }
+        };
+    pendingClusterRunnables.put(clusterManagerId, runnable);
+    clusterThrottleHandler.postDelayed(runnable, delay);
   }
 
   /** Removes item from the ClusterManager it belongs to. */

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/ClusterManagersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/ClusterManagersController.java
@@ -200,32 +200,19 @@ class ClusterManagersController
   }
 
   /**
-   * Reindexes a single item in the ClusterManager's spatial index.
+   * Removes an item from the ClusterManager's spatial index without triggering a recluster.
    *
-   * <p>When a clustered marker's position changes in-place, the algorithm's QuadTree retains the
-   * stale coordinates. This method forces a remove + add cycle so the QuadTree stores the updated
-   * position, then re-clusters.
+   * <p>This MUST be called BEFORE the item's position is mutated. The underlying {@code QuadTree}
+   * locates entries by their current {@code getPosition()}, so removing after mutation would search
+   * at the new coordinates and miss the stale entry at the old coordinates.
+   *
+   * <p>Callers are expected to re-add the item (via {@link #addItem} or {@link #addItems}) after
+   * mutating its position, which will also trigger {@code cluster()}.
    */
-  public void reindexItem(@NonNull String clusterManagerId, @NonNull MarkerBuilder item) {
+  public void removeItemSilently(@NonNull String clusterManagerId, @NonNull MarkerBuilder item) {
     ClusterManager<MarkerBuilder> clusterManager = clusterManagerIdToManager.get(clusterManagerId);
     if (clusterManager != null) {
       clusterManager.removeItem(item);
-      clusterManager.addItem(item);
-      clusterManager.cluster();
-    }
-  }
-
-  /**
-   * Batch-reindexes multiple items in the ClusterManager's spatial index. Only calls {@code
-   * cluster()} once at the end for efficiency.
-   */
-  public void reindexItems(
-      @NonNull String clusterManagerId, @NonNull List<MarkerBuilder> items) {
-    ClusterManager<MarkerBuilder> clusterManager = clusterManagerIdToManager.get(clusterManagerId);
-    if (clusterManager != null) {
-      clusterManager.removeItems(items);
-      clusterManager.addItems(items);
-      clusterManager.cluster();
     }
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
@@ -134,12 +134,7 @@ class MarkersController {
           }
         }
       } else {
-        // Remove from spatial index BEFORE mutating position — the QuadTree
-        // locates entries by getPosition(), so removal must happen while
-        // the builder still holds the old coordinates.
-        if (clusterManagerId != null) {
-          clusterManagersController.removeItemSilently(clusterManagerId, markerBuilder);
-        }
+        LatLng oldPosition = markerBuilder.getPosition();
 
         Convert.interpretMarkerOptions(
             markerToChange, markerBuilder, assetManager, density, bitmapDescriptorFactoryWrapper);
@@ -153,7 +148,13 @@ class MarkersController {
               bitmapDescriptorFactoryWrapper);
         }
 
-        if (clusterManagerId != null) {
+        if (clusterManagerId != null && !markerBuilder.getPosition().equals(oldPosition)) {
+          LatLng newPosition = markerBuilder.getPosition();
+          // Temporarily restore old position so QuadTree removal finds the
+          // stale entry at the original coordinates.
+          markerBuilder.setPosition(oldPosition);
+          clusterManagersController.removeItemSilently(clusterManagerId, markerBuilder);
+          markerBuilder.setPosition(newPosition);
           markersToReaddByCluster
               .computeIfAbsent(clusterManagerId, k -> new ArrayList<>())
               .add(markerBuilder);
@@ -396,10 +397,7 @@ class MarkersController {
       return;
     }
 
-    // Remove from spatial index BEFORE mutating position (see changeMarkers).
-    if (clusterManagerId != null) {
-      clusterManagersController.removeItemSilently(clusterManagerId, markerBuilder);
-    }
+    LatLng oldPosition = markerBuilder.getPosition();
 
     Convert.interpretMarkerOptions(
         marker, markerBuilder, assetManager, density, bitmapDescriptorFactoryWrapper);
@@ -410,7 +408,11 @@ class MarkersController {
           marker, markerController, assetManager, density, bitmapDescriptorFactoryWrapper);
     }
 
-    if (clusterManagerId != null) {
+    if (clusterManagerId != null && !markerBuilder.getPosition().equals(oldPosition)) {
+      LatLng newPosition = markerBuilder.getPosition();
+      markerBuilder.setPosition(oldPosition);
+      clusterManagersController.removeItemSilently(clusterManagerId, markerBuilder);
+      markerBuilder.setPosition(newPosition);
       clusterManagersController.addItem(markerBuilder);
     }
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
@@ -170,8 +170,13 @@ class MarkersController {
       clusterManagersController.addItems(entry.getKey(), entry.getValue());
     }
 
+    // Re-add por mudança de POSIÇÃO (caminho quente de marcadores animados): o
+    // marcador visível já foi movido acima via MarkerController, então aqui só
+    // sincronizamos o índice espacial sem clusterizar e agendamos um único
+    // cluster() com debounce. Evita re-clustering da frota a cada frame de lerp.
     for (Map.Entry<String, List<MarkerBuilder>> entry : markersToReaddByCluster.entrySet()) {
-      clusterManagersController.addItems(entry.getKey(), entry.getValue());
+      clusterManagersController.addItemsSilently(entry.getKey(), entry.getValue());
+      clusterManagersController.scheduleClusterThrottled(entry.getKey());
     }
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
@@ -88,9 +88,9 @@ class MarkersController {
   }
 
   void changeMarkers(@NonNull List<PlatformMarker> markersToChange) {
-    // Collect markers that need cluster manager changes for batch processing
     Map<String, List<MarkerBuilder>> markersToAddByCluster = new HashMap<>();
     Map<String, List<MarkerBuilder>> markersToRemoveByCluster = new HashMap<>();
+    Map<String, List<MarkerBuilder>> markersToReindexByCluster = new HashMap<>();
 
     for (PlatformMarker markerToChange : markersToChange) {
       String markerId = markerToChange.getMarkerId();
@@ -102,16 +102,13 @@ class MarkersController {
       String clusterManagerId = markerToChange.getClusterManagerId();
       String oldClusterManagerId = markerBuilder.clusterManagerId();
 
-      // If the cluster ID on the updated marker has changed, collect for batch processing
       if (!(Objects.equals(clusterManagerId, oldClusterManagerId))) {
-        // Remove from old cluster manager
         if (oldClusterManagerId != null) {
           markersToRemoveByCluster
               .computeIfAbsent(oldClusterManagerId, k -> new ArrayList<>())
               .add(markerBuilder);
         }
 
-        // Prepare new marker for addition
         MarkerBuilder newMarkerBuilder = new MarkerBuilder(markerId, clusterManagerId, markerType);
         Convert.interpretMarkerOptions(
             markerToChange,
@@ -126,11 +123,9 @@ class MarkersController {
               .computeIfAbsent(clusterManagerId, k -> new ArrayList<>())
               .add(newMarkerBuilder);
         } else {
-          // Add to map immediately if not clustered
           addMarkerToCollection(markerId, newMarkerBuilder);
         }
 
-        // Clean up old marker controller if it's not clustered
         if (oldClusterManagerId == null) {
           MarkerController oldController = markerIdToController.remove(markerId);
           if (oldController != null && markerCollection != null) {
@@ -139,7 +134,8 @@ class MarkersController {
           }
         }
       } else {
-        // Update existing marker in place
+        LatLng oldPosition = markerBuilder.getPosition();
+
         Convert.interpretMarkerOptions(
             markerToChange, markerBuilder, assetManager, density, bitmapDescriptorFactoryWrapper);
         MarkerController markerController = markerIdToController.get(markerId);
@@ -151,17 +147,25 @@ class MarkersController {
               density,
               bitmapDescriptorFactoryWrapper);
         }
+
+        if (clusterManagerId != null && !markerBuilder.getPosition().equals(oldPosition)) {
+          markersToReindexByCluster
+              .computeIfAbsent(clusterManagerId, k -> new ArrayList<>())
+              .add(markerBuilder);
+        }
       }
     }
 
-    // Batch remove from cluster managers
     for (Map.Entry<String, List<MarkerBuilder>> entry : markersToRemoveByCluster.entrySet()) {
       clusterManagersController.removeItems(entry.getKey(), entry.getValue());
     }
 
-    // Batch add to cluster managers
     for (Map.Entry<String, List<MarkerBuilder>> entry : markersToAddByCluster.entrySet()) {
       clusterManagersController.addItems(entry.getKey(), entry.getValue());
+    }
+
+    for (Map.Entry<String, List<MarkerBuilder>> entry : markersToReindexByCluster.entrySet()) {
+      clusterManagersController.reindexItems(entry.getKey(), entry.getValue());
     }
   }
 
@@ -381,23 +385,25 @@ class MarkersController {
     String clusterManagerId = marker.getClusterManagerId();
     String oldClusterManagerId = markerBuilder.clusterManagerId();
 
-    // If the cluster ID on the updated marker has changed, the marker needs to
-    // be removed and re-added to update its cluster manager state.
     if (!(Objects.equals(clusterManagerId, oldClusterManagerId))) {
       removeMarker(markerId);
       addMarker(marker);
       return;
     }
 
-    // Update marker builder.
+    LatLng oldPosition = markerBuilder.getPosition();
+
     Convert.interpretMarkerOptions(
         marker, markerBuilder, assetManager, density, bitmapDescriptorFactoryWrapper);
 
-    // Update existing marker on map.
     MarkerController markerController = markerIdToController.get(markerId);
     if (markerController != null) {
       Convert.interpretMarkerOptions(
           marker, markerController, assetManager, density, bitmapDescriptorFactoryWrapper);
+    }
+
+    if (clusterManagerId != null && !markerBuilder.getPosition().equals(oldPosition)) {
+      clusterManagersController.reindexItem(clusterManagerId, markerBuilder);
     }
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
@@ -90,7 +90,7 @@ class MarkersController {
   void changeMarkers(@NonNull List<PlatformMarker> markersToChange) {
     Map<String, List<MarkerBuilder>> markersToAddByCluster = new HashMap<>();
     Map<String, List<MarkerBuilder>> markersToRemoveByCluster = new HashMap<>();
-    Map<String, List<MarkerBuilder>> markersToReindexByCluster = new HashMap<>();
+    Map<String, List<MarkerBuilder>> markersToReaddByCluster = new HashMap<>();
 
     for (PlatformMarker markerToChange : markersToChange) {
       String markerId = markerToChange.getMarkerId();
@@ -134,7 +134,12 @@ class MarkersController {
           }
         }
       } else {
-        LatLng oldPosition = markerBuilder.getPosition();
+        // Remove from spatial index BEFORE mutating position — the QuadTree
+        // locates entries by getPosition(), so removal must happen while
+        // the builder still holds the old coordinates.
+        if (clusterManagerId != null) {
+          clusterManagersController.removeItemSilently(clusterManagerId, markerBuilder);
+        }
 
         Convert.interpretMarkerOptions(
             markerToChange, markerBuilder, assetManager, density, bitmapDescriptorFactoryWrapper);
@@ -148,8 +153,8 @@ class MarkersController {
               bitmapDescriptorFactoryWrapper);
         }
 
-        if (clusterManagerId != null && !markerBuilder.getPosition().equals(oldPosition)) {
-          markersToReindexByCluster
+        if (clusterManagerId != null) {
+          markersToReaddByCluster
               .computeIfAbsent(clusterManagerId, k -> new ArrayList<>())
               .add(markerBuilder);
         }
@@ -164,8 +169,8 @@ class MarkersController {
       clusterManagersController.addItems(entry.getKey(), entry.getValue());
     }
 
-    for (Map.Entry<String, List<MarkerBuilder>> entry : markersToReindexByCluster.entrySet()) {
-      clusterManagersController.reindexItems(entry.getKey(), entry.getValue());
+    for (Map.Entry<String, List<MarkerBuilder>> entry : markersToReaddByCluster.entrySet()) {
+      clusterManagersController.addItems(entry.getKey(), entry.getValue());
     }
   }
 
@@ -391,7 +396,10 @@ class MarkersController {
       return;
     }
 
-    LatLng oldPosition = markerBuilder.getPosition();
+    // Remove from spatial index BEFORE mutating position (see changeMarkers).
+    if (clusterManagerId != null) {
+      clusterManagersController.removeItemSilently(clusterManagerId, markerBuilder);
+    }
 
     Convert.interpretMarkerOptions(
         marker, markerBuilder, assetManager, density, bitmapDescriptorFactoryWrapper);
@@ -402,8 +410,8 @@ class MarkersController {
           marker, markerController, assetManager, density, bitmapDescriptorFactoryWrapper);
     }
 
-    if (clusterManagerId != null && !markerBuilder.getPosition().equals(oldPosition)) {
-      clusterManagersController.reindexItem(clusterManagerId, markerBuilder);
+    if (clusterManagerId != null) {
+      clusterManagersController.addItem(markerBuilder);
     }
   }
 }


### PR DESCRIPTION
## Description

When a clustered marker's position is updated in-place via `MarkersController.changeMarkers()`, the `ClusterManager`'s `NonHierarchicalDistanceBasedAlgorithm` retains stale `QuadTree` entries at the old coordinates. This causes **ghost clusters to appear at positions where no marker currently exists**.

### Root cause

`MarkersController.changeMarkers()` has two code paths when updating a marker:

1. **Cluster ID changed** — correctly calls `removeItem` + `addItem` on the `ClusterManager`, refreshing the spatial index.
2. **Same cluster ID (in-place update)** — calls `interpretMarkerOptions()` to update the `MarkerBuilder` properties (including position), but **does not reindex** the item in the `ClusterManager`. The `QuadTree` inside `NonHierarchicalDistanceBasedAlgorithm` stores a `QuadItem` wrapper that captures the position at insertion time. Without reindexing, the spatial index retains the stale position.

### Fix

- Capture the marker's `LatLng` position **before** `interpretMarkerOptions()` updates the builder.
- After the update, compare old vs. new position.
- If changed and the marker belongs to a `ClusterManager`, call `removeItem` + `addItem` to refresh the `QuadTree`.
- Batch variant (`reindexItems`) added for the public `changeMarkers()` path — calls `cluster()` only once per `ClusterManager` for efficiency.

### Files changed

- `ClusterManagersController.java`: added `reindexItem()` and `reindexItems()` methods.
- `MarkersController.java`: added position-change detection and reindex call in both the `changeMarkers()` (batch) and `changeMarker()` (single) paths.

### Reproduction

1. Create a `GoogleMap` with a `ClusterManager` and several markers.
2. Programmatically update the position of a clustered marker (keeping the same `MarkerId` and `ClusterManagerId`).
3. Observe that ghost clusters appear at the old positions and persist until the `ClusterManager` is fully rebuilt.

### Issues

*No associated issue yet — I will file one in `flutter/flutter` describing the ghost-cluster behavior and link it here before requesting review.*

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
