### PR TITLE
[material_ui] Add global Material style variant

### DIFF
--- a/packages/material_ui/lib/src/app_bar.dart
+++ b/packages/material_ui/lib/src/app_bar.dart
@@ -906,6 +906,8 @@ class _AppBarState extends State<AppBar> {
     final ThemeData theme = Theme.of(context);
     final IconButtonThemeData iconButtonTheme = IconButtonTheme.of(context);
     final AppBarThemeData appBarTheme = AppBarTheme.of(context);
+    final StyleVariant effectiveVariant = appBarTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final AppBarThemeData defaults = theme.useMaterial3
         ? _AppBarDefaultsM3(context)
         : _AppBarDefaultsM2(context);

--- a/packages/material_ui/lib/src/app_bar.dart
+++ b/packages/material_ui/lib/src/app_bar.dart
@@ -907,7 +907,7 @@ class _AppBarState extends State<AppBar> {
     final IconButtonThemeData iconButtonTheme = IconButtonTheme.of(context);
     final AppBarThemeData appBarTheme = AppBarTheme.of(context);
     final StyleVariant effectiveVariant = appBarTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final AppBarThemeData defaults = theme.useMaterial3
         ? _AppBarDefaultsM3(context)
         : _AppBarDefaultsM2(context);

--- a/packages/material_ui/lib/src/app_bar_theme.dart
+++ b/packages/material_ui/lib/src/app_bar_theme.dart
@@ -11,6 +11,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -415,7 +416,7 @@ class AppBarThemeData with Diagnosticable {
          color == null || backgroundColor == null,
          'The color and backgroundColor parameters mean the same thing. Only specify one.',
        ),
-       assert(variant != .material3Expressive, 'Only material3 is supported.');
+       assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides the default value of [AppBar.backgroundColor].
   final Color? backgroundColor;

--- a/packages/material_ui/lib/src/app_bar_theme.dart
+++ b/packages/material_ui/lib/src/app_bar_theme.dart
@@ -410,10 +410,12 @@ class AppBarThemeData with Diagnosticable {
     this.titleTextStyle,
     this.systemOverlayStyle,
     this.actionsPadding,
+    this.variant,
   }) : assert(
          color == null || backgroundColor == null,
          'The color and backgroundColor parameters mean the same thing. Only specify one.',
-       );
+       ),
+       assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides the default value of [AppBar.backgroundColor].
   final Color? backgroundColor;
@@ -466,6 +468,9 @@ class AppBarThemeData with Diagnosticable {
   /// Overrides the default value of [AppBar.actionsPadding].
   final EdgeInsetsGeometry? actionsPadding;
 
+  /// The style variant of Material Design used by [AppBar].
+  final StyleVariant? variant;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   AppBarThemeData copyWith({
@@ -491,6 +496,7 @@ class AppBarThemeData with Diagnosticable {
     TextStyle? titleTextStyle,
     SystemUiOverlayStyle? systemOverlayStyle,
     EdgeInsetsGeometry? actionsPadding,
+    StyleVariant? variant,
   }) {
     return AppBarThemeData(
       backgroundColor: backgroundColor ?? color ?? this.backgroundColor,
@@ -510,6 +516,7 @@ class AppBarThemeData with Diagnosticable {
       titleTextStyle: titleTextStyle ?? this.titleTextStyle,
       systemOverlayStyle: systemOverlayStyle ?? this.systemOverlayStyle,
       actionsPadding: actionsPadding ?? this.actionsPadding,
+      variant: variant ?? this.variant,
     );
   }
 
@@ -538,6 +545,7 @@ class AppBarThemeData with Diagnosticable {
       titleTextStyle: TextStyle.lerp(a.titleTextStyle, b.titleTextStyle, t),
       systemOverlayStyle: t < 0.5 ? a.systemOverlayStyle : b.systemOverlayStyle,
       actionsPadding: EdgeInsetsGeometry.lerp(a.actionsPadding, b.actionsPadding, t),
+      variant: t < 0.5 ? a.variant : b.variant,
     );
   }
 
@@ -560,6 +568,7 @@ class AppBarThemeData with Diagnosticable {
     titleTextStyle,
     systemOverlayStyle,
     actionsPadding,
+    variant,
   );
 
   @override
@@ -587,7 +596,8 @@ class AppBarThemeData with Diagnosticable {
         other.toolbarTextStyle == toolbarTextStyle &&
         other.titleTextStyle == titleTextStyle &&
         other.systemOverlayStyle == systemOverlayStyle &&
-        other.actionsPadding == actionsPadding;
+        other.actionsPadding == actionsPadding &&
+        other.variant == variant;
   }
 
   @override
@@ -633,5 +643,6 @@ class AppBarThemeData with Diagnosticable {
         defaultValue: null,
       ),
     );
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }

--- a/packages/material_ui/lib/src/debug.dart
+++ b/packages/material_ui/lib/src/debug.dart
@@ -11,6 +11,10 @@ import 'scaffold.dart' show Scaffold, ScaffoldMessenger;
 // Examples can assume:
 // late BuildContext context;
 
+/// The assertion message used while Material components do not yet support
+/// Material 3 Expressive.
+const String kUnsupportedStyleVariantAssertionMessage = 'Only material3 is supported.';
+
 /// Asserts that the given context has a [Material] ancestor within the closest
 /// [LookupBoundary].
 ///

--- a/packages/material_ui/lib/src/debug.dart
+++ b/packages/material_ui/lib/src/debug.dart
@@ -13,7 +13,8 @@ import 'scaffold.dart' show Scaffold, ScaffoldMessenger;
 
 /// The assertion message used while Material components do not yet support
 /// Material 3 Expressive.
-const String kUnsupportedStyleVariantAssertionMessage = 'Only material3 is supported.';
+const String kUnsupportedStyleVariantAssertionMessage =
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.';
 
 /// Asserts that the given context has a [Material] ancestor within the closest
 /// [LookupBoundary].

--- a/packages/material_ui/lib/src/elevated_button.dart
+++ b/packages/material_ui/lib/src/elevated_button.dart
@@ -18,6 +18,7 @@ import 'button_style_button.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'constants.dart';
+import 'debug.dart';
 import 'elevated_button_theme.dart';
 import 'ink_ripple.dart';
 import 'ink_well.dart';
