### PR TITLE
[local_auth] Clarify `getAvailableBiometrics` documentation

### DIFF
--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Clarifies the documentation of `getAvailableBiometrics` to note that it
+  returns the biometrics available to the app, which may not include every
+  enrolled biometric.
 
 ## 3.0.1
 

--- a/packages/local_auth/local_auth/lib/src/local_auth.dart
+++ b/packages/local_auth/local_auth/lib/src/local_auth.dart
@@ -90,7 +90,12 @@ class LocalAuthentication {
   Future<bool> isDeviceSupported() async =>
       LocalAuthPlatform.instance.isDeviceSupported();
 
-  /// Returns a list of enrolled biometrics.
+  /// Returns a list of biometrics that are available for the app to use.
+  ///
+  /// This may not include every biometric that is enrolled on the device. For
+  /// example, on iOS a biometric can be enrolled but still be unavailable to
+  /// the app, such as when the user has denied the app permission to use
+  /// biometrics.
   Future<List<BiometricType>> getAvailableBiometrics() =>
       LocalAuthPlatform.instance.getEnrolledBiometrics();
 }


### PR DESCRIPTION
`LocalAuthentication.getAvailableBiometrics()` is documented as returning a list of *enrolled* biometrics, but it actually returns the biometrics that are currently available to the app. These can differ — for example, on iOS a biometric may be enrolled but still unavailable to the app (such as when the user has denied biometric permission).

This updates the dartdoc to describe the real behaviour and adds a CHANGELOG entry. Documentation-only change.

Fixes flutter/flutter#187512
