### PR TITLE
[cupertino_ui] Move over more API samples

### DIFF
--- a/packages/cupertino_ui/example/lib/magnifier/cupertino_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/cupertino_magnifier.0.dart
@@ -1,0 +1,79 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+
+/// Flutter code sample for [CupertinoMagnifier].
+
+void main() => runApp(const CupertinoMagnifierApp());
+
+class CupertinoMagnifierApp extends StatelessWidget {
+  const CupertinoMagnifierApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      theme: CupertinoThemeData(brightness: .light),
+      home: CupertinoMagnifierExample(),
+    );
+  }
+}
+
+class CupertinoMagnifierExample extends StatefulWidget {
+  const CupertinoMagnifierExample({super.key});
+
+  @override
+  State<CupertinoMagnifierExample> createState() =>
+      _CupertinoMagnifierExampleState();
+}
+
+class _CupertinoMagnifierExampleState extends State<CupertinoMagnifierExample> {
+  static const double magnifierRadius = 50.0;
+  Offset dragGesturePosition = .zero;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: const CupertinoNavigationBar(
+        middle: Text('CupertinoMagnifier Sample'),
+      ),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: .center,
+          children: <Widget>[
+            const Text('Drag on the logo!'),
+            RepaintBoundary(
+              child: Stack(
+                children: <Widget>[
+                  GestureDetector(
+                    onPanUpdate: (DragUpdateDetails details) {
+                      setState(() {
+                        dragGesturePosition = details.localPosition;
+                      });
+                    },
+                    onPanDown: (DragDownDetails details) {
+                      setState(() {
+                        dragGesturePosition = details.localPosition;
+                      });
+                    },
+                    child: const FlutterLogo(size: 200),
+                  ),
+                  Positioned(
+                    left: dragGesturePosition.dx - magnifierRadius,
+                    top: dragGesturePosition.dy - magnifierRadius,
+                    child: const CupertinoMagnifier(
+                      magnificationScale: 1.5,
+                      borderRadius: .all(Radius.circular(magnifierRadius)),
+                      additionalFocalPointOffset: Offset(0, -magnifierRadius),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/cupertino_ui/example/lib/magnifier/cupertino_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/cupertino_magnifier.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 
 /// Flutter code sample for [CupertinoMagnifier].
 

--- a/packages/cupertino_ui/example/lib/magnifier/cupertino_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/cupertino_magnifier.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cupertino_ui/example/lib/magnifier/cupertino_text_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/cupertino_text_magnifier.0.dart
@@ -1,0 +1,60 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+
+/// Flutter code sample for [CupertinoTextMagnifier].
+
+void main() => runApp(const CupertinoTextMagnifierApp());
+
+class CupertinoTextMagnifierApp extends StatelessWidget {
+  const CupertinoTextMagnifierApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      theme: CupertinoThemeData(brightness: .light),
+      home: CupertinoTextMagnifierExampleApp(),
+    );
+  }
+}
+
+class CupertinoTextMagnifierExampleApp extends StatefulWidget {
+  const CupertinoTextMagnifierExampleApp({super.key});
+
+  @override
+  State<CupertinoTextMagnifierExampleApp> createState() =>
+      _CupertinoTextMagnifierExampleAppState();
+}
+
+class _CupertinoTextMagnifierExampleAppState
+    extends State<CupertinoTextMagnifierExampleApp> {
+  final MagnifierController _controller = MagnifierController();
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: const CupertinoNavigationBar(
+        middle: Text('CupertinoTextMagnifier Sample'),
+      ),
+      child: Padding(
+        padding: const .symmetric(horizontal: 48.0),
+        child: Center(
+          child: CupertinoTextField(
+            magnifierConfiguration: TextMagnifierConfiguration(
+              magnifierBuilder:
+                  (_, _, ValueNotifier<MagnifierInfo> magnifierInfo) {
+                    return CupertinoTextMagnifier(
+                      controller: _controller,
+                      magnifierInfo: magnifierInfo,
+                    );
+                  },
+            ),
+            controller: TextEditingController(text: 'Hello world!'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/cupertino_ui/example/lib/magnifier/cupertino_text_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/cupertino_text_magnifier.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cupertino_ui/example/lib/magnifier/cupertino_text_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/cupertino_text_magnifier.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 
 /// Flutter code sample for [CupertinoTextMagnifier].
 

--- a/packages/cupertino_ui/example/lib/magnifier/text_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/text_magnifier.0.dart
@@ -1,0 +1,107 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(const TextMagnifierExampleApp(text: 'Hello world!'));
+
+class TextMagnifierExampleApp extends StatelessWidget {
+  const TextMagnifierExampleApp({
+    super.key,
+    this.textDirection = TextDirection.ltr,
+    required this.text,
+  });
+
+  final TextDirection textDirection;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Padding(
+          padding: const .symmetric(horizontal: 48.0),
+          child: Center(
+            child: TextField(
+              textDirection: textDirection,
+              // Create a custom magnifier configuration that
+              // this `TextField` will use to build a magnifier with.
+              magnifierConfiguration: TextMagnifierConfiguration(
+                magnifierBuilder:
+                    (_, _, ValueNotifier<MagnifierInfo> magnifierInfo) =>
+                        CustomMagnifier(magnifierInfo: magnifierInfo),
+              ),
+              controller: TextEditingController(text: text),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class CustomMagnifier extends StatelessWidget {
+  const CustomMagnifier({super.key, required this.magnifierInfo});
+
+  static const Size magnifierSize = Size(200, 200);
+
+  // This magnifier will consume some text data and position itself
+  // based on the info in the magnifier.
+  final ValueNotifier<MagnifierInfo> magnifierInfo;
+
+  @override
+  Widget build(BuildContext context) {
+    // Use a value listenable builder because we want to rebuild
+    // every time the text selection info changes.
+    // `CustomMagnifier` could also be a `StatefulWidget` and call `setState`
+    // when `magnifierInfo` updates. This would be useful for more complex
+    // positioning cases.
+    return ValueListenableBuilder<MagnifierInfo>(
+      valueListenable: magnifierInfo,
+      builder: (BuildContext context, MagnifierInfo currentMagnifierInfo, _) {
+        // We want to position the magnifier at the global position of the gesture.
+        Offset magnifierPosition = currentMagnifierInfo.globalGesturePosition;
+
+        // You may use the `MagnifierInfo` however you'd like:
+        // In this case, we make sure the magnifier never goes out of the current line bounds.
+        magnifierPosition = Offset(
+          clampDouble(
+            magnifierPosition.dx,
+            currentMagnifierInfo.currentLineBoundaries.left,
+            currentMagnifierInfo.currentLineBoundaries.right,
+          ),
+          clampDouble(
+            magnifierPosition.dy,
+            currentMagnifierInfo.currentLineBoundaries.top,
+            currentMagnifierInfo.currentLineBoundaries.bottom,
+          ),
+        );
+
+        // Finally, align the magnifier to the bottom center. The initial anchor is
+        // the top left, so subtract bottom center alignment.
+        magnifierPosition -= Alignment.bottomCenter.alongSize(magnifierSize);
+
+        return Positioned(
+          left: magnifierPosition.dx,
+          top: magnifierPosition.dy,
+          child: RawMagnifier(
+            magnificationScale: 2,
+            // The focal point starts at the center of the magnifier.
+            // We probably want to point below the magnifier, so
+            // offset the focal point by half the magnifier height.
+            focalPointOffset: Offset(0, magnifierSize.height / 2),
+            // Decorate it however we'd like!
+            decoration: const MagnifierDecoration(
+              shape: StarBorder(
+                side: BorderSide(color: Colors.green, width: 2),
+              ),
+            ),
+            size: magnifierSize,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/cupertino_ui/example/lib/magnifier/text_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/text_magnifier.0.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() => runApp(const TextMagnifierExampleApp(text: 'Hello world!'));
 

--- a/packages/cupertino_ui/example/lib/magnifier/text_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/text_magnifier.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cupertino_ui/example/test/magnifier/cupertino_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/cupertino_magnifier.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cupertino_ui/example/test/magnifier/cupertino_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/cupertino_magnifier.0_test.dart
@@ -1,0 +1,65 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui_examples/magnifier/cupertino_magnifier.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('CupertinoMagnifier must be visible', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.CupertinoMagnifierApp());
+
+    final Finder cupertinoMagnifierWidget = find.byType(CupertinoMagnifier);
+    expect(cupertinoMagnifierWidget, findsOneWidget);
+  });
+
+  testWidgets('CupertinoMagnifier is not using the default value', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.CupertinoMagnifierApp());
+    expect(
+      tester.widget(find.byType(CupertinoMagnifier)),
+      isA<CupertinoMagnifier>().having(
+        (CupertinoMagnifier t) => t.magnificationScale,
+        'magnificationScale',
+        1.5,
+      ),
+    );
+  });
+
+  testWidgets('should update CupertinoMagnifier position on drag', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.CupertinoMagnifierApp());
+
+    Matcher isPositionedAt(Offset at) {
+      return isA<Positioned>().having(
+        (Positioned positioned) => Offset(positioned.left!, positioned.top!),
+        'magnifier position',
+        at,
+      );
+    }
+
+    // Make sure magnifier is present.
+    final Finder positionedWidget = find.byType(Positioned);
+    final Widget positionedWidgetInTree = tester.widget(positionedWidget.first);
+    final Positioned oldConcretePositioned =
+        positionedWidgetInTree as Positioned;
+    final Offset centerOfPositioned = tester.getCenter(positionedWidget.first);
+
+    // Drag the magnifier and confirm its new position is expected.
+    const Offset dragDistance = Offset(10, 10);
+    final Offset updatedPositioned = Offset(
+      oldConcretePositioned.left ?? 0.0 + 10.0,
+      oldConcretePositioned.top ?? 0.0 + 10.0,
+    );
+
+    await tester.dragFrom(centerOfPositioned, dragDistance);
+    await tester.pump();
+    expect(positionedWidgetInTree, isPositionedAt(updatedPositioned));
+  });
+}

--- a/packages/cupertino_ui/example/test/magnifier/cupertino_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/cupertino_magnifier.0_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:cupertino_ui_examples/magnifier/cupertino_magnifier.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/cupertino_ui/example/test/magnifier/cupertino_text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/cupertino_text_magnifier.0_test.dart
@@ -1,0 +1,24 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui_examples/magnifier/cupertino_text_magnifier.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('CupertinoTextMagnifier must be visible after longPress', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.CupertinoTextMagnifierApp());
+
+    final Finder cupertinoTextFieldWidget = find.byType(CupertinoTextField);
+    await tester.longPress(cupertinoTextFieldWidget);
+
+    final Finder cupertinoTextMagnifierWidget = find.byType(
+      CupertinoTextMagnifier,
+    );
+    expect(cupertinoTextMagnifierWidget, findsOneWidget);
+  });
+}

--- a/packages/cupertino_ui/example/test/magnifier/cupertino_text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/cupertino_text_magnifier.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cupertino_ui/example/test/magnifier/cupertino_text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/cupertino_text_magnifier.0_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:cupertino_ui_examples/magnifier/cupertino_text_magnifier.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:cupertino_ui_examples/magnifier/text_magnifier.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+List<TextSelectionPoint> _globalize(
+  Iterable<TextSelectionPoint> points,
+  RenderBox box,
+) {
+  return points.map<TextSelectionPoint>((TextSelectionPoint point) {
+    return TextSelectionPoint(box.localToGlobal(point.point), point.direction);
+  }).toList();
+}
+
+RenderEditable _findRenderEditable<T extends State<StatefulWidget>>(
+  WidgetTester tester,
+) {
+  return (tester.state(find.byType(TextField))
+          as TextSelectionGestureDetectorBuilderDelegate)
+      .editableTextKey
+      .currentState!
+      .renderEditable;
+}
+
+Offset _textOffsetToPosition<T extends State<StatefulWidget>>(
+  WidgetTester tester,
+  int offset,
+) {
+  final RenderEditable renderEditable = _findRenderEditable(tester);
+
+  final List<TextSelectionPoint> endpoints = renderEditable
+      .getEndpointsForSelection(TextSelection.collapsed(offset: offset))
+      .map<TextSelectionPoint>(
+        (TextSelectionPoint point) => TextSelectionPoint(
+          renderEditable.localToGlobal(point.point),
+          point.direction,
+        ),
+      )
+      .toList();
+
+  return endpoints[0].point + const Offset(0.0, -2.0);
+}
+
+void main() {
+  const Duration durationBetweenActions = Duration(milliseconds: 20);
+  const String defaultText = 'I am a magnifier, fear me!';
+
+  Future<void> showMagnifier(WidgetTester tester, int textOffset) async {
+    assert(textOffset >= 0);
+    final Offset tapOffset = _textOffsetToPosition(tester, textOffset);
+
+    // Double tap 'Magnifier' word to show the selection handles.
+    final TestGesture testGesture = await tester.startGesture(tapOffset);
+    await tester.pump(durationBetweenActions);
+    await testGesture.up();
+    await tester.pump(durationBetweenActions);
+    await testGesture.down(tapOffset);
+    await tester.pump(durationBetweenActions);
+    await testGesture.up();
+    await tester.pumpAndSettle();
+
+    final TextEditingController controller = tester
+        .firstWidget<TextField>(find.byType(TextField))
+        .controller!;
+
+    final TextSelection selection = controller.selection;
+    final RenderEditable renderEditable = _findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = _globalize(
+      renderEditable.getEndpointsForSelection(selection),
+      renderEditable,
+    );
+
+    final Offset handlePos = endpoints.last.point + const Offset(10.0, 10.0);
+
+    final TestGesture gesture = await tester.startGesture(handlePos);
+
+    await gesture.moveTo(_textOffsetToPosition(tester, defaultText.length - 2));
+    await tester.pump();
+  }
+
+  testWidgets(
+    'should show custom magnifier on drag',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.TextMagnifierExampleApp(text: defaultText),
+      );
+
+      await showMagnifier(tester, defaultText.indexOf('e'));
+      expect(find.byType(example.CustomMagnifier), findsOneWidget);
+
+      await expectLater(
+        find.byType(example.TextMagnifierExampleApp),
+        matchesGoldenFile('text_magnifier.0_test.png'),
+      );
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{.iOS, .android}),
+    // This image is flaky. https://github.com/flutter/flutter/issues/144350
+    skip: true,
+  );
+
+  testWidgets('should show custom magnifier in RTL', (
+    WidgetTester tester,
+  ) async {
+    const String text = 'أثارت زر';
+    const String textToTapOn = 'ت';
+
+    await tester.pumpWidget(
+      const example.TextMagnifierExampleApp(textDirection: .rtl, text: text),
+    );
+
+    await showMagnifier(tester, text.indexOf(textToTapOn));
+
+    expect(find.byType(example.CustomMagnifier), findsOneWidget);
+  });
+}

--- a/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:cupertino_ui_examples/magnifier/text_magnifier.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
This adds missing samples referenced in the cupertino_ui API docs.
Some of these were misplaced in the widgets/ API directory in flutter/flutter, I will push up a PR to reflect the move there as well so we do not lose track of it.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
