### PR TITLE
[webview_flutter] Document NavigationDelegate callbacks

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.14.1
+
+* Adds documentation for `NavigationDelegate` callback parameters.
+
 ## 4.14.0
 
 * Add method to retrieve cookies. See `WebViewCookieManager.getCookies`.

--- a/packages/webview_flutter/webview_flutter/lib/src/navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/navigation_delegate.dart
@@ -38,9 +38,15 @@ class NavigationDelegate {
   /// Constructs a [NavigationDelegate].
   ///
   /// {@template webview_fluttter.NavigationDelegate.constructor}
-  /// **`onUrlChange`:** invoked when the underlying web view changes to a new url.
+  /// **`onNavigationRequest`:** invoked when a navigation request is pending.
+  /// **`onPageStarted`:** invoked when a page starts loading.
+  /// **`onPageFinished`:** invoked when a page finishes loading.
+  /// **`onProgress`:** invoked when page loading progress changes.
+  /// **`onWebResourceError`:** invoked when a web resource loading error occurs.
+  /// **`onUrlChange`:** invoked when the underlying web view changes to a new URL.
   /// **`onHttpAuthRequest`:** invoked when the web view is requesting authentication.
-  /// **`onSslAuthError`:** Invoked when the web view receives a recoverable SSL
+  /// **`onHttpError`:** invoked when an HTTP error status code is received.
+  /// **`onSslAuthError`:** invoked when the web view receives a recoverable SSL
   ///   error for a certificate. The host application must call either
   ///   [SslAuthError.cancel] or [SslAuthError.proceed].
   /// {@endtemplate}

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget backed by the system webview.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.14.0
+version: 4.14.1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Description

Adds documentation for callback parameters accepted by `NavigationDelegate`.

Previously, the constructor documentation only described `onUrlChange`, `onHttpAuthRequest`, and `onSslAuthError`, while other commonly used callbacks such as `onNavigationRequest`, `onPageStarted`, `onPageFinished`, `onProgress`, `onWebResourceError`, and `onHttpError` were undocumented.

This change updates the NavigationDelegate constructor documentation to cover all supported callbacks and improves consistency in the existing descriptions.

Fixes flutter/flutter#187780

## Tests

Tests are not needed because this is a documentation-only change.

## Version and CHANGELOG

Updated the package version to `4.14.1` and added a CHANGELOG entry for the `NavigationDelegate` documentation improvements.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
