### PR TITLE
[camera_platform_interface] Make setJpegImageQuality default a no-op

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 2.13.1
 
+* Changes the default implementation of `setJpegImageQuality` to a no-op so that
+  platforms that do not support it ignore the setting instead of throwing.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.13.0

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -337,7 +337,12 @@ abstract class CameraPlatform extends PlatformInterface {
   ///
   /// This only applies to images captured in JPEG format.
   /// The [quality] must be between 1 (lowest) and 100 (highest).
-  Future<void> setJpegImageQuality(int cameraId, int quality) {
-    throw UnimplementedError('setJpegImageQuality() is not implemented.');
+  ///
+  /// This is a best-effort setting; platforms that do not support controlling
+  /// the JPEG quality ignore it. The default implementation is a no-op so that
+  /// calling it is always safe.
+  Future<void> setJpegImageQuality(int cameraId, int quality) async {
+    // No-op by default. Platforms that support setting the JPEG quality
+    // override this method.
   }
 }

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.13.0
+version: 2.13.1
 
 environment:
   sdk: ^3.10.0

--- a/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
+++ b/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
@@ -353,12 +353,12 @@ void main() {
       expect(() => cameraPlatform.resumePreview(1), throwsUnimplementedError);
     });
 
-    test('Default implementation of setJpegImageQuality() should throw unimplemented error', () {
+    test('Default implementation of setJpegImageQuality() is a no-op', () {
       // Arrange
       final cameraPlatform = ExtendsCameraPlatform();
 
       // Act & Assert
-      expect(() => cameraPlatform.setJpegImageQuality(1, 50), throwsUnimplementedError);
+      expect(cameraPlatform.setJpegImageQuality(1, 50), completes);
     });
 
     test('Default implementation of supportsImageStreaming() should return false', () {


### PR DESCRIPTION
The default implementation of `setJpegImageQuality` threw `UnimplementedError`, but there is no support-query API for it, so a client has no way to know whether it is safe to call (raised in review of flutter/packages#11155). JPEG quality is a best-effort setting, so this changes the default to a no-op: platforms that support it override the method, and platforms that don't (e.g. web) simply ignore it.