### PR TITLE
[google_maps_flutter] Add onPointOfInterestTap callback

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.18.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.17.1
 
 * Updates README to link to implementation packages for platform-specific

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
@@ -35,6 +35,7 @@ class _MapClickBodyState extends State<_MapClickBody> {
   GoogleMapController? mapController;
   LatLng? _lastTap;
   LatLng? _lastLongPress;
+  String? _lastPoiPlaceId;
 
   @override
   Widget build(BuildContext context) {
@@ -49,6 +50,11 @@ class _MapClickBodyState extends State<_MapClickBody> {
       onLongPress: (LatLng pos) {
         setState(() {
           _lastLongPress = pos;
+        });
+      },
+      onPointOfInterestTap: (PointOfInterestId pointOfInterestId) {
+        setState(() {
+          _lastPoiPlaceId = pointOfInterestId.value;
         });
       },
     );
@@ -71,6 +77,16 @@ class _MapClickBodyState extends State<_MapClickBody> {
       columnChildren.add(
         Center(
           child: Text(_lastLongPress != null ? 'Long pressed' : '', textAlign: TextAlign.center),
+        ),
+      );
+      final lastPoiTap = 'POI place ID:\n${_lastPoiPlaceId ?? ""}\n';
+      columnChildren.add(Center(child: Text(lastPoiTap, textAlign: TextAlign.center)));
+      columnChildren.add(
+        Center(
+          child: Text(
+            _lastPoiPlaceId != null ? 'POI tapped' : '',
+            textAlign: TextAlign.center,
+          ),
         ),
       );
     }

--- a/packages/google_maps_flutter/google_maps_flutter/lib/google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/google_maps_flutter.dart
@@ -54,6 +54,7 @@ export 'package:google_maps_flutter_platform_interface/google_maps_flutter_platf
         MinMaxZoomPreference,
         PatternItem,
         PinConfig,
+        PointOfInterestId,
         Polygon,
         PolygonId,
         Polyline,

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
@@ -59,15 +59,13 @@ class GoogleMapController {
             .listen((_) => _googleMapState.widget.onCameraIdle!()),
       );
     }
-    if (_googleMapState.widget.onPointOfInterestTap != null) {
-      _streamSubscriptions.add(
-        GoogleMapsFlutterPlatform.instance
-            .onPointOfInterestTap(mapId: mapId)
-            .listen(
-              (PointOfInterestTapEvent e) => _googleMapState.onPointOfInterestTap(e.value),
-            ),
-      );
-    }
+    _streamSubscriptions.add(
+      GoogleMapsFlutterPlatform.instance
+          .onPointOfInterestTap(mapId: mapId)
+          .listen(
+            (PointOfInterestTapEvent e) => _googleMapState.onPointOfInterestTap(e.value),
+          ),
+    );
     _streamSubscriptions.add(
       GoogleMapsFlutterPlatform.instance
           .onMarkerTap(mapId: mapId)

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
@@ -59,6 +59,15 @@ class GoogleMapController {
             .listen((_) => _googleMapState.widget.onCameraIdle!()),
       );
     }
+    if (_googleMapState.widget.onPointOfInterestTap != null) {
+      _streamSubscriptions.add(
+        GoogleMapsFlutterPlatform.instance
+            .onPointOfInterestTap(mapId: mapId)
+            .listen(
+              (PointOfInterestTapEvent e) => _googleMapState.onPointOfInterestTap(e.value),
+            ),
+      );
+    }
     _streamSubscriptions.add(
       GoogleMapsFlutterPlatform.instance
           .onMarkerTap(mapId: mapId)

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -133,6 +133,7 @@ class GoogleMap extends StatefulWidget {
     this.onCameraIdle,
     this.onTap,
     this.onLongPress,
+    this.onPointOfInterestTap,
     this.markerType = GoogleMapMarkerType.marker,
     this.colorScheme,
     String? mapId,
@@ -296,6 +297,11 @@ class GoogleMap extends StatefulWidget {
 
   /// Called every time a [GoogleMap] is long pressed.
   final ArgumentCallback<LatLng>? onLongPress;
+
+  /// Called when a point of interest on the map is tapped.
+  ///
+  /// May not be supported on all platforms.
+  final ArgumentCallback<PointOfInterestId>? onPointOfInterestTap;
 
   /// True if a "My Location" layer should be shown on the map.
   ///
@@ -682,6 +688,14 @@ class _GoogleMapState extends State<GoogleMap> {
     final VoidCallback? onTap = marker.infoWindow.onTap;
     if (onTap != null) {
       onTap();
+    }
+  }
+
+  void onPointOfInterestTap(PointOfInterestId pointOfInterestId) {
+    final ArgumentCallback<PointOfInterestId>? onPointOfInterestTap =
+        widget.onPointOfInterestTap;
+    if (onPointOfInterestTap != null) {
+      onPointOfInterestTap(pointOfInterestId);
     }
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.17.1
+version: 2.18.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/fake_google_maps_flutter_platform.dart
@@ -228,6 +228,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter/test/google_map_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/google_map_test.dart
@@ -776,4 +776,29 @@ void main() {
       const GoogleMap(initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)));
     }, returnsNormally);
   });
+
+  testWidgets('onPointOfInterestTap invokes callback', (WidgetTester tester) async {
+    final poiCompleter = Completer<PointOfInterestId>();
+    final controllerCompleter = Completer<GoogleMapController>();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GoogleMap(
+          initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
+          onMapCreated: controllerCompleter.complete,
+          onPointOfInterestTap: poiCompleter.complete,
+        ),
+      ),
+    );
+
+    await controllerCompleter.future;
+    final int mapId = platform.createdIds.first;
+
+    platform.mapEventStreamController.add(
+      PointOfInterestTapEvent(mapId, const PointOfInterestId('place-123')),
+    );
+
+    expect(await poiCompleter.future, const PointOfInterestId('place-123'));
+  });
 }

