### PR TITLE
[cupertino_ui] Migrate `nav_bar_test.dart` to `SemanticsHandle`

### DIFF
--- a/packages/cupertino_ui/test/nav_bar_test.dart
+++ b/packages/cupertino_ui/test/nav_bar_test.dart
@@ -1092,8 +1092,6 @@ void main() {
   });
 
   testWidgets('CupertinoSliverNavigationBar has semantics', (WidgetTester tester) async {
-    final SemanticsHandle handle = tester.ensureSemantics();
-
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -1110,13 +1108,9 @@ void main() {
       tester.getSemantics(find.text('Large Title')),
       isSemantics(label: 'Large Title', isHeader: true, textDirection: TextDirection.ltr),
     );
-
-    handle.dispose();
   });
 
   testWidgets('CupertinoNavigationBar has semantics', (WidgetTester tester) async {
-    final SemanticsHandle handle = tester.ensureSemantics();
-
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoPageScaffold(
@@ -1130,13 +1124,9 @@ void main() {
       tester.getSemantics(find.text('Fixed Title')),
       isSemantics(label: 'Fixed Title', isHeader: true, textDirection: TextDirection.ltr),
     );
-
-    handle.dispose();
   });
 
   testWidgets('Large CupertinoNavigationBar has semantics', (WidgetTester tester) async {
-    final SemanticsHandle handle = tester.ensureSemantics();
-
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoPageScaffold(
@@ -1150,8 +1140,6 @@ void main() {
       tester.getSemantics(find.text('Fixed Title')),
       isSemantics(label: 'Fixed Title', isHeader: true, textDirection: TextDirection.ltr),
     );
-
-    handle.dispose();
   });
 
   testWidgets('Border can be overridden in sliver nav bar', (WidgetTester tester) async {

--- a/packages/cupertino_ui/test/nav_bar_test.dart
+++ b/packages/cupertino_ui/test/nav_bar_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
@@ -14,8 +11,6 @@ import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../widgets/semantics_tester.dart';
 
 int count = 0;
 
@@ -1078,7 +1073,7 @@ void main() {
   });
 
   testWidgets('CupertinoSliverNavigationBar has semantics', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
       const CupertinoApp(
@@ -1093,19 +1088,15 @@ void main() {
     );
 
     expect(
-      semantics.nodesWith(
-        label: 'Large Title',
-        flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-        textDirection: TextDirection.ltr,
-      ),
-      hasLength(1),
+      tester.getSemantics(find.text('Large Title')),
+      isSemantics(label: 'Large Title', isHeader: true, textDirection: TextDirection.ltr),
     );
 
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('CupertinoNavigationBar has semantics', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
       CupertinoApp(
@@ -1117,19 +1108,15 @@ void main() {
     );
 
     expect(
-      semantics.nodesWith(
-        label: 'Fixed Title',
-        flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-        textDirection: TextDirection.ltr,
-      ),
-      hasLength(1),
+      tester.getSemantics(find.text('Fixed Title')),
+      isSemantics(label: 'Fixed Title', isHeader: true, textDirection: TextDirection.ltr),
     );
 
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('Large CupertinoNavigationBar has semantics', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
       CupertinoApp(
@@ -1141,15 +1128,11 @@ void main() {
     );
 
     expect(
-      semantics.nodesWith(
-        label: 'Fixed Title',
-        flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-        textDirection: TextDirection.ltr,
-      ),
-      hasLength(1),
+      tester.getSemantics(find.text('Fixed Title')),
+      isSemantics(label: 'Fixed Title', isHeader: true, textDirection: TextDirection.ltr),
     );
 
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('Border can be overridden in sliver nav bar', (WidgetTester tester) async {

--- a/packages/cupertino_ui/test/nav_bar_test.dart
+++ b/packages/cupertino_ui/test/nav_bar_test.dart
@@ -7,6 +7,7 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
+import 'dart:async';
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -53,15 +54,17 @@ void main() {
       const CupertinoApp(home: CupertinoNavigationBar(middle: Text('Title'))),
     );
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            builder: (BuildContext context) {
-              return const CupertinoNavigationBar(middle: Text('Page 2'));
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              builder: (BuildContext context) {
+                return const CupertinoNavigationBar(middle: Text('Page 2'));
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
@@ -75,15 +78,17 @@ void main() {
       const CupertinoApp(home: CupertinoNavigationBar.large(largeTitle: Text('Title'))),
     );
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            builder: (BuildContext context) {
-              return const CupertinoNavigationBar.large(largeTitle: Text('Page 2'));
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              builder: (BuildContext context) {
+                return const CupertinoNavigationBar.large(largeTitle: Text('Page 2'));
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
@@ -227,11 +232,13 @@ void main() {
         home: const CupertinoNavigationBar(middle: Text('Page 1')),
       ),
     );
-    navigator.currentState!.push<void>(
-      CupertinoPageRoute<void>(
-        builder: (BuildContext context) {
-          return const CupertinoNavigationBar(middle: Text('Page 2'));
-        },
+    unawaited(
+      navigator.currentState!.push<void>(
+        CupertinoPageRoute<void>(
+          builder: (BuildContext context) {
+            return const CupertinoNavigationBar(middle: Text('Page 2'));
+          },
+        ),
       ),
     );
     await tester.pumpAndSettle();
@@ -799,15 +806,17 @@ void main() {
 
     expect(find.byType(CupertinoButton), findsNothing);
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            builder: (BuildContext context) {
-              return const CupertinoNavigationBar(middle: Text('Page 2'));
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              builder: (BuildContext context) {
+                return const CupertinoNavigationBar(middle: Text('Page 2'));
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
@@ -815,16 +824,18 @@ void main() {
     expect(find.byType(CupertinoButton), findsOneWidget);
     expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)), findsOneWidget);
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            fullscreenDialog: true,
-            builder: (BuildContext context) {
-              return const CupertinoNavigationBar(middle: Text('Dialog page'));
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              fullscreenDialog: true,
+              builder: (BuildContext context) {
+                return const CupertinoNavigationBar(middle: Text('Dialog page'));
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
@@ -856,18 +867,20 @@ void main() {
 
     expect(find.byType(CupertinoButton), findsNothing);
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoSheetRoute<void>(
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(middle: Text('Page 2')),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoSheetRoute<void>(
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(middle: Text('Page 2')),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
@@ -876,19 +889,21 @@ void main() {
     expect(find.byType(CupertinoButton), findsNothing);
     expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)), findsNothing);
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoSheetRoute<void>(
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                child: CustomScrollView(
-                  slivers: <Widget>[CupertinoSliverNavigationBar(largeTitle: Text('Page 3'))],
-                ),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoSheetRoute<void>(
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  child: CustomScrollView(
+                    slivers: <Widget>[CupertinoSliverNavigationBar(largeTitle: Text('Page 3'))],
+                  ),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
@@ -901,36 +916,40 @@ void main() {
   testWidgets('Long back label turns into "back"', (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoApp(home: Placeholder()));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(previousPageTitle: '012345678901'),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(previousPageTitle: '012345678901'),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
     expect(find.widgetWithText(CupertinoButton, '012345678901'), findsOneWidget);
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(previousPageTitle: '0123456789012'),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(previousPageTitle: '0123456789012'),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -1601,33 +1620,37 @@ void main() {
       'show previous page title when possible', (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoApp(home: Placeholder()));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'An iPod',
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'A Phone',
-            builder: (BuildContext context) {
-              return const CupertinoNavigationBarBackButton();
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'A Phone',
+              builder: (BuildContext context) {
+                return const CupertinoNavigationBarBackButton();
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -1641,38 +1664,42 @@ void main() {
     var backPressed = false;
     await tester.pumpWidget(const CupertinoApp(home: Placeholder()));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'An iPod',
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'A Phone',
-            builder: (BuildContext context) {
-              return CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(
-                  leading: CupertinoNavigationBarBackButton(onPressed: () => backPressed = true),
-                ),
-                child: const Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'A Phone',
+              builder: (BuildContext context) {
+                return CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(
+                    leading: CupertinoNavigationBarBackButton(onPressed: () => backPressed = true),
+                  ),
+                  child: const Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
@@ -2078,18 +2105,20 @@ void main() {
       ),
     );
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(middle: Text('Page 2'), border: null),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(middle: Text('Page 2'), border: null),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removed the cross-import of `widgets/semantics_tester.dart`. Replaced `SemanticsTester` with `SemanticsHandle`.
* Removed `@Skip` annotation, all tests in this file has passed. `semantics_tester.dart` has existed in `cupertino_ui`, so we can directly import `semantics_tester.dart`;
* Moved the file to `test/` folder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.