### PR TITLE
[google_maps_flutter] Add editable polyline and polygon support (web)

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.18.0
+
+* Adds support for editable polylines and polygons on web.
+
 ## 2.17.1
 
 * Updates README to link to implementation packages for platform-specific

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
@@ -93,8 +93,20 @@ class GoogleMapController {
     );
     _streamSubscriptions.add(
       GoogleMapsFlutterPlatform.instance
+          .onPolylineEdited(mapId: mapId)
+          .listen((PolylineEditEvent e) => _googleMapState.onPolylineEdited(e.value, e.points)),
+    );
+    _streamSubscriptions.add(
+      GoogleMapsFlutterPlatform.instance
           .onPolygonTap(mapId: mapId)
           .listen((PolygonTapEvent e) => _googleMapState.onPolygonTap(e.value)),
+    );
+    _streamSubscriptions.add(
+      GoogleMapsFlutterPlatform.instance
+          .onPolygonEdited(mapId: mapId)
+          .listen(
+            (PolygonEditEvent e) => _googleMapState.onPolygonEdited(e.value, e.points, e.holes),
+          ),
     );
     _streamSubscriptions.add(
       GoogleMapsFlutterPlatform.instance

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -641,6 +641,14 @@ class _GoogleMapState extends State<GoogleMap> {
     }
   }
 
