### PR TITLE
[google_maps_flutter] Add onPointOfInterestTap callback

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.18.0
 
 * Adds support for mapTypeControlEnabled, fullscreenControlEnabled, and streetViewControlEnabled on web.

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
@@ -35,6 +35,7 @@ class _MapClickBodyState extends State<_MapClickBody> {
   GoogleMapController? mapController;
   LatLng? _lastTap;
   LatLng? _lastLongPress;
+  String? _lastPointOfInterestPlaceId;
 
   @override
   Widget build(BuildContext context) {
@@ -49,6 +50,11 @@ class _MapClickBodyState extends State<_MapClickBody> {
       onLongPress: (LatLng pos) {
         setState(() {
           _lastLongPress = pos;
+        });
+      },
+      onPointOfInterestTap: (PointOfInterestId pointOfInterestId) {
+        setState(() {
+          _lastPointOfInterestPlaceId = pointOfInterestId.value;
         });
       },
     );
@@ -71,6 +77,17 @@ class _MapClickBodyState extends State<_MapClickBody> {
       columnChildren.add(
         Center(
           child: Text(_lastLongPress != null ? 'Long pressed' : '', textAlign: TextAlign.center),
+        ),
+      );
+      final lastPointOfInterestTap =
+          'Point of interest place ID:\n${_lastPointOfInterestPlaceId ?? ""}';
+      columnChildren.add(Center(child: Text(lastPointOfInterestTap, textAlign: TextAlign.center)));
+      columnChildren.add(
+        Center(
+          child: Text(
+            _lastPointOfInterestPlaceId != null ? 'Point of interest tapped' : '',
+            textAlign: TextAlign.center,
+          ),
         ),
       );
     }

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -32,3 +32,10 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_android: {path: ../../../../packages/google_maps_flutter/google_maps_flutter_android}
+  google_maps_flutter_ios: {path: ../../../../packages/google_maps_flutter/google_maps_flutter_ios}
+  google_maps_flutter_platform_interface: {path: ../../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}
+  google_maps_flutter_web: {path: ../../../../packages/google_maps_flutter/google_maps_flutter_web}

--- a/packages/google_maps_flutter/google_maps_flutter/lib/google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/google_maps_flutter.dart
@@ -54,6 +54,7 @@ export 'package:google_maps_flutter_platform_interface/google_maps_flutter_platf
         MinMaxZoomPreference,
         PatternItem,
         PinConfig,
+        PointOfInterestId,
         Polygon,
         PolygonId,
         Polyline,

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
@@ -61,6 +61,11 @@ class GoogleMapController {
     }
     _streamSubscriptions.add(
       GoogleMapsFlutterPlatform.instance
+          .onPointOfInterestTap(mapId: mapId)
+          .listen((PointOfInterestTapEvent e) => _googleMapState.onPointOfInterestTap(e.value)),
+    );
+    _streamSubscriptions.add(
+      GoogleMapsFlutterPlatform.instance
           .onMarkerTap(mapId: mapId)
           .listen((MarkerTapEvent e) => _googleMapState.onMarkerTap(e.value)),
     );

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -136,6 +136,7 @@ class GoogleMap extends StatefulWidget {
     this.onCameraIdle,
     this.onTap,
     this.onLongPress,
+    this.onPointOfInterestTap,
     this.markerType = GoogleMapMarkerType.marker,
     this.colorScheme,
     String? mapId,
@@ -299,6 +300,11 @@ class GoogleMap extends StatefulWidget {
 
   /// Called every time a [GoogleMap] is long pressed.
   final ArgumentCallback<LatLng>? onLongPress;
+
+  /// Called when a point of interest on the map is tapped.
+  ///
+  /// May not be supported on all platforms.
+  final ArgumentCallback<PointOfInterestId>? onPointOfInterestTap;
 
   /// True if a "My Location" layer should be shown on the map.
   ///
@@ -700,6 +706,13 @@ class _GoogleMapState extends State<GoogleMap> {
     final VoidCallback? onTap = marker.infoWindow.onTap;
     if (onTap != null) {
       onTap();
+    }
+  }
+
+  void onPointOfInterestTap(PointOfInterestId pointOfInterestId) {
+    final ArgumentCallback<PointOfInterestId>? onPointOfInterestTap = widget.onPointOfInterestTap;
+    if (onPointOfInterestTap != null) {
+      onPointOfInterestTap(pointOfInterestId);
     }
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.0
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0
@@ -21,10 +21,10 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_android: ^2.19.1
-  google_maps_flutter_ios: ^2.18.0
-  google_maps_flutter_platform_interface: ^2.16.0
-  google_maps_flutter_web: ^0.6.3
+  google_maps_flutter_android: ^2.20.0
+  google_maps_flutter_ios: ^2.19.0
+  google_maps_flutter_platform_interface: ^2.17.0
+  google_maps_flutter_web: ^0.6.4
 
 dev_dependencies:
   flutter_test:
@@ -41,3 +41,10 @@ topics:
 # The example deliberately includes limited-use secrets.
 false_secrets:
   - /example/web/index.html
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_android: {path: ../../../packages/google_maps_flutter/google_maps_flutter_android}
+  google_maps_flutter_ios: {path: ../../../packages/google_maps_flutter/google_maps_flutter_ios}
+  google_maps_flutter_platform_interface: {path: ../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}
+  google_maps_flutter_web: {path: ../../../packages/google_maps_flutter/google_maps_flutter_web}

--- a/packages/google_maps_flutter/google_maps_flutter/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/fake_google_maps_flutter_platform.dart
@@ -228,6 +228,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter/test/google_maps_flutter_export_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/google_maps_flutter_export_test.dart
@@ -50,6 +50,7 @@ void main() {
       main_file.MinMaxZoomPreference;
       main_file.PatternItem;
       main_file.PinConfig;
+      main_file.PointOfInterestId;
       main_file.Polygon;
       main_file.PolygonId;
       main_file.Polyline;

--- a/packages/google_maps_flutter/google_maps_flutter/test/point_of_interest_tap_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/point_of_interest_tap_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+import 'fake_google_maps_flutter_platform.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late FakeGoogleMapsFlutterPlatform platform;
+
+  setUp(() {
+    platform = FakeGoogleMapsFlutterPlatform();
+    GoogleMapsFlutterPlatform.instance = platform;
+  });
+
+  testWidgets('onPointOfInterestTap callback receives place ID from platform event', (
+    WidgetTester tester,
+  ) async {
+    PointOfInterestId? tappedPointOfInterestId;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GoogleMap(
+          initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
+          onPointOfInterestTap: (PointOfInterestId pointOfInterestId) {
+            tappedPointOfInterestId = pointOfInterestId;
+          },
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(platform.createdIds, isNotEmpty);
+    final int mapId = platform.createdIds.first;
+
+    platform.mapEventStreamController.add(
+      PointOfInterestTapEvent(mapId, const PointOfInterestId('place-123')),
+    );
+
+    await tester.pump();
+
+    expect(tappedPointOfInterestId, const PointOfInterestId('place-123'));
+  });
+}

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.20.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.19.12
 
 * Bumps the androidx group across 10 directories with 1 update.

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -38,6 +38,7 @@ import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.MapCapabilities;
 import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.PointOfInterest;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.TileOverlay;
@@ -386,6 +387,14 @@ class GoogleMapController
   }
 
   @Override
+  public void onPoiClick(PointOfInterest pointOfInterest) {
+    if (pointOfInterest.placeId != null) {
+      flutterApi.onPointOfInterestTap(
+          pointOfInterest.placeId, (Result<Unit> result) -> Unit.INSTANCE);
+    }
+  }
+
+  @Override
   public void onGroundOverlayClick(@NonNull GroundOverlay groundOverlay) {
     groundOverlaysController.onGroundOverlayTap(groundOverlay.getId());
   }
@@ -421,6 +430,7 @@ class GoogleMapController
     googleMap.setOnPolygonClickListener(listener);
     googleMap.setOnPolylineClickListener(listener);
     googleMap.setOnCircleClickListener(listener);
+    googleMap.setOnPoiClickListener(listener);
     googleMap.setOnMapClickListener(listener);
     googleMap.setOnMapLongClickListener(listener);
     googleMap.setOnGroundOverlayClickListener(listener);

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapListener.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapListener.java
@@ -15,6 +15,7 @@ interface GoogleMapListener
         GoogleMap.OnPolygonClickListener,
         GoogleMap.OnPolylineClickListener,
         GoogleMap.OnCircleClickListener,
+        GoogleMap.OnPoiClickListener,
         GoogleMap.OnMapClickListener,
         GoogleMap.OnMapLongClickListener,
         GoogleMap.OnMarkerDragListener,

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/kotlin/io/flutter/plugins/googlemaps/Messages.kt
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/kotlin/io/flutter/plugins/googlemaps/Messages.kt
@@ -4071,6 +4071,25 @@ class MapsCallbackApi(
       }
     }
   }
+  /** Called when a point of interest is tapped. */
+  fun onPointOfInterestTap(placeIdArg: String, callback: (Result<Unit>) -> Unit) {
+    val separatedMessageChannelSuffix =
+        if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+        "dev.flutter.pigeon.google_maps_flutter_android.MapsCallbackApi.onPointOfInterestTap$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(placeIdArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(MessagesPigeonUtils.createConnectionError(channelName)))
+      }
+    }
+  }
   /** Called when a marker cluster is tapped. */
   fun onClusterTap(clusterArg: PlatformCluster, callback: (Result<Unit>) -> Unit) {
     val separatedMessageChannelSuffix =

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
@@ -27,6 +27,7 @@ import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.MapCapabilities;
 import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.PointOfInterest;
 import com.google.maps.android.clustering.ClusterManager;
 import io.flutter.plugin.common.BinaryMessenger;
 import java.util.ArrayList;
@@ -256,6 +257,28 @@ public class GoogleMapControllerTest {
 
     googleMapController.onClusterItemInfoWindowClick(markerBuilder);
     verify(mockMarkersController, times(1)).onClusterItemInfoWindowTap(markerBuilder.markerId());
+  }
+
+  @Test
+  public void OnPoiClickCallsFlutterApi() {
+    GoogleMapController googleMapController = getGoogleMapControllerWithMockedDependencies();
+    googleMapController.onMapReady(mockGoogleMap);
+
+    PointOfInterest pointOfInterest =
+        new PointOfInterest(new LatLng(0, 0), "place-123", "Test Place");
+    googleMapController.onPoiClick(pointOfInterest);
+
+    verify(flutterApi, times(1)).onPointOfInterestTap(eq("place-123"), any());
+  }
+
+  @Test
+  public void OnPoiClickNullPlaceIdDoesNotCallFlutterApi() {
+    GoogleMapController googleMapController = getGoogleMapControllerWithMockedDependencies();
+    googleMapController.onMapReady(mockGoogleMap);
+
+    googleMapController.onPoiClick(new PointOfInterest(new LatLng(0, 0), null, "Test Place"));
+
+    verify(flutterApi, times(0)).onPointOfInterestTap(any(), any());
   }
 
   @Test

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -33,3 +33,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<GroundOverlayTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -206,6 +206,11 @@ class GoogleMapsFlutterAndroid extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -1077,6 +1082,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/messages.g.dart
@@ -3436,6 +3436,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3720,6 +3723,31 @@ abstract class MapsCallbackApi {
           final String arg_circleId = args[0]! as String;
           try {
             api.onCircleTap(arg_circleId);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_android.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final String arg_placeId = args[0]! as String;
+          try {
+            api.onPointOfInterestTap(arg_placeId);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_android/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pigeons/messages.dart
@@ -831,6 +831,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_android
 description: Android implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.19.12
+version: 2.20.0
 
 environment:
   sdk: ^3.12.0
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
-  google_maps_flutter_platform_interface: ^2.13.0
+  google_maps_flutter_platform_interface: ^2.17.0
   meta: ^1.10.0
   stream_transform: ^2.0.0
 
@@ -38,3 +38,7 @@ topics:
   - google-maps
   - google-maps-flutter
   - map
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
@@ -978,6 +978,20 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterAndroid();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(maps.onPointOfInterestTap(mapId: mapId));
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.18.4
 
 * Fixes a potential compilation issue in tile downscaling.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.swift
@@ -38,6 +38,98 @@ class StubBinaryMessenger: NSObject, FlutterBinaryMessenger {
   }
 }
 
+/// Fake implementation of FGMMapsCallbackApiProtocol that records the calls it receives.
+class MockMapsCallbackApi: NSObject, FGMMapsCallbackApiProtocol {
+  var lastTappedPointOfInterestPlaceIdentifier: String?
+
+  func didTapPointOfInterest(
+    withPlaceIdentifier placeIdentifier: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) {
+    lastTappedPointOfInterestPlaceIdentifier = placeIdentifier
+    completion(nil)
+  }
+
+  func didStartCameraMove(completion: @escaping (FlutterError?) -> Void) { completion(nil) }
+
+  func didMoveCamera(
+    to cameraPosition: FGMPlatformCameraPosition,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didIdleCamera(completion: @escaping (FlutterError?) -> Void) { completion(nil) }
+
+  func didTap(
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didLongPress(
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapMarker(
+    withIdentifier markerId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didStartDragForMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didDragMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didEndDragForMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapInfoWindowOfMarker(
+    withIdentifier markerId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapCircle(
+    withIdentifier circleId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTap(
+    _ cluster: FGMPlatformCluster,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapPolygon(
+    withIdentifier polygonId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapPolyline(
+    withIdentifier polylineId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapGroundOverlay(
+    withIdentifier groundOverlayId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func tile(
+    withOverlayIdentifier tileOverlayId: String,
+    location: FGMPlatformPoint,
+    zoom: Int,
+    completion: @escaping (FGMPlatformTile?, FlutterError?) -> Void
+  ) { completion(nil, nil) }
+}
+
 class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
   var viewController: UIViewController? { nil }
   func publish(_ value: NSObject) {}
@@ -74,7 +166,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     for _ in 0..<10 {
@@ -133,7 +226,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let mockTransactionWrapper = MockCATransaction()
@@ -165,7 +259,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let mockTransactionWrapper = MockCATransaction()
@@ -188,6 +283,34 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
     #expect(mockTransactionWrapper.animationDuration == durationMilliseconds.doubleValue / 1000)
   }
 
+  @Test func didTapPOIForwardsPlaceIdentifierToCallbackApi() {
+    let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+    let mapViewOptions = GMSMapViewOptions()
+    mapViewOptions.frame = frame
+    mapViewOptions.camera = GMSCameraPosition(latitude: 0, longitude: 0, zoom: 0)
+
+    let mapView = PartiallyMockedMapView(options: mapViewOptions)
+
+    let callbackApi = MockMapsCallbackApi()
+    let controller = FGMGoogleMapController(
+      mapView: mapView,
+      viewIdentifier: 0,
+      creationParameters: emptyCreationParameters(),
+      assetProvider: TestAssetProvider(),
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: callbackApi
+    )
+
+    controller.mapView(
+      mapView,
+      didTapPOIWithPlaceID: "place-123",
+      name: "Test Place",
+      location: CLLocationCoordinate2DMake(0, 0)
+    )
+
+    #expect(callbackApi.lastTappedPointOfInterestPlaceIdentifier == "place-123")
+  }
+
   @Test func inspectorAPICameraPosition() throws {
     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
     let mapViewOptions = GMSMapViewOptions()
@@ -205,7 +328,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: binaryMessenger
+      binaryMessenger: binaryMessenger,
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let inspector = FGMMapInspector(

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/TestUtils/TestMapEventHandler.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/TestUtils/TestMapEventHandler.swift
@@ -32,6 +32,8 @@ class TestMapEventHandler: NSObject, FGMMapEventDelegate {
 
   func didTapCircle(withIdentifier circleId: String) {}
 
+  func didTapPointOfInterest(withPlaceIdentifier placeIdentifier: String) {}
+
   func didTap(_ cluster: FGMPlatformCluster) {}
 
   func didTapPolygon(withIdentifier polygonId: String) {}

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -31,3 +31,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
@@ -11,6 +11,7 @@
 #import "FGMConversionUtils.h"
 #import "FGMGroundOverlayController.h"
 #import "FGMHeatmapController.h"
+#import "FGMMapsCallbackApiProtocol.h"
 #import "FGMMarkerUserData.h"
 #import "FGMTileOverlayController.h"
 #import "google_maps_flutter_pigeon_messages.g.h"
@@ -99,17 +100,138 @@
 
 #pragma mark -
 
+/// Non-test implementation of FGMMapsCallbackApiProtocol, passing calls through to a
+/// FGMMapsCallbackApi instance.
+@interface FGMDefaultMapsCallbackApi : NSObject <FGMMapsCallbackApiProtocol>
+@property(strong, nonatomic) FGMMapsCallbackApi *callbackApi;
+
+- (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                   messageChannelSuffix:(NSString *)messageChannelSuffix;
+@end
+
+@implementation FGMDefaultMapsCallbackApi
+
+- (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                   messageChannelSuffix:(NSString *)messageChannelSuffix {
+  self = [super init];
+  if (self) {
+    _callbackApi = [[FGMMapsCallbackApi alloc] initWithBinaryMessenger:binaryMessenger
+                                                  messageChannelSuffix:messageChannelSuffix];
+  }
+  return self;
+}
+
+- (void)didStartCameraMoveWithCompletion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didStartCameraMoveWithCompletion:completion];
+}
+
+- (void)didMoveCameraToPosition:(FGMPlatformCameraPosition *)cameraPosition
+                     completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didMoveCameraToPosition:cameraPosition completion:completion];
+}
+
+- (void)didIdleCameraWithCompletion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didIdleCameraWithCompletion:completion];
+}
+
+- (void)didTapAtPosition:(FGMPlatformLatLng *)position
+              completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapAtPosition:position completion:completion];
+}
+
+- (void)didLongPressAtPosition:(FGMPlatformLatLng *)position
+                    completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didLongPressAtPosition:position completion:completion];
+}
+
+- (void)didTapMarkerWithIdentifier:(NSString *)markerId
+                        completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapMarkerWithIdentifier:markerId completion:completion];
+}
+
+- (void)didStartDragForMarkerWithIdentifier:(NSString *)markerId
+                                 atPosition:(FGMPlatformLatLng *)position
+                                 completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didStartDragForMarkerWithIdentifier:markerId
+                                             atPosition:position
+                                             completion:completion];
+}
+
+- (void)didDragMarkerWithIdentifier:(NSString *)markerId
+                         atPosition:(FGMPlatformLatLng *)position
+                         completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didDragMarkerWithIdentifier:markerId atPosition:position completion:completion];
+}
+
+- (void)didEndDragForMarkerWithIdentifier:(NSString *)markerId
+                               atPosition:(FGMPlatformLatLng *)position
+                               completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didEndDragForMarkerWithIdentifier:markerId
+                                           atPosition:position
+                                           completion:completion];
+}
+
+- (void)didTapInfoWindowOfMarkerWithIdentifier:(NSString *)markerId
+                                    completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapInfoWindowOfMarkerWithIdentifier:markerId completion:completion];
+}
+
+- (void)didTapCircleWithIdentifier:(NSString *)circleId
+                        completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapCircleWithIdentifier:circleId completion:completion];
+}
+
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier
+                                      completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPointOfInterestWithPlaceIdentifier:placeIdentifier completion:completion];
+}
+
+- (void)didTapCluster:(FGMPlatformCluster *)cluster
+           completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapCluster:cluster completion:completion];
+}
+
+- (void)didTapPolygonWithIdentifier:(NSString *)polygonId
+                         completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPolygonWithIdentifier:polygonId completion:completion];
+}
+
+- (void)didTapPolylineWithIdentifier:(NSString *)polylineId
+                          completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPolylineWithIdentifier:polylineId completion:completion];
+}
+
+- (void)didTapGroundOverlayWithIdentifier:(NSString *)groundOverlayId
+                               completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapGroundOverlayWithIdentifier:groundOverlayId completion:completion];
+}
+
+- (void)tileWithOverlayIdentifier:(NSString *)tileOverlayId
+                         location:(FGMPlatformPoint *)location
+                             zoom:(NSInteger)zoom
+                       completion:(void (^)(FGMPlatformTile *_Nullable,
+                                            FlutterError *_Nullable))completion {
+  [self.callbackApi tileWithOverlayIdentifier:tileOverlayId
+                                     location:location
+                                         zoom:zoom
+                                   completion:completion];
+}
+
+@end
+
+#pragma mark -
+
 /// Non-test implementation of FGMAssetProvider, wrapping a FGMMapsCallbackApi
 /// instance.
 @interface FGMDefaultMapEventHandler : NSObject <FGMMapEventDelegate>
