### PR TITLE
[various] Check in auto-upgrade to analysis options

### DIFF
--- a/packages/animations/analysis_options.yaml
+++ b/packages/animations/analysis_options.yaml
@@ -2,6 +2,15 @@
 # default of enabling unawaited_futures. Please do NOT add more changes
 # here without consulting with #hackers-ecosystem on Discord.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../analysis_options.yaml
 
 linter:

--- a/packages/cupertino_ui/analysis_options.yaml
+++ b/packages/cupertino_ui/analysis_options.yaml
@@ -6,3 +6,10 @@ analyzer:
     # TODO(justinmc): Remove the following exclusion when cross-imports are
     # fixed. See https://github.com/flutter/flutter/issues/177028.
     - "temporarily_disabled_tests/**"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/cupertino_ui/example/analysis_options.yaml
+++ b/packages/cupertino_ui/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/packages/flutter_lints/example/analysis_options.yaml
+++ b/packages/flutter_lints/example/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/packages/go_router/analysis_options.yaml
+++ b/packages/go_router/analysis_options.yaml
@@ -9,3 +9,10 @@ analyzer:
   exclude:
     # This directory deliberately has errors, to test `fix`.
     - "test_fixes/**"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/go_router_builder/example/analysis_options.yaml
+++ b/packages/go_router_builder/example/analysis_options.yaml
@@ -2,5 +2,14 @@
 # output. Since we want the output to default to what the default formatter
 # would use, rather than the custom line length used in this repository, use
 # 80 for this example so it matches.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 formatter:
   page_width: 80

--- a/packages/material_ui/analysis_options.yaml
+++ b/packages/material_ui/analysis_options.yaml
@@ -6,3 +6,10 @@ analyzer:
     # TODO(justinmc): Remove the following exclusion when cross-imports are
     # fixed. See https://github.com/flutter/flutter/issues/177028.
     - "temporarily_disabled_tests/**"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/material_ui/example/analysis_options.yaml
+++ b/packages/material_ui/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/packages/web_benchmarks/testing/test_app/analysis_options.yaml
+++ b/packages/web_benchmarks/testing/test_app/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:


### PR DESCRIPTION
`flutter pub get` with the latest `master` automatically adds exclusions to any package-local analysis options. This checks in those changes to avoid having diffs either locally, or in CI (triggering failures in the format check since the format check looks for any diffs currently, so this will unblock the roller).