### PR TITLE
[cupertino_ui] Remove `image_data.dart` import from `scaffold_test.dart`

### DIFF
--- a/packages/cupertino_ui/test/scaffold_test.dart
+++ b/packages/cupertino_ui/test/scaffold_test.dart
@@ -2,15 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
-import 'dart:typed_data';
-
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../image_data.dart';
 
 /// Integration tests testing both [CupertinoPageScaffold] and [CupertinoTabScaffold].
 void main() {
@@ -215,15 +208,9 @@ void main() {
         home: CupertinoTabScaffold(
           tabBar: CupertinoTabBar(
             backgroundColor: CupertinoColors.white,
-            items: <BottomNavigationBarItem>[
-              BottomNavigationBarItem(
-                icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
-                label: 'Tab 1',
-              ),
-              BottomNavigationBarItem(
-                icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
-                label: 'Tab 2',
-              ),
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(icon: Icon(CupertinoIcons.search), label: 'Tab 1'),
+              BottomNavigationBarItem(icon: Icon(CupertinoIcons.settings), label: 'Tab 2'),
             ],
           ),
           tabBuilder: (BuildContext context, int index) {
@@ -255,15 +242,9 @@ void main() {
           data: const MediaQueryData(padding: EdgeInsets.symmetric(vertical: 20.0)),
           child: CupertinoTabScaffold(
             tabBar: CupertinoTabBar(
-              items: <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                  icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
-                  label: 'Tab 1',
-                ),
-                BottomNavigationBarItem(
-                  icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
-                  label: 'Tab 2',
-                ),
+              items: const <BottomNavigationBarItem>[
+                BottomNavigationBarItem(icon: Icon(CupertinoIcons.search), label: 'Tab 1'),
+                BottomNavigationBarItem(icon: Icon(CupertinoIcons.settings), label: 'Tab 2'),
               ],
             ),
             tabBuilder: (BuildContext context, int index) {
@@ -303,15 +284,9 @@ void main() {
       CupertinoApp(
         home: CupertinoTabScaffold(
           tabBar: CupertinoTabBar(
-            items: <BottomNavigationBarItem>[
-              BottomNavigationBarItem(
-                icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
-                label: 'Tab 1',
-              ),
-              BottomNavigationBarItem(
-                icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
-                label: 'Tab 2',
-              ),
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(icon: Icon(CupertinoIcons.search), label: 'Tab 1'),
+              BottomNavigationBarItem(icon: Icon(CupertinoIcons.settings), label: 'Tab 2'),
             ],
           ),
           tabBuilder: (BuildContext context, int index) {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removes the `../image_data.dart` import from `scaffold_test.dart`.
* Replaces transparent image placeholder tab icons with existing-style Cupertino icons (`CupertinoIcons.search` and `CupertinoIcons.settings`).
* Removes the `@Skip` tag and moves the file to the `test/` folder.

Notes:
* `scaffold_test.dart` only used `kTransparentImage` as placeholder tab icons. Since these tests cover scaffold layout, tab scaffold padding, and independent tab navigation rather than image rendering, using existing Cupertino icons avoids adding a package-local image fixture for this file.

## Pre-Review Checklist

  - [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
  - [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
  - [x] I read the [Tree Hygiene] page, which explains my responsibilities.
  - [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
  - [x] I signed the [CLA].
  - [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
  - [x] I [linked to at least one issue that this PR fixes] in the description above.
  - [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented
  exception this PR falls under[^1].
  - [x] I updated/added any relevant documentation (doc comments with `///`).
  - [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
  - [x] All existing and new tests are passing.
