### PR TITLE
[video_player_platform_interface] Improve seek performance on Android

### DIFF
--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.9.0
+
+* Adds `backBufferDurationMs` to `VideoPlayerOptions` to support configuring ExoPlayer back buffer duration on Android.
+
 ## 6.8.0
 
 * Adds `preventsDisplaySleepDuringVideoPlayback` to `VideoPlayerOptions` and

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.9.0
 
-* Adds `backBufferDurationMs` to `VideoPlayerOptions` to support configuring ExoPlayer back buffer duration on Android.
+* Adds `backBufferDurationMs` to `VideoPlayerOptions` to support configuring the back buffer duration.
 
 ## 6.8.0
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -474,8 +474,8 @@ class VideoPlayerOptions {
     this.webOptions,
     this.backBufferDurationMs,
   }) : assert(
-         backBufferDurationMs == null || backBufferDurationMs > 0,
-         'backBufferDurationMs must be greater than zero',
+         backBufferDurationMs == null || backBufferDurationMs >= 0,
+         'backBufferDurationMs must be zero or greater',
        );
 
   /// Set this to true to keep playing video in background, when app goes in background.

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -499,10 +499,10 @@ class VideoPlayerOptions {
   /// Additional web controls
   final VideoPlayerWebOptions? webOptions;
 
-  /// ** Android only **. Sets ExoPlayer's back buffer duration in milliseconds.
-  /// 
-  /// This is not possible on iOS because AVPlayer does not provide a way to
-  /// configure the back buffer duration.
+  /// The duration, in milliseconds, of media to retain in the buffer prior to 
+  /// the current playback position.
+  ///
+  /// Ignored on platforms that do not support controlling the back buffer.
   final int? backBufferDurationMs;
 }
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -500,6 +500,9 @@ class VideoPlayerOptions {
   final VideoPlayerWebOptions? webOptions;
 
   /// ** Android only **. Sets ExoPlayer's back buffer duration in milliseconds.
+  /// 
+  /// This is not possible on iOS because AVPlayer does not provide a way to
+  /// configure the back buffer duration.
   final int? backBufferDurationMs;
 }
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -472,7 +472,11 @@ class VideoPlayerOptions {
     this.allowBackgroundPlayback = false,
     this.preventsDisplaySleepDuringVideoPlayback = true,
     this.webOptions,
-  });
+    this.backBufferDurationMs,
+  }) : assert(
+         backBufferDurationMs == null || backBufferDurationMs > 0,
+         'backBufferDurationMs must be greater than zero',
+       );
 
   /// Set this to true to keep playing video in background, when app goes in background.
   /// The default value is false.
@@ -494,6 +498,9 @@ class VideoPlayerOptions {
 
   /// Additional web controls
   final VideoPlayerWebOptions? webOptions;
+
+  /// ** Android only **. Sets ExoPlayer's back buffer duration in milliseconds.
+  final int? backBufferDurationMs;
 }
 
 /// [VideoPlayerWebOptions] can be optionally used to set additional web settings
@@ -593,13 +600,20 @@ class VideoViewOptions {
 @immutable
 class VideoCreationOptions {
   /// Constructs an instance of [VideoCreationOptions].
-  const VideoCreationOptions({required this.dataSource, required this.viewType});
+  const VideoCreationOptions({
+    required this.dataSource,
+    required this.viewType,
+    this.videoPlayerOptions,
+  });
 
   /// The data source used to create the player.
   final DataSource dataSource;
 
   /// The type of view to be used for displaying the video player
   final VideoViewType viewType;
+
+  /// Additional configuration options for the video player.
+  final VideoPlayerOptions? videoPlayerOptions;
 }
 
 /// Represents an audio track in a video with its metadata.

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -499,7 +499,7 @@ class VideoPlayerOptions {
   /// Additional web controls
   final VideoPlayerWebOptions? webOptions;
 
-  /// The duration, in milliseconds, of media to retain in the buffer prior to 
+  /// The duration, in milliseconds, of media to retain in the buffer prior to
   /// the current playback position.
   ///
   /// Ignored on platforms that do not support controlling the back buffer.

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/video_player/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.8.0
+version: 6.9.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/video_player/video_player_platform_interface/test/video_player_options_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/video_player_options_test.dart
@@ -18,4 +18,12 @@ void main() {
     final options = VideoPlayerOptions();
     expect(options.preventsDisplaySleepDuringVideoPlayback, true);
   });
+  test('VideoPlayerOptions backBufferDurationMs defaults to null', () {
+    final options = VideoPlayerOptions();
+    expect(options.backBufferDurationMs, null);
+  });
+  test('VideoPlayerOptions backBufferDurationMs stores configured value', () {
+    final options = VideoPlayerOptions(backBufferDurationMs: 20000);
+    expect(options.backBufferDurationMs, 20000);
+  });
 }


### PR DESCRIPTION
Adds `backBufferDurationMs` to `video_player_platform_interface`

This PR has only the platform interface package changes from the main PR: https://github.com/flutter/packages/pull/11810.

Following PR split as per [Changing federated plugins](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins)

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.