### PR TITLE
[go_router] Fix predictive back popping inactive StatefulShellBranch routes

### DIFF
--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -279,9 +279,9 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
             ShellRouteMatch match,
             RouteMatchList matchList,
             List<NavigatorObserver>? observers,
-            String? restorationScopeId,
+            String? restorationScopeId, {
             ValueListenable<bool>? navigatorActive,
-          ) {
+          }) {
             return PopScope(
               // Prevent ShellRoute from being popped, for example
               // by an iOS back gesture, when the route has active sub-routes.

--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'configuration.dart';
@@ -135,6 +136,7 @@ class _CustomNavigator extends StatefulWidget {
     required this.errorBuilder,
     required this.errorPageBuilder,
     required this.requestFocus,
+    this.navigatorActive,
   });
 
   final GlobalKey<NavigatorState> navigatorKey;
@@ -153,6 +155,7 @@ class _CustomNavigator extends StatefulWidget {
   final GoRouterWidgetBuilder? errorBuilder;
   final GoRouterPageBuilder? errorPageBuilder;
   final bool requestFocus;
+  final ValueListenable<bool>? navigatorActive;
 
   @override
   State<StatefulWidget> createState() => _CustomNavigatorState();
@@ -277,6 +280,7 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
             RouteMatchList matchList,
             List<NavigatorObserver>? observers,
             String? restorationScopeId,
+            ValueListenable<bool>? navigatorActive,
           ) {
             return PopScope(
               // Prevent ShellRoute from being popped, for example
@@ -294,6 +298,7 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
                 configuration: widget.configuration,
                 observers: observers ?? const <NavigatorObserver>[],
                 onPopPageWithRouteMatch: widget.onPopPageWithRouteMatch,
+                navigatorActive: navigatorActive,
                 // This is used to recursively build pages under this shell route.
                 errorBuilder: widget.errorBuilder,
                 errorPageBuilder: widget.errorPageBuilder,
@@ -368,12 +373,15 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
   Page<Object?> _buildPlatformAdapterPage(BuildContext context, GoRouterState state, Widget child) {
     // build the page based on app type
     _cacheAppType(context);
+    final Widget pageChild = widget.navigatorActive == null
+        ? child
+        : _BranchNavigatorPopScope(navigatorActive: widget.navigatorActive!, child: child);
     return _pageBuilderForAppType!(
       key: state.pageKey,
       name: state.name ?? state.path,
       arguments: <String, String>{...state.pathParameters, ...state.uri.queryParameters},
       restorationId: state.pageKey.value,
-      child: child,
+      child: pageChild,
     );
   }
 
@@ -438,6 +446,24 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
           onPopPage: _handlePopPage,
         ),
       ),
+    );
+  }
+}
+
+class _BranchNavigatorPopScope extends StatelessWidget {
+  const _BranchNavigatorPopScope({required this.navigatorActive, required this.child});
+
+  final ValueListenable<bool> navigatorActive;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: navigatorActive,
+      child: child,
+      builder: (BuildContext context, bool isActive, Widget? child) {
+        return PopScope<Object?>(canPop: isActive, child: child!);
+      },
     );
   }
 }

--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -166,6 +166,15 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
   late Map<Page<Object?>, RouteMatchBase> _pageToRouteMatchBase;
   final GoRouterStateRegistry _registry = GoRouterStateRegistry();
   List<Page<Object?>>? _pages;
