### PR TITLE
[file_selector_android] Surface file-copy failures to Dart instead of crashing

### DIFF
--- a/packages/file_selector/file_selector_android/CHANGELOG.md
+++ b/packages/file_selector/file_selector_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2+9
+
+* Fixes a crash when a selected file cannot be copied to a readable location (for
+  example, on a `SecurityException`).
+
 ## 0.5.2+8
 
 * Bumps the androidx group across 10 directories with 1 update.

--- a/packages/file_selector/file_selector_android/android/src/main/java/dev/flutter/packages/file_selector_android/FileSelectorApiImpl.java
+++ b/packages/file_selector/file_selector_android/android/src/main/java/dev/flutter/packages/file_selector_android/FileSelectorApiImpl.java
@@ -383,6 +383,16 @@ public class FileSelectorApiImpl implements FileSelectorApi {
               e.getMessage() == null ? "" : e.getMessage());
     }
 
+    if (uriPath == null) {
+      // `getPathFromCopyOfFileFromUri` can fail to produce a path: either by
+      // throwing (handled above by returning a null `uriPath`) or by returning
+      // null directly. Return null so the caller surfaces the failure to Dart,
+      // instead of building a `FileResponse` with a null `path`, which the
+      // non-null field rejects at runtime.
+      // See https://github.com/flutter/flutter/issues/159568.
+      return null;
+    }
+
     return new FileResponse(uriPath, contentResolver.getType(uri), name, size, bytes, nativeError);
   }
 }

--- a/packages/file_selector/file_selector_android/android/src/test/java/dev/flutter/packages/file_selector_android/FileSelectorAndroidPluginTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/dev/flutter/packages/file_selector_android/FileSelectorAndroidPluginTest.java
@@ -6,10 +6,10 @@ package dev.flutter.packages.file_selector_android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -71,7 +71,9 @@ public class FileSelectorAndroidPluginTest {
     when(mockCursor.getInt(1)).thenReturn(size);
 
     when(mockResolver.query(uri, null, null, null, null, null)).thenReturn(mockCursor);
-    when(mockResolver.getType(uri)).thenReturn(mimeType);
+    // `getType` is only reached when a `FileResponse` is built, so it is unused by
+    // the error-path tests; keep it lenient to avoid strict-stubbing warnings.
+    lenient().when(mockResolver.getType(uri)).thenReturn(mimeType);
     when(mockResolver.openInputStream(uri)).thenReturn(mock(InputStream.class));
   }
 
@@ -214,35 +216,24 @@ public class FileSelectorAndroidPluginTest {
     }
   }
 
