### PR TITLE
`gen_defaults` should follow new versioning strategy

### DIFF
--- a/packages/material_ui/tool/gen_defaults/templates/template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/template.dart
@@ -8,61 +8,86 @@ import 'package:meta/meta.dart';
 
 enum _MaterialVersion { material3, material3Expressive }
 
-abstract class M3TokenTemplate extends _TokenTemplate {
+/// A template for generating Material 3 component defaults.
+abstract class M3TokenTemplate extends TokenTemplate {
   const M3TokenTemplate();
 
   @override
   _MaterialVersion get _version => _MaterialVersion.material3;
 }
 
-abstract class M3ETokenTemplate extends _TokenTemplate {
+/// A template for generating Material 3 Expressive component defaults.
+abstract class M3ETokenTemplate extends TokenTemplate {
   const M3ETokenTemplate();
 
   @override
   _MaterialVersion get _version => _MaterialVersion.material3Expressive;
 }
 
-abstract class _TokenTemplate {
-  const _TokenTemplate();
+@visibleForTesting
+abstract class TokenTemplate {
+  const TokenTemplate();
 
-  static const String copyrightHeader = '''
+  /// The copyright header prepended to all generated defaults files.
+  static const String _copyrightHeader = '''
 // Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 ''';
 
-  static const String headerComment = '''
+  /// The warning comment prepended to all generated defaults files informing
+  /// readers not to edit them by hand.
+  static const String _headerComment = '''
 
 // Do not edit by hand. The code is generated from data in the Material
 // Design token database by the script:
 //   packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart.
 ''';
 
-  /// The Material version this template is for.
-  _MaterialVersion get _version;
+  /// Returns a regular expression used to verify that the generated contents
+  /// declare a class named [className].
+  static RegExp _classRegExp(String className) => RegExp('class\\s+$className\\b');
 
   /// The name of the template, which corresponds to the target file name.
   /// E.g., 'typography' for generating 'typography_defaults.g.dart'.
   String get name;
 
+  /// The path to the library's directory where generated files are placed.
   @visibleForTesting
   String get materialLib {
     const packagePath = 'packages/material_ui';
     const generatedDirectory = 'lib/src/generated';
-    final String relativeOutputPath = switch (_version) {
-      _MaterialVersion.material3 => generatedDirectory,
-      _MaterialVersion.material3Expressive => '$generatedDirectory/material_3_expressive',
-    };
     if (Directory(packagePath).existsSync()) {
-      return '$packagePath/$relativeOutputPath';
+      return '$packagePath/$generatedDirectory';
     }
-    return relativeOutputPath;
+    return generatedDirectory;
   }
 
-  String generateContents();
+  /// The Material version this template is for.
+  _MaterialVersion get _version;
 
+  /// The name of the class that will be generated (e.g. `_ButtonDefaults` or `_ButtonExpressiveDefaults`).
+  String get _className {
+    assert(name.length > 1);
+    final String capitalizedName = name[0].toUpperCase() + name.substring(1).toLowerCase();
+    return switch (_version) {
+      _MaterialVersion.material3 => '_${capitalizedName}Defaults',
+      _MaterialVersion.material3Expressive => '_${capitalizedName}ExpressiveDefaults',
+    };
+  }
+
+  /// Returns the body of the generated file as a string.
+  ///
+  /// The [className] parameter must be used to declare the class.
+  String generateContents(String className);
+
+  /// Generates the file under the target path [materialLib] and formats it.
   void generateFile({bool verbose = false}) {
-    final fileName = '$materialLib/${name}_defaults.g.dart';
+    final String outputFileName = switch (_version) {
+      _MaterialVersion.material3 => '${name}_defaults.g.dart',
+      _MaterialVersion.material3Expressive => '${name}_expressive_defaults.g.dart',
+    };
+    final fileName = '$materialLib/$outputFileName';
     if (verbose) {
       stdout.writeln('Generating file: $fileName');
       stdout.writeln('Target parent file name: $name.dart');
@@ -80,15 +105,18 @@ abstract class _TokenTemplate {
     if (verbose) {
       stdout.writeln('Generating contents...');
     }
+    final String contents = generateContents(_className);
+    assert(
+      contents.contains(_classRegExp(_className)) || contents.isEmpty,
+      'The generated contents for "$name" must define the class "$_className". '
+      'Make sure you are utilizing the passed `className` parameter.',
+    );
+
     final buffer = StringBuffer();
-    buffer.write(copyrightHeader);
-    buffer.write(headerComment);
-    final String partOfPath = switch (_version) {
-      _MaterialVersion.material3 => '../$parentName',
-      _MaterialVersion.material3Expressive => '../../material_3_expressive/$parentName',
-    };
-    buffer.write("part of '$partOfPath';\n\n");
-    buffer.write(generateContents());
+    buffer.write(_copyrightHeader);
+    buffer.write(_headerComment);
+    buffer.write("part of '../$parentName';\n\n");
+    buffer.write(contents);
 
     if (verbose) {
       stdout.writeln('Writing generated contents to $fileName...');

--- a/packages/material_ui/tool/gen_defaults/templates/template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/template.dart
@@ -44,12 +44,16 @@ abstract class TokenTemplate {
 //   packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart.
 ''';
 
+  /// The regular expression used to verify that a template name is written with
+  /// spaces and capitalized words (e.g., "Icon Button").
+  static final RegExp _classNameRegexp = RegExp(r'^[A-Z][a-zA-Z0-9]*( [A-Z][a-zA-Z0-9]*)*$');
+
   /// Returns a regular expression used to verify that the generated contents
   /// declare a class named [className].
   static RegExp _classRegExp(String className) => RegExp('class\\s+$className\\b');
 
   /// The name of the template, which corresponds to the target file name.
-  /// E.g., 'typography' for generating 'typography_defaults.g.dart'.
+  /// E.g., 'Icon Button' for generating 'icon_button_m3_defaults.g.dart'.
   String get name;
 
   /// The path to the library's directory where generated files are placed.
@@ -66,13 +70,17 @@ abstract class TokenTemplate {
   /// The Material version this template is for.
   _MaterialVersion get _version;
 
-  /// The name of the class that will be generated (e.g. `_ButtonDefaults` or `_ButtonExpressiveDefaults`).
+  /// The name of the class that will be generated (e.g. `_M3IconButtonDefaults`
+  /// or `_M3EIconButtonDefaults`).
   String get _className {
-    assert(name.length > 1);
-    final String capitalizedName = name[0].toUpperCase() + name.substring(1).toLowerCase();
+    assert(
+      _classNameRegexp.hasMatch(name),
+      'The template name "$name" must use spaces and capitalized words (e.g., "Typography" or "Icon Button").',
+    );
+    final String camelName = name.replaceAll(' ', '');
     return switch (_version) {
-      _MaterialVersion.material3 => '_M3${capitalizedName}Defaults',
-      _MaterialVersion.material3Expressive => '_M3E${capitalizedName}Defaults',
+      _MaterialVersion.material3 => '_M3${camelName}Defaults',
+      _MaterialVersion.material3Expressive => '_M3E${camelName}Defaults',
     };
   }
 
@@ -83,9 +91,10 @@ abstract class TokenTemplate {
 
   /// Generates the file under the target path [materialLib] and formats it.
   void generateFile({bool verbose = false}) {
+    final String snakeName = name.toLowerCase().replaceAll(' ', '_');
     final String outputFileName = switch (_version) {
-      _MaterialVersion.material3 => '${name}_defaults.g.dart',
-      _MaterialVersion.material3Expressive => '${name}_expressive_defaults.g.dart',
+      _MaterialVersion.material3 => '${snakeName}_m3_defaults.g.dart',
+      _MaterialVersion.material3Expressive => '${snakeName}_m3e_defaults.g.dart',
     };
     final fileName = '$materialLib/$outputFileName';
     if (verbose) {

--- a/packages/material_ui/tool/gen_defaults/templates/template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/template.dart
@@ -71,8 +71,8 @@ abstract class TokenTemplate {
     assert(name.length > 1);
     final String capitalizedName = name[0].toUpperCase() + name.substring(1).toLowerCase();
     return switch (_version) {
-      _MaterialVersion.material3 => '_${capitalizedName}Defaults',
-      _MaterialVersion.material3Expressive => '_${capitalizedName}ExpressiveDefaults',
+      _MaterialVersion.material3 => '_M3${capitalizedName}Defaults',
+      _MaterialVersion.material3Expressive => '_M3E${capitalizedName}Defaults',
     };
   }
 

--- a/packages/material_ui/tool/gen_defaults/templates/template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/template.dart
@@ -52,6 +52,10 @@ abstract class TokenTemplate {
   /// E.g., 'Icon Button' for generating 'icon_button_m3_defaults.g.dart'.
   String get name;
 
+  /// The path of the parent file relative to `lib/src`.
+  /// E.g., 'icon_button.dart' or 'buttons/icon_button.dart'.
+  String get parentFilePath;
+
   /// The path to the library's directory where generated files are placed.
   @visibleForTesting
   String get materialLib {
@@ -99,8 +103,12 @@ abstract class TokenTemplate {
     final fileName = '$materialLib/$outputFileName';
     if (verbose) {
       stdout.writeln('Generating file: $fileName');
-      stdout.writeln('Target parent file name: $name.dart');
+      stdout.writeln('Target parent file path: lib/src/$parentFilePath');
     }
+    assert(
+      !parentFilePath.startsWith('/') && !parentFilePath.startsWith('lib/'),
+      'parentFilePath must be relative to lib/src/ (e.g. "icon_button.dart").',
+    );
     final file = File(fileName);
     if (!file.existsSync()) {
       if (verbose) {
@@ -108,8 +116,6 @@ abstract class TokenTemplate {
       }
       file.createSync(recursive: true);
     }
-
-    final parentName = '$name.dart';
 
     if (verbose) {
       stdout.writeln('Generating contents...');
@@ -124,7 +130,7 @@ abstract class TokenTemplate {
     final buffer = StringBuffer();
     buffer.write(_copyrightHeader);
     buffer.write(_headerComment);
-    buffer.write("part of '../$parentName';\n\n");
+    buffer.write("part of '../$parentFilePath';\n\n");
     buffer.write(contents);
 
     if (verbose) {

--- a/packages/material_ui/tool/gen_defaults/templates/template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/template.dart
@@ -46,11 +46,7 @@ abstract class TokenTemplate {
 
   /// The regular expression used to verify that a template name is written with
   /// spaces and capitalized words (e.g., "Icon Button").
-  static final RegExp _classNameRegexp = RegExp(r'^[A-Z][a-zA-Z0-9]*( [A-Z][a-zA-Z0-9]*)*$');
-
-  /// Returns a regular expression used to verify that the generated contents
-  /// declare a class named [className].
-  static RegExp _classRegExp(String className) => RegExp('class\\s+$className\\b');
+  static final RegExp _nameRegExp = RegExp(r'^[A-Z][a-zA-Z0-9]*( [A-Z][a-zA-Z0-9]*)*$');
 
   /// The name of the template, which corresponds to the target file name.
   /// E.g., 'Icon Button' for generating 'icon_button_m3_defaults.g.dart'.
@@ -74,7 +70,7 @@ abstract class TokenTemplate {
   /// or `_M3EIconButtonDefaults`).
   String get _className {
     assert(
-      _classNameRegexp.hasMatch(name),
+      _nameRegExp.hasMatch(name),
       'The template name "$name" must use spaces and capitalized words (e.g., "Typography" or "Icon Button").',
     );
     final String camelName = name.replaceAll(' ', '');
@@ -83,6 +79,10 @@ abstract class TokenTemplate {
       _MaterialVersion.material3Expressive => '_M3E${camelName}Defaults',
     };
   }
+
+  /// The regular expression used to verify that the generated contents declare
+  /// the class.
+  RegExp get _classRegExp => RegExp('class\\s+$_className\\b');
 
   /// Returns the body of the generated file as a string.
   ///
@@ -116,7 +116,7 @@ abstract class TokenTemplate {
     }
     final String contents = generateContents(_className);
     assert(
-      contents.contains(_classRegExp(_className)) || contents.isEmpty,
+      contents.contains(_classRegExp),
       'The generated contents for "$name" must define the class "$_className". '
       'Make sure you are utilizing the passed `className` parameter.',
     );

--- a/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
+++ b/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
@@ -101,21 +101,21 @@ const _fileHeader = '''
 ''';
 
 const _buttonExpressiveDefaultsClass = '''
-class _ButtonExpressiveDefaults {
+class _M3EButtonDefaults {
   static const double height = 40.0;
   static const double borderRadius = 8.0;
 }
 ''';
 
 const _buttonDefaultsClass = '''
-class _ButtonDefaults {
+class _M3ButtonDefaults {
   static const double height = 40.0;
   static const double borderRadius = 8.0;
 }
 ''';
 
 const formattedClass = '''
-class _UnformattedDefaults {
+class _M3UnformattedDefaults {
   final int x = 1;
   final String y = 'hello';
 }

--- a/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
+++ b/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
@@ -23,16 +23,16 @@ void main() {
 
     for (final isM3E in <bool>[true, false]) {
       TokenTemplate buttonTemplate() =>
-          isM3E ? M3EButtonTemplate(testPath()) : M3ButtonTemplate(testPath());
+          isM3E ? M3EIconButtonTemplate(testPath()) : M3IconButtonTemplate(testPath());
 
       String filePath() {
-        final fileName = 'button${isM3E ? '_expressive' : ''}_defaults.g.dart';
+        final fileName = 'icon_button_m3${isM3E ? 'e' : ''}_defaults.g.dart';
         return '${testPath()}/$fileName';
       }
 
       group(isM3E ? 'M3E Template' : 'M3 Template', () {
         test(
-          'will generate a part file ending in ${isM3E ? '_expressive' : ''}_defaults.g.dart',
+          'will generate a part file ending in icon_button_m3${isM3E ? 'e' : ''}_defaults.g.dart',
           () {
             buttonTemplate().generateFile(verbose: true);
             expect(File(filePath()).existsSync(), isTrue);
@@ -70,7 +70,7 @@ void main() {
       final template = UnformattedTemplate(testPath());
       template.generateFile();
 
-      final file = File('${testPath()}/unformatted_defaults.g.dart');
+      final file = File('${testPath()}/unformatted_m3_defaults.g.dart');
       expect(file.readAsStringSync(), contains(formattedClass));
     });
 
@@ -83,6 +83,20 @@ void main() {
             (AssertionError e) => e.message,
             'message',
             contains('Make sure you are utilizing the passed `className` parameter.'),
+          ),
+        ),
+      );
+    });
+
+    test('throws AssertionError if name is not in Spaced / TitleCase', () {
+      final template = SnakeCaseNameTemplate(testPath());
+      expect(
+        () => template.generateFile(),
+        throwsA(
+          isA<AssertionError>().having(
+            (AssertionError e) => e.message,
+            'message',
+            contains('must use spaces and capitalized words'),
           ),
         ),
       );
@@ -101,14 +115,14 @@ const _fileHeader = '''
 ''';
 
 const _buttonExpressiveDefaultsClass = '''
-class _M3EButtonDefaults {
+class _M3EIconButtonDefaults {
   static const double height = 40.0;
   static const double borderRadius = 8.0;
 }
 ''';
 
 const _buttonDefaultsClass = '''
-class _M3ButtonDefaults {
+class _M3IconButtonDefaults {
   static const double height = 40.0;
   static const double borderRadius = 8.0;
 }

--- a/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
+++ b/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:test/test.dart';
+import '../templates/template.dart';
 import 'test_fixtures/test_templates.dart';
 
 void main() {
@@ -20,43 +21,50 @@ void main() {
       tempDir!.deleteSync(recursive: true);
     });
 
-    test('will generate a part file ending in _defaults.g.dart', () {
-      final template = ButtonTemplate(testPath());
-      template.generateFile(verbose: true);
+    for (final isM3E in <bool>[true, false]) {
+      TokenTemplate buttonTemplate() =>
+          isM3E ? M3EButtonTemplate(testPath()) : M3ButtonTemplate(testPath());
 
-      final file = File('${testPath()}/button_defaults.g.dart');
-      expect(file.existsSync(), isTrue);
-    });
+      String filePath() {
+        final fileName = 'button${isM3E ? '_expressive' : ''}_defaults.g.dart';
+        return '${testPath()}/$fileName';
+      }
 
-    test('will generate a file with the correct header text', () {
-      final template = ButtonTemplate(testPath());
-      template.generateFile();
+      group(isM3E ? 'M3E Template' : 'M3 Template', () {
+        test(
+          'will generate a part file ending in ${isM3E ? '_expressive' : ''}_defaults.g.dart',
+          () {
+            buttonTemplate().generateFile(verbose: true);
+            expect(File(filePath()).existsSync(), isTrue);
+          },
+        );
 
-      final file = File('${testPath()}/button_defaults.g.dart');
-      final String fileContents = file.readAsStringSync();
-      expect(fileContents, contains(_fileHeader));
-    });
+        test('will generate a file with the correct header text', () {
+          buttonTemplate().generateFile(verbose: true);
+          final String fileContents = File(filePath()).readAsStringSync();
+          expect(fileContents, contains(_fileHeader));
+        });
 
-    test('will generate a file with the expected contents', () {
-      final template = ButtonTemplate(testPath());
-      template.generateFile();
+        test('will generate a file with the expected contents', () {
+          buttonTemplate().generateFile(verbose: true);
+          final String fileContents = File(filePath()).readAsStringSync();
+          expect(
+            fileContents,
+            contains(isM3E ? _buttonExpressiveDefaultsClass : _buttonDefaultsClass),
+          );
+        });
 
-      final file = File('${testPath()}/button_defaults.g.dart');
-      final String fileContents = file.readAsStringSync();
-      expect(fileContents, contains(_buttonDefaultsClass));
-    });
+        test('will completely overwrite any previous code', () {
+          final file = File(filePath());
+          const randomText = 'Pre-existing random text.';
+          file.writeAsStringSync(randomText);
 
-    test('will completely overwrite any previous code', () {
-      final file = File('${testPath()}/button_defaults.g.dart');
-      const randomText = 'Pre-existing random text.';
-      file.writeAsStringSync(randomText);
-
-      final template = ButtonTemplate(testPath());
-      template.generateFile();
-      final String fileContents = file.readAsStringSync();
-      expect(fileContents, isNot(contains(randomText)));
-      expect(fileContents, contains(_buttonDefaultsClass));
-    });
+          buttonTemplate().generateFile(verbose: true);
+          final String fileContents = file.readAsStringSync();
+          expect(fileContents, isNot(contains(randomText)));
+        });
+      });
+    }
 
     test('will run dart format over the generated file', () {
       final template = UnformattedTemplate(testPath());
@@ -66,23 +74,18 @@ void main() {
       expect(file.readAsStringSync(), contains(formattedClass));
     });
 
-    test('materialLib path resolves correctly based on MaterialVersion', () {
-      final m3Template = TestM3Template();
-      final m3ExpressiveTemplate = TestM3ExpressiveTemplate();
-      const materialUiDir = 'packages/material_ui';
-      const generatedDir = 'lib/src/generated';
-
-      final bool hasPackageDir = Directory(materialUiDir).existsSync();
-      if (hasPackageDir) {
-        expect(m3Template.materialLib, '$materialUiDir/$generatedDir');
-        expect(
-          m3ExpressiveTemplate.materialLib,
-          '$materialUiDir/$generatedDir/material_3_expressive',
-        );
-      } else {
-        expect(m3Template.materialLib, generatedDir);
-        expect(m3ExpressiveTemplate.materialLib, '$generatedDir/material_3_expressive');
-      }
+    test('throws AssertionError if class name is not defined in generateContents', () {
+      final template = InvalidTemplate(testPath());
+      expect(
+        () => template.generateFile(),
+        throwsA(
+          isA<AssertionError>().having(
+            (AssertionError e) => e.message,
+            'message',
+            contains('Make sure you are utilizing the passed `className` parameter.'),
+          ),
+        ),
+      );
     });
   });
 }
@@ -97,6 +100,13 @@ const _fileHeader = '''
 //   packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart.
 ''';
 
+const _buttonExpressiveDefaultsClass = '''
+class _ButtonExpressiveDefaults {
+  static const double height = 40.0;
+  static const double borderRadius = 8.0;
+}
+''';
+
 const _buttonDefaultsClass = '''
 class _ButtonDefaults {
   static const double height = 40.0;
@@ -105,7 +115,7 @@ class _ButtonDefaults {
 ''';
 
 const formattedClass = '''
-class UnformattedClass {
+class _UnformattedDefaults {
   final int x = 1;
   final String y = 'hello';
 }

--- a/packages/material_ui/tool/gen_defaults/test/test_fixtures/icon_button_token_data.dart
+++ b/packages/material_ui/tool/gen_defaults/test/test_fixtures/icon_button_token_data.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-class TokenButton {
+class TokenIconButton {
   static const double height = 40.0;
   static const double borderRadius = 8.0;
 }

--- a/packages/material_ui/tool/gen_defaults/test/test_fixtures/test_templates.dart
+++ b/packages/material_ui/tool/gen_defaults/test/test_fixtures/test_templates.dart
@@ -5,13 +5,13 @@
 import '../../templates/template.dart';
 import 'button_token_data.dart';
 
-class M3EButtonTemplate extends M3ETokenTemplate {
-  M3EButtonTemplate(this.customMaterialLib);
+class M3EIconButtonTemplate extends M3ETokenTemplate {
+  M3EIconButtonTemplate(this.customMaterialLib);
 
   final String customMaterialLib;
 
   @override
-  String get name => 'button';
+  String get name => 'Icon Button';
 
   @override
   String get materialLib => customMaterialLib;
@@ -27,13 +27,13 @@ class $className {
   }
 }
 
-class M3ButtonTemplate extends M3TokenTemplate {
-  M3ButtonTemplate(this.customMaterialLib);
+class M3IconButtonTemplate extends M3TokenTemplate {
+  M3IconButtonTemplate(this.customMaterialLib);
 
   final String customMaterialLib;
 
   @override
-  String get name => 'button';
+  String get name => 'Icon Button';
 
   @override
   String get materialLib => customMaterialLib;
@@ -55,7 +55,7 @@ class UnformattedTemplate extends M3TokenTemplate {
   final String customMaterialLib;
 
   @override
-  String get name => 'unformatted';
+  String get name => 'Unformatted';
 
   @override
   String get materialLib => customMaterialLib;
@@ -77,7 +77,7 @@ class InvalidTemplate extends M3TokenTemplate {
   final String customMaterialLib;
 
   @override
-  String get name => 'invalid';
+  String get name => 'Invalid';
 
   @override
   String get materialLib => customMaterialLib;
@@ -90,4 +90,19 @@ class _SomeOtherClassNameDefaults {
 }
 ''';
   }
+}
+
+class SnakeCaseNameTemplate extends M3TokenTemplate {
+  SnakeCaseNameTemplate(this.customMaterialLib);
+
+  final String customMaterialLib;
+
+  @override
+  String get name => 'snake_case_name';
+
+  @override
+  String get materialLib => customMaterialLib;
+
+  @override
+  String generateContents(String className) => '';
 }

--- a/packages/material_ui/tool/gen_defaults/test/test_fixtures/test_templates.dart
+++ b/packages/material_ui/tool/gen_defaults/test/test_fixtures/test_templates.dart
@@ -14,6 +14,9 @@ class M3EIconButtonTemplate extends M3ETokenTemplate {
   String get name => 'Icon Button';
 
   @override
+  String get parentFilePath => 'icon_button.dart';
+
+  @override
   String get materialLib => customMaterialLib;
 
   @override
@@ -34,6 +37,9 @@ class M3IconButtonTemplate extends M3TokenTemplate {
 
   @override
   String get name => 'Icon Button';
+
+  @override
+  String get parentFilePath => 'icon_button.dart';
 
   @override
   String get materialLib => customMaterialLib;
@@ -58,6 +64,9 @@ class UnformattedTemplate extends M3TokenTemplate {
   String get name => 'Unformatted';
 
   @override
+  String get parentFilePath => 'unformatted.dart';
+
+  @override
   String get materialLib => customMaterialLib;
 
   @override
@@ -80,6 +89,9 @@ class InvalidTemplate extends M3TokenTemplate {
   String get name => 'Invalid';
 
   @override
+  String get parentFilePath => 'invalid.dart';
+
+  @override
   String get materialLib => customMaterialLib;
 
   @override
@@ -99,6 +111,9 @@ class SnakeCaseNameTemplate extends M3TokenTemplate {
 
   @override
   String get name => 'snake_case_name';
+
+  @override
+  String get parentFilePath => 'snake_case_name.dart';
 
   @override
   String get materialLib => customMaterialLib;

--- a/packages/material_ui/tool/gen_defaults/test/test_fixtures/test_templates.dart
+++ b/packages/material_ui/tool/gen_defaults/test/test_fixtures/test_templates.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import '../../templates/template.dart';
-import 'button_token_data.dart';
+import 'icon_button_token_data.dart';
 
 class M3EIconButtonTemplate extends M3ETokenTemplate {
   M3EIconButtonTemplate(this.customMaterialLib);
@@ -23,8 +23,8 @@ class M3EIconButtonTemplate extends M3ETokenTemplate {
   String generateContents(String className) {
     return '''
 class $className {
-  static const double height = ${TokenButton.height};
-  static const double borderRadius = ${TokenButton.borderRadius};
+  static const double height = ${TokenIconButton.height};
+  static const double borderRadius = ${TokenIconButton.borderRadius};
 }
 ''';
   }
@@ -48,8 +48,8 @@ class M3IconButtonTemplate extends M3TokenTemplate {
   String generateContents(String className) {
     return '''
 class $className {
-  static const double height = ${TokenButton.height};
-  static const double borderRadius = ${TokenButton.borderRadius};
+  static const double height = ${TokenIconButton.height};
+  static const double borderRadius = ${TokenIconButton.borderRadius};
 }
 ''';
   }

--- a/packages/material_ui/tool/gen_defaults/test/test_fixtures/test_templates.dart
+++ b/packages/material_ui/tool/gen_defaults/test/test_fixtures/test_templates.dart
@@ -5,8 +5,8 @@
 import '../../templates/template.dart';
 import 'button_token_data.dart';
 
-class ButtonTemplate extends M3ETokenTemplate {
-  ButtonTemplate(this.customMaterialLib);
+class M3EButtonTemplate extends M3ETokenTemplate {
+  M3EButtonTemplate(this.customMaterialLib);
 
   final String customMaterialLib;
 
@@ -17,9 +17,31 @@ class ButtonTemplate extends M3ETokenTemplate {
   String get materialLib => customMaterialLib;
 
   @override
-  String generateContents() {
+  String generateContents(String className) {
     return '''
-class _ButtonDefaults {
+class $className {
+  static const double height = ${TokenButton.height};
+  static const double borderRadius = ${TokenButton.borderRadius};
+}
+''';
+  }
+}
+
+class M3ButtonTemplate extends M3TokenTemplate {
+  M3ButtonTemplate(this.customMaterialLib);
+
+  final String customMaterialLib;
+
+  @override
+  String get name => 'button';
+
+  @override
+  String get materialLib => customMaterialLib;
+
+  @override
+  String generateContents(String className) {
+    return '''
+class $className {
   static const double height = ${TokenButton.height};
   static const double borderRadius = ${TokenButton.borderRadius};
 }
@@ -39,9 +61,9 @@ class UnformattedTemplate extends M3TokenTemplate {
   String get materialLib => customMaterialLib;
 
   @override
-  String generateContents() {
+  String generateContents(String className) {
     return '''
-class   UnformattedClass   {
+class   $className   {
 final    int    x = 1  ;
   final String y   =   'hello' ;
 }
@@ -49,18 +71,23 @@ final    int    x = 1  ;
   }
 }
 
-class TestM3Template extends M3TokenTemplate {
-  @override
-  String get name => 'm3';
+class InvalidTemplate extends M3TokenTemplate {
+  InvalidTemplate(this.customMaterialLib);
+
+  final String customMaterialLib;
 
   @override
-  String generateContents() => '';
+  String get name => 'invalid';
+
+  @override
+  String get materialLib => customMaterialLib;
+
+  @override
+  String generateContents(String className) {
+    return '''
+class _SomeOtherClassNameDefaults {
+  final int x = 1;
 }
-
-class TestM3ExpressiveTemplate extends M3ETokenTemplate {
-  @override
-  String get name => 'm3e';
-
-  @override
-  String generateContents() => '';
+''';
+  }
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/186906
Work towards https://github.com/flutter/flutter/issues/187899

Previously, the `gen_defaults` script generated the files in different directories based on whether or not the template was an M3 or M3E template. Since we are planning on using an variant enum instead of different libraries to separate M3 and M3E implementations, the `gen_defaults` script needs to be accordingly updated. 

**Before:**

```
lib/src/
├── button.dart                      ← Editable M3 parent file
├── material_3_expressive/
│   └── button.dart                  ← Editable M3E parent file
└── generated/
    ├── button_defaults.g.dart       ← Generated M3 part file
    └── material_3_expressive/
        └── button_defaults.g.dart   ← Generated M3E part file
```

**After:**

```
lib/src/
├── button.dart                              ← Editable M3/M3E parent file
└── generated/
    ├── button_m3_defaults.g.dart            ← Generated M3 part file
    └── button_m3e_defaults.g.dart           ← Generated M3E part file
```


The template now creates the generated class name as well, either `M3NameDefaults` or `M3ENameDefaults` (e.g. `M3EButtonDefaults`).


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.


If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
