### PR TITLE
[url_launcher_android] Fix WebView content obscured by navigation bar on Android 15+

### DIFF
--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Fixes WebView content being obscured by system navigation bar on Android 15+
 
 ## 6.3.30
 

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -93,6 +93,8 @@ public class WebViewActivity extends Activity {
     super.onCreate(savedInstanceState);
     webview = new WebView(this);
     setContentView(webview);
+    // Apply system window insets as padding to prevent WebView content
+// from being obscured by system bars (e.g. navigation bar) on Android 15+.
     ViewCompat.setOnApplyWindowInsetsListener(
         webview,
         (v, insets) -> {

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -24,6 +24,9 @@ import androidx.core.content.ContextCompat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.graphics.Insets;
 
 /*  Launches WebView activity */
 public class WebViewActivity extends Activity {
@@ -90,6 +93,18 @@ public class WebViewActivity extends Activity {
     super.onCreate(savedInstanceState);
     webview = new WebView(this);
     setContentView(webview);
+    ViewCompat.setOnApplyWindowInsetsListener(webview, (v, insets) -> {
+    Insets systemBars = insets.getInsets(
+        WindowInsetsCompat.Type.systemBars()
+    );
+    v.setPadding(
+        systemBars.left,
+        systemBars.top,
+        systemBars.right,
+        systemBars.bottom
+    );
+    return insets;
+});
     // Get the Intent that started this activity and extract the string
     final Intent intent = getIntent();
     final String url = intent.getStringExtra(URL_EXTRA);

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -21,12 +21,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
-import androidx.core.graphics.Insets;
 
 /*  Launches WebView activity */
 public class WebViewActivity extends Activity {
@@ -93,18 +93,13 @@ public class WebViewActivity extends Activity {
     super.onCreate(savedInstanceState);
     webview = new WebView(this);
     setContentView(webview);
-    ViewCompat.setOnApplyWindowInsetsListener(webview, (v, insets) -> {
-    Insets systemBars = insets.getInsets(
-        WindowInsetsCompat.Type.systemBars()
-    );
-    v.setPadding(
-        systemBars.left,
-        systemBars.top,
-        systemBars.right,
-        systemBars.bottom
-    );
-    return insets;
-});
+    ViewCompat.setOnApplyWindowInsetsListener(
+        webview,
+        (v, insets) -> {
+          Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+          v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+          return insets;
+        });
     // Get the Intent that started this activity and extract the string
     final Intent intent = getIntent();
     final String url = intent.getStringExtra(URL_EXTRA);

--- a/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -26,16 +26,17 @@ public class WebViewActivityTest {
   public void onCreate_webviewIsNotNull() {
     WebViewActivity activity =
         Robolectric.buildActivity(
-                WebViewActivity.class,
-                WebViewActivity.createIntent(
-                    ApplicationProvider.getApplicationContext(),
-                    "https://flutter.dev",
-                    false,
-                    false,
-                    new Bundle()))
+            WebViewActivity.class,
+            WebViewActivity.createIntent(
+                ApplicationProvider.getApplicationContext(),
+                "https://flutter.dev",
+                false,
+                false,
+                new Bundle()))
             .create()
             .get();
 
     assertNotNull(activity.webview);
   }
 }
+

--- a/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -1,17 +1,41 @@
 // Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
 package io.flutter.plugins.urllauncher;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+import android.os.Bundle;
+import androidx.test.core.app.ApplicationProvider;
 import java.util.Collections;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
 
+@RunWith(RobolectricTestRunner.class)
 public class WebViewActivityTest {
+
   @Test
   public void extractHeaders_returnsEmptyMapWhenHeadersBundleNull() {
     assertEquals(WebViewActivity.extractHeaders(null), Collections.emptyMap());
+  }
+
+  @Test
+  public void onCreate_webviewIsNotNull() {
+    WebViewActivity activity =
+        Robolectric.buildActivity(
+                WebViewActivity.class,
+                WebViewActivity.createIntent(
+                    ApplicationProvider.getApplicationContext(),
+                    "https://flutter.dev",
+                    false,
+                    false,
+                    new Bundle()))
+            .create()
+            .get();
+
+    assertNotNull(activity.webview);
   }
 }

--- a/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -26,17 +26,16 @@ public class WebViewActivityTest {
   public void onCreate_webviewIsNotNull() {
     WebViewActivity activity =
         Robolectric.buildActivity(
-            WebViewActivity.class,
-            WebViewActivity.createIntent(
-                ApplicationProvider.getApplicationContext(),
-                "https://flutter.dev",
-                false,
-                false,
-                new Bundle()))
+                WebViewActivity.class,
+                WebViewActivity.createIntent(
+                    ApplicationProvider.getApplicationContext(),
+                    "https://flutter.dev",
+                    false,
+                    false,
+                    new Bundle()))
             .create()
             .get();
 
     assertNotNull(activity.webview);
   }
 }
-


### PR DESCRIPTION
Fixes flutter/flutter#170333

## Problem
On Android 15+ devices with button navigation bar, WebView content 
launched via `LaunchMode.inAppWebView` is obscured by the system 
navigation bar. Interactive elements like cookie banners are not tappable.

## Fix
Added `ViewCompat.setOnApplyWindowInsetsListener` to `WebViewActivity` 
to apply proper padding based on system window insets, ensuring WebView 
content respects the navigation bar area.

## Testing
Tested on Android 15 emulator with button navigation enabled.

"Note: The existing unit tests fail to compile due to a pre-existing Robolectric 4.16 compatibility issue unrelated to this change. This can be verified by running tests on the unmodified main branch."

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
