### PR TITLE
[tool] Make more commands work without Flutter

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.14.2
+
+* Ensures that pub commands use `flutter` or `dart` depending on whether the
+  package requires Flutter for analysis and publishing, to support
+  non-Flutter-based repositories
+
 ## 0.14.1
 
 * Adds `min_dart` as an alternative to `min_flutter` in tool configuration.

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 * Ensures that pub commands use `flutter` or `dart` depending on whether the
   package requires Flutter for analysis and publishing, to support
-  non-Flutter-based repositories
+  non-Flutter-based repositories.
+* Adds `--skip-if-not-supporting-dart-version` to support package constraints
+  via Dart versions rather than Flutter versions.
 
 ## 0.14.1
 

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -357,8 +357,11 @@ class AnalyzeCommand extends PackageLoopingCommand {
   }
 
   Future<bool> _runPubCommand(RepositoryPackage package, String command) async {
+    final String pubCommand = package.requiresFlutter()
+        ? flutterCommand
+        : 'dart';
     final int exitCode = await processRunner.runAndStream(
-      flutterCommand,
+      pubCommand,
       <String>['pub', command],
       workingDir: package.directory,
     );

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -13,6 +13,7 @@ import 'common/gradle.dart';
 import 'common/output_utils.dart';
 import 'common/package_looping_command.dart';
 import 'common/plugin_utils.dart';
+import 'common/pub_utils.dart';
 import 'common/repository_package.dart';
 import 'common/xcode.dart';
 
@@ -357,15 +358,13 @@ class AnalyzeCommand extends PackageLoopingCommand {
   }
 
   Future<bool> _runPubCommand(RepositoryPackage package, String command) async {
-    final String pubCommand = package.requiresFlutter()
-        ? flutterCommand
-        : _dartBinaryPath;
-    final int exitCode = await processRunner.runAndStream(
-      pubCommand,
-      <String>['pub', command],
-      workingDir: package.directory,
+    return runPubCommand(
+      <String>[command],
+      package,
+      processRunner,
+      platform,
+      dartSdkPathOverride: _dartBinaryPath,
     );
-    return exitCode == 0;
   }
 
   /// Runs Gradle lint analysis for the given package, and returns the result

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -359,7 +359,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
   Future<bool> _runPubCommand(RepositoryPackage package, String command) async {
     final String pubCommand = package.requiresFlutter()
         ? flutterCommand
-        : 'dart';
+        : _dartBinaryPath;
     final int exitCode = await processRunner.runAndStream(
       pubCommand,
       <String>['pub', command],

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -95,10 +95,19 @@ abstract class PackageLoopingCommand extends PackageCommand {
           'the provided version, or a Dart version newer than the '
           'corresponding Dart version.',
     );
+    argParser.addOption(
+      _skipByDartVersionArg,
+      help:
+          'Skip any packages that require a Dart version newer than the '
+          'provided version.',
+    );
   }
 
   static const String _skipByFlutterVersionArg =
       'skip-if-not-supporting-flutter-version';
+
+  static const String _skipByDartVersionArg =
+      'skip-if-not-supporting-dart-version';
 
   /// Packages that had at least one [logWarning] call.
   final Set<PackageEnumerationEntry> _packagesWithWarnings =
@@ -289,9 +298,15 @@ abstract class PackageLoopingCommand extends PackageCommand {
     final Version? minFlutterVersion = minFlutterVersionArg.isEmpty
         ? null
         : Version.parse(minFlutterVersionArg);
-    final Version? minDartVersion = minFlutterVersion == null
-        ? null
-        : getDartSdkForFlutterSdk(minFlutterVersion);
+
+    // Use the explicit Dart min if provided, otherwise fall back to the
+    // version corresponding to the Flutter min if that was provided.
+    final String minDartVersionArg = getStringArg(_skipByDartVersionArg);
+    final Version? minDartVersion = minDartVersionArg.isNotEmpty
+        ? Version.parse(minDartVersionArg)
+        : (minFlutterVersion == null
+              ? null
+              : getDartSdkForFlutterSdk(minFlutterVersion));
 
     final runStart = DateTime.now();
 

--- a/script/tool/lib/src/common/pub_utils.dart
+++ b/script/tool/lib/src/common/pub_utils.dart
@@ -20,14 +20,34 @@ Future<bool> runPubGet(
   Platform platform, {
   bool streamOutput = true,
 }) async {
-  // Running `dart pub get` on a Flutter package can fail if a non-Flutter Dart
-  // is first in the path, so use `flutter pub get` for any Flutter package.
-  final bool useFlutter = package.requiresFlutter();
-  final command = useFlutter
-      ? (platform.isWindows ? 'flutter.bat' : 'flutter')
-      : 'dart';
-  final args = <String>['pub', 'get'];
+  return runPubCommand(
+    <String>['get'],
+    package,
+    processRunner,
+    platform,
+    streamOutput: streamOutput,
+  );
+}
 
+/// Runs a pub command with the given arguments in [package],
+/// using either 'dart' or 'flutter' depending on the package type.
+///
+/// If [streamOutput] is false, output will only be printed if the command
+/// fails.
+Future<bool> runPubCommand(
+  List<String> commandArgs,
+  RepositoryPackage package,
+  ProcessRunner processRunner,
+  Platform platform, {
+  bool streamOutput = true,
+  String? dartSdkPathOverride,
+}) async {
+  final String command = _pubCommand(
+    package,
+    platform,
+    dartSdkPathOverride: dartSdkPathOverride,
+  );
+  final args = <String>['pub', ...commandArgs];
   final int exitCode;
   if (streamOutput) {
     exitCode = await processRunner.runAndStream(
@@ -47,4 +67,33 @@ Future<bool> runPubGet(
     }
   }
   return exitCode == 0;
+}
+
+/// Starts a pub command with the given arguments in [package],
+/// using either 'dart' or 'flutter' depending on the package type, and returns
+/// a process that can be used to wait for completion and stream output.
+///
+/// If no output capturing is necessary, prefer [runPubCommand].
+Future<io.Process> startPubCommand(
+  List<String> commandArgs,
+  RepositoryPackage package,
+  ProcessRunner processRunner,
+  Platform platform,
+) async {
+  return processRunner.start(_pubCommand(package, platform), <String>[
+    'pub',
+    ...commandArgs,
+  ], workingDirectory: package.directory);
+}
+
+String _pubCommand(
+  RepositoryPackage package,
+  Platform platform, {
+  String? dartSdkPathOverride,
+}) {
+  // Running `dart pub get` on a Flutter package can fail if a non-Flutter Dart
+  // is first in the path, so use `flutter pub get` for any Flutter package.
+  return package.requiresFlutter()
+      ? (platform.isWindows ? 'flutter.bat' : 'flutter')
+      : (dartSdkPathOverride ?? 'dart');
 }

--- a/script/tool/lib/src/common/pub_utils.dart
+++ b/script/tool/lib/src/common/pub_utils.dart
@@ -12,22 +12,17 @@ import 'repository_package.dart';
 /// Runs either `dart pub get` or `flutter pub get` in [package], depending on
 /// the package type.
 ///
-/// If [alwaysUseFlutter] is true, it will use `flutter pub get` regardless.
-/// This can be useful, for instance, to get the `flutter`-default behavior
-/// of fetching example packages as well.
-///
 /// If [streamOutput] is false, output will only be printed if the command
 /// fails.
 Future<bool> runPubGet(
   RepositoryPackage package,
   ProcessRunner processRunner,
   Platform platform, {
-  bool alwaysUseFlutter = false,
   bool streamOutput = true,
 }) async {
   // Running `dart pub get` on a Flutter package can fail if a non-Flutter Dart
   // is first in the path, so use `flutter pub get` for any Flutter package.
-  final bool useFlutter = alwaysUseFlutter || package.requiresFlutter();
+  final bool useFlutter = package.requiresFlutter();
   final command = useFlutter
       ? (platform.isWindows ? 'flutter.bat' : 'flutter')
       : 'dart';

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -164,7 +164,7 @@ class PublishCheckCommand extends PackageLoopingCommand {
 
     print('Running pub publish --dry-run:');
     final io.Process process = await startPubCommand(
-      <String>['publish', '--', '--dry-run'],
+      <String>['publish', '--dry-run'],
       package,
       processRunner,
       platform,

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -163,8 +163,11 @@ class PublishCheckCommand extends PackageLoopingCommand {
     await _fetchExampleDeps(package);
 
     print('Running pub publish --dry-run:');
+    final String pubCommand = package.requiresFlutter()
+        ? flutterCommand
+        : 'dart';
     final io.Process process = await processRunner.start(
-      flutterCommand,
+      pubCommand,
       <String>['pub', 'publish', '--', '--dry-run'],
       workingDirectory: package.directory,
     );

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -163,13 +163,11 @@ class PublishCheckCommand extends PackageLoopingCommand {
     await _fetchExampleDeps(package);
 
     print('Running pub publish --dry-run:');
-    final String pubCommand = package.requiresFlutter()
-        ? flutterCommand
-        : 'dart';
-    final io.Process process = await processRunner.start(
-      pubCommand,
-      <String>['pub', 'publish', '--', '--dry-run'],
-      workingDirectory: package.directory,
+    final io.Process process = await startPubCommand(
+      <String>['publish', '--', '--dry-run'],
+      package,
+      processRunner,
+      platform,
     );
 
     final outputBuffer = StringBuffer();

--- a/script/tool/lib/src/publish_command.dart
+++ b/script/tool/lib/src/publish_command.dart
@@ -477,8 +477,11 @@ Safe to ignore if the package is deleted in this commit.
       _ensureValidPubCredential();
     }
 
+    final String pubCommand = package.requiresFlutter()
+        ? flutterCommand
+        : 'dart';
     final io.Process publish = await processRunner.start(
-      flutterCommand,
+      pubCommand,
       <String>['pub', 'publish', ..._publishFlags],
       workingDirectory: package.directory,
     );

--- a/script/tool/lib/src/publish_command.dart
+++ b/script/tool/lib/src/publish_command.dart
@@ -477,13 +477,11 @@ Safe to ignore if the package is deleted in this commit.
       _ensureValidPubCredential();
     }
 
-    final String pubCommand = package.requiresFlutter()
-        ? flutterCommand
-        : 'dart';
-    final io.Process publish = await processRunner.start(
-      pubCommand,
-      <String>['pub', 'publish', ..._publishFlags],
-      workingDirectory: package.directory,
+    final io.Process publish = await startPubCommand(
+      <String>['publish', ..._publishFlags],
+      package,
+      processRunner,
+      platform,
     );
     publish.stdout.transform(utf8.decoder).listen((String data) => print(data));
     publish.stderr.transform(utf8.decoder).listen((String data) => print(data));

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity and CI utils for Flutter team package repositories.
 repository: https://github.com/flutter/packages/tree/main/script/tool
-version: 0.14.1
+version: 0.14.2
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -196,18 +196,9 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('dart', const <String>[
-            'pub',
-            'get',
-          ], mainPackage.path),
-          ProcessCall('dart', const <String>[
-            'pub',
-            'get',
-          ], subpackage1.path),
-          ProcessCall('dart', const <String>[
-            'pub',
-            'get',
-          ], subpackage2.path),
+          ProcessCall('dart', const <String>['pub', 'get'], mainPackage.path),
+          ProcessCall('dart', const <String>['pub', 'get'], subpackage1.path),
+          ProcessCall('dart', const <String>['pub', 'get'], subpackage2.path),
           ProcessCall('dart', const <String>[
             'analyze',
             '--fatal-infos',
@@ -274,10 +265,7 @@ void main() {
         expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('dart', const <String>[
-              'pub',
-              'get',
-            ], mainPackage.path),
+            ProcessCall('dart', const <String>['pub', 'get'], mainPackage.path),
             ProcessCall('dart', const <String>[
               'analyze',
               '--fatal-infos',

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -136,6 +136,8 @@ void main() {
 
   group('dart analyze', () {
     test('analyzes all packages', () async {
+      // Create a non-Flutter Dart package and a Flutter plugin to make sure
+      // the right command is used for each.
       final RepositoryPackage package1 = createFakePackage('a', packagesDir);
       final RepositoryPackage plugin2 = createFakePlugin('b', packagesDir);
 
@@ -144,7 +146,7 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>['pub', 'get'], package1.path),
+          ProcessCall('dart', const <String>['pub', 'get'], package1.path),
           ProcessCall('dart', const <String>[
             'analyze',
             '--fatal-infos',
@@ -158,7 +160,7 @@ void main() {
       );
     });
 
-    test('skips flutter pub get for examples', () async {
+    test('skips pub get for examples', () async {
       final RepositoryPackage plugin1 = createFakePlugin('a', packagesDir);
 
       await runCapturingPrint(runner, <String>['analyze']);
@@ -175,7 +177,7 @@ void main() {
       );
     });
 
-    test('runs flutter pub get for non-example subpackages', () async {
+    test('runs pub get for non-example subpackages', () async {
       final RepositoryPackage mainPackage = createFakePackage('a', packagesDir);
       final Directory otherPackagesDir = mainPackage.directory.childDirectory(
         'other_packages',
@@ -194,15 +196,15 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>[
+          ProcessCall('dart', const <String>[
             'pub',
             'get',
           ], mainPackage.path),
-          ProcessCall('flutter', const <String>[
+          ProcessCall('dart', const <String>[
             'pub',
             'get',
           ], subpackage1.path),
-          ProcessCall('flutter', const <String>[
+          ProcessCall('dart', const <String>[
             'pub',
             'get',
           ], subpackage2.path),
@@ -225,7 +227,7 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>['pub', 'get'], package.path),
+          ProcessCall('dart', const <String>['pub', 'get'], package.path),
           ProcessCall('dart', const <String>[
             'analyze',
             '--fatal-infos',
@@ -255,7 +257,7 @@ void main() {
     });
 
     test(
-      'does not run flutter pub get for non-example subpackages with --lib-only',
+      'does not run pub get for non-example subpackages with --lib-only',
       () async {
         final RepositoryPackage mainPackage = createFakePackage(
           'a',
@@ -272,7 +274,7 @@ void main() {
         expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('flutter', const <String>[
+            ProcessCall('dart', const <String>[
               'pub',
               'get',
             ], mainPackage.path),

--- a/script/tool/test/common/package_looping_command_test.dart
+++ b/script/tool/test/common/package_looping_command_test.dart
@@ -501,7 +501,51 @@ skip/b
       );
     });
 
-    test('skips unsupported Dart versions when requested', () async {
+    test(
+      'skips unsupported Dart versions when requested implicitly by Flutter version',
+      () async {
+        final RepositoryPackage excluded = createFakePackage(
+          'excluded_package',
+          packagesDir,
+          dartConstraint: '>=2.18.0 <4.0.0',
+        );
+        final RepositoryPackage included = createFakePackage(
+          'a_package',
+          packagesDir,
+        );
+
+        final TestPackageLoopingCommand command = createTestCommand(
+          packageLoopingType: PackageLoopingType.includeAllSubpackages,
+          hasLongOutput: false,
+        );
+        final List<String> output = await runCommand(
+          command,
+          arguments: <String>[
+            '--skip-if-not-supporting-flutter-version=3.0.0', // Flutter 3.0.0 -> Dart 2.17.0
+          ],
+        );
+
+        expect(
+          command.checkedPackages,
+          unorderedEquals(<String>[
+            included.path,
+            getExampleDir(included).path,
+          ]),
+        );
+        expect(command.checkedPackages, isNot(contains(excluded.path)));
+
+        expect(
+          output,
+          containsAllInOrder(<String>[
+            '${_startHeadingColor}Running for a_package...$_endColor',
+            '${_startHeadingColor}Running for excluded_package...$_endColor',
+            '$_startSkipColor  SKIPPING: Does not support Dart 2.17.0$_endColor',
+          ]),
+        );
+      },
+    );
+
+    test('skips unsupported Dart versions when requested explicitly', () async {
       final RepositoryPackage excluded = createFakePackage(
         'excluded_package',
         packagesDir,
@@ -518,9 +562,7 @@ skip/b
       );
       final List<String> output = await runCommand(
         command,
-        arguments: <String>[
-          '--skip-if-not-supporting-flutter-version=3.0.0', // Flutter 3.0.0 -> Dart 2.17.0
-        ],
+        arguments: <String>['--skip-if-not-supporting-dart-version=2.17.0'],
       );
 
       expect(

--- a/script/tool/test/common/pub_utils_test.dart
+++ b/script/tool/test/common/pub_utils_test.dart
@@ -53,23 +53,6 @@ void main() {
     );
   });
 
-  test('runs with Flutter for a Dart package when requested', () async {
-    final RepositoryPackage package = createFakePackage(
-      'a_package',
-      packagesDir,
-    );
-    final platform = MockPlatform();
-
-    await runPubGet(package, processRunner, platform, alwaysUseFlutter: true);
-
-    expect(
-      processRunner.recordedCalls,
-      orderedEquals(<ProcessCall>[
-        ProcessCall('flutter', const <String>['pub', 'get'], package.path),
-      ]),
-    );
-  });
-
   test('uses the correct Flutter command on Windows', () async {
     final RepositoryPackage package = createFakePackage(
       'a_package',

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -329,7 +329,8 @@ void main() {
 
         runner = configureRunner(httpClient: mockClient);
 
-        processRunner.mockProcessesForExecutable['flutter'] = <FakeProcessInfo>[
+        processRunner.mockProcessesForExecutable['dart'] = <FakeProcessInfo>[
+          FakeProcessInfo(MockProcess(), <String>['pub', 'get']),
           FakeProcessInfo(
             MockProcess(exitCode: 1, stdout: 'Some error from pub'),
             <String>['pub', 'publish'],
@@ -355,7 +356,7 @@ void main() {
         expect(
           processRunner.recordedCalls,
           contains(
-            ProcessCall('flutter', const <String>[
+            ProcessCall('dart', const <String>[
               'pub',
               'publish',
               '--',
@@ -426,7 +427,7 @@ void main() {
         expect(
           processRunner.recordedCalls,
           contains(
-            ProcessCall('flutter', const <String>[
+            ProcessCall('dart', const <String>[
               'pub',
               'publish',
               '--',
@@ -496,7 +497,7 @@ void main() {
               'run',
               'tool/pre_publish.dart',
             ], package.directory.path),
-            ProcessCall('flutter', const <String>[
+            ProcessCall('dart', const <String>[
               'pub',
               'publish',
               '--',

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -71,13 +71,11 @@ void main() {
           ProcessCall('flutter', const <String>[
             'pub',
             'publish',
-            '--',
             '--dry-run',
           ], plugin1.path),
           ProcessCall('flutter', const <String>[
             'pub',
             'publish',
-            '--',
             '--dry-run',
           ], plugin2.path),
         ]),
@@ -117,14 +115,12 @@ void main() {
           ProcessCall('flutter', const <String>[
             'pub',
             'publish',
-            '--',
             '--dry-run',
           ], plugin1.path),
           // plugin2 has no examples, so there's no extra 'dart pub get' calls.
           ProcessCall('flutter', const <String>[
             'pub',
             'publish',
-            '--',
             '--dry-run',
           ], plugin2.path),
         ]),
@@ -359,7 +355,6 @@ void main() {
             ProcessCall('dart', const <String>[
               'pub',
               'publish',
-              '--',
               '--dry-run',
             ], package.path),
           ),
@@ -430,7 +425,6 @@ void main() {
             ProcessCall('dart', const <String>[
               'pub',
               'publish',
-              '--',
               '--dry-run',
             ], package.path),
           ),
@@ -500,7 +494,6 @@ void main() {
             ProcessCall('dart', const <String>[
               'pub',
               'publish',
-              '--',
               '--dry-run',
             ], package.directory.path),
           ]),

--- a/script/tool/test/publish_command_test.dart
+++ b/script/tool/test/publish_command_test.dart
@@ -285,6 +285,30 @@ void main() {
       );
     });
 
+    test('uses dart rather than flutter for non-Flutter packages', () async {
+      final RepositoryPackage package = createFakePackage(
+        'foo',
+        packagesDir,
+        isFlutter: false,
+        examples: <String>[],
+      );
+
+      await runCapturingPrint(commandRunner, <String>[
+        'publish',
+        '--packages=foo',
+      ]);
+
+      expect(
+        processRunner.recordedCalls,
+        contains(
+          ProcessCall('dart', const <String>[
+            'pub',
+            'publish',
+          ], package.directory.path),
+        ),
+      );
+    });
+
     test('forwards --pub-publish-flags to pub publish', () async {
       final RepositoryPackage plugin = createFakePlugin(
         'foo',

--- a/script/tool/test/publish_command_test.dart
+++ b/script/tool/test/publish_command_test.dart
@@ -289,7 +289,6 @@ void main() {
       final RepositoryPackage package = createFakePackage(
         'foo',
         packagesDir,
-        isFlutter: false,
         examples: <String>[],
       );
 


### PR DESCRIPTION
- Updates some cases where 'flutter' was used unconditionally, now that we need to support a repository without Flutter installed.
  - Removes some outdated comments and plumbing for forcing `flutter pub` over `dart pub`, as the reason we used to do it no longer applies now that `dart pub` also fetches examples by default.
- Adds `--skip-if-not-supporting-dart-version` to support N-1 and N-2 testing in core-packages.