### PR TITLE
[pigeon] Report a clear error for enhanced enums

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 27.1.2
+
+* Reports a clear error when an input file uses an enhanced enum (one with a
+  constructor, fields, methods, or arguments on its values), instead of
+  silently generating incorrect output.
+
 ## 27.1.1
 
 * [dart] Adds usage documentation to generated event channel methods, and

--- a/packages/pigeon/lib/src/generator_tools.dart
+++ b/packages/pigeon/lib/src/generator_tools.dart
@@ -15,7 +15,7 @@ import 'generator.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '27.1.1';
+const String pigeonVersion = '27.1.2';
 
 /// Default plugin package name.
 const String defaultPluginPackageName = 'dev.flutter.pigeon';

--- a/packages/pigeon/lib/src/pigeon_lib_internal.dart
+++ b/packages/pigeon/lib/src/pigeon_lib_internal.dart
@@ -1747,6 +1747,31 @@ class RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
 
   @override
   Object? visitEnumDeclaration(dart_ast.EnumDeclaration node) {
+    // Enhanced enums (those with a constructor, fields, methods, or arguments
+    // on their values) aren't supported by Pigeon. Detect them and emit a
+    // clear error instead of silently dropping the extra members, which
+    // previously produced confusing output (the enum's fields were coalesced
+    // into the following class).
+    // See https://github.com/flutter/flutter/issues/160827.
+    //
+    // The enum is still registered below (by its value names) so that classes
+    // referencing it don't produce additional, confusing "Unknown type"
+    // errors; recording the error here already prevents code generation.
+    final bool hasEnumMembers = node.body.members.isNotEmpty;
+    final bool hasConstantArguments = node.body.constants.any(
+      (dart_ast.EnumConstantDeclaration e) => e.arguments != null,
+    );
+    final bool isEnhancedEnum = hasEnumMembers || hasConstantArguments;
+    if (isEnhancedEnum) {
+      _errors.add(
+        Error(
+          message:
+              'Pigeon doesn\'t support enhanced enums ("${node.namePart.typeName.lexeme}"). '
+              'Use a plain enum without a constructor, fields, methods, or arguments on its values.',
+          lineNumber: calculateLineNumber(source, node.offset),
+        ),
+      );
+    }
     _enums.add(
       Enum(
         name: node.namePart.typeName.lexeme,
@@ -1761,7 +1786,13 @@ class RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
         documentationComments: _documentationCommentsParser(node.documentationComment?.tokens),
       ),
     );
-    node.visitChildren(this);
+    // Don't visit the children of an enhanced enum: the declaration is
+    // already reported as unsupported, and the visitor doesn't expect
+    // class-like members outside of a class (for example, a getter would
+    // fail visitMethodDeclaration's parameter access).
+    if (!isEnhancedEnum) {
+      node.visitChildren(this);
+    }
     return null;
   }
 

--- a/packages/pigeon/lib/src/pigeon_lib_internal.dart
+++ b/packages/pigeon/lib/src/pigeon_lib_internal.dart
@@ -1757,17 +1757,20 @@ class RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
     // The enum is still registered below (by its value names) so that classes
     // referencing it don't produce additional, confusing "Unknown type"
     // errors; recording the error here already prevents code generation.
-    final bool hasEnumMembers = node.body.members.isNotEmpty;
-    final bool hasConstantArguments = node.body.constants.any(
-      (dart_ast.EnumConstantDeclaration e) => e.arguments != null,
-    );
-    final bool isEnhancedEnum = hasEnumMembers || hasConstantArguments;
+    final bool isEnhancedEnum =
+        node.body.members.isNotEmpty ||
+        node.body.constants.any((dart_ast.EnumConstantDeclaration e) => e.arguments != null) ||
+        node.namePart.typeParameters != null ||
+        node.namePart is dart_ast.PrimaryConstructorDeclaration ||
+        node.withClause != null ||
+        node.implementsClause != null;
     if (isEnhancedEnum) {
       _errors.add(
         Error(
           message:
               'Pigeon doesn\'t support enhanced enums ("${node.namePart.typeName.lexeme}"). '
-              'Use a plain enum without a constructor, fields, methods, or arguments on its values.',
+              'Use a plain enum without a constructor, fields, methods, type parameters, '
+              'mixins, interfaces, or arguments on its values.',
           lineNumber: calculateLineNumber(source, node.offset),
         ),
       );

--- a/packages/pigeon/lib/src/pigeon_lib_internal.dart
+++ b/packages/pigeon/lib/src/pigeon_lib_internal.dart
@@ -1748,15 +1748,7 @@ class RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
   @override
   Object? visitEnumDeclaration(dart_ast.EnumDeclaration node) {
     // Enhanced enums (those with a constructor, fields, methods, or arguments
-    // on their values) aren't supported by Pigeon. Detect them and emit a
-    // clear error instead of silently dropping the extra members, which
-    // previously produced confusing output (the enum's fields were coalesced
-    // into the following class).
-    // See https://github.com/flutter/flutter/issues/160827.
-    //
-    // The enum is still registered below (by its value names) so that classes
-    // referencing it don't produce additional, confusing "Unknown type"
-    // errors; recording the error here already prevents code generation.
+    // on their values) aren't supported by Pigeon.
     final bool isEnhancedEnum =
         node.body.members.isNotEmpty ||
         node.body.constants.any((dart_ast.EnumConstantDeclaration e) => e.arguments != null) ||
@@ -1791,8 +1783,7 @@ class RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
     );
     // Don't visit the children of an enhanced enum: the declaration is
     // already reported as unsupported, and the visitor doesn't expect
-    // class-like members outside of a class (for example, a getter would
-    // fail visitMethodDeclaration's parameter access).
+    // class-like members outside of a class.
     if (!isEnhancedEnum) {
       node.visitChildren(this);
     }

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 27.1.1 # This must match the version in lib/src/generator_tools.dart
+version: 27.1.2 # This must match the version in lib/src/generator_tools.dart
 
 environment:
   sdk: ^3.10.0

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -301,6 +301,32 @@ abstract class Api {
     expect(results.errors[0].message, contains('Enum1'));
   });
 
