### PR TITLE
[image_picker_ios] Image picker with source camera no-ops on successive calls

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.13+7
+
+* Fixes early dismissal of image picker.
+
 ## 0.8.13+6
 
 * Replaces deprecated `kUTTypeGIF` with `UTTypeGIF` to fix iOS 15+ deprecation warnings.

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -323,6 +323,67 @@
   [plugin imagePickerControllerDidCancel:controller];
 }
 
+- (void)testCancelResultIsNotSentUntilDismissalCompletes {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  __block NSArray<NSString *> *pickResult = nil;
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *_Nullable result, FlutterError *_Nullable error) {
+        pickResult = result;
+      }];
+
+  __block void (^dismissCompletion)(void) = nil;
+  id mockPicker = OCMClassMock([UIImagePickerController class]);
+  OCMStub([mockPicker
+      dismissViewControllerAnimated:YES
+                         completion:[OCMArg checkWithBlock:^BOOL(void (^completion)(void)) {
+                           dismissCompletion = [completion copy];
+                           return YES;
+                         }]]);
+
+  [plugin imagePickerControllerDidCancel:mockPicker];
+
+  XCTAssertNotNil(dismissCompletion);
+  XCTAssertNil(pickResult, @"The cancel result should not be sent before dismissal completes.");
+
+  dismissCompletion();
+
+  XCTAssertEqualObjects(pickResult, @[]);
+}
+
+- (void)testPickResultIsNotSentUntilDismissalCompletes {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  __block NSArray<NSString *> *pickResult = nil;
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *_Nullable result, FlutterError *_Nullable error) {
+        pickResult = result;
+      }];
+
+  // Capture the dismissal completion instead of running it, so the test controls
+  // when dismissal "finishes".
+  __block void (^dismissCompletion)(void) = nil;
+  id mockPicker = OCMClassMock([UIImagePickerController class]);
+  OCMStub([mockPicker
+      dismissViewControllerAnimated:YES
+                         completion:[OCMArg checkWithBlock:^BOOL(void (^completion)(void)) {
+                           dismissCompletion = [completion copy];
+                           return YES;
+                         }]]);
+
+  UIImage *image = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
+  [plugin imagePickerController:mockPicker
+      didFinishPickingMediaWithInfo:@{UIImagePickerControllerOriginalImage : image}];
+
+  XCTAssertNotNil(dismissCompletion);
+  XCTAssertNil(pickResult, @"The picked media should not be sent before dismissal completes.");
+
+  dismissCompletion();
+
+  XCTAssertEqual(pickResult.count, 1);
+  XCTAssertGreaterThan(pickResult.firstObject.length, 0);
+}
+
 - (void)testCameraPickerInteractionBlockerWindowIsAddedAndRemoved {
   id mockUIImagePicker = OCMClassMock([UIImagePickerController class]);
   id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);

--- a/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
@@ -533,12 +533,15 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
 
 - (void)imagePickerController:(UIImagePickerController *)picker
     didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info {
-  NSURL *videoURL = info[UIImagePickerControllerMediaURL];
   __weak typeof(self) weakSelf = self;
   [picker dismissViewControllerAnimated:YES
                              completion:^{
                                [weakSelf removeInteractionBlocker];
+                               [weakSelf sendCallResultWithPickerInfo:info];
                              }];
+}
+
+- (void)sendCallResultWithPickerInfo:(NSDictionary<NSString *, id> *)info {
   // The method dismissViewControllerAnimated does not immediately prevent
   // further didFinishPickingMediaWithInfo invocations. A nil check is necessary
   // to prevent below code to be unwantly executed multiple times and cause a
@@ -546,6 +549,7 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   if (!self.callContext) {
     return;
   }
+  NSURL *videoURL = info[UIImagePickerControllerMediaURL];
   if (videoURL != nil) {
     if (@available(iOS 13.0, *)) {
       NSURL *destination = [FLTImagePickerPhotoAssetUtil saveVideoFromURL:videoURL];
@@ -628,8 +632,8 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   [picker dismissViewControllerAnimated:YES
                              completion:^{
                                [weakSelf removeInteractionBlocker];
+                               [weakSelf sendCallResultWithSavedPathList:nil];
                              }];
-  [self sendCallResultWithSavedPathList:nil];
 }
 
 #pragma mark -

--- a/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
@@ -533,11 +533,14 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
 
 - (void)imagePickerController:(UIImagePickerController *)picker
     didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info {
+  FLTImagePickerMethodCallContext *context = self.callContext;
   __weak typeof(self) weakSelf = self;
   [picker dismissViewControllerAnimated:YES
                              completion:^{
                                [weakSelf removeInteractionBlocker];
-                               [weakSelf sendCallResultWithPickerInfo:info];
+                               if (weakSelf.callContext == context) {
+                                 [weakSelf sendCallResultWithPickerInfo:info];
+                               }
                              }];
 }
 
@@ -628,11 +631,14 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
+  FLTImagePickerMethodCallContext *context = self.callContext;
   __weak typeof(self) weakSelf = self;
   [picker dismissViewControllerAnimated:YES
                              completion:^{
                                [weakSelf removeInteractionBlocker];
-                               [weakSelf sendCallResultWithSavedPathList:nil];
+                               if (weakSelf.callContext == context) {
+                                 [weakSelf sendCallResultWithSavedPathList:nil];
+                               }
                              }];
 }
 

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.13+6
+version: 0.8.13+7
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

When doing `_picker.pickImage(source: ImageSource.camera);` , The `dismissViewControllerAnimated` returned immediately and so the value was returned before the animated to dismiss completed, making a second immediate call to the same method error out. This PR makes the value returnal passed to the completion callback on the dismiss animation

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/188734

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
