### PR TITLE
[camera_android_camerax] Add a workspace file that contains where jetski can work

### DIFF
--- a/packages/camera/camera_android_camerax/camera_android_camerax.code-workspace
+++ b/packages/camera/camera_android_camerax/camera_android_camerax.code-workspace
@@ -1,0 +1,14 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../../../script"
+		},
+		{
+			"path": "../../../third_party"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
The point of this pr is to debate if a file like this can be checked in. 

Why check in a workspace file. It allows for consistency across teammates. In this case agents and skills that insist that changes not happen outside of a workspace can better help guide an agent but only if we have a consistent definition of workspace. My gut says that we would only need one of these for camerax. One that is for contributors then for an automated agent checking out *just* the camera_android_camerax will probably be ok. The best argument for a second one would be if we had an agent that was constrained by not being allowed to make developer facing changes and we limited it to code that was less likely to be visible. 