--- a/packages/google_maps_flutter/google_maps_flutter/test/google_maps_flutter_export_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/google_maps_flutter_export_test.dart
@@ -50,6 +50,7 @@ void main() {
       main_file.MinMaxZoomPreference;
       main_file.PatternItem;
       main_file.PinConfig;
+      main_file.PointOfInterestId;
       main_file.Polygon;
       main_file.PolygonId;
       main_file.Polyline;

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.20.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.19.12
 
 * Bumps the androidx group across 10 directories with 1 update.

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -388,8 +388,10 @@ class GoogleMapController
 
   @Override
   public void onPoiClick(PointOfInterest pointOfInterest) {
-    flutterApi.onPointOfInterestTap(
-        pointOfInterest.placeId, (Result<Unit> result) -> Unit.INSTANCE);
+    if (pointOfInterest != null && pointOfInterest.placeId != null) {
+      flutterApi.onPointOfInterestTap(
+          pointOfInterest.placeId, (Result<Unit> result) -> Unit.INSTANCE);
+    }
   }
 
   @Override

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -38,6 +38,7 @@ import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.MapCapabilities;
 import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.PointOfInterest;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.TileOverlay;
@@ -386,6 +387,12 @@ class GoogleMapController
   }
 
   @Override
+  public void onPoiClick(PointOfInterest pointOfInterest) {
+    flutterApi.onPointOfInterestTap(
+        pointOfInterest.placeId, (Result<Unit> result) -> Unit.INSTANCE);
+  }
+
+  @Override
   public void onGroundOverlayClick(@NonNull GroundOverlay groundOverlay) {
     groundOverlaysController.onGroundOverlayTap(groundOverlay.getId());
   }
@@ -421,6 +428,7 @@ class GoogleMapController
     googleMap.setOnPolygonClickListener(listener);
     googleMap.setOnPolylineClickListener(listener);
     googleMap.setOnCircleClickListener(listener);
+    googleMap.setOnPoiClickListener(listener);
     googleMap.setOnMapClickListener(listener);
     googleMap.setOnMapLongClickListener(listener);
     googleMap.setOnGroundOverlayClickListener(listener);

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapListener.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapListener.java
@@ -15,6 +15,7 @@ interface GoogleMapListener
         GoogleMap.OnPolygonClickListener,
         GoogleMap.OnPolylineClickListener,
         GoogleMap.OnCircleClickListener,
+        GoogleMap.OnPoiClickListener,
         GoogleMap.OnMapClickListener,
         GoogleMap.OnMapLongClickListener,
         GoogleMap.OnMarkerDragListener,

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/kotlin/io/flutter/plugins/googlemaps/Messages.kt
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/kotlin/io/flutter/plugins/googlemaps/Messages.kt
@@ -4071,6 +4071,25 @@ class MapsCallbackApi(
       }
     }
   }