-@property(strong, nonatomic) FGMMapsCallbackApi *callbackHandler;
+@property(strong, nonatomic) id<FGMMapsCallbackApiProtocol> callbackHandler;
 
-- (instancetype)initWithCallbackHandler:(FGMMapsCallbackApi *)callbackHandler;
+- (instancetype)initWithCallbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler;
 @end
 
 @implementation FGMDefaultMapEventHandler
 
-- (instancetype)initWithCallbackHandler:(FGMMapsCallbackApi *)callbackHandler {
+- (instancetype)initWithCallbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler {
   self = [super init];
   if (self) {
     _callbackHandler = callbackHandler;
@@ -186,6 +308,12 @@
                                         }];
 }
 
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier {
+  [self.callbackHandler didTapPointOfInterestWithPlaceIdentifier:placeIdentifier
+                                                      completion:^(FlutterError *_){
+                                                      }];
+}
+
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
   [self.callbackHandler didTapCluster:cluster
                            completion:^(FlutterError *_){
@@ -246,7 +374,7 @@
 @interface FGMGoogleMapController () <FGMTileProviderDelegate>
 
 @property(nonatomic, strong) GMSMapView *mapView;
-@property(nonatomic, strong) FGMMapsCallbackApi *dartCallbackHandler;
+@property(nonatomic, strong) id<FGMMapsCallbackApiProtocol> dartCallbackHandler;
 @property(nonatomic, strong) FGMDefaultMapEventHandler *mapEventHandler;
 @property(nonatomic, assign) BOOL trackCameraPosition;
 @property(nonatomic, strong) FGMClusterManagersController *clusterManagersController;
@@ -290,18 +418,23 @@
 
   GMSMapView *mapView = [[GMSMapView alloc] initWithOptions:options];
 
+  NSString *pigeonSuffix = [NSString stringWithFormat:@"%lld", viewId];
   return [self initWithMapView:mapView
                 viewIdentifier:viewId
             creationParameters:creationParameters
                  assetProvider:[[FGMDefaultAssetProvider alloc] initWithRegistrar:registrar]
-               binaryMessenger:registrar.messenger];
+               binaryMessenger:registrar.messenger
+               callbackHandler:[[FGMDefaultMapsCallbackApi alloc]
+                                   initWithBinaryMessenger:registrar.messenger
+                                      messageChannelSuffix:pigeonSuffix]];
 }
 
 - (instancetype)initWithMapView:(GMSMapView *_Nonnull)mapView
                  viewIdentifier:(int64_t)viewId
              creationParameters:(FGMPlatformMapViewCreationParams *)creationParameters
                   assetProvider:(NSObject<FGMAssetProvider> *)assetProvider
