### PR TITLE
[in_app_purchase] Bump `in_app_purchase_android` version from `0.4.x` to `0.5.0`

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+* Updates `in_app_purchase_android` dependency to `^0.5.0`.
+
 ## 3.2.4
 
 * Bump org.json:json from 20251224 to 20260522 in example.

--- a/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  in_app_purchase_android: ^0.4.0
+  in_app_purchase_android: ^0.5.0
   in_app_purchase_storekit: ^0.4.0
   shared_preferences: ^2.0.0
 

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.2.4
+version: 3.3.0
 
 environment:
   sdk: ^3.10.0
@@ -21,7 +21,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  in_app_purchase_android: ^0.4.0
+  in_app_purchase_android: ^0.5.0
   in_app_purchase_platform_interface: ^1.4.0
   in_app_purchase_storekit: ^0.4.0
 


### PR DESCRIPTION
Bumps the version

fixes https://github.com/flutter/flutter/issues/171523