+  late final _BranchNavigatorPopScopeObserver? _branchNavigatorPopScopeObserver;
+
+  @override
+  void initState() {
+    super.initState();
+    _branchNavigatorPopScopeObserver = widget.navigatorActive == null
+        ? null
+        : _BranchNavigatorPopScopeObserver(widget.navigatorActive!);
+  }
 
   @override
   void didUpdateWidget(_CustomNavigator oldWidget) {
@@ -195,6 +204,7 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
 
   @override
   void dispose() {
+    _branchNavigatorPopScopeObserver?.dispose();
     _controller?.dispose();
     _registry.dispose();
     super.dispose();
@@ -373,15 +383,12 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
   Page<Object?> _buildPlatformAdapterPage(BuildContext context, GoRouterState state, Widget child) {
     // build the page based on app type
     _cacheAppType(context);
-    final Widget pageChild = widget.navigatorActive == null
-        ? child
-        : _BranchNavigatorPopScope(navigatorActive: widget.navigatorActive!, child: child);
     return _pageBuilderForAppType!(
       key: state.pageKey,
       name: state.name ?? state.path,
       arguments: <String, String>{...state.pathParameters, ...state.uri.queryParameters},
       restorationId: state.pageKey.value,
-      child: pageChild,
+      child: child,
     );
   }
 
@@ -442,7 +449,9 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
           requestFocus: widget.requestFocus,
           restorationScopeId: widget.navigatorRestorationId,
           pages: _pages!,
-          observers: widget.observers,
+          observers: _branchNavigatorPopScopeObserver == null
+              ? widget.observers
+              : <NavigatorObserver>[...widget.observers, _branchNavigatorPopScopeObserver],
           onPopPage: _handlePopPage,
         ),
       ),
@@ -450,20 +459,30 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
   }
 }
 
-class _BranchNavigatorPopScope extends StatelessWidget {
-  const _BranchNavigatorPopScope({required this.navigatorActive, required this.child});
+class _BranchNavigatorPopScopeObserver extends NavigatorObserver implements PopEntry<Object?> {
+  _BranchNavigatorPopScopeObserver(this.navigatorActive);
 
   final ValueListenable<bool> navigatorActive;
-  final Widget child;
+  ModalRoute<Object?>? _route;
 
   @override
-  Widget build(BuildContext context) {
-    return ValueListenableBuilder<bool>(
-      valueListenable: navigatorActive,
-      child: child,
-      builder: (BuildContext context, bool isActive, Widget? child) {
-        return PopScope<Object?>(canPop: isActive, child: child!);
-      },
-    );
+  ValueListenable<bool> get canPopNotifier => navigatorActive;
+
+  @override
+  void onPopInvoked(bool didPop) {}
+
+  @override
+  void onPopInvokedWithResult(bool didPop, Object? result) {}
+
+  @override
+  void didChangeTop(Route<dynamic> topRoute, Route<dynamic>? previousTopRoute) {
+    _route?.unregisterPopEntry(this);
+    _route = topRoute is ModalRoute<Object?> ? topRoute : null;
+    _route?.registerPopEntry(this);
+  }
+
+  void dispose() {
+    _route?.unregisterPopEntry(this);
+    _route = null;
   }
 }

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -55,6 +55,7 @@ typedef NavigatorBuilder =
       RouteMatchList matchList,
       List<NavigatorObserver>? observers,
       String? restorationScopeId,
+      ValueListenable<bool>? navigatorActive,
     );
 
 /// Signature for function used in [RouteBase.onExit].
@@ -567,6 +568,7 @@ class ShellRouteContext {
     List<NavigatorObserver>? observers,
     bool notifyRootObserver,
     String? restorationScopeId,
+    ValueListenable<bool>? navigatorActive,
   ) {
     final effectiveObservers = <NavigatorObserver>[...?observers];
 
@@ -583,6 +585,7 @@ class ShellRouteContext {
       routeMatchList,
       effectiveObservers,
       restorationScopeId,
+      navigatorActive,
     );
   }
 }
@@ -731,6 +734,7 @@ class ShellRoute extends ShellRouteBase {
         observers,
         notifyRootObserver,
         restorationScopeId,
+        null,
       );
       return builder!(context, state, navigator);
     }
@@ -749,6 +753,7 @@ class ShellRoute extends ShellRouteBase {
         observers,
         notifyRootObserver,
         restorationScopeId,
+        null,
       );
       return pageBuilder!(context, state, navigator);
     }
@@ -1375,10 +1380,19 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
         branch.observers,
         route.notifyRootObserver,
         branch.restorationScopeId,
+        branchState.navigatorActive,
       );
     }
+    _updateActiveBranchNavigatorFlags();
 
     _cleanUpObsoleteBranches();
+  }
+
+  void _updateActiveBranchNavigatorFlags() {
+    for (var i = 0; i < route.branches.length; i++) {
+      final _StatefulShellBranchState? branchState = _branchState[route.branches[i]];
+      branchState?.navigatorActive.value = i == currentIndex;
+    }
   }
 
   void _preloadBranches() {
@@ -1398,15 +1412,17 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
         });
         assert(match != null);
 
