### PR TITLE
[cupertino_ui] Migrate `segmented_control_test.dart` to `SemanticsHandle`

### DIFF
--- a/packages/cupertino_ui/test/segmented_control_test.dart
+++ b/packages/cupertino_ui/test/segmented_control_test.dart
@@ -808,8 +808,6 @@ void main() {
   });
 
   testWidgets('Segmented control semantics', (WidgetTester tester) async {
-    final SemanticsHandle handle = tester.ensureSemantics();
-
     final children = <int, Widget>{};
     children[0] = const Text('Child 1');
     children[1] = const Text('Child 2');
@@ -906,8 +904,6 @@ void main() {
         hasFocusAction: true,
       ),
     );
-
-    handle.dispose();
   });
 
   testWidgets('Non-centered taps work on smaller widgets', (WidgetTester tester) async {

--- a/packages/cupertino_ui/test/segmented_control_test.dart
+++ b/packages/cupertino_ui/test/segmented_control_test.dart
@@ -836,13 +836,13 @@ void main() {
       ),
     );
 
-    // Assert parent role
+    // Assert parent role.
     final SemanticsNode segmentedControlNode = tester.getSemantics(
       find.byType(CupertinoSegmentedControl<int>),
     );
     expect(segmentedControlNode.role, ui.SemanticsRole.radioGroup);
 
-    // Assert Child 1 (selected)
+    // Assert Child 1 (selected).
     expect(
       find.semantics.byLabel('Child 1'),
       isSemantics(
@@ -857,7 +857,7 @@ void main() {
       ),
     );
 
-    // Assert Child 2 (unselected)
+    // Assert Child 2 (unselected).
     expect(
       find.semantics.byLabel('Child 2'),
       isSemantics(
@@ -876,7 +876,7 @@ void main() {
     await tester.tap(find.text('Child 2'));
     await tester.pump();
 
-    // Assert Child 1 (now unselected)
+    // Assert Child 1 (now unselected).
     expect(
       find.semantics.byLabel('Child 1'),
       isSemantics(
@@ -891,7 +891,7 @@ void main() {
       ),
     );
 
-    // Assert Child 2 (now selected and focused)
+    // Assert Child 2 (now selected and focused).
     expect(
       find.semantics.byLabel('Child 2'),
       isSemantics(

--- a/packages/cupertino_ui/test/segmented_control_test.dart
+++ b/packages/cupertino_ui/test/segmented_control_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
@@ -18,8 +15,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../widgets/semantics_tester.dart';
 
 RenderBox getRenderSegmentedControl(WidgetTester tester) {
   return tester.allRenderObjects.firstWhere((RenderObject currentObject) {
@@ -813,7 +808,7 @@ void main() {
   });
 
   testWidgets('Segmented control semantics', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
 
     final children = <int, Widget>{};
     children[0] = const Text('Child 1');
@@ -841,91 +836,78 @@ void main() {
       ),
     );
 
+    // Assert parent role
+    final SemanticsNode segmentedControlNode = tester.getSemantics(
+      find.byType(CupertinoSegmentedControl<int>),
+    );
+    expect(segmentedControlNode.role, ui.SemanticsRole.radioGroup);
+
+    // Assert Child 1 (selected)
     expect(
-      semantics,
-      hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics.rootChild(
-              role: SemanticsRole.radioGroup,
-              children: <TestSemantics>[
-                TestSemantics(
-                  label: 'Child 1',
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isButton,
-                    SemanticsFlag.isInMutuallyExclusiveGroup,
-                    SemanticsFlag.hasSelectedState,
-                    SemanticsFlag.isSelected,
-                    SemanticsFlag.isFocusable,
-                  ],
-                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                ),
-                TestSemantics(
-                  label: 'Child 2',
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isButton,
-                    SemanticsFlag.isInMutuallyExclusiveGroup,
-                    // Declares that it is selectable, but not currently selected.
-                    SemanticsFlag.hasSelectedState,
-                    SemanticsFlag.isFocusable,
-                  ],
-                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                ),
-              ],
-            ),
-          ],
-        ),
-        ignoreId: true,
-        ignoreRect: true,
-        ignoreTransform: true,
+      find.semantics.byLabel('Child 1'),
+      isSemantics(
+        label: 'Child 1',
+        isButton: true,
+        isInMutuallyExclusiveGroup: true,
+        hasSelectedState: true,
+        isSelected: true,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
       ),
     );
 
+    // Assert Child 2 (unselected)
+    expect(
+      find.semantics.byLabel('Child 2'),
+      isSemantics(
+        label: 'Child 2',
+        isButton: true,
+        isInMutuallyExclusiveGroup: true,
+        hasSelectedState: true,
+        isSelected: false,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
+      ),
+    );
+
+    // Tap Child 2
     await tester.tap(find.text('Child 2'));
     await tester.pump();
 
+    // Assert Child 1 (now unselected)
     expect(
-      semantics,
-      hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics.rootChild(
-              role: SemanticsRole.radioGroup,
-              children: <TestSemantics>[
-                TestSemantics(
-                  label: 'Child 1',
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isButton,
-                    SemanticsFlag.isInMutuallyExclusiveGroup,
-                    // Declares that it is selectable, but not currently selected.
-                    SemanticsFlag.hasSelectedState,
-                    SemanticsFlag.isFocusable,
-                  ],
-                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                ),
-                TestSemantics(
-                  label: 'Child 2',
-                  flags: <SemanticsFlag>[
-                    SemanticsFlag.isButton,
-                    SemanticsFlag.isInMutuallyExclusiveGroup,
-                    SemanticsFlag.hasSelectedState,
-                    SemanticsFlag.isSelected,
-                    SemanticsFlag.isFocusable,
-                    SemanticsFlag.isFocused,
-                  ],
-                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-                ),
-              ],
-            ),
-          ],
-        ),
-        ignoreId: true,
-        ignoreRect: true,
-        ignoreTransform: true,
+      find.semantics.byLabel('Child 1'),
+      isSemantics(
+        label: 'Child 1',
+        isButton: true,
+        isInMutuallyExclusiveGroup: true,
+        hasSelectedState: true,
+        isSelected: false,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
       ),
     );
 
-    semantics.dispose();
+    // Assert Child 2 (now selected and focused)
+    expect(
+      find.semantics.byLabel('Child 2'),
+      isSemantics(
+        label: 'Child 2',
+        isButton: true,
+        isInMutuallyExclusiveGroup: true,
+        hasSelectedState: true,
+        isSelected: true,
+        isFocusable: true,
+        isFocused: true,
+        hasTapAction: true,
+        hasFocusAction: true,
+      ),
+    );
+
+    handle.dispose();
   });
 
   testWidgets('Non-centered taps work on smaller widgets', (WidgetTester tester) async {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removed the cross-import of `widgets/semantics_tester.dart`. Replaced `SemanticsTester` with `SemanticsHandle`.
* Removed `@Skip` annotation, all tests in this file has passed. `semantics_tester.dart` has existed in `cupertino_ui`, so we can directly import `semantics_tester.dart`;
* Moved the file to `test/` folder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.