### PR TITLE
[material_ui] Preserve Tooltip semantics when disabled by TooltipVisibility

### DIFF
--- a/packages/material_ui/lib/src/tooltip.dart
+++ b/packages/material_ui/lib/src/tooltip.dart
@@ -566,6 +566,14 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
         ignorePointer: widget.ignorePointer ?? widget.message != null,
         child: effectiveChild,
       );
+    } else {
+      // A TooltipVisibility ancestor has disabled the tooltip overlay and its
+      // triggers, but the message should still be reported to assistive
+      // technology, matching what RawTooltip does when the tooltip is enabled.
+      effectiveChild = Semantics(
+        tooltip: excludeFromSemantics ? null : _tooltipMessage,
+        child: effectiveChild,
+      );
     }
 
     return effectiveChild;

--- a/packages/material_ui/test/tooltip_visibility_test.dart
+++ b/packages/material_ui/test/tooltip_visibility_test.dart
@@ -189,6 +189,56 @@ void main() {
     await tester.pump();
     expect(find.text(tooltipText), findsOneWidget);
   });
+
+  testWidgets('Tooltip contributes semantics when in TooltipVisibility with visible = false', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/189062.
+    final SemanticsHandle handle = tester.ensureSemantics();
+    const childKey = Key('child');
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: TooltipVisibility(
+          visible: false,
+          child: Tooltip(
+            message: tooltipText,
+            child: SizedBox(key: childKey, width: 100.0, height: 100.0),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byKey(childKey)), containsSemantics(tooltip: tooltipText));
+    handle.dispose();
+  });
+
+  testWidgets(
+    'Tooltip in TooltipVisibility with visible = false contributes no semantics when excluded',
+    (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      const childKey = Key('child');
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: TooltipVisibility(
+            visible: false,
+            child: Tooltip(
+              message: tooltipText,
+              excludeFromSemantics: true,
+              child: SizedBox(key: childKey, width: 100.0, height: 100.0),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byKey(childKey)),
+        isNot(containsSemantics(tooltip: tooltipText)),
+      );
+      handle.dispose();
+    },
+  );
 }
 
 Future<void> setWidgetForTooltipMode(


### PR DESCRIPTION
`TooltipVisibility(visible: false)` is documented to "only visually" disable tooltips while it "continues to provide any semantic information that is provided". Since the `RawTooltip` refactor (flutter/flutter#177678), `TooltipState.build` skips the `RawTooltip` wrapper entirely when the tooltip is disabled. Because the `Semantics(tooltip:)` annotation now lives inside `RawTooltip`, it is dropped along with it, so assistive technologies stop announcing the tooltip message — for example, an `IconButton` with `tooltip: 'Add'` under `TooltipVisibility(visible: false)` is announced as just "button". Before that refactor, the `Semantics` wrapper was applied unconditionally and only gesture handling was gated on visibility.

This change restores the documented behavior: when a `TooltipVisibility` ancestor disables the tooltip, the child is still wrapped in the same `Semantics(tooltip:)` annotation that `RawTooltip` applies when the tooltip is enabled, honoring `excludeFromSemantics`. It adds a regression test that fails without the fix, plus a test verifying that `excludeFromSemantics: true` still suppresses the semantics when the tooltip is disabled.

This supersedes flutter/flutter#189171, which targeted the frozen Material library in flutter/flutter and is being ported here per the porting instructions in flutter/flutter#188444 and the code freeze policy in flutter/flutter#184093.

`material_ui` is not yet published (`publish_to: none`), so no version/CHANGELOG update is included, matching other `[material_ui]` PRs.

Fixes https://github.com/flutter/flutter/issues/189062

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
