### PR TITLE
[ci] Allow mustache_template deps

### DIFF
--- a/.repo_tool_config.yaml
+++ b/.repo_tool_config.yaml
@@ -50,6 +50,9 @@ allowed_dependencies:
 
     ## Allowed by default:
 
+    # flutter/core-packages
+    - mustache_template
+
     # Dart-team-owned packages
     - analyzer
     - args


### PR DESCRIPTION
`mustache_template` was moved to flutter/core-packages, but I didn't realize that `google_fonts` uses it in its generator. Now that it's not in-repo, that requires an explicit allowance so that pubspec validation passes.