-                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger {
+                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                callbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler {
   if (self = [super init]) {
     _mapView = mapView;
 
@@ -310,8 +443,7 @@
     // https://github.com/flutter/flutter/issues/104121
     [self interpretMapConfiguration:creationParameters.mapConfiguration];
     NSString *pigeonSuffix = [NSString stringWithFormat:@"%lld", viewId];
-    _dartCallbackHandler = [[FGMMapsCallbackApi alloc] initWithBinaryMessenger:binaryMessenger
-                                                          messageChannelSuffix:pigeonSuffix];
+    _dartCallbackHandler = callbackHandler;
     _mapEventHandler =
         [[FGMDefaultMapEventHandler alloc] initWithCallbackHandler:_dartCallbackHandler];
     FGMPlatformMarkerType markerType = creationParameters.mapConfiguration.markerType;
@@ -556,6 +688,13 @@
   } else if ([self.groundOverlaysController hasGroundOverlaysWithIdentifier:overlayId]) {
     [self.groundOverlaysController didTapGroundOverlayWithIdentifier:overlayId];
   }
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+  [self.mapEventHandler didTapPointOfInterestWithPlaceIdentifier:placeID];
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
@@ -2336,11 +2336,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updatePolylinesByAdding:
-                                                                 changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updatePolylinesByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updatePolylinesByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updatePolylinesByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformPolyline *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2367,11 +2367,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateTileOverlaysByAdding:
-                                                                    changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateTileOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformTileOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2398,11 +2398,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateGroundOverlaysByAdding:
-                                                                      changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateGroundOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformGroundOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2631,11 +2631,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:
-                                                                                       error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_markerId = GetNullableObjectAtIndex(args, 0);
@@ -3054,6 +3054,32 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
              binaryMessenger:self.binaryMessenger
                        codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
   [channel sendMessage:@[ arg_circleId ?: [NSNull null] ]
+                 reply:^(NSArray<id> *reply) {
+                   if (reply != nil) {
+                     if (reply.count > 1) {
+                       completion([FlutterError errorWithCode:reply[0]
+                                                      message:reply[1]
+                                                      details:reply[2]]);
+                     } else {
+                       completion(nil);
+                     }
+                   } else {
+                     completion(createConnectionError(channelName));
+                   }
+                 }];
+}
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)arg_placeId
+                                      completion:(void (^)(FlutterError *_Nullable))completion {
+  NSString *channelName = [NSString
+      stringWithFormat:
+          @"%@%@",
+          @"dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap",
+          _messageChannelSuffix];
+  FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+      messageChannelWithName:channelName
+             binaryMessenger:self.binaryMessenger
+                       codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
+  [channel sendMessage:@[ arg_placeId ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMGoogleMapController_Test.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMGoogleMapController_Test.h
@@ -8,6 +8,7 @@
 #import "FGMAssetProvider.h"
 #import "FGMCATransactionWrapper.h"
 #import "FGMGoogleMapController.h"
+#import "FGMMapsCallbackApiProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,11 +49,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param creationParameters Parameters for initialising the map view.
 /// @param assetProvider The asset provider to use for looking up assets.
 /// @param binaryMessenger The binary messenger to use for sending messages to Dart.
+/// @param callbackHandler The callback API to use for sending events to Dart.
 - (instancetype)initWithMapView:(GMSMapView *)mapView
                  viewIdentifier:(int64_t)viewId
              creationParameters:(FGMPlatformMapViewCreationParams *)creationParameters
                   assetProvider:(NSObject<FGMAssetProvider> *)assetProvider
-                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger;
+                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                callbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler;
 
 // The main Pigeon API implementation.
 @property(nonatomic, strong, readonly) FGMMapCallHandler *callHandler;

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapEventDelegate.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapEventDelegate.h
@@ -50,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId;
 
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier;
+
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster;
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapsCallbackApiProtocol.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapsCallbackApiProtocol.h
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import Foundation;
+
+#import "google_maps_flutter_pigeon_messages.g.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Protocol for FGMMapsCallbackApi to allow mocking in tests.
+///
+/// This is a one-to-one abstraction of the Pigeon-generated API, so that unit tests can inject a
+/// fake in place of the real implementation rather than asserting on Pigeon channel internals.
+@protocol FGMMapsCallbackApiProtocol <NSObject>
+
+/// Called when the map camera starts moving.
+- (void)didStartCameraMoveWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map camera moves.
+- (void)didMoveCameraToPosition:(FGMPlatformCameraPosition *)cameraPosition
+                     completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map camera stops moving.
+- (void)didIdleCameraWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map, not a specifc map object, is tapped.
+- (void)didTapAtPosition:(FGMPlatformLatLng *)position
+              completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map, not a specifc map object, is long pressed.
+- (void)didLongPressAtPosition:(FGMPlatformLatLng *)position
+                    completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker is tapped.
+- (void)didTapMarkerWithIdentifier:(NSString *)markerId
+                        completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag starts.
+- (void)didStartDragForMarkerWithIdentifier:(NSString *)markerId
+                                 atPosition:(FGMPlatformLatLng *)position
+                                 completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag updates.
+- (void)didDragMarkerWithIdentifier:(NSString *)markerId
+                         atPosition:(FGMPlatformLatLng *)position
+                         completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag ends.
+- (void)didEndDragForMarkerWithIdentifier:(NSString *)markerId
+                               atPosition:(FGMPlatformLatLng *)position
+                               completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker's info window is tapped.
+- (void)didTapInfoWindowOfMarkerWithIdentifier:(NSString *)markerId
+                                    completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a circle is tapped.
+- (void)didTapCircleWithIdentifier:(NSString *)circleId
+                        completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier
+                                      completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker cluster is tapped.
+- (void)didTapCluster:(FGMPlatformCluster *)cluster
+           completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a polygon is tapped.
+- (void)didTapPolygonWithIdentifier:(NSString *)polygonId
+                         completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a polyline is tapped.
+- (void)didTapPolylineWithIdentifier:(NSString *)polylineId
+                          completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a ground overlay is tapped.
+- (void)didTapGroundOverlayWithIdentifier:(NSString *)groundOverlayId
+                               completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called to get data for a map tile.
+- (void)tileWithOverlayIdentifier:(NSString *)tileOverlayId
+                         location:(FGMPlatformPoint *)location
+                             zoom:(NSInteger)zoom
+                       completion:(void (^)(FGMPlatformTile *_Nullable,
+                                            FlutterError *_Nullable))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
@@ -910,6 +910,9 @@ extern void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId
                         completion:(void (^)(FlutterError *_Nullable))completion;
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeId
+                                      completion:(void (^)(FlutterError *_Nullable))completion;
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster
            completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
@@ -183,6 +183,11 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -987,6 +992,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/messages.g.dart
@@ -3355,6 +3355,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3723,6 +3726,39 @@ abstract class MapsCallbackApi {
           );
           try {
             api.onCircleTap(arg_circleId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_placeId = (args[0] as String?);
+          assert(
+            arg_placeId != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null, expected non-null String.',
+          );
+          try {
+            api.onPointOfInterestTap(arg_placeId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pigeons/messages.dart
@@ -832,6 +832,10 @@ abstract class MapsCallbackApi {
   @ObjCSelector('didTapCircleWithIdentifier:')
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  @ObjCSelector('didTapPointOfInterestWithPlaceIdentifier:')
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   @ObjCSelector('didTapCluster:')
   void onClusterTap(PlatformCluster cluster);

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.4
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.17.0
   stream_transform: ^2.0.0
 
 dev_dependencies:
@@ -37,3 +37,7 @@ topics:
   - google-maps
   - google-maps-flutter
   - map
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
@@ -905,6 +905,20 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterIOS();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(maps.onPointOfInterestTap(mapId: mapId));
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.18.5
 
 * Fixes a potential compilation issue in tile downscaling.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerTests/GoogleMapsTests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerTests/GoogleMapsTests.swift
@@ -38,6 +38,98 @@ class StubBinaryMessenger: NSObject, FlutterBinaryMessenger {
   }
 }
 
+/// Fake implementation of FGMMapsCallbackApiProtocol that records the calls it receives.
+class MockMapsCallbackApi: NSObject, FGMMapsCallbackApiProtocol {
+  var lastTappedPointOfInterestPlaceIdentifier: String?
+
+  func didTapPointOfInterest(
+    withPlaceIdentifier placeIdentifier: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) {
+    lastTappedPointOfInterestPlaceIdentifier = placeIdentifier
+    completion(nil)
+  }
+
+  func didStartCameraMove(completion: @escaping (FlutterError?) -> Void) { completion(nil) }
+
+  func didMoveCamera(
+    to cameraPosition: FGMPlatformCameraPosition,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didIdleCamera(completion: @escaping (FlutterError?) -> Void) { completion(nil) }
+
+  func didTap(
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didLongPress(
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapMarker(
+    withIdentifier markerId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didStartDragForMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didDragMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didEndDragForMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapInfoWindowOfMarker(
+    withIdentifier markerId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapCircle(
+    withIdentifier circleId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTap(
+    _ cluster: FGMPlatformCluster,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapPolygon(
+    withIdentifier polygonId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapPolyline(
+    withIdentifier polylineId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapGroundOverlay(
+    withIdentifier groundOverlayId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func tile(
+    withOverlayIdentifier tileOverlayId: String,
+    location: FGMPlatformPoint,
+    zoom: Int,
+    completion: @escaping (FGMPlatformTile?, FlutterError?) -> Void
+  ) { completion(nil, nil) }
+}
+
 class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
   var viewController: UIViewController? { nil }
   func publish(_ value: NSObject) {}
@@ -74,7 +166,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     for _ in 0..<10 {
@@ -133,7 +226,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let mockTransactionWrapper = MockCATransaction()
@@ -165,7 +259,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let mockTransactionWrapper = MockCATransaction()
@@ -188,6 +283,34 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
     #expect(mockTransactionWrapper.animationDuration == durationMilliseconds.doubleValue / 1000)
   }
 
+  @Test func didTapPOIForwardsPlaceIdentifierToCallbackApi() {
+    let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+    let mapViewOptions = GMSMapViewOptions()
+    mapViewOptions.frame = frame
+    mapViewOptions.camera = GMSCameraPosition(latitude: 0, longitude: 0, zoom: 0)
+
+    let mapView = PartiallyMockedMapView(options: mapViewOptions)
+
+    let callbackApi = MockMapsCallbackApi()
+    let controller = FGMGoogleMapController(
+      mapView: mapView,
+      viewIdentifier: 0,
+      creationParameters: emptyCreationParameters(),
+      assetProvider: TestAssetProvider(),
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: callbackApi
+    )
+
+    controller.mapView(
+      mapView,
+      didTapPOIWithPlaceID: "place-123",
+      name: "Test Place",
+      location: CLLocationCoordinate2DMake(0, 0)
+    )
+
+    #expect(callbackApi.lastTappedPointOfInterestPlaceIdentifier == "place-123")
+  }
+
   @Test func inspectorAPICameraPosition() throws {
     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
     let mapViewOptions = GMSMapViewOptions()
@@ -205,7 +328,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: binaryMessenger
+      binaryMessenger: binaryMessenger,
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let inspector = FGMMapInspector(

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerTests/TestUtils/TestMapEventHandler.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerTests/TestUtils/TestMapEventHandler.swift
@@ -32,6 +32,8 @@ class TestMapEventHandler: NSObject, FGMMapEventDelegate {
 
   func didTapCircle(withIdentifier circleId: String) {}
 
+  func didTapPointOfInterest(withPlaceIdentifier placeIdentifier: String) {}
+
   func didTap(_ cluster: FGMPlatformCluster) {}
 
   func didTapPolygon(withIdentifier polygonId: String) {}

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/pubspec.yaml
@@ -31,3 +31,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMGoogleMapController.m
@@ -11,6 +11,7 @@
 #import "FGMConversionUtils.h"
 #import "FGMGroundOverlayController.h"
 #import "FGMHeatmapController.h"
+#import "FGMMapsCallbackApiProtocol.h"
 #import "FGMMarkerUserData.h"
 #import "FGMTileOverlayController.h"
 #import "google_maps_flutter_pigeon_messages.g.h"
@@ -99,17 +100,138 @@
 
 #pragma mark -
 
+/// Non-test implementation of FGMMapsCallbackApiProtocol, passing calls through to a
+/// FGMMapsCallbackApi instance.
+@interface FGMDefaultMapsCallbackApi : NSObject <FGMMapsCallbackApiProtocol>
+@property(strong, nonatomic) FGMMapsCallbackApi *callbackApi;
+
+- (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                   messageChannelSuffix:(NSString *)messageChannelSuffix;
+@end
+
+@implementation FGMDefaultMapsCallbackApi
+
+- (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                   messageChannelSuffix:(NSString *)messageChannelSuffix {
+  self = [super init];
+  if (self) {
+    _callbackApi = [[FGMMapsCallbackApi alloc] initWithBinaryMessenger:binaryMessenger
+                                                  messageChannelSuffix:messageChannelSuffix];
+  }
+  return self;
+}
+
+- (void)didStartCameraMoveWithCompletion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didStartCameraMoveWithCompletion:completion];
+}
+
+- (void)didMoveCameraToPosition:(FGMPlatformCameraPosition *)cameraPosition
+                     completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didMoveCameraToPosition:cameraPosition completion:completion];
+}
+
+- (void)didIdleCameraWithCompletion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didIdleCameraWithCompletion:completion];
+}
+
+- (void)didTapAtPosition:(FGMPlatformLatLng *)position
+              completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapAtPosition:position completion:completion];
+}
+
+- (void)didLongPressAtPosition:(FGMPlatformLatLng *)position
+                    completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didLongPressAtPosition:position completion:completion];
+}
+
+- (void)didTapMarkerWithIdentifier:(NSString *)markerId
+                        completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapMarkerWithIdentifier:markerId completion:completion];
+}
+
+- (void)didStartDragForMarkerWithIdentifier:(NSString *)markerId
+                                 atPosition:(FGMPlatformLatLng *)position
+                                 completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didStartDragForMarkerWithIdentifier:markerId
+                                             atPosition:position
+                                             completion:completion];
+}
+
+- (void)didDragMarkerWithIdentifier:(NSString *)markerId
+                         atPosition:(FGMPlatformLatLng *)position
+                         completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didDragMarkerWithIdentifier:markerId atPosition:position completion:completion];
+}
+
+- (void)didEndDragForMarkerWithIdentifier:(NSString *)markerId
+                               atPosition:(FGMPlatformLatLng *)position
+                               completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didEndDragForMarkerWithIdentifier:markerId
+                                           atPosition:position
+                                           completion:completion];
+}
+
+- (void)didTapInfoWindowOfMarkerWithIdentifier:(NSString *)markerId
+                                    completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapInfoWindowOfMarkerWithIdentifier:markerId completion:completion];
+}
+
+- (void)didTapCircleWithIdentifier:(NSString *)circleId
+                        completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapCircleWithIdentifier:circleId completion:completion];
+}
+
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier
+                                      completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPointOfInterestWithPlaceIdentifier:placeIdentifier completion:completion];
+}
+
+- (void)didTapCluster:(FGMPlatformCluster *)cluster
+           completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapCluster:cluster completion:completion];
+}
+
+- (void)didTapPolygonWithIdentifier:(NSString *)polygonId
+                         completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPolygonWithIdentifier:polygonId completion:completion];
+}
+
+- (void)didTapPolylineWithIdentifier:(NSString *)polylineId
+                          completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPolylineWithIdentifier:polylineId completion:completion];
+}
+
+- (void)didTapGroundOverlayWithIdentifier:(NSString *)groundOverlayId
+                               completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapGroundOverlayWithIdentifier:groundOverlayId completion:completion];
+}
+
+- (void)tileWithOverlayIdentifier:(NSString *)tileOverlayId
+                         location:(FGMPlatformPoint *)location
+                             zoom:(NSInteger)zoom
+                       completion:(void (^)(FGMPlatformTile *_Nullable,
+                                            FlutterError *_Nullable))completion {
+  [self.callbackApi tileWithOverlayIdentifier:tileOverlayId
+                                     location:location
+                                         zoom:zoom
+                                   completion:completion];
+}
+
+@end
+
+#pragma mark -
+
 /// Non-test implementation of FGMAssetProvider, wrapping a FGMMapsCallbackApi
 /// instance.
 @interface FGMDefaultMapEventHandler : NSObject <FGMMapEventDelegate>
