### PR TITLE
[cupertino_ui] Re-enable `tab_scaffold_test.dart`

### DIFF
--- a/packages/cupertino_ui/test/tab_scaffold_test.dart
+++ b/packages/cupertino_ui/test/tab_scaffold_test.dart
@@ -2,16 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/widget_inspector_test_utils.dart';
 import 'navigator_utils.dart';
+import 'widget_inspector_test_utils.dart';
 
 late List<int> selectedTabs;
 

--- a/packages/cupertino_ui/test/widget_inspector_test_utils.dart
+++ b/packages/cupertino_ui/test/widget_inspector_test_utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cupertino_ui/test/widget_inspector_test_utils.dart
+++ b/packages/cupertino_ui/test/widget_inspector_test_utils.dart
@@ -96,7 +96,7 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
     // extension where only JSON is allowed.
     return (json.decode(json.encode(await extensions[name]!(arguments)))
             as Map<String, dynamic>)['enabled']
-        as String;
+        .toString();
   }
 
   int rebuildCount = 0;

--- a/packages/cupertino_ui/test/widget_inspector_test_utils.dart
+++ b/packages/cupertino_ui/test/widget_inspector_test_utils.dart
@@ -1,0 +1,121 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Tuple-like test class for storing a [stream] and [eventKind].
+///
+/// Used to store the [stream] and [eventKind] that a dispatched event would be
+/// sent on.
+@immutable
+class DispatchedEventKey {
+  const DispatchedEventKey({required this.stream, required this.eventKind});
+
+  final String stream;
+  final String eventKind;
+
+  @override
+  String toString() {
+    return '[DispatchedEventKey]($stream, $eventKind)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is DispatchedEventKey && stream == other.stream && eventKind == other.eventKind;
+  }
+
+  @override
+  int get hashCode => Object.hash(stream, eventKind);
+}
+
+class TestWidgetInspectorService extends Object with WidgetInspectorService {
+  TestWidgetInspectorService() {
+    selection.addListener(() => selectionChangedCallback?.call());
+  }
+
+  final Map<String, ServiceExtensionCallback> extensions = <String, ServiceExtensionCallback>{};
+
+  final Map<DispatchedEventKey, List<Map<Object, Object?>>> eventsDispatched =
+      <DispatchedEventKey, List<Map<Object, Object?>>>{};
+
+  final List<Object?> objectsInspected = <Object?>[];
+
+  @override
+  void registerServiceExtension({
+    required String name,
+    required ServiceExtensionCallback callback,
+    required RegisterServiceExtensionCallback registerExtension,
+  }) {
+    assert(!extensions.containsKey(name));
+    extensions[name] = callback;
+  }
+
+  @override
+  void postEvent(String eventKind, Map<Object, Object?> eventData, {String stream = 'Extension'}) {
+    dispatchedEvents(eventKind, stream: stream).add(eventData);
+  }
+
+  @override
+  void inspect(Object? object) {
+    objectsInspected.add(object);
+  }
+
+  List<Map<Object, Object?>> dispatchedEvents(String eventKind, {String stream = 'Extension'}) {
+    return eventsDispatched.putIfAbsent(
+      DispatchedEventKey(stream: stream, eventKind: eventKind),
+      () => <Map<Object, Object?>>[],
+    );
+  }
+
+  List<Object?> inspectedObjects() {
+    return objectsInspected;
+  }
+
+  Iterable<Map<Object, Object?>> getServiceExtensionStateChangedEvents(String extensionName) {
+    return dispatchedEvents(
+      'Flutter.ServiceExtensionStateChanged',
+    ).where((Map<Object, Object?> event) => event['extension'] == extensionName);
+  }
+
+  Future<Object?> testExtension(String name, Map<String, String> arguments) async {
+    expect(extensions, contains(name));
+    // Encode and decode to JSON to match behavior using a real service
+    // extension where only JSON is allowed.
+    return (json.decode(json.encode(await extensions[name]!(arguments)))
+        as Map<String, dynamic>)['result'];
+  }
+
+  Future<String> testBoolExtension(String name, Map<String, String> arguments) async {
+    expect(extensions, contains(name));
+    // Encode and decode to JSON to match behavior using a real service
+    // extension where only JSON is allowed.
+    return (json.decode(json.encode(await extensions[name]!(arguments)))
+            as Map<String, dynamic>)['enabled']
+        as String;
+  }
+
+  int rebuildCount = 0;
+
+  @override
+  Future<void> forceRebuild() async {
+    rebuildCount++;
+    final WidgetsBinding binding = WidgetsBinding.instance;
+
+    if (binding.rootElement != null) {
+      binding.buildOwner!.reassemble(binding.rootElement!);
+    }
+  }
+
+  @override
+  void resetAllState() {
+    super.resetAllState();
+    eventsDispatched.clear();
+    objectsInspected.clear();
+    rebuildCount = 0;
+  }
+}


### PR DESCRIPTION
This test re-enables `tab_scaffold_test.dart`, and brings over `widget_inspector_test_utils.dart` into `tests/`.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.