### PR TITLE
[go_router] Add route metadata support to GoRouterState.

### DIFF
--- a/packages/go_router/example/lib/route_metadata.dart
+++ b/packages/go_router/example/lib/route_metadata.dart
@@ -1,0 +1,98 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+void main() => runApp(const RouteMetadataApp());
+
+/// An example that displays metadata from the matched route.
+class RouteMetadataApp extends StatelessWidget {
+  /// Creates a [RouteMetadataApp].
+  const RouteMetadataApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(routerConfig: _router);
+  }
+}
+
+final GoRouter _router = GoRouter(
+  initialLocation: '/books',
+  routes: <RouteBase>[
+    GoRoute(
+      path: '/',
+      redirect: (BuildContext context, GoRouterState state) => '/books',
+    ),
+    GoRoute(
+      path: '/books',
+      metadata: const <String, dynamic>{
+        'section': 'Library',
+        'requiresAuth': true,
+        'analyticsName': 'books',
+      },
+      builder: (BuildContext context, GoRouterState state) {
+        return MetadataScreen(state: state);
+      },
+      routes: <RouteBase>[
+        GoRoute(
+          path: 'preview',
+          metadata: const <String, dynamic>{
+            'requiresAuth': false,
+            'analyticsName': 'book-preview',
+          },
+          builder: (BuildContext context, GoRouterState state) {
+            return MetadataScreen(state: state);
+          },
+        ),
+      ],
+    ),
+  ],
+);
+
+/// Displays the current route metadata.
+class MetadataScreen extends StatelessWidget {
+  /// Creates a [MetadataScreen].
+  const MetadataScreen({required this.state, super.key});
+
+  /// The current route state.
+  final GoRouterState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = state.metadata['analyticsName'] as String;
+    final requiresAuth = state.metadata['requiresAuth'] as bool;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: <Widget>[
+          ListTile(
+            title: const Text('section'),
+            subtitle: Text(state.metadata['section'] as String),
+          ),
+          ListTile(
+            title: const Text('requiresAuth'),
+            subtitle: Text(requiresAuth.toString()),
+          ),
+          ListTile(
+            title: const Text('analyticsName'),
+            subtitle: Text(title),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: () => context.go('/books'),
+            child: const Text('Books'),
+          ),
+          const SizedBox(height: 8),
+          FilledButton(
+            onPressed: () => context.go('/books/preview'),
+            child: const Text('Preview'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/go_router/example/lib/route_metadata.dart
+++ b/packages/go_router/example/lib/route_metadata.dart
@@ -21,10 +21,7 @@ class RouteMetadataApp extends StatelessWidget {
 final GoRouter _router = GoRouter(
   initialLocation: '/books',
   routes: <RouteBase>[
-    GoRoute(
-      path: '/',
-      redirect: (BuildContext context, GoRouterState state) => '/books',
-    ),
+    GoRoute(path: '/', redirect: (BuildContext context, GoRouterState state) => '/books'),
     GoRoute(
       path: '/books',
       metadata: const <String, dynamic>{
@@ -38,10 +35,7 @@ final GoRouter _router = GoRouter(
       routes: <RouteBase>[
         GoRoute(
           path: 'preview',
-          metadata: const <String, dynamic>{
-            'requiresAuth': false,
-            'analyticsName': 'book-preview',
-          },
+          metadata: const <String, dynamic>{'requiresAuth': false, 'analyticsName': 'book-preview'},
           builder: (BuildContext context, GoRouterState state) {
             return MetadataScreen(state: state);
           },
@@ -73,21 +67,12 @@ class MetadataScreen extends StatelessWidget {
             title: const Text('section'),
             subtitle: Text(state.metadata['section'] as String),
           ),
-          ListTile(
-            title: const Text('requiresAuth'),
-            subtitle: Text(requiresAuth.toString()),
-          ),
+          ListTile(title: const Text('requiresAuth'), subtitle: Text(requiresAuth.toString())),
           ListTile(title: const Text('analyticsName'), subtitle: Text(title)),
           const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () => context.go('/books'),
-            child: const Text('Books'),
-          ),
+          FilledButton(onPressed: () => context.go('/books'), child: const Text('Books')),
           const SizedBox(height: 8),
-          FilledButton(
-            onPressed: () => context.go('/books/preview'),
-            child: const Text('Preview'),
-          ),
+          FilledButton(onPressed: () => context.go('/books/preview'), child: const Text('Preview')),
         ],
       ),
     );

--- a/packages/go_router/example/lib/route_metadata.dart
+++ b/packages/go_router/example/lib/route_metadata.dart
@@ -77,10 +77,7 @@ class MetadataScreen extends StatelessWidget {
             title: const Text('requiresAuth'),
             subtitle: Text(requiresAuth.toString()),
           ),
-          ListTile(
-            title: const Text('analyticsName'),
-            subtitle: Text(title),
-          ),
+          ListTile(title: const Text('analyticsName'), subtitle: Text(title)),
           const SizedBox(height: 16),
           FilledButton(
             onPressed: () => context.go('/books'),

--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -388,6 +388,7 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
       error: matchList.error,
       pageKey: ValueKey<String>('${matchList.uri}(error)'),
       topRoute: matchList.lastOrNull?.route,
+      metadata: matchList.topRouteMetadata,
     );
   }
 

--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -113,6 +113,7 @@ class RouteBuilder {
         onPopPageWithRouteMatch: onPopPageWithRouteMatch,
         matchList: matchList,
         matches: matchList.matches,
+        inheritedMetadata: const <String, dynamic>{},
         configuration: configuration,
         errorBuilder: errorBuilder,
         errorPageBuilder: errorPageBuilder,
@@ -131,6 +132,7 @@ class _CustomNavigator extends StatefulWidget {
     required this.onPopPageWithRouteMatch,
     required this.matchList,
     required this.matches,
+    required this.inheritedMetadata,
     required this.configuration,
     required this.errorBuilder,
     required this.errorPageBuilder,
@@ -146,6 +148,7 @@ class _CustomNavigator extends StatefulWidget {
   /// to build navigator in shell route. In this case, these matches come from
   /// the [ShellRouteMatch.matches].
   final List<RouteMatchBase> matches;
+  final Map<String, dynamic> inheritedMetadata;
   final RouteMatchList matchList;
   final RouteConfiguration configuration;
   final PopPageWithRouteMatchCallback onPopPageWithRouteMatch;
@@ -167,7 +170,8 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
   @override
   void didUpdateWidget(_CustomNavigator oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.matchList != oldWidget.matchList) {
+    if (widget.matchList != oldWidget.matchList ||
+        widget.inheritedMetadata != oldWidget.inheritedMetadata) {
       _pages = null;
     }
   }
@@ -205,14 +209,24 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
     if (widget.matchList.isError) {
       pages.add(_buildErrorPage(context, widget.matchList));
     } else {
+      Map<String, dynamic> currentInheritedMetadata = widget.inheritedMetadata;
       for (final RouteMatchBase match in widget.matches) {
-        final Page<Object?>? page = _buildPage(context, match);
+        final Map<String, dynamic> metadata = match is ImperativeRouteMatch
+            ? match.matches.topRouteMetadata
+            : RouteMatchList.mergeMetadata(currentInheritedMetadata, match.route.metadata);
+        final GoRouterState state = match.buildState(
+          widget.configuration,
+          widget.matchList,
+          metadata: metadata,
+        );
+        final Page<Object?>? page = _buildPage(context, match, state);
+        currentInheritedMetadata = metadata;
         if (page == null) {
           continue;
         }
         pages.add(page);
         pageToRouteMatchBase[page] = match;
-        registry[page] = match.buildState(widget.configuration, widget.matchList);
+        registry[page] = state;
       }
     }
     _pages = pages;
@@ -220,23 +234,22 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
     _pageToRouteMatchBase = pageToRouteMatchBase;
   }
 
-  Page<Object?>? _buildPage(BuildContext context, RouteMatchBase match) {
+  Page<Object?>? _buildPage(BuildContext context, RouteMatchBase match, GoRouterState state) {
     if (match is RouteMatch) {
       if (match is ImperativeRouteMatch && match.matches.isError) {
         return _buildErrorPage(context, match.matches);
       }
-      return _buildPageForGoRoute(context, match);
+      return _buildPageForGoRoute(context, match, state);
     }
     if (match is ShellRouteMatch) {
-      return _buildPageForShellRoute(context, match);
+      return _buildPageForShellRoute(context, match, state);
     }
     throw GoError('unknown match type ${match.runtimeType}');
   }
 
   /// Builds a [Page] for a [RouteMatch]
-  Page<Object?>? _buildPageForGoRoute(BuildContext context, RouteMatch match) {
+  Page<Object?>? _buildPageForGoRoute(BuildContext context, RouteMatch match, GoRouterState state) {
     final GoRouterPageBuilder? pageBuilder = match.route.pageBuilder;
-    final GoRouterState state = match.buildState(widget.configuration, widget.matchList);
     if (pageBuilder != null) {
       final Page<Object?> page = pageBuilder(context, state);
       if (page is! NoOpPage) {
@@ -261,8 +274,11 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
   }
 
   /// Builds a [Page] for a [ShellRouteMatch]
-  Page<Object?> _buildPageForShellRoute(BuildContext context, ShellRouteMatch match) {
-    final GoRouterState state = match.buildState(widget.configuration, widget.matchList);
+  Page<Object?> _buildPageForShellRoute(
+    BuildContext context,
+    ShellRouteMatch match,
+    GoRouterState state,
+  ) {
     final GlobalKey<NavigatorState> navigatorKey = match.navigatorKey;
     final shellRouteContext = ShellRouteContext(
       route: match.route,
@@ -291,6 +307,7 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
                 navigatorKey: navigatorKey,
                 matches: match.matches,
                 matchList: matchList,
+                inheritedMetadata: state.metadata,
                 configuration: widget.configuration,
                 observers: observers ?? const <NavigatorObserver>[],
                 onPopPageWithRouteMatch: widget.onPopPageWithRouteMatch,

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -219,6 +219,7 @@ class RouteConfiguration {
       pageKey: const ValueKey<String>('topLevel'),
       topRoute: matchList.lastOrNull?.route,
       error: matchList.error,
+      metadata: matchList.topRouteMetadata,
     );
   }
 

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -539,7 +539,10 @@ class RouteConfiguration {
     final RouteBase route = match.route;
     try {
       final FutureOr<String?> routeRedirectResult = _runInRouterZone(() {
-        return route.redirect!.call(context, match.buildState(this, matchList));
+        return route.redirect!.call(
+          context,
+          match.buildState(this, matchList, metadata: matchList.metadataFor(match)),
+        );
       });
       if (routeRedirectResult is String?) {
         return processRouteRedirect(routeRedirectResult);

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -67,7 +67,11 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList> with ChangeNotifie
     if (lastRoute.onExit != null && navigatorKey.currentContext != null) {
       return !(await lastRoute.onExit!(
         navigatorKey.currentContext!,
-        currentConfiguration.last.buildState(_configuration, currentConfiguration),
+        currentConfiguration.last.buildState(
+          _configuration,
+          currentConfiguration,
+          metadata: currentConfiguration.topRouteMetadata,
+        ),
       ));
     }
 
@@ -156,7 +160,11 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList> with ChangeNotifie
     scheduleMicrotask(() async {
       final bool onExitResult = await routeBase.onExit!(
         navigatorKey.currentContext!,
-        leafMatch.buildState(_configuration, currentConfiguration),
+        leafMatch.buildState(
+          _configuration,
+          currentConfiguration,
+          metadata: currentConfiguration.metadataFor(leafMatch),
+        ),
       );
       if (onExitResult) {
         _completeRouteMatch(result, match);
@@ -193,8 +201,11 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList> with ChangeNotifie
 
   /// The top [GoRouterState], the state of the route that was
   /// last used in either [GoRouter.go] or [GoRouter.push].
-  GoRouterState get state =>
-      currentConfiguration.last.buildState(_configuration, currentConfiguration);
+  GoRouterState get state => currentConfiguration.last.buildState(
+    _configuration,
+    currentConfiguration,
+    metadata: currentConfiguration.topRouteMetadata,
+  );
 
   /// For use by the Router architecture as part of the RouterDelegate.
   GlobalKey<NavigatorState> get navigatorKey => _configuration.navigatorKey;
@@ -293,7 +304,11 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList> with ChangeNotifie
 
     final FutureOr<bool> exitFuture = goRoute.onExit!(
       context,
-      match.buildState(_configuration, currentConfiguration),
+      match.buildState(
+        _configuration,
+        currentConfiguration,
+        metadata: currentConfiguration.metadataFor(match),
+      ),
     );
     if (exitFuture is bool) {
       return handleOnExitResult(exitFuture);

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -322,7 +322,7 @@ class RouteMatch extends RouteMatchBase {
       path: route.path,
       extra: matches.extra,
       topRoute: matches.lastOrNull?.route,
-      metadata: matches.routeMetadataFor(this),
+      metadata: matches._routeMetadataFor(this),
     );
   }
 }
@@ -366,7 +366,7 @@ class ShellRouteMatch extends RouteMatchBase {
 
   @override
   GoRouterState buildState(RouteConfiguration configuration, RouteMatchList matches) {
-    final Map<String, dynamic> metadata = matches.routeMetadataFor(this);
+    final Map<String, dynamic> metadata = matches._routeMetadataFor(this);
     // The route related data is stored in the leaf route match.
     final RouteMatch leafMatch = _lastLeaf;
     if (leafMatch is ImperativeRouteMatch) {
@@ -759,12 +759,7 @@ class RouteMatchList with Diagnosticable {
     return result;
   }
 
-  /// Returns merged metadata for the provided [target] route match.
-  ///
-  /// Metadata is inherited from parent routes and overridden by child routes.
-  /// Returns an empty map when no metadata can be found.
-  @meta.internal
-  Map<String, dynamic> routeMetadataFor(RouteMatchBase target) {
+  Map<String, dynamic> _routeMetadataFor(RouteMatchBase target) {
     return _metadataForRouteMatch(
           matches: matches,
           target: target,
@@ -786,7 +781,7 @@ class RouteMatchList with Diagnosticable {
     if (target is ImperativeRouteMatch) {
       return target.matches.topRouteMetadata;
     }
-    return routeMetadataFor(target);
+    return _routeMetadataFor(target);
   }
 
   static RouteMatchBase? _lastRouteMatchOrNull(List<RouteMatchBase> matches) {

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
@@ -47,7 +48,11 @@ abstract class RouteMatchBase with Diagnosticable {
   String get matchedLocation;
 
   /// Gets the state that represent this route match.
-  GoRouterState buildState(RouteConfiguration configuration, RouteMatchList matches);
+  GoRouterState buildState(
+    RouteConfiguration configuration,
+    RouteMatchList matches, {
+    required Map<String, dynamic> metadata,
+  });
 
   /// Generates a list of [RouteMatchBase] objects by matching the `route` and
   /// its sub-routes with `uri`.
@@ -310,7 +315,11 @@ class RouteMatch extends RouteMatchBase {
   int get hashCode => Object.hash(route, matchedLocation, pageKey);
 
   @override
-  GoRouterState buildState(RouteConfiguration configuration, RouteMatchList matches) {
+  GoRouterState buildState(
+    RouteConfiguration configuration,
+    RouteMatchList matches, {
+    required Map<String, dynamic> metadata,
+  }) {
     return GoRouterState(
       configuration,
       uri: matches.uri,
@@ -322,7 +331,7 @@ class RouteMatch extends RouteMatchBase {
       path: route.path,
       extra: matches.extra,
       topRoute: matches.lastOrNull?.route,
-      metadata: matches._routeMetadataFor(this),
+      metadata: metadata,
     );
   }
 }
@@ -365,8 +374,11 @@ class ShellRouteMatch extends RouteMatchBase {
   final ValueKey<String> pageKey;
 
   @override
-  GoRouterState buildState(RouteConfiguration configuration, RouteMatchList matches) {
-    final Map<String, dynamic> metadata = matches._routeMetadataFor(this);
+  GoRouterState buildState(
+    RouteConfiguration configuration,
+    RouteMatchList matches, {
+    required Map<String, dynamic> metadata,
+  }) {
     // The route related data is stored in the leaf route match.
     final RouteMatch leafMatch = _lastLeaf;
     if (leafMatch is ImperativeRouteMatch) {
@@ -451,7 +463,11 @@ class ImperativeRouteMatch extends RouteMatch {
   }
 
   @override
-  GoRouterState buildState(RouteConfiguration configuration, RouteMatchList matches) {
+  GoRouterState buildState(
+    RouteConfiguration configuration,
+    RouteMatchList matches, {
+    required Map<String, dynamic> metadata,
+  }) {
     return GoRouterState(
       configuration,
       uri: this.matches.uri,
@@ -463,7 +479,7 @@ class ImperativeRouteMatch extends RouteMatch {
       path: route.path,
       extra: this.matches.extra,
       topRoute: this.matches.lastOrNull?.route,
-      metadata: this.matches.topRouteMetadata,
+      metadata: metadata,
     );
   }
 
@@ -759,13 +775,16 @@ class RouteMatchList with Diagnosticable {
     return result;
   }
 
-  Map<String, dynamic> _routeMetadataFor(RouteMatchBase target) {
-    return _metadataForRouteMatch(
-          matches: matches,
-          target: target,
-          inheritedMetadata: const <String, dynamic>{},
-        ) ??
-        const <String, dynamic>{};
+  late final Map<RouteMatchBase, Map<String, dynamic>> _metadataByRouteMatch =
+      _buildMetadataByRouteMatch(matches);
+
+  /// Returns merged metadata for [match].
+  @meta.internal
+  Map<String, dynamic> metadataFor(RouteMatchBase match) {
+    if (match is ImperativeRouteMatch) {
+      return match.matches.topRouteMetadata;
+    }
+    return _metadataByRouteMatch[match] ?? const <String, dynamic>{};
   }
 
   /// Returns merged metadata for the currently matched top route.
@@ -778,10 +797,7 @@ class RouteMatchList with Diagnosticable {
     if (target == null) {
       return const <String, dynamic>{};
     }
-    if (target is ImperativeRouteMatch) {
-      return target.matches.topRouteMetadata;
-    }
-    return _routeMetadataFor(target);
+    return metadataFor(target);
   }
 
   static RouteMatchBase? _lastRouteMatchOrNull(List<RouteMatchBase> matches) {
@@ -795,36 +811,44 @@ class RouteMatchList with Diagnosticable {
     return current;
   }
 
-  static Map<String, dynamic>? _metadataForRouteMatch({
+  static Map<RouteMatchBase, Map<String, dynamic>> _buildMetadataByRouteMatch(
+    List<RouteMatchBase> matches,
+  ) {
+    final Map<RouteMatchBase, Map<String, dynamic>> result =
+        HashMap<RouteMatchBase, Map<String, dynamic>>.identity();
+    _addMetadataByRouteMatch(
+      matches: matches,
+      inheritedMetadata: const <String, dynamic>{},
+      result: result,
+    );
+    return result;
+  }
+
+  static void _addMetadataByRouteMatch({
     required List<RouteMatchBase> matches,
-    required RouteMatchBase target,
     required Map<String, dynamic> inheritedMetadata,
+    required Map<RouteMatchBase, Map<String, dynamic>> result,
   }) {
     var currentInheritedMetadata = inheritedMetadata;
     for (final match in matches) {
-      final Map<String, dynamic> currentMetadata = _mergeMetadata(
-        currentInheritedMetadata,
-        match.route.metadata,
-      );
-      if (identical(match, target)) {
-        return currentMetadata;
-      }
+      final Map<String, dynamic> currentMetadata = match is ImperativeRouteMatch
+          ? match.matches.topRouteMetadata
+          : mergeMetadata(currentInheritedMetadata, match.route.metadata);
+      result[match] = currentMetadata;
       if (match is ShellRouteMatch) {
-        final Map<String, dynamic>? childMetadata = _metadataForRouteMatch(
+        _addMetadataByRouteMatch(
           matches: match.matches,
-          target: target,
           inheritedMetadata: currentMetadata,
+          result: result,
         );
-        if (childMetadata != null) {
-          return childMetadata;
-        }
       }
       currentInheritedMetadata = currentMetadata;
     }
-    return null;
   }
 
-  static Map<String, dynamic> _mergeMetadata(
+  /// Merges metadata inherited from a parent with metadata from its child.
+  @meta.internal
+  static Map<String, dynamic> mergeMetadata(
     Map<String, dynamic> parentMetadata,
     Map<String, dynamic>? currentMetadata,
   ) {

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -322,6 +322,7 @@ class RouteMatch extends RouteMatchBase {
       path: route.path,
       extra: matches.extra,
       topRoute: matches.lastOrNull?.route,
+      metadata: matches.routeMetadataFor(this),
     );
   }
 }
@@ -365,6 +366,7 @@ class ShellRouteMatch extends RouteMatchBase {
 
   @override
   GoRouterState buildState(RouteConfiguration configuration, RouteMatchList matches) {
+    final Map<String, dynamic> metadata = matches.routeMetadataFor(this);
     // The route related data is stored in the leaf route match.
     final RouteMatch leafMatch = _lastLeaf;
     if (leafMatch is ImperativeRouteMatch) {
@@ -379,6 +381,7 @@ class ShellRouteMatch extends RouteMatchBase {
       pageKey: pageKey,
       extra: matches.extra,
       topRoute: matches.lastOrNull?.route,
+      metadata: metadata,
     );
   }
 
@@ -449,7 +452,19 @@ class ImperativeRouteMatch extends RouteMatch {
 
   @override
   GoRouterState buildState(RouteConfiguration configuration, RouteMatchList matches) {
-    return super.buildState(configuration, this.matches);
+    return GoRouterState(
+      configuration,
+      uri: this.matches.uri,
+      matchedLocation: matchedLocation,
+      fullPath: this.matches.fullPath,
+      pathParameters: this.matches.pathParameters,
+      pageKey: pageKey,
+      name: route.name,
+      path: route.path,
+      extra: this.matches.extra,
+      topRoute: this.matches.lastOrNull?.route,
+      metadata: this.matches.topRouteMetadata,
+    );
   }
 
   @override
@@ -742,6 +757,89 @@ class RouteMatchList with Diagnosticable {
       return true;
     });
     return result;
+  }
+
+  /// Returns merged metadata for the provided [target] route match.
+  ///
+  /// Metadata is inherited from parent routes and overridden by child routes.
+  /// Returns an empty map when no metadata can be found.
+  @meta.internal
+  Map<String, dynamic> routeMetadataFor(RouteMatchBase target) {
+    return _metadataForRouteMatch(
+          matches: matches,
+          target: target,
+          inheritedMetadata: const <String, dynamic>{},
+        ) ??
+        const <String, dynamic>{};
+  }
+
+  /// Returns merged metadata for the currently matched top route.
+  ///
+  /// For imperative matches, this resolves metadata from the imperative match's
+  /// own match list.
+  @meta.internal
+  Map<String, dynamic> get topRouteMetadata {
+    final RouteMatchBase? target = _lastRouteMatchOrNull(matches);
+    if (target == null) {
+      return const <String, dynamic>{};
+    }
+    if (target is ImperativeRouteMatch) {
+      return target.matches.topRouteMetadata;
+    }
+    return routeMetadataFor(target);
+  }
+
+  static RouteMatchBase? _lastRouteMatchOrNull(List<RouteMatchBase> matches) {
+    if (matches.isEmpty) {
+      return null;
+    }
+    RouteMatchBase current = matches.last;
+    while (current is ShellRouteMatch && current.matches.isNotEmpty) {
+      current = current.matches.last;
+    }
+    return current;
+  }
+
+  static Map<String, dynamic>? _metadataForRouteMatch({
+    required List<RouteMatchBase> matches,
+    required RouteMatchBase target,
+    required Map<String, dynamic> inheritedMetadata,
+  }) {
+    var currentInheritedMetadata = inheritedMetadata;
+    for (final match in matches) {
+      final Map<String, dynamic> currentMetadata = _mergeMetadata(
+        currentInheritedMetadata,
+        match.route.metadata,
+      );
+      if (identical(match, target)) {
+        return currentMetadata;
+      }
+      if (match is ShellRouteMatch) {
+        final Map<String, dynamic>? childMetadata = _metadataForRouteMatch(
+          matches: match.matches,
+          target: target,
+          inheritedMetadata: currentMetadata,
+        );
+        if (childMetadata != null) {
+          return childMetadata;
+        }
+      }
+      currentInheritedMetadata = currentMetadata;
+    }
+    return null;
+  }
+
+  static Map<String, dynamic> _mergeMetadata(
+    Map<String, dynamic> parentMetadata,
+    Map<String, dynamic>? currentMetadata,
+  ) {
+    if (currentMetadata == null || currentMetadata.isEmpty) {
+      return parentMetadata;
+    }
+    if (parentMetadata.isEmpty) {
+      return Map<String, dynamic>.of(currentMetadata);
+    }
+    return <String, dynamic>{...parentMetadata, ...currentMetadata};
   }
 
   /// Traverse route matches in this match list in preorder until visitor

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -556,6 +556,7 @@ class _OnEnterHandler {
       pageKey: const ValueKey<String>('topLevel'),
       topRoute: matchList.lastOrNull?.route,
       error: matchList.error,
+      metadata: matchList.topRouteMetadata,
     );
   }
 

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -224,9 +224,15 @@ abstract class RouteBase with Diagnosticable {
   /// Navigator instead of the nearest ShellRoute ancestor.
   final GlobalKey<NavigatorState>? parentNavigatorKey;
 
-  /// Metadata associated with the current route.
+  /// Application-defined metadata associated with this route.
   ///
-  /// Metadata is inherited from parent routes and overridden by child routes.
+  /// This can be used to attach static information that is useful while
+  /// building the matched page, such as analytics labels, page titles,
+  /// permissions, or feature flags. The merged metadata for the current match
+  /// is available from [GoRouterState.metadata].
+  ///
+  /// Metadata is inherited from parent routes and child route values override
+  /// parent values with the same key.
   final Map<String, dynamic>? metadata;
 
   /// Builds a lists containing the provided routes along with all their

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -151,7 +151,12 @@ typedef ExitCallback = FutureOr<bool> Function(BuildContext context, GoRouterSta
 /// See [main.dart](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/main.dart)
 @immutable
 abstract class RouteBase with Diagnosticable {
-  const RouteBase._({this.redirect, required this.routes, required this.parentNavigatorKey});
+  const RouteBase._({
+    this.redirect,
+    this.metadata,
+    required this.routes,
+    required this.parentNavigatorKey,
+  });
 
   /// An optional redirect function for this route.
   ///
@@ -219,6 +224,11 @@ abstract class RouteBase with Diagnosticable {
   /// Navigator instead of the nearest ShellRoute ancestor.
   final GlobalKey<NavigatorState>? parentNavigatorKey;
 
+  /// Metadata associated with the current route.
+  ///
+  /// Metadata is inherited from parent routes and overridden by child routes.
+  final Map<String, dynamic>? metadata;
+
   /// Builds a lists containing the provided routes along with all their
   /// descendant [routes].
   static Iterable<RouteBase> routesRecursively(Iterable<RouteBase> routes) {
@@ -263,6 +273,7 @@ class GoRoute extends RouteBase {
     this.pageBuilder,
     super.parentNavigatorKey,
     super.redirect,
+    super.metadata,
     this.onExit,
     this.caseSensitive = true,
     super.routes = const <RouteBase>[],
@@ -476,6 +487,7 @@ abstract class ShellRouteBase extends RouteBase {
     super.redirect,
     required super.routes,
     required super.parentNavigatorKey,
+    super.metadata,
     this.notifyRootObserver = true,
   }) : super._();
 
@@ -690,6 +702,7 @@ class ShellRoute extends ShellRouteBase {
     this.pageBuilder,
     super.notifyRootObserver,
     this.observers,
+    super.metadata,
     required super.routes,
     super.parentNavigatorKey,
     GlobalKey<NavigatorState>? navigatorKey,
@@ -867,6 +880,7 @@ class StatefulShellRoute extends ShellRouteBase {
     super.notifyRootObserver,
     required this.navigatorContainerBuilder,
     super.parentNavigatorKey,
+    super.metadata,
     this.restorationScopeId,
     GlobalKey<StatefulNavigationShellState>? key,
   }) : assert(branches.isNotEmpty),

--- a/packages/go_router/lib/src/state.dart
+++ b/packages/go_router/lib/src/state.dart
@@ -85,10 +85,13 @@ class GoRouterState {
   /// associated GoRouterState to be uniquely identified using [GoRoute.name]
   final GoRoute? topRoute;
 
-  /// Metadata associated with the current route.
+  /// Merged application-defined metadata for the current route match.
   ///
-  /// Metadata is inherited from parent routes and overridden by child routes.
-  /// This map is never null.
+  /// Metadata is inherited from parent routes, and child routes override
+  /// parent values with the same key. For example, if a parent route has
+  /// `{'section': 'library', 'requiresAuth': true}` and the matched child route
+  /// has `{'requiresAuth': false, 'title': 'Preview'}`, this value is
+  /// `{'section': 'library', 'requiresAuth': false, 'title': 'Preview'}`.
   final Map<String, dynamic> metadata;
 
   /// Gets the [GoRouterState] from context.

--- a/packages/go_router/lib/src/state.dart
+++ b/packages/go_router/lib/src/state.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
@@ -27,6 +28,7 @@ class GoRouterState {
     this.error,
     required this.pageKey,
     this.topRoute,
+    this.metadata = const <String, dynamic>{},
   });
   final RouteConfiguration _configuration;
 
@@ -82,6 +84,12 @@ class GoRouterState {
   /// matched location associated with the [ShellRoute]. This allows the [ShellRoute]'s
   /// associated GoRouterState to be uniquely identified using [GoRoute.name]
   final GoRoute? topRoute;
+
+  /// Metadata associated with the current route.
+  ///
+  /// Metadata is inherited from parent routes and overridden by child routes.
+  /// This map is never null.
+  final Map<String, dynamic> metadata;
 
   /// Gets the [GoRouterState] from context.
   ///
@@ -180,7 +188,8 @@ class GoRouterState {
         other.pathParameters == pathParameters &&
         other.extra == extra &&
         other.error == error &&
-        other.pageKey == pageKey;
+        other.pageKey == pageKey &&
+        const MapEquality<String, dynamic>().equals(other.metadata, metadata);
   }
 
   @override
@@ -194,6 +203,12 @@ class GoRouterState {
     extra,
     error,
     pageKey,
+    Object.hashAllUnordered(
+      metadata.entries.map<int>(
+        (MapEntry<String, dynamic> entry) =>
+            Object.hash(entry.key, entry.value),
+      ),
+    ),
   );
 }
 

--- a/packages/go_router/lib/src/state.dart
+++ b/packages/go_router/lib/src/state.dart
@@ -208,8 +208,7 @@ class GoRouterState {
     pageKey,
     Object.hashAllUnordered(
       metadata.entries.map<int>(
-        (MapEntry<String, dynamic> entry) =>
-            Object.hash(entry.key, entry.value),
+        (MapEntry<String, dynamic> entry) => Object.hash(entry.key, entry.value),
       ),
     ),
   );

--- a/packages/go_router/pending_changelogs/change_2026_08_05_1785930286558.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_08_05_1785930286558.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds route `metadata` support, including inheritance and override behavior with exposure on `GoRouterState`.
+version: minor

--- a/packages/go_router/test/go_router_state_test.dart
+++ b/packages/go_router/test/go_router_state_test.dart
@@ -394,5 +394,50 @@ void main() {
       expect(emptyState!.metadata, isEmpty);
       expect(emptyState!.metadata, isNotNull);
     });
+
+    testWidgets('metadata is available after imperative push', (
+      WidgetTester tester,
+    ) async {
+      GoRouterState? pushedState;
+
+      final routes = <RouteBase>[
+        GoRoute(
+          path: '/',
+          metadata: const <String, dynamic>{
+            'fromParent': true,
+            'presentation': 'base',
+          },
+          builder: (BuildContext context, GoRouterState state) {
+            return const Text('home');
+          },
+          routes: <RouteBase>[
+            GoRoute(
+              path: 'push',
+              metadata: const <String, dynamic>{
+                'presentation': 'pushed',
+                'fromChild': true,
+              },
+              builder: (BuildContext context, GoRouterState state) {
+                pushedState = state;
+                return const Text('push');
+              },
+            ),
+          ],
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+      expect(find.text('home'), findsOneWidget);
+
+      router.push('/push');
+      await tester.pumpAndSettle();
+
+      expect(pushedState, isNotNull);
+      expect(pushedState!.metadata, const <String, dynamic>{
+        'fromParent': true,
+        'presentation': 'pushed',
+        'fromChild': true,
+      });
+    });
   });
 }

--- a/packages/go_router/test/go_router_state_test.dart
+++ b/packages/go_router/test/go_router_state_test.dart
@@ -323,5 +323,76 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('B'), findsOneWidget);
     });
+
+    testWidgets('metadata inherits, overrides, and defaults to empty map', (
+      WidgetTester tester,
+    ) async {
+      GoRouterState? inheritedState;
+      GoRouterState? overriddenState;
+      GoRouterState? emptyState;
+
+      final routes = <RouteBase>[
+        GoRoute(
+          path: '/',
+          metadata: const <String, dynamic>{
+            'fromParent': 'yes',
+            'shared': 'parent',
+          },
+          builder: (_, __) => const SizedBox.shrink(),
+          routes: <RouteBase>[
+            GoRoute(
+              path: 'inherit',
+              builder: (BuildContext context, GoRouterState state) {
+                inheritedState = state;
+                return const Text('inherit');
+              },
+            ),
+            GoRoute(
+              path: 'override',
+              metadata: const <String, dynamic>{
+                'shared': 'child',
+                'childOnly': true,
+              },
+              builder: (BuildContext context, GoRouterState state) {
+                overriddenState = state;
+                return const Text('override');
+              },
+            ),
+          ],
+        ),
+        GoRoute(
+          path: '/empty',
+          builder: (BuildContext context, GoRouterState state) {
+            emptyState = state;
+            return const Text('empty');
+          },
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+
+      router.go('/inherit');
+      await tester.pumpAndSettle();
+      expect(inheritedState, isNotNull);
+      expect(inheritedState!.metadata, const <String, dynamic>{
+        'fromParent': 'yes',
+        'shared': 'parent',
+      });
+
+      router.go('/override');
+      await tester.pumpAndSettle();
+      expect(overriddenState, isNotNull);
+      expect(overriddenState!.metadata, const <String, dynamic>{
+        'fromParent': 'yes',
+        'shared': 'child',
+        'childOnly': true,
+      });
+
+      router.go('/empty');
+      await tester.pumpAndSettle();
+      expect(emptyState, isNotNull);
+      expect(emptyState!.metadata, isEmpty);
+      expect(emptyState!.metadata, isNotNull);
+    });
   });
 }

--- a/packages/go_router/test/go_router_state_test.dart
+++ b/packages/go_router/test/go_router_state_test.dart
@@ -334,11 +334,8 @@ void main() {
       final routes = <RouteBase>[
         GoRoute(
           path: '/',
-          metadata: const <String, dynamic>{
-            'fromParent': 'yes',
-            'shared': 'parent',
-          },
-          builder: (_, __) => const SizedBox.shrink(),
+          metadata: const <String, dynamic>{'fromParent': 'yes', 'shared': 'parent'},
+          builder: (_, _) => const SizedBox.shrink(),
           routes: <RouteBase>[
             GoRoute(
               path: 'inherit',
@@ -349,10 +346,7 @@ void main() {
             ),
             GoRoute(
               path: 'override',
-              metadata: const <String, dynamic>{
-                'shared': 'child',
-                'childOnly': true,
-              },
+              metadata: const <String, dynamic>{'shared': 'child', 'childOnly': true},
               builder: (BuildContext context, GoRouterState state) {
                 overriddenState = state;
                 return const Text('override');
@@ -395,28 +389,114 @@ void main() {
       expect(emptyState!.metadata, isNotNull);
     });
 
-    testWidgets('metadata is available after imperative push', (
-      WidgetTester tester,
-    ) async {
+    testWidgets('metadata is accumulated through nested shell routes', (WidgetTester tester) async {
+      GoRouterState? shellState;
+      GoRouterState? leafState;
+
+      final routes = <RouteBase>[
+        GoRoute(
+          path: '/',
+          metadata: const <String, dynamic>{'section': 'root', 'shared': 'root'},
+          builder: (_, _) => const SizedBox.shrink(),
+          routes: <RouteBase>[
+            ShellRoute(
+              metadata: const <String, dynamic>{'shell': true, 'shared': 'shell'},
+              builder: (BuildContext context, GoRouterState state, Widget child) {
+                shellState = state;
+                return child;
+              },
+              routes: <RouteBase>[
+                GoRoute(
+                  path: 'details',
+                  metadata: const <String, dynamic>{'page': 'details', 'shared': 'leaf'},
+                  builder: (BuildContext context, GoRouterState state) {
+                    leafState = state;
+                    return const Text('details');
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+      router.go('/details');
+      await tester.pumpAndSettle();
+
+      expect(shellState, isNotNull);
+      expect(shellState!.metadata, const <String, dynamic>{
+        'section': 'root',
+        'shared': 'shell',
+        'shell': true,
+      });
+      expect(leafState, isNotNull);
+      expect(leafState!.metadata, const <String, dynamic>{
+        'section': 'root',
+        'shared': 'leaf',
+        'shell': true,
+        'page': 'details',
+      });
+      expect(router.state.metadata, leafState!.metadata);
+    });
+
+    testWidgets('metadata is available to redirects and onExit', (WidgetTester tester) async {
+      Map<String, dynamic>? redirectMetadata;
+      Map<String, dynamic>? onExitMetadata;
+
+      final routes = <RouteBase>[
+        GoRoute(
+          path: '/',
+          metadata: const <String, dynamic>{'section': 'root'},
+          builder: (_, _) => const Text('home'),
+          routes: <RouteBase>[
+            GoRoute(
+              path: 'redirect',
+              metadata: const <String, dynamic>{'source': 'redirect'},
+              redirect: (BuildContext context, GoRouterState state) {
+                redirectMetadata = state.metadata;
+                return '/guarded';
+              },
+            ),
+            GoRoute(
+              path: 'guarded',
+              metadata: const <String, dynamic>{'page': 'guarded'},
+              builder: (_, _) => const Text('guarded'),
+              onExit: (BuildContext context, GoRouterState state) {
+                onExitMetadata = state.metadata;
+                return true;
+              },
+            ),
+          ],
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+      router.go('/redirect');
+      await tester.pumpAndSettle();
+
+      expect(redirectMetadata, const <String, dynamic>{'section': 'root', 'source': 'redirect'});
+      expect(find.text('guarded'), findsOneWidget);
+
+      router.go('/');
+      await tester.pumpAndSettle();
+      expect(onExitMetadata, const <String, dynamic>{'section': 'root', 'page': 'guarded'});
+    });
+
+    testWidgets('metadata is available after imperative push', (WidgetTester tester) async {
       GoRouterState? pushedState;
 
       final routes = <RouteBase>[
         GoRoute(
           path: '/',
-          metadata: const <String, dynamic>{
-            'fromParent': true,
-            'presentation': 'base',
-          },
+          metadata: const <String, dynamic>{'fromParent': true, 'presentation': 'base'},
           builder: (BuildContext context, GoRouterState state) {
             return const Text('home');
           },
           routes: <RouteBase>[
             GoRoute(
               path: 'push',
-              metadata: const <String, dynamic>{
-                'presentation': 'pushed',
-                'fromChild': true,
-              },
+              metadata: const <String, dynamic>{'presentation': 'pushed', 'fromChild': true},
               builder: (BuildContext context, GoRouterState state) {
                 pushedState = state;
                 return const Text('push');


### PR DESCRIPTION
This PR adds route `metadata` support across go_router route definitions, match resolution, and `GoRouterState`, including inheritance/override behavior and test coverage.

- Added `metadata` support to `RouteBase` and all relevant route types.
- Propagated merged route metadata into `GoRouterState`.
- Added metadata resolution/merge logic in route matching:
- inherit from parents
- child keys override parent keys
- default to empty map when absent
- Wired top-level/error state builders to include `metadata`.
- Added regression test coverage for metadata inheritance/override/empty behavior.

Fixes flutter/flutter#187049, flutter/flutter#160738.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