+  void onPolygonEdited(PolygonId polygonId, List<LatLng> points, List<List<LatLng>> holes) {
+    final Polygon? polygon = _polygons[polygonId];
+    if (polygon == null) {
+      throw UnknownMapObjectIdError('polygon', polygonId, 'onEdited');
+    }
+    polygon.onEdited?.call(points, holes);
+  }
+
   void onPolylineTap(PolylineId polylineId) {
     final Polyline? polyline = _polylines[polylineId];
     if (polyline == null) {
@@ -650,6 +658,14 @@ class _GoogleMapState extends State<GoogleMap> {
     if (onTap != null) {
       onTap();
     }
+  }
+
+  void onPolylineEdited(PolylineId polylineId, List<LatLng> points) {
+    final Polyline? polyline = _polylines[polylineId];
+    if (polyline == null) {
+      throw UnknownMapObjectIdError('polyline', polylineId, 'onEdited');
+    }
+    polyline.onEdited?.call(points);
   }
 
   void onCircleTap(CircleId circleId) {

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.17.1
+version: 2.18.0
 
 environment:
   sdk: ^3.10.0
@@ -23,8 +23,8 @@ dependencies:
     sdk: flutter
   google_maps_flutter_android: ^2.19.1
   google_maps_flutter_ios: ^2.18.0
-  google_maps_flutter_platform_interface: ^2.15.0
-  google_maps_flutter_web: ^0.6.2
+  google_maps_flutter_platform_interface: ^2.16.0
+  google_maps_flutter_web: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/fake_google_maps_flutter_platform.dart
@@ -218,8 +218,18 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<PolylineEditEvent> onPolylineEdited({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PolylineEditEvent>();
+  }
+
+  @override
   Stream<PolygonTapEvent> onPolygonTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<PolygonTapEvent>();
+  }
+
+  @override
+  Stream<PolygonEditEvent> onPolygonEdited({required int mapId}) {
+    return mapEventStreamController.stream.whereType<PolygonEditEvent>();
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/test/polygon_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/polygon_updates_test.dart
@@ -364,6 +364,37 @@ void main() {
     expect(map.polygonUpdates.last.polygonsToAdd.isEmpty, true);
   });
 
+  testWidgets('Setting editable triggers change', (WidgetTester tester) async {
+    const p1 = Polygon(polygonId: PolygonId('polygon_1'));
+    const p1Editable = Polygon(polygonId: PolygonId('polygon_1'), editable: true);
+
+    await tester.pumpWidget(_mapWithPolygons(<Polygon>{p1}));
+    await tester.pumpWidget(_mapWithPolygons(<Polygon>{p1Editable}));
+
+    final PlatformMapStateRecorder map = platform.lastCreatedMap;
+    expect(map.polygonUpdates.last.polygonsToChange.length, 1);
+    expect(map.polygonUpdates.last.polygonsToChange.first.editable, equals(true));
+    expect(map.polygonUpdates.last.polygonIdsToRemove.isEmpty, true);
+    expect(map.polygonUpdates.last.polygonsToAdd.isEmpty, true);
+  });
+
+  testWidgets('Update onEdited does not trigger platform change', (WidgetTester tester) async {
+    var p1 = const Polygon(polygonId: PolygonId('polygon_1'), editable: true);
+    await tester.pumpWidget(_mapWithPolygons(<Polygon>{p1}));
+
+    p1 = Polygon(
+      polygonId: const PolygonId('polygon_1'),
+      editable: true,
+      onEdited: (List<LatLng> points, List<List<LatLng>> holes) {},
+    );
+    await tester.pumpWidget(_mapWithPolygons(<Polygon>{p1}));
+
+    final PlatformMapStateRecorder map = platform.lastCreatedMap;
+    expect(map.polygonUpdates.last.polygonsToChange.isEmpty, true);
+    expect(map.polygonUpdates.last.polygonIdsToRemove.isEmpty, true);
+    expect(map.polygonUpdates.last.polygonsToAdd.isEmpty, true);
+  });
+
   testWidgets('multi-update with delays', (WidgetTester tester) async {
     platform.simulatePlatformDelay = true;
 

--- a/packages/google_maps_flutter/google_maps_flutter/test/polyline_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/polyline_updates_test.dart
@@ -194,6 +194,37 @@ void main() {
     expect(map.polylineUpdates.last.polylinesToAdd.isEmpty, true);
   });
 
+  testWidgets('Setting editable triggers change', (WidgetTester tester) async {
+    const p1 = Polyline(polylineId: PolylineId('polyline_1'));
+    const p1Editable = Polyline(polylineId: PolylineId('polyline_1'), editable: true);
+
+    await tester.pumpWidget(_mapWithPolylines(<Polyline>{p1}));
+    await tester.pumpWidget(_mapWithPolylines(<Polyline>{p1Editable}));
+
+    final PlatformMapStateRecorder map = platform.lastCreatedMap;
+    expect(map.polylineUpdates.last.polylinesToChange.length, 1);
+    expect(map.polylineUpdates.last.polylinesToChange.first.editable, equals(true));
+    expect(map.polylineUpdates.last.polylineIdsToRemove.isEmpty, true);
+    expect(map.polylineUpdates.last.polylinesToAdd.isEmpty, true);
+  });
+
+  testWidgets('Update onEdited does not trigger platform change', (WidgetTester tester) async {
+    var p1 = const Polyline(polylineId: PolylineId('polyline_1'), editable: true);
+    await tester.pumpWidget(_mapWithPolylines(<Polyline>{p1}));
+
+    p1 = Polyline(
+      polylineId: const PolylineId('polyline_1'),
+      editable: true,
+      onEdited: (List<LatLng> points) {},
+    );
+    await tester.pumpWidget(_mapWithPolylines(<Polyline>{p1}));
+
+    final PlatformMapStateRecorder map = platform.lastCreatedMap;
+    expect(map.polylineUpdates.last.polylinesToChange.isEmpty, true);
+    expect(map.polylineUpdates.last.polylineIdsToRemove.isEmpty, true);
+    expect(map.polylineUpdates.last.polylinesToAdd.isEmpty, true);
+  });
+
   testWidgets('multi-update with delays', (WidgetTester tester) async {
     platform.simulatePlatformDelay = true;
 


### PR DESCRIPTION
> **⚠️ Draft — blocked on the platform interface (and web) landing.**
> This is part 3 of 3 splitting #11492 along the federated plugin, per the
> [contributing guidelines](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins).
> It depends on `google_maps_flutter_platform_interface` **2.16.0** (#11492) and `google_maps_flutter_web` **0.7.0** (#11919). Once those land in `main`, CI's pathified jobs (`make-deps-path-based`) resolve the in-repo packages automatically; this PR will be marked ready then (and is fully green once both publish to pub.dev).

Wires the app-facing package up to the editable polyline/polygon edit events.

### Changes — `google_maps_flutter` (2.17.1 → 2.18.0)

* Subscribes to the platform interface `onPolylineEdited` / `onPolygonEdited` streams in `controller.dart`.
* Dispatches them to the `onEdited` callbacks on `Polyline` / `Polygon` in `google_map.dart`.
* Adds tests for the dispatch and for `editable` change propagation.

### Usage

```dart
Polyline(
  polylineId: const PolylineId('editable-route'),
  points: [...],
  editable: true,
  onEdited: (List<LatLng> updatedPoints) {
    // Handle the updated path.
  },
)
```

Editing is currently web-only; the `editable` property is silently ignored on Android and iOS.

Part of #11492 · Interface PR: #11492 · Web PR: #11919 · Fixes flutter/flutter#71248

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing. *(Blocked: depends on the unpublished interface 2.16.0 (#11492) and web 0.7.0 (#11919). Verified locally — all 120 package tests pass against the in-repo dependencies.)*

[^1]: See the [test exemption] and [version/CHANGELOG exemption] docs for details.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#ai-contributions
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-Hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#formatting
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-Hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog
[semantic versioning]: https://semver.org/
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/main/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#test-exemption
[version/CHANGELOG exemption]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#versionchangelog-exemption