-@property(strong, nonatomic) FGMMapsCallbackApi *callbackHandler;
+@property(strong, nonatomic) id<FGMMapsCallbackApiProtocol> callbackHandler;
 
-- (instancetype)initWithCallbackHandler:(FGMMapsCallbackApi *)callbackHandler;
+- (instancetype)initWithCallbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler;
 @end
 
 @implementation FGMDefaultMapEventHandler
 
-- (instancetype)initWithCallbackHandler:(FGMMapsCallbackApi *)callbackHandler {
+- (instancetype)initWithCallbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler {
   self = [super init];
   if (self) {
     _callbackHandler = callbackHandler;
@@ -186,6 +308,12 @@
                                         }];
 }
 
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier {
+  [self.callbackHandler didTapPointOfInterestWithPlaceIdentifier:placeIdentifier
+                                                      completion:^(FlutterError *_){
+                                                      }];
+}
+
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
   [self.callbackHandler didTapCluster:cluster
                            completion:^(FlutterError *_){
@@ -246,7 +374,7 @@
 @interface FGMGoogleMapController () <FGMTileProviderDelegate>
 
 @property(nonatomic, strong) GMSMapView *mapView;
-@property(nonatomic, strong) FGMMapsCallbackApi *dartCallbackHandler;
+@property(nonatomic, strong) id<FGMMapsCallbackApiProtocol> dartCallbackHandler;
 @property(nonatomic, strong) FGMDefaultMapEventHandler *mapEventHandler;
 @property(nonatomic, assign) BOOL trackCameraPosition;
 @property(nonatomic, strong) FGMClusterManagersController *clusterManagersController;
@@ -290,18 +418,23 @@
 
   GMSMapView *mapView = [[GMSMapView alloc] initWithOptions:options];
 
+  NSString *pigeonSuffix = [NSString stringWithFormat:@"%lld", viewId];
   return [self initWithMapView:mapView
                 viewIdentifier:viewId
             creationParameters:creationParameters
                  assetProvider:[[FGMDefaultAssetProvider alloc] initWithRegistrar:registrar]
-               binaryMessenger:registrar.messenger];
+               binaryMessenger:registrar.messenger
+               callbackHandler:[[FGMDefaultMapsCallbackApi alloc]
+                                   initWithBinaryMessenger:registrar.messenger
+                                      messageChannelSuffix:pigeonSuffix]];
 }
 
 - (instancetype)initWithMapView:(GMSMapView *_Nonnull)mapView
                  viewIdentifier:(int64_t)viewId
              creationParameters:(FGMPlatformMapViewCreationParams *)creationParameters
                   assetProvider:(NSObject<FGMAssetProvider> *)assetProvider
-                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger {
+                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                callbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler {
   if (self = [super init]) {
     _mapView = mapView;
 
@@ -310,8 +443,7 @@
     // https://github.com/flutter/flutter/issues/104121
     [self interpretMapConfiguration:creationParameters.mapConfiguration];
     NSString *pigeonSuffix = [NSString stringWithFormat:@"%lld", viewId];
-    _dartCallbackHandler = [[FGMMapsCallbackApi alloc] initWithBinaryMessenger:binaryMessenger
-                                                          messageChannelSuffix:pigeonSuffix];
+    _dartCallbackHandler = callbackHandler;
     _mapEventHandler =
         [[FGMDefaultMapEventHandler alloc] initWithCallbackHandler:_dartCallbackHandler];
     FGMPlatformMarkerType markerType = creationParameters.mapConfiguration.markerType;
@@ -556,6 +688,13 @@
   } else if ([self.groundOverlaysController hasGroundOverlaysWithIdentifier:overlayId]) {
     [self.groundOverlaysController didTapGroundOverlayWithIdentifier:overlayId];
   }
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+  [self.mapEventHandler didTapPointOfInterestWithPlaceIdentifier:placeID];
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.m
@@ -2336,11 +2336,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updatePolylinesByAdding:
-                                                                 changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updatePolylinesByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updatePolylinesByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updatePolylinesByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformPolyline *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2367,11 +2367,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateTileOverlaysByAdding:
-                                                                    changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateTileOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformTileOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2398,11 +2398,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateGroundOverlaysByAdding:
-                                                                      changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateGroundOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformGroundOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2631,11 +2631,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:
-                                                                                       error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_markerId = GetNullableObjectAtIndex(args, 0);
@@ -3054,6 +3054,32 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
              binaryMessenger:self.binaryMessenger
                        codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
   [channel sendMessage:@[ arg_circleId ?: [NSNull null] ]
+                 reply:^(NSArray<id> *reply) {
+                   if (reply != nil) {
+                     if (reply.count > 1) {
+                       completion([FlutterError errorWithCode:reply[0]
+                                                      message:reply[1]
+                                                      details:reply[2]]);
+                     } else {
+                       completion(nil);
+                     }
+                   } else {
+                     completion(createConnectionError(channelName));
+                   }
+                 }];
+}
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)arg_placeId
+                                      completion:(void (^)(FlutterError *_Nullable))completion {
+  NSString *channelName = [NSString
+      stringWithFormat:
+          @"%@%@",
+          @"dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap",
+          _messageChannelSuffix];
+  FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+      messageChannelWithName:channelName
+             binaryMessenger:self.binaryMessenger
+                       codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
+  [channel sendMessage:@[ arg_placeId ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/FGMGoogleMapController_Test.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/FGMGoogleMapController_Test.h
@@ -8,6 +8,7 @@
 #import "FGMAssetProvider.h"
 #import "FGMCATransactionWrapper.h"
 #import "FGMGoogleMapController.h"
+#import "FGMMapsCallbackApiProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,11 +49,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param creationParameters Parameters for initialising the map view.
 /// @param assetProvider The asset provider to use for looking up assets.
 /// @param binaryMessenger The binary messenger to use for sending messages to Dart.
+/// @param callbackHandler The callback API to use for sending events to Dart.
 - (instancetype)initWithMapView:(GMSMapView *)mapView
                  viewIdentifier:(int64_t)viewId
              creationParameters:(FGMPlatformMapViewCreationParams *)creationParameters
                   assetProvider:(NSObject<FGMAssetProvider> *)assetProvider
-                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger;
+                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                callbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler;
 
 // The main Pigeon API implementation.
 @property(nonatomic, strong, readonly) FGMMapCallHandler *callHandler;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/FGMMapEventDelegate.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/FGMMapEventDelegate.h
@@ -50,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId;
 
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier;
+
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster;
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/FGMMapsCallbackApiProtocol.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/FGMMapsCallbackApiProtocol.h
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import Foundation;
+
+#import "google_maps_flutter_pigeon_messages.g.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Protocol for FGMMapsCallbackApi to allow mocking in tests.
+///
+/// This is a one-to-one abstraction of the Pigeon-generated API, so that unit tests can inject a
+/// fake in place of the real implementation rather than asserting on Pigeon channel internals.
+@protocol FGMMapsCallbackApiProtocol <NSObject>
+
+/// Called when the map camera starts moving.
+- (void)didStartCameraMoveWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map camera moves.
+- (void)didMoveCameraToPosition:(FGMPlatformCameraPosition *)cameraPosition
+                     completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map camera stops moving.
+- (void)didIdleCameraWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map, not a specifc map object, is tapped.
+- (void)didTapAtPosition:(FGMPlatformLatLng *)position
+              completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map, not a specifc map object, is long pressed.
+- (void)didLongPressAtPosition:(FGMPlatformLatLng *)position
+                    completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker is tapped.
+- (void)didTapMarkerWithIdentifier:(NSString *)markerId
+                        completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag starts.
+- (void)didStartDragForMarkerWithIdentifier:(NSString *)markerId
+                                 atPosition:(FGMPlatformLatLng *)position
+                                 completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag updates.
+- (void)didDragMarkerWithIdentifier:(NSString *)markerId
+                         atPosition:(FGMPlatformLatLng *)position
+                         completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag ends.
+- (void)didEndDragForMarkerWithIdentifier:(NSString *)markerId
+                               atPosition:(FGMPlatformLatLng *)position
+                               completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker's info window is tapped.
+- (void)didTapInfoWindowOfMarkerWithIdentifier:(NSString *)markerId
+                                    completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a circle is tapped.
+- (void)didTapCircleWithIdentifier:(NSString *)circleId
+                        completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier
+                                      completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker cluster is tapped.
+- (void)didTapCluster:(FGMPlatformCluster *)cluster
+           completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a polygon is tapped.
+- (void)didTapPolygonWithIdentifier:(NSString *)polygonId
+                         completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a polyline is tapped.
+- (void)didTapPolylineWithIdentifier:(NSString *)polylineId
+                          completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a ground overlay is tapped.
+- (void)didTapGroundOverlayWithIdentifier:(NSString *)groundOverlayId
+                               completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called to get data for a map tile.
+- (void)tileWithOverlayIdentifier:(NSString *)tileOverlayId
+                         location:(FGMPlatformPoint *)location
+                             zoom:(NSInteger)zoom
+                       completion:(void (^)(FGMPlatformTile *_Nullable,
+                                            FlutterError *_Nullable))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/include/google_maps_flutter_ios_sdk10/google_maps_flutter_pigeon_messages.g.h
@@ -910,6 +910,9 @@ extern void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId
                         completion:(void (^)(FlutterError *_Nullable))completion;
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeId
+                                      completion:(void (^)(FlutterError *_Nullable))completion;
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster
            completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/google_maps_flutter_ios.dart
@@ -183,6 +183,11 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -987,6 +992,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/messages.g.dart
@@ -3355,6 +3355,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3723,6 +3726,39 @@ abstract class MapsCallbackApi {
           );
           try {
             api.onCircleTap(arg_circleId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_placeId = (args[0] as String?);
+          assert(
+            arg_placeId != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null, expected non-null String.',
+          );
+          try {
+            api.onPointOfInterestTap(arg_placeId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pigeons/messages.dart
@@ -832,6 +832,10 @@ abstract class MapsCallbackApi {
   @ObjCSelector('didTapCircleWithIdentifier:')
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  @ObjCSelector('didTapPointOfInterestWithPlaceIdentifier:')
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   @ObjCSelector('didTapCluster:')
   void onClusterTap(PlatformCluster cluster);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios_sdk10
 description: iOS implementation of the google_maps_flutter plugin using Google Maps SDK 10.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios_sdk10
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.5
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.17.0
   stream_transform: ^2.0.0
 
 dev_dependencies:
@@ -37,3 +37,7 @@ topics:
   - google-maps
   - google-maps-flutter
   - map
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/test/google_maps_flutter_ios_test.dart
@@ -905,6 +905,20 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterIOS();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(maps.onPointOfInterestTap(mapId: mapId));
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.19.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.18.6
 
 * Fixes a potential compilation issue in tile downscaling.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerTests/GoogleMapsTests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerTests/GoogleMapsTests.swift
@@ -38,6 +38,98 @@ class StubBinaryMessenger: NSObject, FlutterBinaryMessenger {
   }
 }
 
+/// Fake implementation of FGMMapsCallbackApiProtocol that records the calls it receives.
+class MockMapsCallbackApi: NSObject, FGMMapsCallbackApiProtocol {
+  var lastTappedPointOfInterestPlaceIdentifier: String?
+
+  func didTapPointOfInterest(
+    withPlaceIdentifier placeIdentifier: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) {
+    lastTappedPointOfInterestPlaceIdentifier = placeIdentifier
+    completion(nil)
+  }
+
+  func didStartCameraMove(completion: @escaping (FlutterError?) -> Void) { completion(nil) }
+
+  func didMoveCamera(
+    to cameraPosition: FGMPlatformCameraPosition,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didIdleCamera(completion: @escaping (FlutterError?) -> Void) { completion(nil) }
+
+  func didTap(
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didLongPress(
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapMarker(
+    withIdentifier markerId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didStartDragForMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didDragMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didEndDragForMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapInfoWindowOfMarker(
+    withIdentifier markerId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapCircle(
+    withIdentifier circleId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTap(
+    _ cluster: FGMPlatformCluster,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapPolygon(
+    withIdentifier polygonId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapPolyline(
+    withIdentifier polylineId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapGroundOverlay(
+    withIdentifier groundOverlayId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func tile(
+    withOverlayIdentifier tileOverlayId: String,
+    location: FGMPlatformPoint,
+    zoom: Int,
+    completion: @escaping (FGMPlatformTile?, FlutterError?) -> Void
+  ) { completion(nil, nil) }
+}
+
 class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
   var viewController: UIViewController? { nil }
   func publish(_ value: NSObject) {}
@@ -74,7 +166,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     for _ in 0..<10 {
@@ -133,7 +226,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let mockTransactionWrapper = MockCATransaction()
@@ -165,7 +259,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let mockTransactionWrapper = MockCATransaction()
@@ -188,6 +283,34 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
     #expect(mockTransactionWrapper.animationDuration == durationMilliseconds.doubleValue / 1000)
   }
 
+  @Test func didTapPOIForwardsPlaceIdentifierToCallbackApi() {
+    let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+    let mapViewOptions = GMSMapViewOptions()
+    mapViewOptions.frame = frame
+    mapViewOptions.camera = GMSCameraPosition(latitude: 0, longitude: 0, zoom: 0)
+
+    let mapView = PartiallyMockedMapView(options: mapViewOptions)
+
+    let callbackApi = MockMapsCallbackApi()
+    let controller = FGMGoogleMapController(
+      mapView: mapView,
+      viewIdentifier: 0,
+      creationParameters: emptyCreationParameters(),
+      assetProvider: TestAssetProvider(),
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: callbackApi
+    )
+
+    controller.mapView(
+      mapView,
+      didTapPOIWithPlaceID: "place-123",
+      name: "Test Place",
+      location: CLLocationCoordinate2DMake(0, 0)
+    )
+
+    #expect(callbackApi.lastTappedPointOfInterestPlaceIdentifier == "place-123")
+  }
+
   @Test func inspectorAPICameraPosition() throws {
     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
     let mapViewOptions = GMSMapViewOptions()
@@ -205,7 +328,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: binaryMessenger
+      binaryMessenger: binaryMessenger,
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let inspector = FGMMapInspector(

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerTests/TestUtils/TestMapEventHandler.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerTests/TestUtils/TestMapEventHandler.swift
@@ -32,6 +32,8 @@ class TestMapEventHandler: NSObject, FGMMapEventDelegate {
 
   func didTapCircle(withIdentifier circleId: String) {}
 
+  func didTapPointOfInterest(withPlaceIdentifier placeIdentifier: String) {}
+
   func didTap(_ cluster: FGMPlatformCluster) {}
 
   func didTapPolygon(withIdentifier polygonId: String) {}

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/pubspec.yaml
@@ -31,3 +31,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMGoogleMapController.m
@@ -11,6 +11,7 @@
 #import "FGMConversionUtils.h"
 #import "FGMGroundOverlayController.h"
 #import "FGMHeatmapController.h"
+#import "FGMMapsCallbackApiProtocol.h"
 #import "FGMMarkerUserData.h"
 #import "FGMTileOverlayController.h"
 #import "google_maps_flutter_pigeon_messages.g.h"
@@ -99,17 +100,138 @@
 
 #pragma mark -
 
+/// Non-test implementation of FGMMapsCallbackApiProtocol, passing calls through to a
+/// FGMMapsCallbackApi instance.
+@interface FGMDefaultMapsCallbackApi : NSObject <FGMMapsCallbackApiProtocol>
+@property(strong, nonatomic) FGMMapsCallbackApi *callbackApi;
+
+- (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                   messageChannelSuffix:(NSString *)messageChannelSuffix;
+@end
+
+@implementation FGMDefaultMapsCallbackApi
+
+- (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                   messageChannelSuffix:(NSString *)messageChannelSuffix {
+  self = [super init];
+  if (self) {
+    _callbackApi = [[FGMMapsCallbackApi alloc] initWithBinaryMessenger:binaryMessenger
+                                                  messageChannelSuffix:messageChannelSuffix];
+  }
+  return self;
+}
+
+- (void)didStartCameraMoveWithCompletion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didStartCameraMoveWithCompletion:completion];
+}
+
+- (void)didMoveCameraToPosition:(FGMPlatformCameraPosition *)cameraPosition
+                     completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didMoveCameraToPosition:cameraPosition completion:completion];
+}
+
+- (void)didIdleCameraWithCompletion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didIdleCameraWithCompletion:completion];
+}
+
+- (void)didTapAtPosition:(FGMPlatformLatLng *)position
+              completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapAtPosition:position completion:completion];
+}
+
+- (void)didLongPressAtPosition:(FGMPlatformLatLng *)position
+                    completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didLongPressAtPosition:position completion:completion];
+}
+
+- (void)didTapMarkerWithIdentifier:(NSString *)markerId
+                        completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapMarkerWithIdentifier:markerId completion:completion];
+}
+
+- (void)didStartDragForMarkerWithIdentifier:(NSString *)markerId
+                                 atPosition:(FGMPlatformLatLng *)position
+                                 completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didStartDragForMarkerWithIdentifier:markerId
+                                             atPosition:position
+                                             completion:completion];
+}
+
+- (void)didDragMarkerWithIdentifier:(NSString *)markerId
+                         atPosition:(FGMPlatformLatLng *)position
+                         completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didDragMarkerWithIdentifier:markerId atPosition:position completion:completion];
+}
+
+- (void)didEndDragForMarkerWithIdentifier:(NSString *)markerId
+                               atPosition:(FGMPlatformLatLng *)position
+                               completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didEndDragForMarkerWithIdentifier:markerId
+                                           atPosition:position
+                                           completion:completion];
+}
+
+- (void)didTapInfoWindowOfMarkerWithIdentifier:(NSString *)markerId
+                                    completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapInfoWindowOfMarkerWithIdentifier:markerId completion:completion];
+}
+
+- (void)didTapCircleWithIdentifier:(NSString *)circleId
+                        completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapCircleWithIdentifier:circleId completion:completion];
+}
+
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier
+                                      completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPointOfInterestWithPlaceIdentifier:placeIdentifier completion:completion];
+}
+
+- (void)didTapCluster:(FGMPlatformCluster *)cluster
+           completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapCluster:cluster completion:completion];
+}
+
+- (void)didTapPolygonWithIdentifier:(NSString *)polygonId
+                         completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPolygonWithIdentifier:polygonId completion:completion];
+}
+
+- (void)didTapPolylineWithIdentifier:(NSString *)polylineId
+                          completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPolylineWithIdentifier:polylineId completion:completion];
+}
+
+- (void)didTapGroundOverlayWithIdentifier:(NSString *)groundOverlayId
+                               completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapGroundOverlayWithIdentifier:groundOverlayId completion:completion];
+}
+
+- (void)tileWithOverlayIdentifier:(NSString *)tileOverlayId
+                         location:(FGMPlatformPoint *)location
+                             zoom:(NSInteger)zoom
+                       completion:(void (^)(FGMPlatformTile *_Nullable,
+                                            FlutterError *_Nullable))completion {
+  [self.callbackApi tileWithOverlayIdentifier:tileOverlayId
+                                     location:location
+                                         zoom:zoom
+                                   completion:completion];
+}
+
+@end
+
+#pragma mark -
+
 /// Non-test implementation of FGMAssetProvider, wrapping a FGMMapsCallbackApi
 /// instance.
 @interface FGMDefaultMapEventHandler : NSObject <FGMMapEventDelegate>
