### PR TITLE
[go_router] Make ImperativeRouteMatch.complete idempotent

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 17.3.1
+
+- Fixes a "Bad state: Future already completed" crash when an imperatively-pushed
+  route's completion is triggered more than once (for example a rapid double-pop).
+  `ImperativeRouteMatch.complete` is now idempotent. See
+  https://github.com/flutter/flutter/issues/156809.
+
 ## 17.3.0
 
 - Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -444,6 +444,15 @@ class ImperativeRouteMatch extends RouteMatch {
   /// Called when the corresponding [Route] associated with this route match is
   /// completed.
   void complete([dynamic value]) {
+    // Completing is idempotent. The pushed route can be removed more than once
+    // — e.g. a rapid double-pop, or a pop dispatched while a prior removal is
+    // still in flight on a slow device — which would otherwise call complete()
+    // a second time and throw "Bad state: Future already completed". The
+    // awaited result is delivered by the first completion, so the duplicate is
+    // a no-op. See https://github.com/flutter/flutter/issues/156809.
+    if (completer.isCompleted) {
+      return;
+    }
     completer.complete(value);
   }
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 17.3.0
+version: 17.3.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/match_test.dart
+++ b/packages/go_router/test/match_test.dart
@@ -178,6 +178,20 @@ void main() {
     final completer1 = Completer<void>();
     final completer2 = Completer<void>();
 
+    test('complete is idempotent and does not throw when called twice', () async {
+      // Regression test for https://github.com/flutter/flutter/issues/156809:
+      // the pushed route's completer could be completed more than once
+      // (e.g. a rapid double-pop), throwing "Bad state: Future already
+      // completed".
+      final completer = Completer<Object?>();
+      final match = ImperativeRouteMatch(pageKey: key1, matches: matchList1, completer: completer);
+
+      match.complete('result');
+      // A second completion must be a no-op rather than a crash.
+      expect(() => match.complete('ignored'), returnsNormally);
+      expect(await completer.future, 'result');
+    });
+
     test('can equal and has', () async {
       var match1 = ImperativeRouteMatch(pageKey: key1, matches: matchList1, completer: completer1);
       var match2 = ImperativeRouteMatch(pageKey: key1, matches: matchList1, completer: completer1);


### PR DESCRIPTION
## Description

Popping an imperatively-pushed route (`context.push`) can complete its result `Completer` more than once, throwing an uncaught **`Bad state: Future already completed`**. The second completion originates inside go_router itself (`GoRouterDelegate._handlePopPageWithRouteMatch` → `_completeRouteMatch` → `ImperativeRouteMatch.complete`), triggered when the same route's removal is dispatched twice before the first settles — commonly a rapid double-pop, and more likely on lower-end devices where the frame window is wide.

This is a long-standing, still-open crash reported across many issues, reproducible through the current version:
- #156809 (go_router_builder, two consecutive pops)
- #123369, #146938, #157219, #163813, #160696, #180002

`ImperativeRouteMatch.complete` is non-idempotent in every version to date.

## Fix

Make `ImperativeRouteMatch.complete` idempotent: return early when the completer is already completed. The awaited push result is delivered by the first completion, so the duplicate is a safe no-op rather than a crash.

```dart
void complete([dynamic value]) {
  if (completer.isCompleted) {
    return;
  }
  completer.complete(value);
}
```

(Alternative considered: guarding in `GoRouterDelegate._completeRouteMatch`. Happy to move it there if maintainers prefer.)

## Tests

Added a regression test in `match_test.dart` asserting a second `complete()` call does not throw and the first value wins.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/156809

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (`dart format`)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[go_router]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