@@ -393,7 +394,7 @@ class ElevatedButton extends ButtonStyleButton {
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final StyleVariant effectiveVariant = ElevatedButtonTheme.of(context).variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final ColorScheme colorScheme = theme.colorScheme;
     final ButtonStyle buttonStyle = theme.useMaterial3
         ? _ElevatedButtonDefaultsM3(context)

--- a/packages/material_ui/lib/src/elevated_button.dart
+++ b/packages/material_ui/lib/src/elevated_button.dart
@@ -392,6 +392,8 @@ class ElevatedButton extends ButtonStyleButton {
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final StyleVariant effectiveVariant = ElevatedButtonTheme.of(context).variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final ColorScheme colorScheme = theme.colorScheme;
     final ButtonStyle buttonStyle = theme.useMaterial3
         ? _ElevatedButtonDefaultsM3(context)

--- a/packages/material_ui/lib/src/elevated_button_theme.dart
+++ b/packages/material_ui/lib/src/elevated_button_theme.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button_style.dart';
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -40,7 +41,7 @@ class ElevatedButtonThemeData with Diagnosticable {
   ///
   /// The [style] may be null.
   const ElevatedButtonThemeData({this.style, this.variant})
-    : assert(variant != .material3Expressive, 'Only material3 is supported.');
+    : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides for [ElevatedButton]'s default style.
   ///

--- a/packages/material_ui/lib/src/elevated_button_theme.dart
+++ b/packages/material_ui/lib/src/elevated_button_theme.dart
@@ -39,7 +39,8 @@ class ElevatedButtonThemeData with Diagnosticable {
   /// Creates an [ElevatedButtonThemeData].
   ///
   /// The [style] may be null.
-  const ElevatedButtonThemeData({this.style});
+  const ElevatedButtonThemeData({this.style, this.variant})
+    : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides for [ElevatedButton]'s default style.
   ///
@@ -50,6 +51,9 @@ class ElevatedButtonThemeData with Diagnosticable {
   /// If [style] is null, then this theme doesn't override anything.
   final ButtonStyle? style;
 
+  /// The style variant of Material Design used by [ElevatedButton].
+  final StyleVariant? variant;
+
   /// Linearly interpolate between two elevated button themes.
   static ElevatedButtonThemeData? lerp(
     ElevatedButtonThemeData? a,
@@ -59,11 +63,14 @@ class ElevatedButtonThemeData with Diagnosticable {
     if (identical(a, b)) {
       return a;
     }
-    return ElevatedButtonThemeData(style: ButtonStyle.lerp(a?.style, b?.style, t));
+    return ElevatedButtonThemeData(
+      style: ButtonStyle.lerp(a?.style, b?.style, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
+    );
   }
 
   @override
-  int get hashCode => style.hashCode;
+  int get hashCode => Object.hash(style, variant);
 
   @override
   bool operator ==(Object other) {
@@ -73,13 +80,14 @@ class ElevatedButtonThemeData with Diagnosticable {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is ElevatedButtonThemeData && other.style == style;
+    return other is ElevatedButtonThemeData && other.style == style && other.variant == variant;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ButtonStyle>('style', style, defaultValue: null));
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/filled_button.dart
+++ b/packages/material_ui/lib/src/filled_button.dart
@@ -19,6 +19,7 @@ import 'button_style_button.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'constants.dart';
+import 'debug.dart';
 import 'filled_button_theme.dart';
 import 'ink_well.dart';
 import 'material_state.dart';
@@ -432,7 +433,7 @@ class FilledButton extends ButtonStyleButton {
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final StyleVariant effectiveVariant = FilledButtonTheme.of(context).variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final ButtonStyle buttonStyle = switch (_variant) {
       _FilledButtonVariant.filled => _FilledButtonDefaultsM3(context),
       _FilledButtonVariant.tonal => _FilledTonalButtonDefaultsM3(context),

--- a/packages/material_ui/lib/src/filled_button.dart
+++ b/packages/material_ui/lib/src/filled_button.dart
@@ -430,13 +430,16 @@ class FilledButton extends ButtonStyleButton {
   /// [ButtonStyle.padding] is reduced from 24 to 16.
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final StyleVariant effectiveVariant = FilledButtonTheme.of(context).variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final ButtonStyle buttonStyle = switch (_variant) {
       _FilledButtonVariant.filled => _FilledButtonDefaultsM3(context),
       _FilledButtonVariant.tonal => _FilledTonalButtonDefaultsM3(context),
     };
 
     if (_addPadding) {
-      final bool useMaterial3 = Theme.of(context).useMaterial3;
+      final bool useMaterial3 = theme.useMaterial3;
       final double defaultFontSize =
           buttonStyle.textStyle?.resolve(const <WidgetState>{})?.fontSize ?? 14.0;
       final double effectiveTextScale =

--- a/packages/material_ui/lib/src/filled_button_theme.dart
+++ b/packages/material_ui/lib/src/filled_button_theme.dart
@@ -39,7 +39,8 @@ class FilledButtonThemeData with Diagnosticable {
   /// Creates an [FilledButtonThemeData].
   ///
   /// The [style] may be null.
-  const FilledButtonThemeData({this.style});
+  const FilledButtonThemeData({this.style, this.variant})
+    : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides for [FilledButton]'s default style.
   ///
@@ -50,16 +51,22 @@ class FilledButtonThemeData with Diagnosticable {
   /// If [style] is null, then this theme doesn't override anything.
   final ButtonStyle? style;
 
+  /// The style variant of Material Design used by [FilledButton].
+  final StyleVariant? variant;
+
   /// Linearly interpolate between two filled button themes.
   static FilledButtonThemeData? lerp(FilledButtonThemeData? a, FilledButtonThemeData? b, double t) {
     if (identical(a, b)) {
       return a;
     }
-    return FilledButtonThemeData(style: ButtonStyle.lerp(a?.style, b?.style, t));
+    return FilledButtonThemeData(
+      style: ButtonStyle.lerp(a?.style, b?.style, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
+    );
   }
 
   @override
-  int get hashCode => style.hashCode;
+  int get hashCode => Object.hash(style, variant);
 
   @override
   bool operator ==(Object other) {
@@ -69,13 +76,14 @@ class FilledButtonThemeData with Diagnosticable {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is FilledButtonThemeData && other.style == style;
+    return other is FilledButtonThemeData && other.style == style && other.variant == variant;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ButtonStyle>('style', style, defaultValue: null));
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/filled_button_theme.dart
+++ b/packages/material_ui/lib/src/filled_button_theme.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button_style.dart';
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -40,7 +41,7 @@ class FilledButtonThemeData with Diagnosticable {
   ///
   /// The [style] may be null.
   const FilledButtonThemeData({this.style, this.variant})
-    : assert(variant != .material3Expressive, 'Only material3 is supported.');
+    : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides for [FilledButton]'s default style.
   ///

--- a/packages/material_ui/lib/src/floating_action_button.dart
+++ b/packages/material_ui/lib/src/floating_action_button.dart
@@ -15,6 +15,7 @@ import 'package:flutter/widgets.dart';
 
 import 'button.dart';
 import 'color_scheme.dart';
+import 'debug.dart';
 import 'floating_action_button_theme.dart';
 import 'scaffold.dart';
 import 'text_theme.dart';
@@ -492,7 +493,7 @@ class FloatingActionButton extends StatelessWidget {
       context,
     );
     final StyleVariant effectiveVariant = floatingActionButtonTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final FloatingActionButtonThemeData defaults = theme.useMaterial3
         ? _FABDefaultsM3(context, _floatingActionButtonType, child != null)
         : _FABDefaultsM2(context, _floatingActionButtonType, child != null);

--- a/packages/material_ui/lib/src/floating_action_button.dart
+++ b/packages/material_ui/lib/src/floating_action_button.dart
@@ -491,6 +491,8 @@ class FloatingActionButton extends StatelessWidget {
     final FloatingActionButtonThemeData floatingActionButtonTheme = FloatingActionButtonTheme.of(
       context,
     );
+    final StyleVariant effectiveVariant = floatingActionButtonTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final FloatingActionButtonThemeData defaults = theme.useMaterial3
         ? _FABDefaultsM3(context, _floatingActionButtonType, child != null)
         : _FABDefaultsM2(context, _floatingActionButtonType, child != null);

--- a/packages/material_ui/lib/src/floating_action_button_theme.dart
+++ b/packages/material_ui/lib/src/floating_action_button_theme.dart
@@ -64,7 +64,11 @@ class FloatingActionButtonThemeData with Diagnosticable {
     this.extendedPadding,
     this.extendedTextStyle,
     this.mouseCursor,
-  });
+    this.variant,
+  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
+
+  /// The style variant of Material Design used by [FloatingActionButton].
+  final StyleVariant? variant;
 
   /// Color to be used for the unselected, enabled [FloatingActionButton]'s
   /// foreground.
@@ -171,6 +175,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
     EdgeInsetsGeometry? extendedPadding,
     TextStyle? extendedTextStyle,
     WidgetStateProperty<MouseCursor?>? mouseCursor,
+    StyleVariant? variant,
   }) {
     return FloatingActionButtonThemeData(
       foregroundColor: foregroundColor ?? this.foregroundColor,
@@ -194,6 +199,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
       extendedPadding: extendedPadding ?? this.extendedPadding,
       extendedTextStyle: extendedTextStyle ?? this.extendedTextStyle,
       mouseCursor: mouseCursor ?? this.mouseCursor,
+      variant: variant ?? this.variant,
     );
   }
 
@@ -248,6 +254,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
       extendedPadding: EdgeInsetsGeometry.lerp(a?.extendedPadding, b?.extendedPadding, t),
       extendedTextStyle: TextStyle.lerp(a?.extendedTextStyle, b?.extendedTextStyle, t),
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
+      variant: t < 0.5 ? a?.variant : b?.variant,
     );
   }
 
@@ -272,7 +279,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
     extendedSizeConstraints,
     extendedIconLabelSpacing,
     extendedPadding,
-    Object.hash(extendedTextStyle, mouseCursor),
+    Object.hash(extendedTextStyle, mouseCursor, variant),
   );
 
   @override
@@ -304,7 +311,8 @@ class FloatingActionButtonThemeData with Diagnosticable {
         other.extendedIconLabelSpacing == extendedIconLabelSpacing &&
         other.extendedPadding == extendedPadding &&
         other.extendedTextStyle == extendedTextStyle &&
-        other.mouseCursor == mouseCursor;
+        other.mouseCursor == mouseCursor &&
+        other.variant == variant;
   }
 
   @override
@@ -368,6 +376,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
         defaultValue: null,
       ),
     );
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/floating_action_button_theme.dart
+++ b/packages/material_ui/lib/src/floating_action_button_theme.dart
@@ -15,6 +15,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -65,7 +66,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
     this.extendedTextStyle,
     this.mouseCursor,
     this.variant,
-  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
+  }) : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// The style variant of Material Design used by [FloatingActionButton].
   final StyleVariant? variant;

--- a/packages/material_ui/lib/src/icon_button.dart
+++ b/packages/material_ui/lib/src/icon_button.dart
@@ -719,7 +719,7 @@ class IconButton extends StatelessWidget {
 
     if (theme.useMaterial3) {
       final StyleVariant effectiveVariant = IconButtonTheme.of(context).variant ?? theme.variant;
-      assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+      assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
       final Size? minSize = constraints == null
           ? null

--- a/packages/material_ui/lib/src/icon_button.dart
+++ b/packages/material_ui/lib/src/icon_button.dart
@@ -718,6 +718,9 @@ class IconButton extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
 
     if (theme.useMaterial3) {
+      final StyleVariant effectiveVariant = IconButtonTheme.of(context).variant ?? theme.variant;
+      assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+
       final Size? minSize = constraints == null
           ? null
           : Size(constraints!.minWidth, constraints!.minHeight);

--- a/packages/material_ui/lib/src/icon_button_theme.dart
+++ b/packages/material_ui/lib/src/icon_button_theme.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button_style.dart';
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -40,7 +41,7 @@ class IconButtonThemeData with Diagnosticable {
   ///
   /// The [style] may be null.
   const IconButtonThemeData({this.style, this.variant})
-    : assert(variant != .material3Expressive, 'Only material3 is supported.');
+    : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides for [IconButton]'s default style if [ThemeData.useMaterial3]
   /// is set to true.

--- a/packages/material_ui/lib/src/icon_button_theme.dart
+++ b/packages/material_ui/lib/src/icon_button_theme.dart
@@ -39,7 +39,8 @@ class IconButtonThemeData with Diagnosticable {
   /// Creates a [IconButtonThemeData].
   ///
   /// The [style] may be null.
-  const IconButtonThemeData({this.style});
+  const IconButtonThemeData({this.style, this.variant})
+    : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides for [IconButton]'s default style if [ThemeData.useMaterial3]
   /// is set to true.
@@ -50,16 +51,22 @@ class IconButtonThemeData with Diagnosticable {
   /// If [style] is null, then this theme doesn't override anything.
   final ButtonStyle? style;
 
+  /// The style variant of Material Design used by [IconButton].
+  final StyleVariant? variant;
+
   /// Linearly interpolate between two icon button themes.
   static IconButtonThemeData? lerp(IconButtonThemeData? a, IconButtonThemeData? b, double t) {
     if (identical(a, b)) {
       return a;
     }
-    return IconButtonThemeData(style: ButtonStyle.lerp(a?.style, b?.style, t));
+    return IconButtonThemeData(
+      style: ButtonStyle.lerp(a?.style, b?.style, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
+    );
   }
 
   @override
-  int get hashCode => style.hashCode;
+  int get hashCode => Object.hash(style, variant);
 
   @override
   bool operator ==(Object other) {
@@ -69,13 +76,14 @@ class IconButtonThemeData with Diagnosticable {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is IconButtonThemeData && other.style == style;
+    return other is IconButtonThemeData && other.style == style && other.variant == variant;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ButtonStyle>('style', style, defaultValue: null));
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -26,6 +26,7 @@ import 'checkbox.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'constants.dart';
+import 'debug.dart';
 import 'icons.dart';
 import 'ink_well.dart';
 import 'material.dart';
@@ -668,7 +669,7 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
     final ThemeData theme = Theme.of(context);
     final MenuThemeData menuTheme = MenuTheme.of(context);
     final StyleVariant effectiveVariant = menuTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
     final Widget child = _MenuAnchorScope(
       state: this,
@@ -1236,7 +1237,7 @@ class _MenuItemButtonState extends State<MenuItemButton> {
     final ThemeData theme = Theme.of(context);
     final MenuButtonThemeData menuButtonTheme = MenuButtonTheme.of(context);
     final StyleVariant effectiveVariant = menuButtonTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
     // Since we don't want to use the theme style or default style from the
     // TextButton, we merge the styles, merging them in the right order when
@@ -2121,7 +2122,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
     final ThemeData theme = Theme.of(context);
     final MenuButtonThemeData menuButtonTheme = MenuButtonTheme.of(context);
     final StyleVariant effectiveVariant = menuButtonTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
     Offset menuPaddingOffset = widget.alignmentOffset ?? Offset.zero;
     final EdgeInsets menuPadding = _computeMenuPadding(context);

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -665,6 +665,11 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final MenuThemeData menuTheme = MenuTheme.of(context);
+    final StyleVariant effectiveVariant = menuTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+
     final Widget child = _MenuAnchorScope(
       state: this,
       animationStatus: _animationController.status,
@@ -1228,6 +1233,11 @@ class _MenuItemButtonState extends State<MenuItemButton> {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final MenuButtonThemeData menuButtonTheme = MenuButtonTheme.of(context);
+    final StyleVariant effectiveVariant = menuButtonTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+
     // Since we don't want to use the theme style or default style from the
     // TextButton, we merge the styles, merging them in the right order when
     // each type of style exists. Each "*StyleOf" function is only called once.
@@ -2108,6 +2118,11 @@ class _SubmenuButtonState extends State<SubmenuButton> {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final MenuButtonThemeData menuButtonTheme = MenuButtonTheme.of(context);
+    final StyleVariant effectiveVariant = menuButtonTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+
     Offset menuPaddingOffset = widget.alignmentOffset ?? Offset.zero;
     final EdgeInsets menuPadding = _computeMenuPadding(context);
     final Axis orientation = _parent?._orientation ?? Axis.vertical;

--- a/packages/material_ui/lib/src/menu_button_theme.dart
+++ b/packages/material_ui/lib/src/menu_button_theme.dart
@@ -53,7 +53,8 @@ class MenuButtonThemeData with Diagnosticable {
   /// Creates a [MenuButtonThemeData].
   ///
   /// The [style] may be null.
-  const MenuButtonThemeData({this.style});
+  const MenuButtonThemeData({this.style, this.variant})
+    : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides for [SubmenuButton] and [MenuItemButton]'s default style.
   ///
@@ -64,16 +65,22 @@ class MenuButtonThemeData with Diagnosticable {
   /// If [style] is null, then this theme doesn't override anything.
   final ButtonStyle? style;
 
+  /// The style variant of Material Design used by menu buttons.
+  final StyleVariant? variant;
+
   /// Linearly interpolate between two menu button themes.
   static MenuButtonThemeData? lerp(MenuButtonThemeData? a, MenuButtonThemeData? b, double t) {
     if (identical(a, b)) {
       return a;
     }
-    return MenuButtonThemeData(style: ButtonStyle.lerp(a?.style, b?.style, t));
+    return MenuButtonThemeData(
+      style: ButtonStyle.lerp(a?.style, b?.style, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
+    );
   }
 
   @override
-  int get hashCode => style.hashCode;
+  int get hashCode => Object.hash(style, variant);
 
   @override
   bool operator ==(Object other) {
@@ -83,13 +90,14 @@ class MenuButtonThemeData with Diagnosticable {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is MenuButtonThemeData && other.style == style;
+    return other is MenuButtonThemeData && other.style == style && other.variant == variant;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ButtonStyle>('style', style, defaultValue: null));
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/menu_button_theme.dart
+++ b/packages/material_ui/lib/src/menu_button_theme.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button_style.dart';
+import 'debug.dart';
 import 'menu_anchor.dart';
 import 'theme.dart';
 
@@ -54,7 +55,7 @@ class MenuButtonThemeData with Diagnosticable {
   ///
   /// The [style] may be null.
   const MenuButtonThemeData({this.style, this.variant})
-    : assert(variant != .material3Expressive, 'Only material3 is supported.');
+    : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides for [SubmenuButton] and [MenuItemButton]'s default style.
   ///

--- a/packages/material_ui/lib/src/menu_theme.dart
+++ b/packages/material_ui/lib/src/menu_theme.dart
@@ -37,7 +37,8 @@ import 'theme.dart';
 @immutable
 class MenuThemeData with Diagnosticable {
   /// Creates a const set of properties used to configure [MenuTheme].
-  const MenuThemeData({this.style, this.submenuIcon});
+  const MenuThemeData({this.style, this.submenuIcon, this.variant})
+    : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// The [MenuStyle] of a [SubmenuButton] menu.
   ///
@@ -53,6 +54,9 @@ class MenuThemeData with Diagnosticable {
   ///  * [WidgetState.focused].
   final WidgetStateProperty<Widget?>? submenuIcon;
 
+  /// The style variant of Material Design used by menus.
+  final StyleVariant? variant;
+
   /// Linearly interpolate between two menu button themes.
   static MenuThemeData? lerp(MenuThemeData? a, MenuThemeData? b, double t) {
     if (identical(a, b)) {
@@ -61,11 +65,12 @@ class MenuThemeData with Diagnosticable {
     return MenuThemeData(
       style: MenuStyle.lerp(a?.style, b?.style, t),
       submenuIcon: t < 0.5 ? a?.submenuIcon : b?.submenuIcon,
+      variant: t < 0.5 ? a?.variant : b?.variant,
     );
   }
 
   @override
-  int get hashCode => Object.hash(style, submenuIcon);
+  int get hashCode => Object.hash(style, submenuIcon, variant);
 
   @override
   bool operator ==(Object other) {
@@ -75,7 +80,10 @@ class MenuThemeData with Diagnosticable {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is MenuThemeData && other.style == style && other.submenuIcon == submenuIcon;
+    return other is MenuThemeData &&
+        other.style == style &&
+        other.submenuIcon == submenuIcon &&
+        other.variant == variant;
   }
 
   @override
@@ -89,6 +97,7 @@ class MenuThemeData with Diagnosticable {
         defaultValue: null,
       ),
     );
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/menu_theme.dart
+++ b/packages/material_ui/lib/src/menu_theme.dart
@@ -8,6 +8,7 @@ library;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'menu_anchor.dart';
 import 'menu_style.dart';
 import 'theme.dart';
@@ -38,7 +39,7 @@ import 'theme.dart';
 class MenuThemeData with Diagnosticable {
   /// Creates a const set of properties used to configure [MenuTheme].
   const MenuThemeData({this.style, this.submenuIcon, this.variant})
-    : assert(variant != .material3Expressive, 'Only material3 is supported.');
+    : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// The [MenuStyle] of a [SubmenuButton] menu.
   ///

--- a/packages/material_ui/lib/src/navigation_bar.dart
+++ b/packages/material_ui/lib/src/navigation_bar.dart
@@ -275,9 +275,12 @@ class NavigationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     final NavigationBarThemeData defaults = _defaultsFor(context);
 
     final NavigationBarThemeData navigationBarTheme = NavigationBarTheme.of(context);
+    final StyleVariant effectiveVariant = navigationBarTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final double effectiveHeight = height ?? navigationBarTheme.height ?? defaults.height!;
     final NavigationDestinationLabelBehavior effectiveLabelBehavior =
         labelBehavior ?? navigationBarTheme.labelBehavior ?? defaults.labelBehavior!;

--- a/packages/material_ui/lib/src/navigation_bar.dart
+++ b/packages/material_ui/lib/src/navigation_bar.dart
@@ -15,6 +15,7 @@ import 'package:flutter/widgets.dart';
 
 import 'color_scheme.dart';
 import 'colors.dart';
+import 'debug.dart';
 import 'elevation_overlay.dart';
 import 'ink_decoration.dart';
 import 'ink_well.dart';
@@ -280,7 +281,7 @@ class NavigationBar extends StatelessWidget {
 
     final NavigationBarThemeData navigationBarTheme = NavigationBarTheme.of(context);
     final StyleVariant effectiveVariant = navigationBarTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final double effectiveHeight = height ?? navigationBarTheme.height ?? defaults.height!;
     final NavigationDestinationLabelBehavior effectiveLabelBehavior =
         labelBehavior ?? navigationBarTheme.labelBehavior ?? defaults.labelBehavior!;

--- a/packages/material_ui/lib/src/navigation_bar_theme.dart
+++ b/packages/material_ui/lib/src/navigation_bar_theme.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'navigation_bar.dart';
 import 'theme.dart';
 
@@ -53,7 +54,7 @@ class NavigationBarThemeData with Diagnosticable {
     this.overlayColor,
     this.labelPadding,
     this.variant,
-  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
+  }) : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides the default value of [NavigationBar.height].
   final double? height;

--- a/packages/material_ui/lib/src/navigation_bar_theme.dart
+++ b/packages/material_ui/lib/src/navigation_bar_theme.dart
@@ -52,7 +52,8 @@ class NavigationBarThemeData with Diagnosticable {
     this.labelBehavior,
     this.overlayColor,
     this.labelPadding,
-  });
+    this.variant,
+  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides the default value of [NavigationBar.height].
   final double? height;
@@ -97,6 +98,9 @@ class NavigationBarThemeData with Diagnosticable {
   /// Overrides the default value of [NavigationBar.labelPadding].
   final EdgeInsetsGeometry? labelPadding;
 
+  /// The style variant of Material Design used by [NavigationBar].
+  final StyleVariant? variant;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   NavigationBarThemeData copyWith({
@@ -112,6 +116,7 @@ class NavigationBarThemeData with Diagnosticable {
     NavigationDestinationLabelBehavior? labelBehavior,
     WidgetStateProperty<Color?>? overlayColor,
     EdgeInsetsGeometry? labelPadding,
+    StyleVariant? variant,
   }) {
     return NavigationBarThemeData(
       height: height ?? this.height,
@@ -126,6 +131,7 @@ class NavigationBarThemeData with Diagnosticable {
       labelBehavior: labelBehavior ?? this.labelBehavior,
       overlayColor: overlayColor ?? this.overlayColor,
       labelPadding: labelPadding ?? this.labelPadding,
+      variant: variant ?? this.variant,
     );
   }
 
@@ -170,6 +176,7 @@ class NavigationBarThemeData with Diagnosticable {
         Color.lerp,
       ),
       labelPadding: EdgeInsetsGeometry.lerp(a?.labelPadding, b?.labelPadding, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
     );
   }
 
@@ -187,6 +194,7 @@ class NavigationBarThemeData with Diagnosticable {
     labelBehavior,
     overlayColor,
     labelPadding,
+    variant,
   );
 
   @override
@@ -209,7 +217,8 @@ class NavigationBarThemeData with Diagnosticable {
         other.iconTheme == iconTheme &&
         other.labelBehavior == labelBehavior &&
         other.overlayColor == overlayColor &&
-        other.labelPadding == labelPadding;
+        other.labelPadding == labelPadding &&
+        other.variant == variant;
   }
 
   @override
@@ -255,6 +264,7 @@ class NavigationBarThemeData with Diagnosticable {
     properties.add(
       DiagnosticsProperty<EdgeInsetsGeometry>('labelPadding', labelPadding, defaultValue: null),
     );
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/navigation_rail.dart
+++ b/packages/material_ui/lib/src/navigation_rail.dart
@@ -444,8 +444,11 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     final NavigationRailThemeData navigationRailTheme = NavigationRailTheme.of(context);
-    final NavigationRailThemeData defaults = Theme.of(context).useMaterial3
+    final StyleVariant effectiveVariant = navigationRailTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    final NavigationRailThemeData defaults = theme.useMaterial3
         ? _NavigationRailDefaultsM3(context)
         : _NavigationRailDefaultsM2(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
@@ -489,7 +492,7 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
     // For backwards compatibility, in M2 the opacity of the unselected icons needs
     // to be set to the default if it isn't in the given theme. This can be removed
     // when Material 3 is the default.
-    final IconThemeData effectiveUnselectedIconTheme = Theme.of(context).useMaterial3
+    final IconThemeData effectiveUnselectedIconTheme = theme.useMaterial3
         ? unselectedIconTheme
         : unselectedIconTheme.copyWith(
             opacity: unselectedIconTheme.opacity ?? defaults.unselectedIconTheme!.opacity,

--- a/packages/material_ui/lib/src/navigation_rail.dart
+++ b/packages/material_ui/lib/src/navigation_rail.dart
@@ -13,6 +13,7 @@ import 'dart:ui';
 import 'package:flutter/widgets.dart';
 
 import 'color_scheme.dart';
+import 'debug.dart';
 import 'ink_well.dart';
 import 'material.dart';
 import 'material_localizations.dart';
@@ -447,7 +448,7 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
     final ThemeData theme = Theme.of(context);
     final NavigationRailThemeData navigationRailTheme = NavigationRailTheme.of(context);
     final StyleVariant effectiveVariant = navigationRailTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final NavigationRailThemeData defaults = theme.useMaterial3
         ? _NavigationRailDefaultsM3(context)
         : _NavigationRailDefaultsM2(context);

--- a/packages/material_ui/lib/src/navigation_rail_theme.dart
+++ b/packages/material_ui/lib/src/navigation_rail_theme.dart
@@ -11,6 +11,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'navigation_rail.dart';
 import 'theme.dart';
 
@@ -55,7 +56,7 @@ class NavigationRailThemeData with Diagnosticable {
     this.minWidth,
     this.minExtendedWidth,
     this.variant,
-  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
+  }) : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Color to be used for the [NavigationRail]'s background.
   final Color? backgroundColor;

--- a/packages/material_ui/lib/src/navigation_rail_theme.dart
+++ b/packages/material_ui/lib/src/navigation_rail_theme.dart
@@ -54,7 +54,8 @@ class NavigationRailThemeData with Diagnosticable {
     this.indicatorShape,
     this.minWidth,
     this.minExtendedWidth,
-  });
+    this.variant,
+  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Color to be used for the [NavigationRail]'s background.
   final Color? backgroundColor;
@@ -105,6 +106,9 @@ class NavigationRailThemeData with Diagnosticable {
   /// is extended.
   final double? minExtendedWidth;
 
+  /// The style variant of Material Design used by [NavigationRail].
+  final StyleVariant? variant;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   NavigationRailThemeData copyWith({
@@ -121,6 +125,7 @@ class NavigationRailThemeData with Diagnosticable {
     ShapeBorder? indicatorShape,
     double? minWidth,
     double? minExtendedWidth,
+    StyleVariant? variant,
   }) {
     return NavigationRailThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -136,6 +141,7 @@ class NavigationRailThemeData with Diagnosticable {
       indicatorShape: indicatorShape ?? this.indicatorShape,
       minWidth: minWidth ?? this.minWidth,
       minExtendedWidth: minExtendedWidth ?? this.minExtendedWidth,
+      variant: variant ?? this.variant,
     );
   }
 
@@ -178,6 +184,7 @@ class NavigationRailThemeData with Diagnosticable {
       indicatorShape: ShapeBorder.lerp(a?.indicatorShape, b?.indicatorShape, t),
       minWidth: lerpDouble(a?.minWidth, b?.minWidth, t),
       minExtendedWidth: lerpDouble(a?.minExtendedWidth, b?.minExtendedWidth, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
     );
   }
 
@@ -196,6 +203,7 @@ class NavigationRailThemeData with Diagnosticable {
     indicatorShape,
     minWidth,
     minExtendedWidth,
+    variant,
   );
 
   @override
@@ -219,7 +227,8 @@ class NavigationRailThemeData with Diagnosticable {
         other.indicatorColor == indicatorColor &&
         other.indicatorShape == indicatorShape &&
         other.minWidth == minWidth &&
-        other.minExtendedWidth == minExtendedWidth;
+        other.minExtendedWidth == minExtendedWidth &&
+        other.variant == variant;
   }
 
   @override
@@ -290,6 +299,7 @@ class NavigationRailThemeData with Diagnosticable {
         defaultValue: defaultData.minExtendedWidth,
       ),
     );
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/outlined_button.dart
+++ b/packages/material_ui/lib/src/outlined_button.dart
@@ -18,6 +18,7 @@ import 'button_style_button.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'constants.dart';
+import 'debug.dart';
 import 'ink_ripple.dart';
 import 'ink_well.dart';
 import 'material_state.dart';
@@ -349,7 +350,7 @@ class OutlinedButton extends ButtonStyleButton {
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final StyleVariant effectiveVariant = OutlinedButtonTheme.of(context).variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final ColorScheme colorScheme = theme.colorScheme;
     final ButtonStyle buttonStyle = theme.useMaterial3
         ? _OutlinedButtonDefaultsM3(context)

--- a/packages/material_ui/lib/src/outlined_button.dart
+++ b/packages/material_ui/lib/src/outlined_button.dart
@@ -348,6 +348,8 @@ class OutlinedButton extends ButtonStyleButton {
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final StyleVariant effectiveVariant = OutlinedButtonTheme.of(context).variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final ColorScheme colorScheme = theme.colorScheme;
     final ButtonStyle buttonStyle = theme.useMaterial3
         ? _OutlinedButtonDefaultsM3(context)

--- a/packages/material_ui/lib/src/outlined_button_theme.dart
+++ b/packages/material_ui/lib/src/outlined_button_theme.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button_style.dart';
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -40,7 +41,7 @@ class OutlinedButtonThemeData with Diagnosticable {
   ///
   /// The [style] may be null.
   const OutlinedButtonThemeData({this.style, this.variant})
-    : assert(variant != .material3Expressive, 'Only material3 is supported.');
+    : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides for [OutlinedButton]'s default style.
   ///

--- a/packages/material_ui/lib/src/outlined_button_theme.dart
+++ b/packages/material_ui/lib/src/outlined_button_theme.dart
@@ -39,7 +39,8 @@ class OutlinedButtonThemeData with Diagnosticable {
   /// Creates a [OutlinedButtonThemeData].
   ///
   /// The [style] may be null.
-  const OutlinedButtonThemeData({this.style});
+  const OutlinedButtonThemeData({this.style, this.variant})
+    : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides for [OutlinedButton]'s default style.
   ///
@@ -50,6 +51,9 @@ class OutlinedButtonThemeData with Diagnosticable {
   /// If [style] is null, then this theme doesn't override anything.
   final ButtonStyle? style;
 
+  /// The style variant of Material Design used by [OutlinedButton].
+  final StyleVariant? variant;
+
   /// Linearly interpolate between two outlined button themes.
   static OutlinedButtonThemeData? lerp(
     OutlinedButtonThemeData? a,
@@ -59,11 +63,14 @@ class OutlinedButtonThemeData with Diagnosticable {
     if (identical(a, b)) {
       return a;
     }
-    return OutlinedButtonThemeData(style: ButtonStyle.lerp(a?.style, b?.style, t));
+    return OutlinedButtonThemeData(
+      style: ButtonStyle.lerp(a?.style, b?.style, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
+    );
   }
 
   @override
-  int get hashCode => style.hashCode;
+  int get hashCode => Object.hash(style, variant);
 
   @override
   bool operator ==(Object other) {
@@ -73,13 +80,14 @@ class OutlinedButtonThemeData with Diagnosticable {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is OutlinedButtonThemeData && other.style == style;
+    return other is OutlinedButtonThemeData && other.style == style && other.variant == variant;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ButtonStyle>('style', style, defaultValue: null));
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/progress_indicator.dart
+++ b/packages/material_ui/lib/src/progress_indicator.dart
@@ -14,6 +14,7 @@ import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
 
 import 'color_scheme.dart';
+import 'debug.dart';
 import 'material.dart';
 import 'progress_indicator_theme.dart';
 import 'theme.dart';
@@ -650,7 +651,7 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator>
     final ThemeData theme = Theme.of(context);
     final ProgressIndicatorThemeData indicatorTheme = ProgressIndicatorTheme.of(context);
     final StyleVariant effectiveVariant = indicatorTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final TextDirection textDirection = Directionality.of(context);
 
     if (widget._effectiveValue != null) {
@@ -1133,7 +1134,7 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator>
     final ThemeData theme = Theme.of(context);
     final ProgressIndicatorThemeData indicatorTheme = ProgressIndicatorTheme.of(context);
     final StyleVariant effectiveVariant = indicatorTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final bool year2023 = widget.year2023 ?? indicatorTheme.year2023 ?? true;
     final ProgressIndicatorThemeData defaults = switch (theme.useMaterial3) {
       true =>

--- a/packages/material_ui/lib/src/progress_indicator.dart
+++ b/packages/material_ui/lib/src/progress_indicator.dart
@@ -647,6 +647,10 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator>
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ProgressIndicatorThemeData indicatorTheme = ProgressIndicatorTheme.of(context);
+    final StyleVariant effectiveVariant = indicatorTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final TextDirection textDirection = Directionality.of(context);
 
     if (widget._effectiveValue != null) {
@@ -1126,9 +1130,12 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator>
     double offsetValue,
     double rotationValue,
   ) {
+    final ThemeData theme = Theme.of(context);
     final ProgressIndicatorThemeData indicatorTheme = ProgressIndicatorTheme.of(context);
+    final StyleVariant effectiveVariant = indicatorTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final bool year2023 = widget.year2023 ?? indicatorTheme.year2023 ?? true;
-    final ProgressIndicatorThemeData defaults = switch (Theme.of(context).useMaterial3) {
+    final ProgressIndicatorThemeData defaults = switch (theme.useMaterial3) {
       true =>
         year2023
             ? _CircularProgressIndicatorDefaultsM3Year2023(

--- a/packages/material_ui/lib/src/progress_indicator_theme.dart
+++ b/packages/material_ui/lib/src/progress_indicator_theme.dart
@@ -11,6 +11,7 @@ import 'dart:ui' show lerpDouble;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -58,7 +59,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
     this.year2023,
     this.controller,
     this.variant,
-  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
+  }) : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// The color of the [ProgressIndicator]'s indicator.
   ///

--- a/packages/material_ui/lib/src/progress_indicator_theme.dart
+++ b/packages/material_ui/lib/src/progress_indicator_theme.dart
@@ -57,7 +57,8 @@ class ProgressIndicatorThemeData with Diagnosticable {
     )
     this.year2023,
     this.controller,
-  });
+    this.variant,
+  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// The color of the [ProgressIndicator]'s indicator.
   ///
@@ -152,6 +153,9 @@ class ProgressIndicatorThemeData with Diagnosticable {
   /// manage its own internal [AnimationController].
   final AnimationController? controller;
 
+  /// The style variant of Material Design used by progress indicators.
+  final StyleVariant? variant;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   ProgressIndicatorThemeData copyWith({
@@ -171,6 +175,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
     EdgeInsetsGeometry? circularTrackPadding,
     bool? year2023,
     AnimationController? controller,
+    StyleVariant? variant,
   }) {
     return ProgressIndicatorThemeData(
       color: color ?? this.color,
@@ -189,6 +194,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
       circularTrackPadding: circularTrackPadding ?? this.circularTrackPadding,
       year2023: year2023 ?? this.year2023,
       controller: controller ?? this.controller,
+      variant: variant ?? this.variant,
     );
   }
 
@@ -224,6 +230,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
       ),
       year2023: t < 0.5 ? a?.year2023 : b?.year2023,
       controller: t < 0.5 ? a?.controller : b?.controller,
+      variant: t < 0.5 ? a?.variant : b?.variant,
     );
   }
 
@@ -245,6 +252,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
     circularTrackPadding,
     year2023,
     controller,
+    variant,
   );
 
   @override
@@ -271,7 +279,8 @@ class ProgressIndicatorThemeData with Diagnosticable {
         other.trackGap == trackGap &&
         other.circularTrackPadding == circularTrackPadding &&
         other.year2023 == year2023 &&
-        other.controller == controller;
+        other.controller == controller &&
+        other.variant == variant;
   }
 
   @override
@@ -307,6 +316,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
     properties.add(
       DiagnosticsProperty<AnimationController>('controller', controller, defaultValue: null),
     );
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/range_slider.dart
+++ b/packages/material_ui/lib/src/range_slider.dart
@@ -654,7 +654,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     final ThemeData theme = Theme.of(context);
     SliderThemeData sliderTheme = SliderTheme.of(context);
     final StyleVariant effectiveVariant = sliderTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final bool year2023 = widget.year2023 ?? sliderTheme.year2023 ?? true;
     final SliderThemeData defaults = theme.useMaterial3 && !year2023
         ? _RangeSliderDefaultsM3(context)

--- a/packages/material_ui/lib/src/range_slider.dart
+++ b/packages/material_ui/lib/src/range_slider.dart
@@ -653,6 +653,8 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
 
     final ThemeData theme = Theme.of(context);
     SliderThemeData sliderTheme = SliderTheme.of(context);
+    final StyleVariant effectiveVariant = sliderTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final bool year2023 = widget.year2023 ?? sliderTheme.year2023 ?? true;
     final SliderThemeData defaults = theme.useMaterial3 && !year2023
         ? _RangeSliderDefaultsM3(context)

--- a/packages/material_ui/lib/src/search_anchor.dart
+++ b/packages/material_ui/lib/src/search_anchor.dart
@@ -568,6 +568,11 @@ class _SearchAnchorState extends State<SearchAnchor> {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final SearchViewThemeData viewTheme = SearchViewTheme.of(context);
+    final StyleVariant effectiveVariant = viewTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+
     return AnimatedOpacity(
       key: _anchorKey,
       opacity: _getOpacity(),
@@ -1661,8 +1666,11 @@ class _SearchBarState extends State<SearchBar> {
   @override
   Widget build(BuildContext context) {
     final TextDirection textDirection = Directionality.of(context);
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
     final SearchBarThemeData searchBarTheme = SearchBarTheme.of(context);
+    final StyleVariant effectiveVariant = searchBarTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final SearchBarThemeData defaults = _SearchBarDefaultsM3(context);
 
     T? resolve<T>(

--- a/packages/material_ui/lib/src/search_anchor.dart
+++ b/packages/material_ui/lib/src/search_anchor.dart
@@ -19,6 +19,7 @@ import 'button_style.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'constants.dart';
+import 'debug.dart';
 import 'divider.dart';
 import 'divider_theme.dart';
 import 'icon_button.dart';
@@ -571,7 +572,7 @@ class _SearchAnchorState extends State<SearchAnchor> {
     final ThemeData theme = Theme.of(context);
     final SearchViewThemeData viewTheme = SearchViewTheme.of(context);
     final StyleVariant effectiveVariant = viewTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
     return AnimatedOpacity(
       key: _anchorKey,
@@ -1670,7 +1671,7 @@ class _SearchBarState extends State<SearchBar> {
     final ColorScheme colorScheme = theme.colorScheme;
     final SearchBarThemeData searchBarTheme = SearchBarTheme.of(context);
     final StyleVariant effectiveVariant = searchBarTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final SearchBarThemeData defaults = _SearchBarDefaultsM3(context);
 
     T? resolve<T>(

--- a/packages/material_ui/lib/src/search_bar_theme.dart
+++ b/packages/material_ui/lib/src/search_bar_theme.dart
@@ -12,6 +12,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -52,7 +53,7 @@ class SearchBarThemeData with Diagnosticable {
     this.constraints,
     this.textCapitalization,
     this.variant,
-  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
+  }) : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides the default value of the [SearchBar.elevation].
   final WidgetStateProperty<double?>? elevation;

--- a/packages/material_ui/lib/src/search_bar_theme.dart
+++ b/packages/material_ui/lib/src/search_bar_theme.dart
@@ -51,7 +51,8 @@ class SearchBarThemeData with Diagnosticable {
     this.hintStyle,
     this.constraints,
     this.textCapitalization,
-  });
+    this.variant,
+  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides the default value of the [SearchBar.elevation].
   final WidgetStateProperty<double?>? elevation;
@@ -89,6 +90,9 @@ class SearchBarThemeData with Diagnosticable {
   /// Overrides the value of [SearchBar.textCapitalization].
   final TextCapitalization? textCapitalization;
 
+  /// The style variant of Material Design used by [SearchBar].
+  final StyleVariant? variant;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   SearchBarThemeData copyWith({
@@ -104,6 +108,7 @@ class SearchBarThemeData with Diagnosticable {
     WidgetStateProperty<TextStyle?>? hintStyle,
     BoxConstraints? constraints,
     TextCapitalization? textCapitalization,
+    StyleVariant? variant,
   }) {
     return SearchBarThemeData(
       elevation: elevation ?? this.elevation,
@@ -118,6 +123,7 @@ class SearchBarThemeData with Diagnosticable {
       hintStyle: hintStyle ?? this.hintStyle,
       constraints: constraints ?? this.constraints,
       textCapitalization: textCapitalization ?? this.textCapitalization,
+      variant: variant ?? this.variant,
     );
   }
 
@@ -171,6 +177,7 @@ class SearchBarThemeData with Diagnosticable {
       ),
       constraints: BoxConstraints.lerp(a?.constraints, b?.constraints, t),
       textCapitalization: t < 0.5 ? a?.textCapitalization : b?.textCapitalization,
+      variant: t < 0.5 ? a?.variant : b?.variant,
     );
   }
 
@@ -188,6 +195,7 @@ class SearchBarThemeData with Diagnosticable {
     hintStyle,
     constraints,
     textCapitalization,
+    variant,
   );
 
   @override
@@ -210,7 +218,8 @@ class SearchBarThemeData with Diagnosticable {
         other.textStyle == textStyle &&
         other.hintStyle == hintStyle &&
         other.constraints == constraints &&
-        other.textCapitalization == textCapitalization;
+        other.textCapitalization == textCapitalization &&
+        other.variant == variant;
   }
 
   @override
@@ -284,6 +293,7 @@ class SearchBarThemeData with Diagnosticable {
         defaultValue: null,
       ),
     );
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/search_view_theme.dart
+++ b/packages/material_ui/lib/src/search_view_theme.dart
@@ -53,7 +53,8 @@ class SearchViewThemeData with Diagnosticable {
     this.headerTextStyle,
     this.headerHintStyle,
     this.dividerColor,
-  });
+    this.variant,
+  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides the default value of the [SearchAnchor.viewBackgroundColor].
   final Color? backgroundColor;
@@ -93,6 +94,9 @@ class SearchViewThemeData with Diagnosticable {
 
   /// Overrides the value of the divider color for [SearchAnchor.dividerColor].
   final Color? dividerColor;
+    
+  /// The style variant of Material Design used by search views.
+  final StyleVariant? variant;
 
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
@@ -110,6 +114,7 @@ class SearchViewThemeData with Diagnosticable {
     EdgeInsetsGeometry? barPadding,
     bool? shrinkWrap,
     Color? dividerColor,
+    StyleVariant? variant,
   }) {
     return SearchViewThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -125,6 +130,7 @@ class SearchViewThemeData with Diagnosticable {
       barPadding: barPadding ?? this.barPadding,
       shrinkWrap: shrinkWrap ?? this.shrinkWrap,
       dividerColor: dividerColor ?? this.dividerColor,
+      variant: variant ?? this.variant,
     );
   }
 
@@ -147,6 +153,7 @@ class SearchViewThemeData with Diagnosticable {
       barPadding: EdgeInsetsGeometry.lerp(a?.barPadding, b?.barPadding, t),
       shrinkWrap: t < 0.5 ? a?.shrinkWrap : b?.shrinkWrap,
       dividerColor: Color.lerp(a?.dividerColor, b?.dividerColor, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
     );
   }
 
@@ -165,6 +172,7 @@ class SearchViewThemeData with Diagnosticable {
     barPadding,
     shrinkWrap,
     dividerColor,
+    variant,
   );
 
   @override
@@ -188,7 +196,8 @@ class SearchViewThemeData with Diagnosticable {
         other.padding == padding &&
         other.barPadding == barPadding &&
         other.shrinkWrap == shrinkWrap &&
-        other.dividerColor == dividerColor;
+        other.dividerColor == dividerColor &&
+        other.variant == variant;
   }
 
   @override
@@ -221,6 +230,7 @@ class SearchViewThemeData with Diagnosticable {
     );
     properties.add(DiagnosticsProperty<bool?>('shrinkWrap', shrinkWrap, defaultValue: null));
     properties.add(DiagnosticsProperty<Color?>('dividerColor', dividerColor, defaultValue: null));
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 
   // Special case because BorderSide.lerp() doesn't support null arguments

--- a/packages/material_ui/lib/src/search_view_theme.dart
+++ b/packages/material_ui/lib/src/search_view_theme.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -54,7 +55,7 @@ class SearchViewThemeData with Diagnosticable {
     this.headerHintStyle,
     this.dividerColor,
     this.variant,
-  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
+  }) : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides the default value of the [SearchAnchor.viewBackgroundColor].
   final Color? backgroundColor;
@@ -94,7 +95,7 @@ class SearchViewThemeData with Diagnosticable {
 
   /// Overrides the value of the divider color for [SearchAnchor.dividerColor].
   final Color? dividerColor;
-    
+
   /// The style variant of Material Design used by search views.
   final StyleVariant? variant;
 

--- a/packages/material_ui/lib/src/slider.dart
+++ b/packages/material_ui/lib/src/slider.dart
@@ -831,6 +831,8 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   Widget _buildMaterialSlider(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     SliderThemeData sliderTheme = SliderTheme.of(context);
+    final StyleVariant effectiveVariant = sliderTheme.variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final bool year2023 = widget.year2023 ?? sliderTheme.year2023 ?? true;
     final SliderThemeData defaults = switch (theme.useMaterial3) {
       true => year2023 ? _SliderDefaultsM3Year2023(context) : _SliderDefaultsM3(context),

--- a/packages/material_ui/lib/src/slider.dart
+++ b/packages/material_ui/lib/src/slider.dart
@@ -832,7 +832,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     final ThemeData theme = Theme.of(context);
     SliderThemeData sliderTheme = SliderTheme.of(context);
     final StyleVariant effectiveVariant = sliderTheme.variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final bool year2023 = widget.year2023 ?? sliderTheme.year2023 ?? true;
     final SliderThemeData defaults = switch (theme.useMaterial3) {
       true => year2023 ? _SliderDefaultsM3Year2023(context) : _SliderDefaultsM3(context),

--- a/packages/material_ui/lib/src/slider_theme.dart
+++ b/packages/material_ui/lib/src/slider_theme.dart
@@ -14,6 +14,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
+import 'debug.dart';
 import 'range_slider_parts.dart';
 import 'slider.dart';
 import 'slider_parts.dart';
@@ -319,7 +320,7 @@ class SliderThemeData with Diagnosticable {
     )
     this.year2023,
     this.variant,
-  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
+  }) : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Generates a SliderThemeData from three main colors.
   ///
@@ -659,7 +660,7 @@ class SliderThemeData with Diagnosticable {
     'This feature was deprecated after v3.27.0-0.2.pre.',
   )
   final bool? year2023;
-    
+
   /// The style variant of Material Design used by sliders.
   final StyleVariant? variant;
 

--- a/packages/material_ui/lib/src/slider_theme.dart
+++ b/packages/material_ui/lib/src/slider_theme.dart
@@ -318,7 +318,8 @@ class SliderThemeData with Diagnosticable {
       'This feature was deprecated after v3.27.0-0.2.pre.',
     )
     this.year2023,
-  });
+    this.variant,
+  }) : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Generates a SliderThemeData from three main colors.
   ///
@@ -658,6 +659,9 @@ class SliderThemeData with Diagnosticable {
     'This feature was deprecated after v3.27.0-0.2.pre.',
   )
   final bool? year2023;
+    
+  /// The style variant of Material Design used by sliders.
+  final StyleVariant? variant;
 
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
@@ -698,6 +702,7 @@ class SliderThemeData with Diagnosticable {
     WidgetStateProperty<Size?>? thumbSize,
     double? trackGap,
     bool? year2023,
+    StyleVariant? variant,
   }) {
     return SliderThemeData(
       trackHeight: trackHeight ?? this.trackHeight,
@@ -738,6 +743,7 @@ class SliderThemeData with Diagnosticable {
       thumbSize: thumbSize ?? this.thumbSize,
       trackGap: trackGap ?? this.trackGap,
       year2023: year2023 ?? this.year2023,
+      variant: variant ?? this.variant,
     );
   }
 
@@ -821,6 +827,7 @@ class SliderThemeData with Diagnosticable {
       thumbSize: WidgetStateProperty.lerp<Size?>(a.thumbSize, b.thumbSize, t, Size.lerp),
       trackGap: lerpDouble(a.trackGap, b.trackGap, t),
       year2023: t < 0.5 ? a.year2023 : b.year2023,
+      variant: t < 0.5 ? a.variant : b.variant,
     );
   }
 
@@ -862,6 +869,7 @@ class SliderThemeData with Diagnosticable {
       thumbSize,
       trackGap,
       year2023,
+      variant,
     ),
   );
 
@@ -909,7 +917,8 @@ class SliderThemeData with Diagnosticable {
         other.padding == padding &&
         other.thumbSize == thumbSize &&
         other.trackGap == trackGap &&
-        other.year2023 == year2023;
+        other.year2023 == year2023 &&
+        other.variant == variant;
   }
 
   @override
@@ -1144,6 +1153,7 @@ class SliderThemeData with Diagnosticable {
     properties.add(
       DiagnosticsProperty<bool>('year2023', year2023, defaultValue: defaultData.year2023),
     );
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/text_button.dart
+++ b/packages/material_ui/lib/src/text_button.dart
@@ -18,6 +18,7 @@ import 'button_style_button.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'constants.dart';
+import 'debug.dart';
 import 'ink_ripple.dart';
 import 'ink_well.dart';
 import 'material_state.dart';
@@ -379,7 +380,7 @@ class TextButton extends ButtonStyleButton {
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final StyleVariant effectiveVariant = TextButtonTheme.of(context).variant ?? theme.variant;
-    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
+    assert(effectiveVariant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     final ColorScheme colorScheme = theme.colorScheme;
     final ButtonStyle buttonStyle = theme.useMaterial3
         ? _TextButtonDefaultsM3(context)

--- a/packages/material_ui/lib/src/text_button.dart
+++ b/packages/material_ui/lib/src/text_button.dart
@@ -378,6 +378,8 @@ class TextButton extends ButtonStyleButton {
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final StyleVariant effectiveVariant = TextButtonTheme.of(context).variant ?? theme.variant;
+    assert(effectiveVariant != .material3Expressive, 'Only material3 is supported.');
     final ColorScheme colorScheme = theme.colorScheme;
     final ButtonStyle buttonStyle = theme.useMaterial3
         ? _TextButtonDefaultsM3(context)

--- a/packages/material_ui/lib/src/text_button_theme.dart
+++ b/packages/material_ui/lib/src/text_button_theme.dart
@@ -39,7 +39,8 @@ class TextButtonThemeData with Diagnosticable {
   /// Creates a [TextButtonThemeData].
   ///
   /// The [style] may be null.
-  const TextButtonThemeData({this.style});
+  const TextButtonThemeData({this.style, this.variant})
+    : assert(variant != .material3Expressive, 'Only material3 is supported.');
 
   /// Overrides for [TextButton]'s default style.
   ///
@@ -50,16 +51,22 @@ class TextButtonThemeData with Diagnosticable {
   /// If [style] is null, then this theme doesn't override anything.
   final ButtonStyle? style;
 
+  /// The style variant of Material Design used by [TextButton].
+  final StyleVariant? variant;
+
   /// Linearly interpolate between two text button themes.
   static TextButtonThemeData? lerp(TextButtonThemeData? a, TextButtonThemeData? b, double t) {
     if (identical(a, b)) {
       return a;
     }
-    return TextButtonThemeData(style: ButtonStyle.lerp(a?.style, b?.style, t));
+    return TextButtonThemeData(
+      style: ButtonStyle.lerp(a?.style, b?.style, t),
+      variant: t < 0.5 ? a?.variant : b?.variant,
+    );
   }
 
   @override
-  int get hashCode => style.hashCode;
+  int get hashCode => Object.hash(style, variant);
 
   @override
   bool operator ==(Object other) {
@@ -69,13 +76,14 @@ class TextButtonThemeData with Diagnosticable {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is TextButtonThemeData && other.style == style;
+    return other is TextButtonThemeData && other.style == style && other.variant == variant;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ButtonStyle>('style', style, defaultValue: null));
+    properties.add(EnumProperty<StyleVariant>('variant', variant, defaultValue: null));
   }
 }
 

--- a/packages/material_ui/lib/src/text_button_theme.dart
+++ b/packages/material_ui/lib/src/text_button_theme.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button_style.dart';
+import 'debug.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -40,7 +41,7 @@ class TextButtonThemeData with Diagnosticable {
   ///
   /// The [style] may be null.
   const TextButtonThemeData({this.style, this.variant})
-    : assert(variant != .material3Expressive, 'Only material3 is supported.');
+    : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
 
   /// Overrides for [TextButton]'s default style.
   ///

--- a/packages/material_ui/lib/src/theme.dart
+++ b/packages/material_ui/lib/src/theme.dart
@@ -14,7 +14,7 @@ import 'material_localizations.dart';
 import 'theme_data.dart';
 import 'typography.dart';
 
-export 'theme_data.dart' show Brightness, MaterialTapTargetSize, ThemeData;
+export 'theme_data.dart' show Brightness, MaterialTapTargetSize, StyleVariant, ThemeData;
 
 /// The duration over which theme changes animate by default.
 const Duration kThemeAnimationDuration = Duration(milliseconds: 200);

--- a/packages/material_ui/lib/src/theme_data.dart
+++ b/packages/material_ui/lib/src/theme_data.dart
@@ -182,6 +182,15 @@ enum MaterialTapTargetSize {
   shrinkWrap,
 }
 
+/// Defines the Material Design style variant used by Material components.
+enum StyleVariant {
+  /// The Material Design 3 style variant.
+  material3,
+
+  /// The Material Design 3 Expressive style variant.
+  material3Expressive,
+}
+
 /// Defines the configuration of the overall visual [Theme] for a [MaterialApp]
 /// or a widget subtree within the app.
 ///
@@ -282,6 +291,7 @@ class ThemeData with Diagnosticable {
     InteractiveInkFeatureFactory? splashFactory,
     bool? useMaterial3,
     bool? useSystemColors,
+    StyleVariant? variant,
     VisualDensity? visualDensity,
     // COLOR
     ColorScheme? colorScheme,
@@ -385,6 +395,7 @@ class ThemeData with Diagnosticable {
     cupertinoOverrideTheme = cupertinoOverrideTheme?.noDefault();
     extensions ??= <ThemeExtension<dynamic>>[];
     adaptations ??= <Adaptation<Object>>[];
+    variant ??= StyleVariant.material3;
     // TODO(bleroux): Clean this up once the type of `inputDecorationTheme` is changed to `InputDecorationThemeData`
     if (inputDecorationTheme != null) {
       if (inputDecorationTheme is InputDecorationTheme) {
@@ -605,6 +616,7 @@ class ThemeData with Diagnosticable {
       scrollbarTheme: scrollbarTheme,
       splashFactory: splashFactory,
       useMaterial3: useMaterial3,
+      variant: variant,
       visualDensity: visualDensity,
       // COLOR
       canvasColor: canvasColor,
@@ -715,6 +727,7 @@ class ThemeData with Diagnosticable {
     required this.scrollbarTheme,
     required this.splashFactory,
     required this.useMaterial3,
+    required this.variant,
     required this.visualDensity,
     // COLOR
     required this.colorScheme,
@@ -841,6 +854,7 @@ class ThemeData with Diagnosticable {
     required ColorScheme colorScheme,
     TextTheme? textTheme,
     bool? useMaterial3,
+    StyleVariant? variant,
   }) {
     final isDark = colorScheme.brightness == Brightness.dark;
 
@@ -861,6 +875,7 @@ class ThemeData with Diagnosticable {
       textTheme: textTheme,
       applyElevationOverlayColor: isDark,
       useMaterial3: useMaterial3,
+      variant: variant,
     );
   }
 
@@ -868,15 +883,15 @@ class ThemeData with Diagnosticable {
   ///
   /// This theme does not contain text geometry. Instead, it is expected that
   /// this theme is localized using text geometry using [ThemeData.localize].
-  factory ThemeData.light({bool? useMaterial3}) =>
-      ThemeData(brightness: Brightness.light, useMaterial3: useMaterial3);
+  factory ThemeData.light({bool? useMaterial3, StyleVariant? variant}) =>
+      ThemeData(brightness: Brightness.light, useMaterial3: useMaterial3, variant: variant);
 
   /// A default dark theme.
   ///
   /// This theme does not contain text geometry. Instead, it is expected that
   /// this theme is localized using text geometry using [ThemeData.localize].
-  factory ThemeData.dark({bool? useMaterial3}) =>
-      ThemeData(brightness: Brightness.dark, useMaterial3: useMaterial3);
+  factory ThemeData.dark({bool? useMaterial3, StyleVariant? variant}) =>
+      ThemeData(brightness: Brightness.dark, useMaterial3: useMaterial3, variant: variant);
 
   /// The default color theme. Same as [ThemeData.light].
   ///
@@ -887,7 +902,8 @@ class ThemeData with Diagnosticable {
   ///
   /// Most applications would use [Theme.of], which provides correct localized
   /// text geometry.
-  factory ThemeData.fallback({bool? useMaterial3}) => ThemeData.light(useMaterial3: useMaterial3);
+  factory ThemeData.fallback({bool? useMaterial3, StyleVariant? variant}) =>
+      ThemeData.light(useMaterial3: useMaterial3, variant: variant);
 
   /// Used to obtain a particular [Adaptation] from [adaptationMap].
   ///
@@ -1144,6 +1160,11 @@ class ThemeData with Diagnosticable {
   ///
   ///   * [Material 3 specification](https://m3.material.io/).
   final bool useMaterial3;
+
+  /// The Material style variant used by Material components.
+  ///
+  /// Defaults to [StyleVariant.material3].
+  final StyleVariant variant;
 
   /// The density value for specifying the compactness of various UI components.
   ///
@@ -1498,6 +1519,7 @@ class ThemeData with Diagnosticable {
     TargetPlatform? platform,
     ScrollbarThemeData? scrollbarTheme,
     InteractiveInkFeatureFactory? splashFactory,
+    StyleVariant? variant,
     VisualDensity? visualDensity,
     // COLOR
     ColorScheme? colorScheme,
@@ -1634,6 +1656,7 @@ class ThemeData with Diagnosticable {
       // When deprecated useMaterial3 removed, maintain `this.useMaterial3` here
       // for == evaluation.
       useMaterial3: useMaterial3 ?? this.useMaterial3,
+      variant: variant ?? this.variant,
       visualDensity: visualDensity ?? this.visualDensity,
       // COLOR
       canvasColor: canvasColor ?? this.canvasColor,
@@ -1959,6 +1982,7 @@ class ThemeData with Diagnosticable {
       scrollbarTheme: ScrollbarThemeData.lerp(a.scrollbarTheme, b.scrollbarTheme, t),
       splashFactory: t < 0.5 ? a.splashFactory : b.splashFactory,
       useMaterial3: t < 0.5 ? a.useMaterial3 : b.useMaterial3,
+      variant: t < 0.5 ? a.variant : b.variant,
       visualDensity: VisualDensity.lerp(a.visualDensity, b.visualDensity, t),
       // COLOR
       canvasColor: Color.lerp(a.canvasColor, b.canvasColor, t)!,
@@ -2107,6 +2131,7 @@ class ThemeData with Diagnosticable {
         other.scrollbarTheme == scrollbarTheme &&
         other.splashFactory == splashFactory &&
         other.useMaterial3 == useMaterial3 &&
+        other.variant == variant &&
         other.visualDensity == visualDensity &&
         // COLOR
         other.canvasColor == canvasColor &&
@@ -2207,6 +2232,7 @@ class ThemeData with Diagnosticable {
       scrollbarTheme,
       splashFactory,
       useMaterial3,
+      variant,
       visualDensity,
       // COLOR
       canvasColor,
@@ -2378,6 +2404,14 @@ class ThemeData with Diagnosticable {
         'useMaterial3',
         useMaterial3,
         defaultValue: defaultData.useMaterial3,
+        level: DiagnosticLevel.debug,
+      ),
+    );
+    properties.add(
+      EnumProperty<StyleVariant>(
+        'variant',
+        variant,
+        defaultValue: defaultData.variant,
         level: DiagnosticLevel.debug,
       ),
     );

--- a/packages/material_ui/lib/src/theme_data.dart
+++ b/packages/material_ui/lib/src/theme_data.dart
@@ -29,6 +29,7 @@ import 'colors.dart';
 import 'constants.dart';
 import 'data_table_theme.dart';
 import 'date_picker_theme.dart';
+import 'debug.dart';
 import 'dialog_theme.dart';
 import 'divider_theme.dart';
 import 'drawer_theme.dart';
@@ -396,7 +397,7 @@ class ThemeData with Diagnosticable {
     extensions ??= <ThemeExtension<dynamic>>[];
     adaptations ??= <Adaptation<Object>>[];
     variant ??= StyleVariant.material3;
-    assert(variant != .material3Expressive, 'Only material3 is supported.');
+    assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage);
     // TODO(bleroux): Clean this up once the type of `inputDecorationTheme` is changed to `InputDecorationThemeData`
     if (inputDecorationTheme != null) {
       if (inputDecorationTheme is InputDecorationTheme) {
@@ -820,7 +821,7 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.28.0-1.0.pre.',
     )
     required this.indicatorColor,
-  }) : assert(variant != .material3Expressive, 'Only material3 is supported.'),
+  }) : assert(variant != .material3Expressive, kUnsupportedStyleVariantAssertionMessage),
        // DEPRECATED (newest deprecations at the bottom)
        // should not be `required`, use getter pattern to avoid breakages.
        _buttonBarTheme = buttonBarTheme,

--- a/packages/material_ui/lib/src/theme_data.dart
+++ b/packages/material_ui/lib/src/theme_data.dart
@@ -396,6 +396,7 @@ class ThemeData with Diagnosticable {
     extensions ??= <ThemeExtension<dynamic>>[];
     adaptations ??= <Adaptation<Object>>[];
     variant ??= StyleVariant.material3;
+    assert(variant != .material3Expressive, 'Only material3 is supported.');
     // TODO(bleroux): Clean this up once the type of `inputDecorationTheme` is changed to `InputDecorationThemeData`
     if (inputDecorationTheme != null) {
       if (inputDecorationTheme is InputDecorationTheme) {
@@ -819,7 +820,8 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.28.0-1.0.pre.',
     )
     required this.indicatorColor,
-  }) : // DEPRECATED (newest deprecations at the bottom)
+  }) : assert(variant != .material3Expressive, 'Only material3 is supported.'),
+       // DEPRECATED (newest deprecations at the bottom)
        // should not be `required`, use getter pattern to avoid breakages.
        _buttonBarTheme = buttonBarTheme,
        assert(buttonBarTheme != null);
@@ -1161,7 +1163,7 @@ class ThemeData with Diagnosticable {
   ///   * [Material 3 specification](https://m3.material.io/).
   final bool useMaterial3;
 
-  /// The Material style variant used by Material components.
+  /// The style variant of Material Design used by Material components.
   ///
   /// Defaults to [StyleVariant.material3].
   final StyleVariant variant;

--- a/packages/material_ui/test/app_bar_theme_test.dart
+++ b/packages/material_ui/test/app_bar_theme_test.dart
@@ -19,7 +19,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/app_bar_theme_test.dart
+++ b/packages/material_ui/test/app_bar_theme_test.dart
@@ -8,6 +8,21 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _AppBarThemeDataWithExpressiveVariant extends AppBarThemeData {
+  const _AppBarThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   const appBarTheme = AppBarThemeData(
     backgroundColor: Color(0xff00ff00),
@@ -53,6 +68,19 @@ void main() {
   test('AppBarTheme lerp special cases', () {
     const data = AppBarTheme();
     expect(identical(AppBarTheme.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('AppBar asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppBarTheme(
+          data: const _AppBarThemeDataWithExpressiveVariant(),
+          child: AppBar(title: const Text('Title')),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('Material2 - Passing no AppBarTheme returns defaults', (WidgetTester tester) async {

--- a/packages/material_ui/test/app_bar_theme_test.dart
+++ b/packages/material_ui/test/app_bar_theme_test.dart
@@ -19,7 +19,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/elevated_button_theme_test.dart
+++ b/packages/material_ui/test/elevated_button_theme_test.dart
@@ -5,6 +5,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _ElevatedButtonThemeDataWithExpressiveVariant extends ElevatedButtonThemeData {
+  const _ElevatedButtonThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   TextStyle iconStyle(WidgetTester tester, IconData icon) {
     final RichText iconRichText = tester.widget<RichText>(
@@ -17,6 +32,19 @@ void main() {
     expect(ElevatedButtonThemeData.lerp(null, null, 0), null);
     const data = ElevatedButtonThemeData();
     expect(identical(ElevatedButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('ElevatedButton asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ElevatedButtonTheme(
+          data: const _ElevatedButtonThemeDataWithExpressiveVariant(),
+          child: ElevatedButton(onPressed: () {}, child: const Text('Button')),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('Material3: Passing no ElevatedButtonTheme returns defaults', (

--- a/packages/material_ui/test/elevated_button_theme_test.dart
+++ b/packages/material_ui/test/elevated_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/elevated_button_theme_test.dart
+++ b/packages/material_ui/test/elevated_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/filled_button_theme_test.dart
+++ b/packages/material_ui/test/filled_button_theme_test.dart
@@ -5,6 +5,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _FilledButtonThemeDataWithExpressiveVariant extends FilledButtonThemeData {
+  const _FilledButtonThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   TextStyle iconStyle(WidgetTester tester, IconData icon) {
     final RichText iconRichText = tester.widget<RichText>(
@@ -17,6 +32,19 @@ void main() {
     expect(FilledButtonThemeData.lerp(null, null, 0), null);
     const data = FilledButtonThemeData();
     expect(identical(FilledButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('FilledButton asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FilledButtonTheme(
+          data: const _FilledButtonThemeDataWithExpressiveVariant(),
+          child: FilledButton(onPressed: () {}, child: const Text('Button')),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('Passing no FilledButtonTheme returns defaults', (WidgetTester tester) async {

--- a/packages/material_ui/test/filled_button_theme_test.dart
+++ b/packages/material_ui/test/filled_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/filled_button_theme_test.dart
+++ b/packages/material_ui/test/filled_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/floating_action_button_theme_test.dart
+++ b/packages/material_ui/test/floating_action_button_theme_test.dart
@@ -18,7 +18,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/floating_action_button_theme_test.dart
+++ b/packages/material_ui/test/floating_action_button_theme_test.dart
@@ -7,6 +7,21 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _FloatingActionButtonThemeDataWithExpressiveVariant extends FloatingActionButtonThemeData {
+  const _FloatingActionButtonThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   test('FloatingActionButtonThemeData copyWith, ==, hashCode basics', () {
     expect(const FloatingActionButtonThemeData(), const FloatingActionButtonThemeData().copyWith());
@@ -20,6 +35,21 @@ void main() {
     expect(FloatingActionButtonThemeData.lerp(null, null, 0), null);
     const data = FloatingActionButtonThemeData();
     expect(identical(FloatingActionButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('FloatingActionButton asserts on unsupported style variants', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FloatingActionButtonTheme(
+          data: const _FloatingActionButtonThemeDataWithExpressiveVariant(),
+          child: FloatingActionButton(onPressed: () {}),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets(

--- a/packages/material_ui/test/floating_action_button_theme_test.dart
+++ b/packages/material_ui/test/floating_action_button_theme_test.dart
@@ -18,7 +18,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/icon_button_theme_test.dart
+++ b/packages/material_ui/test/icon_button_theme_test.dart
@@ -7,6 +7,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _IconButtonThemeDataWithExpressiveVariant extends IconButtonThemeData {
+  const _IconButtonThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
 void main() {
   RenderObject getOverlayColor(WidgetTester tester) {
     return tester.allRenderObjects.firstWhere(
@@ -18,6 +25,28 @@ void main() {
     expect(IconButtonThemeData.lerp(null, null, 0), null);
     const data = IconButtonThemeData();
     expect(identical(IconButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('IconButton asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: IconButtonTheme(
+            data: _IconButtonThemeDataWithExpressiveVariant(),
+            child: IconButton(onPressed: null, icon: Icon(Icons.ac_unit)),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.takeException(),
+      isA<AssertionError>().having(
+        (AssertionError error) => error.message,
+        'message',
+        'Only material3 is supported.',
+      ),
+    );
   });
 
   testWidgets('Passing no IconButtonTheme returns defaults', (WidgetTester tester) async {

--- a/packages/material_ui/test/icon_button_theme_test.dart
+++ b/packages/material_ui/test/icon_button_theme_test.dart
@@ -44,7 +44,7 @@ void main() {
       isA<AssertionError>().having(
         (AssertionError error) => error.message,
         'message',
-        'Only material3 is supported.',
+        'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
       ),
     );
   });

--- a/packages/material_ui/test/icon_button_theme_test.dart
+++ b/packages/material_ui/test/icon_button_theme_test.dart
@@ -44,7 +44,7 @@ void main() {
       isA<AssertionError>().having(
         (AssertionError error) => error.message,
         'message',
-        'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+        kUnsupportedStyleVariantAssertionMessage,
       ),
     );
   });

--- a/packages/material_ui/test/menu_button_theme_test.dart
+++ b/packages/material_ui/test/menu_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/menu_button_theme_test.dart
+++ b/packages/material_ui/test/menu_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/menu_button_theme_test.dart
+++ b/packages/material_ui/test/menu_button_theme_test.dart
@@ -5,10 +5,54 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _MenuButtonThemeDataWithExpressiveVariant extends MenuButtonThemeData {
+  const _MenuButtonThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   test('MenuButtonThemeData lerp special cases', () {
     expect(MenuButtonThemeData.lerp(null, null, 0), null);
     const data = MenuButtonThemeData();
     expect(identical(MenuButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('MenuItemButton asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MenuButtonTheme(
+          data: const _MenuButtonThemeDataWithExpressiveVariant(),
+          child: MenuItemButton(onPressed: () {}, child: const Text('Item')),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
+  });
+
+  testWidgets('SubmenuButton asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MenuButtonTheme(
+          data: const _MenuButtonThemeDataWithExpressiveVariant(),
+          child: SubmenuButton(
+            menuChildren: <Widget>[MenuItemButton(onPressed: () {}, child: const Text('Item'))],
+            child: const Text('Submenu'),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 }

--- a/packages/material_ui/test/menu_theme_test.dart
+++ b/packages/material_ui/test/menu_theme_test.dart
@@ -18,7 +18,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/menu_theme_test.dart
+++ b/packages/material_ui/test/menu_theme_test.dart
@@ -7,6 +7,21 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _MenuThemeDataWithExpressiveVariant extends MenuThemeData {
+  const _MenuThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   void onPressed(TestMenu item) {}
 
@@ -58,6 +73,24 @@ void main() {
     const menuThemeData = MenuThemeData();
     expect(menuThemeData.style, isNull);
     expect(menuThemeData.submenuIcon, isNull);
+  });
+
+  testWidgets('MenuAnchor asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MenuTheme(
+          data: const _MenuThemeDataWithExpressiveVariant(),
+          child: MenuAnchor(
+            menuChildren: <Widget>[MenuItemButton(onPressed: () {}, child: const Text('Item'))],
+            builder: (BuildContext context, MenuController controller, Widget? child) {
+              return TextButton(onPressed: controller.open, child: const Text('Open'));
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('Default MenuThemeData debugFillProperties', (WidgetTester tester) async {

--- a/packages/material_ui/test/menu_theme_test.dart
+++ b/packages/material_ui/test/menu_theme_test.dart
@@ -18,7 +18,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/navigation_bar_theme_test.dart
+++ b/packages/material_ui/test/navigation_bar_theme_test.dart
@@ -25,7 +25,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/navigation_bar_theme_test.dart
+++ b/packages/material_ui/test/navigation_bar_theme_test.dart
@@ -14,6 +14,21 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _NavigationBarThemeDataWithExpressiveVariant extends NavigationBarThemeData {
+  const _NavigationBarThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   test('copyWith, ==, hashCode basics', () {
     expect(const NavigationBarThemeData(), const NavigationBarThemeData().copyWith());
@@ -27,6 +42,24 @@ void main() {
     expect(NavigationBarThemeData.lerp(null, null, 0), null);
     const data = NavigationBarThemeData();
     expect(identical(NavigationBarThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('NavigationBar asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NavigationBarTheme(
+          data: const _NavigationBarThemeDataWithExpressiveVariant(),
+          child: NavigationBar(
+            destinations: const <Widget>[
+              NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
+              NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('Default debugFillProperties', (WidgetTester tester) async {

--- a/packages/material_ui/test/navigation_bar_theme_test.dart
+++ b/packages/material_ui/test/navigation_bar_theme_test.dart
@@ -25,7 +25,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/navigation_rail_theme_test.dart
+++ b/packages/material_ui/test/navigation_rail_theme_test.dart
@@ -6,7 +6,41 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _NavigationRailThemeDataWithExpressiveVariant extends NavigationRailThemeData {
+  const _NavigationRailThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
+  testWidgets('NavigationRail asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NavigationRailTheme(
+          data: const _NavigationRailThemeDataWithExpressiveVariant(),
+          child: NavigationRail(
+            selectedIndex: 0,
+            destinations: const <NavigationRailDestination>[
+              NavigationRailDestination(icon: Icon(Icons.home), label: Text('Home')),
+              NavigationRailDestination(icon: Icon(Icons.settings), label: Text('Settings')),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
+  });
+
   test('copyWith, ==, hashCode basics', () {
     expect(const NavigationRailThemeData(), const NavigationRailThemeData().copyWith());
     expect(

--- a/packages/material_ui/test/navigation_rail_theme_test.dart
+++ b/packages/material_ui/test/navigation_rail_theme_test.dart
@@ -17,7 +17,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/navigation_rail_theme_test.dart
+++ b/packages/material_ui/test/navigation_rail_theme_test.dart
@@ -17,7 +17,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/outlined_button_theme_test.dart
+++ b/packages/material_ui/test/outlined_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/outlined_button_theme_test.dart
+++ b/packages/material_ui/test/outlined_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/outlined_button_theme_test.dart
+++ b/packages/material_ui/test/outlined_button_theme_test.dart
@@ -5,6 +5,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _OutlinedButtonThemeDataWithExpressiveVariant extends OutlinedButtonThemeData {
+  const _OutlinedButtonThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   TextStyle iconStyle(WidgetTester tester, IconData icon) {
     final RichText iconRichText = tester.widget<RichText>(
@@ -17,6 +32,19 @@ void main() {
     expect(OutlinedButtonThemeData.lerp(null, null, 0), null);
     const data = OutlinedButtonThemeData();
     expect(identical(OutlinedButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('OutlinedButton asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OutlinedButtonTheme(
+          data: const _OutlinedButtonThemeDataWithExpressiveVariant(),
+          child: OutlinedButton(onPressed: () {}, child: const Text('Button')),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('Material3: Passing no OutlinedButtonTheme returns defaults', (

--- a/packages/material_ui/test/progress_indicator_theme_test.dart
+++ b/packages/material_ui/test/progress_indicator_theme_test.dart
@@ -23,7 +23,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/progress_indicator_theme_test.dart
+++ b/packages/material_ui/test/progress_indicator_theme_test.dart
@@ -12,6 +12,21 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _ProgressIndicatorThemeDataWithExpressiveVariant extends ProgressIndicatorThemeData {
+  const _ProgressIndicatorThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   test('ProgressIndicatorThemeData copyWith, ==, hashCode, basics', () {
     expect(const ProgressIndicatorThemeData(), const ProgressIndicatorThemeData().copyWith());
@@ -25,6 +40,36 @@ void main() {
     expect(ProgressIndicatorThemeData.lerp(null, null, 0), null);
     const data = ProgressIndicatorThemeData();
     expect(identical(ProgressIndicatorThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('LinearProgressIndicator asserts on unsupported style variants', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: ProgressIndicatorTheme(
+          data: _ProgressIndicatorThemeDataWithExpressiveVariant(),
+          child: LinearProgressIndicator(),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
+  });
+
+  testWidgets('CircularProgressIndicator asserts on unsupported style variants', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: ProgressIndicatorTheme(
+          data: _ProgressIndicatorThemeDataWithExpressiveVariant(),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('ProgressIndicatorThemeData implements debugFillProperties', (

--- a/packages/material_ui/test/progress_indicator_theme_test.dart
+++ b/packages/material_ui/test/progress_indicator_theme_test.dart
@@ -23,7 +23,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/search_bar_theme_test.dart
+++ b/packages/material_ui/test/search_bar_theme_test.dart
@@ -6,6 +6,21 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _SearchBarThemeDataWithExpressiveVariant extends SearchBarThemeData {
+  const _SearchBarThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   test('SearchBarThemeData copyWith, ==, hashCode basics', () {
     expect(const SearchBarThemeData(), const SearchBarThemeData().copyWith());
@@ -16,6 +31,16 @@ void main() {
     expect(SearchBarThemeData.lerp(null, null, 0), null);
     const data = SearchBarThemeData();
     expect(identical(SearchBarThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('SearchBar asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: SearchBarTheme(data: _SearchBarThemeDataWithExpressiveVariant(), child: SearchBar()),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   test('SearchBarThemeData defaults', () {

--- a/packages/material_ui/test/search_bar_theme_test.dart
+++ b/packages/material_ui/test/search_bar_theme_test.dart
@@ -17,7 +17,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/search_bar_theme_test.dart
+++ b/packages/material_ui/test/search_bar_theme_test.dart
@@ -17,7 +17,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/search_view_theme_test.dart
+++ b/packages/material_ui/test/search_view_theme_test.dart
@@ -6,6 +6,21 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _SearchViewThemeDataWithExpressiveVariant extends SearchViewThemeData {
+  const _SearchViewThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   test('SearchViewThemeData copyWith, ==, hashCode basics', () {
     expect(const SearchViewThemeData(), const SearchViewThemeData().copyWith());
@@ -16,6 +31,26 @@ void main() {
     expect(SearchViewThemeData.lerp(null, null, 0), null);
     const data = SearchViewThemeData();
     expect(identical(SearchViewThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('SearchAnchor asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SearchViewTheme(
+          data: const _SearchViewThemeDataWithExpressiveVariant(),
+          child: SearchAnchor(
+            builder: (BuildContext context, SearchController controller) {
+              return TextButton(onPressed: controller.openView, child: const Text('Search'));
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   test('SearchViewThemeData defaults', () {

--- a/packages/material_ui/test/search_view_theme_test.dart
+++ b/packages/material_ui/test/search_view_theme_test.dart
@@ -17,7 +17,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/search_view_theme_test.dart
+++ b/packages/material_ui/test/search_view_theme_test.dart
@@ -17,7 +17,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/slider_theme_test.dart
+++ b/packages/material_ui/test/slider_theme_test.dart
@@ -18,7 +18,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/slider_theme_test.dart
+++ b/packages/material_ui/test/slider_theme_test.dart
@@ -7,6 +7,21 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _SliderThemeDataWithExpressiveVariant extends SliderThemeData {
+  const _SliderThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   test('SliderThemeData copyWith, ==, hashCode basics', () {
     expect(const SliderThemeData(), const SliderThemeData().copyWith());
@@ -16,6 +31,34 @@ void main() {
   test('SliderThemeData lerp special cases', () {
     const data = SliderThemeData();
     expect(identical(SliderThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('RangeSlider asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SliderTheme(
+          data: const _SliderThemeDataWithExpressiveVariant(),
+          child: Material(
+            child: RangeSlider(values: const RangeValues(0.25, 0.75), onChanged: (_) {}),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
+  });
+
+  testWidgets('Slider asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SliderTheme(
+          data: const _SliderThemeDataWithExpressiveVariant(),
+          child: Material(child: Slider(value: 0.5, onChanged: (_) {})),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('Default SliderThemeData debugFillProperties', (WidgetTester tester) async {

--- a/packages/material_ui/test/slider_theme_test.dart
+++ b/packages/material_ui/test/slider_theme_test.dart
@@ -18,7 +18,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/text_button_theme_test.dart
+++ b/packages/material_ui/test/text_button_theme_test.dart
@@ -5,6 +5,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+class _TextButtonThemeDataWithExpressiveVariant extends TextButtonThemeData {
+  const _TextButtonThemeDataWithExpressiveVariant();
+
+  @override
+  StyleVariant? get variant => .material3Expressive;
+}
+
+Matcher get _throwsUnsupportedStyleVariantAssertion {
+  return isA<AssertionError>().having(
+    (AssertionError error) => error.message,
+    'message',
+    'Only material3 is supported.',
+  );
+}
+
 void main() {
   TextStyle iconStyle(WidgetTester tester, IconData icon) {
     final RichText iconRichText = tester.widget<RichText>(
@@ -17,6 +32,19 @@ void main() {
     expect(TextButtonThemeData.lerp(null, null, 0), null);
     const data = TextButtonThemeData();
     expect(identical(TextButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  testWidgets('TextButton asserts on unsupported style variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TextButtonTheme(
+          data: const _TextButtonThemeDataWithExpressiveVariant(),
+          child: TextButton(onPressed: () {}, child: const Text('Button')),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), _throwsUnsupportedStyleVariantAssertion);
   });
 
   testWidgets('Material3: Passing no TextButtonTheme returns defaults', (

--- a/packages/material_ui/test/text_button_theme_test.dart
+++ b/packages/material_ui/test/text_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported.',
+    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
   );
 }
 

--- a/packages/material_ui/test/text_button_theme_test.dart
+++ b/packages/material_ui/test/text_button_theme_test.dart
@@ -16,7 +16,7 @@ Matcher get _throwsUnsupportedStyleVariantAssertion {
   return isA<AssertionError>().having(
     (AssertionError error) => error.message,
     'message',
-    'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+    kUnsupportedStyleVariantAssertionMessage,
   );
 }
 

--- a/packages/material_ui/test/theme_data_test.dart
+++ b/packages/material_ui/test/theme_data_test.dart
@@ -37,7 +37,7 @@ void main() {
         isA<AssertionError>().having(
           (AssertionError error) => error.message,
           'message',
-          'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+          kUnsupportedStyleVariantAssertionMessage,
         ),
       );
     }
@@ -73,7 +73,7 @@ void main() {
         isA<AssertionError>().having(
           (AssertionError error) => error.message,
           'message',
-          'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+          kUnsupportedStyleVariantAssertionMessage,
         ),
       ),
     );
@@ -85,7 +85,7 @@ void main() {
         isA<AssertionError>().having(
           (AssertionError error) => error.message,
           'message',
-          'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
+          kUnsupportedStyleVariantAssertionMessage,
         ),
       );
     }

--- a/packages/material_ui/test/theme_data_test.dart
+++ b/packages/material_ui/test/theme_data_test.dart
@@ -24,6 +24,43 @@ void main() {
     expect(dawn.primaryColor, Color.lerp(dark.primaryColor, light.primaryColor, 0.25));
   });
 
+  test('ThemeData supports style variants', () {
+    expect(ThemeData().variant, StyleVariant.material3);
+    expect(
+      ThemeData(variant: StyleVariant.material3Expressive).variant,
+      StyleVariant.material3Expressive,
+    );
+    expect(
+      ThemeData.light(variant: StyleVariant.material3Expressive).variant,
+      StyleVariant.material3Expressive,
+    );
+    expect(
+      ThemeData.dark(variant: StyleVariant.material3Expressive).variant,
+      StyleVariant.material3Expressive,
+    );
+    expect(
+      ThemeData.fallback(variant: StyleVariant.material3Expressive).variant,
+      StyleVariant.material3Expressive,
+    );
+  });
+
+  test('ThemeData.copyWith supports style variants', () {
+    final theme = ThemeData();
+    final ThemeData expressiveTheme = theme.copyWith(variant: StyleVariant.material3Expressive);
+
+    expect(expressiveTheme.variant, StyleVariant.material3Expressive);
+    expect(expressiveTheme, isNot(theme));
+    expect(expressiveTheme.hashCode, isNot(theme.hashCode));
+  });
+
+  test('ThemeData.lerp switches style variants discretely', () {
+    final material3 = ThemeData(variant: StyleVariant.material3);
+    final expressive = ThemeData(variant: StyleVariant.material3Expressive);
+
+    expect(ThemeData.lerp(material3, expressive, 0.25).variant, StyleVariant.material3);
+    expect(ThemeData.lerp(material3, expressive, 0.75).variant, StyleVariant.material3Expressive);
+  });
+
   test('ThemeData objects with .styleFrom() members are equal', () {
     ThemeData createThemeData() {
       return ThemeData(
@@ -1290,6 +1327,7 @@ void main() {
       scrollbarTheme: const ScrollbarThemeData(radius: Radius.circular(10.0)),
       splashFactory: InkRipple.splashFactory,
       useMaterial3: false,
+      variant: StyleVariant.material3,
       visualDensity: VisualDensity.standard,
       // COLOR
       canvasColor: Colors.black,
@@ -1419,6 +1457,7 @@ void main() {
       scrollbarTheme: const ScrollbarThemeData(radius: Radius.circular(10.0)),
       splashFactory: InkRipple.splashFactory,
       useMaterial3: true,
+      variant: StyleVariant.material3Expressive,
       visualDensity: VisualDensity.standard,
       // COLOR
       canvasColor: Colors.white,
@@ -1523,6 +1562,7 @@ void main() {
       scrollbarTheme: otherTheme.scrollbarTheme,
       splashFactory: otherTheme.splashFactory,
       useMaterial3: otherTheme.useMaterial3,
+      variant: otherTheme.variant,
       visualDensity: otherTheme.visualDensity,
       // COLOR
       canvasColor: otherTheme.canvasColor,
@@ -1615,6 +1655,7 @@ void main() {
     expect(themeDataCopy.scrollbarTheme, equals(otherTheme.scrollbarTheme));
     expect(themeDataCopy.splashFactory, equals(otherTheme.splashFactory));
     expect(themeDataCopy.useMaterial3, equals(otherTheme.useMaterial3));
+    expect(themeDataCopy.variant, equals(otherTheme.variant));
     expect(themeDataCopy.visualDensity, equals(otherTheme.visualDensity));
     // COLOR
     expect(themeDataCopy.canvasColor, equals(otherTheme.canvasColor));
@@ -1761,8 +1802,9 @@ void main() {
       'platform',
       'scrollbarTheme',
       'splashFactory',
-      'visualDensity',
       'useMaterial3',
+      'variant',
+      'visualDensity',
       // COLOR
       'colorScheme',
       'primaryColor',

--- a/packages/material_ui/test/theme_data_test.dart
+++ b/packages/material_ui/test/theme_data_test.dart
@@ -37,7 +37,7 @@ void main() {
         isA<AssertionError>().having(
           (AssertionError error) => error.message,
           'message',
-          'Only material3 is supported.',
+          'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
         ),
       );
     }
@@ -73,7 +73,7 @@ void main() {
         isA<AssertionError>().having(
           (AssertionError error) => error.message,
           'message',
-          'Only material3 is supported.',
+          'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
         ),
       ),
     );
@@ -85,7 +85,7 @@ void main() {
         isA<AssertionError>().having(
           (AssertionError error) => error.message,
           'message',
-          'Only material3 is supported.',
+          'Only material3 is supported. See https://github.com/orgs/flutter/projects/250 to track support for material3Expressive.',
         ),
       );
     }

--- a/packages/material_ui/test/theme_data_test.dart
+++ b/packages/material_ui/test/theme_data_test.dart
@@ -24,41 +24,104 @@ void main() {
     expect(dawn.primaryColor, Color.lerp(dark.primaryColor, light.primaryColor, 0.25));
   });
 
-  test('ThemeData supports style variants', () {
+  test('ThemeData defaults to Material 3 style variant', () {
     expect(ThemeData().variant, StyleVariant.material3);
+    expect(ThemeData.light().variant, StyleVariant.material3);
+    expect(ThemeData.dark().variant, StyleVariant.material3);
+    expect(ThemeData.fallback().variant, StyleVariant.material3);
+  });
+
+  test('ThemeData asserts on unsupported style variants', () {
+    Matcher throwsUnsupportedStyleVariantAssertion() {
+      return throwsA(
+        isA<AssertionError>().having(
+          (AssertionError error) => error.message,
+          'message',
+          'Only material3 is supported.',
+        ),
+      );
+    }
+
     expect(
-      ThemeData(variant: StyleVariant.material3Expressive).variant,
-      StyleVariant.material3Expressive,
+      () => ThemeData(variant: .material3Expressive),
+      throwsUnsupportedStyleVariantAssertion(),
     );
     expect(
-      ThemeData.light(variant: StyleVariant.material3Expressive).variant,
-      StyleVariant.material3Expressive,
+      () => ThemeData.light(variant: .material3Expressive),
+      throwsUnsupportedStyleVariantAssertion(),
     );
     expect(
-      ThemeData.dark(variant: StyleVariant.material3Expressive).variant,
-      StyleVariant.material3Expressive,
+      () => ThemeData.dark(variant: .material3Expressive),
+      throwsUnsupportedStyleVariantAssertion(),
     );
     expect(
-      ThemeData.fallback(variant: StyleVariant.material3Expressive).variant,
-      StyleVariant.material3Expressive,
+      () => ThemeData.fallback(variant: .material3Expressive),
+      throwsUnsupportedStyleVariantAssertion(),
+    );
+    expect(
+      () => ThemeData.from(colorScheme: const ColorScheme.light(), variant: .material3Expressive),
+      throwsUnsupportedStyleVariantAssertion(),
     );
   });
 
-  test('ThemeData.copyWith supports style variants', () {
+  test('ThemeData.copyWith asserts on unsupported style variants', () {
     final theme = ThemeData();
-    final ThemeData expressiveTheme = theme.copyWith(variant: StyleVariant.material3Expressive);
 
-    expect(expressiveTheme.variant, StyleVariant.material3Expressive);
-    expect(expressiveTheme, isNot(theme));
-    expect(expressiveTheme.hashCode, isNot(theme.hashCode));
+    expect(
+      () => theme.copyWith(variant: .material3Expressive),
+      throwsA(
+        isA<AssertionError>().having(
+          (AssertionError error) => error.message,
+          'message',
+          'Only material3 is supported.',
+        ),
+      ),
+    );
   });
 
-  test('ThemeData.lerp switches style variants discretely', () {
-    final material3 = ThemeData(variant: StyleVariant.material3);
-    final expressive = ThemeData(variant: StyleVariant.material3Expressive);
+  test('component theme data asserts on unsupported style variants', () {
+    Matcher throwsUnsupportedStyleVariantAssertion() {
+      return throwsA(
+        isA<AssertionError>().having(
+          (AssertionError error) => error.message,
+          'message',
+          'Only material3 is supported.',
+        ),
+      );
+    }
 
-    expect(ThemeData.lerp(material3, expressive, 0.25).variant, StyleVariant.material3);
-    expect(ThemeData.lerp(material3, expressive, 0.75).variant, StyleVariant.material3Expressive);
+    final constructors = <ThemeData Function()>[
+      () => ThemeData(appBarTheme: AppBarThemeData(variant: .material3Expressive)),
+      () => ThemeData(elevatedButtonTheme: ElevatedButtonThemeData(variant: .material3Expressive)),
+      () => ThemeData(filledButtonTheme: FilledButtonThemeData(variant: .material3Expressive)),
+      () => ThemeData(
+        floatingActionButtonTheme: FloatingActionButtonThemeData(variant: .material3Expressive),
+      ),
+      () => ThemeData(iconButtonTheme: IconButtonThemeData(variant: .material3Expressive)),
+      () => ThemeData(menuButtonTheme: MenuButtonThemeData(variant: .material3Expressive)),
+      () => ThemeData(menuTheme: MenuThemeData(variant: .material3Expressive)),
+      () => ThemeData(navigationBarTheme: NavigationBarThemeData(variant: .material3Expressive)),
+      () => ThemeData(navigationRailTheme: NavigationRailThemeData(variant: .material3Expressive)),
+      () => ThemeData(outlinedButtonTheme: OutlinedButtonThemeData(variant: .material3Expressive)),
+      () => ThemeData(
+        progressIndicatorTheme: ProgressIndicatorThemeData(variant: .material3Expressive),
+      ),
+      () => ThemeData(searchBarTheme: SearchBarThemeData(variant: .material3Expressive)),
+      () => ThemeData(searchViewTheme: SearchViewThemeData(variant: .material3Expressive)),
+      () => ThemeData(sliderTheme: SliderThemeData(variant: .material3Expressive)),
+      () => ThemeData(textButtonTheme: TextButtonThemeData(variant: .material3Expressive)),
+    ];
+
+    for (final constructor in constructors) {
+      expect(constructor, throwsUnsupportedStyleVariantAssertion());
+    }
+  });
+
+  test('ThemeData.lerp preserves style variants', () {
+    final material3 = ThemeData(variant: StyleVariant.material3);
+
+    expect(ThemeData.lerp(material3, material3, 0.25).variant, StyleVariant.material3);
+    expect(ThemeData.lerp(material3, material3, 0.75).variant, StyleVariant.material3);
   });
 
   test('ThemeData objects with .styleFrom() members are equal', () {
@@ -1457,7 +1520,7 @@ void main() {
       scrollbarTheme: const ScrollbarThemeData(radius: Radius.circular(10.0)),
       splashFactory: InkRipple.splashFactory,
       useMaterial3: true,
-      variant: StyleVariant.material3Expressive,
+      variant: StyleVariant.material3,
       visualDensity: VisualDensity.standard,
       // COLOR
       canvasColor: Colors.white,


### PR DESCRIPTION
This PR is to add a global `StyleVariant` setting to `ThemeData` so Material components can choose between Material 3 and Material 3 Expressive defaults from `ThemeData`.

  ```dart
  enum StyleVariant {
    material3,
    material3Expressive,
  }
```

`ThemeData.variant` currently defaults to `StyleVariant.material3`, preserving existing behavior unless apps explicitly opt in to `StyleVariant.material3Expressive`.

  ### Why default to Material 3?

  To align with Cupertino's proposal, which does not provide a default value for `StyleVariant`, I also considered making `ThemeData.variant` nullable and adding a runtime check similar to `debugCheckHasMaterial`. Migrated components could then require an explicit style variant ancestor, and users could receive warnings when a style variant is deprecated.

  However, that approach seems too strict for the start of the migration:

  - Many tests pump widgets directly without wrapping them in a `Theme` or `MaterialApp`.
  - Users can also use individual Material widgets directly in small tests or examples.
  - Once a component starts reading `ThemeData.variant` by using something like `debugCheckHasStyleVariant`, requiring an explicit variant would make those cases fail even though the default behavior should still be Material 3. That breaking change would mainly serve the deprecation flow rather than improve user behavior today.
  - @dkwingsmt mentioned that Cupertino may require annual deprecations, so clear deprecation warnings are especially important there. Material does not have the same requirement, so I think it is reasonable to use other communication or migration tools if we later decide to change the default value or deprecate an old variant. 

Therefore, this PR gives the global variant a default value of `StyleVariant.material3`. This keeps the migration non-breaking while still giving components a single global source of truth for opting into Material 3 Expressive. If the default ever changes later, that can happen as a separate, intentional migration step. In other words, this defers the breaking change until the point where we intentionally change the default `variant`.

  ### API scope

  This PR only adds the `variant` api to `ThemeData`. It does not add a `MaterialApp.variant` shortcut because apps can already configure the value with:

```dart
  MaterialApp(
    theme: ThemeData(
      variant: StyleVariant.material3Expressive,
    ),
  )
```

 Also wanted to mention, `StyleVariant` is intended to select between Material 3 variants. Components that still support `useMaterial3: false` should continue to use their Material 2 defaults when `useMaterial3` is false, regardless of `ThemeData.variant`. But we should gradually deprecate `useMaterial3` since M2 is too out of date.

  ## Open questions

* Should this PR update CHANGELOG.md and bump pubspec.yaml?

  This is a new public API. However, since this branch targets `m3e_migration` rather than main, I left those files unchanged for now and would like reviewer guidance on whether migration-branch PRs should update package release metadata immediately or defer that until changes are moved to main.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.
