### PR TITLE
[path_provider] Create temp dir in tests if needed

### DIFF
--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -12,7 +12,8 @@ void main() {
 
   testWidgets('getTemporaryDirectory', (WidgetTester tester) async {
     final Directory result = await getTemporaryDirectory();
-    _verifySampleFile(result, 'temporaryDirectory');
+    // getTemporaryDirectory does not guarantee that the returned directory exists.
+    _verifySampleFile(result, 'temporaryDirectory', createDirectory: true);
   });
 
   testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
@@ -109,7 +110,9 @@ void main() {
 
 /// Verify a file called [name] in [directory] by recreating it with test
 /// contents when necessary.
-void _verifySampleFile(Directory? directory, String name) {
+///
+/// If [createDirectory] is true, the directory will be created if missing.
+void _verifySampleFile(Directory? directory, String name, {bool createDirectory = false}) {
   expect(directory, isNotNull);
   if (directory == null) {
     return;
@@ -119,6 +122,10 @@ void _verifySampleFile(Directory? directory, String name) {
   if (file.existsSync()) {
     file.deleteSync();
     expect(file.existsSync(), isFalse);
+  }
+
+  if (createDirectory && !directory.existsSync()) {
+    directory.createSync(recursive: true);
   }
 
   file.writeAsStringSync('Hello world!');

--- a/packages/path_provider/path_provider_foundation/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_foundation/example/integration_test/path_provider_test.dart
@@ -29,7 +29,8 @@ void main() {
     testWidgets('getTemporaryDirectory', (WidgetTester tester) async {
       final PathProviderPlatform provider = PathProviderPlatform.instance;
       final String? result = await provider.getTemporaryPath();
-      _verifySampleFile(result, 'temporaryDirectory');
+      // getTemporaryPath does not guarantee that the returned directory exists.
+      _verifySampleFile(result, 'temporaryDirectory', createDirectory: true);
     });
 
     testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
@@ -374,7 +375,7 @@ NSArray _arrayWithString(String s) {
 /// contents when necessary.
 ///
 /// If [createDirectory] is true, the directory will be created if missing.
-void _verifySampleFile(String? directoryPath, String name) {
+void _verifySampleFile(String? directoryPath, String name, {bool createDirectory = false}) {
   expect(directoryPath, isNotNull);
   if (directoryPath == null) {
     return;
@@ -385,6 +386,10 @@ void _verifySampleFile(String? directoryPath, String name) {
   if (file.existsSync()) {
     file.deleteSync();
     expect(file.existsSync(), isFalse);
+  }
+
+  if (createDirectory && !directory.existsSync()) {
+    directory.createSync(recursive: true);
   }
 
   file.writeAsStringSync('Hello world!');


### PR DESCRIPTION
The integration test step that validates that a file can be created in the returned directory assumes that the directory already exists, which isn't guaranteed to be true for getTemporaryDirectory, and this is now failing on macOS in CI. To avoid the failure, create the directory if necessary for the tests that run on macOS.

Hopefully fixes https://github.com/flutter/flutter/issues/187563

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
