### PR TITLE
[path_provider] Document null vs UnsupportedError return semantics

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 * Updates README to reflect currently supported OS versions for the latest
   versions of the endorsed platform implementations.
+* Documents the difference between a `null` return and an `UnsupportedError`
+  from `getDownloadsDirectory`.
   * Applications built with older versions of Flutter will continue to
     use compatible versions of the platform implementations.
 

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,12 +1,12 @@
-## NEXT
+## 2.1.6
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 * Updates README to reflect currently supported OS versions for the latest
   versions of the endorsed platform implementations.
-* Documents the difference between a `null` return and an `UnsupportedError`
-  from `getDownloadsDirectory`.
   * Applications built with older versions of Flutter will continue to
     use compatible versions of the platform implementations.
+* Documents the difference between a `null` return and an `UnsupportedError`
+  from `getDownloadsDirectory`.
 
 ## 2.1.5
 

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -217,8 +217,13 @@ Future<List<Directory>?> getExternalStorageDirectories({
 /// The returned directory is not guaranteed to exist, so clients should verify
 /// that it does before using it, and potentially create it if necessary.
 ///
-/// Throws an [UnsupportedError] if this is not supported on the current
-/// platform.
+/// Returns `null` when the current platform supports the concept of a
+/// downloads directory but no such directory is currently available. For
+/// example, on Linux this can happen when `xdg-user-dir` is not installed
+/// or fails when called.
+///
+/// Throws an [UnsupportedError] when the current platform has no concept of
+/// a downloads directory at all.
 Future<Directory?> getDownloadsDirectory() async {
   final String? path = await _platform.getDownloadsPath();
   if (path == null) {

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 repository: https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.5
+version: 2.1.6
 
 environment:
   sdk: ^3.10.0

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Documents the implementation contract for `null` versus `UnsupportedError`
+  return semantics on `getDownloadsPath`.
 
 ## 2.1.2
 

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.1.3
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 * Documents the implementation contract for `null` versus `UnsupportedError`

--- a/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
@@ -105,6 +105,14 @@ abstract class PathProviderPlatform extends PlatformInterface {
 
   /// Path to the directory where downloaded files can be stored.
   /// This is typically only relevant on desktop operating systems.
+  ///
+  /// Implementations should return `null` when the platform supports the
+  /// concept of a downloads directory but no such directory is currently
+  /// available (for example, on Linux when `xdg-user-dir` is not installed
+  /// or fails when called).
+  ///
+  /// Implementations should throw an [UnsupportedError] when the platform
+  /// has no concept of a downloads directory at all.
   Future<String?> getDownloadsPath() {
     throw UnimplementedError('getDownloadsPath() has not been implemented.');
   }

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Updates the dartdoc for `getDownloadsDirectory` in `path_provider` and the matching `getDownloadsPath` contract on `PathProviderPlatform` to explain both return-value cases:

- `null` — the platform supports the concept of a downloads directory but no such directory is currently available (concrete example: Linux without `xdg-user-dir` installed, or where `xdg-user-dir` fails when called).
- `UnsupportedError` — the current platform has no concept of a downloads directory at all.

Previously the dartdoc only mentioned the `UnsupportedError` case, which left users unsure when they might see a `null` result.

The wording matches the explanations already given by maintainers in the linked issue thread.

Fixes flutter/flutter#143238

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

This is a documentation-only change to public dartdoc comments. No code behavior changes; no new tests are required per the auto-exempt rules for changes that only affect comments/documentation.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests