### PR TITLE
[url_launcher_android] Support intent:// URIs in launchUrl and canLaunchUrl

### DIFF
--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## NEXT
+
+* Supports `intent://` URIs in `launchUrl` and `canLaunchUrl` by parsing them
+  with `Intent.parseUri`, preserving the action, data URI, and package encoded
+  in the URI rather than silently replacing the action with `ACTION_VIEW`.
+
 ## 6.3.32
 
 * Bumps the androidx group across 10 directories with 1 update.

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncher.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncher.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
@@ -64,8 +65,17 @@ final class UrlLauncher implements UrlLauncherApi {
 
   @Override
   public boolean canLaunchUrl(@NonNull String url) {
-    Intent launchIntent = new Intent(Intent.ACTION_VIEW);
-    launchIntent.setData(Uri.parse(url));
+    Intent launchIntent;
+    if (url.startsWith("intent://")) {
+      try {
+        launchIntent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+      } catch (URISyntaxException e) {
+        return false;
+      }
+    } else {
+      launchIntent = new Intent(Intent.ACTION_VIEW);
+      launchIntent.setData(Uri.parse(url));
+    }
     String componentName = intentResolver.getHandlerComponentName(launchIntent);
     if (BuildConfig.DEBUG) {
       Log.i(TAG, "component name for " + url + " is " + componentName);
@@ -84,10 +94,19 @@ final class UrlLauncher implements UrlLauncherApi {
     ensureActivity();
     assert activity != null;
 
-    Intent launchIntent =
-        new Intent(Intent.ACTION_VIEW)
-            .setData(Uri.parse(url))
-            .putExtra(Browser.EXTRA_HEADERS, extractBundle(headers));
+    Intent launchIntent;
+    if (url.startsWith("intent://")) {
+      try {
+        launchIntent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+      } catch (URISyntaxException e) {
+        return false;
+      }
+    } else {
+      launchIntent =
+          new Intent(Intent.ACTION_VIEW)
+              .setData(Uri.parse(url))
+              .putExtra(Browser.EXTRA_HEADERS, extractBundle(headers));
+    }
     if (requireNonBrowser && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       launchIntent.addFlags(Intent.FLAG_ACTIVITY_REQUIRE_NON_BROWSER);
     }

--- a/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/UrlLauncherTest.java
+++ b/packages/url_launcher/url_launcher_android/android/src/test/java/io/flutter/plugins/urllauncher/UrlLauncherTest.java
@@ -66,6 +66,35 @@ public class UrlLauncherTest {
     assertFalse(result);
   }
 
+  @Test
+  public void canLaunch_parsesIntentSchemeUri() {
+    UrlLauncher.IntentResolver resolver = mock(UrlLauncher.IntentResolver.class);
+    UrlLauncher api = new UrlLauncher(ApplicationProvider.getApplicationContext(), resolver);
+    String intentUrl =
+        "intent://details?id=com.example.app"
+            + "#Intent;scheme=bazaar;package=com.example.store;"
+            + "action=android.intent.action.EDIT;end";
+    when(resolver.getHandlerComponentName(any())).thenReturn(null);
+
+    api.canLaunchUrl(intentUrl);
+
+    final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+    verify(resolver).getHandlerComponentName(intentCaptor.capture());
+    assertEquals(Intent.ACTION_EDIT, intentCaptor.getValue().getAction());
+    assertEquals(
+        Uri.parse("bazaar://details?id=com.example.app"), intentCaptor.getValue().getData());
+    assertEquals("com.example.store", intentCaptor.getValue().getPackage());
+  }
+
+  @Test
+  public void canLaunch_returnsFalseForMalformedIntentSchemeUri() {
+    UrlLauncher api = new UrlLauncher(ApplicationProvider.getApplicationContext(), intent -> null);
+
+    boolean result = api.canLaunchUrl("intent://[malformed");
+
+    assertFalse(result);
+  }
+
   // Integration testing on emulators won't work as expected without the workaround this tests
   // for, since it will be returned even for intentionally bogus schemes.
   @Test
@@ -145,6 +174,38 @@ public class UrlLauncherTest {
     boolean result = api.launchUrl("https://flutter.dev", new HashMap<>(), false);
 
     assertTrue(result);
+  }
+
+  @Test
+  public void launch_parsesIntentSchemeUri() {
+    Activity activity = mock(Activity.class);
+    UrlLauncher api = new UrlLauncher(ApplicationProvider.getApplicationContext());
+    api.setActivity(activity);
+    String intentUrl =
+        "intent://details?id=com.example.app"
+            + "#Intent;scheme=bazaar;package=com.example.store;"
+            + "action=android.intent.action.EDIT;end";
+    doThrow(new ActivityNotFoundException()).when(activity).startActivity(any());
+
+    api.launchUrl(intentUrl, new HashMap<>(), false);
+
+    final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+    verify(activity).startActivity(intentCaptor.capture());
+    assertEquals(Intent.ACTION_EDIT, intentCaptor.getValue().getAction());
+    assertEquals(
+        Uri.parse("bazaar://details?id=com.example.app"), intentCaptor.getValue().getData());
+    assertEquals("com.example.store", intentCaptor.getValue().getPackage());
+  }
+
+  @Test
+  public void launch_returnsFalseForMalformedIntentSchemeUri() {
+    Activity activity = mock(Activity.class);
+    UrlLauncher api = new UrlLauncher(ApplicationProvider.getApplicationContext());
+    api.setActivity(activity);
+
+    boolean result = api.launchUrl("intent://[malformed", new HashMap<>(), false);
+
+    assertFalse(result);
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes flutter/flutter#188068

`url_launcher_android` always constructs `new Intent(Intent.ACTION_VIEW)` for every URL, silently ignoring the action encoded in `intent://` URIs. This means any call like:

```dart
await launchUrl(
  Uri.parse('intent://details?id=com.example.app'
    '#Intent;scheme=bazaar;package=com.example.store;action=android.intent.action.EDIT;end'),
  mode: LaunchMode.externalApplication,
);
```

…fires `ACTION_VIEW` instead of `ACTION_EDIT`, breaking the intent.

## Fix

Detect `intent://` URLs in both `canLaunchUrl` and `launchUrl` and delegate to `Intent.parseUri(url, Intent.URI_INTENT_SCHEME)`, which is exactly how Android browsers handle this URI scheme. Non-`intent://` URLs take the existing `ACTION_VIEW` path unchanged.

## Tests

Added 4 tests to `UrlLauncherTest`:
- `canLaunch_parsesIntentSchemeUri` — verifies action, data URI, and package are correctly extracted
- `canLaunch_returnsFalseForMalformedIntentSchemeUri` — verifies `URISyntaxException` returns `false`
- `launch_parsesIntentSchemeUri` — same as above for `launchUrl`
- `launch_returnsFalseForMalformedIntentSchemeUri`

## Related issue

flutter/flutter#188068