### PR TITLE
[material_ui, cupertino_ui] Migrate several doc directives for demonstration

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,6 +16,9 @@ analyzer:
     # something (https://github.com/flutter/flutter/issues/143312)
     deprecated_member_use: ignore
     deprecated_member_use_from_same_package: ignore
+    # `dart analyze` hasn't recognized this new directive yet.
+    # Remove it once https://github.com/dart-lang/sdk/pull/63646 is landed.
+    doc_directive_unknown: ignore
   exclude: # DIFFERENT FROM FLUTTER/FLUTTER
     # Ignore generated files
     - '**/*.pb.dart'

--- a/packages/cupertino_ui/lib/src/menu_anchor.dart
+++ b/packages/cupertino_ui/lib/src/menu_anchor.dart
@@ -295,19 +295,25 @@ typedef CupertinoMenuAnimationStatusChangedCallback = void Function(AnimationSta
 /// invoked every time the [AnimationStatus] of the menu animation changes.
 ///
 /// ## Usage
-/// {@tool sample}
+// TODO(dkwingsmt): Replace the following block with a blue example container
+// when it's supported.  https://github.com/dart-lang/dartdoc/issues/4243
+///
 /// This example demonstrates a simple [CupertinoMenuAnchor] that wraps
 /// a button.
 ///
-/// ** See code in examples/api/lib/cupertino/menu_anchor/menu_anchor.0.dart **
-/// {@end-tool}
+/// {@example /example/lib/menu_anchor/menu_anchor.0.dart}
 ///
-/// {@tool dartpad}
+// TODO(dkwingsmt): End of the blue example container.
+///
+// TODO(dkwingsmt): Replace the following block with a blue example container
+// when it's supported.  https://github.com/dart-lang/dartdoc/issues/4243
+///
 /// This example demonstrates a [CupertinoMenuAnchor] that wraps a button and
 /// shows a menu with three [CupertinoMenuItem]s and one [CupertinoMenuDivider].
 ///
-/// ** See code in examples/api/lib/cupertino/menu_anchor/menu_anchor.1.dart **
-/// {@end-tool}
+/// {@example /example/lib/menu_anchor/menu_anchor.1.dart}
+///
+// TODO(dkwingsmt): End of the blue example container.
 ///
 /// See also:
 ///

--- a/packages/cupertino_ui/lib/src/menu_anchor.dart
+++ b/packages/cupertino_ui/lib/src/menu_anchor.dart
@@ -296,7 +296,7 @@ typedef CupertinoMenuAnimationStatusChangedCallback = void Function(AnimationSta
 ///
 /// ## Usage
 // TODO(dkwingsmt): Replace the following block with a blue example container
-// when it's supported.  https://github.com/dart-lang/dartdoc/issues/4243
+// when it's supported. https://github.com/dart-lang/dartdoc/issues/4243
 ///
 /// This example demonstrates a simple [CupertinoMenuAnchor] that wraps
 /// a button.
@@ -306,7 +306,7 @@ typedef CupertinoMenuAnimationStatusChangedCallback = void Function(AnimationSta
 // TODO(dkwingsmt): End of the blue example container.
 ///
 // TODO(dkwingsmt): Replace the following block with a blue example container
-// when it's supported.  https://github.com/dart-lang/dartdoc/issues/4243
+// when it's supported. https://github.com/dart-lang/dartdoc/issues/4243
 ///
 /// This example demonstrates a [CupertinoMenuAnchor] that wraps a button and
 /// shows a menu with three [CupertinoMenuItem]s and one [CupertinoMenuDivider].

--- a/packages/material_ui/lib/src/carousel.dart
+++ b/packages/material_ui/lib/src/carousel.dart
@@ -51,7 +51,10 @@ import 'theme.dart';
 /// [CarouselView.weighted] is used, then set the [flexWeights] to only have
 /// one integer in the array.
 ///
-/// {@tool snippet}
+// TODO(dkwingsmt): Replace the following block with a blue example container
+// when it's supported.  https://github.com/dart-lang/dartdoc/issues/4243
+// TODO(dkwingsmt): Add unit tests to this code snippet.
+// https://github.com/flutter/flutter/issues/188530
 ///
 /// This code snippet shows how to get a vertical full-screen carousel by using
 /// [itemExtent] in [CarouselView].
@@ -82,7 +85,8 @@ import 'theme.dart';
 ///   ),
 /// ),
 /// ```
-/// {@end-tool}
+///
+// TODO(dkwingsmt): End of the blue example container.
 ///
 /// In [CarouselView.weighted], weights are relative proportions. For example,
 /// if the layout weights is `[3, 2, 1]`, it means the first visible item occupies
@@ -108,7 +112,9 @@ import 'theme.dart';
 /// visible items may be slightly compressed during scrolling. The [shrinkExtent]
 /// property controls the minimum allowable size for these compressed items.
 ///
-/// {@tool dartpad}
+// TODO(dkwingsmt): Replace the following block with a blue example container
+// when it's supported.  https://github.com/dart-lang/dartdoc/issues/4243
+///
 /// Here is an example to show different carousel layouts that [CarouselView]
 /// and [CarouselView.weighted] can build.
 ///
@@ -120,9 +126,13 @@ import 'theme.dart';
 ///
 /// This key-driven behavior is dictated by the [ScrollBehavior.pointerAxisModifiers],
 /// while [ScrollBehavior.dragDevices] manages what devices can drag a scrollable.
+//
+// TODO(dkwingsmt): Replace the example with a dartpad block when it's
+// supported. https://github.com/dart-lang/dartdoc/issues/4123
 ///
-/// ** See code in examples/api/lib/material/carousel/carousel.0.dart **
-/// {@end-tool}
+/// {@example /example/lib/carousel/carousel.0.dart}
+///
+// TODO(dkwingsmt): End of the blue example container.
 ///
 /// See also:
 ///

--- a/packages/material_ui/lib/src/carousel.dart
+++ b/packages/material_ui/lib/src/carousel.dart
@@ -52,7 +52,7 @@ import 'theme.dart';
 /// one integer in the array.
 ///
 // TODO(dkwingsmt): Replace the following block with a blue example container
-// when it's supported.  https://github.com/dart-lang/dartdoc/issues/4243
+// when it's supported. https://github.com/dart-lang/dartdoc/issues/4243
 // TODO(dkwingsmt): Add unit tests to this code snippet.
 // https://github.com/flutter/flutter/issues/188530
 ///
@@ -113,7 +113,7 @@ import 'theme.dart';
 /// property controls the minimum allowable size for these compressed items.
 ///
 // TODO(dkwingsmt): Replace the following block with a blue example container
-// when it's supported.  https://github.com/dart-lang/dartdoc/issues/4243
+// when it's supported. https://github.com/dart-lang/dartdoc/issues/4243
 ///
 /// Here is an example to show different carousel layouts that [CarouselView]
 /// and [CarouselView.weighted] can build.


### PR DESCRIPTION
This PR migrates several doc directives to reach agreement before I perform a mass search-and-replace throughout the codebase.

To be exact, this PR migrates one `{@tool snippet}` directive, one `{@tool dartpad}` directive, and two `{@tool sample}` directives (which are actually all `sample` usages throughout the codebase).

The TODO comments are left for features to be implemented by the Dart team or unit tests that do not block the initial release.

### Result

The result looks like this:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/14a18ac0-710d-4332-9218-18f2acea7cc2" />

and

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e3d38133-11d5-402b-a77d-6f6d51a7177d" />

### Known issue 1: No max-height for code snippets

It is a known flaw that the code blocks do not have a max height. The API doc page will display full source code, which is harder to read.

Solve it requires extra CSS rules, which is included in a previous proposal https://github.com/dart-lang/dartdoc/issues/4243.

### Known issue 2: `dart analyze` does not recognize the `example` directive

Even though `dartdoc` has supported the `example` directive, `dart analyze` still does not recognize it, causing warnings in IDE and CI. A PR https://github.com/dart-lang/sdk/pull/63646 has been opened to solve this. Before the fix is landed in (hopefully) the next Dart version, we'll have to ignore this rule.

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
