### PR TITLE
[local_auth] Clarify getAvailableBiometrics documentation

### DIFF
--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 3.0.2
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 * Clarifies the `getAvailableBiometrics` documentation to explain that it

--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Clarifies the `getAvailableBiometrics` documentation to explain that it
+  returns the biometrics available for the app to use, which may not include all
+  biometrics enrolled on the device.
 
 ## 3.0.1
 

--- a/packages/local_auth/local_auth/lib/src/local_auth.dart
+++ b/packages/local_auth/local_auth/lib/src/local_auth.dart
@@ -88,7 +88,14 @@ class LocalAuthentication {
   /// fail over to device credentials.
   Future<bool> isDeviceSupported() async => LocalAuthPlatform.instance.isDeviceSupported();
 
-  /// Returns a list of enrolled biometrics.
+  /// Returns a list of the biometric types that are available for the app to
+  /// use.
+  ///
+  /// This is not necessarily the same as the full set of biometrics enrolled on
+  /// the device; a biometric type can be enrolled but still be unavailable to
+  /// the app. For example, on iOS the returned list will not include a biometric
+  /// type if the user has denied the app permission to use it, even when that
+  /// biometric is enrolled on the device.
   Future<List<BiometricType>> getAvailableBiometrics() =>
       LocalAuthPlatform.instance.getEnrolledBiometrics();
 }

--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth
 description: Flutter plugin to allow local authentication via biometrics, passcode, pin, or pattern.
 repository: https://github.com/flutter/packages/tree/main/packages/local_auth/local_auth
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 3.0.1
+version: 3.0.2
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Updates the documentation for `LocalAuthentication.getAvailableBiometrics()`.

The previous doc comment said "Returns a list of enrolled biometrics", which is not accurate: a biometric can be enrolled on the device but still be unavailable to the app. For example, on iOS the returned list will not include a biometric type when the user has denied the app permission to use it, even though that biometric is enrolled — "not enrolled" and "not available" are distinct states. The updated doc clarifies that the method returns the biometrics that are available for the app to use, which may not include every biometric enrolled on the device, and gives the iOS permission-denied case as an example.

Fixes flutter/flutter#187512

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

This is a documentation-only change (it only modifies a `///` doc comment), so it does not add tests, per the test exemption for documentation-only changes. Because the comment is a `///` doc on an exported API, the package version is bumped (3.0.1 → 3.0.2) with a corresponding CHANGELOG entry.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
