### PR TITLE
Update `legacy` test to be in Warn Range

### DIFF
--- a/.ci/legacy_project/README.md
+++ b/.ci/legacy_project/README.md
@@ -41,12 +41,12 @@ and then deleting everything but `android/` from it:
   `build.gradle` to maintain compatibility with plugins that use
   Flutter's most recently supported API version.
 - Modifies `gradle-wrapper.properties` to upgrade the Gradle version
-  from 8.4 to 8.11.1. If a user runs into an error with the Gradle
+  from 8.4 to 8.14. If a user runs into an error with the Gradle
   version, the warning is clear on how to upgrade the version to
   one that we support.
 - Modifies `settings.gradle` to upgrade the Android Gradle Plugin (AGP)
   from version 8.3.0 (originally set in `build.gradle`; see bullet below)
-  to 8.9.1. If a user runs into an error with the AGP version, the warning
+  to 8.11.1. If a user runs into an error with the AGP version, the warning
   is clear on how to upgrade the version to one that we support.
 - Refactor plugin to use declarative Gradle apply instead of the
   imperative apply (this includes moving where the Android Gradle

--- a/.ci/legacy_project/all_packages/android/gradle/wrapper/gradle-wrapper.properties
+++ b/.ci/legacy_project/all_packages/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/.ci/legacy_project/all_packages/android/settings.gradle
+++ b/.ci/legacy_project/all_packages/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.9.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 


### PR DESCRIPTION
I updated the error and warn versions in this PR: https://github.com/flutter/flutter/pull/189109, which broke the flutter roll into packages. The legacy version was below the error version, so I upgraded the version to the error version (which is in the warn range).

Some helpful definitions:
[very low version, error version) --> in error range; app fails (legacy test fell in this range)
[error version, warn version) --> in warn range (warning logs)
[warn version, some very modern version) --> safe range (no logs)

Fixes: https://github.com/flutter/flutter/issues/189218
Related to: https://github.com/flutter/flutter/issues/189383 

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