+  test('enum with a mixin or interface is an error', () {
+    const code = '''
+mixin Mixin1 {}
+
+abstract class Interface1 {}
+
+enum Enum1 with Mixin1 implements Interface1 {
+  one,
+  two,
+}
+
+class ClassWithEnum {
+  Enum1? enum1;
+}
+
+@HostApi
+abstract class Api {
+  ClassWithEnum foo();
+}
+''';
+    final ParseResults results = parseSource(code);
+    expect(results.errors, hasLength(1));
+    expect(results.errors[0].message, contains('enhanced enums'));
+    expect(results.errors[0].message, contains('Enum1'));
+  });
+
   test('plain enum with a trailing semicolon is not an error', () {
     const code = '''
 enum Enum1 {

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -276,6 +276,99 @@ abstract class Api {
     expect(results.root.classes[0].fields[0].name, equals('enum1'));
   });
 
+  test('enhanced enum with a constructor and fields is an error', () {
+    const code = '''
+enum Enum1 {
+  one(1),
+  two(2);
+
+  const Enum1(this.value);
+  final int value;
+}
+
+class ClassWithEnum {
+  Enum1? enum1;
+}
+
+@HostApi
+abstract class Api {
+  ClassWithEnum foo();
+}
+''';
+    final ParseResults results = parseSource(code);
+    expect(results.errors, hasLength(1));
+    expect(results.errors[0].message, contains('enhanced enums'));
+    expect(results.errors[0].message, contains('Enum1'));
+  });
+
+  test('plain enum with a trailing semicolon is not an error', () {
+    const code = '''
+enum Enum1 {
+  one,
+  two;
+}
+
+class ClassWithEnum {
+  Enum1? enum1;
+}
+
+@HostApi
+abstract class Api {
+  ClassWithEnum foo();
+}
+''';
+    final ParseResults results = parseSource(code);
+    expect(results.errors, isEmpty);
+  });
+
+  test('enhanced enum with a getter is an error and does not crash', () {
+    const code = '''
+enum Enum1 {
+  one(1),
+  two(2);
+
+  const Enum1(this.value);
+  final int value;
+  int get doubled => value * 2;
+}
+
+class ClassWithEnum {
+  Enum1? enum1;
+}
+
+@HostApi
+abstract class Api {
+  ClassWithEnum foo();
+}
+''';
+    final ParseResults results = parseSource(code);
+    expect(results.errors, hasLength(1));
+    expect(results.errors[0].message, contains('enhanced enums'));
+    expect(results.errors[0].message, contains('Enum1'));
+  });
+
+  test('enum with arguments on its values is an error', () {
+    const code = '''
+enum Enum1 {
+  one(1),
+  two(2);
+}
+
+class ClassWithEnum {
+  Enum1? enum1;
+}
+
+@HostApi
+abstract class Api {
+  ClassWithEnum foo();
+}
+''';
+    final ParseResults results = parseSource(code);
+    expect(results.errors, hasLength(1));
+    expect(results.errors[0].message, contains('enhanced enums'));
+    expect(results.errors[0].message, contains('Enum1'));
+  });
+
   test('two methods', () {
     const code = '''
 class Input1 {


### PR DESCRIPTION
Pigeon's input parser silently ignored the extra syntax in enhanced enums (constructors, fields, methods, or arguments on values), reading only the value names. This produced confusing generated output — as described in the linked issue, the enum's fields were effectively coalesced into the next class — with no indication that the input was unsupported.

This change detects enhanced enums in `visitEnumDeclaration` and reports a clear, source-located error:

```
Pigeon doesn't support enhanced enums ("Enum1"). Use a plain enum without a constructor, fields, methods, or arguments on its values.
```

Implementation notes:

- The enum is still registered by its value names so that classes referencing it don't produce additional cascading "Unknown type" errors — the user sees exactly one actionable message, and recording the error already prevents code generation.
- The visitor no longer walks the enhanced enum's body. Its class-like members aren't expected outside of a class by the rest of the visitor; in particular, a getter inside an enum previously crashed the parser on a null parameter list (`visitMethodDeclaration`'s `node.parameters!`). One of the new tests covers this case.
- Plain enums (including the legal trailing-semicolon form `enum E { a, b; }`) are unaffected; a test guards against false positives.

The scope follows the approach discussed and agreed in the issue thread (silent failure → clear error; no attempt to actually support enhanced enums).

Fixes https://github.com/flutter/flutter/issues/160827

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

Four new tests in `pigeon_lib_test.dart`: enhanced enum with constructor+fields, enhanced enum with only arguments on values, enhanced enum with a getter (the previous parser-crash case), and a plain enum with a trailing semicolon (false-positive guard). The full `pigeon_lib_test.dart` suite (113 tests) and `version_test.dart` pass locally.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests