### PR TITLE
[tool] Check for any Flutter SDK dependency

### DIFF
--- a/packages/vector_graphics_codec/dart_test.yaml
+++ b/packages/vector_graphics_codec/dart_test.yaml
@@ -1,6 +1,0 @@
-# See https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#arguments
-override_platforms:
-  chrome:
-    settings:
-      executable: chrome
-      arguments: --no-sandbox

--- a/script/tool/lib/src/common/repository_package.dart
+++ b/script/tool/lib/src/common/repository_package.dart
@@ -129,10 +129,17 @@ class RepositoryPackage {
 
   /// Returns true if the package depends on Flutter.
   bool requiresFlutter() {
-    const flutterDependency = 'flutter';
     final Pubspec pubspec = parsePubspec();
-    return pubspec.dependencies.containsKey(flutterDependency) ||
-        pubspec.devDependencies.containsKey(flutterDependency);
+    return _includesFlutterSdkDependency(pubspec.dependencies) ||
+        _includesFlutterSdkDependency(pubspec.devDependencies);
+  }
+
+  /// True if this package has a dependency on Flutter.
+  bool _includesFlutterSdkDependency(Map<String, Dependency> deps) {
+    const flutterSdkDependencyName = 'flutter';
+    return deps.values.whereType<SdkDependency>().any(
+      (SdkDependency dependency) => dependency.sdk == flutterSdkDependencyName,
+    );
   }
 
   /// True if this appears to be a federated plugin package, according to

--- a/script/tool/test/common/repository_package_test.dart
+++ b/script/tool/test/common/repository_package_test.dart
@@ -227,6 +227,16 @@ void main() {
       expect(package.requiresFlutter(), true);
     });
 
+    test('returns true for a dev dependency on other Flutter SDK packages', () async {
+      final RepositoryPackage package = createFakePackage('a_package', packagesDir);
+      final File pubspecFile = package.pubspecFile;
+      final Pubspec pubspec = package.parsePubspec();
+      pubspec.devDependencies['flutter_test'] = SdkDependency('flutter');
+      pubspecFile.writeAsStringSync(pubspec.toString());
+
+      expect(package.requiresFlutter(), true);
+    });
+
     test('returns false for non-Flutter package', () async {
       final RepositoryPackage package = createFakePackage('a_package', packagesDir);
       expect(package.requiresFlutter(), false);


### PR DESCRIPTION
When determining whether a package requires `flutter`, look for any `sdk: flutter` dependency rather than just for the `flutter` dependency in particular. This will ensure that includes, for example, packages with a `flutter_test` dev dependency, but no `flutter` dependency.