-@property(strong, nonatomic) FGMMapsCallbackApi *callbackHandler;
+@property(strong, nonatomic) id<FGMMapsCallbackApiProtocol> callbackHandler;
 
-- (instancetype)initWithCallbackHandler:(FGMMapsCallbackApi *)callbackHandler;
+- (instancetype)initWithCallbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler;
 @end
 
 @implementation FGMDefaultMapEventHandler
 
-- (instancetype)initWithCallbackHandler:(FGMMapsCallbackApi *)callbackHandler {
+- (instancetype)initWithCallbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler {
   self = [super init];
   if (self) {
     _callbackHandler = callbackHandler;
@@ -186,6 +308,12 @@
                                         }];
 }
 
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier {
+  [self.callbackHandler didTapPointOfInterestWithPlaceIdentifier:placeIdentifier
+                                                      completion:^(FlutterError *_){
+                                                      }];
+}
+
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
   [self.callbackHandler didTapCluster:cluster
                            completion:^(FlutterError *_){
@@ -246,7 +374,7 @@
 @interface FGMGoogleMapController () <FGMTileProviderDelegate>
 
 @property(nonatomic, strong) GMSMapView *mapView;
-@property(nonatomic, strong) FGMMapsCallbackApi *dartCallbackHandler;
+@property(nonatomic, strong) id<FGMMapsCallbackApiProtocol> dartCallbackHandler;
 @property(nonatomic, strong) FGMDefaultMapEventHandler *mapEventHandler;
 @property(nonatomic, assign) BOOL trackCameraPosition;
 @property(nonatomic, strong) FGMClusterManagersController *clusterManagersController;
@@ -290,18 +418,23 @@
 
   GMSMapView *mapView = [[GMSMapView alloc] initWithOptions:options];
 
+  NSString *pigeonSuffix = [NSString stringWithFormat:@"%lld", viewId];
   return [self initWithMapView:mapView
                 viewIdentifier:viewId
             creationParameters:creationParameters
                  assetProvider:[[FGMDefaultAssetProvider alloc] initWithRegistrar:registrar]
-               binaryMessenger:registrar.messenger];
+               binaryMessenger:registrar.messenger
+               callbackHandler:[[FGMDefaultMapsCallbackApi alloc]
+                                   initWithBinaryMessenger:registrar.messenger
+                                      messageChannelSuffix:pigeonSuffix]];
 }
 
 - (instancetype)initWithMapView:(GMSMapView *_Nonnull)mapView
                  viewIdentifier:(int64_t)viewId
              creationParameters:(FGMPlatformMapViewCreationParams *)creationParameters
                   assetProvider:(NSObject<FGMAssetProvider> *)assetProvider
