### PR TITLE
[material_ui] Remove widgets import in `scaffold_test.dart`

### DIFF
--- a/packages/material_ui/temporarily_disabled_tests/scaffold_test.dart
+++ b/packages/material_ui/temporarily_disabled_tests/scaffold_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -15,7 +12,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-import '../widgets/semantics_tester.dart';
+import '../test/semantics_tester.dart';
 
 // From bottom_sheet.dart.
 const Duration _bottomSheetExitDuration = Duration(milliseconds: 200);

--- a/packages/material_ui/test/scaffold_test.dart
+++ b/packages/material_ui/test/scaffold_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async' show unawaited;
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -1078,7 +1079,7 @@ void main() {
       };
       await tester.pumpWidget(MaterialApp(routes: routes));
 
-      Navigator.pushNamed(rootKey.currentContext!, '/scaffold');
+      unawaited(Navigator.pushNamed(rootKey.currentContext!, '/scaffold'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
@@ -1122,7 +1123,7 @@ void main() {
         ),
       );
 
-      tester.state<NavigatorState>(find.byType(Navigator)).push(routeBuilder());
+      unawaited(tester.state<NavigatorState>(find.byType(Navigator)).push(routeBuilder()));
 
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));

--- a/packages/material_ui/test/scaffold_test.dart
+++ b/packages/material_ui/test/scaffold_test.dart
@@ -6,13 +6,13 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show DragStartBehavior;
-import 'package:material_ui/material_ui.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
+import 'package:material_ui/material_ui.dart';
 
-import '../test/semantics_tester.dart';
+import 'semantics_tester.dart';
 
 // From bottom_sheet.dart.
 const Duration _bottomSheetExitDuration = Duration(milliseconds: 200);


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removed the cross-import of `semantics_tester.dart` from `material_ui/temporarily_disabled_tests/scaffold_test.dart`. 
* Removed @Skip tag, all tests in this file has passed. `semantics_tester.dart` has existed in `material_ui`, so we can directly import `../test/semantics_tester.dart';`
* Moved the file to `test/` folder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.
