### PR TITLE
[pigeon] Disable iOS test parallelization

### DIFF
--- a/packages/pigeon/example/app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/pigeon/example/app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -57,7 +57,7 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "331C8080294A63A400263BE5"

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -58,7 +58,7 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33AA165E291EB8B600ECBEEB"

--- a/packages/pigeon/platform_tests/test_plugin/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/pigeon/platform_tests/test_plugin/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -58,7 +58,7 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33A341B4291ECCA100D34E0F"


### PR DESCRIPTION
Parallelizing tests isn't worth the overhead (and potential flake) of starting up multiple simulators.

May address https://github.com/flutter/flutter/issues/189005