### PR TITLE
[image_picker] Handle pickMultiImage limit of one

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.2.3
 
+* Handles a `pickMultiImage` limit of 1 by using single-image selection.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 1.2.2

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -109,6 +109,7 @@ class ImagePicker {
   /// supported for the image that is picked, a warning message will be logged.
   ///
   /// The `limit` parameter modifies the maximum number of images that can be selected.
+  /// A value of 1 delegates to the single-image picker.
   /// This value may be ignored by platforms that cannot support it.
   ///
   /// Use `requestFullMetadata` (defaults to `true`) to control how much additional
@@ -130,6 +131,16 @@ class ImagePicker {
     int? limit,
     bool requestFullMetadata = true,
   }) {
+    if (limit == 1) {
+      return pickImage(
+        source: ImageSource.gallery,
+        maxWidth: maxWidth,
+        maxHeight: maxHeight,
+        imageQuality: imageQuality,
+        requestFullMetadata: requestFullMetadata,
+      ).then((XFile? image) => <XFile>[if (image != null) image]);
+    }
+
     final imageOptions = ImageOptions.createAndValidate(
       maxWidth: maxWidth,
       maxHeight: maxHeight,

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 1.2.2
+version: 1.2.3
 
 environment:
   sdk: ^3.10.0

--- a/packages/image_picker/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/image_picker/test/image_picker_test.dart
@@ -610,13 +610,72 @@ void main() {
           expect(() => picker.pickMultiImage(maxHeight: -1.0), throwsArgumentError);
         });
 
-        test('does not accept a limit argument lower than 2', () {
+        test('does not accept a limit argument lower than 1', () {
           final picker = ImagePicker();
           expect(() => picker.pickMultiImage(limit: -1), throwsArgumentError);
 
           expect(() => picker.pickMultiImage(limit: 0), throwsArgumentError);
+        });
 
-          expect(() => picker.pickMultiImage(limit: 1), throwsArgumentError);
+        test('uses the single-image picker for a limit of 1', () async {
+          final image = XFile('picked-image.jpg');
+          when(
+            mockPlatform.getImageFromSource(
+              source: anyNamed('source'),
+              options: anyNamed('options'),
+            ),
+          ).thenAnswer((Invocation _) async => image);
+
+          final List<XFile> result = await ImagePicker().pickMultiImage(
+            maxWidth: 10,
+            maxHeight: 20,
+            imageQuality: 70,
+            limit: 1,
+            requestFullMetadata: false,
+          );
+
+          expect(result, <XFile>[image]);
+          verify(
+            mockPlatform.getImageFromSource(
+              source: ImageSource.gallery,
+              options: argThat(
+                isInstanceOf<ImagePickerOptions>()
+                    .having(
+                      (ImagePickerOptions options) => options.maxWidth,
+                      'maxWidth',
+                      equals(10),
+                    )
+                    .having(
+                      (ImagePickerOptions options) => options.maxHeight,
+                      'maxHeight',
+                      equals(20),
+                    )
+                    .having(
+                      (ImagePickerOptions options) => options.imageQuality,
+                      'imageQuality',
+                      equals(70),
+                    )
+                    .having(
+                      (ImagePickerOptions options) => options.requestFullMetadata,
+                      'requestFullMetadata',
+                      isFalse,
+                    ),
+                named: 'options',
+              ),
+            ),
+          );
+          verifyNever(mockPlatform.getMultiImageWithOptions(options: anyNamed('options')));
+        });
+
+        test('returns an empty list when single-image selection is canceled', () async {
+          when(
+            mockPlatform.getImageFromSource(
+              source: anyNamed('source'),
+              options: anyNamed('options'),
+            ),
+          ).thenAnswer((Invocation _) async => null);
+
+          expect(await ImagePicker().pickMultiImage(limit: 1), isEmpty);
         });
 
         test('handles an empty image file response gracefully', () async {


### PR DESCRIPTION
This updates `ImagePicker.pickMultiImage` to handle `limit: 1` by delegating to the gallery single-image picker and wrapping the nulla
<img width="871" height="869" alt="Screenshot 2026-06-07 at 12 22 33 PM" src="https://github.com/user-attachments/assets/7930b103-af5f-4b94-a0c4-b7c0e34d0207" />
ble result as a zero-or-one-item list. This avoids the previous `ArgumentError` while preserving width, height, quality, and metadata options.

Fixes https://github.com/flutter/flutter/issues/187347

## Testing

- `dart run script/tool/bin/flutter_plugin_tools.dart analyze --packages=image_picker/image_picker`
- `dart run script/tool/bin/flutter_plugin_tools.dart test --packages=image_picker/image_picker`
- `dart run script/tool/bin/flutter_plugin_tools.dart validate --check-for-missing-changes --packages=image_picker/image_picker`
- Manual Flutter web verification: `pickMultiImage(limit: 1)` selected and displayed exactly one image; cancellation completed without an error.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style