### PR TITLE
[in_app_purchase_android] Add obfuscated profile ID support

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.5.2
 
-* Adds support for passing `obfuscatedProfileId` through
-  `GooglePlayPurchaseParam`.
+* Adds support for passing `obfuscatedProfileId` through `GooglePlayPurchaseParam`.
 
 ## 0.5.1
 

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2
+
+* Adds support for passing `obfuscatedProfileId` through
+  `GooglePlayPurchaseParam`.
+
 ## 0.5.1
 
 * Adds support to overlay billing related messages. See `InAppPurchaseAndroidPlatformAddition.showInAppMessages`.

--- a/packages/in_app_purchase/in_app_purchase_android/lib/src/in_app_purchase_android_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/lib/src/in_app_purchase_android_platform.dart
@@ -152,10 +152,12 @@ class InAppPurchaseAndroidPlatform extends InAppPurchasePlatform {
   Future<bool> buyNonConsumable({required PurchaseParam purchaseParam}) async {
     ChangeSubscriptionParam? changeSubscriptionParam;
     String? offerToken;
+    String? obfuscatedProfileId;
 
     if (purchaseParam is GooglePlayPurchaseParam) {
       changeSubscriptionParam = purchaseParam.changeSubscriptionParam;
       offerToken = purchaseParam.offerToken;
+      obfuscatedProfileId = purchaseParam.obfuscatedProfileId;
     }
 
     if (offerToken == null && purchaseParam.productDetails is GooglePlayProductDetails) {
@@ -167,6 +169,7 @@ class InAppPurchaseAndroidPlatform extends InAppPurchasePlatform {
         product: purchaseParam.productDetails.id,
         offerToken: offerToken,
         accountId: purchaseParam.applicationUserName,
+        obfuscatedProfileId: obfuscatedProfileId,
         oldProduct: changeSubscriptionParam?.oldPurchaseDetails.productID,
         purchaseToken:
             changeSubscriptionParam?.oldPurchaseDetails.verificationData.serverVerificationData,

--- a/packages/in_app_purchase/in_app_purchase_android/lib/src/types/google_play_purchase_param.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/lib/src/types/google_play_purchase_param.dart
@@ -12,9 +12,18 @@ class GooglePlayPurchaseParam extends PurchaseParam {
   GooglePlayPurchaseParam({
     required super.productDetails,
     super.applicationUserName,
+    this.obfuscatedProfileId,
     this.changeSubscriptionParam,
     this.offerToken,
   });
+
+  /// The obfuscated profile id specified when making a purchase.
+  ///
+  /// This is passed to Google Play as the obfuscated profile id. It should be
+  /// an obfuscated identifier that is uniquely associated with the user's
+  /// profile in your app, and must not contain personally identifiable
+  /// information.
+  final String? obfuscatedProfileId;
 
   /// The 'changeSubscriptionParam' containing information for upgrading or
   /// downgrading an existing subscription.

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: An implementation for the Android platform of the Flutter `in_app_p
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
 
-version: 0.5.1
+version: 0.5.2
 
 environment:
   sdk: ^3.12.0

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
@@ -358,6 +358,7 @@ void main() {
     test('buy non consumable, serializes and deserializes data', () async {
       const ProductDetailsWrapper productDetails = dummyOneTimeProductDetails;
       const accountId = 'hashedAccountId';
+      const profileId = 'hashedProfileId';
       const debugMessage = 'dummy message';
       const BillingResponse sentCode = BillingResponse.ok;
       const expectedBillingResult = BillingResultWrapper(
@@ -403,10 +404,15 @@ void main() {
       final purchaseParam = GooglePlayPurchaseParam(
         productDetails: GooglePlayProductDetails.fromProductDetails(productDetails).first,
         applicationUserName: accountId,
+        obfuscatedProfileId: profileId,
       );
       final bool launchResult = await iapAndroidPlatform.buyNonConsumable(
         purchaseParam: purchaseParam,
       );
+      final VerificationResult verification = verify(mockApi.launchBillingFlow(captureAny));
+      final params = verification.captured.single as PlatformBillingFlowParams;
+      expect(params.accountId, equals(accountId));
+      expect(params.obfuscatedProfileId, equals(profileId));
 
       final PurchaseDetails result = await completer.future;
       expect(launchResult, isTrue);


### PR DESCRIPTION
As mentioned in [#130128](https://github.com/flutter/flutter/issues/130128), Google Play Billing supports passing an obfuscated profile ID in addition to an obfuscated account ID.

This adds an Android-specific `obfuscatedProfileId` parameter to `GooglePlayPurchaseParam`, and passes it through to the Play Billing flow.

```dart
final purchaseParam = GooglePlayPurchaseParam(
  productDetails: productDetails,
  applicationUserName: hashedAccountId,
  obfuscatedProfileId: hashedProfileId,
);
```

Fixes flutter/flutter#130128.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
