### PR TITLE
[material_ui, cupertino_ui] Remove unused `@template`s

### DIFF
--- a/packages/cupertino_ui/lib/src/adaptive_text_selection_toolbar.dart
+++ b/packages/cupertino_ui/lib/src/adaptive_text_selection_toolbar.dart
@@ -17,12 +17,10 @@ import 'text_selection_toolbar_button.dart';
 /// The default Cupertino context menu for text selection for the current
 /// platform with the given children.
 ///
-/// {@template flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.platforms}
 /// Builds the mobile Cupertino context menu on all mobile platforms, not just
 /// iOS, and builds the desktop Cupertino context menu on all desktop platforms,
 /// not just MacOS. For a widget that builds the native-looking context menu for
 /// all platforms, see [AdaptiveTextSelectionToolbar].
-/// {@endtemplate}
 ///
 /// See also:
 ///

--- a/packages/cupertino_ui/lib/src/app.dart
+++ b/packages/cupertino_ui/lib/src/app.dart
@@ -53,11 +53,9 @@ import 'theme.dart';
 /// widget, which the [CupertinoApp] composes. If you use Material widgets, a
 /// [MaterialApp] also creates the needed dependencies for Cupertino widgets.
 ///
-/// {@template flutter.cupertino.CupertinoApp.defaultSelectionStyle}
 /// The [CupertinoApp] automatically creates a [DefaultSelectionStyle] with
 /// selectionColor sets to [CupertinoThemeData.primaryColor] with 0.2 opacity
 /// and cursorColor sets to [CupertinoThemeData.primaryColor].
-/// {@endtemplate}
 ///
 /// Use this widget with caution on Android since it may produce behaviors
 /// Android users are not expecting such as:

--- a/packages/cupertino_ui/lib/src/checkbox.dart
+++ b/packages/cupertino_ui/lib/src/checkbox.dart
@@ -199,7 +199,6 @@ class CupertinoCheckbox extends StatefulWidget {
   /// Defaults to [CupertinoColors.activeBlue].
   final Color? activeColor;
 
-  /// {@template flutter.cupertino.CupertinoCheckbox.fillColor}
   /// The color used to fill this checkbox.
   ///
   /// Resolves in the following states:
@@ -231,7 +230,6 @@ class CupertinoCheckbox extends StatefulWidget {
   /// ```
   ///
   /// </callout-box>
-  /// {@endtemplate}
   ///
   /// If [fillColor] resolves to null for the requested state, then the fill color
   /// falls back to [activeColor] if the state includes [WidgetState.selected],

--- a/packages/cupertino_ui/lib/src/switch.dart
+++ b/packages/cupertino_ui/lib/src/switch.dart
@@ -464,17 +464,14 @@ class CupertinoSwitch extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@template flutter.cupertino.CupertinoSwitch.applyTheme}
   /// Whether to apply the ambient [CupertinoThemeData].
   ///
   /// If true, the track uses [CupertinoThemeData.primaryColor] for the track
   /// when the switch is on.
   ///
   /// Defaults to [CupertinoThemeData.applyThemeToAll].
-  /// {@endtemplate}
   final bool? applyTheme;
 
-  /// {@template flutter.cupertino.CupertinoSwitch.dragStartBehavior}
   /// Determines the way that drag start behavior is handled.
   ///
   /// If set to [DragStartBehavior.start], the drag behavior used to move the
@@ -493,7 +490,6 @@ class CupertinoSwitch extends StatefulWidget {
   ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for
   ///    the different behaviors.
   ///
-  /// {@endtemplate}
   final DragStartBehavior dragStartBehavior;
 
   @override

--- a/packages/material_ui/lib/src/adaptive_text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/adaptive_text_selection_toolbar.dart
@@ -20,7 +20,6 @@ import 'theme.dart';
 
 /// The default context menu for text selection for the current platform.
 ///
-/// {@template flutter.material.AdaptiveTextSelectionToolbar.contextMenuBuilders}
 /// Typically, this widget would be passed to `contextMenuBuilder` in a
 /// supported parent widget, such as:
 ///
@@ -29,7 +28,6 @@ import 'theme.dart';
 /// * [CupertinoTextField.contextMenuBuilder]
 /// * [SelectionArea.contextMenuBuilder]
 /// * [SelectableText.contextMenuBuilder]
-/// {@endtemplate}
 ///
 /// See also:
 ///
@@ -195,9 +193,7 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   /// The children of the toolbar, typically buttons.
   final List<Widget>? children;
 
-  /// {@template flutter.material.AdaptiveTextSelectionToolbar.anchors}
   /// The location on which to anchor the menu.
-  /// {@endtemplate}
   final TextSelectionToolbarAnchors anchors;
 
   /// Returns the default button label String for the button of the given

--- a/packages/material_ui/lib/src/app.dart
+++ b/packages/material_ui/lib/src/app.dart
@@ -107,13 +107,11 @@ enum ThemeMode {
 /// This widget also configures the observer of the top-level [Navigator] (if
 /// any) to perform [Hero] animations.
 ///
-/// {@template flutter.material.MaterialApp.defaultSelectionStyle}
 /// The [MaterialApp] automatically creates a [DefaultSelectionStyle]. It uses
 /// the colors in the [ThemeData.textSelectionTheme] if they are not null;
 /// otherwise, the [MaterialApp] sets [DefaultSelectionStyle.selectionColor] to
 /// [ColorScheme.primary] with 0.4 opacity and
 /// [DefaultSelectionStyle.cursorColor] to [ColorScheme.primary].
-/// {@endtemplate}
 ///
 /// If [home], [routes], [onGenerateRoute], and [onUnknownRoute] are all null,
 /// and [builder] is not null, then no [Navigator] is created.
@@ -767,14 +765,12 @@ class MaterialApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.restorationScopeId}
   final String? restorationScopeId;
 
-  /// {@template flutter.material.materialApp.scrollBehavior}
   /// The default [ScrollBehavior] for the application.
   ///
   /// [ScrollBehavior]s describe how [Scrollable] widgets behave. Providing
   /// a [ScrollBehavior] can set the default [ScrollPhysics] across
   /// an application, and manage [Scrollable] decorations like [Scrollbar]s and
   /// [GlowingOverscrollIndicator]s.
-  /// {@endtemplate}
   ///
   /// When null, defaults to [MaterialScrollBehavior].
   ///

--- a/packages/material_ui/lib/src/app_bar.dart
+++ b/packages/material_ui/lib/src/app_bar.dart
@@ -694,7 +694,6 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final double? titleSpacing;
 
-  /// {@template flutter.material.appbar.toolbarOpacity}
   /// How opaque the toolbar part of the app bar is.
   ///
   /// A value of 1.0 is fully opaque, and a value of 0.0 is fully transparent.
@@ -702,10 +701,8 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// Typically, this value is not changed from its default value (1.0). It is
   /// used by [SliverAppBar] to animate the opacity of the toolbar when the app
   /// bar is scrolled.
-  /// {@endtemplate}
   final double toolbarOpacity;
 
-  /// {@template flutter.material.appbar.bottomOpacity}
   /// How opaque the bottom part of the app bar is.
   ///
   /// A value of 1.0 is fully opaque, and a value of 0.0 is fully transparent.
@@ -713,15 +710,12 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// Typically, this value is not changed from its default value (1.0). It is
   /// used by [SliverAppBar] to animate the opacity of the toolbar when the app
   /// bar is scrolled.
-  /// {@endtemplate}
   final double bottomOpacity;
 
-  /// {@template flutter.material.appbar.preferredSize}
   /// A size whose height is the sum of [toolbarHeight] and the [bottom] widget's
   /// preferred height.
   ///
   /// [Scaffold] uses this size to set its app bar's height.
-  /// {@endtemplate}
   @override
   final Size preferredSize;
 

--- a/packages/material_ui/lib/src/bottom_sheet.dart
+++ b/packages/material_ui/lib/src/bottom_sheet.dart
@@ -1047,13 +1047,11 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   /// To disable the modal bottom sheet animation, use [AnimationStyle.noAnimation].
   final AnimationStyle? sheetAnimationStyle;
 
-  /// {@template flutter.material.ModalBottomSheetRoute.barrierOnTapHint}
   /// The semantic hint text that informs users what will happen if they
   /// tap on the widget. Announced in the format of 'Double tap to ...'.
   ///
   /// If the field is null, the default hint will be used, which results in
   /// announcement of 'Double tap to activate'.
-  /// {@endtemplate}
   ///
   /// See also:
   ///

--- a/packages/material_ui/lib/src/desktop_text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/desktop_text_selection_toolbar.dart
@@ -35,10 +35,8 @@ class DesktopTextSelectionToolbar extends StatelessWidget {
   const DesktopTextSelectionToolbar({super.key, required this.anchor, required this.children})
     : assert(children.length > 0);
 
-  /// {@template flutter.material.DesktopTextSelectionToolbar.anchor}
   /// The point where the toolbar will attempt to position itself as closely as
   /// possible.
-  /// {@endtemplate}
   final Offset anchor;
 
   /// {@macro flutter.material.TextSelectionToolbar.children}

--- a/packages/material_ui/lib/src/dialog.dart
+++ b/packages/material_ui/lib/src/dialog.dart
@@ -195,21 +195,17 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final Color? surfaceTintColor;
 
-  /// {@template flutter.material.dialog.insetAnimationDuration}
   /// The duration of the animation to show when the system keyboard intrudes
   /// into the space that the dialog is placed in.
   ///
   /// Defaults to 100 milliseconds when [Dialog] is used, and [Duration.zero]
   /// when [Dialog.fullscreen] is used.
-  /// {@endtemplate}
   final Duration insetAnimationDuration;
 
-  /// {@template flutter.material.dialog.insetAnimationCurve}
   /// The curve to use for the animation shown when the system keyboard intrudes
   /// into the space that the dialog is placed in.
   ///
   /// Defaults to [Curves.decelerate].
-  /// {@endtemplate}
   final Curve insetAnimationCurve;
 
   /// {@template flutter.material.dialog.insetPadding}
@@ -1603,10 +1599,8 @@ class _DialogContentPage extends Page<void> {
 /// argument is ignored as dialogs are displayed in their own windows which
 /// manage focus traversal independently.
 ///
-/// {@template flutter.material.dialog.requestFocus}
 /// The `requestFocus` argument is used to specify whether the dialog should
 /// request focus when shown.
-/// {@endtemplate}
 /// {@macro flutter.widgets.navigator.Route.requestFocus}
 /// If windowing is enabled via `flutter config --enable-windowing`, then this
 /// argument is ignored as dialogs are displayed in their own windows which are

--- a/packages/material_ui/lib/src/list_tile.dart
+++ b/packages/material_ui/lib/src/list_tile.dart
@@ -701,7 +701,6 @@ class ListTile extends StatelessWidget {
   /// {@macro flutter.material.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
-  /// {@template flutter.material.ListTile.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
@@ -710,7 +709,6 @@ class ListTile extends StatelessWidget {
   ///
   ///  * [WidgetState.selected].
   ///  * [WidgetState.disabled].
-  /// {@endtemplate}
   ///
   /// If null, then the value of [ListTileThemeData.mouseCursor] is used. If
   /// that is also null, then [WidgetStateMouseCursor.clickable] is used.

--- a/packages/material_ui/lib/src/material.dart
+++ b/packages/material_ui/lib/src/material.dart
@@ -268,7 +268,6 @@ class Material extends StatefulWidget {
 
   /// The color to paint the shadow below the material.
   ///
-  /// {@template flutter.material.material.shadowColor}
   /// If null and [ThemeData.useMaterial3] is true then [ThemeData]'s
   /// [ColorScheme.shadow] will be used. If [ThemeData.useMaterial3] is false
   /// then [ThemeData.shadowColor] will be used.
@@ -281,13 +280,11 @@ class Material extends StatefulWidget {
   ///    property if it is null.
   ///  * [ThemeData.applyElevationOverlayColor], which turns elevation overlay
   /// on or off for dark themes.
-  /// {@endtemplate}
   final Color? shadowColor;
 
   /// The color of the surface tint overlay applied to the material color
   /// to indicate elevation.
   ///
-  /// {@template flutter.material.material.surfaceTintColor}
   /// Material Design 3 introduced a new way for some components to indicate
   /// their elevation by using a surface tint color overlay on top of the
   /// base material [color]. This overlay is painted with an opacity that is
@@ -308,7 +305,6 @@ class Material extends StatefulWidget {
   ///     tint.
   ///   * https://m3.material.io/styles/color/the-color-system/color-roles
   ///     which specifies how the overlay is applied.
-  /// {@endtemplate}
   final Color? surfaceTintColor;
 
   /// The typographical style to use for text within this material.
@@ -316,13 +312,11 @@ class Material extends StatefulWidget {
 
   /// Defines the material's shape as well its shadow.
   ///
-  /// {@template flutter.material.material.shape}
   /// If shape is non null, the [borderRadius] is ignored and the material's
   /// clip boundary and shadow are defined by the shape.
   ///
   /// A shadow is only displayed if the [elevation] is greater than
   /// zero.
-  /// {@endtemplate}
   final ShapeBorder? shape;
 
   /// Whether to paint the [shape] border in front of the [child].

--- a/packages/material_ui/lib/src/progress_indicator.dart
+++ b/packages/material_ui/lib/src/progress_indicator.dart
@@ -88,7 +88,6 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// for the given use case. See the subclass documentation for details.
   final Color? backgroundColor;
 
-  /// {@template flutter.progress_indicator.ProgressIndicator.color}
   /// The progress indicator's color.
   ///
   /// This is only used if [ProgressIndicator.valueColor] is null.
@@ -96,7 +95,6 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// [ProgressIndicatorThemeData.color] will be used. If that
   /// is null then the current theme's [ColorScheme.primary] will
   /// be used by default.
-  /// {@endtemplate}
   final Color? color;
 
   /// The progress indicator's color as an animated value.

--- a/packages/material_ui/lib/src/radio.dart
+++ b/packages/material_ui/lib/src/radio.dart
@@ -189,21 +189,18 @@ class Radio<T> extends StatefulWidget {
   /// {@macro flutter.widget.RawRadio.value}
   final T value;
 
-  /// {@template flutter.material.Radio.groupValue}
   /// The currently selected value for a group of radio buttons.
   ///
   /// This radio button is considered selected if its [value] matches the
   /// [groupValue].
   ///
   /// This is deprecated, use [RadioGroup] to manage group value instead.
-  /// {@endtemplate}
   @Deprecated(
     'Use a RadioGroup ancestor to manage group value instead. '
     'This feature was deprecated after v3.32.0-0.0.pre.',
   )
   final T? groupValue;
 
-  /// {@template flutter.material.Radio.onChanged}
   /// Called when the user selects this radio button.
   ///
   /// The radio button passes [value] as a parameter to this callback. The radio
@@ -221,7 +218,6 @@ class Radio<T> extends StatefulWidget {
   /// The callback provided to [onChanged] should update the state of the parent
   /// [StatefulWidget] using the [State.setState] method, so that the parent
   /// gets rebuilt.
-  /// {@endtemplate}
   ///
   /// For example:
   ///
@@ -427,7 +423,6 @@ class Radio<T> extends StatefulWidget {
 
   final _RadioType _radioType;
 
-  /// {@template flutter.material.Radio.enabled}
   /// Whether this widget is interactive.
   ///
   /// If not provided, this widget will be interactable if one of the following
@@ -439,7 +434,6 @@ class Radio<T> extends StatefulWidget {
   ///
   /// If this is set to true, one of the above condition must also be true.
   /// Otherwise, an assertion error is thrown.
-  /// {@endtemplate}
   final bool? enabled;
 
   /// {@template flutter.material.Radio.backgroundColor}

--- a/packages/material_ui/lib/src/text_field.dart
+++ b/packages/material_ui/lib/src/text_field.dart
@@ -739,7 +739,6 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.selectionEnabled}
   bool get selectionEnabled => enableInteractiveSelection;
 
-  /// {@template flutter.material.textfield.onTap}
   /// Called for the first tap in a series of taps.
   ///
   /// The text field builds a [GestureDetector] to handle input events like tap,
@@ -758,7 +757,6 @@ class TextField extends StatefulWidget {
   ///
   /// To listen to arbitrary pointer events without competing with the
   /// text field's internal gesture detector, use a [Listener].
-  /// {@endtemplate}
   ///
   /// If [onTapAlwaysCalled] is enabled, this will also be called for consecutive
   /// taps.

--- a/packages/material_ui/lib/src/text_form_field.dart
+++ b/packages/material_ui/lib/src/text_form_field.dart
@@ -339,10 +339,8 @@ class TextFormField extends FormField<String> {
   /// {@macro flutter.widgets.editableText.groupId}
   final Object groupId;
 
-  /// {@template flutter.material.TextFormField.onChanged}
   /// Called when the user initiates a change to the TextField's
   /// value: when they have inserted or deleted text or reset the form.
-  /// {@endtemplate}
   final ValueChanged<String>? onChanged;
 
   static Widget _defaultContextMenuBuilder(

--- a/packages/material_ui/lib/src/text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/text_selection_toolbar.dart
@@ -48,18 +48,14 @@ class TextSelectionToolbar extends StatelessWidget {
     required this.children,
   }) : assert(children.length > 0);
 
-  /// {@template flutter.material.TextSelectionToolbar.anchorAbove}
   /// The focal point above which the toolbar attempts to position itself.
   ///
   /// If there is not enough room above before reaching the top of the screen,
   /// then the toolbar will position itself below [anchorBelow].
-  /// {@endtemplate}
   final Offset anchorAbove;
 
-  /// {@template flutter.material.TextSelectionToolbar.anchorBelow}
   /// The focal point below which the toolbar attempts to position itself, if it
   /// doesn't fit above [anchorAbove].
-  /// {@endtemplate}
   final Offset anchorBelow;
 
   /// {@template flutter.material.TextSelectionToolbar.children}
@@ -75,12 +71,10 @@ class TextSelectionToolbar extends StatelessWidget {
   ///     style text selection toolbar text button.
   final List<Widget> children;
 
-  /// {@template flutter.material.TextSelectionToolbar.toolbarBuilder}
   /// Builds the toolbar container.
   ///
   /// Useful for customizing the high-level background of the toolbar. The given
   /// child Widget will contain all of the [children].
-  /// {@endtemplate}
   final ToolbarBuilder toolbarBuilder;
 
   /// The size of the text selection handles.


### PR DESCRIPTION
This PR removes `{@template}`s that are defined in Material or Cupertino but are not used in either library.

Removing these directives is necessary, because otherwise `dartdoc` will see the same macro defined in both M/C and the Flutter framework, and recognize them as duplicate templates. The result is that changing the content of the macros in M/C will be useless, because dartdoc will always replace them with the version from the Flutter framework.

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
