### PR TITLE
[material_ui, cupertino_ui] Add a main example for the Pub Example tab

### DIFF
--- a/packages/cupertino_ui/CHANGELOG.md
+++ b/packages/cupertino_ui/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Adds an example application demonstrating the package, shown on the pub.dev "Example" tab.
 
 ## 0.0.1
 

--- a/packages/cupertino_ui/example/README.md
+++ b/packages/cupertino_ui/example/README.md
@@ -1,6 +1,12 @@
 # cupertino_ui API Example Code
-This directory contains the example code that is referenced in the documentation
-in cupertino_ui's source code.
+
+[`lib/main.dart`](lib/main.dart) is a small showcase app that demonstrates
+`cupertino_ui`'s theming and a selection of commonly used components. It is the
+example shown on the package's [pub.dev](https://pub.dev) **Example** tab, and
+can be run from this directory with `flutter run`.
+
+The rest of this directory contains the API documentation code samples that are
+referenced from the documentation in cupertino_ui's source code.
 
 These examples were originally located [in
 flutter/flutter](https://github.com/flutter/flutter/tree/master/examples/api)

--- a/packages/cupertino_ui/example/lib/main.dart
+++ b/packages/cupertino_ui/example/lib/main.dart
@@ -1,0 +1,201 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cupertino_ui/cupertino_ui.dart';
+
+void main() {
+  runApp(const CupertinoExampleApp());
+}
+
+/// A small showcase app for the cupertino_ui package.
+class CupertinoExampleApp extends StatefulWidget {
+  const CupertinoExampleApp({super.key});
+
+  @override
+  State<CupertinoExampleApp> createState() => _CupertinoExampleAppState();
+}
+
+class _CupertinoExampleAppState extends State<CupertinoExampleApp> {
+  // A null brightness follows the system setting.
+  Brightness? _brightness;
+
+  void _setBrightness(Brightness? brightness) {
+    setState(() {
+      _brightness = brightness;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: 'cupertino_ui example',
+      debugShowCheckedModeBanner: false,
+      theme: CupertinoThemeData(brightness: _brightness),
+      home: _HomeScreen(
+        brightness: _brightness,
+        onBrightnessChanged: _setBrightness,
+      ),
+    );
+  }
+}
+
+class _HomeScreen extends StatefulWidget {
+  const _HomeScreen({
+    required this.brightness,
+    required this.onBrightnessChanged,
+  });
+
+  final Brightness? brightness;
+  final ValueChanged<Brightness?> onBrightnessChanged;
+
+  @override
+  State<_HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<_HomeScreen> {
+  bool _notificationsEnabled = true;
+  double _volume = 0.5;
+  final TextEditingController _nameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _showInfoDialog() {
+    return showCupertinoDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return CupertinoAlertDialog(
+          title: const Text('cupertino_ui'),
+          content: const Text(
+            'The official Cupertino widget library for Flutter, as a '
+            'standalone package.',
+          ),
+          actions: <Widget>[
+            CupertinoDialogAction(
+              isDefaultAction: true,
+              onPressed: () => Navigator.pop(context),
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: const CupertinoNavigationBar(middle: Text('cupertino_ui')),
+      child: SafeArea(
+        child: ListView(
+          children: <Widget>[
+            CupertinoListSection.insetGrouped(
+              header: const Text('Appearance'),
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 6,
+                  ),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: CupertinoSlidingSegmentedControl<int>(
+                      groupValue: _brightnessToSegment(widget.brightness),
+                      onValueChanged: (int? value) {
+                        if (value != null) {
+                          widget.onBrightnessChanged(
+                            _segmentToBrightness(value),
+                          );
+                        }
+                      },
+                      children: const <int, Widget>{
+                        0: _SegmentLabel('Auto'),
+                        1: _SegmentLabel('Light'),
+                        2: _SegmentLabel('Dark'),
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            CupertinoListSection.insetGrouped(
+              header: const Text('Controls'),
+              hasLeading: false,
+              children: <Widget>[
+                CupertinoListTile(
+                  title: const Text('Notifications'),
+                  trailing: CupertinoSwitch(
+                    value: _notificationsEnabled,
+                    onChanged: (bool value) {
+                      setState(() => _notificationsEnabled = value);
+                    },
+                  ),
+                ),
+                CupertinoListTile(
+                  title: const Text('Volume'),
+                  subtitle: CupertinoSlider(
+                    value: _volume,
+                    onChanged: (double value) {
+                      setState(() => _volume = value);
+                    },
+                  ),
+                ),
+              ],
+            ),
+            CupertinoListSection.insetGrouped(
+              header: const Text('Profile'),
+              children: <Widget>[
+                CupertinoTextField.borderless(
+                  controller: _nameController,
+                  placeholder: 'Name',
+                  padding: const EdgeInsets.all(16),
+                ),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: CupertinoButton.filled(
+                onPressed: _showInfoDialog,
+                child: const Text('About this package'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static int _brightnessToSegment(Brightness? brightness) {
+    return switch (brightness) {
+      null => 0,
+      Brightness.light => 1,
+      Brightness.dark => 2,
+    };
+  }
+
+  static Brightness? _segmentToBrightness(int segment) {
+    return switch (segment) {
+      1 => Brightness.light,
+      2 => Brightness.dark,
+      _ => null,
+    };
+  }
+}
+
+class _SegmentLabel extends StatelessWidget {
+  const _SegmentLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Text(text),
+    );
+  }
+}

--- a/packages/cupertino_ui/example/test/main_test.dart
+++ b/packages/cupertino_ui/example/test/main_test.dart
@@ -1,0 +1,62 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:cupertino_ui_examples/main.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders the showcase components', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.CupertinoExampleApp());
+
+    expect(find.byType(CupertinoListSection), findsNWidgets(3));
+    expect(find.byType(CupertinoSlidingSegmentedControl<int>), findsOneWidget);
+    expect(find.byType(CupertinoSwitch), findsOneWidget);
+    expect(find.byType(CupertinoSlider), findsOneWidget);
+    expect(find.byType(CupertinoTextField), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('changes brightness via the segmented control', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.CupertinoExampleApp());
+
+    CupertinoApp app = tester.widget(find.byType(CupertinoApp));
+    expect(app.theme?.brightness, isNull);
+
+    await tester.tap(find.text('Dark'));
+    await tester.pumpAndSettle();
+
+    app = tester.widget(find.byType(CupertinoApp));
+    expect(app.theme?.brightness, Brightness.dark);
+  });
+
+  testWidgets('opens and dismisses the info dialog', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.CupertinoExampleApp());
+
+    await tester.tap(find.text('About this package'));
+    await tester.pumpAndSettle();
+    expect(find.byType(CupertinoAlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.byType(CupertinoAlertDialog), findsNothing);
+  });
+
+  testWidgets('toggles the notifications switch', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.CupertinoExampleApp());
+
+    CupertinoSwitch toggle = tester.widget(find.byType(CupertinoSwitch));
+    expect(toggle.value, isTrue);
+
+    await tester.tap(find.byType(CupertinoSwitch));
+    await tester.pumpAndSettle();
+
+    toggle = tester.widget(find.byType(CupertinoSwitch));
+    expect(toggle.value, isFalse);
+  });
+}

--- a/packages/material_ui/CHANGELOG.md
+++ b/packages/material_ui/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Adds an example application demonstrating the package, shown on the pub.dev "Example" tab.
 
 ## 0.0.1
 

--- a/packages/material_ui/example/README.md
+++ b/packages/material_ui/example/README.md
@@ -1,6 +1,12 @@
 # material_ui API Example Code
-This directory contains the example code that is referenced in the documentation
-in material_ui's source code.
+
+[`lib/main.dart`](lib/main.dart) is a small showcase app that demonstrates
+`material_ui`'s theming and a selection of commonly used components. It is the
+example shown on the package's [pub.dev](https://pub.dev) **Example** tab, and
+can be run from this directory with `flutter run`.
+
+The rest of this directory contains the API documentation code samples that are
+referenced from the documentation in material_ui's source code.
 
 These examples were originally located [in
 flutter/flutter](https://github.com/flutter/flutter/tree/master/examples/api)

--- a/packages/material_ui/example/lib/main.dart
+++ b/packages/material_ui/example/lib/main.dart
@@ -1,0 +1,180 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:material_ui/material_ui.dart';
+
+void main() {
+  runApp(const MaterialExampleApp());
+}
+
+/// A small showcase app for the material_ui package.
+class MaterialExampleApp extends StatefulWidget {
+  const MaterialExampleApp({super.key});
+
+  @override
+  State<MaterialExampleApp> createState() => _MaterialExampleAppState();
+}
+
+class _MaterialExampleAppState extends State<MaterialExampleApp> {
+  ThemeMode _themeMode = ThemeMode.system;
+
+  void _setThemeMode(ThemeMode mode) {
+    setState(() {
+      _themeMode = mode;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'material_ui example',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+      ),
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.indigo,
+          brightness: Brightness.dark,
+        ),
+      ),
+      themeMode: _themeMode,
+      home: _HomeScreen(
+        themeMode: _themeMode,
+        onThemeModeChanged: _setThemeMode,
+      ),
+    );
+  }
+}
+
+class _HomeScreen extends StatefulWidget {
+  const _HomeScreen({
+    required this.themeMode,
+    required this.onThemeModeChanged,
+  });
+
+  final ThemeMode themeMode;
+  final ValueChanged<ThemeMode> onThemeModeChanged;
+
+  @override
+  State<_HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<_HomeScreen> {
+  int _counter = 0;
+  bool _notificationsEnabled = true;
+  double _volume = 0.5;
+  final Set<String> _selectedTopics = <String>{'Flutter'};
+
+  static const List<String> _topics = <String>['Flutter', 'Material', 'Dart'];
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextStyle? sectionStyle = theme.textTheme.titleMedium;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('material_ui')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: <Widget>[
+          Text('Appearance', style: sectionStyle),
+          const SizedBox(height: 8),
+          SegmentedButton<ThemeMode>(
+            segments: const <ButtonSegment<ThemeMode>>[
+              ButtonSegment<ThemeMode>(
+                value: ThemeMode.system,
+                label: Text('System'),
+                icon: Icon(Icons.brightness_auto),
+              ),
+              ButtonSegment<ThemeMode>(
+                value: ThemeMode.light,
+                label: Text('Light'),
+                icon: Icon(Icons.light_mode),
+              ),
+              ButtonSegment<ThemeMode>(
+                value: ThemeMode.dark,
+                label: Text('Dark'),
+                icon: Icon(Icons.dark_mode),
+              ),
+            ],
+            selected: <ThemeMode>{widget.themeMode},
+            onSelectionChanged: (Set<ThemeMode> selection) {
+              widget.onThemeModeChanged(selection.first);
+            },
+          ),
+          const SizedBox(height: 24),
+          Text('Buttons', style: sectionStyle),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: <Widget>[
+              FilledButton(onPressed: () {}, child: const Text('Filled')),
+              ElevatedButton(onPressed: () {}, child: const Text('Elevated')),
+              OutlinedButton(onPressed: () {}, child: const Text('Outlined')),
+              TextButton(onPressed: () {}, child: const Text('Text')),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Text('Topics', style: sectionStyle),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            children: <Widget>[
+              for (final String topic in _topics)
+                FilterChip(
+                  label: Text(topic),
+                  selected: _selectedTopics.contains(topic),
+                  onSelected: (bool selected) {
+                    setState(() {
+                      if (selected) {
+                        _selectedTopics.add(topic);
+                      } else {
+                        _selectedTopics.remove(topic);
+                      }
+                    });
+                  },
+                ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Card(
+            clipBehavior: Clip.antiAlias,
+            child: Column(
+              children: <Widget>[
+                SwitchListTile(
+                  title: const Text('Enable notifications'),
+                  value: _notificationsEnabled,
+                  onChanged: (bool value) {
+                    setState(() => _notificationsEnabled = value);
+                  },
+                ),
+                const Divider(height: 1),
+                ListTile(
+                  title: const Text('Volume'),
+                  subtitle: Slider(
+                    value: _volume,
+                    onChanged: (double value) {
+                      setState(() => _volume = value);
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: Text('Button tapped $_counter times', style: sectionStyle),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => setState(() => _counter++),
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/packages/material_ui/example/test/main_test.dart
+++ b/packages/material_ui/example/test/main_test.dart
@@ -1,0 +1,75 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/main.dart' as example;
+
+void main() {
+  testWidgets('renders the showcase components', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.MaterialExampleApp());
+
+    expect(find.byType(SegmentedButton<ThemeMode>), findsOneWidget);
+    expect(find.byType(FilledButton), findsOneWidget);
+    expect(find.byType(FilterChip), findsNWidgets(3));
+    expect(find.byType(Card), findsOneWidget);
+    expect(find.byType(Slider), findsOneWidget);
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('increments the counter when the FAB is tapped', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.MaterialExampleApp());
+    expect(find.text('Button tapped 0 times'), findsOneWidget);
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+
+    expect(find.text('Button tapped 1 times'), findsOneWidget);
+  });
+
+  testWidgets('changes theme mode via the segmented button', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.MaterialExampleApp());
+
+    MaterialApp app = tester.widget(find.byType(MaterialApp));
+    expect(app.themeMode, ThemeMode.system);
+
+    await tester.tap(find.text('Dark'));
+    await tester.pumpAndSettle();
+
+    app = tester.widget(find.byType(MaterialApp));
+    expect(app.themeMode, ThemeMode.dark);
+  });
+
+  testWidgets('toggles the notifications switch', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.MaterialExampleApp());
+
+    SwitchListTile tile = tester.widget(find.byType(SwitchListTile));
+    expect(tile.value, isTrue);
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+
+    tile = tester.widget(find.byType(SwitchListTile));
+    expect(tile.value, isFalse);
+  });
+
+  testWidgets('toggles a filter chip selection', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.MaterialExampleApp());
+
+    // The 'Flutter' topic starts selected; tapping it clears the selection.
+    FilterChip chip = tester.widget(find.widgetWithText(FilterChip, 'Flutter'));
+    expect(chip.selected, isTrue);
+
+    await tester.tap(find.text('Flutter'));
+    await tester.pumpAndSettle();
+
+    chip = tester.widget(find.widgetWithText(FilterChip, 'Flutter'));
+    expect(chip.selected, isFalse);
+  });
+}


### PR DESCRIPTION
## What and why

pub.dev shows a single file on each package's **Example** tab. It picks the first match
in pub's search order, where `example/lib/main.dart` ranks above `example/README.md`. Neither
`material_ui` nor `cupertino_ui` currently has one, so the tab has nothing representative
to show.

This adds `example/lib/main.dart` to each package: a single, self-contained screen that
demonstrates the package's theming (light / dark / system) and a handful of commonly used
components. Each imports **only** its own barrel
(`package:material_ui/material_ui.dart` / `package:cupertino_ui/cupertino_ui.dart`),
consistent with the decoupling effort. The existing per-widget API samples under
`example/lib/<widget>/` are left untouched. They remain the "many extras," analogous to
`signals_flutter`'s `example/lib/examples/`.

- **material_ui:** a `SegmentedButton` theme switcher, Filled/Elevated/Outlined/Text
  buttons, `FilterChip`s, a `Card` with a `SwitchListTile` + `Slider`, and a counter
  `FloatingActionButton`.
- **cupertino_ui:** inset-grouped `CupertinoListSection`s with a brightness
  `CupertinoSlidingSegmentedControl` (Auto/Light/Dark), `CupertinoSwitch`,
  `CupertinoSlider`, `CupertinoTextField`, and a `CupertinoButton.filled` that opens a
  `CupertinoAlertDialog`.

A widget test is added for each example, and the example `README.md` + `CHANGELOG.md` are
updated.

Fixes flutter/flutter#187942

## Verification

- `flutter_plugin_tools` `format`, `analyze` (`--fatal-infos`), `validate`, and
  `license-check` all pass; `publish-check` correctly skips both packages
  (`publish_to: none`).
- New example widget tests pass, and the full example suites still pass
  (material_ui 367, cupertino_ui 75).
- Ran each example on the **iOS Simulator** (iPhone 16e, iOS 26) and the **Android
  emulator** (API 36); both render correctly with the expected initial state on both
  platforms. (Screenshots below.)

## Screenshots

Each example running on the iOS Simulator and Android emulator, with the expected
initial state:

| | iOS (iPhone 16e) | Android (API 36) |
|---|---|---|
| **material_ui** | <img src="https://raw.githubusercontent.com/0xharkirat/packages/pr-187942-assets/screenshots/material_ui_ios.png" width="230"> | <img src="https://raw.githubusercontent.com/0xharkirat/packages/pr-187942-assets/screenshots/material_ui_android.png" width="230"> |
| **cupertino_ui** | <img src="https://raw.githubusercontent.com/0xharkirat/packages/pr-187942-assets/screenshots/cupertino_ui_ios.png" width="230"> | <img src="https://raw.githubusercontent.com/0xharkirat/packages/pr-187942-assets/screenshots/cupertino_ui_android.png" width="230"> |

## Notes for reviewers

- I kept each `main.dart` to a **single focused screen** rather than a full gallery,
  mirroring `signals_flutter`'s minimal main example, and left richer demos to the
  existing per-widget samples. **I'm very happy to make it more minimal (fewer widgets /
  less code), or conversely to grow it into a richer multi-screen gallery, whichever the
  team prefers.** Just let me know the preferred direction.
- No version bump: both packages are `publish_to: none`, so I appended a bullet to the
  existing unreleased `## NEXT` CHANGELOG section rather than bumping the version.
- Example tests are intentionally lean per the example `README` guidance ("take care not
  to complicate the example strictly for the purpose of testing").

_Prepared with AI assistance (Claude Code); I reviewed, ran, and verified every change
(including an independent cross-model review) before opening this PR._

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style] (both packages are `publish_to: none`; appended to the existing `## NEXT` section).
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
