### PR TITLE
[material_ui] Remove `widgets/` import in `flexible_space_bar_test.dart`, `app_bar_sliver_test.dart` and partial fix in `chip_test.dart`

### DIFF
--- a/packages/material_ui/temporarily_disabled_tests/chip_test.dart
+++ b/packages/material_ui/temporarily_disabled_tests/chip_test.dart
@@ -19,7 +19,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/feedback_tester.dart';
-import '../widgets/semantics_tester.dart';
+import '../test/semantics_tester.dart';
 
 Finder findRenderChipElement() {
   return find.byElementPredicate((Element e) => '${e.renderObject.runtimeType}' == '_RenderChip');

--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2,15 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
-import 'package:material_ui/material_ui.dart';
+import 'dart:async' show unawaited;
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
-import '../widgets/semantics_tester.dart';
 import 'app_bar_utils.dart';
+import 'semantics_tester.dart';
 
 Widget buildSliverAppBarApp({
   bool floating = false,
@@ -71,22 +70,24 @@ void main() {
               return Center(
                 child: FilledButton(
                   onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute<void>(
-                        builder: (BuildContext context) {
-                          return Scaffold(
-                            body: CustomScrollView(
-                              primary: true,
-                              slivers: <Widget>[
-                                const SliverAppBar.large(title: Text(title)),
-                                SliverToBoxAdapter(
-                                  child: Container(height: 1200, color: Colors.orange[400]),
-                                ),
-                              ],
-                            ),
-                          );
-                        },
+                    unawaited(
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute<void>(
+                          builder: (BuildContext context) {
+                            return Scaffold(
+                              body: CustomScrollView(
+                                primary: true,
+                                slivers: <Widget>[
+                                  const SliverAppBar.large(title: Text(title)),
+                                  SliverToBoxAdapter(
+                                    child: Container(height: 1200, color: Colors.orange[400]),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        ),
                       ),
                     );
                   },

--- a/packages/material_ui/test/flexible_space_bar_test.dart
+++ b/packages/material_ui/test/flexible_space_bar_test.dart
@@ -2,18 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'package:material_ui/material_ui.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../widgets/semantics_tester.dart';
+import 'package:material_ui/material_ui.dart';
+
+import 'semantics_tester.dart';
 
 void main() {
   testWidgets('FlexibleSpaceBar centers title on iOS', (WidgetTester tester) async {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removed the cross-import of `widgets/semantics_tester.dart`.
* Removed @Skip tag, all tests in this file has passed. `semantics_tester.dart` has existed in material_ui, so we can directly import `semantics_tester.dart`;
* Moved the file to `test/` folder.

Note: `chip_test.dart` only partially remove the widgets/ dependency and still stay in `temporarily_disabled_tests` folder. Once https://github.com/flutter/flutter/pull/184279 is ported over, this file can be move out of the folder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.
