### PR TITLE
[material_ui] Remove `widgets` import from `material_test.dart`

### DIFF
--- a/packages/material_ui/test/material_test.dart
+++ b/packages/material_ui/test/material_test.dart
@@ -66,8 +66,8 @@ class PaintRecorder extends CustomPainter {
   bool shouldRepaint(PaintRecorder oldDelegate) => false;
 }
 
-class FakeView extends TestFlutterView {
-  FakeView(ui.FlutterView view, {this.viewId = 100})
+class _FakeView extends TestFlutterView {
+  _FakeView(ui.FlutterView view)
     : super(
         view: view,
         platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
@@ -75,7 +75,7 @@ class FakeView extends TestFlutterView {
       );
 
   @override
-  final int viewId;
+  int get viewId => 100;
 
   @override
   void render(ui.Scene scene, {ui.Size? size}) {
@@ -1243,7 +1243,7 @@ void main() {
                 builder: (BuildContext context) {
                   outsideView = Material.maybeOf(context);
                   return View(
-                    view: FakeView(tester.view),
+                    view: _FakeView(tester.view),
                     child: Builder(
                       builder: (BuildContext context) {
                         insideView = Material.maybeOf(context);

--- a/packages/material_ui/test/material_test.dart
+++ b/packages/material_ui/test/material_test.dart
@@ -2,20 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'package:material_ui/material_ui.dart';
+import 'dart:ui' as ui;
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
-import '../widgets/multi_view_testing.dart';
+import 'package:material_ui/material_ui.dart';
+
 import 'test_border.dart' show TestBorder;
 
 class NotifyMaterial extends StatelessWidget {
@@ -65,6 +64,30 @@ class PaintRecorder extends CustomPainter {
 
   @override
   bool shouldRepaint(PaintRecorder oldDelegate) => false;
+}
+
+class FakeView extends TestFlutterView {
+  FakeView(ui.FlutterView view, {this.viewId = 100})
+    : super(
+        view: view,
+        platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
+        display: view.display as TestDisplay,
+      );
+
+  @override
+  final int viewId;
+
+  @override
+  void render(ui.Scene scene, {ui.Size? size}) {
+    // Do not render the scene in the engine. The engine only observes one
+    // instance of FlutterView, and the framework should not render more than
+    // one Scene per frame.
+  }
+
+  @override
+  void updateSemantics(ui.SemanticsUpdate update) {
+    // Do not send updates for this fake view to the engine's primary view.
+  }
 }
 
 class ElevationColor {

--- a/packages/material_ui/test/material_test.dart
+++ b/packages/material_ui/test/material_test.dart
@@ -7,7 +7,7 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'dart:ui' as ui;
+import 'dart:ui' show Scene, SemanticsUpdate;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -67,25 +67,21 @@ class PaintRecorder extends CustomPainter {
 }
 
 class _FakeView extends TestFlutterView {
-  _FakeView(ui.FlutterView view)
-    : super(
-        view: view,
-        platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
-        display: view.display as TestDisplay,
-      );
+  _FakeView(TestFlutterView view)
+    : super(view: view, platformDispatcher: view.platformDispatcher, display: view.display);
 
   @override
   int get viewId => 100;
 
   @override
-  void render(ui.Scene scene, {ui.Size? size}) {
+  void render(Scene scene, {Size? size}) {
     // Do not render the scene in the engine. The engine only observes one
     // instance of FlutterView, and the framework should not render more than
     // one Scene per frame.
   }
 
   @override
-  void updateSemantics(ui.SemanticsUpdate update) {
+  void updateSemantics(SemanticsUpdate update) {
     // Do not send updates for this fake view to the engine's primary view.
   }
 }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

  This PR:
  * Removed the cross-import of `widgets/multi_view_testing.dart`.
  * Removed @Skip tag, all tests in this file have passed.
  * Moved the file to `test/` folder.

I did not copy `multi_view_testing.dart` wholesale because `material_test.dart` only needs a minimal fake secondary view for one `View`/`ViewAnchor` assertion. The rest of `multi_view_testing.dart` is used by Flutter’s widgets-layer tests, not by this Material test. Keeping `_FakeView` private avoids adding unused shared test infrastructure until another `material_ui` test actually needs it.

  ## Pre-Review Checklist

  - [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
  - [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
  - [x] I read the [Tree Hygiene] page, which explains my responsibilities.
  - [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
  - [x] I signed the [CLA].
  - [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
  - [x] I [linked to at least one issue that this PR fixes] in the description above.
  - [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented
  exception this PR falls under[^1].
  - [x] I updated/added any relevant documentation (doc comments with `///`).
  - [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
  - [x] All existing and new tests are passing.