+  /** Called when a point of interest is tapped. */
+  fun onPointOfInterestTap(placeIdArg: String, callback: (Result<Unit>) -> Unit) {
+    val separatedMessageChannelSuffix =
+        if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+        "dev.flutter.pigeon.google_maps_flutter_android.MapsCallbackApi.onPointOfInterestTap$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(placeIdArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(MessagesPigeonUtils.createConnectionError(channelName)))
+      }
+    }
+  }
   /** Called when a marker cluster is tapped. */
   fun onClusterTap(clusterArg: PlatformCluster, callback: (Result<Unit>) -> Unit) {
     val separatedMessageChannelSuffix =

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
@@ -27,6 +27,7 @@ import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.MapCapabilities;
 import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.PointOfInterest;
 import com.google.maps.android.clustering.ClusterManager;
 import io.flutter.plugin.common.BinaryMessenger;
 import java.util.ArrayList;
@@ -256,6 +257,18 @@ public class GoogleMapControllerTest {
 
     googleMapController.onClusterItemInfoWindowClick(markerBuilder);
     verify(mockMarkersController, times(1)).onClusterItemInfoWindowTap(markerBuilder.markerId());
+  }
+
+  @Test
+  public void OnPoiClickCallsFlutterApi() {
+    GoogleMapController googleMapController = getGoogleMapControllerWithMockedDependencies();
+    googleMapController.onMapReady(mockGoogleMap);
+
+    PointOfInterest pointOfInterest =
+        new PointOfInterest(new LatLng(0, 0), "place-123", "Test Place");
+    googleMapController.onPoiClick(pointOfInterest);
+
+    verify(flutterApi, times(1)).onPointOfInterestTap(eq("place-123"), any());
   }
 
   @Test

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<GroundOverlayTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -206,6 +206,11 @@ class GoogleMapsFlutterAndroid extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -1077,6 +1082,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/messages.g.dart
@@ -3436,6 +3436,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3720,6 +3723,31 @@ abstract class MapsCallbackApi {
           final String arg_circleId = args[0]! as String;
           try {
             api.onCircleTap(arg_circleId);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_android.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final String arg_placeId = args[0]! as String;
+          try {
+            api.onPointOfInterestTap(arg_placeId);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_android/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pigeons/messages.dart
@@ -831,6 +831,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_android
 description: Android implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.19.12
+version: 2.20.0
 
 environment:
   sdk: ^3.12.0

--- a/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
@@ -978,6 +978,22 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterAndroid();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(
+      maps.onPointOfInterestTap(mapId: mapId),
+    );
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.18.3
 
 * Updates README to include setup information.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.m
@@ -189,6 +189,27 @@
                  [durationMilliseconds doubleValue] / 1000);
 }
 
+- (void)testDidTapPOIForwardsPlaceId {
+  CGRect frame = CGRectMake(0, 0, 100, 100);
+  GMSMapViewOptions *mapViewOptions = [[GMSMapViewOptions alloc] init];
+  mapViewOptions.frame = frame;
+  mapViewOptions.camera = [[GMSCameraPosition alloc] initWithLatitude:0 longitude:0 zoom:0];
+
+  PartiallyMockedMapView *mapView = [[PartiallyMockedMapView alloc] initWithOptions:mapViewOptions];
+
+  FGMGoogleMapController *controller =
+      [[FGMGoogleMapController alloc] initWithMapView:mapView
+                                       viewIdentifier:0
+                                   creationParameters:[self emptyCreationParameters]
+                                        assetProvider:[[TestAssetProvider alloc] init]
+                                      binaryMessenger:[[StubBinaryMessenger alloc] init]];
+
+  [controller mapView:mapView
+      didTapPOIWithPlaceID:@"place-123"
+                      name:@"Test Place"
+                  location:CLLocationCoordinate2DMake(0, 0)];
+}
+
 - (void)testInspectorAPICameraPosition {
   CGRect frame = CGRectMake(0, 0, 100, 100);
   GMSMapViewOptions *mapViewOptions = [[GMSMapViewOptions alloc] init];

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
@@ -186,6 +186,12 @@
                                         }];
 }
 
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId {
+  [self.callbackHandler didTapPointOfInterestWithPlaceId:placeId
+                                              completion:^(FlutterError *_){
+                                              }];
+}
+
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
   [self.callbackHandler didTapCluster:cluster
                            completion:^(FlutterError *_){
@@ -556,6 +562,13 @@
   } else if ([self.groundOverlaysController hasGroundOverlaysWithIdentifier:overlayId]) {
     [self.groundOverlaysController didTapGroundOverlayWithIdentifier:overlayId];
   }
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+  [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
@@ -568,7 +568,9 @@
     didTapPOIWithPlaceID:(NSString *)placeID
                     name:(NSString *)name
                 location:(CLLocationCoordinate2D)location {
-  [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
+  if (placeID != nil) {
+    [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
+  }
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
@@ -2336,11 +2336,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updatePolylinesByAdding:
-                                                                 changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updatePolylinesByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updatePolylinesByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updatePolylinesByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformPolyline *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2367,11 +2367,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateTileOverlaysByAdding:
-                                                                    changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateTileOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformTileOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2398,11 +2398,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateGroundOverlaysByAdding:
-                                                                      changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateGroundOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformGroundOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2631,11 +2631,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:
-                                                                                       error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_markerId = GetNullableObjectAtIndex(args, 0);
@@ -3054,6 +3054,32 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
              binaryMessenger:self.binaryMessenger
                        codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
   [channel sendMessage:@[ arg_circleId ?: [NSNull null] ]
+                 reply:^(NSArray<id> *reply) {
+                   if (reply != nil) {
+                     if (reply.count > 1) {
+                       completion([FlutterError errorWithCode:reply[0]
+                                                      message:reply[1]
+                                                      details:reply[2]]);
+                     } else {
+                       completion(nil);
+                     }
+                   } else {
+                     completion(createConnectionError(channelName));
+                   }
+                 }];
+}
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)arg_placeId
+                              completion:(void (^)(FlutterError *_Nullable))completion {
+  NSString *channelName = [NSString
+      stringWithFormat:
+          @"%@%@",
+          @"dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap",
+          _messageChannelSuffix];
+  FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+      messageChannelWithName:channelName
+             binaryMessenger:self.binaryMessenger
+                       codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
+  [channel sendMessage:@[ arg_placeId ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapEventDelegate.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapEventDelegate.h
@@ -30,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when the map, not a specifc map object, is long pressed.
 - (void)didLongPressAtPosition:(FGMPlatformLatLng *)position;
 
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId;
+
 /// Called when a marker is tapped.
 - (void)didTapMarkerWithIdentifier:(NSString *)markerId;
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
@@ -910,6 +910,9 @@ extern void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId
                         completion:(void (^)(FlutterError *_Nullable))completion;
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId
+                              completion:(void (^)(FlutterError *_Nullable))completion;
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster
            completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
@@ -183,6 +183,11 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -987,6 +992,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/messages.g.dart
@@ -3355,6 +3355,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3723,6 +3726,39 @@ abstract class MapsCallbackApi {
           );
           try {
             api.onCircleTap(arg_circleId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_placeId = (args[0] as String?);
+          assert(
+            arg_placeId != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null, expected non-null String.',
+          );
+          try {
+            api.onPointOfInterestTap(arg_placeId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pigeons/messages.dart
@@ -832,6 +832,10 @@ abstract class MapsCallbackApi {
   @ObjCSelector('didTapCircleWithIdentifier:')
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  @ObjCSelector('didTapPointOfInterestWithPlaceId:')
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   @ObjCSelector('didTapCluster:')
   void onClusterTap(PlatformCluster cluster);

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.3
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
@@ -905,6 +905,22 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterIOS();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(
+      maps.onPointOfInterestTap(mapId: mapId),
+    );
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.18.4
 
 * Updates README to include setup information.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerTests/GoogleMapsTests.m
@@ -189,6 +189,27 @@
                  [durationMilliseconds doubleValue] / 1000);
 }
 
+- (void)testDidTapPOIForwardsPlaceId {
+  CGRect frame = CGRectMake(0, 0, 100, 100);
+  GMSMapViewOptions *mapViewOptions = [[GMSMapViewOptions alloc] init];
+  mapViewOptions.frame = frame;
+  mapViewOptions.camera = [[GMSCameraPosition alloc] initWithLatitude:0 longitude:0 zoom:0];
+
+  PartiallyMockedMapView *mapView = [[PartiallyMockedMapView alloc] initWithOptions:mapViewOptions];
+
+  FGMGoogleMapController *controller =
+      [[FGMGoogleMapController alloc] initWithMapView:mapView
+                                       viewIdentifier:0
+                                   creationParameters:[self emptyCreationParameters]
+                                        assetProvider:[[TestAssetProvider alloc] init]
+                                      binaryMessenger:[[StubBinaryMessenger alloc] init]];
+
+  [controller mapView:mapView
+      didTapPOIWithPlaceID:@"place-123"
+                      name:@"Test Place"
+                  location:CLLocationCoordinate2DMake(0, 0)];
+}
+
 - (void)testInspectorAPICameraPosition {
   CGRect frame = CGRectMake(0, 0, 100, 100);
   GMSMapViewOptions *mapViewOptions = [[GMSMapViewOptions alloc] init];

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMGoogleMapController.m
@@ -186,6 +186,12 @@
                                         }];
 }
 
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId {
+  [self.callbackHandler didTapPointOfInterestWithPlaceId:placeId
+                                              completion:^(FlutterError *_){
+                                              }];
+}
+
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
   [self.callbackHandler didTapCluster:cluster
                            completion:^(FlutterError *_){
@@ -556,6 +562,13 @@
   } else if ([self.groundOverlaysController hasGroundOverlaysWithIdentifier:overlayId]) {
     [self.groundOverlaysController didTapGroundOverlayWithIdentifier:overlayId];
   }
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+  [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMGoogleMapController.m
@@ -568,7 +568,9 @@
     didTapPOIWithPlaceID:(NSString *)placeID
                     name:(NSString *)name
                 location:(CLLocationCoordinate2D)location {
-  [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
+  if (placeID != nil) {
+    [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
+  }
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.m
@@ -2336,11 +2336,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updatePolylinesByAdding:
-                                                                 changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updatePolylinesByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updatePolylinesByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updatePolylinesByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformPolyline *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2367,11 +2367,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateTileOverlaysByAdding:
-                                                                    changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateTileOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformTileOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2398,11 +2398,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateGroundOverlaysByAdding:
-                                                                      changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateGroundOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformGroundOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2631,11 +2631,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:
-                                                                                       error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_markerId = GetNullableObjectAtIndex(args, 0);
@@ -3054,6 +3054,32 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
              binaryMessenger:self.binaryMessenger
                        codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
   [channel sendMessage:@[ arg_circleId ?: [NSNull null] ]
+                 reply:^(NSArray<id> *reply) {
+                   if (reply != nil) {
+                     if (reply.count > 1) {
+                       completion([FlutterError errorWithCode:reply[0]
+                                                      message:reply[1]
+                                                      details:reply[2]]);
+                     } else {
+                       completion(nil);
+                     }
+                   } else {
+                     completion(createConnectionError(channelName));
+                   }
+                 }];
+}
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)arg_placeId
+                              completion:(void (^)(FlutterError *_Nullable))completion {
+  NSString *channelName = [NSString
+      stringWithFormat:
+          @"%@%@",
+          @"dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap",
+          _messageChannelSuffix];
+  FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+      messageChannelWithName:channelName
+             binaryMessenger:self.binaryMessenger
+                       codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
+  [channel sendMessage:@[ arg_placeId ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/FGMMapEventDelegate.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/FGMMapEventDelegate.h
@@ -30,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when the map, not a specifc map object, is long pressed.
 - (void)didLongPressAtPosition:(FGMPlatformLatLng *)position;
 
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId;
+
 /// Called when a marker is tapped.
 - (void)didTapMarkerWithIdentifier:(NSString *)markerId;
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.h
@@ -910,6 +910,9 @@ extern void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId
                         completion:(void (^)(FlutterError *_Nullable))completion;
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId
+                              completion:(void (^)(FlutterError *_Nullable))completion;
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster
            completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/google_maps_flutter_ios.dart
@@ -183,6 +183,11 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -987,6 +992,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/messages.g.dart
@@ -3355,6 +3355,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3723,6 +3726,39 @@ abstract class MapsCallbackApi {
           );
           try {
             api.onCircleTap(arg_circleId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_placeId = (args[0] as String?);
+          assert(
+            arg_placeId != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null, expected non-null String.',
+          );
+          try {
+            api.onPointOfInterestTap(arg_placeId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pigeons/messages.dart
@@ -832,6 +832,10 @@ abstract class MapsCallbackApi {
   @ObjCSelector('didTapCircleWithIdentifier:')
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  @ObjCSelector('didTapPointOfInterestWithPlaceId:')
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   @ObjCSelector('didTapCluster:')
   void onClusterTap(PlatformCluster cluster);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios_sdk10
 description: iOS implementation of the google_maps_flutter plugin using Google Maps SDK 10.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios_sdk10
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.4
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/test/google_maps_flutter_ios_test.dart
@@ -905,6 +905,22 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterIOS();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(
+      maps.onPointOfInterestTap(mapId: mapId),
+    );
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.18.4
 
 * Updates README to include setup information.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerTests/GoogleMapsTests.m
@@ -189,6 +189,27 @@
                  [durationMilliseconds doubleValue] / 1000);
 }
 
+- (void)testDidTapPOIForwardsPlaceId {
+  CGRect frame = CGRectMake(0, 0, 100, 100);
+  GMSMapViewOptions *mapViewOptions = [[GMSMapViewOptions alloc] init];
+  mapViewOptions.frame = frame;
+  mapViewOptions.camera = [[GMSCameraPosition alloc] initWithLatitude:0 longitude:0 zoom:0];
+
+  PartiallyMockedMapView *mapView = [[PartiallyMockedMapView alloc] initWithOptions:mapViewOptions];
+
+  FGMGoogleMapController *controller =
+      [[FGMGoogleMapController alloc] initWithMapView:mapView
+                                       viewIdentifier:0
+                                   creationParameters:[self emptyCreationParameters]
+                                        assetProvider:[[TestAssetProvider alloc] init]
+                                      binaryMessenger:[[StubBinaryMessenger alloc] init]];
+
+  [controller mapView:mapView
+      didTapPOIWithPlaceID:@"place-123"
+                      name:@"Test Place"
+                  location:CLLocationCoordinate2DMake(0, 0)];
+}
+
 - (void)testInspectorAPICameraPosition {
   CGRect frame = CGRectMake(0, 0, 100, 100);
   GMSMapViewOptions *mapViewOptions = [[GMSMapViewOptions alloc] init];

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMGoogleMapController.m
@@ -186,6 +186,12 @@
                                         }];
 }
 
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId {
+  [self.callbackHandler didTapPointOfInterestWithPlaceId:placeId
+                                              completion:^(FlutterError *_){
+                                              }];
+}
+
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
   [self.callbackHandler didTapCluster:cluster
                            completion:^(FlutterError *_){
@@ -556,6 +562,13 @@
   } else if ([self.groundOverlaysController hasGroundOverlaysWithIdentifier:overlayId]) {
     [self.groundOverlaysController didTapGroundOverlayWithIdentifier:overlayId];
   }
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+  [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMGoogleMapController.m
@@ -568,7 +568,9 @@
     didTapPOIWithPlaceID:(NSString *)placeID
                     name:(NSString *)name
                 location:(CLLocationCoordinate2D)location {
-  [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
+  if (placeID != nil) {
+    [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
+  }
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.m
@@ -2336,11 +2336,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updatePolylinesByAdding:
-                                                                 changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updatePolylinesByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updatePolylinesByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updatePolylinesByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformPolyline *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2367,11 +2367,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateTileOverlaysByAdding:
-                                                                    changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateTileOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformTileOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2398,11 +2398,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateGroundOverlaysByAdding:
-                                                                      changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateGroundOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformGroundOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2631,11 +2631,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:
-                                                                                       error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_markerId = GetNullableObjectAtIndex(args, 0);
@@ -3054,6 +3054,32 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
              binaryMessenger:self.binaryMessenger
                        codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
   [channel sendMessage:@[ arg_circleId ?: [NSNull null] ]
+                 reply:^(NSArray<id> *reply) {
+                   if (reply != nil) {
+                     if (reply.count > 1) {
+                       completion([FlutterError errorWithCode:reply[0]
+                                                      message:reply[1]
+                                                      details:reply[2]]);
+                     } else {
+                       completion(nil);
+                     }
+                   } else {
+                     completion(createConnectionError(channelName));
+                   }
+                 }];
+}
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)arg_placeId
+                              completion:(void (^)(FlutterError *_Nullable))completion {
+  NSString *channelName = [NSString
+      stringWithFormat:
+          @"%@%@",
+          @"dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap",
+          _messageChannelSuffix];
+  FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+      messageChannelWithName:channelName
+             binaryMessenger:self.binaryMessenger
+                       codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
+  [channel sendMessage:@[ arg_placeId ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/FGMMapEventDelegate.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/FGMMapEventDelegate.h
@@ -30,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when the map, not a specifc map object, is long pressed.
 - (void)didLongPressAtPosition:(FGMPlatformLatLng *)position;
 
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId;
+
 /// Called when a marker is tapped.
 - (void)didTapMarkerWithIdentifier:(NSString *)markerId;
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.h
@@ -910,6 +910,9 @@ extern void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId
                         completion:(void (^)(FlutterError *_Nullable))completion;
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId
+                              completion:(void (^)(FlutterError *_Nullable))completion;
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster
            completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/google_maps_flutter_ios.dart
@@ -183,6 +183,11 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -987,6 +992,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/messages.g.dart
@@ -3355,6 +3355,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3723,6 +3726,39 @@ abstract class MapsCallbackApi {
           );
           try {
             api.onCircleTap(arg_circleId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_placeId = (args[0] as String?);
+          assert(
+            arg_placeId != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null, expected non-null String.',
+          );
+          try {
+            api.onPointOfInterestTap(arg_placeId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pigeons/messages.dart
@@ -832,6 +832,10 @@ abstract class MapsCallbackApi {
   @ObjCSelector('didTapCircleWithIdentifier:')
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  @ObjCSelector('didTapPointOfInterestWithPlaceId:')
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   @ObjCSelector('didTapCluster:')
   void onClusterTap(PlatformCluster cluster);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios_sdk9
 description: iOS implementation of the google_maps_flutter plugin using Google Maps SDK 9.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios_sdk9
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.4
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/test/google_maps_flutter_ios_test.dart
@@ -905,6 +905,22 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterIOS();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(
+      maps.onPointOfInterestTap(mapId: mapId),
+    );
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerTests/GoogleMapsTests.m
@@ -189,6 +189,27 @@
                  [durationMilliseconds doubleValue] / 1000);
 }
 
+- (void)testDidTapPOIForwardsPlaceId {
+  CGRect frame = CGRectMake(0, 0, 100, 100);
+  GMSMapViewOptions *mapViewOptions = [[GMSMapViewOptions alloc] init];
+  mapViewOptions.frame = frame;
+  mapViewOptions.camera = [[GMSCameraPosition alloc] initWithLatitude:0 longitude:0 zoom:0];
+
+  PartiallyMockedMapView *mapView = [[PartiallyMockedMapView alloc] initWithOptions:mapViewOptions];
+
+  FGMGoogleMapController *controller =
+      [[FGMGoogleMapController alloc] initWithMapView:mapView
+                                       viewIdentifier:0
+                                   creationParameters:[self emptyCreationParameters]
+                                        assetProvider:[[TestAssetProvider alloc] init]
+                                      binaryMessenger:[[StubBinaryMessenger alloc] init]];
+
+  [controller mapView:mapView
+      didTapPOIWithPlaceID:@"place-123"
+                      name:@"Test Place"
+                  location:CLLocationCoordinate2DMake(0, 0)];
+}
+
 - (void)testInspectorAPICameraPosition {
   CGRect frame = CGRectMake(0, 0, 100, 100);
   GMSMapViewOptions *mapViewOptions = [[GMSMapViewOptions alloc] init];

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
@@ -188,8 +188,8 @@
 
 - (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId {
   [self.callbackHandler didTapPointOfInterestWithPlaceId:placeId
-                                            completion:^(FlutterError *_){
-                                            }];
+                                              completion:^(FlutterError *_){
+                                              }];
 }
 
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
@@ -568,7 +568,9 @@
     didTapPOIWithPlaceID:(NSString *)placeID
                     name:(NSString *)name
                 location:(CLLocationCoordinate2D)location {
-  [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
+  if (placeID != nil) {
+    [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
+  }
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
@@ -186,6 +186,12 @@
                                         }];
 }
 
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId {
+  [self.callbackHandler didTapPointOfInterestWithPlaceId:placeId
+                                            completion:^(FlutterError *_){
+                                            }];
+}
+
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
   [self.callbackHandler didTapCluster:cluster
                            completion:^(FlutterError *_){
@@ -556,6 +562,13 @@
   } else if ([self.groundOverlaysController hasGroundOverlaysWithIdentifier:overlayId]) {
     [self.groundOverlaysController didTapGroundOverlayWithIdentifier:overlayId];
   }
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+  [self.mapEventHandler didTapPointOfInterestWithPlaceId:placeID];
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
@@ -2336,11 +2336,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updatePolylinesByAdding:
-                                                                 changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updatePolylinesByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updatePolylinesByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updatePolylinesByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformPolyline *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2367,11 +2367,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateTileOverlaysByAdding:
-                                                                    changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateTileOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformTileOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2398,11 +2398,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateGroundOverlaysByAdding:
-                                                                      changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateGroundOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformGroundOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2631,11 +2631,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:
-                                                                                       error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_markerId = GetNullableObjectAtIndex(args, 0);
@@ -3054,6 +3054,32 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
              binaryMessenger:self.binaryMessenger
                        codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
   [channel sendMessage:@[ arg_circleId ?: [NSNull null] ]
+                 reply:^(NSArray<id> *reply) {
+                   if (reply != nil) {
+                     if (reply.count > 1) {
+                       completion([FlutterError errorWithCode:reply[0]
+                                                      message:reply[1]
+                                                      details:reply[2]]);
+                     } else {
+                       completion(nil);
+                     }
+                   } else {
+                     completion(createConnectionError(channelName));
+                   }
+                 }];
+}
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)arg_placeId
+                              completion:(void (^)(FlutterError *_Nullable))completion {
+  NSString *channelName = [NSString
+      stringWithFormat:
+          @"%@%@",
+          @"dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap",
+          _messageChannelSuffix];
+  FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+      messageChannelWithName:channelName
+             binaryMessenger:self.binaryMessenger
+                       codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
+  [channel sendMessage:@[ arg_placeId ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapEventDelegate.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapEventDelegate.h
@@ -30,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when the map, not a specifc map object, is long pressed.
 - (void)didLongPressAtPosition:(FGMPlatformLatLng *)position;
 
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId;
+
 /// Called when a marker is tapped.
 - (void)didTapMarkerWithIdentifier:(NSString *)markerId;
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
@@ -910,6 +910,9 @@ extern void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId
                         completion:(void (^)(FlutterError *_Nullable))completion;
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceId:(NSString *)placeId
+                              completion:(void (^)(FlutterError *_Nullable))completion;
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster
            completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/google_maps_flutter_ios.dart
@@ -183,6 +183,11 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -987,6 +992,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/messages.g.dart
@@ -3355,6 +3355,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3723,6 +3726,39 @@ abstract class MapsCallbackApi {
           );
           try {
             api.onCircleTap(arg_circleId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_placeId = (args[0] as String?);
+          assert(
+            arg_placeId != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null, expected non-null String.',
+          );
+          try {
+            api.onPointOfInterestTap(arg_placeId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/pigeons/messages.dart
@@ -832,6 +832,10 @@ abstract class MapsCallbackApi {
   @ObjCSelector('didTapCircleWithIdentifier:')
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  @ObjCSelector('didTapPointOfInterestWithPlaceId:')
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   @ObjCSelector('didTapCluster:')
   void onClusterTap(PlatformCluster cluster);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/test/google_maps_flutter_ios_test.dart
@@ -905,6 +905,22 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterIOS();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(
+      maps.onPointOfInterestTap(mapId: mapId),
+    );
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.16.0
 
+* Adds support for tapping points of interest on the map.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.15.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/events/map_event.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/events/map_event.dart
@@ -160,6 +160,15 @@ class GroundOverlayTapEvent extends MapEvent<GroundOverlayId> {
   GroundOverlayTapEvent(super.mapId, super.croundOverlayId);
 }
 
+/// An event fired when a point of interest is tapped.
+class PointOfInterestTapEvent extends MapEvent<PointOfInterestId> {
+  /// Build a PointOfInterestTap Event triggered from the map represented by `mapId`.
+  ///
+  /// The `value` of this event is a [PointOfInterestId] object that represents the
+  /// tapped point of interest.
+  PointOfInterestTapEvent(super.mapId, super.pointOfInterestId);
+}
+
 /// An event fired when a Map is tapped.
 class MapTapEvent extends _PositionedMapEvent<void> {
   /// Build an MapTap Event triggered from the map represented by `mapId`.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
@@ -156,6 +156,11 @@ class MethodChannelGoogleMapsFlutter extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return _events(mapId).whereType<MapTapEvent>();
   }
@@ -232,6 +237,14 @@ class MethodChannelGoogleMapsFlutter extends GoogleMapsFlutterPlatform {
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
         _mapEventStreamController.add(
           CircleTapEvent(mapId, CircleId(arguments['circleId']! as String)),
+        );
+      case 'map#onPointOfInterestTap':
+        final Map<String, Object?> arguments = _getArgumentDictionary(call);
+        _mapEventStreamController.add(
+          PointOfInterestTapEvent(
+            mapId,
+            PointOfInterestId(arguments['placeId']! as String),
+          ),
         );
       case 'map#onTap':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
@@ -337,6 +337,11 @@ abstract class GoogleMapsFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('onCircleTap() has not been implemented.');
   }
 
+  /// A point of interest has been tapped.
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return const Stream<PointOfInterestTapEvent>.empty();
+  }
+
   /// A Map has been tapped at a certain [LatLng].
   Stream<MapTapEvent> onTap({required int mapId}) {
     throw UnimplementedError('onTap() has not been implemented.');

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/point_of_interest_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/point_of_interest_id.dart
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart' show immutable, objectRuntimeType;
+
+/// Uniquely identifies a point of interest on a [GoogleMap].
+///
+/// The [value] is the Google Maps place ID for the tapped point of interest.
+@immutable
+class PointOfInterestId {
+  /// Creates an immutable identifier for a point of interest.
+  const PointOfInterestId(this.value);
+
+  /// The Google Maps place ID for the point of interest.
+  final String value;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is PointOfInterestId && value == other.value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() {
+    return '${objectRuntimeType(this, 'PointOfInterestId')}($value)';
+  }
+}

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/types.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/types.dart
@@ -28,6 +28,7 @@ export 'maps_object_updates.dart';
 export 'marker.dart';
 export 'marker_updates.dart';
 export 'pattern_item.dart';
+export 'point_of_interest_id.dart';
 export 'polygon.dart';
 export 'polygon_updates.dart';
 export 'polyline.dart';

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.15.0
+version: 2.16.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/method_channel/method_channel_google_maps_flutter_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/method_channel/method_channel_google_maps_flutter_test.dart
@@ -119,5 +119,22 @@ void main() {
       expect((await markerDragStream.next).value.value, equals('drag-marker'));
       expect((await markerDragEndStream.next).value.value, equals('drag-end-marker'));
     });
+
+    test('point of interest tap sends event to correct stream', () async {
+      const mapId = 1;
+      const placeId = 'place-123';
+      final jsonEvent = <dynamic, dynamic>{'placeId': placeId};
+
+      final maps = MethodChannelGoogleMapsFlutter();
+      maps.ensureChannelInitialized(mapId);
+
+      final stream = StreamQueue<PointOfInterestTapEvent>(
+        maps.onPointOfInterestTap(mapId: mapId),
+      );
+
+      await sendPlatformMessage(mapId, 'map#onPointOfInterestTap', jsonEvent);
+
+      expect((await stream.next).value.value, equals(placeId));
+    });
   });
 }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
@@ -95,6 +95,12 @@ void main() {
       );
     });
 
+    test('onPointOfInterestTap() returns empty stream', () async {
+      final Stream<PointOfInterestTapEvent> stream = BuildViewGoogleMapsFlutterPlatform()
+          .onPointOfInterestTap(mapId: 0);
+      expect(await stream.isEmpty, isTrue);
+    });
+
     test('default implementation of `getStyleError` returns null', () async {
       final GoogleMapsFlutterPlatform platform = BuildViewGoogleMapsFlutterPlatform();
       expect(await platform.getStyleError(mapId: 0), null);

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/point_of_interest_id_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/point_of_interest_id_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+void main() {
+  test('PointOfInterestId equality', () {
+    const id1 = PointOfInterestId('place-123');
+    const id2 = PointOfInterestId('place-123');
+    const id3 = PointOfInterestId('place-456');
+
+    expect(id1, equals(id2));
+    expect(id1, isNot(equals(id3)));
+    expect(id1.hashCode, equals(id2.hashCode));
+  });
+
+  test('PointOfInterestId toString', () {
+    const id = PointOfInterestId('place-123');
+    expect(id.toString(), contains('place-123'));
+  });
+}

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+* Adds support for tapping points of interest on the map.
+
 ## 0.6.2+3
 
 * Updates README to include setup information.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/google_maps_controller_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/google_maps_controller_test.dart
@@ -248,6 +248,37 @@ void main() {
         expect(events[4], isA<CameraIdleEvent>());
       });
 
+      testWidgets('emits point of interest tap when click has placeId', (WidgetTester tester) async {
+        controller = createController()
+          ..debugSetOverrides(
+            createMap: (_, _) => map,
+            circles: circles,
+            heatmaps: heatmaps,
+            markers: markers,
+            polygons: polygons,
+            polylines: polylines,
+            groundOverlays: groundOverlays,
+          )
+          ..init();
+
+        final Stream<MapEvent<Object?>> capturedEvents = stream.stream.take(1);
+
+        gmaps.event.trigger(
+          map,
+          'click',
+          gmaps.IconMouseEvent(placeId: 'place-123')..latLng = gmaps.LatLng(0, 0),
+        );
+
+        final List<MapEvent<Object?>> events = await capturedEvents.toList();
+
+        expect(events, hasLength(1));
+        expect(events[0], isA<PointOfInterestTapEvent>());
+        expect(
+          (events[0] as PointOfInterestTapEvent).value,
+          const PointOfInterestId('place-123'),
+        );
+      });
+
       testWidgets('stops listening to map events once disposed', (WidgetTester tester) async {
         controller = createController()
           ..debugSetOverrides(

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/google_maps_plugin_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/google_maps_plugin_test.dart
@@ -467,6 +467,18 @@ void main() {
 
         await testStreamFiltering(stream, event);
       });
+      testWidgets('onPointOfInterestTap', (WidgetTester tester) async {
+        final event = PointOfInterestTapEvent(
+          mapId,
+          const PointOfInterestId('place-123'),
+        );
+
+        final Stream<PointOfInterestTapEvent> stream = plugin.onPointOfInterestTap(
+          mapId: mapId,
+        );
+
+        await testStreamFiltering(stream, event);
+      });
       // Map taps
       testWidgets('onTap', (WidgetTester tester) async {
         final event = MapTapEvent(mapId, const LatLng(43.3597, -5.8458));

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/google_maps_flutter_web.dart
@@ -7,6 +7,7 @@ library google_maps_flutter_web;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:ui_web' as ui_web;
 
 import 'package:collection/collection.dart';

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
@@ -289,6 +289,15 @@ class GoogleMapController {
     _onClickSubscription = map.onClick.listen((gmaps.MapMouseEventOrIconMouseEvent event) {
       assert(event.latLng != null);
       if (!_streamController.isClosed) {
+        if (event.hasProperty('placeId'.toJS).toDart) {
+          final String? placeId = (event as gmaps.IconMouseEvent).placeId;
+          if (placeId != null) {
+            _streamController.add(
+              PointOfInterestTapEvent(_mapId, PointOfInterestId(placeId)),
+            );
+            return;
+          }
+        }
         _streamController.add(MapTapEvent(_mapId, gmLatLngToLatLng(event.latLng!)));
       }
     });

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
@@ -245,6 +245,11 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return _events(mapId).whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.6.2+3
+version: 0.6.3
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Summary

Adds `onPointOfInterestTap` to the `google_maps_flutter` federated plugin, forwarding **place ID only** via a new `PointOfInterestId` type (per maintainer feedback on #4052 / #10963).

- **platform_interface**: `PointOfInterestId`, `PointOfInterestTapEvent`, `onPointOfInterestTap({required int mapId})` stream, method-channel wiring
- **android**: `OnPoiClickListener` → Pigeon → Dart
- **ios** (+ sdk9 / sdk10 / shared_code): `didTapPOIWithPlaceID` delegate → Pigeon → Dart
- **web**: emits POI tap when map click `IconMouseEvent` has `placeId`; skips plain map tap
- **app-facing**: `GoogleMap.onPointOfInterestTap` callback + controller subscription
- **tests**: Dart unit tests on all packages; Android Robolectric `OnPoiClickCallsFlutterApi`; iOS `testDidTapPOIForwardsPlaceId`; web integration tests in `example/latest`
- **example**: POI tap logging added to `map_click.dart`

This is a **combination PR** for federated-plugin review. Path-based `dependency_overrides` are included for CI/local testing per [changing federated plugins](https://github.com/flutter/flutter/blob/main/docs/ecosystem/contributing/README.md#changing-federated-plugins) and should be split/removed before landing individual package PRs.

Fixes flutter/flutter#60695

## Test plan

- [x] `flutter_plugin_tools.dart analyze` (7 packages)
- [x] `flutter_plugin_tools.dart dart-test` (11 packages)
- [x] `flutter_plugin_tools.dart validate`
- [x] `flutter_plugin_tools.dart license-check`
- [x] Android native unit tests (`OnPoiClickCallsFlutterApi`, JDK 21)
- [x] iOS native unit test (`testDidTapPOIForwardsPlaceId`, after `pod install`)
- [x] `google_maps_flutter_ios` `run_tests.dart` sync validation
- [x] LUCI presubmit (dart shards, web integration, Android platform tests, publish-check expected override warning)


Made with [Cursor](https://cursor.com)