### PR TITLE
[material_ui] Move over more API samples

### DIFF
--- a/packages/material_ui/example/lib/material_state/material_state_outlined_border.0.dart
+++ b/packages/material_ui/example/lib/material_state/material_state_outlined_border.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/lib/material_state/material_state_outlined_border.0.dart
+++ b/packages/material_ui/example/lib/material_state/material_state_outlined_border.0.dart
@@ -1,0 +1,60 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:material_ui/material_ui.dart';
+
+/// Flutter code sample for [WidgetStateOutlinedBorder].
+
+void main() => runApp(const WidgetStateOutlinedBorderExampleApp());
+
+class WidgetStateOutlinedBorderExampleApp extends StatelessWidget {
+  const WidgetStateOutlinedBorderExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(home: WidgetStateOutlinedBorderExample());
+  }
+}
+
+class SelectedBorder extends RoundedRectangleBorder
+    implements WidgetStateOutlinedBorder {
+  const SelectedBorder();
+
+  @override
+  OutlinedBorder? resolve(Set<WidgetState> states) {
+    if (states.contains(WidgetState.selected)) {
+      return const RoundedRectangleBorder();
+    }
+    return null; // Defer to default value on the theme or widget.
+  }
+}
+
+class WidgetStateOutlinedBorderExample extends StatefulWidget {
+  const WidgetStateOutlinedBorderExample({super.key});
+
+  @override
+  State<WidgetStateOutlinedBorderExample> createState() =>
+      _WidgetStateOutlinedBorderExampleState();
+}
+
+class _WidgetStateOutlinedBorderExampleState
+    extends State<WidgetStateOutlinedBorderExample> {
+  bool isSelected = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      child: FilterChip(
+        label: const Text('Select chip'),
+        selected: isSelected,
+        onSelected: (bool value) {
+          setState(() {
+            isSelected = value;
+          });
+        },
+        shape: const SelectedBorder(),
+      ),
+    );
+  }
+}

