### PR TITLE
[material_ui, cupertino_ui] Migrate `@macro`s that are defined in Material and used in Cupertino

### DIFF
--- a/packages/cupertino_ui/lib/src/adaptive_text_selection_toolbar.dart
+++ b/packages/cupertino_ui/lib/src/adaptive_text_selection_toolbar.dart
@@ -158,7 +158,9 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
          onShare: null, // See https://github.com/flutter/flutter/issues/141775.
        );
 
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.anchors}
+  /// {@template flutter.cupertino.AdaptiveTextSelectionToolbar.anchors}
+  /// The location on which to anchor the menu.
+  /// {@endtemplate}
   final TextSelectionToolbarAnchors anchors;
 
   /// The children of the toolbar, typically buttons.

--- a/packages/cupertino_ui/lib/src/app.dart
+++ b/packages/cupertino_ui/lib/src/app.dart
@@ -447,7 +447,7 @@ class CupertinoApp extends StatefulWidget {
 
   /// {@template flutter.cupertino.materialApp.scrollBehavior}
   /// The default [ScrollBehavior] for the application.
-  /// 
+  ///
   /// [ScrollBehavior]s describe how [Scrollable] widgets behave. Providing
   /// a [ScrollBehavior] can set the default [ScrollPhysics] across
   /// an application, and manage [Scrollable] decorations like [Scrollbar]s and

--- a/packages/cupertino_ui/lib/src/app.dart
+++ b/packages/cupertino_ui/lib/src/app.dart
@@ -445,7 +445,14 @@ class CupertinoApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.restorationScopeId}
   final String? restorationScopeId;
 
-  /// {@macro flutter.material.materialApp.scrollBehavior}
+  /// {@template flutter.cupertino.materialApp.scrollBehavior}
+  /// The default [ScrollBehavior] for the application.
+  /// 
+  /// [ScrollBehavior]s describe how [Scrollable] widgets behave. Providing
+  /// a [ScrollBehavior] can set the default [ScrollPhysics] across
+  /// an application, and manage [Scrollable] decorations like [Scrollbar]s and
+  /// [GlowingOverscrollIndicator]s.
+  /// {@endtemplate}
   ///
   /// When null, defaults to [CupertinoScrollBehavior].
   ///

--- a/packages/cupertino_ui/lib/src/desktop_text_selection_toolbar.dart
+++ b/packages/cupertino_ui/lib/src/desktop_text_selection_toolbar.dart
@@ -86,10 +86,13 @@ class CupertinoDesktopTextSelectionToolbar extends StatelessWidget {
     ];
   }
 
-  /// {@macro flutter.material.DesktopTextSelectionToolbar.anchor}
+  /// {@template flutter.cupertino.DesktopTextSelectionToolbar.anchor}
+  /// The point where the toolbar will attempt to position itself as closely as
+  /// possible.
+  /// {@endtemplate}
   final Offset anchor;
 
-  /// {@macro flutter.material.TextSelectionToolbar.children}
+  /// {@macro flutter.cupertino.TextSelectionToolbar.children}
   ///
   /// See also:
   ///   * [CupertinoDesktopTextSelectionToolbarButton], which builds a default

