### PR TITLE
[cupertino_ui] Migrate `radio_test.dart` to `SemanticsHandle`

### DIFF
--- a/packages/cupertino_ui/test/radio_test.dart
+++ b/packages/cupertino_ui/test/radio_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 // reduced-test-set:
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
@@ -17,8 +14,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../widgets/semantics_tester.dart';
 
 void main() {
   testWidgets('Radio control test', (WidgetTester tester) async {
@@ -146,7 +141,7 @@ void main() {
   });
 
   testWidgets('Radio selected semantics - platform adaptive', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
       CupertinoApp(
@@ -158,29 +153,26 @@ void main() {
         defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS;
     expect(
-      semantics,
-      includesNodeWith(
-        flags: <SemanticsFlag>[
-          SemanticsFlag.isInMutuallyExclusiveGroup,
-          SemanticsFlag.hasCheckedState,
-          SemanticsFlag.hasEnabledState,
-          SemanticsFlag.isEnabled,
-          SemanticsFlag.isFocusable,
-          SemanticsFlag.isChecked,
-          if (isApple) SemanticsFlag.hasSelectedState,
-          if (isApple) SemanticsFlag.isSelected,
-        ],
-        actions: <SemanticsAction>[
-          SemanticsAction.tap,
-          if (defaultTargetPlatform != TargetPlatform.iOS) SemanticsAction.focus,
-        ],
+      tester.getSemantics(find.byType(CupertinoRadio<int>)),
+      isSemantics(
+        isInMutuallyExclusiveGroup: true,
+        hasCheckedState: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        isFocusable: true,
+        isChecked: true,
+        hasSelectedState: isApple ? true : null,
+        isSelected: isApple ? true : null,
+        hasTapAction: true,
+        hasFocusAction: defaultTargetPlatform != TargetPlatform.iOS ? true : null,
       ),
     );
-    semantics.dispose();
+
+    handle.dispose();
   }, variant: TargetPlatformVariant.all());
 
   testWidgets('Radio semantics', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
       CupertinoApp(
@@ -262,11 +254,12 @@ void main() {
       ),
     );
 
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('has semantic events', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
+
     final Key key = UniqueKey();
     dynamic semanticEvent;
     int? radioValue = 2;
@@ -303,7 +296,7 @@ void main() {
     });
     expect(object.debugSemantics!.getSemanticsData().hasAction(SemanticsAction.tap), true);
 
-    semantics.dispose();
+    handle.dispose();
     tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
       SystemChannels.accessibility,
       null,

--- a/packages/cupertino_ui/test/radio_test.dart
+++ b/packages/cupertino_ui/test/radio_test.dart
@@ -172,8 +172,6 @@ void main() {
   }, variant: TargetPlatformVariant.all());
 
   testWidgets('Radio semantics', (WidgetTester tester) async {
-    final SemanticsHandle handle = tester.ensureSemantics();
-
     await tester.pumpWidget(
       CupertinoApp(
         home: Center(child: CupertinoRadio<int>(value: 1, groupValue: 2, onChanged: (int? i) {})),
@@ -253,13 +251,9 @@ void main() {
         isInMutuallyExclusiveGroup: true,
       ),
     );
-
-    handle.dispose();
   });
 
   testWidgets('has semantic events', (WidgetTester tester) async {
-    final SemanticsHandle handle = tester.ensureSemantics();
-
     final Key key = UniqueKey();
     dynamic semanticEvent;
     int? radioValue = 2;
@@ -296,7 +290,6 @@ void main() {
     });
     expect(object.debugSemantics!.getSemanticsData().hasAction(SemanticsAction.tap), true);
 
-    handle.dispose();
     tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
       SystemChannels.accessibility,
       null,

--- a/packages/cupertino_ui/test/radio_test.dart
+++ b/packages/cupertino_ui/test/radio_test.dart
@@ -172,6 +172,8 @@ void main() {
   }, variant: TargetPlatformVariant.all());
 
   testWidgets('Radio semantics', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+
     await tester.pumpWidget(
       CupertinoApp(
         home: Center(child: CupertinoRadio<int>(value: 1, groupValue: 2, onChanged: (int? i) {})),
@@ -251,9 +253,13 @@ void main() {
         isInMutuallyExclusiveGroup: true,
       ),
     );
+
+    handle.dispose();
   });
 
   testWidgets('has semantic events', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+
     final Key key = UniqueKey();
     dynamic semanticEvent;
     int? radioValue = 2;
@@ -290,6 +296,7 @@ void main() {
     });
     expect(object.debugSemantics!.getSemanticsData().hasAction(SemanticsAction.tap), true);
 
+    handle.dispose();
     tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
       SystemChannels.accessibility,
       null,


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removed the cross-import of `widgets/semantics_tester.dart`. Replaced `SemanticsTester` with `SemanticsHandle`.
* Removed `@Skip` annotation, all tests in this file has passed. `semantics_tester.dart` has existed in `cupertino_ui`, so we can directly import `semantics_tester.dart`;
* Moved the file to `test/` folder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.