### PR TITLE
[google_maps_flutter] Fix iOS &/&& logic

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.18.4
+
+* Fixes a potential compilation issue in tile downscaling.
+
 ## 2.18.3
 
 * Updates README to include setup information.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMTileOverlayController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMTileOverlayController.m
@@ -81,12 +81,12 @@
 - (UIImage *)handleResultTile:(nullable UIImage *)tile {
   CGImageRef imageRef = tile.CGImage;
   CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
-  BOOL isFloat = bitmapInfo && kCGBitmapFloatComponents;
+  BOOL isFloat = bitmapInfo & kCGBitmapFloatComponents;
   size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
 
   // Engine use f16 pixel format for wide gamut images
   // If it is wide gamut, we want to downsample it
-  if (isFloat & (bitsPerComponent == 16)) {
+  if (isFloat && (bitsPerComponent == 16)) {
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGContextRef context =
         CGBitmapContextCreate(nil, tile.size.width, tile.size.height, 8, 0, colorSpace,

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.3
+version: 2.18.4
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.18.5
+
+* Fixes a potential compilation issue in tile downscaling.
+
 ## 2.18.4
 
 * Updates README to include setup information.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMTileOverlayController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/ios/google_maps_flutter_ios_sdk10/Sources/google_maps_flutter_ios_sdk10/FGMTileOverlayController.m
@@ -81,12 +81,12 @@
 - (UIImage *)handleResultTile:(nullable UIImage *)tile {
   CGImageRef imageRef = tile.CGImage;
   CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
-  BOOL isFloat = bitmapInfo && kCGBitmapFloatComponents;
+  BOOL isFloat = bitmapInfo & kCGBitmapFloatComponents;
   size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
 
   // Engine use f16 pixel format for wide gamut images
   // If it is wide gamut, we want to downsample it
-  if (isFloat & (bitsPerComponent == 16)) {
+  if (isFloat && (bitsPerComponent == 16)) {
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGContextRef context =
         CGBitmapContextCreate(nil, tile.size.width, tile.size.height, 8, 0, colorSpace,

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios_sdk10
 description: iOS implementation of the google_maps_flutter plugin using Google Maps SDK 10.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios_sdk10
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.4
+version: 2.18.5
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.18.6
+
+* Fixes a potential compilation issue in tile downscaling.
+
 ## 2.18.5
 
 * Corrects the README header.

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMTileOverlayController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/ios/google_maps_flutter_ios_sdk9/Sources/google_maps_flutter_ios_sdk9/FGMTileOverlayController.m
@@ -81,12 +81,12 @@
 - (UIImage *)handleResultTile:(nullable UIImage *)tile {
   CGImageRef imageRef = tile.CGImage;
   CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
-  BOOL isFloat = bitmapInfo && kCGBitmapFloatComponents;
+  BOOL isFloat = bitmapInfo & kCGBitmapFloatComponents;
   size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
 
   // Engine use f16 pixel format for wide gamut images
   // If it is wide gamut, we want to downsample it
-  if (isFloat & (bitsPerComponent == 16)) {
+  if (isFloat && (bitsPerComponent == 16)) {
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGContextRef context =
         CGBitmapContextCreate(nil, tile.size.width, tile.size.height, 8, 0, colorSpace,

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios_sdk9
 description: iOS implementation of the google_maps_flutter plugin using Google Maps SDK 9.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_ios_sdk9
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.5
+version: 2.18.6
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMTileOverlayController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/ios/google_maps_flutter_ios/Sources/google_maps_flutter_ios/FGMTileOverlayController.m
@@ -81,12 +81,12 @@
 - (UIImage *)handleResultTile:(nullable UIImage *)tile {
   CGImageRef imageRef = tile.CGImage;
   CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
-  BOOL isFloat = bitmapInfo && kCGBitmapFloatComponents;
+  BOOL isFloat = bitmapInfo & kCGBitmapFloatComponents;
   size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
 
   // Engine use f16 pixel format for wide gamut images
   // If it is wide gamut, we want to downsample it
-  if (isFloat & (bitsPerComponent == 16)) {
+  if (isFloat && (bitsPerComponent == 16)) {
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGContextRef context =
         CGBitmapContextCreate(nil, tile.size.width, tile.size.height, 8, 0, colorSpace,


### PR DESCRIPTION
Fixes incorrect use of `&&` and `&` in the tile downscaling logic added in https://github.com/flutter/packages/pull/6377

The code would generally do the right thing by accident, because `isFloat` would always end up true, so it would downsample any 16-bit image. The incorrect operators cause complitation failure in some compilation environments, however (like google3).

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
