### PR TITLE
[vector_graphics] Provide textDirection for semantics label to avoid crash without Directionality

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.2.3
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Fixes a crash when a `semanticsLabel` is provided without an ambient `Directionality` (flutter/flutter#175532).
 
 ## 1.2.2
 

--- a/packages/vector_graphics/lib/src/vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/vector_graphics.dart
@@ -538,6 +538,7 @@ class _VectorGraphicWidgetState extends State<VectorGraphic> {
         container: widget.semanticsLabel != null,
         image: true,
         label: widget.semanticsLabel ?? '',
+        textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
         child: child,
       );
     }

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -2,7 +2,7 @@ name: vector_graphics
 description: A vector graphics rendering package for Flutter using a binary encoding.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-version: 1.2.2
+version: 1.2.3
 
 environment:
   sdk: ^3.10.0

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -415,6 +415,23 @@ void main() {
     );
   });
 
+  testWidgets('Semantic label works without an ambient Directionality (flutter/flutter#175532)', (
+    WidgetTester tester,
+  ) async {
+    final testBundle = TestAssetBundle();
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        bundle: testBundle,
+        child: const VectorGraphic(loader: AssetBytesLoader('foo.svg'), semanticsLabel: 'Foo'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.bySemanticsLabel('Foo'), findsOneWidget);
+  });
+
   testWidgets('Default placeholder builder', (WidgetTester tester) async {
     final testBundle = TestAssetBundle();
 


### PR DESCRIPTION
## Description

When a `VectorGraphic` (and therefore `SvgPicture`, which delegates to it) is given a `semanticsLabel` but there is no `Directionality` ancestor in the widget tree, the app crashes at frame flush with:

```
A SemanticsData object with label "..." had a null textDirection.
package:flutter/src/semantics/semantics.dart: Failed assertion: 'attributedLabel.string == '' || textDirection != null'
```

The `Semantics` node created for the label in `_VectorGraphicWidgetState.build` passed a non-empty `label` but never supplied a `textDirection`, and did not resolve the ambient `Directionality`. With no `Directionality` in scope, the null text direction propagated to `SemanticsData`, which asserts. (This is why the issue only reproduces outside of a `MaterialApp`/`WidgetsApp`, where a `Directionality` is normally present — a triager was previously unable to reproduce it for that reason.)

This PR resolves the text direction with `Directionality.maybeOf(context) ?? TextDirection.ltr`, so a labeled decorative graphic no longer crashes when no `Directionality` is in scope.

The pre-existing test `Can add semantic label` had to wrap the widget in a `Directionality` to pass; this PR adds a regression test that omits the wrapper and verifies no exception is thrown and the label is present.

## Issues fixed by this PR

Fixes flutter/flutter#175532

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.