### PR TITLE
[cupertino_ui] Migrate `route_test.dart` to `SemanticsHandle`

### DIFF
--- a/packages/cupertino_ui/test/route_test.dart
+++ b/packages/cupertino_ui/test/route_test.dart
@@ -2071,8 +2071,6 @@ void main() {
     WidgetTester tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-    final SemanticsHandle handle = tester.ensureSemantics();
-
     await tester.pumpWidget(
       CupertinoApp(
         home: Navigator(
@@ -2102,14 +2100,12 @@ void main() {
     expect(find.semantics.byLabel('Dismiss'), findsNothing);
 
     debugDefaultTargetPlatformOverride = null;
-    handle.dispose();
   });
 
   testWidgets('showCupertinoModalPopup allows for semantics dismiss when set', (
     WidgetTester tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-    final SemanticsHandle handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
       CupertinoApp(
@@ -2144,7 +2140,6 @@ void main() {
     );
 
     debugDefaultTargetPlatformOverride = null;
-    handle.dispose();
   });
 
   testWidgets('showCupertinoModalPopup passes RouteSettings to PopupRoute', (

--- a/packages/cupertino_ui/test/route_test.dart
+++ b/packages/cupertino_ui/test/route_test.dart
@@ -231,12 +231,12 @@ void main() {
       },
     );
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(route2);
+    unawaited(tester.state<NavigatorState>(find.byType(Navigator)).push(route2));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(route3);
+    unawaited(tester.state<NavigatorState>(find.byType(Navigator)).push(route3));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));

--- a/packages/cupertino_ui/test/route_test.dart
+++ b/packages/cupertino_ui/test/route_test.dart
@@ -2,11 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: only_throw_errors, unawaited_futures
-
 @TestOn('!chrome')
 library;
 
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:cupertino_ui/cupertino_ui.dart';
@@ -2549,12 +2548,14 @@ void main() {
       );
       final BuildContext context = tester.element(find.text('Test'));
 
-      showCupertinoDialog<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return const Placeholder();
-        },
-        anchorPoint: const Offset(1000, 0),
+      unawaited(
+        showCupertinoDialog<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return const Placeholder();
+          },
+          anchorPoint: const Offset(1000, 0),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2587,11 +2588,13 @@ void main() {
       );
       final BuildContext context = tester.element(find.text('Test'));
 
-      showCupertinoDialog<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return const Placeholder();
-        },
+      unawaited(
+        showCupertinoDialog<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return const Placeholder();
+          },
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2624,11 +2627,13 @@ void main() {
       );
       final BuildContext context = tester.element(find.text('Test'));
 
-      showCupertinoDialog<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return const Placeholder();
-        },
+      unawaited(
+        showCupertinoDialog<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return const Placeholder();
+          },
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2663,12 +2668,14 @@ void main() {
       );
 
       final BuildContext context = tester.element(find.text('Test'));
-      showCupertinoModalPopup<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return const Placeholder();
-        },
-        anchorPoint: const Offset(1000, 0),
+      unawaited(
+        showCupertinoModalPopup<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return const Placeholder();
+          },
+          anchorPoint: const Offset(1000, 0),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2701,11 +2708,13 @@ void main() {
       );
 
       final BuildContext context = tester.element(find.text('Test'));
-      showCupertinoModalPopup<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return const Placeholder();
-        },
+      unawaited(
+        showCupertinoModalPopup<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return const Placeholder();
+          },
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2738,11 +2747,13 @@ void main() {
       );
 
       final BuildContext context = tester.element(find.text('Test'));
-      showCupertinoModalPopup<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return const Placeholder();
-        },
+      unawaited(
+        showCupertinoModalPopup<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return const Placeholder();
+          },
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -3127,10 +3138,12 @@ void main() {
     await tester.pump();
     expect(focusNode.hasFocus, true);
 
-    showCupertinoModalPopup<void>(
-      context: navigatorKey.currentContext!,
-      requestFocus: true,
-      builder: (BuildContext context) => const Text('popup'),
+    unawaited(
+      showCupertinoModalPopup<void>(
+        context: navigatorKey.currentContext!,
+        requestFocus: true,
+        builder: (BuildContext context) => const Text('popup'),
+      ),
     );
     await tester.pumpAndSettle();
     expect(FocusScope.of(tester.element(find.text('popup'))).hasFocus, true);
@@ -3140,10 +3153,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(focusNode.hasFocus, true);
 
-    showCupertinoModalPopup<void>(
-      context: navigatorKey.currentContext!,
-      requestFocus: false,
-      builder: (BuildContext context) => const Text('popup'),
+    unawaited(
+      showCupertinoModalPopup<void>(
+        context: navigatorKey.currentContext!,
+        requestFocus: false,
+        builder: (BuildContext context) => const Text('popup'),
+      ),
     );
     await tester.pumpAndSettle();
     expect(FocusScope.of(tester.element(find.text('popup'))).hasFocus, false);
@@ -3164,10 +3179,12 @@ void main() {
     await tester.pump();
     expect(focusNode.hasFocus, true);
 
-    showCupertinoDialog<void>(
-      context: navigatorKey.currentContext!,
-      requestFocus: true,
-      builder: (BuildContext context) => const Text('dialog'),
+    unawaited(
+      showCupertinoDialog<void>(
+        context: navigatorKey.currentContext!,
+        requestFocus: true,
+        builder: (BuildContext context) => const Text('dialog'),
+      ),
     );
     await tester.pumpAndSettle();
     expect(FocusScope.of(tester.element(find.text('dialog'))).hasFocus, true);
@@ -3177,10 +3194,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(focusNode.hasFocus, true);
 
-    showCupertinoDialog<void>(
-      context: navigatorKey.currentContext!,
-      requestFocus: false,
-      builder: (BuildContext context) => const Text('dialog'),
+    unawaited(
+      showCupertinoDialog<void>(
+        context: navigatorKey.currentContext!,
+        requestFocus: false,
+        builder: (BuildContext context) => const Text('dialog'),
+      ),
     );
     await tester.pumpAndSettle();
     expect(FocusScope.of(tester.element(find.text('dialog'))).hasFocus, false);

--- a/packages/cupertino_ui/test/route_test.dart
+++ b/packages/cupertino_ui/test/route_test.dart
@@ -1567,11 +1567,11 @@ void main() {
           if (paintColor.value == color.value) {
             return true;
           }
-          throw '''
+          fail('''
   For a rect with an expected left-side position: $dx (drawn at ${rect.left}):
               Expected a rect with color: $color,
               And drew a rect with color: $paintColor.
-          ''';
+          ''');
         });
       }
 
@@ -1649,10 +1649,10 @@ void main() {
               final bool isOnScreen = rect.left >= 0 && rect.right <= 600.0;
 
               if (isOnScreen) {
-                throw '''
+                fail('''
     Expected: no visible rects on-screen.
     Found: $rect.
-        ''';
+        ''');
               }
             }
             return true;

--- a/packages/cupertino_ui/test/route_test.dart
+++ b/packages/cupertino_ui/test/route_test.dart
@@ -2,9 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
+// ignore_for_file: only_throw_errors, unawaited_futures
+
 @TestOn('!chrome')
 library;
 
@@ -14,8 +13,6 @@ import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../widgets/semantics_tester.dart';
 
 void main() {
   late MockNavigatorObserver navigatorObserver;
@@ -2045,7 +2042,8 @@ void main() {
     WidgetTester tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
+
     await tester.pumpWidget(
       CupertinoApp(
         home: Navigator(
@@ -2072,24 +2070,18 @@ void main() {
     await tester.tap(find.text('tap'));
     await tester.pumpAndSettle();
 
-    expect(
-      semantics,
-      isNot(
-        includesNodeWith(
-          actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-          label: 'Dismiss',
-        ),
-      ),
-    );
+    expect(find.semantics.byLabel('Dismiss'), findsNothing);
+
     debugDefaultTargetPlatformOverride = null;
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('showCupertinoModalPopup allows for semantics dismiss when set', (
     WidgetTester tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-    final semantics = SemanticsTester(tester);
+    final SemanticsHandle handle = tester.ensureSemantics();
+
     await tester.pumpWidget(
       CupertinoApp(
         home: Navigator(
@@ -2118,14 +2110,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      semantics,
-      includesNodeWith(
-        actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.dismiss],
-        label: 'Dismiss',
-      ),
+      find.semantics.byLabel('Dismiss'),
+      isSemantics(label: 'Dismiss', hasTapAction: true, hasDismissAction: true),
     );
+
     debugDefaultTargetPlatformOverride = null;
-    semantics.dispose();
+    handle.dispose();
   });
 
   testWidgets('showCupertinoModalPopup passes RouteSettings to PopupRoute', (

--- a/packages/cupertino_ui/test/route_test.dart
+++ b/packages/cupertino_ui/test/route_test.dart
@@ -23,19 +23,21 @@ void main() {
   testWidgets('Middle auto-populates with title', (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoApp(home: Placeholder()));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'An iPod',
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -54,18 +56,20 @@ void main() {
     addTearDown(tester.view.reset);
     await tester.pumpWidget(const CupertinoApp(home: Placeholder()));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'An iPod',
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                child: CustomScrollView(slivers: <Widget>[CupertinoSliverNavigationBar()]),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  child: CustomScrollView(slivers: <Widget>[CupertinoSliverNavigationBar()]),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -106,36 +110,40 @@ void main() {
   ) async {
     await tester.pumpWidget(const CupertinoApp(home: Placeholder()));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'An iPod',
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'A Phone',
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'A Phone',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
@@ -156,36 +164,40 @@ void main() {
   testWidgets('Previous title is correct on first transition frame', (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoApp(home: Placeholder()));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'An iPod',
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(
-          CupertinoPageRoute<void>(
-            title: 'A Phone',
-            builder: (BuildContext context) {
-              return const CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(),
-                child: Placeholder(),
-              );
-            },
+    unawaited(
+      tester
+          .state<NavigatorState>(find.byType(Navigator))
+          .push(
+            CupertinoPageRoute<void>(
+              title: 'A Phone',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
           ),
-        );
+    );
 
     // Trigger the route push
     await tester.pump();
@@ -366,12 +378,14 @@ void main() {
     // Use the navigator to push a route instead of tapping the 'push' button.
     // The topmost route (the one that's animating away), ignores input while
     // the pop is underway because route.navigator.userGestureInProgress.
-    Navigator.push<void>(
-      scaffoldKey.currentContext!,
-      CupertinoPageRoute<void>(
-        builder: (BuildContext context) {
-          return const CupertinoPageScaffold(child: Center(child: Text('route')));
-        },
+    unawaited(
+      Navigator.push<void>(
+        scaffoldKey.currentContext!,
+        CupertinoPageRoute<void>(
+          builder: (BuildContext context) {
+            return const CupertinoPageScaffold(child: Center(child: Text('route')));
+          },
+        ),
       ),
     );
 
@@ -598,12 +612,14 @@ void main() {
 
     // Programmatically push and observe that Page 3 was pushed as if there were
     // no back gesture.
-    Navigator.push<void>(
-      scaffoldKey.currentContext!,
-      CupertinoPageRoute<void>(
-        builder: (BuildContext context) {
-          return const CupertinoPageScaffold(child: Center(child: Text('Page 3')));
-        },
+    unawaited(
+      Navigator.push<void>(
+        scaffoldKey.currentContext!,
+        CupertinoPageRoute<void>(
+          builder: (BuildContext context) {
+            return const CupertinoPageScaffold(child: Center(child: Text('Page 3')));
+          },
+        ),
       ),
     );
     await tester.pumpAndSettle();
@@ -682,12 +698,14 @@ void main() {
 
     // Programmatically push and observe that Page 3 was pushed as if there were
     // no back gesture.
-    Navigator.push<void>(
-      scaffoldKey.currentContext!,
-      CupertinoPageRoute<void>(
-        builder: (BuildContext context) {
-          return const CupertinoPageScaffold(child: Center(child: Text('Page 3')));
-        },
+    unawaited(
+      Navigator.push<void>(
+        scaffoldKey.currentContext!,
+        CupertinoPageRoute<void>(
+          builder: (BuildContext context) {
+            return const CupertinoPageScaffold(child: Center(child: Text('Page 3')));
+          },
+        ),
       ),
     );
     await tester.pumpAndSettle();
@@ -1224,7 +1242,7 @@ void main() {
       },
     );
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(route2);
+    unawaited(tester.state<NavigatorState>(find.byType(Navigator)).push(route2));
     // The whole transition is 500ms based on CupertinoPageRoute.transitionDuration.
     // Break it up into small chunks.
     //
@@ -1280,7 +1298,7 @@ void main() {
       },
     );
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(route2);
+    unawaited(tester.state<NavigatorState>(find.byType(Navigator)).push(route2));
 
     await tester.pumpAndSettle();
 
@@ -1347,7 +1365,7 @@ void main() {
       },
     );
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(route2);
+    unawaited(tester.state<NavigatorState>(find.byType(Navigator)).push(route2));
 
     await tester.pumpAndSettle();
 
@@ -1391,7 +1409,7 @@ void main() {
       },
     );
 
-    navigatorKey.currentState!.push(route2);
+    unawaited(navigatorKey.currentState!.push(route2));
     await tester.pumpAndSettle();
     expect(navigatorObserver.invocations.removeLast(), NavigatorInvocation.didPush);
 
@@ -1443,7 +1461,7 @@ void main() {
       ),
     );
 
-    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
+    unawaited(tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next'));
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -1482,7 +1500,7 @@ void main() {
       ),
     );
 
-    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
+    unawaited(tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next'));
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -1522,9 +1540,11 @@ void main() {
     ) async {
       await tester.pumpWidget(const CupertinoApp(home: SizedBox.expand()));
 
-      tester
-          .state<NavigatorState>(find.byType(Navigator))
-          .push(buildRoute(fullscreenDialog: false));
+      unawaited(
+        tester
+            .state<NavigatorState>(find.byType(Navigator))
+            .push(buildRoute(fullscreenDialog: false)),
+      );
       await tester.pumpAndSettle();
 
       expect(
@@ -1538,7 +1558,11 @@ void main() {
     ) async {
       await tester.pumpWidget(const CupertinoApp(home: SizedBox.expand()));
 
-      tester.state<NavigatorState>(find.byType(Navigator)).push(buildRoute(fullscreenDialog: true));
+      unawaited(
+        tester
+            .state<NavigatorState>(find.byType(Navigator))
+            .push(buildRoute(fullscreenDialog: true)),
+      );
       await tester.pumpAndSettle();
 
       expect(tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color, isNull);
@@ -1577,9 +1601,11 @@ void main() {
 
       await tester.pumpWidget(const CupertinoApp(home: SizedBox.expand()));
 
-      tester
-          .state<NavigatorState>(find.byType(Navigator))
-          .push(buildRoute(fullscreenDialog: false));
+      unawaited(
+        tester
+            .state<NavigatorState>(find.byType(Navigator))
+            .push(buildRoute(fullscreenDialog: false)),
+      );
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1));
 
@@ -1661,9 +1687,11 @@ void main() {
 
         await tester.pumpWidget(const CupertinoApp(home: SizedBox.expand()));
 
-        tester
-            .state<NavigatorState>(find.byType(Navigator))
-            .push(buildRoute(fullscreenDialog: true));
+        unawaited(
+          tester
+              .state<NavigatorState>(find.byType(Navigator))
+              .push(buildRoute(fullscreenDialog: true)),
+        );
         await tester.pump();
 
         final RenderBox box = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
@@ -1774,22 +1802,24 @@ void main() {
     expect(homeTapCount, 1);
     expect(pageTapCount, 0);
 
-    Navigator.push<void>(
-      homeScaffoldKey.currentContext!,
-      CupertinoPageRoute<void>(
-        builder: (BuildContext context) {
-          return CupertinoPageScaffold(
-            key: pageScaffoldKey,
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: GestureDetector(
-                onTap: () {
-                  pageTapCount += 1;
-                },
+    unawaited(
+      Navigator.push<void>(
+        homeScaffoldKey.currentContext!,
+        CupertinoPageRoute<void>(
+          builder: (BuildContext context) {
+            return CupertinoPageScaffold(
+              key: pageScaffoldKey,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: GestureDetector(
+                  onTap: () {
+                    pageTapCount += 1;
+                  },
+                ),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
 
@@ -1893,7 +1923,7 @@ void main() {
     var box = tester.renderObject(find.byKey(container)) as RenderBox;
     final double initialPosition = box.localToGlobal(Offset.zero).dx;
 
-    navigator.currentState!.pushNamed('/page2');
+    unawaited(navigator.currentState!.pushNamed('/page2'));
     await tester.pumpAndSettle();
     box = tester.renderObject(find.byKey(container)) as RenderBox;
     final double finalPosition = box.localToGlobal(Offset.zero).dx;
@@ -2906,7 +2936,7 @@ void main() {
 
     final double pageTitleDX = tester.getTopLeft(find.text('Page 1')).dx;
 
-    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
+    unawaited(tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
@@ -2955,10 +2985,12 @@ void main() {
 
       // Bring up dialog.
       final NavigatorState navigator = Navigator.of(savedContext);
-      navigator.push(
-        CupertinoDialogRoute<void>(
-          context: savedContext,
-          builder: (BuildContext context) => const Text(dialogText),
+      unawaited(
+        navigator.push(
+          CupertinoDialogRoute<void>(
+            context: savedContext,
+            builder: (BuildContext context) => const Text(dialogText),
+          ),
         ),
       );
       await tester.pump();
@@ -2976,11 +3008,13 @@ void main() {
       expect(getCupertinoTextFieldFocusNode()?.hasFocus, true);
 
       // Bring up dialog again with requestFocus to false.
-      navigator.push(
-        CupertinoDialogRoute<void>(
-          context: savedContext,
-          requestFocus: false,
-          builder: (BuildContext context) => const Text(dialogText),
+      unawaited(
+        navigator.push(
+          CupertinoDialogRoute<void>(
+            context: savedContext,
+            requestFocus: false,
+            builder: (BuildContext context) => const Text(dialogText),
+          ),
         ),
       );
       await tester.pump();
@@ -3029,8 +3063,10 @@ void main() {
 
       // Bring up popup.
       final NavigatorState navigator = Navigator.of(savedContext);
-      navigator.push(
-        CupertinoModalPopupRoute<void>(builder: (BuildContext context) => const Text(dialogText)),
+      unawaited(
+        navigator.push(
+          CupertinoModalPopupRoute<void>(builder: (BuildContext context) => const Text(dialogText)),
+        ),
       );
       await tester.pump();
 
@@ -3047,10 +3083,12 @@ void main() {
       expect(getCupertinoTextFieldFocusNode()?.hasFocus, true);
 
       // Bring up popup again with requestFocus to false.
-      navigator.push(
-        CupertinoModalPopupRoute<void>(
-          requestFocus: false,
-          builder: (BuildContext context) => const Text(dialogText),
+      unawaited(
+        navigator.push(
+          CupertinoModalPopupRoute<void>(
+            requestFocus: false,
+            builder: (BuildContext context) => const Text(dialogText),
+          ),
         ),
       );
       await tester.pump();
@@ -3083,11 +3121,13 @@ void main() {
 
       // Navigate to page two with text.
       final NavigatorState navigator = Navigator.of(savedContext);
-      navigator.push(
-        CupertinoPageRoute<void>(
-          builder: (BuildContext context) {
-            return const Text(pageTwoText);
-          },
+      unawaited(
+        navigator.push(
+          CupertinoPageRoute<void>(
+            builder: (BuildContext context) {
+              return const Text(pageTwoText);
+            },
+          ),
         ),
       );
       await tester.pump();
@@ -3104,12 +3144,14 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100)); // Advance route transition animation.
 
       // Navigate to page two again with requestFocus set to false.
-      navigator.push(
-        CupertinoPageRoute<void>(
-          requestFocus: false,
-          builder: (BuildContext context) {
-            return const Text(pageTwoText);
-          },
+      unawaited(
+        navigator.push(
+          CupertinoPageRoute<void>(
+            requestFocus: false,
+            builder: (BuildContext context) {
+              return const Text(pageTwoText);
+            },
+          ),
         ),
       );
       await tester.pump();


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removed the cross-import of `widgets/semantics_tester.dart`. Replaced `SemanticsTester` with `SemanticsHandle`.
* Removed `@Skip` annotation, all tests in this file has passed. `semantics_tester.dart` has existed in `cupertino_ui`, so we can directly import `semantics_tester.dart`;
* Moved the file to `test/` folder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.