+        final _StatefulShellBranchState branchState = _branchStateFor(branch, false);
+        branchState.navigatorActive.value = false;
         final Widget navigator = widget.shellRouteContext.navigatorBuilder(
           branch.navigatorKey,
           match!,
           matchList,
           branch.observers,
           branch.restorationScopeId,
+          branchState.navigatorActive,
         );
 
-        final _StatefulShellBranchState branchState = _branchStateFor(branch, false);
         branchState.location.value = matchList;
         branchState.navigator = navigator;
       }
@@ -1491,9 +1507,11 @@ class _StatefulShellBranchState {
 
   Widget? navigator;
   final _RestorableRouteMatchList location;
+  final ValueNotifier<bool> navigatorActive = ValueNotifier<bool>(false);
 
   void dispose() {
     location.dispose();
+    navigatorActive.dispose();
   }
 }
 

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -54,9 +54,9 @@ typedef NavigatorBuilder =
       ShellRouteMatch match,
       RouteMatchList matchList,
       List<NavigatorObserver>? observers,
-      String? restorationScopeId,
+      String? restorationScopeId, {
       ValueListenable<bool>? navigatorActive,
-    );
+    });
 
 /// Signature for function used in [RouteBase.onExit].
 ///
@@ -567,9 +567,9 @@ class ShellRouteContext {
     BuildContext context,
     List<NavigatorObserver>? observers,
     bool notifyRootObserver,
-    String? restorationScopeId,
+    String? restorationScopeId, {
     ValueListenable<bool>? navigatorActive,
-  ) {
+  }) {
     final effectiveObservers = <NavigatorObserver>[...?observers];
 
     if (notifyRootObserver) {
@@ -585,7 +585,7 @@ class ShellRouteContext {
       routeMatchList,
       effectiveObservers,
       restorationScopeId,
-      navigatorActive,
+      navigatorActive: navigatorActive,
     );
   }
 }
@@ -734,7 +734,6 @@ class ShellRoute extends ShellRouteBase {
         observers,
         notifyRootObserver,
         restorationScopeId,
-        null,
       );
       return builder!(context, state, navigator);
     }
@@ -753,7 +752,6 @@ class ShellRoute extends ShellRouteBase {
         observers,
         notifyRootObserver,
         restorationScopeId,
-        null,
       );
       return pageBuilder!(context, state, navigator);
     }
@@ -1380,7 +1378,7 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
         branch.observers,
         route.notifyRootObserver,
         branch.restorationScopeId,
-        branchState.navigatorActive,
+        navigatorActive: branchState.navigatorActive,
       );
     }
     _updateActiveBranchNavigatorFlags();
@@ -1420,7 +1418,7 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
           matchList,
           branch.observers,
           branch.restorationScopeId,
-          branchState.navigatorActive,
+          navigatorActive: branchState.navigatorActive,
         );
 
         branchState.location.value = matchList;

--- a/packages/go_router/pending_changelogs/change_2026_06_16_1781632636645.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_06_16_1781632636645.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes Android system/predictive back popping inactive StatefulShellBranch navigators.
+version: patch

