### PR TITLE
[cupertino_ui] Migrate `sliding_segmented_control_test.dart` to `SemanticsHandle`

### DIFF
--- a/packages/cupertino_ui/test/sliding_segmented_control_test.dart
+++ b/packages/cupertino_ui/test/sliding_segmented_control_test.dart
@@ -941,8 +941,6 @@ void main() {
   });
 
   testWidgets('Segmented control semantics', (WidgetTester tester) async {
-    final SemanticsHandle handle = tester.ensureSemantics();
-
     const children = <int, Widget>{0: Text('Child 1'), 1: Text('Child 2')};
 
     await tester.pumpWidget(
@@ -1026,8 +1024,6 @@ void main() {
         hasFocusAction: true,
       ),
     );
-
-    handle.dispose();
   });
 
   testWidgets('Non-centered taps work on smaller widgets', (WidgetTester tester) async {

--- a/packages/cupertino_ui/test/sliding_segmented_control_test.dart
+++ b/packages/cupertino_ui/test/sliding_segmented_control_test.dart
@@ -994,6 +994,11 @@ void main() {
     await tester.pump();
 
     expect(
+      tester.getSemantics(find.byType(CupertinoSlidingSegmentedControl<int>)).role,
+      SemanticsRole.radioGroup,
+    );
+
+    expect(
       tester.getSemantics(find.text('Child 1')),
       isSemantics(
         label: 'Child 1',

--- a/packages/cupertino_ui/test/sliding_segmented_control_test.dart
+++ b/packages/cupertino_ui/test/sliding_segmented_control_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 // reduced-test-set:
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
@@ -19,8 +16,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../widgets/semantics_tester.dart';
 
 RenderBox getRenderSegmentedControl(WidgetTester tester) {
   return tester.allRenderObjects.firstWhere((RenderObject currentObject) {
@@ -946,7 +941,8 @@ void main() {
   });
 
   testWidgets('Segmented control semantics', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
+
     const children = <int, Widget>{0: Text('Child 1'), 1: Text('Child 2')};
 
     await tester.pumpWidget(
@@ -962,42 +958,35 @@ void main() {
     );
 
     expect(
-      semantics,
-      hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics.rootChild(
-              role: SemanticsRole.radioGroup,
-              children: <TestSemantics>[
-                TestSemantics(
-                  label: 'Child 1',
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isButton,
-                    SemanticsFlag.isInMutuallyExclusiveGroup,
-                    SemanticsFlag.hasSelectedState,
-                    SemanticsFlag.isSelected,
-                    SemanticsFlag.isFocusable,
-                  ],
-                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                ),
-                TestSemantics(
-                  label: 'Child 2',
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isButton,
-                    SemanticsFlag.isInMutuallyExclusiveGroup,
-                    // Declares that it is selectable, but not currently selected.
-                    SemanticsFlag.hasSelectedState,
-                    SemanticsFlag.isFocusable,
-                  ],
-                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                ),
-              ],
-            ),
-          ],
-        ),
-        ignoreId: true,
-        ignoreRect: true,
-        ignoreTransform: true,
+      tester.getSemantics(find.byType(CupertinoSlidingSegmentedControl<int>)).role,
+      SemanticsRole.radioGroup,
+    );
+
+    expect(
+      tester.getSemantics(find.text('Child 1')),
+      isSemantics(
+        label: 'Child 1',
+        isButton: true,
+        isInMutuallyExclusiveGroup: true,
+        hasSelectedState: true,
+        isSelected: true,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
+      ),
+    );
+
+    expect(
+      tester.getSemantics(find.text('Child 2')),
+      isSemantics(
+        label: 'Child 2',
+        isButton: true,
+        isInMutuallyExclusiveGroup: true,
+        hasSelectedState: true,
+        isSelected: false,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
       ),
     );
 
@@ -1005,47 +994,35 @@ void main() {
     await tester.pump();
 
     expect(
-      semantics,
-      hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics.rootChild(
-              role: SemanticsRole.radioGroup,
-              children: <TestSemantics>[
-                TestSemantics(
-                  label: 'Child 1',
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isButton,
-                    SemanticsFlag.isInMutuallyExclusiveGroup,
-                    // Declares that it is selectable, but not currently selected.
-                    SemanticsFlag.hasSelectedState,
-                    SemanticsFlag.isFocusable,
-                  ],
-                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                ),
-                TestSemantics(
-                  label: 'Child 2',
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isButton,
-                    SemanticsFlag.isInMutuallyExclusiveGroup,
-                    SemanticsFlag.hasSelectedState,
-                    SemanticsFlag.isSelected,
-                    SemanticsFlag.isFocusable,
-                    SemanticsFlag.isFocused,
-                  ],
-                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                ),
-              ],
-            ),
-          ],
-        ),
-        ignoreId: true,
-        ignoreRect: true,
-        ignoreTransform: true,
+      tester.getSemantics(find.text('Child 1')),
+      isSemantics(
+        label: 'Child 1',
+        isButton: true,
+        isInMutuallyExclusiveGroup: true,
+        hasSelectedState: true,
+        isSelected: false,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
       ),
     );
 
-    semantics.dispose();
+    expect(
+      tester.getSemantics(find.text('Child 2')),
+      isSemantics(
+        label: 'Child 2',
+        isButton: true,
+        isInMutuallyExclusiveGroup: true,
+        hasSelectedState: true,
+        isSelected: true,
+        isFocusable: true,
+        isFocused: true,
+        hasTapAction: true,
+        hasFocusAction: true,
+      ),
+    );
+
+    handle.dispose();
   });
 
   testWidgets('Non-centered taps work on smaller widgets', (WidgetTester tester) async {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removed the cross-import of `widgets/semantics_tester.dart`. Replaced `SemanticsTester` with `SemanticsHandle`.
* Removed `@Skip` annotation, all tests in this file has passed. `semantics_tester.dart` has existed in `cupertino_ui`, so we can directly import `semantics_tester.dart`;
* Moved the file to `test/` folder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.