### PR TITLE
[material_ui, cupertino_ui] Add `linkToSource`

### DIFF
--- a/packages/cupertino_ui/dartdoc_options.yaml
+++ b/packages/cupertino_ui/dartdoc_options.yaml
@@ -1,0 +1,4 @@
+dartdoc:
+  linkToSource:
+    root: '.'
+    uriTemplate: 'https://github.com/flutter/packages/blob/cupertino_ui-v0.0.2/packages/cupertino_ui/%f%#L%l%'

--- a/packages/cupertino_ui/pubspec.yaml
+++ b/packages/cupertino_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cupertino_ui
 description: The official Flutter Cupertino Design Library, implementing the iOS design system.
-version: 0.0.2
+version: 0.0.2 # When updating version, also update the following files: dartdoc_options.yaml
 publish_to: none
 repository: https://github.com/flutter/packages/tree/main/packages/cupertino_ui
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A%20cupertino%22

--- a/packages/material_ui/dartdoc_options.yaml
+++ b/packages/material_ui/dartdoc_options.yaml
@@ -1,0 +1,4 @@
+dartdoc:
+  linkToSource:
+    root: '.'
+    uriTemplate: 'https://github.com/flutter/packages/blob/material_ui-v0.0.2/packages/cupertino_ui/%f%#L%l%'

--- a/packages/material_ui/pubspec.yaml
+++ b/packages/material_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: material_ui
 description: The official Flutter Material UI Library, implementing Google's Material Design design system.
-version: 0.0.2
+version: 0.0.2 # When updating version, also update the following files: dartdoc_options.yaml
 publish_to: none
 repository: https://github.com/flutter/packages/tree/main/packages/material_ui
 issue_tracker:  https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A%20material%20design%22


### PR DESCRIPTION
This PR adds the `linkToSource` option to `dartdoc_options.yaml`. This enables the "link to source" button in API docs, which is present in Flutter's doc. This button links to the source code for this class on Github.

<img width="1200" height="746" alt="Screenshot 2026-06-24 at 5 29 30 PM" src="https://github.com/user-attachments/assets/310fb853-79d6-4c8d-aed0-58d83dbbf1b8" />

The catch is, while the URL format supports a `%r%` parameter according to `dartdoc`'s [Doc](https://pub.dev/documentation/dartdoc/latest/), it's not very reliable, for that the revision parameter is often empty, which leads to crashes. The solution is typically to hard code it, either with `main` (suboptimal) or the current published version. I recommend the latter; in fact, the `dartdoc` repo themselves update the link to the current published version manually: https://github.com/dart-lang/dartdoc/commit/869c9ff266ed3e28a8992e407d148c3b0fbe9488 . However, this requires more work during version bump.



## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