--- a/packages/go_router/test/stateful_shell_route_system_back_test.dart
+++ b/packages/go_router/test/stateful_shell_route_system_back_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
@@ -86,6 +87,93 @@ void main() {
       await simulateAndroidBackButton(tester);
       await tester.pumpAndSettle();
       expect(find.text('Home'), findsOneWidget);
+    });
+
+    testWidgets('does not pop inactive StatefulShellRoute branches', (WidgetTester tester) async {
+      final List<String> pops = <String>[];
+      StatefulNavigationShell? navigationShell;
+      addTearDown(() async {
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+      });
+
+      final GoRouter router = await createRouter(
+        <RouteBase>[
+          StatefulShellRoute.indexedStack(
+            builder: (BuildContext context, GoRouterState state, StatefulNavigationShell shell) {
+              navigationShell = shell;
+              return shell;
+            },
+            branches: <StatefulShellBranch>[
+              StatefulShellBranch(
+                observers: <NavigatorObserver>[_RecordingNavigatorObserver('/A', pops)],
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/A1',
+                    builder: (_, _) => const _BranchScreen(title: 'Stack A - 1', canPop: false),
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: '/A2',
+                        builder: (_, _) => const _BranchScreen(title: 'Stack A - 2'),
+                        routes: <RouteBase>[
+                          GoRoute(
+                            path: '/A3',
+                            builder: (_, _) => const _BranchScreen(title: 'Stack A - 3'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                observers: <NavigatorObserver>[_RecordingNavigatorObserver('/B', pops)],
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/B1',
+                    builder: (_, _) => const _BranchScreen(title: 'Stack B - 1', canPop: false),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                observers: <NavigatorObserver>[_RecordingNavigatorObserver('/C', pops)],
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/C1',
+                    builder: (_, _) => const _BranchScreen(title: 'Stack C - 1', canPop: false),
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: '/C2',
+                        builder: (_, _) => const _BranchScreen(title: 'Stack C - 2'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+        tester,
+        initialLocation: '/A1',
+      );
+
+      router.go('/A1/A2/A3');
+      await tester.pumpAndSettle();
+      expect(find.text('Stack A - 3'), findsOneWidget);
+
+      router.go('/C1/C2');
+      await tester.pumpAndSettle();
+      expect(find.text('Stack C - 2'), findsOneWidget);
+
+      navigationShell!.goBranch(1);
+      await tester.pumpAndSettle();
+      expect(find.text('Stack B - 1'), findsOneWidget);
+
+      await simulateAndroidPredictiveBackGesture(tester);
+      await tester.pump();
+
+      expect(find.text('Stack B - 1'), findsOneWidget);
+      expect(pops, isEmpty);
     });
   });
 }
@@ -171,4 +259,65 @@ class _TestAppState extends State<_TestApp> {
   Widget build(BuildContext context) {
     return MaterialApp.router(routerConfig: _router);
   }
+}
+
+class _BranchScreen extends StatelessWidget {
+  const _BranchScreen({required this.title, this.canPop = true});
+
+  final String title;
+  final bool canPop;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope<Object?>(
+      canPop: canPop,
+      child: Scaffold(body: Center(child: Text(title))),
+    );
+  }
+}
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  _RecordingNavigatorObserver(this.branch, this.pops);
+
+  final String branch;
+  final List<String> pops;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pops.add('$branch ${route.settings.name} -> ${previousRoute?.settings.name}');
+  }
+}
+
+Future<void> simulateAndroidPredictiveBackGesture(WidgetTester tester) async {
+  await _handleAndroidPredictiveBackMessage(
+    tester,
+    const MethodCall('startBackGesture', <String, dynamic>{
+      'touchOffset': <double>[5.0, 300.0],
+      'progress': 0.0,
+      'swipeEdge': 0,
+    }),
+  );
+  await tester.pump();
+
+  await _handleAndroidPredictiveBackMessage(
+    tester,
+    const MethodCall('updateBackGestureProgress', <String, dynamic>{
+      'x': 100.0,
+      'y': 300.0,
+      'progress': 0.35,
+      'swipeEdge': 0,
+    }),
+  );
+  await tester.pump();
+
+  await _handleAndroidPredictiveBackMessage(tester, const MethodCall('commitBackGesture'));
+}
+
+Future<void> _handleAndroidPredictiveBackMessage(WidgetTester tester, MethodCall methodCall) async {
+  final ByteData message = const StandardMethodCodec().encodeMethodCall(methodCall);
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    'flutter/backgesture',
+    message,
+    (ByteData? _) {},
+  );
 }

--- a/packages/go_router/test/stateful_shell_route_system_back_test.dart
+++ b/packages/go_router/test/stateful_shell_route_system_back_test.dart
@@ -90,7 +90,7 @@ void main() {
     });
 
     testWidgets('does not pop inactive StatefulShellRoute branches', (WidgetTester tester) async {
-      final List<String> pops = <String>[];
+      final pops = <String>[];
       StatefulNavigationShell? navigationShell;
       addTearDown(() async {
         await tester.pumpWidget(const SizedBox.shrink());

--- a/packages/go_router/test/stateful_shell_route_system_back_test.dart
+++ b/packages/go_router/test/stateful_shell_route_system_back_test.dart
@@ -89,92 +89,104 @@ void main() {
       expect(find.text('Home'), findsOneWidget);
     });
 
-    testWidgets('does not pop inactive StatefulShellRoute branches', (WidgetTester tester) async {
-      final pops = <String>[];
-      StatefulNavigationShell? navigationShell;
-      addTearDown(() async {
-        await tester.pumpWidget(const SizedBox.shrink());
+    for (final usePageBuilder in <bool>[false, true]) {
+      testWidgets('does not pop inactive StatefulShellRoute branches with '
+          '${usePageBuilder ? 'pageBuilder' : 'builder'}', (WidgetTester tester) async {
+        final pops = <String>[];
+        StatefulNavigationShell? navigationShell;
+        addTearDown(() async {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+        });
+
+        final GoRouter router = await createRouter(
+          <RouteBase>[
+            StatefulShellRoute.indexedStack(
+              builder: (BuildContext context, GoRouterState state, StatefulNavigationShell shell) {
+                navigationShell = shell;
+                return shell;
+              },
+              branches: <StatefulShellBranch>[
+                StatefulShellBranch(
+                  observers: <NavigatorObserver>[_RecordingNavigatorObserver('/A', pops)],
+                  routes: <RouteBase>[
+                    _buildBranchRoute(
+                      path: '/A1',
+                      title: 'Stack A - 1',
+                      canPop: false,
+                      usePageBuilder: usePageBuilder,
+                      routes: <RouteBase>[
+                        _buildBranchRoute(
+                          path: '/A2',
+                          title: 'Stack A - 2',
+                          usePageBuilder: usePageBuilder,
+                          routes: <RouteBase>[
+                            _buildBranchRoute(
+                              path: '/A3',
+                              title: 'Stack A - 3',
+                              usePageBuilder: usePageBuilder,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                StatefulShellBranch(
+                  observers: <NavigatorObserver>[_RecordingNavigatorObserver('/B', pops)],
+                  routes: <RouteBase>[
+                    _buildBranchRoute(
+                      path: '/B1',
+                      title: 'Stack B - 1',
+                      canPop: false,
+                      usePageBuilder: usePageBuilder,
+                    ),
+                  ],
+                ),
+                StatefulShellBranch(
+                  observers: <NavigatorObserver>[_RecordingNavigatorObserver('/C', pops)],
+                  routes: <RouteBase>[
+                    _buildBranchRoute(
+                      path: '/C1',
+                      title: 'Stack C - 1',
+                      canPop: false,
+                      usePageBuilder: usePageBuilder,
+                      routes: <RouteBase>[
+                        _buildBranchRoute(
+                          path: '/C2',
+                          title: 'Stack C - 2',
+                          usePageBuilder: usePageBuilder,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+          tester,
+          initialLocation: '/A1',
+        );
+
+        router.go('/A1/A2/A3');
+        await tester.pumpAndSettle();
+        expect(find.text('Stack A - 3'), findsOneWidget);
+
+        router.go('/C1/C2');
+        await tester.pumpAndSettle();
+        expect(find.text('Stack C - 2'), findsOneWidget);
+
+        navigationShell!.goBranch(1);
+        await tester.pumpAndSettle();
+        expect(find.text('Stack B - 1'), findsOneWidget);
+
+        await simulateAndroidPredictiveBackGesture(tester);
         await tester.pump();
+
+        expect(find.text('Stack B - 1'), findsOneWidget);
+        expect(pops, isEmpty);
       });
-
-      final GoRouter router = await createRouter(
-        <RouteBase>[
-          StatefulShellRoute.indexedStack(
-            builder: (BuildContext context, GoRouterState state, StatefulNavigationShell shell) {
-              navigationShell = shell;
-              return shell;
-            },
-            branches: <StatefulShellBranch>[
-              StatefulShellBranch(
-                observers: <NavigatorObserver>[_RecordingNavigatorObserver('/A', pops)],
-                routes: <RouteBase>[
-                  GoRoute(
-                    path: '/A1',
-                    builder: (_, _) => const _BranchScreen(title: 'Stack A - 1', canPop: false),
-                    routes: <RouteBase>[
-                      GoRoute(
-                        path: '/A2',
-                        builder: (_, _) => const _BranchScreen(title: 'Stack A - 2'),
-                        routes: <RouteBase>[
-                          GoRoute(
-                            path: '/A3',
-                            builder: (_, _) => const _BranchScreen(title: 'Stack A - 3'),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-              StatefulShellBranch(
-                observers: <NavigatorObserver>[_RecordingNavigatorObserver('/B', pops)],
-                routes: <RouteBase>[
-                  GoRoute(
-                    path: '/B1',
-                    builder: (_, _) => const _BranchScreen(title: 'Stack B - 1', canPop: false),
-                  ),
-                ],
-              ),
-              StatefulShellBranch(
-                observers: <NavigatorObserver>[_RecordingNavigatorObserver('/C', pops)],
-                routes: <RouteBase>[
-                  GoRoute(
-                    path: '/C1',
-                    builder: (_, _) => const _BranchScreen(title: 'Stack C - 1', canPop: false),
-                    routes: <RouteBase>[
-                      GoRoute(
-                        path: '/C2',
-                        builder: (_, _) => const _BranchScreen(title: 'Stack C - 2'),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ],
-        tester,
-        initialLocation: '/A1',
-      );
-
-      router.go('/A1/A2/A3');
-      await tester.pumpAndSettle();
-      expect(find.text('Stack A - 3'), findsOneWidget);
-
-      router.go('/C1/C2');
-      await tester.pumpAndSettle();
-      expect(find.text('Stack C - 2'), findsOneWidget);
-
-      navigationShell!.goBranch(1);
-      await tester.pumpAndSettle();
-      expect(find.text('Stack B - 1'), findsOneWidget);
-
-      await simulateAndroidPredictiveBackGesture(tester);
-      await tester.pump();
-
-      expect(find.text('Stack B - 1'), findsOneWidget);
-      expect(pops, isEmpty);
-    });
+    }
   });
 }
 
@@ -274,6 +286,25 @@ class _BranchScreen extends StatelessWidget {
       child: Scaffold(body: Center(child: Text(title))),
     );
   }
+}
+
+GoRoute _buildBranchRoute({
+  required String path,
+  required String title,
+  required bool usePageBuilder,
+  bool canPop = true,
+  List<RouteBase> routes = const <RouteBase>[],
+}) {
+  final Widget child = _BranchScreen(title: title, canPop: canPop);
+  return GoRoute(
+    path: path,
+    builder: usePageBuilder ? null : (_, _) => child,
+    pageBuilder: usePageBuilder
+        ? (_, GoRouterState state) =>
+              MaterialPage<void>(key: state.pageKey, name: path, child: child)
+        : null,
+    routes: routes,
+  );
 }
 
 class _RecordingNavigatorObserver extends NavigatorObserver {


### PR DESCRIPTION
# PR title

[go_router] Fix predictive back popping inactive StatefulShellBranch routes

# PR body

Fixes flutter/flutter#188018

## Description

This fixes Android system/predictive back handling for `StatefulShellRoute.indexedStack`.

Previously, when branch B was active, Android system/predictive back could still pop routes from inactive branch navigators. For example, inactive branch A and C routes could be popped while the active location remained `/B1`.

This change tracks whether a stateful shell branch navigator is active and prevents inactive branch navigators from participating in system/predictive back handling.

A regression test was added to verify that system/predictive back on the active branch does not pop inactive `StatefulShellBranch` navigators.

## Issues fixed

Fixes flutter/flutter#188018

## Tests

Ran from `packages/go_router`:

```text
flutter test test/stateful_shell_route_system_back_test.dart
flutter test test/shell_route_system_back_test.dart
flutter test test/delegate_test.dart
flutter test test/go_router_test.dart
flutter analyze
git diff --check
```

## Notes

No before/after screenshots are included because this is a navigation state/Android system-back behavior fix covered by a regression test.

No public API documentation update is needed because this does not add or change a public API. The behavior is covered by the added regression test.

**Version/CHANGELOG note** : `go_router` uses batched release metadata, so this PR adds a pending changelog entry with `version: patch`.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests