### PR TITLE
[material_ui] Migrate a snippet in `MaterialApp`'s API doc to `{@example}` and add unit tests

### DIFF
--- a/packages/material_ui/example/lib/app/app.snippet.0.dart
+++ b/packages/material_ui/example/lib/app/app.snippet.0.dart
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:material_ui/material_ui.dart';
+
+/// Flutter code sample for [MaterialApp].
+
+void main() {
+  runApp(const MaterialAppExample());
+}
+
+class MaterialAppExample extends StatelessWidget {
+  const MaterialAppExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return
+    // #region content
+    MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Home'),
+        ),
+      ),
+      debugShowCheckedModeBanner: false,
+    )
+    // #endregion content
+    ;
+  }
+}

--- a/packages/material_ui/example/test/app/app.snippet.0_test.dart
+++ b/packages/material_ui/example/test/app/app.snippet.0_test.dart
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/app/app.snippet.0.dart' as example;
+
+void main() {
+  testWidgets('The app is mounted without a checked mode banner', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.MaterialAppExample());
+    expect(find.byType(MaterialApp), findsOne);
+    expect(find.byType(CheckedModeBanner), findsNothing);
+  });
+}

--- a/packages/material_ui/lib/src/app.dart
+++ b/packages/material_ui/lib/src/app.dart
@@ -128,16 +128,7 @@ enum ThemeMode {
 ///
 /// ![The MaterialApp displays a Scaffold ](https://flutter.github.io/assets-for-api-docs/assets/material/basic_material_app.png)
 ///
-/// ```dart
-/// MaterialApp(
-///   home: Scaffold(
-///     appBar: AppBar(
-///       title: const Text('Home'),
-///     ),
-///   ),
-///   debugShowCheckedModeBanner: false,
-/// )
-/// ```
+/// {@example /example/lib/app/app.snippet.0.dart#content indent=strip}
 ///
 // TODO(framework): End of the blue example container.
 ///


### PR DESCRIPTION
This PR demonstrates how to migrate an inline API documentation snippet into a separate file and verify it with unit tests.

### Steps
1. Creating a new example file using `#region` and `#endregion` directives to isolate the snippet.
    * A file can have multiple regions, and the region name doesn't have to be `content`  if necessary.
2. Adding a corresponding test file to ensure the snippet functions correctly.
3. Updating the original documentation to use the new `@example` directive.
4. Remove the TODO.

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
