### PR TITLE
[google_maps_flutter_web] Add editable polyline and polygon support

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0
+
+* Adds support for editable polylines and polygons via the native Google Maps JavaScript API `editable` feature.
+
 ## 0.6.2+3
 
 * Updates README to include setup information.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/shape_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/shape_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_maps/google_maps.dart' as gmaps;
@@ -135,6 +136,119 @@ void main() {
         }, throwsAssertionError);
       });
     });
+
+    group('onEdited', () {
+      late gmaps.Polygon editablePolygon;
+
+      setUp(() {
+        editablePolygon = gmaps.Polygon(
+          gmaps.PolygonOptions()
+            ..editable = true
+            ..paths = <JSArray<gmaps.LatLng>>[
+              <gmaps.LatLng>[gmaps.LatLng(0, 0), gmaps.LatLng(1, 0), gmaps.LatLng(1, 1)].toJS,
+              <gmaps.LatLng>[
+                gmaps.LatLng(0.1, 0.1),
+                gmaps.LatLng(0.2, 0.1),
+                gmaps.LatLng(0.2, 0.2),
+              ].toJS,
+            ].toJS,
+        );
+      });
+
+      testWidgets('fires onEdited on setAt with outer path and holes', (WidgetTester tester) async {
+        final completer = Completer<({List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes})>();
+        PolygonController(
+          polygon: editablePolygon,
+          onEdited: (List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes) {
+            if (!completer.isCompleted) {
+              completer.complete((outer: outer, holes: holes));
+            }
+          },
+        );
+
+        editablePolygon.paths.getAt(0).setAt(0, gmaps.LatLng(5, 5));
+
+        final ({List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes}) result =
+            await completer.future;
+        expect(result.outer, hasLength(3));
+        expect(result.outer.first.lat, 5);
+        expect(result.outer.first.lng, 5);
+        expect(result.holes, hasLength(1));
+        expect(result.holes.first, hasLength(3));
+      });
+
+      testWidgets('fires onEdited when a hole path is mutated', (WidgetTester tester) async {
+        final completer = Completer<({List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes})>();
+        PolygonController(
+          polygon: editablePolygon,
+          onEdited: (List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes) {
+            if (!completer.isCompleted) {
+              completer.complete((outer: outer, holes: holes));
+            }
+          },
+        );
+
+        editablePolygon.paths.getAt(1).setAt(0, gmaps.LatLng(0.9, 0.9));
+
+        final ({List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes}) result =
+            await completer.future;
+        expect(result.outer, hasLength(3));
+        expect(result.holes, hasLength(1));
+        expect(result.holes.first.first.lat, 0.9);
+        expect(result.holes.first.first.lng, 0.9);
+      });
+
+      testWidgets('fires onEdited on insertAt', (WidgetTester tester) async {
+        final completer = Completer<List<gmaps.LatLng>>();
+        PolygonController(
+          polygon: editablePolygon,
+          onEdited: (List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes) {
+            if (!completer.isCompleted) {
+              completer.complete(outer);
+            }
+          },
+        );
+
+        editablePolygon.paths.getAt(0).insertAt(0, gmaps.LatLng(9, 9));
+
+        final List<gmaps.LatLng> result = await completer.future;
+        expect(result, hasLength(4));
+        expect(result.first.lat, 9);
+      });
+
+      testWidgets('fires onEdited on removeAt', (WidgetTester tester) async {
+        final completer = Completer<List<gmaps.LatLng>>();
+        PolygonController(
+          polygon: editablePolygon,
+          onEdited: (List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes) {
+            if (!completer.isCompleted) {
+              completer.complete(outer);
+            }
+          },
+        );
+
+        editablePolygon.paths.getAt(0).removeAt(0);
+
+        final List<gmaps.LatLng> result = await completer.future;
+        expect(result, hasLength(2));
+      });
+
+      testWidgets('remove cancels onEdited subscriptions', (WidgetTester tester) async {
+        var callCount = 0;
+        final controller = PolygonController(
+          polygon: editablePolygon,
+          onEdited: (List<gmaps.LatLng> outer, List<List<gmaps.LatLng>> holes) {
+            callCount++;
+          },
+        );
+
+        controller.remove();
+        editablePolygon.paths.getAt(0).setAt(0, gmaps.LatLng(7, 7));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(callCount, 0);
+      });
+    });
   });
 
   group('PolylineController', () {
@@ -186,6 +300,89 @@ void main() {
         expect(() {
           controller.update(options);
         }, throwsAssertionError);
+      });
+    });
+
+    group('onEdited', () {
+      late gmaps.Polyline editablePolyline;
+
+      setUp(() {
+        editablePolyline = gmaps.Polyline(
+          gmaps.PolylineOptions()
+            ..editable = true
+            ..path = <gmaps.LatLng>[gmaps.LatLng(0, 0), gmaps.LatLng(1, 1)].toJS,
+        );
+      });
+
+      testWidgets('fires onEdited on setAt with updated path', (WidgetTester tester) async {
+        final completer = Completer<List<gmaps.LatLng>>();
+        PolylineController(
+          polyline: editablePolyline,
+          onEdited: (List<gmaps.LatLng> path) {
+            if (!completer.isCompleted) {
+              completer.complete(path);
+            }
+          },
+        );
+
+        editablePolyline.path.setAt(0, gmaps.LatLng(2, 2));
+
+        final List<gmaps.LatLng> result = await completer.future;
+        expect(result, hasLength(2));
+        expect(result.first.lat, 2);
+        expect(result.first.lng, 2);
+      });
+
+      testWidgets('fires onEdited on insertAt with updated path', (WidgetTester tester) async {
+        final completer = Completer<List<gmaps.LatLng>>();
+        PolylineController(
+          polyline: editablePolyline,
+          onEdited: (List<gmaps.LatLng> path) {
+            if (!completer.isCompleted) {
+              completer.complete(path);
+            }
+          },
+        );
+
+        editablePolyline.path.insertAt(0, gmaps.LatLng(9, 9));
+
+        final List<gmaps.LatLng> result = await completer.future;
+        expect(result, hasLength(3));
+        expect(result.first.lat, 9);
+      });
+
+      testWidgets('fires onEdited on removeAt with updated path', (WidgetTester tester) async {
+        final completer = Completer<List<gmaps.LatLng>>();
+        PolylineController(
+          polyline: editablePolyline,
+          onEdited: (List<gmaps.LatLng> path) {
+            if (!completer.isCompleted) {
+              completer.complete(path);
+            }
+          },
+        );
+
+        editablePolyline.path.removeAt(0);
+
+        final List<gmaps.LatLng> result = await completer.future;
+        expect(result, hasLength(1));
+        expect(result.first.lat, 1);
+      });
+
+      testWidgets('remove cancels onEdited subscriptions', (WidgetTester tester) async {
+        var callCount = 0;
+        final controller = PolylineController(
+          polyline: editablePolyline,
+          onEdited: (List<gmaps.LatLng> path) {
+            callCount++;
+          },
+        );
+
+        controller.remove();
+        editablePolyline.path.setAt(0, gmaps.LatLng(3, 3));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(callCount, 0);
       });
     });
   });

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/shapes_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/shapes_test.dart
@@ -307,6 +307,130 @@ void main() {
       expect(polygon1Clickable, true);
       expect(polygon2Clickable, false);
     });
