### PR TITLE
[cupertino_ui] Create util files. Remove widgets import in `adaptive_text_selection_toolbar_test.dart` and `text_selection_test.dart`

### DIFF
--- a/packages/cupertino_ui/test/adaptive_text_selection_toolbar_test.dart
+++ b/packages/cupertino_ui/test/adaptive_text_selection_toolbar_test.dart
@@ -2,17 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
-import '../widgets/text_selection_toolbar_utils.dart';
+import 'clipboard_utils.dart';
 import 'live_text_utils.dart';
+import 'text_selection_toolbar_utils.dart';
 
 void main() {
   final mockClipboard = MockClipboard();

--- a/packages/cupertino_ui/test/clipboard_utils.dart
+++ b/packages/cupertino_ui/test/clipboard_utils.dart
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+
+class MockClipboard {
+  MockClipboard({this.hasStringsThrows = false});
+
+  final bool hasStringsThrows;
+
+  dynamic clipboardData = <String, dynamic>{'text': null};
+
+  Future<Object?> handleMethodCall(MethodCall methodCall) async {
+    switch (methodCall.method) {
+      case 'Clipboard.getData':
+        return clipboardData;
+      case 'Clipboard.hasStrings':
+        if (hasStringsThrows) {
+          throw Exception();
+        }
+        final clipboardDataMap = clipboardData as Map<String, dynamic>?;
+        final text = clipboardDataMap?['text'] as String?;
+        return <String, bool>{'value': text != null && text.isNotEmpty};
+      case 'Clipboard.setData':
+        clipboardData = methodCall.arguments;
+    }
+    return null;
+  }
+}

--- a/packages/cupertino_ui/test/text_selection_test.dart
+++ b/packages/cupertino_ui/test/text_selection_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
@@ -18,7 +15,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/clipboard_utils.dart';
+import 'clipboard_utils.dart';
 import 'editable_text_utils.dart' show findRenderEditable, textOffsetToPosition;
 
 class _LongCupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLocalizations> {

--- a/packages/cupertino_ui/test/text_selection_toolbar_utils.dart
+++ b/packages/cupertino_ui/test/text_selection_toolbar_utils.dart
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Finder findCupertinoOverflowNextButton() {
+  return find.byWidgetPredicate((Widget widget) {
+    return widget is CustomPaint &&
+        '${widget.painter?.runtimeType}' == '_RightCupertinoChevronPainter';
+  });
+}
+
+Finder findCupertinoOverflowBackButton() {
+  return find.byWidgetPredicate((Widget widget) {
+    return widget is CustomPaint &&
+        '${widget.painter?.runtimeType}' == '_LeftCupertinoChevronPainter';
+  });
+}
+
+Future<void> tapCupertinoOverflowNextButton(WidgetTester tester) async {
+  await tester.tapAt(tester.getCenter(findCupertinoOverflowNextButton()));
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removed the cross-import of `widgets/clipboard_utils.dart` and `widgets/text_selection_toolbar_utils.dart`.
* Removed @Skip tag, all tests in this file has passed. Created util files for `clipboard_utils.dart` and `text_selection_toolbar_utils.dart`
* Moved the files to `test/` folder.

This is to port changes in https://github.com/flutter/flutter/pull/184278
## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.