-                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger {
+                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                callbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler {
   if (self = [super init]) {
     _mapView = mapView;
 
@@ -310,8 +443,7 @@
     // https://github.com/flutter/flutter/issues/104121
     [self interpretMapConfiguration:creationParameters.mapConfiguration];
     NSString *pigeonSuffix = [NSString stringWithFormat:@"%lld", viewId];
-    _dartCallbackHandler = [[FGMMapsCallbackApi alloc] initWithBinaryMessenger:binaryMessenger
-                                                          messageChannelSuffix:pigeonSuffix];
+    _dartCallbackHandler = callbackHandler;
     _mapEventHandler =
         [[FGMDefaultMapEventHandler alloc] initWithCallbackHandler:_dartCallbackHandler];
     FGMPlatformMarkerType markerType = creationParameters.mapConfiguration.markerType;
@@ -556,6 +688,13 @@
   } else if ([self.groundOverlaysController hasGroundOverlaysWithIdentifier:overlayId]) {
     [self.groundOverlaysController didTapGroundOverlayWithIdentifier:overlayId];
   }
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+  [self.mapEventHandler didTapPointOfInterestWithPlaceIdentifier:placeID];
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.m
@@ -2336,11 +2336,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updatePolylinesByAdding:
-                                                                 changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updatePolylinesByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updatePolylinesByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updatePolylinesByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformPolyline *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2367,11 +2367,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateTileOverlaysByAdding:
-                                                                    changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateTileOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformTileOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2398,11 +2398,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateGroundOverlaysByAdding:
-                                                                      changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateGroundOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformGroundOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2631,11 +2631,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:
-                                                                                       error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_markerId = GetNullableObjectAtIndex(args, 0);
@@ -3054,6 +3054,32 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
              binaryMessenger:self.binaryMessenger
                        codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
   [channel sendMessage:@[ arg_circleId ?: [NSNull null] ]
+                 reply:^(NSArray<id> *reply) {
+                   if (reply != nil) {
+                     if (reply.count > 1) {
+                       completion([FlutterError errorWithCode:reply[0]
+                                                      message:reply[1]
+                                                      details:reply[2]]);
+                     } else {
+                       completion(nil);
+                     }
+                   } else {
+                     completion(createConnectionError(channelName));
+                   }
+                 }];
+}
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)arg_placeId
+                                      completion:(void (^)(FlutterError *_Nullable))completion {
+  NSString *channelName = [NSString
+      stringWithFormat:
+          @"%@%@",
+          @"dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap",
+          _messageChannelSuffix];
+  FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+      messageChannelWithName:channelName
+             binaryMessenger:self.binaryMessenger
+                       codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
+  [channel sendMessage:@[ arg_placeId ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/FGMGoogleMapController_Test.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/FGMGoogleMapController_Test.h
@@ -8,6 +8,7 @@
 #import "FGMAssetProvider.h"
 #import "FGMCATransactionWrapper.h"
 #import "FGMGoogleMapController.h"
+#import "FGMMapsCallbackApiProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,11 +49,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param creationParameters Parameters for initialising the map view.
 /// @param assetProvider The asset provider to use for looking up assets.
 /// @param binaryMessenger The binary messenger to use for sending messages to Dart.
+/// @param callbackHandler The callback API to use for sending events to Dart.
 - (instancetype)initWithMapView:(GMSMapView *)mapView
                  viewIdentifier:(int64_t)viewId
              creationParameters:(FGMPlatformMapViewCreationParams *)creationParameters
                   assetProvider:(NSObject<FGMAssetProvider> *)assetProvider
-                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger;
+                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                callbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler;
 
 // The main Pigeon API implementation.
 @property(nonatomic, strong, readonly) FGMMapCallHandler *callHandler;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/FGMMapEventDelegate.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/FGMMapEventDelegate.h
@@ -50,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId;
 
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier;
+
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster;
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/FGMMapsCallbackApiProtocol.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/FGMMapsCallbackApiProtocol.h
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import Foundation;
+
+#import "google_maps_flutter_pigeon_messages.g.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Protocol for FGMMapsCallbackApi to allow mocking in tests.
+///
+/// This is a one-to-one abstraction of the Pigeon-generated API, so that unit tests can inject a
+/// fake in place of the real implementation rather than asserting on Pigeon channel internals.
+@protocol FGMMapsCallbackApiProtocol <NSObject>
+
+/// Called when the map camera starts moving.
+- (void)didStartCameraMoveWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map camera moves.
+- (void)didMoveCameraToPosition:(FGMPlatformCameraPosition *)cameraPosition
+                     completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map camera stops moving.
+- (void)didIdleCameraWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map, not a specifc map object, is tapped.
+- (void)didTapAtPosition:(FGMPlatformLatLng *)position
+              completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map, not a specifc map object, is long pressed.
+- (void)didLongPressAtPosition:(FGMPlatformLatLng *)position
+                    completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker is tapped.
+- (void)didTapMarkerWithIdentifier:(NSString *)markerId
+                        completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag starts.
+- (void)didStartDragForMarkerWithIdentifier:(NSString *)markerId
+                                 atPosition:(FGMPlatformLatLng *)position
+                                 completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag updates.
+- (void)didDragMarkerWithIdentifier:(NSString *)markerId
+                         atPosition:(FGMPlatformLatLng *)position
+                         completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag ends.
+- (void)didEndDragForMarkerWithIdentifier:(NSString *)markerId
+                               atPosition:(FGMPlatformLatLng *)position
+                               completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker's info window is tapped.
+- (void)didTapInfoWindowOfMarkerWithIdentifier:(NSString *)markerId
+                                    completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a circle is tapped.
+- (void)didTapCircleWithIdentifier:(NSString *)circleId
+                        completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier
+                                      completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker cluster is tapped.
+- (void)didTapCluster:(FGMPlatformCluster *)cluster
+           completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a polygon is tapped.
+- (void)didTapPolygonWithIdentifier:(NSString *)polygonId
+                         completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a polyline is tapped.
+- (void)didTapPolylineWithIdentifier:(NSString *)polylineId
+                          completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a ground overlay is tapped.
+- (void)didTapGroundOverlayWithIdentifier:(NSString *)groundOverlayId
+                               completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called to get data for a map tile.
+- (void)tileWithOverlayIdentifier:(NSString *)tileOverlayId
+                         location:(FGMPlatformPoint *)location
+                             zoom:(NSInteger)zoom
+                       completion:(void (^)(FGMPlatformTile *_Nullable,
+                                            FlutterError *_Nullable))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/include/google_maps_flutter_ios_sdk9/google_maps_flutter_pigeon_messages.g.h
@@ -910,6 +910,9 @@ extern void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId
                         completion:(void (^)(FlutterError *_Nullable))completion;
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeId
+                                      completion:(void (^)(FlutterError *_Nullable))completion;
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster
            completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/google_maps_flutter_ios.dart
@@ -183,6 +183,11 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -987,6 +992,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/messages.g.dart
@@ -3355,6 +3355,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3723,6 +3726,39 @@ abstract class MapsCallbackApi {
           );
           try {
             api.onCircleTap(arg_circleId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_placeId = (args[0] as String?);
+          assert(
+            arg_placeId != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null, expected non-null String.',
+          );
+          try {
+            api.onPointOfInterestTap(arg_placeId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pigeons/messages.dart
@@ -832,6 +832,10 @@ abstract class MapsCallbackApi {
   @ObjCSelector('didTapCircleWithIdentifier:')
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  @ObjCSelector('didTapPointOfInterestWithPlaceIdentifier:')
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   @ObjCSelector('didTapCluster:')
   void onClusterTap(PlatformCluster cluster);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios_sdk9
 description: iOS implementation of the google_maps_flutter plugin using Google Maps SDK 9.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios_sdk9
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.6
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.17.0
   stream_transform: ^2.0.0
 
 dev_dependencies:
@@ -37,3 +37,7 @@ topics:
   - google-maps
   - google-maps-flutter
   - map
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/test/google_maps_flutter_ios_test.dart
@@ -905,6 +905,20 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterIOS();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(maps.onPointOfInterestTap(mapId: mapId));
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerTests/GoogleMapsTests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerTests/GoogleMapsTests.swift
@@ -38,6 +38,98 @@ class StubBinaryMessenger: NSObject, FlutterBinaryMessenger {
   }
 }
 
+/// Fake implementation of FGMMapsCallbackApiProtocol that records the calls it receives.
+class MockMapsCallbackApi: NSObject, FGMMapsCallbackApiProtocol {
+  var lastTappedPointOfInterestPlaceIdentifier: String?
+
+  func didTapPointOfInterest(
+    withPlaceIdentifier placeIdentifier: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) {
+    lastTappedPointOfInterestPlaceIdentifier = placeIdentifier
+    completion(nil)
+  }
+
+  func didStartCameraMove(completion: @escaping (FlutterError?) -> Void) { completion(nil) }
+
+  func didMoveCamera(
+    to cameraPosition: FGMPlatformCameraPosition,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didIdleCamera(completion: @escaping (FlutterError?) -> Void) { completion(nil) }
+
+  func didTap(
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didLongPress(
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapMarker(
+    withIdentifier markerId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didStartDragForMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didDragMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didEndDragForMarker(
+    withIdentifier markerId: String,
+    atPosition position: FGMPlatformLatLng,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapInfoWindowOfMarker(
+    withIdentifier markerId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapCircle(
+    withIdentifier circleId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTap(
+    _ cluster: FGMPlatformCluster,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapPolygon(
+    withIdentifier polygonId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapPolyline(
+    withIdentifier polylineId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func didTapGroundOverlay(
+    withIdentifier groundOverlayId: String,
+    completion: @escaping (FlutterError?) -> Void
+  ) { completion(nil) }
+
+  func tile(
+    withOverlayIdentifier tileOverlayId: String,
+    location: FGMPlatformPoint,
+    zoom: Int,
+    completion: @escaping (FGMPlatformTile?, FlutterError?) -> Void
+  ) { completion(nil, nil) }
+}
+
 class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
   var viewController: UIViewController? { nil }
   func publish(_ value: NSObject) {}
@@ -74,7 +166,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     for _ in 0..<10 {
@@ -133,7 +226,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let mockTransactionWrapper = MockCATransaction()
@@ -165,7 +259,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: StubBinaryMessenger()
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let mockTransactionWrapper = MockCATransaction()
@@ -188,6 +283,34 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
     #expect(mockTransactionWrapper.animationDuration == durationMilliseconds.doubleValue / 1000)
   }
 
+  @Test func didTapPOIForwardsPlaceIdentifierToCallbackApi() {
+    let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+    let mapViewOptions = GMSMapViewOptions()
+    mapViewOptions.frame = frame
+    mapViewOptions.camera = GMSCameraPosition(latitude: 0, longitude: 0, zoom: 0)
+
+    let mapView = PartiallyMockedMapView(options: mapViewOptions)
+
+    let callbackApi = MockMapsCallbackApi()
+    let controller = FGMGoogleMapController(
+      mapView: mapView,
+      viewIdentifier: 0,
+      creationParameters: emptyCreationParameters(),
+      assetProvider: TestAssetProvider(),
+      binaryMessenger: StubBinaryMessenger(),
+      callbackHandler: callbackApi
+    )
+
+    controller.mapView(
+      mapView,
+      didTapPOIWithPlaceID: "place-123",
+      name: "Test Place",
+      location: CLLocationCoordinate2DMake(0, 0)
+    )
+
+    #expect(callbackApi.lastTappedPointOfInterestPlaceIdentifier == "place-123")
+  }
+
   @Test func inspectorAPICameraPosition() throws {
     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
     let mapViewOptions = GMSMapViewOptions()
@@ -205,7 +328,8 @@ class StubPluginRegistrar: NSObject, FlutterPluginRegistrar {
       viewIdentifier: 0,
       creationParameters: emptyCreationParameters(),
       assetProvider: TestAssetProvider(),
-      binaryMessenger: binaryMessenger
+      binaryMessenger: binaryMessenger,
+      callbackHandler: MockMapsCallbackApi()
     )
 
     let inspector = FGMMapInspector(

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerTests/TestUtils/TestMapEventHandler.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerTests/TestUtils/TestMapEventHandler.swift
@@ -32,6 +32,8 @@ class TestMapEventHandler: NSObject, FGMMapEventDelegate {
 
   func didTapCircle(withIdentifier circleId: String) {}
 
+  func didTapPointOfInterest(withPlaceIdentifier placeIdentifier: String) {}
+
   func didTap(_ cluster: FGMPlatformCluster) {}
 
   func didTapPolygon(withIdentifier polygonId: String) {}

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/test/fake_google_maps_flutter_platform.dart
@@ -207,6 +207,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMGoogleMapController.m
@@ -11,6 +11,7 @@
 #import "FGMConversionUtils.h"
 #import "FGMGroundOverlayController.h"
 #import "FGMHeatmapController.h"
+#import "FGMMapsCallbackApiProtocol.h"
 #import "FGMMarkerUserData.h"
 #import "FGMTileOverlayController.h"
 #import "google_maps_flutter_pigeon_messages.g.h"
@@ -99,17 +100,138 @@
 
 #pragma mark -
 
+/// Non-test implementation of FGMMapsCallbackApiProtocol, passing calls through to a
+/// FGMMapsCallbackApi instance.
+@interface FGMDefaultMapsCallbackApi : NSObject <FGMMapsCallbackApiProtocol>
+@property(strong, nonatomic) FGMMapsCallbackApi *callbackApi;
+
+- (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                   messageChannelSuffix:(NSString *)messageChannelSuffix;
+@end
+
+@implementation FGMDefaultMapsCallbackApi
+
+- (instancetype)initWithBinaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                   messageChannelSuffix:(NSString *)messageChannelSuffix {
+  self = [super init];
+  if (self) {
+    _callbackApi = [[FGMMapsCallbackApi alloc] initWithBinaryMessenger:binaryMessenger
+                                                  messageChannelSuffix:messageChannelSuffix];
+  }
+  return self;
+}
+
+- (void)didStartCameraMoveWithCompletion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didStartCameraMoveWithCompletion:completion];
+}
+
+- (void)didMoveCameraToPosition:(FGMPlatformCameraPosition *)cameraPosition
+                     completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didMoveCameraToPosition:cameraPosition completion:completion];
+}
+
+- (void)didIdleCameraWithCompletion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didIdleCameraWithCompletion:completion];
+}
+
+- (void)didTapAtPosition:(FGMPlatformLatLng *)position
+              completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapAtPosition:position completion:completion];
+}
+
+- (void)didLongPressAtPosition:(FGMPlatformLatLng *)position
+                    completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didLongPressAtPosition:position completion:completion];
+}
+
+- (void)didTapMarkerWithIdentifier:(NSString *)markerId
+                        completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapMarkerWithIdentifier:markerId completion:completion];
+}
+
+- (void)didStartDragForMarkerWithIdentifier:(NSString *)markerId
+                                 atPosition:(FGMPlatformLatLng *)position
+                                 completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didStartDragForMarkerWithIdentifier:markerId
+                                             atPosition:position
+                                             completion:completion];
+}
+
+- (void)didDragMarkerWithIdentifier:(NSString *)markerId
+                         atPosition:(FGMPlatformLatLng *)position
+                         completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didDragMarkerWithIdentifier:markerId atPosition:position completion:completion];
+}
+
+- (void)didEndDragForMarkerWithIdentifier:(NSString *)markerId
+                               atPosition:(FGMPlatformLatLng *)position
+                               completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didEndDragForMarkerWithIdentifier:markerId
+                                           atPosition:position
+                                           completion:completion];
+}
+
+- (void)didTapInfoWindowOfMarkerWithIdentifier:(NSString *)markerId
+                                    completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapInfoWindowOfMarkerWithIdentifier:markerId completion:completion];
+}
+
+- (void)didTapCircleWithIdentifier:(NSString *)circleId
+                        completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapCircleWithIdentifier:circleId completion:completion];
+}
+
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier
+                                      completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPointOfInterestWithPlaceIdentifier:placeIdentifier completion:completion];
+}
+
+- (void)didTapCluster:(FGMPlatformCluster *)cluster
+           completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapCluster:cluster completion:completion];
+}
+
+- (void)didTapPolygonWithIdentifier:(NSString *)polygonId
+                         completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPolygonWithIdentifier:polygonId completion:completion];
+}
+
+- (void)didTapPolylineWithIdentifier:(NSString *)polylineId
+                          completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapPolylineWithIdentifier:polylineId completion:completion];
+}
+
+- (void)didTapGroundOverlayWithIdentifier:(NSString *)groundOverlayId
+                               completion:(void (^)(FlutterError *_Nullable))completion {
+  [self.callbackApi didTapGroundOverlayWithIdentifier:groundOverlayId completion:completion];
+}
+
+- (void)tileWithOverlayIdentifier:(NSString *)tileOverlayId
+                         location:(FGMPlatformPoint *)location
+                             zoom:(NSInteger)zoom
+                       completion:(void (^)(FGMPlatformTile *_Nullable,
+                                            FlutterError *_Nullable))completion {
+  [self.callbackApi tileWithOverlayIdentifier:tileOverlayId
+                                     location:location
+                                         zoom:zoom
+                                   completion:completion];
+}
+
+@end
+
+#pragma mark -
+
 /// Non-test implementation of FGMAssetProvider, wrapping a FGMMapsCallbackApi
 /// instance.
 @interface FGMDefaultMapEventHandler : NSObject <FGMMapEventDelegate>
