### PR TITLE
Add side method channel to lock camera focus at infinity

### DIFF
--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/CameraAndroidCameraxPlugin.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/CameraAndroidCameraxPlugin.java
@@ -15,6 +15,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 public final class CameraAndroidCameraxPlugin implements FlutterPlugin, ActivityAware {
   private FlutterPluginBinding pluginBinding;
   @VisibleForTesting @Nullable ProxyApiRegistrar proxyApiRegistrar;
+  @Nullable private FocusLockChannel focusLockChannel;
 
   /**
    * Initialize this within the {@code #configureFlutterEngine} of a Flutter activity or fragment.
@@ -33,6 +34,7 @@ public final class CameraAndroidCameraxPlugin implements FlutterPlugin, Activity
             binding.getApplicationContext(),
             binding.getTextureRegistry());
     proxyApiRegistrar.setUp();
+    focusLockChannel = new FocusLockChannel(binding.getBinaryMessenger());
   }
 
   @Override
@@ -42,6 +44,10 @@ public final class CameraAndroidCameraxPlugin implements FlutterPlugin, Activity
       proxyApiRegistrar.tearDown();
       proxyApiRegistrar.getInstanceManager().stopFinalizationListener();
       proxyApiRegistrar = null;
+    }
+    if (focusLockChannel != null) {
+      focusLockChannel.tearDown();
+      focusLockChannel = null;
     }
   }
 

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/CameraProxyApi.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/CameraProxyApi.java
@@ -22,7 +22,9 @@ class CameraProxyApi extends PigeonApiCamera {
   @NonNull
   @Override
   public CameraControl cameraControl(Camera pigeonInstance) {
-    return pigeonInstance.getCameraControl();
+    final CameraControl control = pigeonInstance.getCameraControl();
+    FocusLockChannel.setActiveCameraControl(control);
+    return control;
   }
 
   @NonNull

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/FocusLockChannel.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/FocusLockChannel.java
@@ -1,0 +1,102 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// yuvrecorder patch: exposes a side method channel that locks the active
+// CameraX camera's focus at infinity by setting CONTROL_AF_MODE=OFF and
+// LENS_FOCUS_DISTANCE=0 (0 diopters = infinity) via Camera2Interop.
+//
+// Re-applies the lock on every CameraX use-case rebind (e.g. startImageStream
+// recreates the capture session and drops prior Camera2Interop options).
+
+package io.flutter.plugins.camerax;
+
+import android.hardware.camera2.CameraMetadata;
+import android.hardware.camera2.CaptureRequest;
+import android.os.Handler;
+import android.os.Looper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.camera.camera2.interop.Camera2CameraControl;
+import androidx.camera.camera2.interop.CaptureRequestOptions;
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop;
+import androidx.camera.core.CameraControl;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+@ExperimentalCamera2Interop
+final class FocusLockChannel implements MethodChannel.MethodCallHandler {
+  static final String CHANNEL = "dev.aircraft.yuvrecorder/camera_focus";
+
+  @Nullable private static volatile CameraControl activeCameraControl;
+  // When true, every rebind that produces a fresh CameraControl re-applies
+  // infinity focus automatically (CameraX drops Camera2Interop options on
+  // use-case rebind, e.g. when startImageStream binds ImageAnalysis).
+  private static volatile boolean reapplyAtInfinityOnRebind = false;
+
+  static void setActiveCameraControl(@Nullable CameraControl control) {
+    activeCameraControl = control;
+    if (control != null && reapplyAtInfinityOnRebind) {
+      try {
+        Camera2CameraControl.from(control).addCaptureRequestOptions(infinityOptions());
+      } catch (Throwable ignored) {
+        // Best-effort; explicit method-channel calls surface real failures.
+      }
+    }
+  }
+
+  private static CaptureRequestOptions infinityOptions() {
+    return new CaptureRequestOptions.Builder()
+        .setCaptureRequestOption(
+            CaptureRequest.CONTROL_AF_MODE, CameraMetadata.CONTROL_AF_MODE_OFF)
+        .setCaptureRequestOption(CaptureRequest.LENS_FOCUS_DISTANCE, 0.0f)
+        .build();
+  }
+
+  private final MethodChannel channel;
+  private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+  FocusLockChannel(@NonNull BinaryMessenger messenger) {
+    channel = new MethodChannel(messenger, CHANNEL);
+    channel.setMethodCallHandler(this);
+  }
+
+  void tearDown() {
+    channel.setMethodCallHandler(null);
+    activeCameraControl = null;
+    reapplyAtInfinityOnRebind = false;
+  }
+
+  @Override
+  public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+    final CameraControl control = activeCameraControl;
+    if (control == null) {
+      result.error("no_camera", "Camera is not bound yet.", null);
+      return;
+    }
+    switch (call.method) {
+      case "lockFocusAtInfinity":
+        reapplyAtInfinityOnRebind = true;
+        applyOptions(control, infinityOptions(), result);
+        return;
+      default:
+        result.notImplemented();
+    }
+  }
+
+  private void applyOptions(
+      @NonNull CameraControl control,
+      @NonNull CaptureRequestOptions options,
+      @NonNull MethodChannel.Result result) {
+    try {
+      Camera2CameraControl.from(control)
+          .addCaptureRequestOptions(options)
+          .addListener(
+              () -> mainHandler.post(() -> result.success(null)),
+              command -> command.run());
+    } catch (Throwable t) {
+      mainHandler.post(() -> result.error("focus_lock_failed", t.getMessage(), null));
+    }
+  }
+}

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/ProcessCameraProviderProxyApi.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/ProcessCameraProviderProxyApi.java
@@ -84,10 +84,12 @@ class ProcessCameraProviderProxyApi extends PigeonApiProcessCameraProvider {
   public void unbind(
       ProcessCameraProvider pigeonInstance, @NonNull List<? extends UseCase> useCases) {
     pigeonInstance.unbind(useCases.toArray(new UseCase[0]));
+    FocusLockChannel.setActiveCameraControl(null);
   }
 
   @Override
   public void unbindAll(ProcessCameraProvider pigeonInstance) {
     pigeonInstance.unbindAll();
+    FocusLockChannel.setActiveCameraControl(null);
   }
 }

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/CameraPlugin.swift
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/CameraPlugin.swift
@@ -25,6 +25,7 @@ public final class CameraPlugin: NSObject, FlutterPlugin {
 
   /// An internal camera object that manages camera's state and performs camera operations.
   var camera: Camera?
+  private var focusLockChannel: FocusLockChannel?
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let instance = CameraPlugin(
@@ -44,6 +45,10 @@ public final class CameraPlugin: NSObject, FlutterPlugin {
     )
 
     SetUpFCPCameraApi(registrar.messenger(), instance)
+    instance.focusLockChannel = FocusLockChannel(
+      messenger: registrar.messenger(),
+      cameraPlugin: instance,
+      captureSessionQueue: instance.captureSessionQueue)
   }
 
   init(
@@ -84,6 +89,8 @@ public final class CameraPlugin: NSObject, FlutterPlugin {
 
   public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
     UIDevice.current.endGeneratingDeviceOrientationNotifications()
+    focusLockChannel?.tearDown()
+    focusLockChannel = nil
   }
 
   private static func flutterErrorFromNSError(_ error: NSError) -> FlutterError {

--- a/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FocusLockChannel.swift
+++ b/packages/camera/camera_avfoundation/ios/camera_avfoundation/Sources/camera_avfoundation/FocusLockChannel.swift
@@ -1,0 +1,81 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// yuvrecorder patch: exposes a side method channel that locks the active
+// AVCaptureDevice's focus at infinity via setFocusModeLocked(lensPosition: 1.0)
+// (lensPosition 1.0 = farthest focal point = optical infinity).
+
+import AVFoundation
+import Flutter
+
+#if canImport(camera_avfoundation_objc)
+  import camera_avfoundation_objc
+#endif
+
+final class FocusLockChannel: NSObject {
+  static let channelName = "dev.aircraft.yuvrecorder/camera_focus"
+
+  private let channel: FlutterMethodChannel
+  private weak var cameraPlugin: CameraPlugin?
+  private let captureSessionQueue: DispatchQueue
+
+  init(
+    messenger: FlutterBinaryMessenger,
+    cameraPlugin: CameraPlugin,
+    captureSessionQueue: DispatchQueue
+  ) {
+    self.channel = FlutterMethodChannel(name: Self.channelName, binaryMessenger: messenger)
+    self.cameraPlugin = cameraPlugin
+    self.captureSessionQueue = captureSessionQueue
+    super.init()
+    self.channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call: call, result: result)
+    }
+  }
+
+  func tearDown() {
+    channel.setMethodCallHandler(nil)
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "lockFocusAtInfinity":
+      lockFocusAtInfinity(result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func lockFocusAtInfinity(result: @escaping FlutterResult) {
+    captureSessionQueue.async { [weak self] in
+      guard let cam = self?.cameraPlugin?.camera as? FLTCam else {
+        result(
+          FlutterError(code: "no_camera", message: "Camera is not initialized yet.", details: nil))
+        return
+      }
+      let device = cam.captureDevice.device
+      guard device.isFocusModeSupported(.locked),
+        device.isLockingFocusWithCustomLensPositionSupported
+      else {
+        result(
+          FlutterError(
+            code: "unsupported",
+            message: "Device does not support locking focus at a custom lens position.",
+            details: nil))
+        return
+      }
+      do {
+        try device.lockForConfiguration()
+      } catch {
+        result(FlutterError(code: "lock_failed", message: error.localizedDescription, details: nil))
+        return
+      }
+      // lensPosition 1.0 = farthest = infinity.
+      device.setFocusModeLocked(lensPosition: 1.0) { _ in
+        device.unlockForConfiguration()
+        result(nil)
+      }
+    }
+  }
+}

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 0.9.22+1
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.3.0
   flutter: ">=3.35.0"
 
 flutter:


### PR DESCRIPTION
Adds a `dev.aircraft.yuvrecorder/camera_focus` MethodChannel to both camera_android_camerax and camera_avfoundation. Calling `lockFocusAtInfinity` pins the lens at optical infinity:

  Android: Camera2Interop CaptureRequestOptions with
           CONTROL_AF_MODE=OFF and LENS_FOCUS_DISTANCE=0.0 (0 diopters).
           Re-applied automatically on every use-case rebind so
           startImageStream (which recreates the capture session) does
           not silently revert to continuous autofocus.

  iOS:     AVCaptureDevice.setFocusModeLocked(lensPosition: 1.0)
           (lensPosition 1.0 = farthest = infinity).

Also lowers camera_avfoundation Dart sdk constraint from ^3.9.0 to ^3.3.0 to remain compatible with Flutter stable (Dart 3.8.x).

Motivated by yuvrecorder only ever recording distant targets where any close-focus excursion is always wrong.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