-  // This test was created when error handling was moved from FileUtils.java to
-  // FileSelectorApiImpl.java
-  // in https://github.com/flutter/packages/pull/8184, so as to maintain the existing test.
-  // The behavior is actually an error case and should be fixed,
-  // see: https://github.com/flutter/flutter/issues/159568.
-  // Remove when fixed!
+  // Regression test for https://github.com/flutter/flutter/issues/159568: a
+  // `SecurityException` while copying a selected file must be surfaced to Dart
+  // as a failed result, rather than crashing by building a `FileResponse` with a
+  // null `path` (which the non-null `path` field rejects at runtime).
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Test
-  public void
-      openFileThrowsNullPointerException_whenSecurityExceptionInGetPathFromCopyOfFileFromUri()
-          throws FileNotFoundException {
+  public void openFilesCompletesWithError_whenSecurityExceptionInGetPathFromCopyOfFileFromUri()
+      throws FileNotFoundException {
 
     try (MockedStatic<FileUtils> mockedFileUtils = mockStatic(FileUtils.class)) {
 
       final ContentResolver mockContentResolver = mock(ContentResolver.class);
 
       final Uri mockUri = mock(Uri.class);
-      final String mockUriPath = "some/path/";
       mockedFileUtils
           .when(() -> FileUtils.getPathFromCopyOfFileFromUri(any(Context.class), eq(mockUri)))
           .thenThrow(SecurityException.class);
       mockContentResolver(mockContentResolver, mockUri, "filename", 30, "text/plain");
-
-      final Uri mockUri2 = mock(Uri.class);
-      final String mockUri2Path = "some/other/path/";
-      mockedFileUtils
-          .when(() -> FileUtils.getPathFromCopyOfFileFromUri(any(Context.class), eq(mockUri2)))
-          .thenAnswer((Answer<String>) invocation -> mockUri2Path);
-      mockContentResolver(mockContentResolver, mockUri2, "filename2", 40, "image/jpg");
 
       when(mockObjectFactory.newIntent(Intent.ACTION_OPEN_DOCUMENT)).thenReturn(mockIntent);
       when(mockObjectFactory.newDataInputStream(any())).thenReturn(mock(DataInputStream.class));
@@ -254,11 +245,15 @@ public class FileSelectorAndroidPluginTest {
               mockObjectFactory,
               (version) -> Build.VERSION.SDK_INT >= version);
 
+      final Boolean[] callbackCalled = new Boolean[1];
+      final Throwable[] failure = new Throwable[1];
       fileSelectorApi.openFiles(
           null,
           new FileTypes(Collections.emptyList(), Collections.emptyList()),
           ResultCompat.asCompatCallback(
               (reply) -> {
+                callbackCalled[0] = true;
+                failure[0] = reply.exceptionOrNull();
                 return null;
               }));
       verify(mockIntent).addCategory(Intent.CATEGORY_OPENABLE);
@@ -272,24 +267,77 @@ public class FileSelectorAndroidPluginTest {
 
       final Intent resultMockIntent = mock(Intent.class);
       final ClipData mockClipData = mock(ClipData.class);
-      when(mockClipData.getItemCount()).thenReturn(2);
+      when(mockClipData.getItemCount()).thenReturn(1);
 
       final ClipData.Item mockClipDataItem = mock(ClipData.Item.class);
       when(mockClipDataItem.getUri()).thenReturn(mockUri);
       when(mockClipData.getItemAt(0)).thenReturn(mockClipDataItem);
 
-      final ClipData.Item mockClipDataItem2 = mock(ClipData.Item.class);
-      when(mockClipDataItem2.getUri()).thenReturn(mockUri2);
-      when(mockClipData.getItemAt(1)).thenReturn(mockClipDataItem2);
-
       when(resultMockIntent.getClipData()).thenReturn(mockClipData);
 
-      assertThrows(
-          NullPointerException.class,
-          () ->
-              listenerArgumentCaptor
-                  .getValue()
-                  .onActivityResult(222, Activity.RESULT_OK, resultMockIntent));
+      // Previously this threw a NullPointerException (see #159568); it must now
+      // complete the callback with a failure instead of crashing.
+      listenerArgumentCaptor.getValue().onActivityResult(222, Activity.RESULT_OK, resultMockIntent);
+
+      assertTrue(callbackCalled[0]);
+      assertNotNull(failure[0]);
+      assertTrue(failure[0].getMessage().contains("Failed to read file"));
+    }
+  }
+
+  // Regression test for https://github.com/flutter/flutter/issues/159568: the
+  // single-file `openFile` path must likewise surface a copy failure to Dart
+  // instead of crashing.
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  public void openFileCompletesWithError_whenSecurityExceptionInGetPathFromCopyOfFileFromUri()
+      throws FileNotFoundException {
+
+    try (MockedStatic<FileUtils> mockedFileUtils = mockStatic(FileUtils.class)) {
+
+      final ContentResolver mockContentResolver = mock(ContentResolver.class);
+
+      final Uri mockUri = mock(Uri.class);
+      mockedFileUtils
+          .when(() -> FileUtils.getPathFromCopyOfFileFromUri(any(Context.class), eq(mockUri)))
+          .thenThrow(SecurityException.class);
+      mockContentResolver(mockContentResolver, mockUri, "filename", 30, "text/plain");
+
+      when(mockObjectFactory.newIntent(Intent.ACTION_OPEN_DOCUMENT)).thenReturn(mockIntent);
+      when(mockObjectFactory.newDataInputStream(any())).thenReturn(mock(DataInputStream.class));
+      when(mockActivity.getContentResolver()).thenReturn(mockContentResolver);
+      when(mockActivityBinding.getActivity()).thenReturn(mockActivity);
+      final FileSelectorApiImpl fileSelectorApi =
+          new FileSelectorApiImpl(
+              mockActivityBinding,
+              mockObjectFactory,
+              (version) -> Build.VERSION.SDK_INT >= version);
+
+      final Boolean[] callbackCalled = new Boolean[1];
+      final Throwable[] failure = new Throwable[1];
+      fileSelectorApi.openFile(
+          null,
+          new FileTypes(Collections.emptyList(), Collections.emptyList()),
+          ResultCompat.asCompatCallback(
+              (reply) -> {
+                callbackCalled[0] = true;
+                failure[0] = reply.exceptionOrNull();
+                return null;
+              }));
+
+      verify(mockActivity).startActivityForResult(mockIntent, 221);
+
+      final ArgumentCaptor<PluginRegistry.ActivityResultListener> listenerArgumentCaptor =
+          ArgumentCaptor.forClass(PluginRegistry.ActivityResultListener.class);
+      verify(mockActivityBinding).addActivityResultListener(listenerArgumentCaptor.capture());
+
+      final Intent resultMockIntent = mock(Intent.class);
+      when(resultMockIntent.getData()).thenReturn(mockUri);
+      listenerArgumentCaptor.getValue().onActivityResult(221, Activity.RESULT_OK, resultMockIntent);
+
+      assertTrue(callbackCalled[0]);
+      assertNotNull(failure[0]);
+      assertTrue(failure[0].getMessage().contains("Failed to read file"));
     }
   }
 

--- a/packages/file_selector/file_selector_android/android/src/test/java/dev/flutter/packages/file_selector_android/FileSelectorAndroidPluginTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/dev/flutter/packages/file_selector_android/FileSelectorAndroidPluginTest.java
@@ -245,7 +245,7 @@ public class FileSelectorAndroidPluginTest {
               mockObjectFactory,
               (version) -> Build.VERSION.SDK_INT >= version);
 
-      final Boolean[] callbackCalled = new Boolean[1];
+      final boolean[] callbackCalled = new boolean[1];
       final Throwable[] failure = new Throwable[1];
       fileSelectorApi.openFiles(
           null,
@@ -313,7 +313,7 @@ public class FileSelectorAndroidPluginTest {
               mockObjectFactory,
               (version) -> Build.VERSION.SDK_INT >= version);
 
-      final Boolean[] callbackCalled = new Boolean[1];
+      final boolean[] callbackCalled = new boolean[1];
       final Throwable[] failure = new Throwable[1];
       fileSelectorApi.openFile(
           null,

--- a/packages/file_selector/file_selector_android/pubspec.yaml
+++ b/packages/file_selector/file_selector_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_android
 description: Android implementation of the file_selector package.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.5.2+8
+version: 0.5.2+9
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
`file_selector_android` crashes when a selected file can't be copied to a readable location.

`FileSelectorApiImpl.toFileResponse` catches `IOException`/`SecurityException` from `FileUtils.getPathFromCopyOfFileFromUri` and sets the path to `null`, but then still builds a `FileResponse` with that null `path`. Since `path` is non-null in the Pigeon-generated `FileResponse`, this throws — a `NullPointerException` since the move to the Kotlin Pigeon generator (the issue reported it as an `IllegalStateException` on the older Java generator) — so the app crashes instead of surfacing an error.

When no path can be produced, `toFileResponse` now returns `null`. The callers already handle that by completing the result with an error (the same `completeWithError("Failed to read file: …")` path they use elsewhere when a file can't be read), so the failure now reaches Dart as a `PlatformException` instead of crashing the app.

I kept this scoped to the crash. The issue also suggests moving these branches onto the typed `FileSelectorNativeException` mechanism (like #8184); that would need a Pigeon regeneration and a Dart-facing API change, so I left it out here — happy to do it as a follow-up if that's the preferred direction.

The existing test that documented the crash (marked "Remove when fixed") now asserts the failure is surfaced, plus a matching test for the single-file `openFile` path.

Fixes flutter/flutter#159568

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
