### PR TITLE
[camera] Guard CameraController value updates after dispose

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.12.1
 
+* Fixes a crash where a `CameraController` could update its value after being disposed, throwing "A CameraController was used after being disposed." (see [flutter/flutter#184959](https://github.com/flutter/flutter/issues/184959)).
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 0.12.0+1

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.12.1
+## 0.12.0+2
 
-* Fixes a crash where a `CameraController` could update its value after being disposed, throwing "A CameraController was used after being disposed." (see [flutter/flutter#184959](https://github.com/flutter/flutter/issues/184959)).
+* Fixes a crash where a `CameraController` could update its value after being disposed, throwing "A CameraController was used after being disposed".
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 0.12.0+1

--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -337,7 +337,9 @@ class CameraController extends ValueNotifier<CameraValue> {
       _deviceOrientationSubscription ??= CameraPlatform.instance
           .onDeviceOrientationChanged()
           .listen((DeviceOrientationChangedEvent event) {
-            value = value.copyWith(deviceOrientation: event.orientation);
+            if (!_isDisposed) {
+              value = value.copyWith(deviceOrientation: event.orientation);
+            }
           });
 
       _cameraId = await CameraPlatform.instance.createCameraWithSettings(
@@ -355,7 +357,9 @@ class CameraController extends ValueNotifier<CameraValue> {
 
       unawaited(
         CameraPlatform.instance.onCameraError(_cameraId).first.then((CameraErrorEvent event) {
-          value = value.copyWith(errorDescription: event.description);
+          if (!_isDisposed) {
+            value = value.copyWith(errorDescription: event.description);
+          }
         }),
       );
 
@@ -364,25 +368,20 @@ class CameraController extends ValueNotifier<CameraValue> {
         imageFormatGroup: imageFormatGroup ?? ImageFormatGroup.unknown,
       );
 
-      value = value.copyWith(
-        isInitialized: true,
-        description: description,
-        previewSize: await initializeCompleter.future.then(
-          (CameraInitializedEvent event) => Size(event.previewWidth, event.previewHeight),
-        ),
-        exposureMode: await initializeCompleter.future.then(
-          (CameraInitializedEvent event) => event.exposureMode,
-        ),
-        focusMode: await initializeCompleter.future.then(
-          (CameraInitializedEvent event) => event.focusMode,
-        ),
-        exposurePointSupported: await initializeCompleter.future.then(
-          (CameraInitializedEvent event) => event.exposurePointSupported,
-        ),
-        focusPointSupported: await initializeCompleter.future.then(
-          (CameraInitializedEvent event) => event.focusPointSupported,
-        ),
-      );
+      final CameraInitializedEvent event = await initializeCompleter.future;
+
+      // The controller may be disposed while awaiting initialization above.
+      if (!_isDisposed) {
+        value = value.copyWith(
+          isInitialized: true,
+          description: description,
+          previewSize: Size(event.previewWidth, event.previewHeight),
+          exposureMode: event.exposureMode,
+          focusMode: event.focusMode,
+          exposurePointSupported: event.exposurePointSupported,
+          focusPointSupported: event.focusPointSupported,
+        );
+      }
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     } finally {

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.12.0+1
+version: 0.12.1
 
 environment:
   sdk: ^3.10.0

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.12.1
+version: 0.12.0+2
 
 environment:
   sdk: ^3.10.0

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -3428,6 +3428,54 @@ void main() {
       expect(cameraController.value.errorDescription, mockOnCameraErrorEvent.description);
     });
   });
+
+  group('does not update value after dispose', () {
+    test('when initialization completes after dispose', () async {
+      final platform = MockDelayedInitializeCameraPlatform();
+      CameraPlatform.instance = platform;
+
+      final cameraController = CameraController(
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
+
+      final Future<void> initializeFuture = cameraController.initialize();
+      await pumpEventQueue();
+
+      // Dispose while initialization is still in flight, then let it complete.
+      final Future<void> disposeFuture = cameraController.dispose();
+      platform.initializeCameraCompleter.complete();
+
+      await expectLater(initializeFuture, completes);
+      await disposeFuture;
+    });
+
+    test('when a camera error event arrives after dispose', () async {
+      final platform = MockControllableErrorCameraPlatform();
+      CameraPlatform.instance = platform;
+
+      final cameraController = CameraController(
+        const CameraDescription(
+          name: 'cam',
+          lensDirection: CameraLensDirection.back,
+          sensorOrientation: 90,
+        ),
+        ResolutionPreset.max,
+      );
+      await cameraController.initialize();
+      await cameraController.dispose();
+
+      // A camera error arriving after dispose must not update `value`.
+      platform.cameraErrorController.add(const CameraErrorEvent(13, 'late error'));
+      await pumpEventQueue();
+
+      expect(cameraController.value.errorDescription, isNull);
+    });
+  });
 }
 
 class MockCameraPlatform extends Mock with MockPlatformInterfaceMixin implements CameraPlatform {
@@ -3610,4 +3658,27 @@ class MockCameraDescription extends CameraDescription {
 
   @override
   String get name => 'back';
+}
+
+/// A platform whose [initializeCamera] only completes once
+/// [initializeCameraCompleter] is completed, so a test can dispose the
+/// controller while initialization is still in flight.
+class MockDelayedInitializeCameraPlatform extends MockCameraPlatform {
+  final Completer<void> initializeCameraCompleter = Completer<void>();
+
+  @override
+  Future<void> initializeCamera(
+    int? cameraId, {
+    ImageFormatGroup? imageFormatGroup = ImageFormatGroup.unknown,
+  }) => initializeCameraCompleter.future;
+}
+
+/// A platform whose camera error events are driven by [cameraErrorController],
+/// so a test can emit an error after the controller has been disposed.
+class MockControllableErrorCameraPlatform extends MockCameraPlatform {
+  final StreamController<CameraErrorEvent> cameraErrorController =
+      StreamController<CameraErrorEvent>.broadcast();
+
+  @override
+  Stream<CameraErrorEvent> onCameraError(int cameraId) => cameraErrorController.stream;
 }


### PR DESCRIPTION
Guards the `value` assignments in `_initializeWithDescription` so they no longer run after `dispose()`, fixing the "A CameraController was used after being disposed." crash.

These user-level steps, using the reproduction app in flutter/flutter#184959, trigger the crash:
1. Open camera A.
2. Close it before initialization finished (disposing the controller).
3. Open camera B.
4. Adjust an exposure/zoom slider.

When the controller is disposed while initialization is still in flight, the deferred `value` updates could call `notifyListeners()` on a disposed `ChangeNotifier`, throwing the exception above.
This adds `if (!_isDisposed)` guards (and awaits the initialization event only once) so those updates are skipped after dispose.
The guard lives in shared Dart code, so it also covers iOS and web.

Part of flutter/flutter#184959.

This PR addresses only the Dart-layer crash. As @mbcorona noted in https://github.com/flutter/flutter/issues/184959#issuecomment-4238459981, the ANR observed on Android has a separate native root cause (`ImageReader` not severing the stream on dispose, "BufferQueue has been abandoned"), which was routed to team-android. That native issue is not addressed here and should be handled separately in `camera_android_camerax`.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
