### PR TITLE
Update url_launcher_ios description in pubspec.yaml

### DIFF
--- a/packages/url_launcher/url_launcher_ios/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_ios/pubspec.yaml
@@ -1,5 +1,5 @@
 name: url_launcher_ios
-description: iOS implementation of the url_launcher plugin.
+description: The iOS implementation of the url_launcher plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
 version: 6.4.1


### PR DESCRIPTION
Description:

This PR fixes the pubspec.yaml description for url_launcher_ios, which was too short (less than 50 characters) and failed validation.
The description has been updated from "iOS implementation of the url_launcher plugin." to "The iOS implementation of the url_launcher plugin."
This brings it to at least 50 characters, meeting the 50-180 character requirement.

Why:

The package fails pub.dev validation with the error: "The package description is too short. Use 50 to 180 characters..."

This simple change resolves the issue.