+
+    testWidgets('addPolygons forwards editable to the gmaps Polygon', (WidgetTester tester) async {
+      final polygons = <Polygon>{
+        const Polygon(
+          polygonId: PolygonId('editable'),
+          editable: true,
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 0), LatLng(1, 1)],
+        ),
+        const Polygon(
+          polygonId: PolygonId('not-editable'),
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 0), LatLng(1, 1)],
+        ),
+      };
+
+      controller.addPolygons(polygons);
+
+      final gmaps.Polygon editable = controller.polygons[const PolygonId('editable')]!.polygon!;
+      final gmaps.Polygon notEditable =
+          controller.polygons[const PolygonId('not-editable')]!.polygon!;
+
+      expect((editable.get('editable')! as JSBoolean).toDart, isTrue);
+      expect((notEditable.get('editable')! as JSBoolean).toDart, isFalse);
+    });
+
+    testWidgets('emits PolygonEditEvent with points and holes on edit', (
+      WidgetTester tester,
+    ) async {
+      controller.addPolygons(<Polygon>{
+        const Polygon(
+          polygonId: PolygonId('p'),
+          editable: true,
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 0), LatLng(1, 1)],
+          holes: <List<LatLng>>[
+            <LatLng>[LatLng(0.1, 0.1), LatLng(0.2, 0.1), LatLng(0.2, 0.2)],
+          ],
+        ),
+      });
+
+      final Future<PolygonEditEvent> received = events.stream
+          .where((MapEvent<Object?> e) => e is PolygonEditEvent)
+          .cast<PolygonEditEvent>()
+          .first;
+      final gmaps.Polygon gmPolygon = controller.polygons[const PolygonId('p')]!.polygon!;
+      gmPolygon.paths.getAt(0).setAt(0, gmaps.LatLng(5, 5));
+
+      final PolygonEditEvent event = await received;
+      expect(event.value, const PolygonId('p'));
+      expect(event.points, hasLength(3));
+      expect(event.points.first, const LatLng(5, 5));
+      expect(event.holes, hasLength(1));
+      expect(event.holes.first, hasLength(3));
+    });
+
+    testWidgets('emits PolygonEditEvent reflecting hole mutations', (WidgetTester tester) async {
+      controller.addPolygons(<Polygon>{
+        const Polygon(
+          polygonId: PolygonId('p'),
+          editable: true,
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 0), LatLng(1, 1)],
+          holes: <List<LatLng>>[
+            <LatLng>[LatLng(0.1, 0.1), LatLng(0.2, 0.1), LatLng(0.2, 0.2)],
+          ],
+        ),
+      });
+
+      final Future<PolygonEditEvent> received = events.stream
+          .where((MapEvent<Object?> e) => e is PolygonEditEvent)
+          .cast<PolygonEditEvent>()
+          .first;
+      final gmaps.Polygon gmPolygon = controller.polygons[const PolygonId('p')]!.polygon!;
+      gmPolygon.paths.getAt(1).setAt(0, gmaps.LatLng(0.9, 0.9));
+
+      final PolygonEditEvent event = await received;
+      expect(event.holes.first.first, const LatLng(0.9, 0.9));
+    });
+
+    testWidgets('does not emit PolygonEditEvent when not editable', (WidgetTester tester) async {
+      controller.addPolygons(<Polygon>{
+        const Polygon(
+          polygonId: PolygonId('p'),
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 0), LatLng(1, 1)],
+        ),
+      });
+      PolygonEditEvent? captured;
+      final StreamSubscription<PolygonEditEvent> sub = events.stream
+          .where((MapEvent<Object?> e) => e is PolygonEditEvent)
+          .cast<PolygonEditEvent>()
+          .listen((PolygonEditEvent e) => captured = e);
+
+      final gmaps.Polygon gmPolygon = controller.polygons[const PolygonId('p')]!.polygon!;
+      gmPolygon.paths.getAt(0).setAt(0, gmaps.LatLng(5, 5));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(captured, isNull);
+      await sub.cancel();
+    });
+
+    testWidgets('changePolygons rewires listeners when editable is toggled on', (
+      WidgetTester tester,
+    ) async {
+      controller.addPolygons(<Polygon>{
+        const Polygon(
+          polygonId: PolygonId('t'),
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 0), LatLng(1, 1)],
+        ),
+      });
+      controller.changePolygons(<Polygon>{
+        const Polygon(
+          polygonId: PolygonId('t'),
+          editable: true,
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 0), LatLng(1, 1)],
+        ),
+      });
+
+      final Future<PolygonEditEvent> received = events.stream
+          .where((MapEvent<Object?> e) => e is PolygonEditEvent)
+          .cast<PolygonEditEvent>()
+          .first;
+      final gmaps.Polygon gmPolygon = controller.polygons[const PolygonId('t')]!.polygon!;
+      gmPolygon.paths.getAt(0).setAt(0, gmaps.LatLng(7, 7));
+
+      final PolygonEditEvent event = await received;
+      expect(event.points.first, const LatLng(7, 7));
+    });
   });
 
   group('PolylinesController', () {
@@ -401,6 +525,97 @@ void main() {
 
       expect(polyline1Clickable, true);
       expect(polyline2Clickable, false);
+    });
+
+    testWidgets('addPolylines forwards editable to the gmaps Polyline', (
+      WidgetTester tester,
+    ) async {
+      final polylines = <Polyline>{
+        const Polyline(
+          polylineId: PolylineId('editable'),
+          editable: true,
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 1)],
+        ),
+        const Polyline(
+          polylineId: PolylineId('not-editable'),
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 1)],
+        ),
+      };
+
+      controller.addPolylines(polylines);
+
+      final gmaps.Polyline editable = controller.lines[const PolylineId('editable')]!.line!;
+      final gmaps.Polyline notEditable = controller.lines[const PolylineId('not-editable')]!.line!;
+
+      expect((editable.get('editable')! as JSBoolean).toDart, isTrue);
+      expect((notEditable.get('editable')! as JSBoolean).toDart, isFalse);
+    });
+
+    testWidgets('emits PolylineEditEvent on path mutation when editable', (
+      WidgetTester tester,
+    ) async {
+      controller.addPolylines(<Polyline>{
+        const Polyline(
+          polylineId: PolylineId('e'),
+          editable: true,
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 1)],
+        ),
+      });
+
+      final Future<PolylineEditEvent> received = events.stream
+          .where((MapEvent<Object?> e) => e is PolylineEditEvent)
+          .cast<PolylineEditEvent>()
+          .first;
+      final gmaps.Polyline line = controller.lines[const PolylineId('e')]!.line!;
+      line.path.setAt(0, gmaps.LatLng(5, 5));
+
+      final PolylineEditEvent event = await received;
+      expect(event.value, const PolylineId('e'));
+      expect(event.points, hasLength(2));
+      expect(event.points.first, const LatLng(5, 5));
+    });
+
+    testWidgets('does not emit PolylineEditEvent when not editable', (WidgetTester tester) async {
+      controller.addPolylines(<Polyline>{
+        const Polyline(polylineId: PolylineId('n'), points: <LatLng>[LatLng(0, 0), LatLng(1, 1)]),
+      });
+      PolylineEditEvent? captured;
+      final StreamSubscription<PolylineEditEvent> sub = events.stream
+          .where((MapEvent<Object?> e) => e is PolylineEditEvent)
+          .cast<PolylineEditEvent>()
+          .listen((PolylineEditEvent e) => captured = e);
+
+      final gmaps.Polyline line = controller.lines[const PolylineId('n')]!.line!;
+      line.path.setAt(0, gmaps.LatLng(5, 5));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(captured, isNull);
+      await sub.cancel();
+    });
+
+    testWidgets('changePolylines rewires listeners when editable is toggled on', (
+      WidgetTester tester,
+    ) async {
+      controller.addPolylines(<Polyline>{
+        const Polyline(polylineId: PolylineId('t'), points: <LatLng>[LatLng(0, 0), LatLng(1, 1)]),
+      });
+      controller.changePolylines(<Polyline>{
+        const Polyline(
+          polylineId: PolylineId('t'),
+          editable: true,
+          points: <LatLng>[LatLng(0, 0), LatLng(1, 1)],
+        ),
+      });
+
+      final Future<PolylineEditEvent> received = events.stream
+          .where((MapEvent<Object?> e) => e is PolylineEditEvent)
+          .cast<PolylineEditEvent>()
+          .first;
+      final gmaps.Polyline line = controller.lines[const PolylineId('t')]!.line!;
+      line.path.setAt(0, gmaps.LatLng(9, 9));
+
+      final PolylineEditEvent event = await received;
+      expect(event.points.first, const LatLng(9, 9));
     });
   });
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -808,7 +808,8 @@ gmaps.PolygonOptions _polygonOptionsFromPolygon(gmaps.Map googleMap, Polygon pol
     ..visible = polygon.visible
     ..zIndex = polygon.zIndex
     ..geodesic = polygon.geodesic
-    ..clickable = polygon.consumeTapEvents;
+    ..clickable = polygon.consumeTapEvents
+    ..editable = polygon.editable;
 }
 
 List<gmaps.LatLng> _ensureHoleHasReverseWinding(
@@ -867,7 +868,8 @@ gmaps.PolylineOptions _polylineOptionsFromPolyline(gmaps.Map googleMap, Polyline
     ..visible = polyline.visible
     ..zIndex = polyline.zIndex
     ..geodesic = polyline.geodesic
-    ..clickable = polyline.consumeTapEvents;
+    ..clickable = polyline.consumeTapEvents
+    ..editable = polyline.editable;
   //  this.endCap = Cap.buttCap,
   //  this.jointType = JointType.mitered,
   //  this.patterns = const <PatternItem>[],

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
@@ -235,8 +235,18 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PolylineEditEvent> onPolylineEdited({required int mapId}) {
+    return _events(mapId).whereType<PolylineEditEvent>();
+  }
+
+  @override
   Stream<PolygonTapEvent> onPolygonTap({required int mapId}) {
     return _events(mapId).whereType<PolygonTapEvent>();
+  }
+
+  @override
+  Stream<PolygonEditEvent> onPolygonEdited({required int mapId}) {
+    return _events(mapId).whereType<PolygonEditEvent>();
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polygon.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polygon.dart
@@ -11,12 +11,18 @@ class PolygonController {
     required gmaps.Polygon polygon,
     bool consumeTapEvents = false,
     VoidCallback? onTap,
+    void Function(List<gmaps.LatLng> points, List<List<gmaps.LatLng>> holes)? onEdited,
   }) : _polygon = polygon,
        _consumeTapEvents = consumeTapEvents {
     if (onTap != null) {
-      polygon.onClick.listen((gmaps.PolyMouseEvent event) {
-        onTap.call();
-      });
+      _subscriptions.add(
+        polygon.onClick.listen((gmaps.PolyMouseEvent event) {
+          onTap.call();
+        }),
+      );
+    }
+    if (onEdited != null) {
+      _listenToPathEdits(polygon, onEdited);
     }
   }
 
@@ -24,12 +30,48 @@ class PolygonController {
 
   final bool _consumeTapEvents;
 
+  final List<StreamSubscription<dynamic>> _subscriptions = <StreamSubscription<dynamic>>[];
+
   /// Returns the wrapped [gmaps.Polygon]. Only used for testing.
   @visibleForTesting
   gmaps.Polygon? get polygon => _polygon;
 
   /// Returns `true` if this Controller will use its own `onTap` handler to consume events.
   bool get consumeTapEvents => _consumeTapEvents;
+
+  List<gmaps.LatLng> _readMvcPath(gmaps.MVCArray<gmaps.LatLng> mvcPath) {
+    final points = <gmaps.LatLng>[];
+    for (var i = 0; i < mvcPath.length.toInt(); i++) {
+      points.add(mvcPath.getAt(i));
+    }
+    return points;
+  }
+
+  void _listenToPathEdits(
+    gmaps.Polygon polygon,
+    void Function(List<gmaps.LatLng> points, List<List<gmaps.LatLng>> holes) onEdited,
+  ) {
+    void emitCurrentPaths() {
+      final gmaps.MVCArray<gmaps.MVCArray<gmaps.LatLng>> allPaths = polygon.paths;
+      final List<gmaps.LatLng> outerPath = allPaths.length.toInt() > 0
+          ? _readMvcPath(allPaths.getAt(0))
+          : <gmaps.LatLng>[];
+      final holes = <List<gmaps.LatLng>>[];
+      for (var i = 1; i < allPaths.length.toInt(); i++) {
+        holes.add(_readMvcPath(allPaths.getAt(i)));
+      }
+      onEdited(outerPath, holes);
+    }
+
+    // Listen on all paths (outer boundary + holes).
+    final gmaps.MVCArray<gmaps.MVCArray<gmaps.LatLng>> allPaths = polygon.paths;
+    for (var i = 0; i < allPaths.length.toInt(); i++) {
+      final gmaps.MVCArray<gmaps.LatLng> path = allPaths.getAt(i);
+      _subscriptions.add(path.onSetAt.listen((_) => emitCurrentPaths()));
+      _subscriptions.add(path.onInsertAt.listen((_) => emitCurrentPaths()));
+      _subscriptions.add(path.onRemoveAt.listen((_) => emitCurrentPaths()));
+    }
+  }
 
   /// Updates the options of the wrapped [gmaps.Polygon] object.
   ///
@@ -45,6 +87,10 @@ class PolygonController {
       _polygon!.visible = false;
       _polygon!.map = null;
       _polygon = null;
+      for (final StreamSubscription<dynamic> sub in _subscriptions) {
+        sub.cancel();
+      }
+      _subscriptions.clear();
     }
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polygons.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polygons.dart
@@ -37,6 +37,11 @@ class PolygonsController extends GeometryController {
       onTap: () {
         _onPolygonTap(polygon.polygonId);
       },
+      onEdited: polygon.editable
+          ? (List<gmaps.LatLng> path, List<List<gmaps.LatLng>> holes) {
+              _onPolygonEdited(polygon.polygonId, path, holes);
+            }
+          : null,
     );
     _polygonIdToController[polygon.polygonId] = controller;
   }
@@ -47,8 +52,10 @@ class PolygonsController extends GeometryController {
   }
 
   void _changePolygon(Polygon polygon) {
-    final PolygonController? polygonController = _polygonIdToController[polygon.polygonId];
-    polygonController?.update(_polygonOptionsFromPolygon(googleMap, polygon));
+    // Remove and recreate the controller to ensure edit listeners are
+    // properly set up when the editable property changes.
+    _removePolygon(polygon.polygonId);
+    _addPolygon(polygon);
   }
 
   /// Removes a set of [PolygonId]s from the cache.
@@ -69,5 +76,22 @@ class PolygonsController extends GeometryController {
     // Comment here: https://github.com/flutter/flutter/issues/64084
     _streamController.add(PolygonTapEvent(mapId, polygonId));
     return _polygonIdToController[polygonId]?.consumeTapEvents ?? false;
+  }
+
+  void _onPolygonEdited(
+    PolygonId polygonId,
+    List<gmaps.LatLng> path,
+    List<List<gmaps.LatLng>> holes,
+  ) {
+    final List<LatLng> points = path
+        .map((gmaps.LatLng p) => LatLng(p.lat.toDouble(), p.lng.toDouble()))
+        .toList();
+    final List<List<LatLng>> convertedHoles = holes
+        .map(
+          (List<gmaps.LatLng> hole) =>
+              hole.map((gmaps.LatLng p) => LatLng(p.lat.toDouble(), p.lng.toDouble())).toList(),
+        )
+        .toList();
+    _streamController.add(PolygonEditEvent(mapId, polygonId, points, convertedHoles));
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polyline.dart
@@ -4,19 +4,25 @@
 
 part of '../google_maps_flutter_web.dart';
 
-/// The `PolygonController` class wraps a [gmaps.Polyline] and its `onTap` behavior.
+/// The `PolylineController` class wraps a [gmaps.Polyline] and its `onTap` behavior.
 class PolylineController {
   /// Creates a `PolylineController` that wraps a [gmaps.Polyline] object and its `onTap` behavior.
   PolylineController({
     required gmaps.Polyline polyline,
     bool consumeTapEvents = false,
     VoidCallback? onTap,
+    void Function(List<gmaps.LatLng> path)? onEdited,
   }) : _polyline = polyline,
        _consumeTapEvents = consumeTapEvents {
     if (onTap != null) {
-      polyline.onClick.listen((gmaps.PolyMouseEvent event) {
-        onTap.call();
-      });
+      _subscriptions.add(
+        polyline.onClick.listen((gmaps.PolyMouseEvent event) {
+          onTap.call();
+        }),
+      );
+    }
+    if (onEdited != null) {
+      _listenToPathEdits(polyline, onEdited);
     }
   }
 
@@ -24,12 +30,36 @@ class PolylineController {
 
   final bool _consumeTapEvents;
 
+  final List<StreamSubscription<dynamic>> _subscriptions = <StreamSubscription<dynamic>>[];
+
   /// Returns the wrapped [gmaps.Polyline]. Only used for testing.
   @visibleForTesting
   gmaps.Polyline? get line => _polyline;
 
   /// Returns `true` if this Controller will use its own `onTap` handler to consume events.
   bool get consumeTapEvents => _consumeTapEvents;
+
+  List<gmaps.LatLng> _readPath(gmaps.Polyline polyline) {
+    final gmaps.MVCArray<gmaps.LatLng> path = polyline.path;
+    final points = <gmaps.LatLng>[];
+    for (var i = 0; i < path.length.toInt(); i++) {
+      points.add(path.getAt(i));
+    }
+    return points;
+  }
+
+  void _listenToPathEdits(
+    gmaps.Polyline polyline,
+    void Function(List<gmaps.LatLng> path) onEdited,
+  ) {
+    void emitCurrentPath() {
+      onEdited(_readPath(polyline));
+    }
+
+    _subscriptions.add(polyline.path.onSetAt.listen((_) => emitCurrentPath()));
+    _subscriptions.add(polyline.path.onInsertAt.listen((_) => emitCurrentPath()));
+    _subscriptions.add(polyline.path.onRemoveAt.listen((_) => emitCurrentPath()));
+  }
 
   /// Updates the options of the wrapped [gmaps.Polyline] object.
   ///
@@ -45,6 +75,10 @@ class PolylineController {
       _polyline!.visible = false;
       _polyline!.map = null;
       _polyline = null;
+      for (final StreamSubscription<dynamic> sub in _subscriptions) {
+        sub.cancel();
+      }
+      _subscriptions.clear();
     }
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polylines.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polylines.dart
@@ -37,6 +37,11 @@ class PolylinesController extends GeometryController {
       onTap: () {
         _onPolylineTap(polyline.polylineId);
       },
+      onEdited: polyline.editable
+          ? (List<gmaps.LatLng> path) {
+              _onPolylineEdited(polyline.polylineId, path);
+            }
+          : null,
     );
     _polylineIdToController[polyline.polylineId] = controller;
   }
@@ -47,8 +52,10 @@ class PolylinesController extends GeometryController {
   }
 
   void _changePolyline(Polyline polyline) {
-    final PolylineController? polylineController = _polylineIdToController[polyline.polylineId];
-    polylineController?.update(_polylineOptionsFromPolyline(googleMap, polyline));
+    // Remove and recreate the controller to ensure edit listeners are
+    // properly set up when the editable property changes.
+    _removePolyline(polyline.polylineId);
+    _addPolyline(polyline);
   }
 
   /// Removes a set of [PolylineId]s from the cache.
@@ -70,5 +77,12 @@ class PolylinesController extends GeometryController {
     // Comment here: https://github.com/flutter/flutter/issues/64084
     _streamController.add(PolylineTapEvent(mapId, polylineId));
     return _polylineIdToController[polylineId]?.consumeTapEvents ?? false;
+  }
+
+  void _onPolylineEdited(PolylineId polylineId, List<gmaps.LatLng> path) {
+    final List<LatLng> points = path
+        .map((gmaps.LatLng p) => LatLng(p.lat.toDouble(), p.lng.toDouble()))
+        .toList();
+    _streamController.add(PolylineEditEvent(mapId, polylineId, points));
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.6.2+3
+version: 0.7.0
 
 environment:
   sdk: ^3.10.0
@@ -23,7 +23,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   google_maps: ^8.1.0
-  google_maps_flutter_platform_interface: ^2.15.0
+  google_maps_flutter_platform_interface: ^2.16.0
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0
   web: ^1.0.0


### PR DESCRIPTION
> **⚠️ Draft — blocked on the platform interface landing.**
> This is part 2 of 3 splitting #11492 along the federated plugin, per the
> [contributing guidelines](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins).
> It depends on `google_maps_flutter_platform_interface` **2.16.0** (#11492). Once that lands in `main`, CI's pathified jobs (`make-deps-path-based`) resolve the in-repo interface automatically; this PR will be marked ready then (and is fully green once 2.16.0 publishes to pub.dev).

Implements editable polylines and polygons on the **web** platform, using the native Google Maps JavaScript API `editable` feature.

### Changes — `google_maps_flutter_web` (0.6.2+3 → 0.7.0)

* Wires `editable` through `_polylineOptionsFromPolyline()` / `_polygonOptionsFromPolygon()`.
* Subscribes to the path `MVCArray` events (`onSetAt`, `onInsertAt`, `onRemoveAt`) in `PolylineController` / `PolygonController`.
* Emits `PolylineEditEvent` / `PolygonEditEvent` (including polygon holes) over the shared event stream.
* Recreates the controller on change so edit listeners are rewired when `editable` toggles.
* Adds integration tests for the edit events in `example/latest/integration_test/`.

This feature is web-only; the `editable` property is silently ignored on Android and iOS.

Part of #11492 · Interface PR: #11492 · App-facing PR: #11920 · Fixes flutter/flutter#71248

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing. *(Blocked: depends on the unpublished interface 2.16.0 from #11492. Verified locally against the in-repo interface.)*

[^1]: See the [test exemption] and [version/CHANGELOG exemption] docs for details.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#ai-contributions
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-Hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#formatting
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-Hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog
[semantic versioning]: https://semver.org/
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#test-exemption
[version/CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#versionchangelog-exemption