--- a/packages/material_ui/example/lib/material_state/material_state_outlined_border.0.dart
+++ b/packages/material_ui/example/lib/material_state/material_state_outlined_border.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/lib/text_field/text_field_magnifier.0.dart
+++ b/packages/material_ui/example/lib/text_field/text_field_magnifier.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/lib/text_field/text_field_magnifier.0.dart
+++ b/packages/material_ui/example/lib/text_field/text_field_magnifier.0.dart
@@ -1,0 +1,107 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:material_ui/material_ui.dart';
+
+void main() => runApp(const TextMagnifierExampleApp(text: 'Hello world!'));
+
+class TextMagnifierExampleApp extends StatelessWidget {
+  const TextMagnifierExampleApp({
+    super.key,
+    this.textDirection = TextDirection.ltr,
+    required this.text,
+  });
+
+  final TextDirection textDirection;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Padding(
+          padding: const .symmetric(horizontal: 48.0),
+          child: Center(
+            child: TextField(
+              textDirection: textDirection,
+              // Create a custom magnifier configuration that
+              // this `TextField` will use to build a magnifier with.
+              magnifierConfiguration: TextMagnifierConfiguration(
+                magnifierBuilder:
+                    (_, _, ValueNotifier<MagnifierInfo> magnifierInfo) =>
+                        CustomMagnifier(magnifierInfo: magnifierInfo),
+              ),
+              controller: TextEditingController(text: text),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class CustomMagnifier extends StatelessWidget {
+  const CustomMagnifier({super.key, required this.magnifierInfo});
+
+  static const Size magnifierSize = Size(200, 200);
+
+  // This magnifier will consume some text data and position itself
+  // based on the info in the magnifier.
+  final ValueNotifier<MagnifierInfo> magnifierInfo;
+
+  @override
+  Widget build(BuildContext context) {
+    // Use a value listenable builder because we want to rebuild
+    // every time the text selection info changes.
+    // `CustomMagnifier` could also be a `StatefulWidget` and call `setState`
+    // when `magnifierInfo` updates. This would be useful for more complex
+    // positioning cases.
+    return ValueListenableBuilder<MagnifierInfo>(
+      valueListenable: magnifierInfo,
+      builder: (BuildContext context, MagnifierInfo currentMagnifierInfo, _) {
+        // We want to position the magnifier at the global position of the gesture.
+        Offset magnifierPosition = currentMagnifierInfo.globalGesturePosition;
+
+        // You may use the `MagnifierInfo` however you'd like:
+        // In this case, we make sure the magnifier never goes out of the current line bounds.
+        magnifierPosition = Offset(
+          clampDouble(
+            magnifierPosition.dx,
+            currentMagnifierInfo.currentLineBoundaries.left,
+            currentMagnifierInfo.currentLineBoundaries.right,
+          ),
+          clampDouble(
+            magnifierPosition.dy,
+            currentMagnifierInfo.currentLineBoundaries.top,
+            currentMagnifierInfo.currentLineBoundaries.bottom,
+          ),
+        );
+
+        // Finally, align the magnifier to the bottom center. The initial anchor is
+        // the top left, so subtract bottom center alignment.
+        magnifierPosition -= Alignment.bottomCenter.alongSize(magnifierSize);
+
+        return Positioned(
+          left: magnifierPosition.dx,
+          top: magnifierPosition.dy,
+          child: RawMagnifier(
+            magnificationScale: 2,
+            // The focal point starts at the center of the magnifier.
+            // We probably want to point below the magnifier, so
+            // offset the focal point by half the magnifier height.
+            focalPointOffset: Offset(0, magnifierSize.height / 2),
+            // Decorate it however we'd like!
+            decoration: const MagnifierDecoration(
+              shape: StarBorder(
+                side: BorderSide(color: Colors.green, width: 2),
+              ),
+            ),
+            size: magnifierSize,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/material_ui/example/lib/text_field/text_field_magnifier.0.dart
+++ b/packages/material_ui/example/lib/text_field/text_field_magnifier.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/lib/text_field/text_field_tap_region.0.dart
+++ b/packages/material_ui/example/lib/text_field/text_field_tap_region.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/lib/text_field/text_field_tap_region.0.dart
+++ b/packages/material_ui/example/lib/text_field/text_field_tap_region.0.dart
@@ -1,0 +1,258 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// Flutter code sample for [TextFieldTapRegion].
+
+void main() => runApp(const TapRegionApp());
+
+class TapRegionApp extends StatelessWidget {
+  const TapRegionApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('TextFieldTapRegion Example')),
+        body: const TextFieldTapRegionExample(),
+      ),
+    );
+  }
+}
+
+class TextFieldTapRegionExample extends StatefulWidget {
+  const TextFieldTapRegionExample({super.key});
+
+  @override
+  State<TextFieldTapRegionExample> createState() =>
+      _TextFieldTapRegionExampleState();
+}
+
+class _TextFieldTapRegionExampleState extends State<TextFieldTapRegionExample> {
+  int value = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: <Widget>[
+        Center(
+          child: Padding(
+            padding: const .all(20.0),
+            child: SizedBox(
+              width: 150,
+              height: 80,
+              child: IntegerSpinnerField(
+                value: value,
+                autofocus: true,
+                onChanged: (int newValue) {
+                  if (value == newValue) {
+                    // Avoid unnecessary redraws.
+                    return;
+                  }
+                  setState(() {
+                    // Update the value and redraw.
+                    value = newValue;
+                  });
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// An integer example of the generic [SpinnerField] that validates input and
+/// increments by a delta.
+class IntegerSpinnerField extends StatelessWidget {
+  const IntegerSpinnerField({
+    super.key,
+    required this.value,
+    this.autofocus = false,
+    this.delta = 1,
+    this.onChanged,
+  });
+
+  final int value;
+  final bool autofocus;
+  final int delta;
+  final ValueChanged<int>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SpinnerField<int>(
+      value: value,
+      onChanged: onChanged,
+      autofocus: autofocus,
+      fromString: (String stringValue) => int.tryParse(stringValue) ?? value,
+      increment: (int i) => i + delta,
+      decrement: (int i) => i - delta,
+      // Add a text formatter that only allows integer values and a leading
+      // minus sign.
+      inputFormatters: <TextInputFormatter>[
+        TextInputFormatter.withFunction((
+          TextEditingValue oldValue,
+          TextEditingValue newValue,
+        ) {
+          String newString;
+          if (newValue.text.startsWith('-')) {
+            newString = '-${newValue.text.replaceAll(RegExp(r'\D'), '')}';
+          } else {
+            newString = newValue.text.replaceAll(RegExp(r'\D'), '');
+          }
+          return newValue.copyWith(
+            text: newString,
+            selection: newValue.selection.copyWith(
+              baseOffset: newValue.selection.baseOffset.clamp(
+                0,
+                newString.length,
+              ),
+              extentOffset: newValue.selection.extentOffset.clamp(
+                0,
+                newString.length,
+              ),
+            ),
+          );
+        }),
+      ],
+    );
+  }
+}
+
+/// A generic "spinner" field example which adds extra buttons next to a
+/// [TextField] to increment and decrement the value.
+///
+/// This widget uses [TextFieldTapRegion] to indicate that tapping on the
+/// spinner buttons should not cause the text field to lose focus.
+class SpinnerField<T> extends StatefulWidget {
+  SpinnerField({
+    super.key,
+    required this.value,
+    required this.fromString,
+    this.autofocus = false,
+    String Function(T value)? asString,
+    this.increment,
+    this.decrement,
+    this.onChanged,
+    this.inputFormatters = const <TextInputFormatter>[],
+  }) : asString = asString ?? ((T value) => value.toString());
+
+  final T value;
+  final T Function(T value)? increment;
+  final T Function(T value)? decrement;
+  final String Function(T value) asString;
+  final T Function(String value) fromString;
+  final ValueChanged<T>? onChanged;
+  final List<TextInputFormatter> inputFormatters;
+  final bool autofocus;
+
+  @override
+  State<SpinnerField<T>> createState() => _SpinnerFieldState<T>();
+}
+
+class _SpinnerFieldState<T> extends State<SpinnerField<T>> {
+  TextEditingController controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _updateText(widget.asString(widget.value));
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(covariant SpinnerField<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.asString != widget.asString ||
+        oldWidget.value != widget.value) {
+      final String newText = widget.asString(widget.value);
+      _updateText(newText);
+    }
+  }
+
+  void _updateText(String text, {bool collapsed = true}) {
+    if (text != controller.text) {
+      controller.value = TextEditingValue(
+        text: text,
+        selection: collapsed
+            ? TextSelection.collapsed(offset: text.length)
+            : TextSelection(baseOffset: 0, extentOffset: text.length),
+      );
+    }
+  }
+
+  void _spin(T Function(T value)? spinFunction) {
+    if (spinFunction == null) {
+      return;
+    }
+    final T newValue = spinFunction(widget.value);
+    widget.onChanged?.call(newValue);
+    _updateText(widget.asString(newValue), collapsed: false);
+  }
+
+  void _increment() {
+    _spin(widget.increment);
+  }
+
+  void _decrement() {
+    _spin(widget.decrement);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.arrowUp): _increment,
+        const SingleActivator(LogicalKeyboardKey.arrowDown): _decrement,
+      },
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: TextField(
+              autofocus: widget.autofocus,
+              inputFormatters: widget.inputFormatters,
+              decoration: const InputDecoration(border: OutlineInputBorder()),
+              onChanged: (String value) =>
+                  widget.onChanged?.call(widget.fromString(value)),
+              controller: controller,
+              textAlign: .center,
+            ),
+          ),
+          const SizedBox(width: 12),
+          // Without this TextFieldTapRegion, tapping on the buttons below would
+          // increment the value, but it would cause the text field to be
+          // unfocused, since tapping outside of a text field should unfocus it
+          // on non-mobile platforms.
+          TextFieldTapRegion(
+            child: Column(
+              mainAxisAlignment: .center,
+              children: <Widget>[
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: _increment,
+                    child: const Icon(Icons.add),
+                  ),
+                ),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: _decrement,
+                    child: const Icon(Icons.remove),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/material_ui/example/lib/text_field/text_field_tap_region.0.dart
+++ b/packages/material_ui/example/lib/text_field/text_field_tap_region.0.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/test/material_state/material_state_outlined_border.0_test.dart
+++ b/packages/material_ui/example/test/material_state/material_state_outlined_border.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/test/material_state/material_state_outlined_border.0_test.dart
+++ b/packages/material_ui/example/test/material_state/material_state_outlined_border.0_test.dart
@@ -1,0 +1,60 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/material_state/material_state_outlined_border.0.dart'
+    as example;
+
+void main() {
+  Finder findBorderShape(OutlinedBorder? shape) {
+    return find.descendant(
+      of: find.byType(FilterChip),
+      matching: find.byWidgetPredicate((Widget widget) {
+        if (widget is! Material) {
+          return false;
+        }
+        return widget.shape == shape;
+      }),
+    );
+  }
+
+  testWidgets('FilterChip displays the correct border when selected', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const example.WidgetStateOutlinedBorderExampleApp(),
+    );
+
+    expect(
+      findBorderShape(
+        const RoundedRectangleBorder(
+          side: BorderSide(color: Colors.transparent),
+        ),
+      ),
+      findsOne,
+    );
+  });
+
+  testWidgets('FilterChip displays the correct border when not selected', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const example.WidgetStateOutlinedBorderExampleApp(),
+    );
+
+    await tester.tap(find.byType(FilterChip));
+    await tester.pumpAndSettle();
+
+    expect(
+      findBorderShape(
+        RoundedRectangleBorder(
+          side: const BorderSide(color: Color(0xFFCAC4D0)),
+          borderRadius: .circular(8),
+        ),
+      ),
+      findsOne,
+    );
+  });
+}

--- a/packages/material_ui/example/test/material_state/material_state_outlined_border.0_test.dart
+++ b/packages/material_ui/example/test/material_state/material_state_outlined_border.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/test/text_field/text_field_magnifier.0_test.dart
+++ b/packages/material_ui/example/test/text_field/text_field_magnifier.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/test/text_field/text_field_magnifier.0_test.dart
+++ b/packages/material_ui/example/test/text_field/text_field_magnifier.0_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/text_field/text_field_magnifier.0.dart'
+    as example;
+
+List<TextSelectionPoint> _globalize(
+  Iterable<TextSelectionPoint> points,
+  RenderBox box,
+) {
+  return points.map<TextSelectionPoint>((TextSelectionPoint point) {
+    return TextSelectionPoint(box.localToGlobal(point.point), point.direction);
+  }).toList();
+}
+
+RenderEditable _findRenderEditable<T extends State<StatefulWidget>>(
+  WidgetTester tester,
+) {
+  return (tester.state(find.byType(TextField))
+          as TextSelectionGestureDetectorBuilderDelegate)
+      .editableTextKey
+      .currentState!
+      .renderEditable;
+}
+
+Offset _textOffsetToPosition<T extends State<StatefulWidget>>(
+  WidgetTester tester,
+  int offset,
+) {
+  final RenderEditable renderEditable = _findRenderEditable(tester);
+
+  final List<TextSelectionPoint> endpoints = renderEditable
+      .getEndpointsForSelection(TextSelection.collapsed(offset: offset))
+      .map<TextSelectionPoint>(
+        (TextSelectionPoint point) => TextSelectionPoint(
+          renderEditable.localToGlobal(point.point),
+          point.direction,
+        ),
+      )
+      .toList();
+
+  return endpoints[0].point + const Offset(0.0, -2.0);
+}
+
+void main() {
+  const Duration durationBetweenActions = Duration(milliseconds: 20);
+  const String defaultText = 'I am a magnifier, fear me!';
+
+  Future<void> showMagnifier(WidgetTester tester, int textOffset) async {
+    assert(textOffset >= 0);
+    final Offset tapOffset = _textOffsetToPosition(tester, textOffset);
+
+    // Double tap 'Magnifier' word to show the selection handles.
+    final TestGesture testGesture = await tester.startGesture(tapOffset);
+    await tester.pump(durationBetweenActions);
+    await testGesture.up();
+    await tester.pump(durationBetweenActions);
+    await testGesture.down(tapOffset);
+    await tester.pump(durationBetweenActions);
+    await testGesture.up();
+    await tester.pumpAndSettle();
+
+    final TextEditingController controller = tester
+        .firstWidget<TextField>(find.byType(TextField))
+        .controller!;
+
+    final TextSelection selection = controller.selection;
+    final RenderEditable renderEditable = _findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = _globalize(
+      renderEditable.getEndpointsForSelection(selection),
+      renderEditable,
+    );
+
+    final Offset handlePos = endpoints.last.point + const Offset(10.0, 10.0);
+
+    final TestGesture gesture = await tester.startGesture(handlePos);
+
+    await gesture.moveTo(_textOffsetToPosition(tester, defaultText.length - 2));
+    await tester.pump();
+  }
+
+  testWidgets(
+    'should show custom magnifier on drag',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.TextMagnifierExampleApp(text: defaultText),
+      );
+
+      await showMagnifier(tester, defaultText.indexOf('e'));
+      expect(find.byType(example.CustomMagnifier), findsOneWidget);
+
+      await expectLater(
+        find.byType(example.TextMagnifierExampleApp),
+        matchesGoldenFile('text_magnifier.0_test.png'),
+      );
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{.iOS, .android}),
+    // This image is flaky. https://github.com/flutter/flutter/issues/144350
+    skip: true,
+  );
+
+  testWidgets('should show custom magnifier in RTL', (
+    WidgetTester tester,
+  ) async {
+    const String text = 'أثارت زر';
+    const String textToTapOn = 'ت';
+
+    await tester.pumpWidget(
+      const example.TextMagnifierExampleApp(textDirection: .rtl, text: text),
+    );
+
+    await showMagnifier(tester, text.indexOf(textToTapOn));
+
+    expect(find.byType(example.CustomMagnifier), findsOneWidget);
+  });
+}

--- a/packages/material_ui/example/test/text_field/text_field_magnifier.0_test.dart
+++ b/packages/material_ui/example/test/text_field/text_field_magnifier.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/test/text_field/text_field_tap_region.0_test.dart
+++ b/packages/material_ui/example/test/text_field/text_field_tap_region.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/test/text_field/text_field_tap_region.0_test.dart
+++ b/packages/material_ui/example/test/text_field/text_field_tap_region.0_test.dart
@@ -1,0 +1,99 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/text_field/text_field_tap_region.0.dart'
+    as example;
+
+void main() {
+  testWidgets('shows a text field with a zero count, and the spinner buttons', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.TapRegionApp());
+
+    expect(find.byType(TextField), findsOneWidget);
+    expect(getFieldValue(tester).text, equals('0'));
+    expect(find.byIcon(Icons.add), findsOneWidget);
+    expect(find.byIcon(Icons.remove), findsOneWidget);
+  });
+
+  testWidgets('tapping increment/decrement works', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.TapRegionApp());
+    await tester.pump();
+
+    expect(getFieldValue(tester).text, equals('0'));
+    expect(
+      getFieldValue(tester).selection,
+      equals(const TextSelection.collapsed(offset: 1)),
+    );
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    expect(getFieldValue(tester).text, equals('1'));
+    expect(
+      getFieldValue(tester).selection,
+      equals(const TextSelection(baseOffset: 0, extentOffset: 1)),
+    );
+
+    await tester.tap(find.byIcon(Icons.remove));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.remove));
+    await tester.pumpAndSettle();
+
+    expect(getFieldValue(tester).text, equals('-1'));
+    expect(
+      getFieldValue(tester).selection,
+      equals(const TextSelection(baseOffset: 0, extentOffset: 2)),
+    );
+  });
+
+  testWidgets('entering text and then incrementing/decrementing works', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.TapRegionApp());
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    expect(getFieldValue(tester).text, equals('1'));
+    expect(
+      getFieldValue(tester).selection,
+      equals(const TextSelection(baseOffset: 0, extentOffset: 1)),
+    );
+
+    await tester.enterText(find.byType(TextField), '123');
+    await tester.pumpAndSettle();
+    expect(getFieldValue(tester).text, equals('123'));
+    expect(
+      getFieldValue(tester).selection,
+      equals(const TextSelection.collapsed(offset: 3)),
+    );
+
+    await tester.tap(find.byIcon(Icons.remove));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.remove));
+    await tester.pumpAndSettle();
+
+    expect(getFieldValue(tester).text, equals('121'));
+    expect(
+      getFieldValue(tester).selection,
+      equals(const TextSelection(baseOffset: 0, extentOffset: 3)),
+    );
+    final FocusNode textFieldFocusNode = Focus.of(
+      tester.element(
+        find.byWidgetPredicate((Widget widget) {
+          return widget.runtimeType.toString() == '_Editable';
+        }),
+      ),
+    );
+    expect(textFieldFocusNode.hasPrimaryFocus, isTrue);
+  });
+}
+
+TextEditingValue getFieldValue(WidgetTester tester) {
+  return (tester.widget(find.byType(TextField)) as TextField).controller!.value;
+}

--- a/packages/material_ui/example/test/text_field/text_field_tap_region.0_test.dart
+++ b/packages/material_ui/example/test/text_field/text_field_tap_region.0_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
This adds missing samples referenced in the material_ui API docs.
Some of these were misplaced in the widgets/ API directory in flutter/flutter, I will push up a PR to reflect the move there as well so we do not lose track of it.

Towards https://github.com/flutter/flutter/issues/172936 and https://github.com/flutter/flutter/issues/172937

Related:
* https://github.com/flutter/packages/pull/12078, which migrates samples in `material_ui` and depends on this PR.
* https://github.com/flutter/packages/pull/12086, which moves similar missing sample files for `cupertino_ui`


## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
