### PR TITLE
[pigeon] add error on empty class

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 27.1.1
+
+* Fixes validation bug where empty classes without `sealed` keyword were not correctly flagged with an error.
+
 ## 27.1.0
 
 * [swift] Adds `CaseIterable` conformance to generated enums.

--- a/packages/pigeon/lib/src/generator_tools.dart
+++ b/packages/pigeon/lib/src/generator_tools.dart
@@ -15,7 +15,7 @@ import 'generator.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '27.1.0';
+const String pigeonVersion = '27.1.1';
 
 /// Default plugin package name.
 const String defaultPluginPackageName = 'dev.flutter.pigeon';

--- a/packages/pigeon/lib/src/pigeon_lib_internal.dart
+++ b/packages/pigeon/lib/src/pigeon_lib_internal.dart
@@ -619,6 +619,25 @@ List<Error> _validateAst(Root root, String source) {
         ),
       );
     }
+    if (classDefinition.isSealed) {
+      if (classDefinition.fields.isNotEmpty) {
+        result.add(
+          Error(message: 'Sealed class: "${classDefinition.name}" must not contain fields.'),
+        );
+      }
+    }
+    if (classDefinition.fields.isEmpty && !classDefinition.isSealed) {
+      result.add(
+        Error(message: 'Class: "${classDefinition.name}" must contain fields or be sealed.'),
+      );
+    }
+    if (classDefinition.superClass != null) {
+      if (!classDefinition.superClass!.isSealed) {
+        result.add(
+          Error(message: 'Child class: "${classDefinition.name}" must extend a sealed class.'),
+        );
+      }
+    }
     for (final NamedType field in getFieldsInSerializationOrder(classDefinition)) {
       final String? matchingPrefix = _findMatchingPrefixOrNull(
         field.name,
@@ -643,26 +662,6 @@ List<Error> _validateAst(Root root, String source) {
             lineNumber: _calculateLineNumberNullable(source, field.offset),
           ),
         );
-      }
-      if (classDefinition.isSealed) {
-        if (classDefinition.fields.isNotEmpty) {
-          result.add(
-            Error(
-              message: 'Sealed class: "${classDefinition.name}" must not contain fields.',
-              lineNumber: _calculateLineNumberNullable(source, field.offset),
-            ),
-          );
-        }
-      }
-      if (classDefinition.superClass != null) {
-        if (!classDefinition.superClass!.isSealed) {
-          result.add(
-            Error(
-              message: 'Child class: "${classDefinition.name}" must extend a sealed class.',
-              lineNumber: _calculateLineNumberNullable(source, field.offset),
-            ),
-          );
-        }
       }
     }
   }
@@ -1805,22 +1804,21 @@ class RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
               lineNumber: calculateLineNumber(source, node.offset),
             ),
           );
-        } else {
-          final dart_ast.TypeArgumentList? typeArguments = type.typeArguments;
-          final String name = node.fields.variables[0].name.lexeme;
-          final field = NamedType(
-            type: TypeDeclaration(
-              baseName: _getNamedTypeQualifiedName(type),
-              isNullable: type.question != null,
-              typeArguments: _typeAnnotationsToTypeArguments(typeArguments),
-            ),
-            name: name,
-            offset: node.offset,
-            defaultValue: _currentClassDefaultValues[name],
-            documentationComments: _documentationCommentsParser(node.documentationComment?.tokens),
-          );
-          _currentClass!.fields.add(field);
         }
+        final dart_ast.TypeArgumentList? typeArguments = type.typeArguments;
+        final String name = node.fields.variables[0].name.lexeme;
+        final field = NamedType(
+          type: TypeDeclaration(
+            baseName: _getNamedTypeQualifiedName(type),
+            isNullable: type.question != null,
+            typeArguments: _typeAnnotationsToTypeArguments(typeArguments),
+          ),
+          name: name,
+          offset: node.offset,
+          defaultValue: _currentClassDefaultValues[name],
+          documentationComments: _documentationCommentsParser(node.documentationComment?.tokens),
+        );
+        _currentClass!.fields.add(field);
       } else {
         _errors.add(
           Error(
@@ -1969,23 +1967,22 @@ class RootBuilder extends dart_ast_visitor.RecursiveAstVisitor<Object?> {
             lineNumber: calculateLineNumber(source, node.offset),
           ),
         );
-      } else {
-        final dart_ast.TypeArgumentList? typeArguments = type.typeArguments;
-        (_currentApi as AstProxyApi?)!.fields.add(
-          ApiField(
-            type: TypeDeclaration(
-              baseName: _getNamedTypeQualifiedName(type),
-              isNullable: type.question != null,
-              typeArguments: _typeAnnotationsToTypeArguments(typeArguments),
-            ),
-            name: node.fields.variables[0].name.lexeme,
-            isAttached: _hasMetadata(node.metadata, 'attached') || isStatic,
-            isStatic: isStatic,
-            offset: node.offset,
-            documentationComments: _documentationCommentsParser(node.documentationComment?.tokens),
-          ),
-        );
       }
+      final dart_ast.TypeArgumentList? typeArguments = type.typeArguments;
+      (_currentApi as AstProxyApi?)!.fields.add(
+        ApiField(
+          type: TypeDeclaration(
+            baseName: _getNamedTypeQualifiedName(type),
+            isNullable: type.question != null,
+            typeArguments: _typeAnnotationsToTypeArguments(typeArguments),
+          ),
+          name: node.fields.variables[0].name.lexeme,
+          isAttached: _hasMetadata(node.metadata, 'attached') || isStatic,
+          isStatic: isStatic,
+          offset: node.offset,
+          documentationComments: _documentationCommentsParser(node.documentationComment?.tokens),
+        ),
+      );
     }
   }
 }

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 27.1.0 # This must match the version in lib/src/generator_tools.dart
+version: 27.1.1 # This must match the version in lib/src/generator_tools.dart
 
 environment:
   sdk: ^3.10.0

--- a/packages/pigeon/test/pigeon_lib_test.dart
+++ b/packages/pigeon/test/pigeon_lib_test.dart
@@ -215,6 +215,23 @@ abstract class Api {
     expect(results.errors[0].message, contains('dynamic'));
   });
 
+  test('empty class error', () {
+    const source = '''
+class EmptyClass {}
+
+@HostApi()
+abstract class Api {
+  void foo(EmptyClass empty);
+}
+''';
+    final ParseResults results = parseSource(source);
+    expect(results.errors, hasLength(1));
+    expect(
+      results.errors[0].message,
+      contains('Class: "EmptyClass" must contain fields or be sealed.'),
+    );
+  });
+
   test('Only allow one api annotation', () {
     const source = '''
 @HostApi()
@@ -1703,7 +1720,9 @@ abstract class EventChannelApi {
   group('sealed inheritance validation', () {
     test('super class must be sealed', () {
       const code = '''
-class DataClass {}
+class DataClass {
+  int? someField;
+}
 class ChildClass extends DataClass {
   ChildClass(this.input);
   int input;


### PR DESCRIPTION
just adds an error if a user tries to use an empty class that isn't sealed

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
