### PR TITLE
[go_router] Make ImperativeRouteMatch.complete idempotent

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 17.2.4
+
+- Fixes `Bad state: Future already completed` thrown by
+  `ImperativeRouteMatch.complete` when `_handlePopPageWithRouteMatch` is
+  invoked twice for the same imperative match before either scheduled
+  microtask runs (e.g. iOS interactive back-edge pop gesture, chained
+  `context.pop(result)` calls for nested modals). The completer is now
+  idempotent — a second `complete` call after the future has resolved is
+  silently ignored.
+
 ## 17.2.3
 
 - Fixes an assertion failure when navigating to URLs with hash fragments missing a leading slash.

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -485,7 +485,24 @@ class ImperativeRouteMatch extends RouteMatch {
 
   /// Called when the corresponding [Route] associated with this route match is
   /// completed.
+  ///
+  /// This is idempotent: a second call after the future has already
+  /// completed is silently ignored. `GoRouteData`'s default
+  /// `onExit => true` forces every pop through the
+  /// `scheduleMicrotask` path in
+  /// `GoRouterDelegate._handlePopPageWithRouteMatch`, which makes it
+  /// possible for two microtasks to be scheduled for the same match
+  /// before either runs (e.g., the iOS interactive back-edge gesture
+  /// firing `Navigator.onPopPage` twice, or chained
+  /// `context.pop(result)` calls for nested modals). Without this
+  /// guard the second microtask throws
+  /// `Bad state: Future already completed`. The page is already gone
+  /// from `currentConfiguration` and the `.push()` future has already
+  /// resolved by then, so a second complete has no useful meaning.
   void complete([dynamic value]) {
+    if (completer.isCompleted) {
+      return;
+    }
     completer.complete(value);
   }
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 17.2.3
+version: 17.2.4
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/match_test.dart
+++ b/packages/go_router/test/match_test.dart
@@ -248,6 +248,30 @@ void main() {
       expect(match1 == match2, isFalse);
       expect(match1.hashCode == match2.hashCode, isFalse);
     });
+
+    test('complete is idempotent — second call is a no-op', () async {
+      // Regression test for the `Bad state: Future already completed`
+      // throw observed when `GoRouterDelegate._handlePopPageWithRouteMatch`
+      // fires twice for the same imperative match before either
+      // scheduled microtask runs `_completeRouteMatch` (e.g. the iOS
+      // interactive back-edge gesture, or chained `context.pop(result)`
+      // calls for nested modals). See
+      // https://github.com/flutter/flutter/issues/187326 and the
+      // duplicates cross-referenced there.
+      final completer = Completer<Object?>();
+      final match = ImperativeRouteMatch(
+        pageKey: const ValueKey<String>('idempotent'),
+        matches: matchList1,
+        completer: completer,
+      );
+
+      match.complete('first');
+      // Must not throw — the page is already gone from
+      // currentConfiguration and the future has already resolved.
+      match.complete('second');
+
+      expect(await completer.future, 'first');
+    });
   });
 }
 


### PR DESCRIPTION
## Description

Adds an `isCompleted` guard inside `ImperativeRouteMatch.complete` so calling it a second time after the future has already resolved is silently ignored instead of throwing `Bad state: Future already completed`.

### Root cause

`GoRouteData` ships a default `FutureOr<bool> onExit(...) => true`, and `go_router_builder` wires it into every generated `$route` factory. That makes `routeBase.onExit != null` for every route declared via `@TypedGoRoute` / `GoRouteData`, which forces every pop through the `scheduleMicrotask` path in `GoRouterDelegate._handlePopPageWithRouteMatch`:

```dart
scheduleMicrotask(() async {
  final bool onExitResult = await routeBase.onExit!(...);
  if (onExitResult) {
    _completeRouteMatch(result, match);
  }
});
return false;
```

Because the callback returns `false`, the Navigator does **not** mark the popped page as resolved synchronously — the page is only actually removed when the microtask eventually runs `_completeRouteMatch` → `currentConfiguration.remove(match)` → `notifyListeners` → Navigator rebuild without the page.

If the framework reaches `_handlePopPageWithRouteMatch` a **second** time for the same `ImperativeRouteMatch` before either microtask runs, both microtasks call `_completeRouteMatch`. The first one completes the Completer and removes the match; the second one calls `completer.complete(value)` against an already-completed Completer and throws.

Triggers observed in the wild include:

- iOS interactive back-edge swipe gesture firing `Navigator.onPopPage` more than once during the commit/animation window for Page-based routes.
- Chained `context.pop(result)` calls bubbling a value through nested modals.
- Async dialog dismiss racing the route under the dialog popping itself.

### Behavior change

User-visible behavior is unchanged either way — `currentConfiguration` is already updated and `notifyListeners` rebuilds the Navigator without the popped page before the second microtask fires. The error only manifests as a noisy throw in apps' global error handlers (`PlatformDispatcher.onError` / `FlutterError.onError`), typically forwarded to crash-reporting as fatal.

With this patch, the second `complete` call is a no-op, the original future value is preserved, and no exception is thrown.

## Tests

`packages/go_router/test/match_test.dart` gains one regression test under the existing `group('ImperativeRouteMatch')`:

```dart
test('complete is idempotent — second call is a no-op', () async {
  final completer = Completer<Object?>();
  final match = ImperativeRouteMatch(
    pageKey: const ValueKey<String>('idempotent'),
    matches: matchList1,
    completer: completer,
  );

  match.complete('first');
  // Must not throw.
  match.complete('second');

  expect(await completer.future, 'first');
});
```

Verified locally:

- `dart analyze packages/go_router/` — clean.
- `flutter test packages/go_router/` — 430 passed, 2 skipped (no regressions; new test passes).

## Related Issues

- Fixes flutter/flutter#187326 (this PR's issue; full diagnosis + repro recipe).
- Also addresses the same root cause behind:
  - flutter/flutter#160696 (open) — chained `context.pop()` during loading-dialog dismissal.
  - flutter/flutter#176493 (closed) — chained pop in `ShellRoute` nested route-stack.
  - flutter/flutter#163813 (closed) — async login with modal navigation.
  - flutter/flutter#146938 (closed) — `go` / `goNamed` after `pop`.
  - flutter/flutter#123369 (closed, oldest) — original `context.pop()` complaint.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [packages style guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`.
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], and updated or removed any [TODO]s.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[packages style guide]: https://github.com/flutter/packages/blob/main/style-guide.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/main/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/main/docs/ecosystem/contributing/README.md#changelog-style
[TODO]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#comments
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
