### PR TITLE
[cupertino_ui] Issue 169509 cupertino button label

### DIFF
--- a/packages/cupertino_ui/CHANGELOG.md
+++ b/packages/cupertino_ui/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.0.2
 
+* Add `label` and `labelAlignment` properties to `CupertinoButton` to allow for a label to be displayed alongside the button's child widget.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 0.0.1

--- a/packages/cupertino_ui/lib/src/button.dart
+++ b/packages/cupertino_ui/lib/src/button.dart
@@ -7,6 +7,7 @@ library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 
@@ -44,6 +45,20 @@ enum _CupertinoButtonStyle {
   filled,
 }
 
+/// The alignment of a [CupertinoButton]'s [label] relative to its [child].
+///
+/// The visual effect of `labelAlignment` depends on the ambient [TextDirection].
+/// If the text direction is [TextDirection.ltr], then [CupertinoButtonLabelAlignment.start]
+/// and [CupertinoButtonLabelAlignment.end] align the label on the left or the right respectively.
+/// If the text direction is [TextDirection.rtl], then the alignments are reversed.
+enum CupertinoButtonLabelAlignment {
+  /// The label is placed before the child.
+  start,
+
+  /// The label is placed after the child.
+  end,
+}
+
 /// An iOS-style button.
 ///
 /// Takes in a text or an icon that fades out and in on touch. May optionally have a
@@ -76,6 +91,7 @@ class CupertinoButton extends StatefulWidget {
   const CupertinoButton({
     super.key,
     required this.child,
+    this.label,
     this.sizeStyle = CupertinoButtonSize.large,
     this.padding,
     this.color,
@@ -90,6 +106,7 @@ class CupertinoButton extends StatefulWidget {
     this.pressedOpacity = 0.4,
     this.borderRadius,
     this.alignment = Alignment.center,
+    this.labelAlignment = .start,
     this.focusColor,
     this.focusNode,
     this.onFocusChange,
@@ -113,6 +130,7 @@ class CupertinoButton extends StatefulWidget {
   const CupertinoButton.tinted({
     super.key,
     required this.child,
+    this.label,
     this.sizeStyle = CupertinoButtonSize.large,
     this.padding,
     this.color,
@@ -127,6 +145,7 @@ class CupertinoButton extends StatefulWidget {
     this.pressedOpacity = 0.4,
     this.borderRadius,
     this.alignment = Alignment.center,
+    this.labelAlignment = .start,
     this.focusColor,
     this.focusNode,
     this.onFocusChange,
@@ -144,6 +163,7 @@ class CupertinoButton extends StatefulWidget {
   const CupertinoButton.filled({
     super.key,
     required this.child,
+    this.label,
     this.sizeStyle = CupertinoButtonSize.large,
     this.padding,
     this.color,
@@ -158,6 +178,7 @@ class CupertinoButton extends StatefulWidget {
     this.pressedOpacity = 0.4,
     this.borderRadius,
     this.alignment = Alignment.center,
+    this.labelAlignment = .start,
     this.focusColor,
     this.focusNode,
     this.onFocusChange,
@@ -173,6 +194,11 @@ class CupertinoButton extends StatefulWidget {
   ///
   /// Typically a [Text] widget.
   final Widget child;
+
+  /// The label of the button, which is displayed before the [child] widget.
+  ///
+  /// Typically a [Icon] widget.
+  final Widget? label;
 
   /// The amount of space to surround the child inside the bounds of the button.
   ///
@@ -252,6 +278,11 @@ class CupertinoButton extends StatefulWidget {
   ///
   /// Always defaults to [Alignment.center].
   final AlignmentGeometry alignment;
+
+  /// The alignment of the button's [label] relative to its [child].
+  ///
+  /// Defaults to [CupertinoButtonLabelAlignment.start].
+  final CupertinoButtonLabelAlignment labelAlignment;
 
   /// The color to use for the focus highlight for keyboard interactions.
   ///
@@ -597,7 +628,26 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
                       heightFactor: 1.0,
                       child: DefaultTextStyle(
                         style: textStyle,
-                        child: IconTheme(data: iconTheme, child: widget.child),
+                        child: IconTheme(
+                          data: iconTheme,
+                          child: widget.label != null
+                              ? Row(
+                                  mainAxisSize: .min,
+                                  mainAxisAlignment: .center,
+                                  children: widget.labelAlignment == .start
+                                      ? <Widget>[
+                                          widget.label!,
+                                          const SizedBox(width: 8),
+                                          widget.child,
+                                        ]
+                                      : <Widget>[
+                                          widget.child,
+                                          const SizedBox(width: 8),
+                                          widget.label!,
+                                        ],
+                                )
+                              : widget.child,
+                        ),
                       ),
                     ),
                   ),

--- a/packages/cupertino_ui/test/button_test.dart
+++ b/packages/cupertino_ui/test/button_test.dart
@@ -1129,6 +1129,66 @@ void main() {
     );
     expect(tester.getSize(find.byType(CupertinoButton)), Size.zero);
   });
+
+  group('CupertinoButton label and labelAlignment', () {
+    const Widget labelWidget = Text('Label');
+    const Widget childWidget = Text('Child');
+
+    testWidgets('Label visible', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoButton(onPressed: () {}, label: labelWidget, child: childWidget),
+        ),
+      );
+      expect(find.text('Label'), findsOneWidget);
+      expect(find.text('Child'), findsOneWidget);
+    });
+    testWidgets('Label not visible', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoButton(onPressed: () {}, child: childWidget),
+        ),
+      );
+      expect(find.text('Label'), findsNothing);
+      expect(find.text('Child'), findsOneWidget);
+    });
+    testWidgets('Label alignment - start', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoButton(onPressed: () {}, label: labelWidget, child: childWidget),
+        ),
+      );
+      final Row row = tester.widget<Row>(
+        find.descendant(of: find.byType(CupertinoButton), matching: find.byType(Row)),
+      );
+      expect(row.children.length, 3);
+      expect(row.children[0], labelWidget);
+      expect(row.children[1], isA<SizedBox>());
+      expect((row.children[1] as SizedBox).width, 8.0);
+      expect(row.children[2], childWidget);
+    });
+    testWidgets('Label alignment - end', (WidgetTester tester) async {
+      // Label alignment end
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoButton(
+            onPressed: () {},
+            label: labelWidget,
+            labelAlignment: CupertinoButtonLabelAlignment.end,
+            child: childWidget,
+          ),
+        ),
+      );
+      final Row row = tester.widget<Row>(
+        find.descendant(of: find.byType(CupertinoButton), matching: find.byType(Row)),
+      );
+      expect(row.children.length, 3);
+      expect(row.children[0], childWidget);
+      expect(row.children[1], isA<SizedBox>());
+      expect((row.children[1] as SizedBox).width, 8.0);
+      expect(row.children[2], labelWidget);
+    });
+  });
 }
 
 Widget boilerplate({required Widget child}) {


### PR DESCRIPTION
Add label and labelAlignment to CupertinoButton

Fixes https://github.com/flutter/flutter/issues/169509

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
