### PR TITLE
[material_ui] Add hyphens param to _TextStyleProxy.getParagraphStyle override

### DIFF
--- a/packages/material_ui/test/theme_test.dart
+++ b/packages/material_ui/test/theme_test.dart
@@ -1342,6 +1342,7 @@ class _TextStyleProxy implements TextStyle {
     FontStyle? fontStyle,
     double? height,
     StrutStyle? strutStyle,
+    ui.Hyphens? hyphens,
   }) {
     throw UnimplementedError();
   }


### PR DESCRIPTION
Adds the new `hyphens` parameter to the `_TextStyleProxy.getParagraphStyle` override in `material_ui`'s `theme_test.dart`.

This is a companion to flutter/flutter#185152, which adds an optional `hyphens` parameter to `TextStyle.getParagraphStyle` as part of the soft-hyphen (U+00AD) rendering feature. `_TextStyleProxy` `implements TextStyle` and overrides `getParagraphStyle`; once #185152 rolls into this repo's pinned Flutter the override is invalid unless it also accepts the new parameter. This is the `flutter_plugins` presubmit failure surfaced on #185152.

Because `hyphens` is added as an optional named parameter, the override stays valid against **both** the current pinned Flutter (where it is simply an extra optional param) and the updated framework (where it matches the new supertype signature). So this PR is green on its own and unblocks #185152's `flutter_plugins` check once merged.

Fixes flutter/flutter#18443 (companion to flutter/flutter#185152).

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

**CHANGELOG/version exemption:** test-only change — this updates a test double (`_TextStyleProxy`) whose overrides all `throw UnimplementedError()`; there is no shipped code change, so no version bump or CHANGELOG entry is warranted.

**Test exemption:** mechanical override-signature update to a test double; the added parameter is unused (`throw UnimplementedError()`), so there is no behavior to test.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