-@property(strong, nonatomic) FGMMapsCallbackApi *callbackHandler;
+@property(strong, nonatomic) id<FGMMapsCallbackApiProtocol> callbackHandler;
 
-- (instancetype)initWithCallbackHandler:(FGMMapsCallbackApi *)callbackHandler;
+- (instancetype)initWithCallbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler;
 @end
 
 @implementation FGMDefaultMapEventHandler
 
-- (instancetype)initWithCallbackHandler:(FGMMapsCallbackApi *)callbackHandler {
+- (instancetype)initWithCallbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler {
   self = [super init];
   if (self) {
     _callbackHandler = callbackHandler;
@@ -186,6 +308,12 @@
                                         }];
 }
 
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier {
+  [self.callbackHandler didTapPointOfInterestWithPlaceIdentifier:placeIdentifier
+                                                      completion:^(FlutterError *_){
+                                                      }];
+}
+
 - (void)didTapCluster:(FGMPlatformCluster *)cluster {
   [self.callbackHandler didTapCluster:cluster
                            completion:^(FlutterError *_){
@@ -246,7 +374,7 @@
 @interface FGMGoogleMapController () <FGMTileProviderDelegate>
 
 @property(nonatomic, strong) GMSMapView *mapView;
-@property(nonatomic, strong) FGMMapsCallbackApi *dartCallbackHandler;
+@property(nonatomic, strong) id<FGMMapsCallbackApiProtocol> dartCallbackHandler;
 @property(nonatomic, strong) FGMDefaultMapEventHandler *mapEventHandler;
 @property(nonatomic, assign) BOOL trackCameraPosition;
 @property(nonatomic, strong) FGMClusterManagersController *clusterManagersController;
@@ -290,18 +418,23 @@
 
   GMSMapView *mapView = [[GMSMapView alloc] initWithOptions:options];
 
+  NSString *pigeonSuffix = [NSString stringWithFormat:@"%lld", viewId];
   return [self initWithMapView:mapView
                 viewIdentifier:viewId
             creationParameters:creationParameters
                  assetProvider:[[FGMDefaultAssetProvider alloc] initWithRegistrar:registrar]
-               binaryMessenger:registrar.messenger];
+               binaryMessenger:registrar.messenger
+               callbackHandler:[[FGMDefaultMapsCallbackApi alloc]
+                                   initWithBinaryMessenger:registrar.messenger
+                                      messageChannelSuffix:pigeonSuffix]];
 }
 
 - (instancetype)initWithMapView:(GMSMapView *_Nonnull)mapView
                  viewIdentifier:(int64_t)viewId
              creationParameters:(FGMPlatformMapViewCreationParams *)creationParameters
                   assetProvider:(NSObject<FGMAssetProvider> *)assetProvider
-                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger {
+                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                callbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler {
   if (self = [super init]) {
     _mapView = mapView;
 
@@ -310,8 +443,7 @@
     // https://github.com/flutter/flutter/issues/104121
     [self interpretMapConfiguration:creationParameters.mapConfiguration];
     NSString *pigeonSuffix = [NSString stringWithFormat:@"%lld", viewId];
-    _dartCallbackHandler = [[FGMMapsCallbackApi alloc] initWithBinaryMessenger:binaryMessenger
-                                                          messageChannelSuffix:pigeonSuffix];
+    _dartCallbackHandler = callbackHandler;
     _mapEventHandler =
         [[FGMDefaultMapEventHandler alloc] initWithCallbackHandler:_dartCallbackHandler];
     FGMPlatformMarkerType markerType = creationParameters.mapConfiguration.markerType;
@@ -556,6 +688,13 @@
   } else if ([self.groundOverlaysController hasGroundOverlaysWithIdentifier:overlayId]) {
     [self.groundOverlaysController didTapGroundOverlayWithIdentifier:overlayId];
   }
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+  [self.mapEventHandler didTapPointOfInterestWithPlaceIdentifier:placeID];
 }
 
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.m
@@ -2336,11 +2336,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updatePolylinesByAdding:
-                                                                 changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updatePolylinesByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updatePolylinesByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updatePolylinesByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformPolyline *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2367,11 +2367,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateTileOverlaysByAdding:
-                                                                    changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateTileOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateTileOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformTileOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2398,11 +2398,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(updateGroundOverlaysByAdding:
-                                                                      changing:removing:error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(updateGroundOverlaysByAdding:changing:removing:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(updateGroundOverlaysByAdding:changing:removing:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSArray<FGMPlatformGroundOverlay *> *arg_toAdd = GetNullableObjectAtIndex(args, 0);
@@ -2631,11 +2631,11 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
         binaryMessenger:binaryMessenger
                   codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:
-                                                                                       error:)],
-                @"FGMMapsApi api (%@) doesn't respond to "
-                @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
-                api);
+      NSCAssert(
+          [api respondsToSelector:@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)],
+          @"FGMMapsApi api (%@) doesn't respond to "
+          @"@selector(isShowingInfoWindowForMarkerWithIdentifier:error:)",
+          api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray<id> *args = message;
         NSString *arg_markerId = GetNullableObjectAtIndex(args, 0);
@@ -3054,6 +3054,32 @@ void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger,
              binaryMessenger:self.binaryMessenger
                        codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
   [channel sendMessage:@[ arg_circleId ?: [NSNull null] ]
+                 reply:^(NSArray<id> *reply) {
+                   if (reply != nil) {
+                     if (reply.count > 1) {
+                       completion([FlutterError errorWithCode:reply[0]
+                                                      message:reply[1]
+                                                      details:reply[2]]);
+                     } else {
+                       completion(nil);
+                     }
+                   } else {
+                     completion(createConnectionError(channelName));
+                   }
+                 }];
+}
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)arg_placeId
+                                      completion:(void (^)(FlutterError *_Nullable))completion {
+  NSString *channelName = [NSString
+      stringWithFormat:
+          @"%@%@",
+          @"dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap",
+          _messageChannelSuffix];
+  FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+      messageChannelWithName:channelName
+             binaryMessenger:self.binaryMessenger
+                       codec:FGMGetGoogleMapsFlutterPigeonMessagesCodec()];
+  [channel sendMessage:@[ arg_placeId ?: [NSNull null] ]
                  reply:^(NSArray<id> *reply) {
                    if (reply != nil) {
                      if (reply.count > 1) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMGoogleMapController_Test.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMGoogleMapController_Test.h
@@ -8,6 +8,7 @@
 #import "FGMAssetProvider.h"
 #import "FGMCATransactionWrapper.h"
 #import "FGMGoogleMapController.h"
+#import "FGMMapsCallbackApiProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,11 +49,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param creationParameters Parameters for initialising the map view.
 /// @param assetProvider The asset provider to use for looking up assets.
 /// @param binaryMessenger The binary messenger to use for sending messages to Dart.
+/// @param callbackHandler The callback API to use for sending events to Dart.
 - (instancetype)initWithMapView:(GMSMapView *)mapView
                  viewIdentifier:(int64_t)viewId
              creationParameters:(FGMPlatformMapViewCreationParams *)creationParameters
                   assetProvider:(NSObject<FGMAssetProvider> *)assetProvider
-                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger;
+                binaryMessenger:(NSObject<FlutterBinaryMessenger> *)binaryMessenger
+                callbackHandler:(id<FGMMapsCallbackApiProtocol>)callbackHandler;
 
 // The main Pigeon API implementation.
 @property(nonatomic, strong, readonly) FGMMapCallHandler *callHandler;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapEventDelegate.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapEventDelegate.h
@@ -50,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId;
 
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier;
+
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster;
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapsCallbackApiProtocol.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/FGMMapsCallbackApiProtocol.h
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import Foundation;
+
+#import "google_maps_flutter_pigeon_messages.g.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Protocol for FGMMapsCallbackApi to allow mocking in tests.
+///
+/// This is a one-to-one abstraction of the Pigeon-generated API, so that unit tests can inject a
+/// fake in place of the real implementation rather than asserting on Pigeon channel internals.
+@protocol FGMMapsCallbackApiProtocol <NSObject>
+
+/// Called when the map camera starts moving.
+- (void)didStartCameraMoveWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map camera moves.
+- (void)didMoveCameraToPosition:(FGMPlatformCameraPosition *)cameraPosition
+                     completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map camera stops moving.
+- (void)didIdleCameraWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map, not a specifc map object, is tapped.
+- (void)didTapAtPosition:(FGMPlatformLatLng *)position
+              completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when the map, not a specifc map object, is long pressed.
+- (void)didLongPressAtPosition:(FGMPlatformLatLng *)position
+                    completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker is tapped.
+- (void)didTapMarkerWithIdentifier:(NSString *)markerId
+                        completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag starts.
+- (void)didStartDragForMarkerWithIdentifier:(NSString *)markerId
+                                 atPosition:(FGMPlatformLatLng *)position
+                                 completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag updates.
+- (void)didDragMarkerWithIdentifier:(NSString *)markerId
+                         atPosition:(FGMPlatformLatLng *)position
+                         completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker drag ends.
+- (void)didEndDragForMarkerWithIdentifier:(NSString *)markerId
+                               atPosition:(FGMPlatformLatLng *)position
+                               completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker's info window is tapped.
+- (void)didTapInfoWindowOfMarkerWithIdentifier:(NSString *)markerId
+                                    completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a circle is tapped.
+- (void)didTapCircleWithIdentifier:(NSString *)circleId
+                        completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeIdentifier
+                                      completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a marker cluster is tapped.
+- (void)didTapCluster:(FGMPlatformCluster *)cluster
+           completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a polygon is tapped.
+- (void)didTapPolygonWithIdentifier:(NSString *)polygonId
+                         completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a polyline is tapped.
+- (void)didTapPolylineWithIdentifier:(NSString *)polylineId
+                          completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called when a ground overlay is tapped.
+- (void)didTapGroundOverlayWithIdentifier:(NSString *)groundOverlayId
+                               completion:(void (^)(FlutterError *_Nullable))completion;
+
+/// Called to get data for a map tile.
+- (void)tileWithOverlayIdentifier:(NSString *)tileOverlayId
+                         location:(FGMPlatformPoint *)location
+                             zoom:(NSInteger)zoom
+                       completion:(void (^)(FGMPlatformTile *_Nullable,
+                                            FlutterError *_Nullable))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/include/google_maps_flutter_ios/google_maps_flutter_pigeon_messages.g.h
@@ -910,6 +910,9 @@ extern void SetUpFGMMapsApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger
 /// Called when a circle is tapped.
 - (void)didTapCircleWithIdentifier:(NSString *)circleId
                         completion:(void (^)(FlutterError *_Nullable))completion;
+/// Called when a point of interest is tapped.
+- (void)didTapPointOfInterestWithPlaceIdentifier:(NSString *)placeId
+                                      completion:(void (^)(FlutterError *_Nullable))completion;
 /// Called when a marker cluster is tapped.
 - (void)didTapCluster:(FGMPlatformCluster *)cluster
            completion:(void (^)(FlutterError *_Nullable))completion;

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/google_maps_flutter_ios.dart
@@ -183,6 +183,11 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<GroundOverlayTapEvent> onGroundOverlayTap({required int mapId}) {
     return _events(mapId).whereType<GroundOverlayTapEvent>();
   }
@@ -987,6 +992,11 @@ class HostMapMessageHandler implements MapsCallbackApi {
   @override
   void onCircleTap(String circleId) {
     streamController.add(CircleTapEvent(mapId, CircleId(circleId)));
+  }
+
+  @override
+  void onPointOfInterestTap(String placeId) {
+    streamController.add(PointOfInterestTapEvent(mapId, PointOfInterestId(placeId)));
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/messages.g.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/messages.g.dart
@@ -3355,6 +3355,9 @@ abstract class MapsCallbackApi {
   /// Called when a circle is tapped.
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   void onClusterTap(PlatformCluster cluster);
 
@@ -3723,6 +3726,39 @@ abstract class MapsCallbackApi {
           );
           try {
             api.onCircleTap(arg_circleId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_placeId = (args[0] as String?);
+          assert(
+            arg_placeId != null,
+            'Argument for dev.flutter.pigeon.google_maps_flutter_ios.MapsCallbackApi.onPointOfInterestTap was null, expected non-null String.',
+          );
+          try {
+            api.onPointOfInterestTap(arg_placeId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/pigeons/messages.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/pigeons/messages.dart
@@ -832,6 +832,10 @@ abstract class MapsCallbackApi {
   @ObjCSelector('didTapCircleWithIdentifier:')
   void onCircleTap(String circleId);
 
+  /// Called when a point of interest is tapped.
+  @ObjCSelector('didTapPointOfInterestWithPlaceIdentifier:')
+  void onPointOfInterestTap(String placeId);
+
   /// Called when a marker cluster is tapped.
   @ObjCSelector('didTapCluster:')
   void onClusterTap(PlatformCluster cluster);

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/test/google_maps_flutter_ios_test.dart
@@ -905,6 +905,20 @@ void main() {
     expect((await stream.next).value.value, equals(objectId));
   });
 
+  test('points of interest send tap events to correct stream', () async {
+    const mapId = 1;
+    const placeId = 'place-123';
+
+    final maps = GoogleMapsFlutterIOS();
+    final HostMapMessageHandler callbackHandler = maps.ensureHandlerInitialized(mapId);
+
+    final stream = StreamQueue<PointOfInterestTapEvent>(maps.onPointOfInterestTap(mapId: mapId));
+
+    callbackHandler.onPointOfInterestTap(placeId);
+
+    expect((await stream.next).value.value, equals(placeId));
+  });
+
   test('clusters send tap events to correct stream', () async {
     const mapId = 1;
     const managerId = 'manager-id';

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.17.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.16.0
 
 * Adds support for `mapTypeControlEnabled`, `fullscreenControlEnabled`, and `streetViewControlEnabled` for web.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/events/map_event.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/events/map_event.dart
@@ -160,6 +160,15 @@ class GroundOverlayTapEvent extends MapEvent<GroundOverlayId> {
   GroundOverlayTapEvent(super.mapId, super.croundOverlayId);
 }
 
+/// An event fired when a point of interest is tapped.
+class PointOfInterestTapEvent extends MapEvent<PointOfInterestId> {
+  /// Build a PointOfInterestTap Event triggered from the map represented by `mapId`.
+  ///
+  /// The `value` of this event is a [PointOfInterestId] object that represents the
+  /// tapped point of interest.
+  PointOfInterestTapEvent(super.mapId, super.pointOfInterestId);
+}
+
 /// An event fired when a Map is tapped.
 class MapTapEvent extends _PositionedMapEvent<void> {
   /// Build an MapTap Event triggered from the map represented by `mapId`.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
@@ -337,6 +337,11 @@ abstract class GoogleMapsFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('onCircleTap() has not been implemented.');
   }
 
+  /// A point of interest has been tapped.
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return const Stream<PointOfInterestTapEvent>.empty();
+  }
+
   /// A Map has been tapped at a certain [LatLng].
   Stream<MapTapEvent> onTap({required int mapId}) {
     throw UnimplementedError('onTap() has not been implemented.');

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/point_of_interest_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/point_of_interest_id.dart
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart' show immutable;
+
+import 'types.dart';
+
+/// Uniquely identifies a point of interest on a [GoogleMap].
+///
+/// The [value] is the Google Maps place ID for the tapped point of interest.
+@immutable
+class PointOfInterestId extends MapsObjectId<PointOfInterestId> {
+  /// Creates an immutable identifier for a point of interest.
+  const PointOfInterestId(super.value);
+}

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/types.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/types.dart
@@ -28,6 +28,7 @@ export 'maps_object_updates.dart';
 export 'marker.dart';
 export 'marker_updates.dart';
 export 'pattern_item.dart';
+export 'point_of_interest_id.dart';
 export 'polygon.dart';
 export 'polygon_updates.dart';
 export 'polyline.dart';

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.16.0
+version: 2.17.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
@@ -95,6 +95,12 @@ void main() {
       );
     });
 
+    test('onPointOfInterestTap() returns empty stream', () async {
+      final Stream<PointOfInterestTapEvent> stream = BuildViewGoogleMapsFlutterPlatform()
+          .onPointOfInterestTap(mapId: 0);
+      expect(await stream.isEmpty, isTrue);
+    });
+
     test('default implementation of `getStyleError` returns null', () async {
       final GoogleMapsFlutterPlatform platform = BuildViewGoogleMapsFlutterPlatform();
       expect(await platform.getStyleError(mapId: 0), null);

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/point_of_interest_id_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/point_of_interest_id_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+void main() {
+  test('PointOfInterestId equality', () {
+    const id1 = PointOfInterestId('place-123');
+    const id2 = PointOfInterestId('place-123');
+    const id3 = PointOfInterestId('place-456');
+
+    expect(id1, equals(id2));
+    expect(id1, isNot(equals(id3)));
+    expect(id1.hashCode, equals(id2.hashCode));
+  });
+
+  test('PointOfInterestId toString', () {
+    const id = PointOfInterestId('place-123');
+    expect(id.toString(), contains('place-123'));
+  });
+}

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4
+
+* Adds support for tapping points of interest on the map.
+
 ## 0.6.3
 
 * Adds support for mapTypeControlEnabled, fullscreenControlEnabled, and streetViewControlEnabled.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/3-64/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/3-64/pubspec.yaml
@@ -19,3 +19,7 @@ dev_dependencies:
   google_maps: ^8.1.0
   integration_test:
     sdk: flutter
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/google_maps_controller_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/google_maps_controller_test.dart
@@ -248,6 +248,36 @@ void main() {
         expect(events[4], isA<CameraIdleEvent>());
       });
 
+      testWidgets('emits point of interest tap when click has placeId', (
+        WidgetTester tester,
+      ) async {
+        controller = createController()
+          ..debugSetOverrides(
+            createMap: (_, _) => map,
+            circles: circles,
+            heatmaps: heatmaps,
+            markers: markers,
+            polygons: polygons,
+            polylines: polylines,
+            groundOverlays: groundOverlays,
+          )
+          ..init();
+
+        final Stream<MapEvent<Object?>> capturedEvents = stream.stream.take(1);
+
+        gmaps.event.trigger(
+          map,
+          'click',
+          gmaps.IconMouseEvent(placeId: 'place-123')..latLng = gmaps.LatLng(0, 0),
+        );
+
+        final List<MapEvent<Object?>> events = await capturedEvents.toList();
+
+        expect(events, hasLength(1));
+        expect(events[0], isA<PointOfInterestTapEvent>());
+        expect((events[0] as PointOfInterestTapEvent).value, const PointOfInterestId('place-123'));
+      });
+
       testWidgets('stops listening to map events once disposed', (WidgetTester tester) async {
         controller = createController()
           ..debugSetOverrides(

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/google_maps_plugin_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/google_maps_plugin_test.dart
@@ -467,6 +467,13 @@ void main() {
 
         await testStreamFiltering(stream, event);
       });
+      testWidgets('onPointOfInterestTap', (WidgetTester tester) async {
+        final event = PointOfInterestTapEvent(mapId, const PointOfInterestId('place-123'));
+
+        final Stream<PointOfInterestTapEvent> stream = plugin.onPointOfInterestTap(mapId: mapId);
+
+        await testStreamFiltering(stream, event);
+      });
       // Map taps
       testWidgets('onTap', (WidgetTester tester) async {
         final event = MapTapEvent(mapId, const LatLng(43.3597, -5.8458));

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/pubspec.yaml
@@ -28,9 +28,8 @@ flutter:
   assets:
     - assets/
 
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
 dependency_overrides:
-  # Override the google_maps_flutter dependency on google_maps_flutter_web.
-  # TODO(ditman): Unwind the circular dependency. This will create problems
-  # if we need to make a breaking change to google_maps_flutter_web.
-  google_maps_flutter_web:
-    path: ../..
+  google_maps_flutter_platform_interface: {path: ../../../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}
+  google_maps_flutter_web: {path: ../..}

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/google_maps_flutter_web.dart
@@ -7,6 +7,7 @@ library google_maps_flutter_web;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:ui_web' as ui_web;
 
 import 'package:collection/collection.dart';

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/google_maps_flutter_web.dart
@@ -7,7 +7,6 @@ library google_maps_flutter_web;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
 import 'dart:ui_web' as ui_web;
 
 import 'package:collection/collection.dart';
@@ -25,6 +24,7 @@ import 'package:web/web.dart' as web;
 
 import 'src/dom_window_extension.dart';
 import 'src/google_maps_inspector_web.dart';
+import 'src/map_mouse_event_extension.dart';
 import 'src/map_styler.dart';
 import 'src/marker_clustering.dart';
 import 'src/third_party/to_screen_location/to_screen_location.dart';

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
@@ -289,6 +289,13 @@ class GoogleMapController {
     _onClickSubscription = map.onClick.listen((gmaps.MapMouseEventOrIconMouseEvent event) {
       assert(event.latLng != null);
       if (!_streamController.isClosed) {
+        if (event.hasProperty('placeId'.toJS).toDart) {
+          final String? placeId = (event as gmaps.IconMouseEvent).placeId;
+          if (placeId != null) {
+            _streamController.add(PointOfInterestTapEvent(_mapId, PointOfInterestId(placeId)));
+            return;
+          }
+        }
         _streamController.add(MapTapEvent(_mapId, gmLatLngToLatLng(event.latLng!)));
       }
     });

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
@@ -289,12 +289,10 @@ class GoogleMapController {
     _onClickSubscription = map.onClick.listen((gmaps.MapMouseEventOrIconMouseEvent event) {
       assert(event.latLng != null);
       if (!_streamController.isClosed) {
-        if (event.hasProperty('placeId'.toJS).toDart) {
-          final String? placeId = (event as gmaps.IconMouseEvent).placeId;
-          if (placeId != null) {
-            _streamController.add(PointOfInterestTapEvent(_mapId, PointOfInterestId(placeId)));
-            return;
-          }
+        final String? placeId = event.placeId;
+        if (placeId != null) {
+          _streamController.add(PointOfInterestTapEvent(_mapId, PointOfInterestId(placeId)));
+          return;
         }
         _streamController.add(MapTapEvent(_mapId, gmLatLngToLatLng(event.latLng!)));
       }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
@@ -245,6 +245,11 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return _events(mapId).whereType<PointOfInterestTapEvent>();
+  }
+
+  @override
   Stream<MapTapEvent> onTap({required int mapId}) {
     return _events(mapId).whereType<MapTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/map_mouse_event_extension.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/map_mouse_event_extension.dart
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@JS()
+library;
+
+import 'dart:js_interop';
+
+import 'package:google_maps/google_maps.dart' as gmaps;
+
+/// Exposes the `placeId` property on map click events.
+///
+/// [gmaps.MapMouseEventOrIconMouseEvent] only binds `latLng` upstream. POI
+/// clicks are [gmaps.IconMouseEvent]s and carry a `placeId`; this extension
+/// reads that property without `dart:js_interop_unsafe`. Prefer adding
+/// `placeId` to the upstream binding when possible.
+extension PlaceIdExtension on gmaps.MapMouseEventOrIconMouseEvent {
+  /// The place ID of a tapped point of interest, if this event is an icon
+  /// mouse event. Otherwise `null`.
+  external String? placeId;
+}

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.6.3
+version: 0.6.4
 
 environment:
   sdk: ^3.10.0
@@ -23,7 +23,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   google_maps: ^8.1.0
-  google_maps_flutter_platform_interface: ^2.16.0
+  google_maps_flutter_platform_interface: ^2.17.0
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0
   web: ^1.0.0
@@ -40,3 +40,7 @@ topics:
 # The example deliberately includes limited-use secrets.
 false_secrets:
   - /example/**/web/index.html
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  google_maps_flutter_platform_interface: {path: ../../../packages/google_maps_flutter/google_maps_flutter_platform_interface}


### PR DESCRIPTION
Adds `GoogleMap.onPointOfInterestTap`, a callback that fires when the user taps a built-in map point of interest. The callback receives a `PointOfInterestId` containing the place ID only, matching maintainer feedback on https://github.com/flutter/packages/pull/4052 and https://github.com/flutter/packages/pull/10963.

The change is wired through the federated plugin stack: platform_interface (type + event stream), Android (`OnPoiClickListener`), iOS including sdk9/sdk10/shared (`didTapPOIWithPlaceID`), web (`IconMouseEvent.placeId` on map click), and the app-facing `google_maps_flutter` package. Tests cover Dart unit tests, Android Robolectric, iOS native, and web integration tests in the web example.

Fixes flutter/flutter#60695

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