--- a/packages/cupertino_ui/lib/src/dialog.dart
+++ b/packages/cupertino_ui/lib/src/dialog.dart
@@ -292,7 +292,7 @@ class CupertinoAlertDialog extends StatefulWidget {
   /// {@template flutter.cupertino.dialog.insetAnimationDuration}
   /// The duration of the animation to show when the system keyboard intrudes
   /// into the space that the dialog is placed in.
-  /// 
+  ///
   /// Defaults to 100 milliseconds when [Dialog] is used, and [Duration.zero]
   /// when [Dialog.fullscreen] is used.
   /// {@endtemplate}
@@ -301,7 +301,7 @@ class CupertinoAlertDialog extends StatefulWidget {
   /// {@template flutter.cupertino.dialog.insetAnimationCurve}
   /// The curve to use for the animation shown when the system keyboard intrudes
   /// into the space that the dialog is placed in.
-  /// 
+  ///
   /// Defaults to [Curves.decelerate].
   /// {@endtemplate}
   final Curve insetAnimationCurve;

--- a/packages/cupertino_ui/lib/src/dialog.dart
+++ b/packages/cupertino_ui/lib/src/dialog.dart
@@ -289,10 +289,21 @@ class CupertinoAlertDialog extends StatefulWidget {
   ///    section when it is long.
   final ScrollController? actionScrollController;
 
-  /// {@macro flutter.material.dialog.insetAnimationDuration}
+  /// {@template flutter.cupertino.dialog.insetAnimationDuration}
+  /// The duration of the animation to show when the system keyboard intrudes
+  /// into the space that the dialog is placed in.
+  /// 
+  /// Defaults to 100 milliseconds when [Dialog] is used, and [Duration.zero]
+  /// when [Dialog.fullscreen] is used.
+  /// {@endtemplate}
   final Duration insetAnimationDuration;
 
-  /// {@macro flutter.material.dialog.insetAnimationCurve}
+  /// {@template flutter.cupertino.dialog.insetAnimationCurve}
+  /// The curve to use for the animation shown when the system keyboard intrudes
+  /// into the space that the dialog is placed in.
+  /// 
+  /// Defaults to [Curves.decelerate].
+  /// {@endtemplate}
   final Curve insetAnimationCurve;
 
   @override

--- a/packages/cupertino_ui/lib/src/form_section.dart
+++ b/packages/cupertino_ui/lib/src/form_section.dart
@@ -56,7 +56,7 @@ const EdgeInsetsDirectional _kFormDefaultInsetGroupedRowsMargin = EdgeInsetsDire
 /// The [backgroundColor] parameter sets the background color behind the section.
 /// If null, defaults to [CupertinoColors.systemGroupedBackground].
 ///
-/// {@macro flutter.material.Material.clipBehavior}
+/// {@macro flutter.cupertino.Material.clipBehavior}
 ///
 /// See also:
 ///
@@ -95,7 +95,7 @@ class CupertinoFormSection extends StatelessWidget {
   /// The [backgroundColor] parameter sets the background color behind the
   /// section. If null, defaults to [CupertinoColors.systemGroupedBackground].
   ///
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   const CupertinoFormSection({
     super.key,
     required this.children,
@@ -141,7 +141,7 @@ class CupertinoFormSection extends StatelessWidget {
   /// The [backgroundColor] parameter sets the background color behind the
   /// section. If null, defaults to [CupertinoColors.systemGroupedBackground].
   ///
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   const CupertinoFormSection.insetGrouped({
     super.key,
     required this.children,
@@ -194,7 +194,7 @@ class CupertinoFormSection extends StatelessWidget {
   /// Defaults to [CupertinoColors.systemGroupedBackground].
   final Color backgroundColor;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/cupertino_ui/lib/src/list_section.dart
+++ b/packages/cupertino_ui/lib/src/list_section.dart
@@ -159,7 +159,7 @@ enum CupertinoListSectionType {
 /// The [backgroundColor] of the section defaults to
 /// [CupertinoColors.systemGroupedBackground].
 ///
-/// {@macro flutter.material.Material.clipBehavior}
+/// {@macro flutter.cupertino.Material.clipBehavior}
 ///
 /// <callout-box>
 ///
@@ -241,7 +241,7 @@ class CupertinoListSection extends StatelessWidget {
   /// The [topMargin] is used to specify the margin above the list section. It
   /// matches the iOS look by default.
   ///
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   const CupertinoListSection({
     super.key,
     this.children,
@@ -305,7 +305,7 @@ class CupertinoListSection extends StatelessWidget {
   /// widgets contain leading or not. Used for calculating correct starting
   /// margin for the divider between rows.
   ///
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   const CupertinoListSection.insetGrouped({
     super.key,
     this.children,
@@ -378,7 +378,7 @@ class CupertinoListSection extends StatelessWidget {
   /// Defaults to [CupertinoColors.systemGroupedBackground].
   final Color backgroundColor;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/cupertino_ui/lib/src/menu_anchor.dart
+++ b/packages/cupertino_ui/lib/src/menu_anchor.dart
@@ -1798,7 +1798,12 @@ class CupertinoMenuItem extends StatelessWidget implements CupertinoMenuEntry {
   /// pointer event, which is always between frames.
   final ValueChanged<bool>? onHover;
 
-  /// {@macro flutter.material.inkwell.onFocusChange}
+  /// {@template flutter.cupertino.inkwell.onFocusChange}
+  /// Handler called when the focus changes.
+  /// 
+  /// Called with true if this widget's node gains focus, and false if it loses
+  /// focus.
+  /// {@endtemplate}
   final ValueChanged<bool>? onFocusChange;
 
   /// Whether hovering should request focus for this widget.

--- a/packages/cupertino_ui/lib/src/menu_anchor.dart
+++ b/packages/cupertino_ui/lib/src/menu_anchor.dart
@@ -1800,7 +1800,7 @@ class CupertinoMenuItem extends StatelessWidget implements CupertinoMenuEntry {
 
   /// {@template flutter.cupertino.inkwell.onFocusChange}
   /// Handler called when the focus changes.
-  /// 
+  ///
   /// Called with true if this widget's node gains focus, and false if it loses
   /// focus.
   /// {@endtemplate}

--- a/packages/cupertino_ui/lib/src/radio.dart
+++ b/packages/cupertino_ui/lib/src/radio.dart
@@ -137,10 +137,10 @@ class CupertinoRadio<T> extends StatefulWidget {
 
   /// {@template flutter.cupertino.Radio.groupValue}
   /// The currently selected value for a group of radio buttons.
-  /// 
+  ///
   /// This radio button is considered selected if its [value] matches the
   /// [groupValue].
-  /// 
+  ///
   /// This is deprecated, use [RadioGroup] to manage group value instead.
   /// {@endtemplate}
   @Deprecated(
@@ -151,19 +151,19 @@ class CupertinoRadio<T> extends StatefulWidget {
 
   /// {@template flutter.cupertino.Radio.onChanged}
   /// Called when the user selects this radio button.
-  /// 
+  ///
   /// The radio button passes [value] as a parameter to this callback. The radio
   /// button does not actually change state until the parent widget rebuilds the
   /// radio button with the new [groupValue].
-  /// 
+  ///
   /// If null, the radio button will be displayed as disabled.
-  /// 
+  ///
   /// The provided callback will not be invoked if this radio button is already
   /// selected and [toggleable] is not set to true.
-  /// 
+  ///
   /// If the [toggleable] is set to true, tapping a already selected radio will
   /// invoke this callback with `null` as value.
-  /// 
+  ///
   /// The callback provided to [onChanged] should update the state of the parent
   /// [StatefulWidget] using the [State.setState] method, so that the parent
   /// gets rebuilt.
@@ -259,14 +259,14 @@ class CupertinoRadio<T> extends StatefulWidget {
 
   /// {@template flutter.cupertino.Radio.enabled}
   /// Whether this widget is interactive.
-  /// 
+  ///
   /// If not provided, this widget will be interactable if one of the following
   /// is true:
-  /// 
+  ///
   /// * A [onChanged] is provided.
   /// * Having a [RadioGroup] with the same type T above this widget.
   /// * A [groupRegistry] is provided.
-  /// 
+  ///
   /// If this is set to true, one of the above condition must also be true.
   /// Otherwise, an assertion error is thrown.
   /// {@endtemplate}

--- a/packages/cupertino_ui/lib/src/radio.dart
+++ b/packages/cupertino_ui/lib/src/radio.dart
@@ -135,14 +135,39 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// {@macro flutter.widget.RawRadio.value}
   final T value;
 
-  /// {@macro flutter.material.Radio.groupValue}
+  /// {@template flutter.cupertino.Radio.groupValue}
+  /// The currently selected value for a group of radio buttons.
+  /// 
+  /// This radio button is considered selected if its [value] matches the
+  /// [groupValue].
+  /// 
+  /// This is deprecated, use [RadioGroup] to manage group value instead.
+  /// {@endtemplate}
   @Deprecated(
     'Use a RadioGroup ancestor to manage group value instead. '
     'This feature was deprecated after v3.32.0-0.0.pre.',
   )
   final T? groupValue;
 
-  /// {@macro flutter.material.Radio.onChanged}
+  /// {@template flutter.cupertino.Radio.onChanged}
+  /// Called when the user selects this radio button.
+  /// 
+  /// The radio button passes [value] as a parameter to this callback. The radio
+  /// button does not actually change state until the parent widget rebuilds the
+  /// radio button with the new [groupValue].
+  /// 
+  /// If null, the radio button will be displayed as disabled.
+  /// 
+  /// The provided callback will not be invoked if this radio button is already
+  /// selected and [toggleable] is not set to true.
+  /// 
+  /// If the [toggleable] is set to true, tapping a already selected radio will
+  /// invoke this callback with `null` as value.
+  /// 
+  /// The callback provided to [onChanged] should update the state of the parent
+  /// [StatefulWidget] using the [State.setState] method, so that the parent
+  /// gets rebuilt.
+  /// {@endtemplate}
   ///
   /// For example:
   ///
@@ -232,7 +257,19 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// [RadioGroupRegistry].
   final RadioGroupRegistry<T>? groupRegistry;
 
-  /// {@macro flutter.material.Radio.enabled}
+  /// {@template flutter.cupertino.Radio.enabled}
+  /// Whether this widget is interactive.
+  /// 
+  /// If not provided, this widget will be interactable if one of the following
+  /// is true:
+  /// 
+  /// * A [onChanged] is provided.
+  /// * Having a [RadioGroup] with the same type T above this widget.
+  /// * A [groupRegistry] is provided.
+  /// 
+  /// If this is set to true, one of the above condition must also be true.
+  /// Otherwise, an assertion error is thrown.
+  /// {@endtemplate}
   final bool? enabled;
 
   @override

--- a/packages/cupertino_ui/lib/src/route.dart
+++ b/packages/cupertino_ui/lib/src/route.dart
@@ -1373,7 +1373,10 @@ Widget _buildCupertinoDialogTransitions(
 /// By default, `useRootNavigator` is `true` and the dialog route created by
 /// this method is pushed to the root navigator.
 ///
-/// {@macro flutter.material.dialog.requestFocus}
+/// {@template flutter.cupertino.dialog.requestFocus}
+/// The `requestFocus` argument is used to specify whether the dialog should
+/// request focus when shown.
+/// {@endtemplate}
 /// {@macro flutter.widgets.navigator.Route.requestFocus}
 ///
 /// {@macro flutter.widgets.RawDialogRoute}

--- a/packages/cupertino_ui/lib/src/search_field.dart
+++ b/packages/cupertino_ui/lib/src/search_field.dart
@@ -284,7 +284,7 @@ class CupertinoSearchTextField extends StatefulWidget {
   /// necessarily clearing text.
   final VoidCallback? onSuffixTap;
 
-  /// {@macro flutter.material.textfield.restorationId}
+  /// {@macro flutter.cupertino.textfield.restorationId}
   final String? restorationId;
 
   /// {@macro flutter.widgets.Focus.focusNode}
@@ -293,7 +293,7 @@ class CupertinoSearchTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.material.textfield.onTap}
+  /// {@macro flutter.cupertino.textfield.onTap}
   final VoidCallback? onTap;
 
   /// Whether to enable autocorrection.

--- a/packages/cupertino_ui/lib/src/switch.dart
+++ b/packages/cupertino_ui/lib/src/switch.dart
@@ -288,16 +288,26 @@ class CupertinoSwitch extends StatefulWidget {
   /// (or [Color.fromARGB(255, 255, 255, 255)] in high contrast) when null.
   final Color? offLabelColor;
 
-  /// {@macro flutter.material.switch.activeThumbImage}
+  /// {@template flutter.cupertino.switch.activeThumbImage}
+  /// An image to use on the thumb of this switch when the switch is on.
+  /// {@endtemplate}
   final ImageProvider? activeThumbImage;
 
-  /// {@macro flutter.material.switch.onActiveThumbImageError}
+  /// {@template flutter.cupertino.switch.onActiveThumbImageError}
+  /// An optional error callback for errors emitted when loading
+  /// [activeThumbImage].
+  /// {@endtemplate}
   final ImageErrorListener? onActiveThumbImageError;
 
-  /// {@macro flutter.material.switch.inactiveThumbImage}
+  /// {@template flutter.cupertino.switch.inactiveThumbImage}
+  /// An image to use on the thumb of this switch when the switch is off.
+  /// {@endtemplate}
   final ImageProvider? inactiveThumbImage;
 
-  /// {@macro flutter.material.switch.onInactiveThumbImageError}
+  /// {@template flutter.cupertino.switch.onInactiveThumbImageError}
+  /// An optional error callback for errors emitted when loading
+  /// [inactiveThumbImage].
+  /// {@endtemplate}
   final ImageErrorListener? onInactiveThumbImageError;
 
   /// The outline color of this [CupertinoSwitch]'s track.

--- a/packages/cupertino_ui/lib/src/text_field.dart
+++ b/packages/cupertino_ui/lib/src/text_field.dart
@@ -615,7 +615,7 @@ class CupertinoTextField extends StatefulWidget {
 
   /// {@template flutter.cupertino.InputDecorator.textAlignVertical}
   /// How the text should be aligned vertically.
-  /// 
+  ///
   /// Determines the alignment of the baseline within the available space of
   /// the input (typically a TextField). For example, TextAlignVertical.top will
   /// place the baseline such that the text, and any attached decoration like
@@ -796,21 +796,21 @@ class CupertinoTextField extends StatefulWidget {
 
   /// {@template flutter.cupertino.textfield.onTap}
   /// Called for the first tap in a series of taps.
-  /// 
+  ///
   /// The text field builds a [GestureDetector] to handle input events like tap,
   /// to trigger focus requests, to move the caret, adjust the selection, etc.
   /// Handling some of those events by wrapping the text field with a competing
   /// GestureDetector is problematic.
-  /// 
+  ///
   /// To unconditionally handle taps, without interfering with the text field's
   /// internal gesture detector, provide this callback.
-  /// 
+  ///
   /// If the text field is created with [enabled] false, taps will not be
   /// recognized.
-  /// 
+  ///
   /// To be notified when the text field gains or loses the focus, provide a
   /// [focusNode] and add a listener to that.
-  /// 
+  ///
   /// To listen to arbitrary pointer events without competing with the
   /// text field's internal gesture detector, use a [Listener].
   /// {@endtemplate}
@@ -822,7 +822,7 @@ class CupertinoTextField extends StatefulWidget {
 
   /// {@template flutter.cupertino.Material.clipBehavior}
   /// The content will be clipped (or not) according to this option.
-  /// 
+  ///
   /// See the enum [Clip] for details of all possible options and their common
   /// use cases.
   /// {@endtemplate}
@@ -832,18 +832,18 @@ class CupertinoTextField extends StatefulWidget {
 
   /// {@template flutter.cupertino.textfield.restorationId}
   /// Restoration ID to save and restore the state of the text field.
-  /// 
+  ///
   /// If non-null, the text field will persist and restore its current scroll
   /// offset and - if no [controller] has been provided - the content of the
   /// text field. If a [controller] has been provided, it is the responsibility
   /// of the owner of that controller to persist and restore it, e.g. by using
   /// a [RestorableTextEditingController].
-  /// 
+  ///
   /// The state of this widget is persisted in a [RestorationBucket] claimed
   /// from the surrounding [RestorationScope] using the provided restoration ID.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [RestorationManager], which explains how state restoration works in
   ///    Flutter.
   /// {@endtemplate}

--- a/packages/cupertino_ui/lib/src/text_field.dart
+++ b/packages/cupertino_ui/lib/src/text_field.dart
@@ -167,7 +167,12 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder
 /// rounded rectangle border around the text field. If you set the [decoration]
 /// property to null, the decoration will be removed entirely.
 ///
-/// {@macro flutter.material.textfield.wantKeepAlive}
+/// {@template flutter.cupertino.textfield.wantKeepAlive}
+/// When the widget has focus, it will prevent itself from disposing via its
+/// underlying [EditableText]'s [AutomaticKeepAliveClientMixin.wantKeepAlive] in
+/// order to avoid losing the selection. Removing the focus will allow it to be
+/// disposed.
+/// {@endtemplate}
 ///
 /// Remember to call [TextEditingController.dispose] when it is no longer
 /// needed. This will ensure we discard any resources used by the object.
@@ -608,7 +613,18 @@ class CupertinoTextField extends StatefulWidget {
   )
   final ToolbarOptions? toolbarOptions;
 
-  /// {@macro flutter.material.InputDecorator.textAlignVertical}
+  /// {@template flutter.cupertino.InputDecorator.textAlignVertical}
+  /// How the text should be aligned vertically.
+  /// 
+  /// Determines the alignment of the baseline within the available space of
+  /// the input (typically a TextField). For example, TextAlignVertical.top will
+  /// place the baseline such that the text, and any attached decoration like
+  /// prefix and suffix, is as close to the top of the input as possible without
+  /// overflowing. The heights of the prefix and suffix are similarly included
+  /// for other alignment values. If the height is greater than the height
+  /// available, then the prefix and suffix will be allowed to overflow first
+  /// before the text scrolls.
+  /// {@endtemplate}
   final TextAlignVertical? textAlignVertical;
 
   /// {@macro flutter.widgets.editableText.textDirection}
@@ -778,19 +794,59 @@ class CupertinoTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.selectionEnabled}
   bool get selectionEnabled => enableInteractiveSelection;
 
-  /// {@macro flutter.material.textfield.onTap}
+  /// {@template flutter.cupertino.textfield.onTap}
+  /// Called for the first tap in a series of taps.
+  /// 
+  /// The text field builds a [GestureDetector] to handle input events like tap,
+  /// to trigger focus requests, to move the caret, adjust the selection, etc.
+  /// Handling some of those events by wrapping the text field with a competing
+  /// GestureDetector is problematic.
+  /// 
+  /// To unconditionally handle taps, without interfering with the text field's
+  /// internal gesture detector, provide this callback.
+  /// 
+  /// If the text field is created with [enabled] false, taps will not be
+  /// recognized.
+  /// 
+  /// To be notified when the text field gains or loses the focus, provide a
+  /// [focusNode] and add a listener to that.
+  /// 
+  /// To listen to arbitrary pointer events without competing with the
+  /// text field's internal gesture detector, use a [Listener].
+  /// {@endtemplate}
   final GestureTapCallback? onTap;
 
   /// {@macro flutter.widgets.editableText.autofillHints}
   /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@template flutter.cupertino.Material.clipBehavior}
+  /// The content will be clipped (or not) according to this option.
+  /// 
+  /// See the enum [Clip] for details of all possible options and their common
+  /// use cases.
+  /// {@endtemplate}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
-  /// {@macro flutter.material.textfield.restorationId}
+  /// {@template flutter.cupertino.textfield.restorationId}
+  /// Restoration ID to save and restore the state of the text field.
+  /// 
+  /// If non-null, the text field will persist and restore its current scroll
+  /// offset and - if no [controller] has been provided - the content of the
+  /// text field. If a [controller] has been provided, it is the responsibility
+  /// of the owner of that controller to persist and restore it, e.g. by using
+  /// a [RestorableTextEditingController].
+  /// 
+  /// The state of this widget is persisted in a [RestorationBucket] claimed
+  /// from the surrounding [RestorationScope] using the provided restoration ID.
+  /// 
+  /// See also:
+  /// 
+  ///  * [RestorationManager], which explains how state restoration works in
+  ///    Flutter.
+  /// {@endtemplate}
   final String? restorationId;
 
   /// {@macro flutter.widgets.editableText.scribbleEnabled}

--- a/packages/cupertino_ui/lib/src/text_form_field_row.dart
+++ b/packages/cupertino_ui/lib/src/text_form_field_row.dart
@@ -283,7 +283,10 @@ class CupertinoTextFormFieldRow extends FormField<String> {
   /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController? controller;
 
-  /// {@macro flutter.material.TextFormField.onChanged}
+  /// {@template flutter.cupertino.TextFormField.onChanged}
+  /// Called when the user initiates a change to the TextField's
+  /// value: when they have inserted or deleted text or reset the form.
+  /// {@endtemplate}
   final ValueChanged<String>? onChanged;
 
   static Widget _defaultContextMenuBuilder(

--- a/packages/cupertino_ui/lib/src/text_selection_toolbar.dart
+++ b/packages/cupertino_ui/lib/src/text_selection_toolbar.dart
@@ -99,7 +99,7 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
 
   /// {@template flutter.cupertino.TextSelectionToolbar.anchorAbove}
   /// The focal point above which the toolbar attempts to position itself.
-  /// 
+  ///
   /// If there is not enough room above before reaching the top of the screen,
   /// then the toolbar will position itself below [anchorBelow].
   /// {@endtemplate}
@@ -113,9 +113,9 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
 
   /// {@template flutter.cupertino.TextSelectionToolbar.children}
   /// The children that will be displayed in the text selection toolbar.
-  /// 
+  ///
   /// Typically these are buttons.
-  /// 
+  ///
   /// Must not be empty.
   /// {@endtemplate}
   ///
@@ -126,7 +126,7 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
 
   /// {@template flutter.cupertino.TextSelectionToolbar.toolbarBuilder}
   /// Builds the toolbar container.
-  /// 
+  ///
   /// Useful for customizing the high-level background of the toolbar. The given
   /// child Widget will contain all of the [children].
   /// {@endtemplate}

--- a/packages/cupertino_ui/lib/src/text_selection_toolbar.dart
+++ b/packages/cupertino_ui/lib/src/text_selection_toolbar.dart
@@ -97,20 +97,39 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
     this.toolbarBuilder = _defaultToolbarBuilder,
   }) : assert(children.length > 0);
 
-  /// {@macro flutter.material.TextSelectionToolbar.anchorAbove}
+  /// {@template flutter.cupertino.TextSelectionToolbar.anchorAbove}
+  /// The focal point above which the toolbar attempts to position itself.
+  /// 
+  /// If there is not enough room above before reaching the top of the screen,
+  /// then the toolbar will position itself below [anchorBelow].
+  /// {@endtemplate}
   final Offset anchorAbove;
 
-  /// {@macro flutter.material.TextSelectionToolbar.anchorBelow}
+  /// {@template flutter.cupertino.TextSelectionToolbar.anchorBelow}
+  /// The focal point below which the toolbar attempts to position itself, if it
+  /// doesn't fit above [anchorAbove].
+  /// {@endtemplate}
   final Offset anchorBelow;
 
-  /// {@macro flutter.material.TextSelectionToolbar.children}
+  /// {@template flutter.cupertino.TextSelectionToolbar.children}
+  /// The children that will be displayed in the text selection toolbar.
+  /// 
+  /// Typically these are buttons.
+  /// 
+  /// Must not be empty.
+  /// {@endtemplate}
   ///
   /// See also:
   ///   * [CupertinoTextSelectionToolbarButton], which builds a default
   ///     Cupertino-style text selection toolbar text button.
   final List<Widget> children;
 
-  /// {@macro flutter.material.TextSelectionToolbar.toolbarBuilder}
+  /// {@template flutter.cupertino.TextSelectionToolbar.toolbarBuilder}
+  /// Builds the toolbar container.
+  /// 
+  /// Useful for customizing the high-level background of the toolbar. The given
+  /// child Widget will contain all of the [children].
+  /// {@endtemplate}
   ///
   /// The given anchor and isAbove can be used to position an arrow, as in the
   /// default Cupertino toolbar.

--- a/packages/material_ui/lib/src/adaptive_text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/adaptive_text_selection_toolbar.dart
@@ -195,9 +195,7 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   /// The children of the toolbar, typically buttons.
   final List<Widget>? children;
 
-  /// {@template flutter.material.AdaptiveTextSelectionToolbar.anchors}
-  /// The location on which to anchor the menu.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.AdaptiveTextSelectionToolbar.anchors}
   final TextSelectionToolbarAnchors anchors;
 
   /// Returns the default button label String for the button of the given

--- a/packages/material_ui/lib/src/app.dart
+++ b/packages/material_ui/lib/src/app.dart
@@ -767,14 +767,7 @@ class MaterialApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.restorationScopeId}
   final String? restorationScopeId;
 
-  /// {@template flutter.material.materialApp.scrollBehavior}
-  /// The default [ScrollBehavior] for the application.
-  ///
-  /// [ScrollBehavior]s describe how [Scrollable] widgets behave. Providing
-  /// a [ScrollBehavior] can set the default [ScrollPhysics] across
-  /// an application, and manage [Scrollable] decorations like [Scrollbar]s and
-  /// [GlowingOverscrollIndicator]s.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.materialApp.scrollBehavior}
   ///
   /// When null, defaults to [MaterialScrollBehavior].
   ///

--- a/packages/material_ui/lib/src/app_bar.dart
+++ b/packages/material_ui/lib/src/app_bar.dart
@@ -829,7 +829,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final bool useDefaultSemanticsOrder;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   final Clip? clipBehavior;
 
   /// {@template flutter.material.appbar.actionsPadding}
@@ -2086,7 +2086,7 @@ class SliverAppBar extends StatefulWidget {
   /// This property is used to configure an [AppBar].
   final bool useDefaultSemanticsOrder;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   final Clip? clipBehavior;
 
   /// {@macro flutter.material.appbar.actionsPadding}

--- a/packages/material_ui/lib/src/bottom_app_bar.dart
+++ b/packages/material_ui/lib/src/bottom_app_bar.dart
@@ -141,7 +141,7 @@ class BottomAppBar extends StatefulWidget {
   /// is used. If that's null then the shape will be rectangular with no notch.
   final NotchedShape? shape;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/bottom_sheet.dart
+++ b/packages/material_ui/lib/src/bottom_sheet.dart
@@ -203,7 +203,7 @@ class BottomSheet extends StatefulWidget {
   /// Defaults to null and falls back to [Material]'s default.
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defines the bottom sheet's [Material.clipBehavior].
   ///
@@ -938,7 +938,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   /// If this property is not provided, it falls back to [Material]'s default.
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defines the bottom sheet's [Material.clipBehavior].
   ///

--- a/packages/material_ui/lib/src/button.dart
+++ b/packages/material_ui/lib/src/button.dart
@@ -290,7 +290,7 @@ class RawMaterialButton extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/button_style_button.dart
+++ b/packages/material_ui/lib/src/button_style_button.dart
@@ -144,7 +144,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// Null by default.
   final ButtonStyle? style;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none] unless [ButtonStyle.backgroundBuilder] or
   /// [ButtonStyle.foregroundBuilder] is specified. In those

--- a/packages/material_ui/lib/src/card.dart
+++ b/packages/material_ui/lib/src/card.dart
@@ -219,7 +219,7 @@ class Card extends StatelessWidget {
   /// If false, the border will be painted behind the [child].
   final bool borderOnForeground;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// If this property is null then the ambient [CardThemeData.clipBehavior] is
   /// used. If that's null then the behavior will be [Clip.none].

--- a/packages/material_ui/lib/src/checkbox_list_tile.dart
+++ b/packages/material_ui/lib/src/checkbox_list_tile.dart
@@ -497,7 +497,7 @@ class CheckboxListTile extends StatelessWidget {
   /// If non-null, defines the background color when [CheckboxListTile.selected] is true.
   final Color? selectedTileColor;
 
-  /// {@macro flutter.material.inkwell.onFocusChange}
+  /// {@macro flutter.cupertino.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@macro flutter.material.ListTile.enableFeedback}

--- a/packages/material_ui/lib/src/chip.dart
+++ b/packages/material_ui/lib/src/chip.dart
@@ -143,7 +143,7 @@ abstract interface class ChipAttributes {
   ///  * [WidgetState.pressed].
   OutlinedBorder? get shape;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   Clip get clipBehavior;

--- a/packages/material_ui/lib/src/data_table.dart
+++ b/packages/material_ui/lib/src/data_table.dart
@@ -781,7 +781,7 @@ class DataTable extends StatelessWidget {
   /// The style to use when painting the boundary and interior divisions of the table.
   final TableBorder? border;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// This can be used to clip the content within the border of the [DataTable].
   ///

--- a/packages/material_ui/lib/src/desktop_text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/desktop_text_selection_toolbar.dart
@@ -35,13 +35,10 @@ class DesktopTextSelectionToolbar extends StatelessWidget {
   const DesktopTextSelectionToolbar({super.key, required this.anchor, required this.children})
     : assert(children.length > 0);
 
-  /// {@template flutter.material.DesktopTextSelectionToolbar.anchor}
-  /// The point where the toolbar will attempt to position itself as closely as
-  /// possible.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.DesktopTextSelectionToolbar.anchor}
   final Offset anchor;
 
-  /// {@macro flutter.material.TextSelectionToolbar.children}
+  /// {@macro flutter.cupertino.TextSelectionToolbar.children}
   ///
   /// See also:
   ///   * [DesktopTextSelectionToolbarButton], which builds a default

--- a/packages/material_ui/lib/src/dialog.dart
+++ b/packages/material_ui/lib/src/dialog.dart
@@ -195,21 +195,10 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final Color? surfaceTintColor;
 
-  /// {@template flutter.material.dialog.insetAnimationDuration}
-  /// The duration of the animation to show when the system keyboard intrudes
-  /// into the space that the dialog is placed in.
-  ///
-  /// Defaults to 100 milliseconds when [Dialog] is used, and [Duration.zero]
-  /// when [Dialog.fullscreen] is used.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.dialog.insetAnimationDuration}
   final Duration insetAnimationDuration;
 
-  /// {@template flutter.material.dialog.insetAnimationCurve}
-  /// The curve to use for the animation shown when the system keyboard intrudes
-  /// into the space that the dialog is placed in.
-  ///
-  /// Defaults to [Curves.decelerate].
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.dialog.insetAnimationCurve}
   final Curve insetAnimationCurve;
 
   /// {@template flutter.material.dialog.insetPadding}
@@ -1603,10 +1592,7 @@ class _DialogContentPage extends Page<void> {
 /// argument is ignored as dialogs are displayed in their own windows which
 /// manage focus traversal independently.
 ///
-/// {@template flutter.material.dialog.requestFocus}
-/// The `requestFocus` argument is used to specify whether the dialog should
-/// request focus when shown.
-/// {@endtemplate}
+/// {@macro flutter.cupertino.dialog.requestFocus}
 /// {@macro flutter.widgets.navigator.Route.requestFocus}
 /// If windowing is enabled via `flutter config --enable-windowing`, then this
 /// argument is ignored as dialogs are displayed in their own windows which are

--- a/packages/material_ui/lib/src/drawer.dart
+++ b/packages/material_ui/lib/src/drawer.dart
@@ -250,7 +250,7 @@ class Drawer extends StatelessWidget {
   ///    value is used.
   final String? semanticLabel;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// The [clipBehavior] argument specifies how to clip the drawer's [shape].
   ///

--- a/packages/material_ui/lib/src/dropdown_menu.dart
+++ b/packages/material_ui/lib/src/dropdown_menu.dart
@@ -712,7 +712,7 @@ class DropdownMenu<T> extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.cursorHeight}
   final double? cursorHeight;
 
-  /// {@macro flutter.material.textfield.restorationId}
+  /// {@macro flutter.cupertino.textfield.restorationId}
   final String? restorationId;
 
   /// An optional controller that allows opening and closing of the menu from

--- a/packages/material_ui/lib/src/expansion_tile.dart
+++ b/packages/material_ui/lib/src/expansion_tile.dart
@@ -400,7 +400,7 @@ class ExpansionTile extends StatefulWidget {
   ///   [ExpansionTileThemeData].
   final ShapeBorder? collapsedShape;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// If this is not null and a custom collapsed or expanded shape is provided,
   /// the value of [clipBehavior] will be used to clip the expansion tile.

--- a/packages/material_ui/lib/src/floating_action_button.dart
+++ b/packages/material_ui/lib/src/floating_action_button.dart
@@ -433,7 +433,7 @@ class FloatingActionButton extends StatelessWidget {
   /// shape as well.
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/ink_well.dart
+++ b/packages/material_ui/lib/src/ink_well.dart
@@ -616,12 +616,7 @@ class InkResponse extends StatelessWidget {
   /// duplication of information.
   final bool excludeFromSemantics;
 
-  /// {@template flutter.material.inkwell.onFocusChange}
-  /// Handler called when the focus changes.
-  ///
-  /// Called with true if this widget's node gains focus, and false if it loses
-  /// focus.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@macro flutter.widgets.Focus.autofocus}

--- a/packages/material_ui/lib/src/input_decorator.dart
+++ b/packages/material_ui/lib/src/input_decorator.dart
@@ -1893,18 +1893,7 @@ class InputDecorator extends StatefulWidget {
   /// How the text in the decoration should be aligned horizontally.
   final TextAlign? textAlign;
 
-  /// {@template flutter.material.InputDecorator.textAlignVertical}
-  /// How the text should be aligned vertically.
-  ///
-  /// Determines the alignment of the baseline within the available space of
-  /// the input (typically a TextField). For example, TextAlignVertical.top will
-  /// place the baseline such that the text, and any attached decoration like
-  /// prefix and suffix, is as close to the top of the input as possible without
-  /// overflowing. The heights of the prefix and suffix are similarly included
-  /// for other alignment values. If the height is greater than the height
-  /// available, then the prefix and suffix will be allowed to overflow first
-  /// before the text scrolls.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.InputDecorator.textAlignVertical}
   final TextAlignVertical? textAlignVertical;
 
   /// Whether the input field has focus.

--- a/packages/material_ui/lib/src/list_tile.dart
+++ b/packages/material_ui/lib/src/list_tile.dart
@@ -698,7 +698,7 @@ class ListTile extends StatelessWidget {
   /// Inoperative if [enabled] is false.
   final GestureLongPressCallback? onLongPress;
 
-  /// {@macro flutter.material.inkwell.onFocusChange}
+  /// {@macro flutter.cupertino.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@template flutter.material.ListTile.mouseCursor}

--- a/packages/material_ui/lib/src/material.dart
+++ b/packages/material_ui/lib/src/material.dart
@@ -331,12 +331,7 @@ class Material extends StatefulWidget {
   /// If false, the border will be painted behind the [child].
   final bool borderOnForeground;
 
-  /// {@template flutter.material.Material.clipBehavior}
-  /// The content will be clipped (or not) according to this option.
-  ///
-  /// See the enum [Clip] for details of all possible options and their common
-  /// use cases.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -839,7 +834,7 @@ class _MaterialInterior extends ImplicitlyAnimatedWidget {
   /// If false, the border will be painted behind the child.
   final bool borderOnForeground;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/material_button.dart
+++ b/packages/material_ui/lib/src/material_button.dart
@@ -343,7 +343,7 @@ class MaterialButton extends StatelessWidget {
   /// [ButtonThemeData.shape].
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -338,7 +338,7 @@ class MenuAnchor extends StatefulWidget {
   /// surrounds if it moves because of view insets changes.
   final LayerLink? layerLink;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -886,7 +886,7 @@ class MenuBar extends StatelessWidget {
   /// Defaults to the ambient [MenuThemeData.style].
   final MenuStyle? style;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1043,7 +1043,7 @@ class MenuItemButton extends StatefulWidget {
   /// {@macro flutter.material.inkwell.statesController}
   final MaterialStatesController? statesController;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1491,7 +1491,7 @@ class CheckboxMenuButton extends StatelessWidget {
   /// {@macro flutter.material.inkwell.statesController}
   final MaterialStatesController? statesController;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1695,7 +1695,7 @@ class RadioMenuButton<T> extends StatelessWidget {
   /// {@macro flutter.material.inkwell.statesController}
   final MaterialStatesController? statesController;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1860,7 +1860,7 @@ class SubmenuButton extends StatefulWidget {
   /// top of the [MenuAnchor] region.
   final Offset? alignmentOffset;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -3627,7 +3627,7 @@ class _MenuPanel extends StatefulWidget {
   /// The menu style that has all the attributes for this menu panel.
   final MenuStyle? menuStyle;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/popup_menu.dart
+++ b/packages/material_ui/lib/src/popup_menu.dart
@@ -1567,7 +1567,7 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// over the button that was used to create it.
   final PopupMenuPosition? position;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// The [clipBehavior] argument is used the clip shape of the menu.
   ///

--- a/packages/material_ui/lib/src/radio.dart
+++ b/packages/material_ui/lib/src/radio.dart
@@ -189,39 +189,14 @@ class Radio<T> extends StatefulWidget {
   /// {@macro flutter.widget.RawRadio.value}
   final T value;
 
-  /// {@template flutter.material.Radio.groupValue}
-  /// The currently selected value for a group of radio buttons.
-  ///
-  /// This radio button is considered selected if its [value] matches the
-  /// [groupValue].
-  ///
-  /// This is deprecated, use [RadioGroup] to manage group value instead.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.Radio.groupValue}
   @Deprecated(
     'Use a RadioGroup ancestor to manage group value instead. '
     'This feature was deprecated after v3.32.0-0.0.pre.',
   )
   final T? groupValue;
 
-  /// {@template flutter.material.Radio.onChanged}
-  /// Called when the user selects this radio button.
-  ///
-  /// The radio button passes [value] as a parameter to this callback. The radio
-  /// button does not actually change state until the parent widget rebuilds the
-  /// radio button with the new [groupValue].
-  ///
-  /// If null, the radio button will be displayed as disabled.
-  ///
-  /// The provided callback will not be invoked if this radio button is already
-  /// selected and [toggleable] is not set to true.
-  ///
-  /// If the [toggleable] is set to true, tapping a already selected radio will
-  /// invoke this callback with `null` as value.
-  ///
-  /// The callback provided to [onChanged] should update the state of the parent
-  /// [StatefulWidget] using the [State.setState] method, so that the parent
-  /// gets rebuilt.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.Radio.onChanged}
   ///
   /// For example:
   ///
@@ -427,19 +402,7 @@ class Radio<T> extends StatefulWidget {
 
   final _RadioType _radioType;
 
-  /// {@template flutter.material.Radio.enabled}
-  /// Whether this widget is interactive.
-  ///
-  /// If not provided, this widget will be interactable if one of the following
-  /// is true:
-  ///
-  /// * A [onChanged] is provided.
-  /// * Having a [RadioGroup] with the same type T above this widget.
-  /// * A [groupRegistry] is provided.
-  ///
-  /// If this is set to true, one of the above condition must also be true.
-  /// Otherwise, an assertion error is thrown.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.Radio.enabled}
   final bool? enabled;
 
   /// {@template flutter.material.Radio.backgroundColor}

--- a/packages/material_ui/lib/src/radio_list_tile.dart
+++ b/packages/material_ui/lib/src/radio_list_tile.dart
@@ -510,7 +510,7 @@ class RadioListTile<T> extends StatefulWidget {
   /// Controls the interactive states of the backing [ListTile].
   final WidgetStatesController? statesController;
 
-  /// {@macro flutter.material.inkwell.onFocusChange}
+  /// {@macro flutter.cupertino.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@macro flutter.material.ListTile.enableFeedback}

--- a/packages/material_ui/lib/src/reorderable_list.dart
+++ b/packages/material_ui/lib/src/reorderable_list.dart
@@ -358,7 +358,7 @@ class ReorderableListView extends StatefulWidget {
   /// {@macro flutter.widgets.scrollable.restorationId}
   final String? restorationId;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/selectable_text.dart
+++ b/packages/material_ui/lib/src/selectable_text.dart
@@ -93,7 +93,7 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
 /// behavior is useful, for example, to make the text bold while using the
 /// default font family and size.
 ///
-/// {@macro flutter.material.textfield.wantKeepAlive}
+/// {@macro flutter.cupertino.textfield.wantKeepAlive}
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/snack_bar.dart
+++ b/packages/material_ui/lib/src/snack_bar.dart
@@ -506,7 +506,7 @@ class SnackBar extends StatefulWidget {
   /// is used. If that is null, then the default is [DismissDirection.down].
   final DismissDirection? dismissDirection;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/switch.dart
+++ b/packages/material_ui/lib/src/switch.dart
@@ -311,26 +311,16 @@ class Switch extends StatelessWidget {
   /// used instead of this color.
   final Color? inactiveTrackColor;
 
-  /// {@template flutter.material.switch.activeThumbImage}
-  /// An image to use on the thumb of this switch when the switch is on.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.switch.activeThumbImage}
   final ImageProvider? activeThumbImage;
 
-  /// {@template flutter.material.switch.onActiveThumbImageError}
-  /// An optional error callback for errors emitted when loading
-  /// [activeThumbImage].
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.switch.onActiveThumbImageError}
   final ImageErrorListener? onActiveThumbImageError;
 
-  /// {@template flutter.material.switch.inactiveThumbImage}
-  /// An image to use on the thumb of this switch when the switch is off.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.switch.inactiveThumbImage}
   final ImageProvider? inactiveThumbImage;
 
-  /// {@template flutter.material.switch.onInactiveThumbImageError}
-  /// An optional error callback for errors emitted when loading
-  /// [inactiveThumbImage].
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.switch.onInactiveThumbImageError}
   final ImageErrorListener? onInactiveThumbImageError;
 
   /// {@template flutter.material.switch.thumbColor}
@@ -627,7 +617,7 @@ class Switch extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
 
-  /// {@macro flutter.material.inkwell.onFocusChange}
+  /// {@macro flutter.cupertino.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@macro flutter.widgets.Focus.autofocus}

--- a/packages/material_ui/lib/src/switch_list_tile.dart
+++ b/packages/material_ui/lib/src/switch_list_tile.dart
@@ -391,18 +391,18 @@ class SwitchListTile extends StatelessWidget {
   /// Ignored if created with [SwitchListTile.adaptive].
   final Color? inactiveTrackColor;
 
-  /// {@macro flutter.material.switch.activeThumbImage}
+  /// {@macro flutter.cupertino.switch.activeThumbImage}
   final ImageProvider? activeThumbImage;
 
-  /// {@macro flutter.material.switch.onActiveThumbImageError}
+  /// {@macro flutter.cupertino.switch.onActiveThumbImageError}
   final ImageErrorListener? onActiveThumbImageError;
 
-  /// {@macro flutter.material.switch.inactiveThumbImage}
+  /// {@macro flutter.cupertino.switch.inactiveThumbImage}
   ///
   /// Ignored if created with [SwitchListTile.adaptive].
   final ImageProvider? inactiveThumbImage;
 
-  /// {@macro flutter.material.switch.onInactiveThumbImageError}
+  /// {@macro flutter.cupertino.switch.onInactiveThumbImageError}
   final ImageErrorListener? onInactiveThumbImageError;
 
   /// The color of this switch's thumb.
@@ -499,7 +499,7 @@ class SwitchListTile extends StatelessWidget {
   /// Controls the interactive states of the backing [ListTile].
   final WidgetStatesController? statesController;
 
-  /// {@macro flutter.material.inkwell.onFocusChange}
+  /// {@macro flutter.cupertino.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@macro flutter.widgets.Focus.autofocus}

--- a/packages/material_ui/lib/src/tabs.dart
+++ b/packages/material_ui/lib/src/tabs.dart
@@ -2305,7 +2305,7 @@ class TabBarView extends StatefulWidget {
   /// {@macro flutter.widgets.pageview.viewportFraction}
   final double viewportFraction;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/text_field.dart
+++ b/packages/material_ui/lib/src/text_field.dart
@@ -99,12 +99,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
 ///
-/// {@template flutter.material.textfield.wantKeepAlive}
-/// When the widget has focus, it will prevent itself from disposing via its
-/// underlying [EditableText]'s [AutomaticKeepAliveClientMixin.wantKeepAlive] in
-/// order to avoid losing the selection. Removing the focus will allow it to be
-/// disposed.
-/// {@endtemplate}
+/// {@macro flutter.cupertino.textfield.wantKeepAlive}
 ///
 /// Remember to call [TextEditingController.dispose] on the [TextEditingController]
 /// when it is no longer needed. This will ensure we discard any resources used
@@ -490,7 +485,7 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.textAlign}
   final TextAlign textAlign;
 
-  /// {@macro flutter.material.InputDecorator.textAlignVertical}
+  /// {@macro flutter.cupertino.InputDecorator.textAlignVertical}
   final TextAlignVertical? textAlignVertical;
 
   /// {@macro flutter.widgets.editableText.textDirection}
@@ -739,26 +734,7 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.selectionEnabled}
   bool get selectionEnabled => enableInteractiveSelection;
 
-  /// {@template flutter.material.textfield.onTap}
-  /// Called for the first tap in a series of taps.
-  ///
-  /// The text field builds a [GestureDetector] to handle input events like tap,
-  /// to trigger focus requests, to move the caret, adjust the selection, etc.
-  /// Handling some of those events by wrapping the text field with a competing
-  /// GestureDetector is problematic.
-  ///
-  /// To unconditionally handle taps, without interfering with the text field's
-  /// internal gesture detector, provide this callback.
-  ///
-  /// If the text field is created with [enabled] false, taps will not be
-  /// recognized.
-  ///
-  /// To be notified when the text field gains or loses the focus, provide a
-  /// [focusNode] and add a listener to that.
-  ///
-  /// To listen to arbitrary pointer events without competing with the
-  /// text field's internal gesture detector, use a [Listener].
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.textfield.onTap}
   ///
   /// If [onTapAlwaysCalled] is enabled, this will also be called for consecutive
   /// taps.
@@ -863,28 +839,12 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// {@macro flutter.cupertino.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
-  /// {@template flutter.material.textfield.restorationId}
-  /// Restoration ID to save and restore the state of the text field.
-  ///
-  /// If non-null, the text field will persist and restore its current scroll
-  /// offset and - if no [controller] has been provided - the content of the
-  /// text field. If a [controller] has been provided, it is the responsibility
-  /// of the owner of that controller to persist and restore it, e.g. by using
-  /// a [RestorableTextEditingController].
-  ///
-  /// The state of this widget is persisted in a [RestorationBucket] claimed
-  /// from the surrounding [RestorationScope] using the provided restoration ID.
-  ///
-  /// See also:
-  ///
-  ///  * [RestorationManager], which explains how state restoration works in
-  ///    Flutter.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.textfield.restorationId}
   final String? restorationId;
 
   /// {@macro flutter.widgets.editableText.scribbleEnabled}

--- a/packages/material_ui/lib/src/text_form_field.dart
+++ b/packages/material_ui/lib/src/text_form_field.dart
@@ -35,7 +35,7 @@ export 'package:flutter/services.dart' show SmartDashesType, SmartQuotesType;
 /// If a [controller] is not specified, [initialValue] can be used to give
 /// the automatically generated controller an initial value.
 ///
-/// {@macro flutter.material.textfield.wantKeepAlive}
+/// {@macro flutter.cupertino.textfield.wantKeepAlive}
 ///
 /// Remember to call [TextEditingController.dispose] of the [TextEditingController]
 /// when it is no longer needed. This will ensure any resources used by the object
@@ -339,10 +339,7 @@ class TextFormField extends FormField<String> {
   /// {@macro flutter.widgets.editableText.groupId}
   final Object groupId;
 
-  /// {@template flutter.material.TextFormField.onChanged}
-  /// Called when the user initiates a change to the TextField's
-  /// value: when they have inserted or deleted text or reset the form.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.TextFormField.onChanged}
   final ValueChanged<String>? onChanged;
 
   static Widget _defaultContextMenuBuilder(

--- a/packages/material_ui/lib/src/text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/text_selection_toolbar.dart
@@ -48,39 +48,20 @@ class TextSelectionToolbar extends StatelessWidget {
     required this.children,
   }) : assert(children.length > 0);
 
-  /// {@template flutter.material.TextSelectionToolbar.anchorAbove}
-  /// The focal point above which the toolbar attempts to position itself.
-  ///
-  /// If there is not enough room above before reaching the top of the screen,
-  /// then the toolbar will position itself below [anchorBelow].
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.TextSelectionToolbar.anchorAbove}
   final Offset anchorAbove;
 
-  /// {@template flutter.material.TextSelectionToolbar.anchorBelow}
-  /// The focal point below which the toolbar attempts to position itself, if it
-  /// doesn't fit above [anchorAbove].
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.TextSelectionToolbar.anchorBelow}
   final Offset anchorBelow;
 
-  /// {@template flutter.material.TextSelectionToolbar.children}
-  /// The children that will be displayed in the text selection toolbar.
-  ///
-  /// Typically these are buttons.
-  ///
-  /// Must not be empty.
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.TextSelectionToolbar.children}
   ///
   /// See also:
   ///   * [TextSelectionToolbarTextButton], which builds a default Material-
   ///     style text selection toolbar text button.
   final List<Widget> children;
 
-  /// {@template flutter.material.TextSelectionToolbar.toolbarBuilder}
-  /// Builds the toolbar container.
-  ///
-  /// Useful for customizing the high-level background of the toolbar. The given
-  /// child Widget will contain all of the [children].
-  /// {@endtemplate}
+  /// {@macro flutter.cupertino.TextSelectionToolbar.toolbarBuilder}
   final ToolbarBuilder toolbarBuilder;
 
   /// The size of the text selection handles.


### PR DESCRIPTION
The `dartdoc` requires that `@macro` will only search `@template` from `dependencies` packages, not `dev_dependencies`. Before this PR, both Cupertino and Material have used macros defined in the other package, and this does not completely work because `cupertino_ui` only lists `material_ui` as a dev dependency. On the other hand, `material_ui` lists `cupertino_ui` as a dependency and we plan to keep this way for a long time due to support for adaptive widgets.

This PR hence solves this macro problem by migrating all malfunctioning macros to be defined in `cupertino_ui` instead.

The changes were made in a script written by Gemini.

### Known issue

Referencing breadcrumbs ("square brackets") from `material_ui` in `cupertino_ui` does not work for now. The result is non-blocking for now, where all widget names (such as `[Button]`) do not have hyperlinks but are simply backticks. This is likely because of https://github.com/dart-lang/sdk/issues/62812. Simply put, `dartdoc` only checks in symbols from `material_ui` if `material_ui` is `import`ed somewhere at least once, which means `material_ui` must be a dependency (not a dev dependency) of `cupertino_ui`. If https://github.com/dart-lang/sdk/issues/62812 can be fixed, a `docImport` would make `dartdoc` checks in symbols.

Also, this problem can be worsened as we develop next generation Cupertino widgets, since `cupertino_ui` is planning to remove the prefixes and therefore have widget name conflicts with `material_ui`, and  [`docImport` currently does not support `as`](https://github.com/dart-lang/sdk/issues/56527). For example, if a widget in `cupertino_ui` refers to a `[Dialog]`, which dialog does it refer to? 

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
