### PR TITLE
[cupertino_ui] Migrate checkbox_test.dart to SemanticsHandle

### DIFF
--- a/packages/cupertino_ui/test/checkbox_test.dart
+++ b/packages/cupertino_ui/test/checkbox_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@Skip(
-  'This file is skipped due to a cross-import that needs to be fixed. Tracked in https://github.com/flutter/flutter/issues/177028.',
-)
 // reduced-test-set:
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
@@ -17,8 +14,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../widgets/semantics_tester.dart';
 
 void main() {
   setUp(() {
@@ -206,7 +201,6 @@ void main() {
   });
 
   testWidgets('has semantics for tristate', (WidgetTester tester) async {
-    final semantics = SemanticsTester(tester);
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoCheckbox(tristate: true, value: null, onChanged: (bool? newValue) {}),
@@ -214,17 +208,16 @@ void main() {
     );
 
     expect(
-      semantics.nodesWith(
-        flags: <SemanticsFlag>[
-          SemanticsFlag.hasCheckedState,
-          SemanticsFlag.hasEnabledState,
-          SemanticsFlag.isEnabled,
-          SemanticsFlag.isFocusable,
-          SemanticsFlag.isCheckStateMixed,
-        ],
-        actions: <SemanticsAction>[SemanticsAction.focus, SemanticsAction.tap],
+      tester.getSemantics(find.byType(CupertinoCheckbox)),
+      matchesSemantics(
+        hasCheckedState: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        isFocusable: true,
+        isCheckStateMixed: true,
+        hasFocusAction: true,
+        hasTapAction: true,
       ),
-      hasLength(1),
     );
 
     await tester.pumpWidget(
@@ -234,17 +227,16 @@ void main() {
     );
 
     expect(
-      semantics.nodesWith(
-        flags: <SemanticsFlag>[
-          SemanticsFlag.hasCheckedState,
-          SemanticsFlag.hasEnabledState,
-          SemanticsFlag.isEnabled,
-          SemanticsFlag.isChecked,
-          SemanticsFlag.isFocusable,
-        ],
-        actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+      tester.getSemantics(find.byType(CupertinoCheckbox)),
+      matchesSemantics(
+        hasCheckedState: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        isChecked: true,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
       ),
-      hasLength(1),
     );
 
     await tester.pumpWidget(
@@ -254,19 +246,16 @@ void main() {
     );
 
     expect(
-      semantics.nodesWith(
-        flags: <SemanticsFlag>[
-          SemanticsFlag.hasCheckedState,
-          SemanticsFlag.hasEnabledState,
-          SemanticsFlag.isEnabled,
-          SemanticsFlag.isFocusable,
-        ],
-        actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+      tester.getSemantics(find.byType(CupertinoCheckbox)),
+      matchesSemantics(
+        hasCheckedState: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        isFocusable: true,
+        hasTapAction: true,
+        hasFocusAction: true,
       ),
-      hasLength(1),
     );
-
-    semantics.dispose();
   });
 
   testWidgets('has semantic events', (WidgetTester tester) async {
@@ -278,7 +267,6 @@ void main() {
         semanticEvent = message;
       },
     );
-    final semanticsTester = SemanticsTester(tester);
 
     await tester.pumpWidget(
       CupertinoApp(
@@ -312,7 +300,6 @@ void main() {
       SystemChannels.accessibility,
       null,
     );
-    semanticsTester.dispose();
   });
 
   testWidgets('Checkbox can configure a semantic label', (WidgetTester tester) async {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/182636 and https://github.com/flutter/flutter/issues/188395

This PR:
* Removes the cross-import of `widgets/semantics_tester.dart` from `checkbox_test.dart`.
* Replaces the remaining `SemanticsTester` usages with `SemanticsHandle` and direct `tester.getSemantics` expectations.
* Removes the `@Skip` annotation and moves the file to the `test/` folder.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.
