### PR TITLE
[cupertino_ui] Fix example path

### DIFF
--- a/packages/cupertino_ui/lib/src/magnifier.dart
+++ b/packages/cupertino_ui/lib/src/magnifier.dart
@@ -21,7 +21,7 @@ import 'theme.dart';
 ///
 /// This sample demonstrates how to use [CupertinoTextMagnifier].
 ///
-/// {@example example/lib/magnifier/cupertino_text_magnifier.0.dart}
+/// {@example /example/lib/magnifier/cupertino_text_magnifier.0.dart}
 ///
 // TODO(framework): End of the blue example container.
 ///
@@ -233,7 +233,7 @@ class _CupertinoTextMagnifierState extends State<CupertinoTextMagnifier>
 ///
 /// This sample demonstrates how to use [CupertinoMagnifier].
 ///
-/// {@example example/lib/magnifier/cupertino_magnifier.0.dart}
+/// {@example /example/lib/magnifier/cupertino_magnifier.0.dart}
 ///
 // TODO(framework): End of the blue example container.
 ///

--- a/packages/cupertino_ui/lib/src/text_field.dart
+++ b/packages/cupertino_ui/lib/src/text_field.dart
@@ -844,7 +844,7 @@ class CupertinoTextField extends StatefulWidget {
   ///
   /// This sample demonstrates how to customize the magnifier that this text field uses.
   ///
-  /// {@example example/lib/magnifier/text_magnifier.0.dart}
+  /// {@example /example/lib/magnifier/text_magnifier.0.dart}
   ///
   // TODO(framework): End of the blue example container.
   final TextMagnifierConfiguration? magnifierConfiguration;


### PR DESCRIPTION
A few example paths are not recognized by `dartdoc` for missing the initial slash.

This is the error log thrown by `dartdoc` before the PR:
```
  warning: example file not found: example/lib/magnifier/cupertino_text_magnifier.0.dart
    from magnifier.CupertinoTextMagnifier: (file:///Users/tongmu/dev/packages/packages/cupertino_ui/lib/src/magnifier.dart:39:7)
  warning: example file not found: example/lib/magnifier/cupertino_magnifier.0.dart
    from magnifier.CupertinoMagnifier: (file:///Users/tongmu/dev/packages/packages/cupertino_ui/lib/src/magnifier.dart:251:7)
  warning: example file not found: example/lib/magnifier/text_magnifier.0.dart
    from text_field.CupertinoTextField.magnifierConfiguration: (file:///Users/tongmu/dev/packages/packages/cupertino_ui/lib/src/text_field.dart:850:37)
```

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
