### PR TITLE
[google_maps_flutter_platform_interface] Adds support for mapTypeControlEnabled, fullscreenControlEnabled, and streetViewControlEnabled for web

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.15.1
+## 2.16.0
 
 * Adds support for `mapTypeControlEnabled`, `fullscreenControlEnabled`, and `streetViewControlEnabled` for web.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.15.1
 
+* Adds support for `mapTypeControlEnabled`, `fullscreenControlEnabled`, and `streetViewControlEnabled` for web.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.15.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
@@ -37,6 +37,9 @@ class MapConfiguration {
     this.indoorViewEnabled,
     this.trafficEnabled,
     this.buildingsEnabled,
+    this.mapTypeControlEnabled,
+    this.fullscreenControlEnabled,
+    this.streetViewControlEnabled,
     String? mapId,
     @Deprecated('cloudMapId is deprecated. Use mapId instead.') String? cloudMapId,
     this.style,
@@ -66,6 +69,21 @@ class MapConfiguration {
 
   /// True if the map toolbar should be shown.
   final bool? mapToolbarEnabled;
+
+  /// True if map type control should be shown.
+  ///
+  /// Web only.
+  final bool? mapTypeControlEnabled;
+
+  /// True if fullscreen control should be shown.
+  ///
+  /// Web only.
+  final bool? fullscreenControlEnabled;
+
+  /// True if street view control should be shown.
+  ///
+  /// Web only.
+  final bool? streetViewControlEnabled;
 
   /// The bounds to display.
   final CameraTargetBounds? cameraTargetBounds;
@@ -210,6 +228,15 @@ class MapConfiguration {
       indoorViewEnabled: indoorViewEnabled != other.indoorViewEnabled ? indoorViewEnabled : null,
       trafficEnabled: trafficEnabled != other.trafficEnabled ? trafficEnabled : null,
       buildingsEnabled: buildingsEnabled != other.buildingsEnabled ? buildingsEnabled : null,
+      mapTypeControlEnabled: mapTypeControlEnabled != other.mapTypeControlEnabled
+          ? mapTypeControlEnabled
+          : null,
+      fullscreenControlEnabled: fullscreenControlEnabled != other.fullscreenControlEnabled
+          ? fullscreenControlEnabled
+          : null,
+      streetViewControlEnabled: streetViewControlEnabled != other.streetViewControlEnabled
+          ? streetViewControlEnabled
+          : null,
       mapId: mapId != other.mapId ? mapId : null,
       style: style != other.style ? style : null,
       markerType: markerType != other.markerType ? markerType : null,
@@ -244,6 +271,9 @@ class MapConfiguration {
       indoorViewEnabled: diff.indoorViewEnabled ?? indoorViewEnabled,
       trafficEnabled: diff.trafficEnabled ?? trafficEnabled,
       buildingsEnabled: diff.buildingsEnabled ?? buildingsEnabled,
+      mapTypeControlEnabled: diff.mapTypeControlEnabled ?? mapTypeControlEnabled,
+      fullscreenControlEnabled: diff.fullscreenControlEnabled ?? fullscreenControlEnabled,
+      streetViewControlEnabled: diff.streetViewControlEnabled ?? streetViewControlEnabled,
       mapId: diff.mapId ?? mapId,
       style: diff.style ?? style,
       markerType: diff.markerType ?? markerType,
@@ -275,6 +305,9 @@ class MapConfiguration {
       indoorViewEnabled == null &&
       trafficEnabled == null &&
       buildingsEnabled == null &&
+      mapTypeControlEnabled == null &&
+      fullscreenControlEnabled == null &&
+      streetViewControlEnabled == null &&
       mapId == null &&
       style == null &&
       markerType == null &&
@@ -311,6 +344,9 @@ class MapConfiguration {
         indoorViewEnabled == other.indoorViewEnabled &&
         trafficEnabled == other.trafficEnabled &&
         buildingsEnabled == other.buildingsEnabled &&
+        mapTypeControlEnabled == other.mapTypeControlEnabled &&
+        fullscreenControlEnabled == other.fullscreenControlEnabled &&
+        streetViewControlEnabled == other.streetViewControlEnabled &&
         mapId == other.mapId &&
         style == other.style &&
         markerType == other.markerType &&
@@ -341,6 +377,9 @@ class MapConfiguration {
     indoorViewEnabled,
     trafficEnabled,
     buildingsEnabled,
+    mapTypeControlEnabled,
+    fullscreenControlEnabled,
+    streetViewControlEnabled,
     mapId,
     style,
     markerType,

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.15.0
+version: 2.15.1
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.15.1
+version: 2.16.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/map_configuration_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/map_configuration_test.dart
@@ -36,6 +36,9 @@ void main() {
       indoorViewEnabled: false,
       trafficEnabled: false,
       buildingsEnabled: false,
+      mapTypeControlEnabled: false,
+      fullscreenControlEnabled: false,
+      streetViewControlEnabled: false,
       style: 'diff base style',
     );
 
@@ -490,6 +493,42 @@ void main() {
       // The hash code should change.
       expect(empty.hashCode, isNot(diff.hashCode));
     });
+
+    test('handle mapTypeControlEnabled', () async {
+      const diff = MapConfiguration(mapTypeControlEnabled: true);
+
+      const empty = MapConfiguration();
+      final MapConfiguration updated = diffBase.applyDiff(diff);
+
+      expect(empty.applyDiff(diff), diff);
+      expect(diff.diffFrom(empty), diff);
+      expect(updated.mapTypeControlEnabled, true);
+      expect(empty.hashCode, isNot(diff.hashCode));
+    });
+
+    test('handle fullscreenControlEnabled', () async {
+      const diff = MapConfiguration(fullscreenControlEnabled: true);
+
+      const empty = MapConfiguration();
+      final MapConfiguration updated = diffBase.applyDiff(diff);
+
+      expect(empty.applyDiff(diff), diff);
+      expect(diff.diffFrom(empty), diff);
+      expect(updated.fullscreenControlEnabled, true);
+      expect(empty.hashCode, isNot(diff.hashCode));
+    });
+
+    test('handle streetViewControlEnabled', () async {
+      const diff = MapConfiguration(streetViewControlEnabled: true);
+
+      const empty = MapConfiguration();
+      final MapConfiguration updated = diffBase.applyDiff(diff);
+
+      expect(empty.applyDiff(diff), diff);
+      expect(diff.diffFrom(empty), diff);
+      expect(updated.streetViewControlEnabled, true);
+      expect(empty.hashCode, isNot(diff.hashCode));
+    });
   });
 
   group('isEmpty', () {
@@ -646,6 +685,24 @@ void main() {
 
     test('is false with colorScheme', () async {
       const diff = MapConfiguration(colorScheme: MapColorScheme.followSystem);
+
+      expect(diff.isEmpty, false);
+    });
+
+    test('is false with mapTypeControlEnabled', () async {
+      const diff = MapConfiguration(mapTypeControlEnabled: true);
+
+      expect(diff.isEmpty, false);
+    });
+
+    test('is false with fullscreenControlEnabled', () async {
+      const diff = MapConfiguration(fullscreenControlEnabled: true);
+
+      expect(diff.isEmpty, false);
+    });
+
+    test('is false with streetViewControlEnabled', () async {
+      const diff = MapConfiguration(streetViewControlEnabled: true);
 
       expect(diff.isEmpty, false);
     });


### PR DESCRIPTION
*Part of https://github.com/flutter/packages/pull/11955*

*Part of: https://github.com/flutter/flutter/issues/104111*

**Context**:
As suggested in the review - https://github.com/flutter/packages/pull/11955#pullrequestreview-4674150031, this is a standalone sub-PR separating out just the platform interface changes. 
It introduces the necessary configuration flags (`mapTypeControlEnabled`, `fullscreenControlEnabled`, and `streetViewControlEnabled`) to `MapConfiguration` to pave the way for the web implementation.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
