### PR TITLE
[ci] Add a third web Dart unit test shard (1/2)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -189,6 +189,16 @@ targets:
       version_file: flutter_master.version
       package_sharding: "--shardIndex 1 --shardCount 2"
 
+  - name: Linux_web web_dart_unit_test_shard_3 master
+    bringup: true
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: web_dart_unit_tests.yaml
+      channel: master
+      version_file: flutter_master.version
+      package_sharding: "--shardIndex 2 --shardCount 3"
+
   - name: Linux_web web_dart_unit_test_shard_1 stable
     recipe: packages/packages
     timeout: 60
@@ -207,7 +217,20 @@ targets:
       version_file: flutter_stable.version
       package_sharding: "--shardIndex 1 --shardCount 2"
 
+  - name: Linux_web web_dart_unit_test_shard_3 stable
+    bringup: true
+    recipe: packages/packages
+    timeout: 60
+    properties:
+      target_file: web_dart_unit_tests.yaml
+      channel: stable
+      version_file: flutter_stable.version
+      package_sharding: "--shardIndex 2 --shardCount 3"
+
   # Wasm unit tests in master
+  # TODO(stuartmorgan): Switch to testing wasm on master and stable and non-wasm
+  # only on master if/when wasm builds become the default on stable; see
+  # https://github.com/flutter/flutter/issues/188813
   - name: Linux_web web_dart_unit_test_wasm_shard_1 master
     recipe: packages/packages
     timeout: 60


### PR DESCRIPTION
The web Dart unit tests are currently some of our slowest tests, and shard 2 is on the brink of hitting the 60 minute timeout. This is the first half of the process of switching from 2 shards to three shards, adding the new tasks in bringup mode but not yet changing the existing shards. Once this lands and propagates, a second PR will switch to actually using three shards.

This brings us closer to our limit of 100 post-submit tasks for our wait-for-release action, but doesn't yet cross it (and we expect that limit to stop being an issue soon).