### PR TITLE
[material_ui] Remove `widgets` imports from `card_test.dart`, `checkbox_list_tile_test.dart`

### DIFF
--- a/packages/material_ui/test/card_test.dart
+++ b/packages/material_ui/test/card_test.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
-import 'package:material_ui/material_ui.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../widgets/semantics_tester.dart';
+import 'package:material_ui/material_ui.dart';
+
+import 'semantics_tester.dart';
 
 void main() {
   testWidgets('Material3 - Card defaults (Elevated card)', (WidgetTester tester) async {

--- a/packages/material_ui/test/checkbox_list_tile_test.dart
+++ b/packages/material_ui/test/checkbox_list_tile_test.dart
@@ -2,17 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:material_ui/material_ui.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
-import '../widgets/feedback_tester.dart';
+import 'feedback_tester.dart';
 
 Widget wrap({required Widget child}) {
   return MediaQuery(


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

  This PR:
  * Removed the cross-imports of `widgets/feedback_tester.dart` and `widgets/semantics_tester.dart`.
  * Removed @Skip tag, all tests in this file have passed.
  * Moved the files to `test/` folder.

  ## Pre-Review Checklist

  - [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
  - [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
  - [x] I read the [Tree Hygiene] page, which explains my responsibilities.
  - [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
  - [x] I signed the [CLA].
  - [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
  - [x] I [linked to at least one issue that this PR fixes] in the description above.
  - [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented
  exception this PR falls under[^1].
  - [x] I updated/added any relevant documentation (doc comments with `///`).
  - [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
  - [x] All existing and new tests are passing.