### PR TITLE
Migrate shared_preferences_android to built-in Kotlin

### DIFF
--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.4.24
 
-* Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+- Migrates to built-in Kotlin
 
 ## 2.4.23
 

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 2.4.24
 
-- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 - Migrates to built-in Kotlin
 
 ## 2.4.23

--- a/packages/shared_preferences/shared_preferences_android/android/build.gradle.kts
+++ b/packages/shared_preferences/shared_preferences_android/android/build.gradle.kts
@@ -4,7 +4,6 @@ group = "io.flutter.plugins.sharedpreferences"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    val kotlinVersion = "2.3.0"
     repositories {
         google()
         mavenCentral()
@@ -12,7 +11,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
 
@@ -31,7 +29,12 @@ tasks.withType<JavaCompile>().configureEach {
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
+}
+
+val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
+
+if (agpMajor < 9) {
+    apply(plugin = "org.jetbrains.kotlin.android")
 }
 
 kotlin {
@@ -85,5 +88,11 @@ android {
                 }
             }
         }
+    }
+}
+
+project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }


### PR DESCRIPTION
Removes explicit Kotlin Gradle Plugin dependency and migrates to Flutter's built-in Kotlin support per the breaking-changes migration guide.