### PR TITLE
[material_ui, cupertino_ui] Rename macro names to package names

### DIFF
--- a/packages/cupertino_ui/lib/src/adaptive_text_selection_toolbar.dart
+++ b/packages/cupertino_ui/lib/src/adaptive_text_selection_toolbar.dart
@@ -17,7 +17,7 @@ import 'text_selection_toolbar_button.dart';
 /// The default Cupertino context menu for text selection for the current
 /// platform with the given children.
 ///
-/// {@template flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.platforms}
+/// {@template cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.platforms}
 /// Builds the mobile Cupertino context menu on all mobile platforms, not just
 /// iOS, and builds the desktop Cupertino context menu on all desktop platforms,
 /// not just MacOS. For a widget that builds the native-looking context menu for
@@ -37,19 +37,19 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// See also:
   ///
-  /// {@template flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.buttonItems}
+  /// {@template cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.buttonItems}
   /// * [CupertinoAdaptiveTextSelectionToolbar.buttonItems], which takes a list
   ///   of [ContextMenuButtonItem]s instead of [children] widgets.
   /// {@endtemplate}
-  /// {@template flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.editable}
+  /// {@template cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.editable}
   /// * [CupertinoAdaptiveTextSelectionToolbar.editable], which builds the
   ///   default Cupertino children for an editable field.
   /// {@endtemplate}
-  /// {@template flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.editableText}
+  /// {@template cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.editableText}
   /// * [CupertinoAdaptiveTextSelectionToolbar.editableText], which builds the
   ///   default Cupertino children for an [EditableText].
   /// {@endtemplate}
-  /// {@template flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.selectable}
+  /// {@template cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.selectable}
   /// * [CupertinoAdaptiveTextSelectionToolbar.selectable], which builds the
   ///   Cupertino children for content that is selectable but not editable.
   /// {@endtemplate}
@@ -64,13 +64,13 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// See also:
   ///
-  /// {@template flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.new}
+  /// {@template cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.new}
   /// * [CupertinoAdaptiveTextSelectionToolbar.new], which takes the children
   ///   directly as a list of widgets.
   /// {@endtemplate}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.editable}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.editableText}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.selectable}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.editable}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.editableText}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.selectable}
   const CupertinoAdaptiveTextSelectionToolbar.buttonItems({
     super.key,
     required this.buttonItems,
@@ -86,10 +86,10 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// * [AdaptiveTextSelectionToolbar.editable], which is similar to this but
   ///   includes Material and Cupertino toolbars.
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.new}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.editableText}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.buttonItems}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.selectable}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.new}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.editableText}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.buttonItems}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.selectable}
   CupertinoAdaptiveTextSelectionToolbar.editable({
     super.key,
     required ClipboardStatus clipboardStatus,
@@ -122,10 +122,10 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// * [AdaptiveTextSelectionToolbar.editableText], which is similar to this
   ///   but includes Material and Cupertino toolbars.
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.new}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.editable}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.buttonItems}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.selectable}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.new}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.editable}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.buttonItems}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.selectable}
   CupertinoAdaptiveTextSelectionToolbar.editableText({
     super.key,
     required EditableTextState editableTextState,
@@ -140,10 +140,10 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// * [AdaptiveTextSelectionToolbar.selectable], which is similar to this but
   ///   includes Material and Cupertino toolbars.
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.new}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.buttonItems}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.editable}
-  /// {@macro flutter.cupertino.CupertinoAdaptiveTextSelectionToolbar.editableText}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.new}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.buttonItems}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.editable}
+  /// {@macro cupertino_ui.CupertinoAdaptiveTextSelectionToolbar.editableText}
   CupertinoAdaptiveTextSelectionToolbar.selectable({
     super.key,
     required VoidCallback onCopy,
@@ -158,7 +158,7 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
          onShare: null, // See https://github.com/flutter/flutter/issues/141775.
        );
 
-  /// {@template flutter.cupertino.AdaptiveTextSelectionToolbar.anchors}
+  /// {@template cupertino_ui.AdaptiveTextSelectionToolbar.anchors}
   /// The location on which to anchor the menu.
   /// {@endtemplate}
   final TextSelectionToolbarAnchors anchors;

--- a/packages/cupertino_ui/lib/src/app.dart
+++ b/packages/cupertino_ui/lib/src/app.dart
@@ -53,7 +53,7 @@ import 'theme.dart';
 /// widget, which the [CupertinoApp] composes. If you use Material widgets, a
 /// [MaterialApp] also creates the needed dependencies for Cupertino widgets.
 ///
-/// {@template flutter.cupertino.CupertinoApp.defaultSelectionStyle}
+/// {@template cupertino_ui.CupertinoApp.defaultSelectionStyle}
 /// The [CupertinoApp] automatically creates a [DefaultSelectionStyle] with
 /// selectionColor sets to [CupertinoThemeData.primaryColor] with 0.2 opacity
 /// and cursorColor sets to [CupertinoThemeData.primaryColor].
@@ -445,7 +445,7 @@ class CupertinoApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.restorationScopeId}
   final String? restorationScopeId;
 
-  /// {@template flutter.cupertino.materialApp.scrollBehavior}
+  /// {@template cupertino_ui.materialApp.scrollBehavior}
   /// The default [ScrollBehavior] for the application.
   ///
   /// [ScrollBehavior]s describe how [Scrollable] widgets behave. Providing

--- a/packages/cupertino_ui/lib/src/checkbox.dart
+++ b/packages/cupertino_ui/lib/src/checkbox.dart
@@ -199,7 +199,7 @@ class CupertinoCheckbox extends StatefulWidget {
   /// Defaults to [CupertinoColors.activeBlue].
   final Color? activeColor;
 
-  /// {@template flutter.cupertino.CupertinoCheckbox.fillColor}
+  /// {@template cupertino_ui.CupertinoCheckbox.fillColor}
   /// The color used to fill this checkbox.
   ///
   /// Resolves in the following states:

--- a/packages/cupertino_ui/lib/src/date_picker.dart
+++ b/packages/cupertino_ui/lib/src/date_picker.dart
@@ -473,7 +473,7 @@ class CupertinoDatePicker extends StatefulWidget {
   /// Function to provide full control over which [DateTime] can be selected.
   final SelectableDayPredicate? selectableDayPredicate;
 
-  /// {@macro flutter.cupertino.picker.itemExtent}
+  /// {@macro cupertino_ui.picker.itemExtent}
   ///
   /// Defaults to a value that matches the default iOS date picker wheel.
   final double itemExtent;
@@ -2260,7 +2260,7 @@ class CupertinoTimerPicker extends StatefulWidget {
   /// Defaults to null, which disables background painting entirely.
   final Color? backgroundColor;
 
-  /// {@macro flutter.cupertino.picker.itemExtent}
+  /// {@macro cupertino_ui.picker.itemExtent}
   ///
   /// Defaults to a value that matches the default iOS timer picker wheel.
   final double itemExtent;

--- a/packages/cupertino_ui/lib/src/desktop_text_selection_toolbar.dart
+++ b/packages/cupertino_ui/lib/src/desktop_text_selection_toolbar.dart
@@ -86,13 +86,13 @@ class CupertinoDesktopTextSelectionToolbar extends StatelessWidget {
     ];
   }
 
-  /// {@template flutter.cupertino.DesktopTextSelectionToolbar.anchor}
+  /// {@template cupertino_ui.DesktopTextSelectionToolbar.anchor}
   /// The point where the toolbar will attempt to position itself as closely as
   /// possible.
   /// {@endtemplate}
   final Offset anchor;
 
-  /// {@macro flutter.cupertino.TextSelectionToolbar.children}
+  /// {@macro cupertino_ui.TextSelectionToolbar.children}
   ///
   /// See also:
   ///   * [CupertinoDesktopTextSelectionToolbarButton], which builds a default

--- a/packages/cupertino_ui/lib/src/desktop_text_selection_toolbar_button.dart
+++ b/packages/cupertino_ui/lib/src/desktop_text_selection_toolbar_button.dart
@@ -51,16 +51,16 @@ class CupertinoDesktopTextSelectionToolbarButton extends StatefulWidget {
        text = null,
        child = null;
 
-  /// {@macro flutter.cupertino.CupertinoTextSelectionToolbarButton.onPressed}
+  /// {@macro cupertino_ui.CupertinoTextSelectionToolbarButton.onPressed}
   final VoidCallback? onPressed;
 
-  /// {@macro flutter.cupertino.CupertinoTextSelectionToolbarButton.child}
+  /// {@macro cupertino_ui.CupertinoTextSelectionToolbarButton.child}
   final Widget? child;
 
-  /// {@macro flutter.cupertino.CupertinoTextSelectionToolbarButton.onPressed}
+  /// {@macro cupertino_ui.CupertinoTextSelectionToolbarButton.onPressed}
   final ContextMenuButtonItem? buttonItem;
 
-  /// {@macro flutter.cupertino.CupertinoTextSelectionToolbarButton.text}
+  /// {@macro cupertino_ui.CupertinoTextSelectionToolbarButton.text}
   final String? text;
 
   @override

--- a/packages/cupertino_ui/lib/src/dialog.dart
+++ b/packages/cupertino_ui/lib/src/dialog.dart
@@ -289,7 +289,7 @@ class CupertinoAlertDialog extends StatefulWidget {
   ///    section when it is long.
   final ScrollController? actionScrollController;
 
-  /// {@template flutter.cupertino.dialog.insetAnimationDuration}
+  /// {@template cupertino_ui.dialog.insetAnimationDuration}
   /// The duration of the animation to show when the system keyboard intrudes
   /// into the space that the dialog is placed in.
   ///
@@ -298,7 +298,7 @@ class CupertinoAlertDialog extends StatefulWidget {
   /// {@endtemplate}
   final Duration insetAnimationDuration;
 
-  /// {@template flutter.cupertino.dialog.insetAnimationCurve}
+  /// {@template cupertino_ui.dialog.insetAnimationCurve}
   /// The curve to use for the animation shown when the system keyboard intrudes
   /// into the space that the dialog is placed in.
   ///

--- a/packages/cupertino_ui/lib/src/form_section.dart
+++ b/packages/cupertino_ui/lib/src/form_section.dart
@@ -56,7 +56,7 @@ const EdgeInsetsDirectional _kFormDefaultInsetGroupedRowsMargin = EdgeInsetsDire
 /// The [backgroundColor] parameter sets the background color behind the section.
 /// If null, defaults to [CupertinoColors.systemGroupedBackground].
 ///
-/// {@macro flutter.cupertino.Material.clipBehavior}
+/// {@macro cupertino_ui.Material.clipBehavior}
 ///
 /// See also:
 ///
@@ -95,7 +95,7 @@ class CupertinoFormSection extends StatelessWidget {
   /// The [backgroundColor] parameter sets the background color behind the
   /// section. If null, defaults to [CupertinoColors.systemGroupedBackground].
   ///
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   const CupertinoFormSection({
     super.key,
     required this.children,
@@ -141,7 +141,7 @@ class CupertinoFormSection extends StatelessWidget {
   /// The [backgroundColor] parameter sets the background color behind the
   /// section. If null, defaults to [CupertinoColors.systemGroupedBackground].
   ///
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   const CupertinoFormSection.insetGrouped({
     super.key,
     required this.children,
@@ -194,7 +194,7 @@ class CupertinoFormSection extends StatelessWidget {
   /// Defaults to [CupertinoColors.systemGroupedBackground].
   final Color backgroundColor;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/cupertino_ui/lib/src/list_section.dart
+++ b/packages/cupertino_ui/lib/src/list_section.dart
@@ -159,7 +159,7 @@ enum CupertinoListSectionType {
 /// The [backgroundColor] of the section defaults to
 /// [CupertinoColors.systemGroupedBackground].
 ///
-/// {@macro flutter.cupertino.Material.clipBehavior}
+/// {@macro cupertino_ui.Material.clipBehavior}
 ///
 /// <callout-box>
 ///
@@ -241,7 +241,7 @@ class CupertinoListSection extends StatelessWidget {
   /// The [topMargin] is used to specify the margin above the list section. It
   /// matches the iOS look by default.
   ///
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   const CupertinoListSection({
     super.key,
     this.children,
@@ -305,7 +305,7 @@ class CupertinoListSection extends StatelessWidget {
   /// widgets contain leading or not. Used for calculating correct starting
   /// margin for the divider between rows.
   ///
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   const CupertinoListSection.insetGrouped({
     super.key,
     this.children,
@@ -378,7 +378,7 @@ class CupertinoListSection extends StatelessWidget {
   /// Defaults to [CupertinoColors.systemGroupedBackground].
   final Color backgroundColor;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/cupertino_ui/lib/src/menu_anchor.dart
+++ b/packages/cupertino_ui/lib/src/menu_anchor.dart
@@ -1798,7 +1798,7 @@ class CupertinoMenuItem extends StatelessWidget implements CupertinoMenuEntry {
   /// pointer event, which is always between frames.
   final ValueChanged<bool>? onHover;
 
-  /// {@template flutter.cupertino.inkwell.onFocusChange}
+  /// {@template cupertino_ui.inkwell.onFocusChange}
   /// Handler called when the focus changes.
   ///
   /// Called with true if this widget's node gains focus, and false if it loses

--- a/packages/cupertino_ui/lib/src/nav_bar.dart
+++ b/packages/cupertino_ui/lib/src/nav_bar.dart
@@ -452,7 +452,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   ///     dynamically change size in response to scrolling.
   final Widget? largeTitle;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.leading}
+  /// {@template cupertino_ui.CupertinoNavigationBar.leading}
   /// Widget to place at the start of the navigation bar. Normally a back button
   /// for a normal page or a cancel button for full page dialogs.
   ///
@@ -461,7 +461,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final Widget? leading;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.automaticallyImplyLeading}
+  /// {@template cupertino_ui.CupertinoNavigationBar.automaticallyImplyLeading}
   /// Controls whether we should try to imply the leading widget if null.
   ///
   /// If true and [leading] is null, automatically try to deduce what the [leading]
@@ -485,7 +485,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// If [middle] widget is not null, this parameter has no effect.
   final bool automaticallyImplyMiddle;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.previousPageTitle}
+  /// {@template cupertino_ui.CupertinoNavigationBar.previousPageTitle}
   /// Manually specify the previous route's title when automatically implying
   /// the leading back button.
   ///
@@ -514,13 +514,13 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   ///    dynamically change size in response to scrolling.
   final Widget? middle;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.trailing}
+  /// {@template cupertino_ui.CupertinoNavigationBar.trailing}
   /// Widget to place at the end of the navigation bar. Normally additional actions
   /// taken on the page such as a search or edit function.
   /// {@endtemplate}
   final Widget? trailing;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.backgroundColor}
+  /// {@template cupertino_ui.CupertinoNavigationBar.backgroundColor}
   /// The background color of the navigation bar. If it contains transparency, the
   /// tab bar will automatically produce a blurring effect to the content
   /// behind it. This behavior can be disabled by setting [enableBackgroundFilterBlur]
@@ -533,7 +533,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final Color? backgroundColor;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.automaticBackgroundVisibility}
+  /// {@template cupertino_ui.CupertinoNavigationBar.automaticBackgroundVisibility}
   /// Whether the navigation bar appears transparent when no content is scrolled under.
   ///
   /// If this is true, the navigation bar's background color will be transparent
@@ -546,7 +546,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final bool automaticBackgroundVisibility;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.brightness}
+  /// {@template cupertino_ui.CupertinoNavigationBar.brightness}
   /// The brightness of the specified [backgroundColor].
   ///
   /// Setting this value changes the style of the system status bar. Typically
@@ -558,7 +558,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final Brightness? brightness;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.padding}
+  /// {@template cupertino_ui.CupertinoNavigationBar.padding}
   /// Padding for the contents of the navigation bar.
   ///
   /// If null, the navigation bar will adopt the following defaults:
@@ -573,14 +573,14 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final EdgeInsetsDirectional? padding;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.border}
+  /// {@template cupertino_ui.CupertinoNavigationBar.border}
   /// The border of the navigation bar. By default renders a single pixel bottom border side.
   ///
   /// If a border is null, the navigation bar will not display a border.
   /// {@endtemplate}
   final Border? border;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.transitionBetweenRoutes}
+  /// {@template cupertino_ui.CupertinoNavigationBar.transitionBetweenRoutes}
   /// Whether to transition between navigation bars.
   ///
   /// When [transitionBetweenRoutes] is true, this navigation bar will transition
@@ -599,7 +599,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final bool transitionBetweenRoutes;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.enableBackgroundFilterBlur}
+  /// {@template cupertino_ui.CupertinoNavigationBar.enableBackgroundFilterBlur}
   /// Whether to have a blur effect when a non-opaque background color is used.
   ///
   /// When [enableBackgroundFilterBlur] is set to false, the blur effect will be
@@ -610,7 +610,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final bool enableBackgroundFilterBlur;
 
-  /// {@template flutter.cupertino.CupertinoNavigationBar.heroTag}
+  /// {@template cupertino_ui.CupertinoNavigationBar.heroTag}
   /// Tag for the navigation bar's Hero widget if [transitionBetweenRoutes] is true.
   ///
   /// Defaults to a common tag between all [CupertinoNavigationBar] and
@@ -1096,12 +1096,12 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// ([CupertinoPageRoute.title]) and [automaticallyImplyTitle] must be true.
   final Widget? largeTitle;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.leading}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.leading}
   ///
   /// This widget is visible in both collapsed and expanded states.
   final Widget? leading;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.automaticallyImplyLeading}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.automaticallyImplyLeading}
   final bool automaticallyImplyLeading;
 
   /// Controls whether we should try to imply the [largeTitle] widget if null.
@@ -1122,7 +1122,7 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// expanded state and [middle] in collapsed state.
   final bool alwaysShowMiddle;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.previousPageTitle}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.previousPageTitle}
   final String? previousPageTitle;
 
   /// A widget to place in the middle of the static navigation bar instead of
@@ -1136,33 +1136,33 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// state.
   final Widget? middle;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.trailing}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.trailing}
   ///
   /// This widget is visible in both collapsed and expanded states.
   final Widget? trailing;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.backgroundColor}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.backgroundColor}
   final Color? backgroundColor;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.automaticBackgroundVisibility}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.automaticBackgroundVisibility}
   final bool automaticBackgroundVisibility;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.enableBackgroundFilterBlur}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.enableBackgroundFilterBlur}
   final bool enableBackgroundFilterBlur;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.brightness}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.brightness}
   final Brightness? brightness;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.padding}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.padding}
   final EdgeInsetsDirectional? padding;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.border}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.border}
   final Border? border;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.transitionBetweenRoutes}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.transitionBetweenRoutes}
   final bool transitionBetweenRoutes;
 
-  /// {@macro flutter.cupertino.CupertinoNavigationBar.heroTag}
+  /// {@macro cupertino_ui.CupertinoNavigationBar.heroTag}
   final Object heroTag;
 
   /// A widget to place at the bottom of the large title or static navigation

--- a/packages/cupertino_ui/lib/src/picker.dart
+++ b/packages/cupertino_ui/lib/src/picker.dart
@@ -181,7 +181,7 @@ class CupertinoPicker extends StatefulWidget {
   /// If null, an implicit one will be created internally.
   final FixedExtentScrollController? scrollController;
 
-  /// {@template flutter.cupertino.picker.itemExtent}
+  /// {@template cupertino_ui.picker.itemExtent}
   /// The uniform height of all children.
   ///
   /// All children will be given the [BoxConstraints] to match this exact

--- a/packages/cupertino_ui/lib/src/radio.dart
+++ b/packages/cupertino_ui/lib/src/radio.dart
@@ -135,7 +135,7 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// {@macro flutter.widget.RawRadio.value}
   final T value;
 
-  /// {@template flutter.cupertino.Radio.groupValue}
+  /// {@template cupertino_ui.Radio.groupValue}
   /// The currently selected value for a group of radio buttons.
   ///
   /// This radio button is considered selected if its [value] matches the
@@ -149,7 +149,7 @@ class CupertinoRadio<T> extends StatefulWidget {
   )
   final T? groupValue;
 
-  /// {@template flutter.cupertino.Radio.onChanged}
+  /// {@template cupertino_ui.Radio.onChanged}
   /// Called when the user selects this radio button.
   ///
   /// The radio button passes [value] as a parameter to this callback. The radio
@@ -257,7 +257,7 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// [RadioGroupRegistry].
   final RadioGroupRegistry<T>? groupRegistry;
 
-  /// {@template flutter.cupertino.Radio.enabled}
+  /// {@template cupertino_ui.Radio.enabled}
   /// Whether this widget is interactive.
   ///
   /// If not provided, this widget will be interactable if one of the following

--- a/packages/cupertino_ui/lib/src/route.dart
+++ b/packages/cupertino_ui/lib/src/route.dart
@@ -79,7 +79,7 @@ final Animatable<Offset> _kBottomUpTween = Tween<Offset>(
 /// A mixin that replaces the entire screen with an iOS transition for a
 /// [PageRoute].
 ///
-/// {@template flutter.cupertino.cupertinoRouteTransitionMixin}
+/// {@template cupertino_ui.cupertinoRouteTransitionMixin}
 /// The page slides in from the right and exits in reverse. The page also shifts
 /// to the left in parallax when another page enters to cover it.
 ///
@@ -97,7 +97,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   @protected
   Widget buildContent(BuildContext context);
 
-  /// {@template flutter.cupertino.CupertinoRouteTransitionMixin.title}
+  /// {@template cupertino_ui.CupertinoRouteTransitionMixin.title}
   /// A title string for this route.
   ///
   /// Used to auto-populate [CupertinoNavigationBar] and
@@ -272,7 +272,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
 
 /// A modal route that replaces the entire screen with an iOS transition.
 ///
-/// {@macro flutter.cupertino.cupertinoRouteTransitionMixin}
+/// {@macro cupertino_ui.cupertinoRouteTransitionMixin}
 ///
 /// By default, when a modal route is replaced by another, the previous route
 /// remains in memory. To free all the resources when this is not necessary, set
@@ -368,7 +368,7 @@ class _PageBasedCupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTr
 
 /// A page that creates a cupertino style [PageRoute].
 ///
-/// {@macro flutter.cupertino.cupertinoRouteTransitionMixin}
+/// {@macro cupertino_ui.cupertinoRouteTransitionMixin}
 ///
 /// By default, when a created modal route is replaced by another, the previous
 /// route remains in memory. To free all the resources when this is not
@@ -401,7 +401,7 @@ class CupertinoPage<T> extends Page<T> {
   /// The content to be shown in the [Route] created by this page.
   final Widget child;
 
-  /// {@macro flutter.cupertino.CupertinoRouteTransitionMixin.title}
+  /// {@macro cupertino_ui.CupertinoRouteTransitionMixin.title}
   final String? title;
 
   /// {@macro flutter.widgets.ModalRoute.maintainState}
@@ -1373,7 +1373,7 @@ Widget _buildCupertinoDialogTransitions(
 /// By default, `useRootNavigator` is `true` and the dialog route created by
 /// this method is pushed to the root navigator.
 ///
-/// {@template flutter.cupertino.dialog.requestFocus}
+/// {@template cupertino_ui.dialog.requestFocus}
 /// The `requestFocus` argument is used to specify whether the dialog should
 /// request focus when shown.
 /// {@endtemplate}

--- a/packages/cupertino_ui/lib/src/search_field.dart
+++ b/packages/cupertino_ui/lib/src/search_field.dart
@@ -284,7 +284,7 @@ class CupertinoSearchTextField extends StatefulWidget {
   /// necessarily clearing text.
   final VoidCallback? onSuffixTap;
 
-  /// {@macro flutter.cupertino.textfield.restorationId}
+  /// {@macro cupertino_ui.textfield.restorationId}
   final String? restorationId;
 
   /// {@macro flutter.widgets.Focus.focusNode}
@@ -293,7 +293,7 @@ class CupertinoSearchTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.cupertino.textfield.onTap}
+  /// {@macro cupertino_ui.textfield.onTap}
   final VoidCallback? onTap;
 
   /// Whether to enable autocorrection.

--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -295,7 +295,7 @@ class CupertinoSheetTransition extends StatefulWidget {
   /// The gap between the top of the screen and the top of the sheet as a ratio
   /// of the screen height.
   ///
-  ///{@template flutter.cupertino.CupertinoSheetTransition.topGap}
+  ///{@template cupertino_ui.CupertinoSheetTransition.topGap}
   /// This value should be between 0.0 and 0.9, where 0.0 means no gap (sheet
   /// extends to the top of the screen) and 0.9 means the sheet covers only the
   /// bottom 10% of the screen. A value of 0.08 represents 8% of the screen height.
@@ -861,7 +861,7 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
   /// The gap between the top of the screen and the top of the sheet as a ratio
   /// of the screen height.
   ///
-  /// {@macro flutter.cupertino.CupertinoSheetTransition.topGap}
+  /// {@macro cupertino_ui.CupertinoSheetTransition.topGap}
   double get topGap;
 
   /// Whether a custom top gap has been set.

--- a/packages/cupertino_ui/lib/src/switch.dart
+++ b/packages/cupertino_ui/lib/src/switch.dart
@@ -288,23 +288,23 @@ class CupertinoSwitch extends StatefulWidget {
   /// (or [Color.fromARGB(255, 255, 255, 255)] in high contrast) when null.
   final Color? offLabelColor;
 
-  /// {@template flutter.cupertino.switch.activeThumbImage}
+  /// {@template cupertino_ui.switch.activeThumbImage}
   /// An image to use on the thumb of this switch when the switch is on.
   /// {@endtemplate}
   final ImageProvider? activeThumbImage;
 
-  /// {@template flutter.cupertino.switch.onActiveThumbImageError}
+  /// {@template cupertino_ui.switch.onActiveThumbImageError}
   /// An optional error callback for errors emitted when loading
   /// [activeThumbImage].
   /// {@endtemplate}
   final ImageErrorListener? onActiveThumbImageError;
 
-  /// {@template flutter.cupertino.switch.inactiveThumbImage}
+  /// {@template cupertino_ui.switch.inactiveThumbImage}
   /// An image to use on the thumb of this switch when the switch is off.
   /// {@endtemplate}
   final ImageProvider? inactiveThumbImage;
 
-  /// {@template flutter.cupertino.switch.onInactiveThumbImageError}
+  /// {@template cupertino_ui.switch.onInactiveThumbImageError}
   /// An optional error callback for errors emitted when loading
   /// [inactiveThumbImage].
   /// {@endtemplate}
@@ -474,7 +474,7 @@ class CupertinoSwitch extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@template flutter.cupertino.CupertinoSwitch.applyTheme}
+  /// {@template cupertino_ui.CupertinoSwitch.applyTheme}
   /// Whether to apply the ambient [CupertinoThemeData].
   ///
   /// If true, the track uses [CupertinoThemeData.primaryColor] for the track
@@ -484,7 +484,7 @@ class CupertinoSwitch extends StatefulWidget {
   /// {@endtemplate}
   final bool? applyTheme;
 
-  /// {@template flutter.cupertino.CupertinoSwitch.dragStartBehavior}
+  /// {@template cupertino_ui.CupertinoSwitch.dragStartBehavior}
   /// Determines the way that drag start behavior is handled.
   ///
   /// If set to [DragStartBehavior.start], the drag behavior used to move the

--- a/packages/cupertino_ui/lib/src/text_field.dart
+++ b/packages/cupertino_ui/lib/src/text_field.dart
@@ -167,7 +167,7 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder
 /// rounded rectangle border around the text field. If you set the [decoration]
 /// property to null, the decoration will be removed entirely.
 ///
-/// {@template flutter.cupertino.textfield.wantKeepAlive}
+/// {@template cupertino_ui.textfield.wantKeepAlive}
 /// When the widget has focus, it will prevent itself from disposing via its
 /// underlying [EditableText]'s [AutomaticKeepAliveClientMixin.wantKeepAlive] in
 /// order to avoid losing the selection. Removing the focus will allow it to be
@@ -613,7 +613,7 @@ class CupertinoTextField extends StatefulWidget {
   )
   final ToolbarOptions? toolbarOptions;
 
-  /// {@template flutter.cupertino.InputDecorator.textAlignVertical}
+  /// {@template cupertino_ui.InputDecorator.textAlignVertical}
   /// How the text should be aligned vertically.
   ///
   /// Determines the alignment of the baseline within the available space of
@@ -794,7 +794,7 @@ class CupertinoTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.selectionEnabled}
   bool get selectionEnabled => enableInteractiveSelection;
 
-  /// {@template flutter.cupertino.textfield.onTap}
+  /// {@template cupertino_ui.textfield.onTap}
   /// Called for the first tap in a series of taps.
   ///
   /// The text field builds a [GestureDetector] to handle input events like tap,
@@ -820,7 +820,7 @@ class CupertinoTextField extends StatefulWidget {
   /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
-  /// {@template flutter.cupertino.Material.clipBehavior}
+  /// {@template cupertino_ui.Material.clipBehavior}
   /// The content will be clipped (or not) according to this option.
   ///
   /// See the enum [Clip] for details of all possible options and their common
@@ -830,7 +830,7 @@ class CupertinoTextField extends StatefulWidget {
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
-  /// {@template flutter.cupertino.textfield.restorationId}
+  /// {@template cupertino_ui.textfield.restorationId}
   /// Restoration ID to save and restore the state of the text field.
   ///
   /// If non-null, the text field will persist and restore its current scroll

--- a/packages/cupertino_ui/lib/src/text_form_field_row.dart
+++ b/packages/cupertino_ui/lib/src/text_form_field_row.dart
@@ -283,7 +283,7 @@ class CupertinoTextFormFieldRow extends FormField<String> {
   /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController? controller;
 
-  /// {@template flutter.cupertino.TextFormField.onChanged}
+  /// {@template cupertino_ui.TextFormField.onChanged}
   /// Called when the user initiates a change to the TextField's
   /// value: when they have inserted or deleted text or reset the form.
   /// {@endtemplate}

--- a/packages/cupertino_ui/lib/src/text_selection_toolbar.dart
+++ b/packages/cupertino_ui/lib/src/text_selection_toolbar.dart
@@ -97,7 +97,7 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
     this.toolbarBuilder = _defaultToolbarBuilder,
   }) : assert(children.length > 0);
 
-  /// {@template flutter.cupertino.TextSelectionToolbar.anchorAbove}
+  /// {@template cupertino_ui.TextSelectionToolbar.anchorAbove}
   /// The focal point above which the toolbar attempts to position itself.
   ///
   /// If there is not enough room above before reaching the top of the screen,
@@ -105,13 +105,13 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
   /// {@endtemplate}
   final Offset anchorAbove;
 
-  /// {@template flutter.cupertino.TextSelectionToolbar.anchorBelow}
+  /// {@template cupertino_ui.TextSelectionToolbar.anchorBelow}
   /// The focal point below which the toolbar attempts to position itself, if it
   /// doesn't fit above [anchorAbove].
   /// {@endtemplate}
   final Offset anchorBelow;
 
-  /// {@template flutter.cupertino.TextSelectionToolbar.children}
+  /// {@template cupertino_ui.TextSelectionToolbar.children}
   /// The children that will be displayed in the text selection toolbar.
   ///
   /// Typically these are buttons.
@@ -124,7 +124,7 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
   ///     Cupertino-style text selection toolbar text button.
   final List<Widget> children;
 
-  /// {@template flutter.cupertino.TextSelectionToolbar.toolbarBuilder}
+  /// {@template cupertino_ui.TextSelectionToolbar.toolbarBuilder}
   /// Builds the toolbar container.
   ///
   /// Useful for customizing the high-level background of the toolbar. The given

--- a/packages/cupertino_ui/lib/src/text_selection_toolbar_button.dart
+++ b/packages/cupertino_ui/lib/src/text_selection_toolbar_button.dart
@@ -53,25 +53,25 @@ class CupertinoTextSelectionToolbarButton extends StatefulWidget {
        text = null,
        onPressed = buttonItem.onPressed;
 
-  /// {@template flutter.cupertino.CupertinoTextSelectionToolbarButton.child}
+  /// {@template cupertino_ui.CupertinoTextSelectionToolbarButton.child}
   /// The child of this button.
   ///
   /// Usually a [Text] or an [Icon].
   /// {@endtemplate}
   final Widget? child;
 
-  /// {@template flutter.cupertino.CupertinoTextSelectionToolbarButton.onPressed}
+  /// {@template cupertino_ui.CupertinoTextSelectionToolbarButton.onPressed}
   /// Called when this button is pressed.
   /// {@endtemplate}
   final VoidCallback? onPressed;
 
-  /// {@template flutter.cupertino.CupertinoTextSelectionToolbarButton.onPressed}
+  /// {@template cupertino_ui.CupertinoTextSelectionToolbarButton.onPressed}
   /// The buttonItem used to generate the button when using
   /// [CupertinoTextSelectionToolbarButton.buttonItem].
   /// {@endtemplate}
   final ContextMenuButtonItem? buttonItem;
 
-  /// {@template flutter.cupertino.CupertinoTextSelectionToolbarButton.text}
+  /// {@template cupertino_ui.CupertinoTextSelectionToolbarButton.text}
   /// The text used in the button's label when using
   /// [CupertinoTextSelectionToolbarButton.text].
   /// {@endtemplate}

--- a/packages/material_ui/lib/src/adaptive_text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/adaptive_text_selection_toolbar.dart
@@ -20,7 +20,7 @@ import 'theme.dart';
 
 /// The default context menu for text selection for the current platform.
 ///
-/// {@template flutter.material.AdaptiveTextSelectionToolbar.contextMenuBuilders}
+/// {@template material_ui.AdaptiveTextSelectionToolbar.contextMenuBuilders}
 /// Typically, this widget would be passed to `contextMenuBuilder` in a
 /// supported parent widget, such as:
 ///
@@ -50,19 +50,19 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// See also:
   ///
-  /// {@template flutter.material.AdaptiveTextSelectionToolbar.buttonItems}
+  /// {@template material_ui.AdaptiveTextSelectionToolbar.buttonItems}
   /// * [AdaptiveTextSelectionToolbar.buttonItems], which takes a list of
   ///   [ContextMenuButtonItem]s instead of [children] widgets.
   /// {@endtemplate}
-  /// {@template flutter.material.AdaptiveTextSelectionToolbar.editable}
+  /// {@template material_ui.AdaptiveTextSelectionToolbar.editable}
   /// * [AdaptiveTextSelectionToolbar.editable], which builds the default
   ///   children for an editable field.
   /// {@endtemplate}
-  /// {@template flutter.material.AdaptiveTextSelectionToolbar.editableText}
+  /// {@template material_ui.AdaptiveTextSelectionToolbar.editableText}
   /// * [AdaptiveTextSelectionToolbar.editableText], which builds the default
   ///   children for an [EditableText].
   /// {@endtemplate}
-  /// {@template flutter.material.AdaptiveTextSelectionToolbar.selectable}
+  /// {@template material_ui.AdaptiveTextSelectionToolbar.selectable}
   /// * [AdaptiveTextSelectionToolbar.selectable], which builds the default
   ///   children for content that is selectable but not editable.
   /// {@endtemplate}
@@ -74,13 +74,13 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// See also:
   ///
-  /// {@template flutter.material.AdaptiveTextSelectionToolbar.new}
+  /// {@template material_ui.AdaptiveTextSelectionToolbar.new}
   /// * [AdaptiveTextSelectionToolbar.new], which takes the children directly as
   ///   a list of widgets.
   /// {@endtemplate}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.editable}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.editableText}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.selectable}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.editable}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.editableText}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.selectable}
   const AdaptiveTextSelectionToolbar.buttonItems({
     super.key,
     required this.buttonItems,
@@ -100,10 +100,10 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// See also:
   ///
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.new}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.editableText}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.buttonItems}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.selectable}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.new}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.editableText}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.buttonItems}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.selectable}
   AdaptiveTextSelectionToolbar.editable({
     super.key,
     required ClipboardStatus clipboardStatus,
@@ -134,10 +134,10 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// See also:
   ///
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.new}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.editable}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.buttonItems}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.selectable}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.new}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.editable}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.buttonItems}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.selectable}
   AdaptiveTextSelectionToolbar.editableText({
     super.key,
     required EditableTextState editableTextState,
@@ -150,10 +150,10 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// See also:
   ///
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.new}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.buttonItems}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.editable}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.editableText}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.new}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.buttonItems}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.editable}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.editableText}
   AdaptiveTextSelectionToolbar.selectable({
     super.key,
     required VoidCallback onCopy,
@@ -174,11 +174,11 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   ///
   /// See also:
   ///
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.new}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.buttonItems}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.editable}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.editableText}
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.selectable}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.new}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.buttonItems}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.editable}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.editableText}
+  /// {@macro material_ui.AdaptiveTextSelectionToolbar.selectable}
   AdaptiveTextSelectionToolbar.selectableRegion({
     super.key,
     required SelectableRegionState selectableRegionState,
@@ -186,7 +186,7 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
        buttonItems = selectableRegionState.contextMenuButtonItems,
        anchors = selectableRegionState.contextMenuAnchors;
 
-  /// {@template flutter.material.AdaptiveTextSelectionToolbar.buttonItems}
+  /// {@template material_ui.AdaptiveTextSelectionToolbar.buttonItems}
   /// The [ContextMenuButtonItem]s that will be turned into the correct button
   /// widgets for the current platform.
   /// {@endtemplate}
@@ -195,7 +195,7 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   /// The children of the toolbar, typically buttons.
   final List<Widget>? children;
 
-  /// {@macro flutter.cupertino.AdaptiveTextSelectionToolbar.anchors}
+  /// {@macro cupertino_ui.AdaptiveTextSelectionToolbar.anchors}
   final TextSelectionToolbarAnchors anchors;
 
   /// Returns the default button label String for the button of the given

--- a/packages/material_ui/lib/src/app.dart
+++ b/packages/material_ui/lib/src/app.dart
@@ -107,7 +107,7 @@ enum ThemeMode {
 /// This widget also configures the observer of the top-level [Navigator] (if
 /// any) to perform [Hero] animations.
 ///
-/// {@template flutter.material.MaterialApp.defaultSelectionStyle}
+/// {@template material_ui.MaterialApp.defaultSelectionStyle}
 /// The [MaterialApp] automatically creates a [DefaultSelectionStyle]. It uses
 /// the colors in the [ThemeData.textSelectionTheme] if they are not null;
 /// otherwise, the [MaterialApp] sets [DefaultSelectionStyle.selectionColor] to
@@ -767,7 +767,7 @@ class MaterialApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.restorationScopeId}
   final String? restorationScopeId;
 
-  /// {@macro flutter.cupertino.materialApp.scrollBehavior}
+  /// {@macro cupertino_ui.materialApp.scrollBehavior}
   ///
   /// When null, defaults to [MaterialScrollBehavior].
   ///

--- a/packages/material_ui/lib/src/app_bar.dart
+++ b/packages/material_ui/lib/src/app_bar.dart
@@ -268,7 +268,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     return preferredSize.height;
   }
 
-  /// {@template flutter.material.appbar.leading}
+  /// {@template material_ui.appbar.leading}
   /// A widget to display before the toolbar's [title].
   ///
   /// Typically the [leading] widget is an [Icon] or an [IconButton].
@@ -321,7 +321,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///  * [Scaffold.drawer], in which the [Drawer] is usually placed.
   final Widget? leading;
 
-  /// {@template flutter.material.appbar.automaticallyImplyLeading}
+  /// {@template material_ui.appbar.automaticallyImplyLeading}
   /// Controls whether we should try to imply the leading widget if null.
   ///
   /// If true and [AppBar.leading] is null, automatically try to deduce what the leading
@@ -330,7 +330,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final bool automaticallyImplyLeading;
 
-  /// {@template flutter.material.appbar.title}
+  /// {@template material_ui.appbar.title}
   /// The primary widget displayed in the app bar.
   ///
   /// Becomes the middle component of the [NavigationToolbar] built by this widget.
@@ -366,7 +366,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// ```
   final Widget? title;
 
-  /// {@template flutter.material.appbar.actions}
+  /// {@template material_ui.appbar.actions}
   /// A list of Widgets to display in a row after the [title] widget.
   ///
   /// Typically these widgets are [IconButton]s representing common operations.
@@ -417,7 +417,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// </callout-box>
   final List<Widget>? actions;
 
-  /// {@template flutter.material.appbar.automaticallyImplyActions}
+  /// {@template material_ui.appbar.automaticallyImplyActions}
   /// Controls whether we should try to imply the actions widget if null.
   ///
   /// If true and [AppBar.actions] is null or empty, automatically try to deduce what the actions
@@ -426,7 +426,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final bool automaticallyImplyActions;
 
-  /// {@template flutter.material.appbar.flexibleSpace}
+  /// {@template material_ui.appbar.flexibleSpace}
   /// This widget is stacked behind the toolbar and the tab bar. Its height will
   /// be the same as the app bar's overall height.
   ///
@@ -438,7 +438,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final Widget? flexibleSpace;
 
-  /// {@template flutter.material.appbar.bottom}
+  /// {@template material_ui.appbar.bottom}
   /// This widget appears across the bottom of the app bar.
   ///
   /// Typically a [TabBar]. Only widgets that implement [PreferredSizeWidget] can
@@ -450,7 +450,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///  * [PreferredSize], which can be used to give an arbitrary widget a preferred size.
   final PreferredSizeWidget? bottom;
 
-  /// {@template flutter.material.appbar.elevation}
+  /// {@template material_ui.appbar.elevation}
   /// The z-coordinate at which to place this app bar relative to its parent.
   ///
   /// This property controls the size of the shadow below the app bar if
@@ -477,7 +477,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    shadow.
   final double? elevation;
 
-  /// {@template flutter.material.appbar.scrolledUnderElevation}
+  /// {@template material_ui.appbar.scrolledUnderElevation}
   /// The elevation that will be used if this app bar has something
   /// scrolled underneath it.
   ///
@@ -505,7 +505,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// else for more complicated layouts.
   final ScrollNotificationPredicate notificationPredicate;
 
-  /// {@template flutter.material.appbar.shadowColor}
+  /// {@template material_ui.appbar.shadowColor}
   /// The color of the shadow below the app bar.
   ///
   /// If this property is null, then the ambient [AppBarThemeData.shadowColor]
@@ -518,7 +518,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///  * [shape], which defines the shape of the app bar and its shadow.
   final Color? shadowColor;
 
-  /// {@template flutter.material.appbar.surfaceTintColor}
+  /// {@template material_ui.appbar.surfaceTintColor}
   /// The color of the surface tint overlay applied to the app bar's
   /// background color to indicate elevation.
   ///
@@ -529,7 +529,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///   * [Material.surfaceTintColor], which described this feature in more detail.
   final Color? surfaceTintColor;
 
-  /// {@template flutter.material.appbar.shape}
+  /// {@template material_ui.appbar.shape}
   /// The shape of the app bar's [Material] as well as its shadow.
   ///
   /// If this property is null, then the ambient [AppBarThemeData.shape]
@@ -560,7 +560,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///  * [shadowColor], which is the color of the shadow below the app bar.
   final ShapeBorder? shape;
 
-  /// {@template flutter.material.appbar.backgroundColor}
+  /// {@template material_ui.appbar.backgroundColor}
   /// The fill color to use for an app bar's [Material].
   ///
   /// If null, then the [AppBarTheme.backgroundColor] is used. If that value is also
@@ -589,7 +589,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    is light or dark.
   final Color? backgroundColor;
 
-  /// {@template flutter.material.appbar.foregroundColor}
+  /// {@template material_ui.appbar.foregroundColor}
   /// The default color for [Text] and [Icon]s within the app bar.
   ///
   /// If null, then [AppBarTheme.foregroundColor] is used. If that
@@ -617,7 +617,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    is light or dark.
   final Color? foregroundColor;
 
-  /// {@template flutter.material.appbar.iconTheme}
+  /// {@template material_ui.appbar.iconTheme}
   /// The color, opacity, and size to use for toolbar icons.
   ///
   /// If this property is null, then a copy of [ThemeData.iconTheme]
@@ -631,7 +631,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    the [actions] list.
   final IconThemeData? iconTheme;
 
-  /// {@template flutter.material.appbar.actionsIconTheme}
+  /// {@template material_ui.appbar.actionsIconTheme}
   /// The color, opacity, and size to use for the icons that appear in the app
   /// bar's [actions].
   ///
@@ -648,7 +648,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///  * [iconTheme], which defines the appearance of all of the toolbar icons.
   final IconThemeData? actionsIconTheme;
 
-  /// {@template flutter.material.appbar.primary}
+  /// {@template material_ui.appbar.primary}
   /// Whether this app bar is being displayed at the top of the screen.
   ///
   /// If true, the app bar's toolbar elements and [bottom] widget will be
@@ -657,7 +657,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final bool primary;
 
-  /// {@template flutter.material.appbar.centerTitle}
+  /// {@template material_ui.appbar.centerTitle}
   /// Whether the title should be centered.
   ///
   /// If this property is null, then [AppBarTheme.centerTitle] of
@@ -666,7 +666,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final bool? centerTitle;
 
-  /// {@template flutter.material.appbar.excludeHeaderSemantics}
+  /// {@template material_ui.appbar.excludeHeaderSemantics}
   /// Whether the title should be wrapped with header [Semantics].
   ///
   /// If false, the title will be used as [SemanticsProperties.namesRoute]
@@ -683,7 +683,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final bool excludeHeaderSemantics;
 
-  /// {@template flutter.material.appbar.titleSpacing}
+  /// {@template material_ui.appbar.titleSpacing}
   /// The spacing around [title] content on the horizontal axis. This spacing is
   /// applied even if there is no [leading] content or [actions]. If you want
   /// [title] to take all the space available, set this value to 0.0.
@@ -694,7 +694,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final double? titleSpacing;
 
-  /// {@template flutter.material.appbar.toolbarOpacity}
+  /// {@template material_ui.appbar.toolbarOpacity}
   /// How opaque the toolbar part of the app bar is.
   ///
   /// A value of 1.0 is fully opaque, and a value of 0.0 is fully transparent.
@@ -705,7 +705,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final double toolbarOpacity;
 
-  /// {@template flutter.material.appbar.bottomOpacity}
+  /// {@template material_ui.appbar.bottomOpacity}
   /// How opaque the bottom part of the app bar is.
   ///
   /// A value of 1.0 is fully opaque, and a value of 0.0 is fully transparent.
@@ -716,7 +716,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final double bottomOpacity;
 
-  /// {@template flutter.material.appbar.preferredSize}
+  /// {@template material_ui.appbar.preferredSize}
   /// A size whose height is the sum of [toolbarHeight] and the [bottom] widget's
   /// preferred height.
   ///
@@ -725,21 +725,21 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   @override
   final Size preferredSize;
 
-  /// {@template flutter.material.appbar.toolbarHeight}
+  /// {@template material_ui.appbar.toolbarHeight}
   /// Defines the height of the toolbar component of an [AppBar].
   ///
   /// By default, the value of [toolbarHeight] is [kToolbarHeight].
   /// {@endtemplate}
   final double? toolbarHeight;
 
-  /// {@template flutter.material.appbar.leadingWidth}
+  /// {@template material_ui.appbar.leadingWidth}
   /// Defines the width of [AppBar.leading] widget.
   ///
   /// By default, the value of [AppBar.leadingWidth] is 56.0.
   /// {@endtemplate}
   final double? leadingWidth;
 
-  /// {@template flutter.material.appbar.toolbarTextStyle}
+  /// {@template material_ui.appbar.toolbarTextStyle}
   /// The default text style for the AppBar's [leading], and
   /// [actions] widgets, but not its [title].
   ///
@@ -756,7 +756,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    widgets in a subtree.
   final TextStyle? toolbarTextStyle;
 
-  /// {@template flutter.material.appbar.titleTextStyle}
+  /// {@template material_ui.appbar.titleTextStyle}
   /// The default text style for the AppBar's [title] widget.
   ///
   /// If this property is null, then [AppBarTheme.titleTextStyle] of
@@ -774,7 +774,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    widgets in a subtree.
   final TextStyle? titleTextStyle;
 
-  /// {@template flutter.material.appbar.systemOverlayStyle}
+  /// {@template material_ui.appbar.systemOverlayStyle}
   /// Specifies the style to use for the system overlays (e.g. the status bar on
   /// Android or iOS, the system navigation bar on Android).
   ///
@@ -796,7 +796,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    system overlays style.
   final SystemUiOverlayStyle? systemOverlayStyle;
 
-  /// {@template flutter.material.appbar.forceMaterialTransparency}
+  /// {@template material_ui.appbar.forceMaterialTransparency}
   /// Forces the AppBar's Material widget type to be [MaterialType.transparency]
   /// (instead of Material's default type).
   ///
@@ -811,7 +811,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final bool forceMaterialTransparency;
 
-  /// {@template flutter.material.appbar.useDefaultSemanticsOrder}
+  /// {@template material_ui.appbar.useDefaultSemanticsOrder}
   /// Whether to use the default semantic ordering for the app bar's children for
   /// accessibility traversal order.
   ///
@@ -829,10 +829,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@endtemplate}
   final bool useDefaultSemanticsOrder;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   final Clip? clipBehavior;
 
-  /// {@template flutter.material.appbar.actionsPadding}
+  /// {@template material_ui.appbar.actionsPadding}
   /// The padding between the [actions] and the end of the AppBar.
   ///
   /// Defaults to zero.
@@ -1824,57 +1824,57 @@ class SliverAppBar extends StatefulWidget {
        ),
        _variant = _SliverAppVariant.large;
 
-  /// {@macro flutter.material.appbar.leading}
+  /// {@macro material_ui.appbar.leading}
   ///
   /// This property is used to configure an [AppBar].
   final Widget? leading;
 
-  /// {@macro flutter.material.appbar.automaticallyImplyLeading}
+  /// {@macro material_ui.appbar.automaticallyImplyLeading}
   ///
   /// This property is used to configure an [AppBar].
   final bool automaticallyImplyLeading;
 
-  /// {@macro flutter.material.appbar.title}
+  /// {@macro material_ui.appbar.title}
   ///
   /// This property is used to configure an [AppBar].
   final Widget? title;
 
-  /// {@macro flutter.material.appbar.actions}
+  /// {@macro material_ui.appbar.actions}
   ///
   /// This property is used to configure an [AppBar].
   final List<Widget>? actions;
 
-  /// {@macro flutter.material.appbar.automaticallyImplyActions}
+  /// {@macro material_ui.appbar.automaticallyImplyActions}
   ///
   /// This property is used to configure an [AppBar].
   final bool automaticallyImplyActions;
 
-  /// {@macro flutter.material.appbar.flexibleSpace}
+  /// {@macro material_ui.appbar.flexibleSpace}
   ///
   /// This property is used to configure an [AppBar].
   final Widget? flexibleSpace;
 
-  /// {@macro flutter.material.appbar.bottom}
+  /// {@macro material_ui.appbar.bottom}
   ///
   /// This property is used to configure an [AppBar].
   final PreferredSizeWidget? bottom;
 
-  /// {@macro flutter.material.appbar.elevation}
+  /// {@macro material_ui.appbar.elevation}
   ///
   /// This property is used to configure an [AppBar].
   final double? elevation;
 
-  /// {@macro flutter.material.appbar.scrolledUnderElevation}
+  /// {@macro material_ui.appbar.scrolledUnderElevation}
   ///
   /// This property is used to configure an [AppBar].
   final double? scrolledUnderElevation;
 
-  /// {@macro flutter.material.appbar.shadowColor}
+  /// {@macro material_ui.appbar.shadowColor}
   ///
   /// This property is used to configure an [AppBar].
   final Color? shadowColor;
 
-  /// {@macro flutter.material.appbar.surfaceTintColor}
+  /// {@macro material_ui.appbar.surfaceTintColor}
   ///
   /// This property is used to configure an [AppBar].
   final Color? surfaceTintColor;
@@ -1890,42 +1890,42 @@ class SliverAppBar extends StatefulWidget {
   /// Ignored when [elevation] is zero.
   final bool forceElevated;
 
-  /// {@macro flutter.material.appbar.backgroundColor}
+  /// {@macro material_ui.appbar.backgroundColor}
   ///
   /// This property is used to configure an [AppBar].
   final Color? backgroundColor;
 
-  /// {@macro flutter.material.appbar.foregroundColor}
+  /// {@macro material_ui.appbar.foregroundColor}
   ///
   /// This property is used to configure an [AppBar].
   final Color? foregroundColor;
 
-  /// {@macro flutter.material.appbar.iconTheme}
+  /// {@macro material_ui.appbar.iconTheme}
   ///
   /// This property is used to configure an [AppBar].
   final IconThemeData? iconTheme;
 
-  /// {@macro flutter.material.appbar.actionsIconTheme}
+  /// {@macro material_ui.appbar.actionsIconTheme}
   ///
   /// This property is used to configure an [AppBar].
   final IconThemeData? actionsIconTheme;
 
-  /// {@macro flutter.material.appbar.primary}
+  /// {@macro material_ui.appbar.primary}
   ///
   /// This property is used to configure an [AppBar].
   final bool primary;
 
-  /// {@macro flutter.material.appbar.centerTitle}
+  /// {@macro material_ui.appbar.centerTitle}
   ///
   /// This property is used to configure an [AppBar].
   final bool? centerTitle;
 
-  /// {@macro flutter.material.appbar.excludeHeaderSemantics}
+  /// {@macro material_ui.appbar.excludeHeaderSemantics}
   ///
   /// This property is used to configure an [AppBar].
   final bool excludeHeaderSemantics;
 
-  /// {@macro flutter.material.appbar.titleSpacing}
+  /// {@macro material_ui.appbar.titleSpacing}
   ///
   /// This property is used to configure an [AppBar].
   final double? titleSpacing;
@@ -1999,7 +1999,7 @@ class SliverAppBar extends StatefulWidget {
   ///    behavior of the app bar in combination with [floating].
   final bool pinned;
 
-  /// {@macro flutter.material.appbar.shape}
+  /// {@macro material_ui.appbar.shape}
   ///
   /// This property is used to configure an [AppBar].
   final ShapeBorder? shape;
@@ -2051,45 +2051,45 @@ class SliverAppBar extends StatefulWidget {
   /// offset specified by [stretchTriggerOffset].
   final AsyncCallback? onStretchTrigger;
 
-  /// {@macro flutter.material.appbar.toolbarHeight}
+  /// {@macro material_ui.appbar.toolbarHeight}
   ///
   /// This property is used to configure an [AppBar].
   final double toolbarHeight;
 
-  /// {@macro flutter.material.appbar.leadingWidth}
+  /// {@macro material_ui.appbar.leadingWidth}
   ///
   /// This property is used to configure an [AppBar].
   final double? leadingWidth;
 
-  /// {@macro flutter.material.appbar.toolbarTextStyle}
+  /// {@macro material_ui.appbar.toolbarTextStyle}
   ///
   /// This property is used to configure an [AppBar].
   final TextStyle? toolbarTextStyle;
 
-  /// {@macro flutter.material.appbar.titleTextStyle}
+  /// {@macro material_ui.appbar.titleTextStyle}
   ///
   /// This property is used to configure an [AppBar].
   final TextStyle? titleTextStyle;
 
-  /// {@macro flutter.material.appbar.systemOverlayStyle}
+  /// {@macro material_ui.appbar.systemOverlayStyle}
   ///
   /// This property is used to configure an [AppBar].
   final SystemUiOverlayStyle? systemOverlayStyle;
 
-  /// {@macro flutter.material.appbar.forceMaterialTransparency}
+  /// {@macro material_ui.appbar.forceMaterialTransparency}
   ///
   /// This property is used to configure an [AppBar].
   final bool forceMaterialTransparency;
 
-  /// {@macro flutter.material.appbar.useDefaultSemanticsOrder}
+  /// {@macro material_ui.appbar.useDefaultSemanticsOrder}
   ///
   /// This property is used to configure an [AppBar].
   final bool useDefaultSemanticsOrder;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   final Clip? clipBehavior;
 
-  /// {@macro flutter.material.appbar.actionsPadding}
+  /// {@macro material_ui.appbar.actionsPadding}
   ///
   /// This property is used to configure an [AppBar].
   final EdgeInsetsGeometry? actionsPadding;

--- a/packages/material_ui/lib/src/bottom_app_bar.dart
+++ b/packages/material_ui/lib/src/bottom_app_bar.dart
@@ -141,7 +141,7 @@ class BottomAppBar extends StatefulWidget {
   /// is used. If that's null then the shape will be rectangular with no notch.
   final NotchedShape? shape;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/bottom_navigation_bar.dart
+++ b/packages/material_ui/lib/src/bottom_navigation_bar.dart
@@ -305,7 +305,7 @@ class BottomNavigationBar extends StatefulWidget {
   ///
   /// If null, defaults to `8.0`.
   ///
-  /// {@macro flutter.material.material.elevation}
+  /// {@macro material_ui.material.elevation}
   final double? elevation;
 
   /// Defines the layout and behavior of a [BottomNavigationBar].

--- a/packages/material_ui/lib/src/bottom_sheet.dart
+++ b/packages/material_ui/lib/src/bottom_sheet.dart
@@ -203,7 +203,7 @@ class BottomSheet extends StatefulWidget {
   /// Defaults to null and falls back to [Material]'s default.
   final ShapeBorder? shape;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defines the bottom sheet's [Material.clipBehavior].
   ///
@@ -804,7 +804,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
 
 /// A route that represents a Material Design modal bottom sheet.
 ///
-/// {@template flutter.material.ModalBottomSheetRoute}
+/// {@template material_ui.ModalBottomSheetRoute}
 /// A modal bottom sheet is an alternative to a menu or a dialog and prevents
 /// the user from interacting with the rest of the app.
 ///
@@ -938,7 +938,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   /// If this property is not provided, it falls back to [Material]'s default.
   final ShapeBorder? shape;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defines the bottom sheet's [Material.clipBehavior].
   ///
@@ -1047,7 +1047,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   /// To disable the modal bottom sheet animation, use [AnimationStyle.noAnimation].
   final AnimationStyle? sheetAnimationStyle;
 
-  /// {@template flutter.material.ModalBottomSheetRoute.barrierOnTapHint}
+  /// {@template material_ui.ModalBottomSheetRoute.barrierOnTapHint}
   /// The semantic hint text that informs users what will happen if they
   /// tap on the widget. Announced in the format of 'Double tap to ...'.
   ///
@@ -1207,7 +1207,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
 
 /// Shows a modal Material Design bottom sheet.
 ///
-/// {@macro flutter.material.ModalBottomSheetRoute}
+/// {@macro material_ui.ModalBottomSheetRoute}
 ///
 /// {@macro flutter.widgets.RawDialogRoute}
 ///

--- a/packages/material_ui/lib/src/bottom_sheet_theme.dart
+++ b/packages/material_ui/lib/src/bottom_sheet_theme.dart
@@ -63,7 +63,7 @@ class BottomSheetThemeData with Diagnosticable {
 
   /// Overrides the default value for [BottomSheet.elevation].
   ///
-  /// {@macro flutter.material.material.elevation}
+  /// {@macro material_ui.material.elevation}
   ///
   /// If null, [BottomSheet] defaults to 0.0.
   final double? elevation;

--- a/packages/material_ui/lib/src/button.dart
+++ b/packages/material_ui/lib/src/button.dart
@@ -110,7 +110,7 @@ class RawMaterialButton extends StatefulWidget {
   /// [State.setState] is not allowed).
   final ValueChanged<bool>? onHighlightChanged;
 
-  /// {@template flutter.material.RawMaterialButton.mouseCursor}
+  /// {@template material_ui.RawMaterialButton.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// button.
   ///
@@ -234,7 +234,7 @@ class RawMaterialButton extends StatefulWidget {
 
   /// Defines how compact the button's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// See also:
   ///
@@ -290,7 +290,7 @@ class RawMaterialButton extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/button_style.dart
+++ b/packages/material_ui/lib/src/button_style.dart
@@ -335,7 +335,7 @@ class ButtonStyle with Diagnosticable {
 
   /// Defines how compact the button's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// See also:
   ///

--- a/packages/material_ui/lib/src/button_style_button.dart
+++ b/packages/material_ui/lib/src/button_style_button.dart
@@ -29,7 +29,7 @@ import 'theme.dart';
 import 'theme_data.dart';
 import 'tooltip.dart';
 
-/// {@template flutter.material.ButtonStyle.iconAlignment}
+/// {@template material_ui.ButtonStyle.iconAlignment}
 /// Determines the alignment of the icon within the widgets such as:
 ///   - [ElevatedButton.icon],
 ///   - [FilledButton.icon],
@@ -144,7 +144,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// Null by default.
   final ButtonStyle? style;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none] unless [ButtonStyle.backgroundBuilder] or
   /// [ButtonStyle.foregroundBuilder] is specified. In those
@@ -157,7 +157,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.material.inkwell.statesController}
+  /// {@macro material_ui.inkwell.statesController}
   final MaterialStatesController? statesController;
 
   /// Determine whether this subtree represents a button.
@@ -169,7 +169,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// Defaults to true.
   final bool? isSemanticButton;
 
-  /// {@macro flutter.material.ButtonStyle.iconAlignment}
+  /// {@macro material_ui.ButtonStyle.iconAlignment}
   @Deprecated(
     'Remove this parameter as it is now ignored. '
     'Use ButtonStyle.iconAlignment instead. '

--- a/packages/material_ui/lib/src/calendar_date_picker.dart
+++ b/packages/material_ui/lib/src/calendar_date_picker.dart
@@ -117,7 +117,7 @@ class CalendarDatePicker extends StatefulWidget {
   /// If [selectableDayPredicate] and [initialDate] are both non-null,
   /// [selectableDayPredicate] must return `true` for the [initialDate].
   ///
-  /// {@template flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@template material_ui.calendar_date_picker.calendarDelegate}
   /// The [calendarDelegate] controls date interpretation, formatting, and
   /// navigation within the picker. By providing a custom implementation,
   /// you can support alternative calendar systems such as Nepali, Hijri,
@@ -192,7 +192,7 @@ class CalendarDatePicker extends StatefulWidget {
   /// Function to provide full control over which dates in the calendar can be selected.
   final SelectableDayPredicate? selectableDayPredicate;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override
@@ -611,7 +611,7 @@ class _MonthPicker extends StatefulWidget {
   /// Optional user supplied predicate function to customize selectable days.
   final SelectableDayPredicate? selectableDayPredicate;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override
@@ -1034,7 +1034,7 @@ class _DayPicker extends StatefulWidget {
   /// Optional user supplied predicate function to customize selectable days.
   final SelectableDayPredicate? selectableDayPredicate;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override
@@ -1421,7 +1421,7 @@ class YearPicker extends StatefulWidget {
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override

--- a/packages/material_ui/lib/src/card.dart
+++ b/packages/material_ui/lib/src/card.dart
@@ -219,7 +219,7 @@ class Card extends StatelessWidget {
   /// If false, the border will be painted behind the [child].
   final bool borderOnForeground;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// If this property is null then the ambient [CardThemeData.clipBehavior] is
   /// used. If that's null then the behavior will be [Clip.none].

--- a/packages/material_ui/lib/src/carousel.dart
+++ b/packages/material_ui/lib/src/carousel.dart
@@ -480,7 +480,7 @@ class CarouselView extends StatefulWidget {
   /// The child widgets for the carousel.
   final List<Widget> children;
 
-  /// {@template flutter.material.CarouselView.onIndexChanged}
+  /// {@template material_ui.CarouselView.onIndexChanged}
   /// A callback invoked when the leading item changes.
   ///
   /// The leading item is the first visible item in the carousel view.
@@ -1927,7 +1927,7 @@ class CarouselController extends ScrollController {
 
   /// The current leading item index in the [CarouselView].
   ///
-  /// {@macro flutter.material.CarouselView.onIndexChanged}
+  /// {@macro material_ui.CarouselView.onIndexChanged}
   int get leadingItem {
     assert(
       positions.isNotEmpty,

--- a/packages/material_ui/lib/src/checkbox.dart
+++ b/packages/material_ui/lib/src/checkbox.dart
@@ -191,7 +191,7 @@ class Checkbox extends StatefulWidget {
   /// ```
   final ValueChanged<bool?>? onChanged;
 
-  /// {@template flutter.material.checkbox.mouseCursor}
+  /// {@template material_ui.checkbox.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
@@ -218,7 +218,7 @@ class Checkbox extends StatefulWidget {
   /// state, it will be used instead of this color.
   final Color? activeColor;
 
-  /// {@template flutter.material.checkbox.fillColor}
+  /// {@template material_ui.checkbox.fillColor}
   /// The color that fills the checkbox, in all [WidgetState]s.
   ///
   /// Resolves in the following states:
@@ -260,7 +260,7 @@ class Checkbox extends StatefulWidget {
   /// default state.
   final WidgetStateProperty<Color?>? fillColor;
 
-  /// {@template flutter.material.checkbox.checkColor}
+  /// {@template material_ui.checkbox.checkColor}
   /// The color to use for the check icon when this checkbox is checked.
   /// {@endtemplate}
   ///
@@ -280,7 +280,7 @@ class Checkbox extends StatefulWidget {
   /// If tristate is false (the default), [value] must not be null.
   final bool tristate;
 
-  /// {@template flutter.material.checkbox.materialTapTargetSize}
+  /// {@template material_ui.checkbox.materialTapTargetSize}
   /// Configures the minimum size of the tap target.
   /// {@endtemplate}
   ///
@@ -293,11 +293,11 @@ class Checkbox extends StatefulWidget {
   ///  * [MaterialTapTargetSize], for a description of how this affects tap targets.
   final MaterialTapTargetSize? materialTapTargetSize;
 
-  /// {@template flutter.material.checkbox.visualDensity}
+  /// {@template material_ui.checkbox.visualDensity}
   /// Defines how compact the checkbox's layout will be.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// If null, then the value of [CheckboxThemeData.visualDensity] is used. If
   /// that is also null and if [ThemeData.useMaterial3] is false, then the
@@ -320,7 +320,7 @@ class Checkbox extends StatefulWidget {
   /// [ThemeData.focusColor] is used.
   final Color? focusColor;
 
-  /// {@template flutter.material.checkbox.hoverColor}
+  /// {@template material_ui.checkbox.hoverColor}
   /// The color for the checkbox's [Material] when a pointer is hovering over it.
   ///
   /// If [overlayColor] returns a non-null color in the [WidgetState.hovered]
@@ -332,7 +332,7 @@ class Checkbox extends StatefulWidget {
   /// [ThemeData.hoverColor] is used.
   final Color? hoverColor;
 
-  /// {@template flutter.material.checkbox.overlayColor}
+  /// {@template material_ui.checkbox.overlayColor}
   /// The color for the checkbox's [Material].
   ///
   /// Resolves in the following states:
@@ -351,7 +351,7 @@ class Checkbox extends StatefulWidget {
   /// is used in the pressed, focused and hovered state.
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@template flutter.material.checkbox.splashRadius}
+  /// {@template material_ui.checkbox.splashRadius}
   /// The splash radius of the circular [Material] ink response.
   /// {@endtemplate}
   ///
@@ -365,7 +365,7 @@ class Checkbox extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@template flutter.material.checkbox.shape}
+  /// {@template material_ui.checkbox.shape}
   /// The shape of the checkbox's [Material].
   /// {@endtemplate}
   ///
@@ -374,7 +374,7 @@ class Checkbox extends StatefulWidget {
   /// with a circular corner radius of 1.0 in Material 2, and 2.0 in Material 3.
   final OutlinedBorder? shape;
 
-  /// {@template flutter.material.checkbox.side}
+  /// {@template material_ui.checkbox.side}
   /// The color and width of the checkbox's border.
   ///
   /// This property can be a [WidgetStateBorderSide] that can
@@ -399,7 +399,7 @@ class Checkbox extends StatefulWidget {
   /// used. If that is also null, then the side will be width 2.
   final BorderSide? side;
 
-  /// {@template flutter.material.checkbox.isError}
+  /// {@template material_ui.checkbox.isError}
   /// True if this checkbox wants to show an error state.
   ///
   /// The checkbox will have different default container color and check color when
@@ -409,7 +409,7 @@ class Checkbox extends StatefulWidget {
   /// Defaults to false.
   final bool isError;
 
-  /// {@template flutter.material.checkbox.semanticLabel}
+  /// {@template material_ui.checkbox.semanticLabel}
   /// The semantic label for the checkbox that will be announced by screen readers.
   ///
   /// This is announced by assistive technologies (e.g TalkBack/VoiceOver).

--- a/packages/material_ui/lib/src/checkbox_list_tile.dart
+++ b/packages/material_ui/lib/src/checkbox_list_tile.dart
@@ -368,7 +368,7 @@ class CheckboxListTile extends StatelessWidget {
   /// Defaults to Color(0xFFFFFFFF).
   final Color? checkColor;
 
-  /// {@macro flutter.material.checkbox.hoverColor}
+  /// {@macro material_ui.checkbox.hoverColor}
   final Color? hoverColor;
 
   /// The color for the checkbox's [Material].
@@ -384,20 +384,20 @@ class CheckboxListTile extends StatelessWidget {
   /// then the default value is used in the pressed and hovered state.
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@macro flutter.material.checkbox.splashRadius}
+  /// {@macro material_ui.checkbox.splashRadius}
   ///
   /// If null, then the value of [CheckboxThemeData.splashRadius] is used. If
   /// that is also null, then [kRadialReactionRadius] is used.
   final double? splashRadius;
 
-  /// {@macro flutter.material.checkbox.materialTapTargetSize}
+  /// {@macro material_ui.checkbox.materialTapTargetSize}
   ///
   /// Defaults to [MaterialTapTargetSize.shrinkWrap].
   final MaterialTapTargetSize? materialTapTargetSize;
 
   /// Defines how compact the list tile's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   final VisualDensity? visualDensity;
 
   /// {@macro flutter.widgets.Focus.focusNode}
@@ -409,10 +409,10 @@ class CheckboxListTile extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.material.ListTile.shape}
+  /// {@macro material_ui.ListTile.shape}
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.checkbox.side}
+  /// {@macro material_ui.checkbox.side}
   ///
   /// The given value is passed directly to [Checkbox.side].
   ///
@@ -421,12 +421,12 @@ class CheckboxListTile extends StatelessWidget {
   /// will be width 2.
   final BorderSide? side;
 
-  /// {@macro flutter.material.checkbox.isError}
+  /// {@macro material_ui.checkbox.isError}
   ///
   /// Defaults to false.
   final bool isError;
 
-  /// {@macro flutter.material.ListTile.tileColor}
+  /// {@macro material_ui.ListTile.tileColor}
   final Color? tileColor;
 
   /// The primary content of the list tile.
@@ -487,7 +487,7 @@ class CheckboxListTile extends StatelessWidget {
   /// If tristate is false (the default), [value] must not be null.
   final bool tristate;
 
-  /// {@macro flutter.material.checkbox.shape}
+  /// {@macro material_ui.checkbox.shape}
   ///
   /// If this property is null then [CheckboxThemeData.shape] of [ThemeData.checkboxTheme]
   /// is used. If that's null then the shape will be a [RoundedRectangleBorder]
@@ -497,26 +497,26 @@ class CheckboxListTile extends StatelessWidget {
   /// If non-null, defines the background color when [CheckboxListTile.selected] is true.
   final Color? selectedTileColor;
 
-  /// {@macro flutter.cupertino.inkwell.onFocusChange}
+  /// {@macro cupertino_ui.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
-  /// {@macro flutter.material.ListTile.enableFeedback}
+  /// {@macro material_ui.ListTile.enableFeedback}
   ///
   /// See also:
   ///
   ///  * [Feedback] for providing platform-specific feedback to certain actions.
   final bool? enableFeedback;
 
-  /// {@macro flutter.material.ListTile.horizontalTitleGap}
+  /// {@macro material_ui.ListTile.horizontalTitleGap}
   final double? horizontalTitleGap;
 
-  /// {@macro flutter.material.ListTile.minVerticalPadding}
+  /// {@macro material_ui.ListTile.minVerticalPadding}
   final double? minVerticalPadding;
 
-  /// {@macro flutter.material.ListTile.minLeadingWidth}
+  /// {@macro material_ui.ListTile.minLeadingWidth}
   final double? minLeadingWidth;
 
-  /// {@macro flutter.material.ListTile.minTileHeight}
+  /// {@macro material_ui.ListTile.minTileHeight}
   final double? minTileHeight;
 
   /// Whether the CheckboxListTile is interactive.
@@ -552,7 +552,7 @@ class CheckboxListTile extends StatelessWidget {
   /// Defaults to 1.0.
   final double checkboxScaleFactor;
 
-  /// {@macro flutter.material.checkbox.semanticLabel}
+  /// {@macro material_ui.checkbox.semanticLabel}
   final String? checkboxSemanticLabel;
 
   final _CheckboxType _checkboxType;

--- a/packages/material_ui/lib/src/checkbox_theme.dart
+++ b/packages/material_ui/lib/src/checkbox_theme.dart
@@ -50,17 +50,17 @@ class CheckboxThemeData with Diagnosticable {
     this.side,
   });
 
-  /// {@macro flutter.material.checkbox.mouseCursor}
+  /// {@macro material_ui.checkbox.mouseCursor}
   ///
   /// If specified, overrides the default value of [Checkbox.mouseCursor].
   final WidgetStateProperty<MouseCursor?>? mouseCursor;
 
-  /// {@macro flutter.material.checkbox.fillColor}
+  /// {@macro material_ui.checkbox.fillColor}
   ///
   /// If specified, overrides the default value of [Checkbox.fillColor].
   final WidgetStateProperty<Color?>? fillColor;
 
-  /// {@macro flutter.material.checkbox.checkColor}
+  /// {@macro material_ui.checkbox.checkColor}
   ///
   /// Resolves in the following states:
   ///  * [WidgetState.selected].
@@ -71,33 +71,33 @@ class CheckboxThemeData with Diagnosticable {
   /// If specified, overrides the default value of [Checkbox.checkColor].
   final WidgetStateProperty<Color?>? checkColor;
 
-  /// {@macro flutter.material.checkbox.overlayColor}
+  /// {@macro material_ui.checkbox.overlayColor}
   ///
   /// If specified, overrides the default value of [Checkbox.overlayColor].
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@macro flutter.material.checkbox.splashRadius}
+  /// {@macro material_ui.checkbox.splashRadius}
   ///
   /// If specified, overrides the default value of [Checkbox.splashRadius].
   final double? splashRadius;
 
-  /// {@macro flutter.material.checkbox.materialTapTargetSize}
+  /// {@macro material_ui.checkbox.materialTapTargetSize}
   ///
   /// If specified, overrides the default value of
   /// [Checkbox.materialTapTargetSize].
   final MaterialTapTargetSize? materialTapTargetSize;
 
-  /// {@macro flutter.material.checkbox.visualDensity}
+  /// {@macro material_ui.checkbox.visualDensity}
   ///
   /// If specified, overrides the default value of [Checkbox.visualDensity].
   final VisualDensity? visualDensity;
 
-  /// {@macro flutter.material.checkbox.shape}
+  /// {@macro material_ui.checkbox.shape}
   ///
   /// If specified, overrides the default value of [Checkbox.shape].
   final OutlinedBorder? shape;
 
-  /// {@macro flutter.material.checkbox.side}
+  /// {@macro material_ui.checkbox.side}
   ///
   /// If specified, overrides the default value of [Checkbox.side].
   final BorderSide? side;

--- a/packages/material_ui/lib/src/chip.dart
+++ b/packages/material_ui/lib/src/chip.dart
@@ -143,7 +143,7 @@ abstract interface class ChipAttributes {
   ///  * [WidgetState.pressed].
   OutlinedBorder? get shape;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   Clip get clipBehavior;
@@ -179,7 +179,7 @@ abstract interface class ChipAttributes {
   ///
   /// Chips are unaffected by horizontal density changes.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// See also:
   ///

--- a/packages/material_ui/lib/src/color_scheme.dart
+++ b/packages/material_ui/lib/src/color_scheme.dart
@@ -62,7 +62,7 @@ enum DynamicSchemeVariant {
   fruitSalad,
 }
 
-/// {@template flutter.material.color_scheme.ColorScheme}
+/// {@template material_ui.color_scheme.ColorScheme}
 /// A set of 45 colors based on the
 /// [Material spec](https://m3.material.io/styles/color/the-color-system/color-roles)
 /// that can be used to configure the color properties of most components.
@@ -70,7 +70,7 @@ enum DynamicSchemeVariant {
 ///
 /// ### Colors in Material 3
 ///
-/// {@macro flutter.material.colors.colorRoles}
+/// {@macro material_ui.colors.colorRoles}
 ///
 /// The main accent color groups in the scheme are [primary], [secondary],
 /// and [tertiary].
@@ -129,7 +129,7 @@ enum DynamicSchemeVariant {
 ///
 /// ### Setting Colors in Flutter
 ///
-///{@macro flutter.material.colors.settingColors}
+///{@macro material_ui.colors.settingColors}
 @immutable
 class ColorScheme with Diagnosticable {
   /// Create a ColorScheme instance from the given colors.

--- a/packages/material_ui/lib/src/colors.dart
+++ b/packages/material_ui/lib/src/colors.dart
@@ -29,7 +29,7 @@ import 'package:flutter/painting.dart';
 /// For more information on colors in Material 3 see
 /// the spec at <https://m3.material.io/styles/color/the-color-system>.
 ///
-///{@template flutter.material.colors.colorRoles}
+///{@template material_ui.colors.colorRoles}
 /// In Material 3, colors are represented using color roles and
 /// corresponding tokens. Each property in the [ColorScheme] class
 /// represents one color role as defined in the spec above.
@@ -37,7 +37,7 @@ import 'package:flutter/painting.dart';
 ///
 /// ### Material 3 Colors in Flutter
 ///
-///{@template flutter.material.colors.settingColors}
+///{@template material_ui.colors.settingColors}
 /// Flutter's Material widgets can be assigned colors at the widget level
 /// using widget properties,
 /// or at the app level using theme classes.

--- a/packages/material_ui/lib/src/data_table.dart
+++ b/packages/material_ui/lib/src/data_table.dart
@@ -573,7 +573,7 @@ class DataTable extends StatelessWidget {
   /// row is selectable.
   final ValueSetter<bool?>? onSelectAll;
 
-  /// {@template flutter.material.dataTable.decoration}
+  /// {@template material_ui.dataTable.decoration}
   /// The background and border decoration for the table.
   /// {@endtemplate}
   ///
@@ -581,7 +581,7 @@ class DataTable extends StatelessWidget {
   /// decoration.
   final Decoration? decoration;
 
-  /// {@template flutter.material.dataTable.dataRowColor}
+  /// {@template material_ui.dataTable.dataRowColor}
   /// The background color for the data rows.
   ///
   /// The effective background color can be made to depend on the
@@ -600,7 +600,7 @@ class DataTable extends StatelessWidget {
   /// translucent color. To set a different color for individual rows, see
   /// [DataRow.color].
   ///
-  /// {@template flutter.material.DataTable.dataRowColor}
+  /// {@template material_ui.DataTable.dataRowColor}
   /// ```dart
   /// DataTable(
   ///   dataRowColor: WidgetStateProperty.resolveWith<Color?>((Set<WidgetState> states) {
@@ -622,7 +622,7 @@ class DataTable extends StatelessWidget {
   /// {@endtemplate}
   final WidgetStateProperty<Color?>? dataRowColor;
 
-  /// {@template flutter.material.dataTable.dataRowHeight}
+  /// {@template material_ui.dataTable.dataRowHeight}
   /// The height of each row (excluding the row that contains column headings).
   /// {@endtemplate}
   ///
@@ -635,7 +635,7 @@ class DataTable extends StatelessWidget {
   )
   double? get dataRowHeight => dataRowMinHeight == dataRowMaxHeight ? dataRowMinHeight : null;
 
-  /// {@template flutter.material.dataTable.dataRowMinHeight}
+  /// {@template material_ui.dataTable.dataRowMinHeight}
   /// The minimum height of each row (excluding the row that contains column headings).
   /// {@endtemplate}
   ///
@@ -644,7 +644,7 @@ class DataTable extends StatelessWidget {
   /// specifications.
   final double? dataRowMinHeight;
 
-  /// {@template flutter.material.dataTable.dataRowMaxHeight}
+  /// {@template material_ui.dataTable.dataRowMaxHeight}
   /// The maximum height of each row (excluding the row that contains column headings).
   /// {@endtemplate}
   ///
@@ -653,7 +653,7 @@ class DataTable extends StatelessWidget {
   /// specifications.
   final double? dataRowMaxHeight;
 
-  /// {@template flutter.material.dataTable.dataTextStyle}
+  /// {@template material_ui.dataTable.dataTextStyle}
   /// The text style for data rows.
   /// {@endtemplate}
   ///
@@ -661,7 +661,7 @@ class DataTable extends StatelessWidget {
   /// style is [TextTheme.bodyMedium].
   final TextStyle? dataTextStyle;
 
-  /// {@template flutter.material.dataTable.headingRowColor}
+  /// {@template material_ui.dataTable.headingRowColor}
   /// The background color for the heading row.
   ///
   /// The effective background color can be made to depend on the
@@ -673,7 +673,7 @@ class DataTable extends StatelessWidget {
   ///
   /// If null, [DataTableThemeData.headingRowColor] is used.
   ///
-  /// {@template flutter.material.DataTable.headingRowColor}
+  /// {@template material_ui.DataTable.headingRowColor}
   /// ```dart
   /// DataTable(
   ///   columns: _columns,
@@ -695,7 +695,7 @@ class DataTable extends StatelessWidget {
   /// {@endtemplate}
   final WidgetStateProperty<Color?>? headingRowColor;
 
-  /// {@template flutter.material.dataTable.headingRowHeight}
+  /// {@template material_ui.dataTable.headingRowHeight}
   /// The height of the heading row.
   /// {@endtemplate}
   ///
@@ -703,7 +703,7 @@ class DataTable extends StatelessWidget {
   /// defaults to 56.0 to adhere to the Material Design specifications.
   final double? headingRowHeight;
 
-  /// {@template flutter.material.dataTable.headingTextStyle}
+  /// {@template material_ui.dataTable.headingTextStyle}
   /// The text style for the heading row.
   /// {@endtemplate}
   ///
@@ -711,7 +711,7 @@ class DataTable extends StatelessWidget {
   /// text style is [TextTheme.titleSmall].
   final TextStyle? headingTextStyle;
 
-  /// {@template flutter.material.dataTable.horizontalMargin}
+  /// {@template material_ui.dataTable.horizontalMargin}
   /// The horizontal margin between the edges of the table and the content
   /// in the first and last cells of each row.
   ///
@@ -727,7 +727,7 @@ class DataTable extends StatelessWidget {
   /// margin between the checkbox and the content in the first data column.
   final double? horizontalMargin;
 
-  /// {@template flutter.material.dataTable.columnSpacing}
+  /// {@template material_ui.dataTable.columnSpacing}
   /// The horizontal margin between the contents of each data column.
   /// {@endtemplate}
   ///
@@ -735,7 +735,7 @@ class DataTable extends StatelessWidget {
   /// to 56.0 to adhere to the Material Design specifications.
   final double? columnSpacing;
 
-  /// {@template flutter.material.dataTable.showCheckboxColumn}
+  /// {@template material_ui.dataTable.showCheckboxColumn}
   /// Whether the widget should display checkboxes for selectable rows.
   ///
   /// If true, a [Checkbox] will be placed at the beginning of each row that is
@@ -752,7 +752,7 @@ class DataTable extends StatelessWidget {
   /// The list may be empty.
   final List<DataRow> rows;
 
-  /// {@template flutter.material.dataTable.dividerThickness}
+  /// {@template material_ui.dataTable.dividerThickness}
   /// The width of the divider that appears between [TableRow]s.
   ///
   /// Must be greater than or equal to zero.
@@ -768,7 +768,7 @@ class DataTable extends StatelessWidget {
   /// around the table defined by [decoration].
   final bool showBottomBorder;
 
-  /// {@template flutter.material.dataTable.checkboxHorizontalMargin}
+  /// {@template material_ui.dataTable.checkboxHorizontalMargin}
   /// Horizontal margin around the checkbox, if it is displayed.
   /// {@endtemplate}
   ///
@@ -781,7 +781,7 @@ class DataTable extends StatelessWidget {
   /// The style to use when painting the boundary and interior divisions of the table.
   final TableBorder? border;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// This can be used to clip the content within the border of the [DataTable].
   ///

--- a/packages/material_ui/lib/src/data_table_theme.dart
+++ b/packages/material_ui/lib/src/data_table_theme.dart
@@ -71,49 +71,49 @@ class DataTableThemeData with Diagnosticable {
        dataRowMinHeight = dataRowHeight ?? dataRowMinHeight,
        dataRowMaxHeight = dataRowHeight ?? dataRowMaxHeight;
 
-  /// {@macro flutter.material.dataTable.decoration}
+  /// {@macro material_ui.dataTable.decoration}
   final Decoration? decoration;
 
-  /// {@macro flutter.material.dataTable.dataRowColor}
-  /// {@macro flutter.material.DataTable.dataRowColor}
+  /// {@macro material_ui.dataTable.dataRowColor}
+  /// {@macro material_ui.DataTable.dataRowColor}
   final WidgetStateProperty<Color?>? dataRowColor;
 
-  /// {@macro flutter.material.dataTable.dataRowHeight}
+  /// {@macro material_ui.dataTable.dataRowHeight}
   @Deprecated(
     'Migrate to use dataRowMinHeight and dataRowMaxHeight instead. '
     'This feature was deprecated after v3.7.0-5.0.pre.',
   )
   double? get dataRowHeight => dataRowMinHeight == dataRowMaxHeight ? dataRowMinHeight : null;
 
-  /// {@macro flutter.material.dataTable.dataRowMinHeight}
+  /// {@macro material_ui.dataTable.dataRowMinHeight}
   final double? dataRowMinHeight;
 
-  /// {@macro flutter.material.dataTable.dataRowMaxHeight}
+  /// {@macro material_ui.dataTable.dataRowMaxHeight}
   final double? dataRowMaxHeight;
 
-  /// {@macro flutter.material.dataTable.dataTextStyle}
+  /// {@macro material_ui.dataTable.dataTextStyle}
   final TextStyle? dataTextStyle;
 
-  /// {@macro flutter.material.dataTable.headingRowColor}
-  /// {@macro flutter.material.DataTable.headingRowColor}
+  /// {@macro material_ui.dataTable.headingRowColor}
+  /// {@macro material_ui.DataTable.headingRowColor}
   final WidgetStateProperty<Color?>? headingRowColor;
 
-  /// {@macro flutter.material.dataTable.headingRowHeight}
+  /// {@macro material_ui.dataTable.headingRowHeight}
   final double? headingRowHeight;
 
-  /// {@macro flutter.material.dataTable.headingTextStyle}
+  /// {@macro material_ui.dataTable.headingTextStyle}
   final TextStyle? headingTextStyle;
 
-  /// {@macro flutter.material.dataTable.horizontalMargin}
+  /// {@macro material_ui.dataTable.horizontalMargin}
   final double? horizontalMargin;
 
-  /// {@macro flutter.material.dataTable.columnSpacing}
+  /// {@macro material_ui.dataTable.columnSpacing}
   final double? columnSpacing;
 
-  /// {@macro flutter.material.dataTable.dividerThickness}
+  /// {@macro material_ui.dataTable.dividerThickness}
   final double? dividerThickness;
 
-  /// {@macro flutter.material.dataTable.checkboxHorizontalMargin}
+  /// {@macro material_ui.dataTable.checkboxHorizontalMargin}
   final double? checkboxHorizontalMargin;
 
   /// If specified, overrides the default value of [DataColumn.mouseCursor].

--- a/packages/material_ui/lib/src/date.dart
+++ b/packages/material_ui/lib/src/date.dart
@@ -42,34 +42,34 @@ abstract class CalendarDelegate<T extends DateTime> {
   /// Returns a [DateTime] representing the current date and time.
   T now();
 
-  /// {@macro flutter.material.date.dateOnly}
+  /// {@macro material_ui.date.dateOnly}
   T dateOnly(T date);
 
-  /// {@macro flutter.material.date.datesOnly}
+  /// {@macro material_ui.date.datesOnly}
   DateTimeRange<T> datesOnly(DateTimeRange<T> range) {
     return DateTimeRange<T>(start: dateOnly(range.start), end: dateOnly(range.end));
   }
 
-  /// {@macro flutter.material.date.isSameDay}
+  /// {@macro material_ui.date.isSameDay}
   bool isSameDay(T? dateA, T? dateB) {
     return dateA?.year == dateB?.year && dateA?.month == dateB?.month && dateA?.day == dateB?.day;
   }
 
-  /// {@macro flutter.material.date.isSameMonth}
+  /// {@macro material_ui.date.isSameMonth}
   bool isSameMonth(T? dateA, T? dateB) {
     return dateA?.year == dateB?.year && dateA?.month == dateB?.month;
   }
 
-  /// {@macro flutter.material.date.monthDelta}
+  /// {@macro material_ui.date.monthDelta}
   int monthDelta(T startDate, T endDate);
 
-  /// {@macro flutter.material.date.addMonthsToMonthDate}
+  /// {@macro material_ui.date.addMonthsToMonthDate}
   T addMonthsToMonthDate(T monthDate, int monthsToAdd);
 
-  /// {@macro flutter.material.date.addDaysToDate}
+  /// {@macro material_ui.date.addDaysToDate}
   T addDaysToDate(T date, int days);
 
-  /// {@macro flutter.material.date.firstDayOffset}
+  /// {@macro material_ui.date.firstDayOffset}
   int firstDayOffset(int year, int month, MaterialLocalizations localizations);
 
   /// Returns the number of days in a month, according to the calendar system.
@@ -198,7 +198,7 @@ class GregorianCalendarDelegate extends CalendarDelegate<DateTime> {
     return DateUtils.firstDayOffset(year, month, localizations);
   }
 
-  /// {@macro flutter.material.date.getDaysInMonth}
+  /// {@macro material_ui.date.getDaysInMonth}
   @override
   int getDaysInMonth(int year, int month) => DateUtils.getDaysInMonth(year, month);
 
@@ -251,7 +251,7 @@ class GregorianCalendarDelegate extends CalendarDelegate<DateTime> {
 
 /// Utility functions for working with dates.
 abstract final class DateUtils {
-  /// {@template flutter.material.date.dateOnly}
+  /// {@template material_ui.date.dateOnly}
   /// Returns a [DateTime] with the date of the original, but time set to
   /// midnight.
   /// {@endtemplate}
@@ -259,7 +259,7 @@ abstract final class DateUtils {
     return DateTime(date.year, date.month, date.day);
   }
 
-  /// {@template flutter.material.date.datesOnly}
+  /// {@template material_ui.date.datesOnly}
   /// Returns a [DateTimeRange] with the dates of the original, but with times
   /// set to midnight.
   ///
@@ -270,7 +270,7 @@ abstract final class DateUtils {
     return DateTimeRange(start: dateOnly(range.start), end: dateOnly(range.end));
   }
 
-  /// {@template flutter.material.date.isSameDay}
+  /// {@template material_ui.date.isSameDay}
   /// Returns true if the two [DateTime] objects have the same day, month, and
   /// year, or are both null.
   /// {@endtemplate}
@@ -278,7 +278,7 @@ abstract final class DateUtils {
     return dateA?.year == dateB?.year && dateA?.month == dateB?.month && dateA?.day == dateB?.day;
   }
 
-  /// {@template flutter.material.date.isSameMonth}
+  /// {@template material_ui.date.isSameMonth}
   /// Returns true if the two [DateTime] objects have the same month and
   /// year, or are both null.
   /// {@endtemplate}
@@ -286,7 +286,7 @@ abstract final class DateUtils {
     return dateA?.year == dateB?.year && dateA?.month == dateB?.month;
   }
 
-  /// {@template flutter.material.date.monthDelta}
+  /// {@template material_ui.date.monthDelta}
   /// Determines the number of months between two [DateTime] objects.
   ///
   /// For example:
@@ -303,7 +303,7 @@ abstract final class DateUtils {
     return (endDate.year - startDate.year) * 12 + endDate.month - startDate.month;
   }
 
-  /// {@template flutter.material.date.addMonthsToMonthDate}
+  /// {@template material_ui.date.addMonthsToMonthDate}
   /// Returns a [DateTime] that is [monthDate] with the added number
   /// of months and the day set to 1 and time set to midnight.
   ///
@@ -321,7 +321,7 @@ abstract final class DateUtils {
     return DateTime(monthDate.year, monthDate.month + monthsToAdd);
   }
 
-  /// {@template flutter.material.date.addDaysToDate}
+  /// {@template material_ui.date.addDaysToDate}
   /// Returns a [DateTime] with the added number of days and time set to
   /// midnight.
   /// {@endtemplate}
@@ -329,7 +329,7 @@ abstract final class DateUtils {
     return DateTime(date.year, date.month, date.day + days);
   }
 
-  /// {@template flutter.material.date.firstDayOffset}
+  /// {@template material_ui.date.firstDayOffset}
   /// Computes the offset from the first day of the week that the first day of
   /// the [month] falls on.
   ///
@@ -375,7 +375,7 @@ abstract final class DateUtils {
     return (weekdayFromMonday - firstDayOfWeekIndex) % 7;
   }
 
-  /// {@template flutter.material.date.getDaysInMonth}
+  /// {@template material_ui.date.getDaysInMonth}
   /// Returns the number of days in a month, according to the proleptic
   /// Gregorian calendar.
   ///

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -100,7 +100,7 @@ const double _fontSizeToScale = 14.0;
 /// or [DatePickerEntryMode.input] (a text input field) mode.
 /// It defaults to [DatePickerEntryMode.calendar].
 ///
-/// {@template flutter.material.date_picker.switchToInputEntryModeIcon}
+/// {@template material_ui.date_picker.switchToInputEntryModeIcon}
 /// An optional [switchToInputEntryModeIcon] argument can be used to
 /// display a custom Icon in the corner of the dialog
 /// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
@@ -108,7 +108,7 @@ const double _fontSizeToScale = 14.0;
 /// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
 /// {@endtemplate}
 ///
-/// {@template flutter.material.date_picker.switchToCalendarEntryModeIcon}
+/// {@template material_ui.date_picker.switchToCalendarEntryModeIcon}
 /// An optional [switchToCalendarEntryModeIcon] argument can be used to
 /// display a custom Icon in the corner of the dialog
 /// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
@@ -122,7 +122,7 @@ const double _fontSizeToScale = 14.0;
 /// this can be used to only allow weekdays for selection. If provided, it must
 /// return true for [initialDate].
 ///
-/// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+/// {@macro material_ui.calendar_date_picker.calendarDelegate}
 ///
 /// The following optional string parameters allow you to override the default
 /// text used for various parts of the dialog:
@@ -427,7 +427,7 @@ class DatePickerDialog extends StatefulWidget {
   /// string. For example, 'Month, Day, Year' for en_US.
   final String? fieldLabelText;
 
-  /// {@template flutter.material.datePickerDialog}
+  /// {@template material_ui.datePickerDialog}
   /// The keyboard type of the [TextField].
   ///
   /// If this is null, it will default to [TextInputType.datetime]
@@ -456,10 +456,10 @@ class DatePickerDialog extends StatefulWidget {
   /// `initialEntryMode` parameter the next time the date picker is shown.
   final ValueChanged<DatePickerEntryMode>? onDatePickerModeChange;
 
-  /// {@macro flutter.material.date_picker.switchToInputEntryModeIcon}
+  /// {@macro material_ui.date_picker.switchToInputEntryModeIcon}
   final Icon? switchToInputEntryModeIcon;
 
-  /// {@macro flutter.material.date_picker.switchToCalendarEntryModeIcon}
+  /// {@macro material_ui.date_picker.switchToCalendarEntryModeIcon}
   final Icon? switchToCalendarEntryModeIcon;
 
   /// The amount of padding added to [MediaQueryData.viewInsets] on the outside
@@ -469,7 +469,7 @@ class DatePickerDialog extends StatefulWidget {
   /// Defaults to `EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0)`.
   final EdgeInsets insetPadding;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override
@@ -1102,11 +1102,11 @@ typedef SelectableDayForRangePredicate =
 /// grid) or [DatePickerEntryMode.input] (two text input fields) mode.
 /// It defaults to [DatePickerEntryMode.calendar].
 ///
-/// {@macro flutter.material.date_picker.switchToInputEntryModeIcon}
+/// {@macro material_ui.date_picker.switchToInputEntryModeIcon}
 ///
-/// {@macro flutter.material.date_picker.switchToCalendarEntryModeIcon}
+/// {@macro material_ui.date_picker.switchToCalendarEntryModeIcon}
 ///
-/// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+/// {@macro material_ui.calendar_date_picker.calendarDelegate}
 ///
 /// The following optional string parameters allow you to override the default
 /// text used for various parts of the dialog:
@@ -1485,7 +1485,7 @@ class DateRangePickerDialog extends StatefulWidget {
   /// is used.
   final String? fieldEndLabelText;
 
-  /// {@macro flutter.material.datePickerDialog}
+  /// {@macro material_ui.datePickerDialog}
   final TextInputType keyboardType;
 
   /// Restoration ID to save and restore the state of the [DateRangePickerDialog].
@@ -1502,16 +1502,16 @@ class DateRangePickerDialog extends StatefulWidget {
   ///    Flutter.
   final String? restorationId;
 
-  /// {@macro flutter.material.date_picker.switchToInputEntryModeIcon}
+  /// {@macro material_ui.date_picker.switchToInputEntryModeIcon}
   final Icon? switchToInputEntryModeIcon;
 
-  /// {@macro flutter.material.date_picker.switchToCalendarEntryModeIcon}
+  /// {@macro material_ui.date_picker.switchToCalendarEntryModeIcon}
   final Icon? switchToCalendarEntryModeIcon;
 
   /// Function to provide full control over which [DateTime] can be selected.
   final SelectableDayForRangePredicate? selectableDayPredicate;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override
@@ -2024,7 +2024,7 @@ class _CalendarDateRangePicker extends StatefulWidget {
   /// Called when the user changes the end date of the selected range.
   final ValueChanged<DateTime?>? onEndDateChanged;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override
@@ -2579,7 +2579,7 @@ class _MonthItem extends StatefulWidget {
 
   final SelectableDayForRangePredicate? selectableDayPredicate;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override
@@ -3322,12 +3322,12 @@ class _InputDateRangePicker extends StatefulWidget {
   /// [_InputDateRangePickerState.validate] to validate.
   final bool autovalidate;
 
-  /// {@macro flutter.material.datePickerDialog}
+  /// {@macro material_ui.datePickerDialog}
   final TextInputType keyboardType;
 
   final SelectableDayForRangePredicate? selectableDayPredicate;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override

--- a/packages/material_ui/lib/src/desktop_text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/desktop_text_selection_toolbar.dart
@@ -35,10 +35,10 @@ class DesktopTextSelectionToolbar extends StatelessWidget {
   const DesktopTextSelectionToolbar({super.key, required this.anchor, required this.children})
     : assert(children.length > 0);
 
-  /// {@macro flutter.cupertino.DesktopTextSelectionToolbar.anchor}
+  /// {@macro cupertino_ui.DesktopTextSelectionToolbar.anchor}
   final Offset anchor;
 
-  /// {@macro flutter.cupertino.TextSelectionToolbar.children}
+  /// {@macro cupertino_ui.TextSelectionToolbar.children}
   ///
   /// See also:
   ///   * [DesktopTextSelectionToolbarButton], which builds a default

--- a/packages/material_ui/lib/src/desktop_text_selection_toolbar_button.dart
+++ b/packages/material_ui/lib/src/desktop_text_selection_toolbar_button.dart
@@ -44,10 +44,10 @@ class DesktopTextSelectionToolbarButton extends StatelessWidget {
          ),
        );
 
-  /// {@macro flutter.material.TextSelectionToolbarTextButton.onPressed}
+  /// {@macro material_ui.TextSelectionToolbarTextButton.onPressed}
   final VoidCallback? onPressed;
 
-  /// {@macro flutter.material.TextSelectionToolbarTextButton.child}
+  /// {@macro material_ui.TextSelectionToolbarTextButton.child}
   final Widget child;
 
   @override

--- a/packages/material_ui/lib/src/dialog.dart
+++ b/packages/material_ui/lib/src/dialog.dart
@@ -117,7 +117,7 @@ class Dialog extends StatelessWidget {
        constraints = null,
        _fullscreen = true;
 
-  /// {@template flutter.material.dialog.backgroundColor}
+  /// {@template material_ui.dialog.backgroundColor}
   /// The background color of the surface of this [Dialog].
   ///
   /// This sets the [Material.color] on this [Dialog]'s [Material].
@@ -131,7 +131,7 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final Color? backgroundColor;
 
-  /// {@template flutter.material.dialog.elevation}
+  /// {@template material_ui.dialog.elevation}
   /// The z-coordinate of this [Dialog].
   ///
   /// Controls how far above the parent the dialog will appear. Elevation is
@@ -153,7 +153,7 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final double? elevation;
 
-  /// {@template flutter.material.dialog.shadowColor}
+  /// {@template material_ui.dialog.shadowColor}
   /// The color used to paint a drop shadow under the dialog's [Material],
   /// which reflects the dialog's [elevation].
   ///
@@ -171,7 +171,7 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final Color? shadowColor;
 
-  /// {@template flutter.material.dialog.surfaceTintColor}
+  /// {@template material_ui.dialog.surfaceTintColor}
   /// The color used as a surface tint overlay on the dialog's background color,
   /// which reflects the dialog's [elevation].
   ///
@@ -195,13 +195,13 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final Color? surfaceTintColor;
 
-  /// {@macro flutter.cupertino.dialog.insetAnimationDuration}
+  /// {@macro cupertino_ui.dialog.insetAnimationDuration}
   final Duration insetAnimationDuration;
 
-  /// {@macro flutter.cupertino.dialog.insetAnimationCurve}
+  /// {@macro cupertino_ui.dialog.insetAnimationCurve}
   final Curve insetAnimationCurve;
 
-  /// {@template flutter.material.dialog.insetPadding}
+  /// {@template material_ui.dialog.insetPadding}
   /// The amount of padding added to [MediaQueryData.viewInsets] on the outside
   /// of the dialog. This defines the minimum space between the screen's edges
   /// and the dialog.
@@ -210,7 +210,7 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final EdgeInsets? insetPadding;
 
-  /// {@template flutter.material.dialog.clipBehavior}
+  /// {@template material_ui.dialog.clipBehavior}
   /// Controls how the contents of the dialog are clipped (or not) to the given
   /// [shape].
   ///
@@ -222,7 +222,7 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final Clip? clipBehavior;
 
-  /// {@template flutter.material.dialog.shape}
+  /// {@template material_ui.dialog.shape}
   /// The shape of this dialog's border.
   ///
   /// Defines the dialog's [Material.shape].
@@ -231,7 +231,7 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final ShapeBorder? shape;
 
-  /// {@template flutter.material.dialog.alignment}
+  /// {@template material_ui.dialog.alignment}
   /// How to align the [Dialog].
   ///
   /// If null, then [DialogThemeData.alignment] is used. If that is also null, the
@@ -252,7 +252,7 @@ class Dialog extends StatelessWidget {
   /// Defaults to [SemanticsRole.dialog].
   final SemanticsRole semanticsRole;
 
-  /// {@template flutter.material.dialog.constraints}
+  /// {@template material_ui.dialog.constraints}
   /// Constrains the size of the dialog.
   ///
   /// If null, then [DialogThemeData.constraints] is used. If that is also null, the
@@ -737,16 +737,16 @@ class AlertDialog extends StatelessWidget {
   /// 8.0 logical pixels on the left and right.
   final EdgeInsetsGeometry? buttonPadding;
 
-  /// {@macro flutter.material.dialog.backgroundColor}
+  /// {@macro material_ui.dialog.backgroundColor}
   final Color? backgroundColor;
 
-  /// {@macro flutter.material.dialog.elevation}
+  /// {@macro material_ui.dialog.elevation}
   final double? elevation;
 
-  /// {@macro flutter.material.dialog.shadowColor}
+  /// {@macro material_ui.dialog.shadowColor}
   final Color? shadowColor;
 
-  /// {@macro flutter.material.dialog.surfaceTintColor}
+  /// {@macro material_ui.dialog.surfaceTintColor}
   final Color? surfaceTintColor;
 
   /// The semantic label of the dialog used by accessibility frameworks to
@@ -764,19 +764,19 @@ class AlertDialog extends StatelessWidget {
   ///    value is used.
   final String? semanticLabel;
 
-  /// {@macro flutter.material.dialog.insetPadding}
+  /// {@macro material_ui.dialog.insetPadding}
   final EdgeInsets? insetPadding;
 
-  /// {@macro flutter.material.dialog.clipBehavior}
+  /// {@macro material_ui.dialog.clipBehavior}
   final Clip? clipBehavior;
 
-  /// {@macro flutter.material.dialog.shape}
+  /// {@macro material_ui.dialog.shape}
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.dialog.alignment}
+  /// {@macro material_ui.dialog.alignment}
   final AlignmentGeometry? alignment;
 
-  /// {@macro flutter.material.dialog.constraints}
+  /// {@macro material_ui.dialog.constraints}
   final BoxConstraints? constraints;
 
   /// Determines whether the [title] and [content] widgets are wrapped in a
@@ -1260,16 +1260,16 @@ class SimpleDialog extends StatelessWidget {
   /// the top padding ends up being 24 pixels.
   final EdgeInsetsGeometry contentPadding;
 
-  /// {@macro flutter.material.dialog.backgroundColor}
+  /// {@macro material_ui.dialog.backgroundColor}
   final Color? backgroundColor;
 
-  /// {@macro flutter.material.dialog.elevation}
+  /// {@macro material_ui.dialog.elevation}
   final double? elevation;
 
-  /// {@macro flutter.material.dialog.shadowColor}
+  /// {@macro material_ui.dialog.shadowColor}
   final Color? shadowColor;
 
-  /// {@macro flutter.material.dialog.surfaceTintColor}
+  /// {@macro material_ui.dialog.surfaceTintColor}
   final Color? surfaceTintColor;
 
   /// Style for the text in the [children] of this [SimpleDialog].
@@ -1292,19 +1292,19 @@ class SimpleDialog extends StatelessWidget {
   ///    value is used.
   final String? semanticLabel;
 
-  /// {@macro flutter.material.dialog.insetPadding}
+  /// {@macro material_ui.dialog.insetPadding}
   final EdgeInsets? insetPadding;
 
-  /// {@macro flutter.material.dialog.clipBehavior}
+  /// {@macro material_ui.dialog.clipBehavior}
   final Clip? clipBehavior;
 
-  /// {@macro flutter.material.dialog.shape}
+  /// {@macro material_ui.dialog.shape}
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.dialog.shape}
+  /// {@macro material_ui.dialog.shape}
   final AlignmentGeometry? alignment;
 
-  /// {@macro flutter.material.dialog.constraints}
+  /// {@macro material_ui.dialog.constraints}
   final BoxConstraints? constraints;
 
   @override
@@ -1592,7 +1592,7 @@ class _DialogContentPage extends Page<void> {
 /// argument is ignored as dialogs are displayed in their own windows which
 /// manage focus traversal independently.
 ///
-/// {@macro flutter.cupertino.dialog.requestFocus}
+/// {@macro cupertino_ui.dialog.requestFocus}
 /// {@macro flutter.widgets.navigator.Route.requestFocus}
 /// If windowing is enabled via `flutter config --enable-windowing`, then this
 /// argument is ignored as dialogs are displayed in their own windows which are

--- a/packages/material_ui/lib/src/divider.dart
+++ b/packages/material_ui/lib/src/divider.dart
@@ -94,7 +94,7 @@ class Divider extends StatelessWidget {
 
   /// The thickness of the line drawn within the divider.
   ///
-  /// {@template flutter.material.Divider.thickness}
+  /// {@template material_ui.Divider.thickness}
   /// A divider with a [thickness] of 0.0 is always drawn as a line with a
   /// height of exactly one device pixel.
   ///
@@ -105,7 +105,7 @@ class Divider extends StatelessWidget {
 
   /// The amount of empty space to the leading edge of the divider.
   ///
-  /// {@template flutter.material.Divider.indent}
+  /// {@template material_ui.Divider.indent}
   /// If this is null, then the [DividerThemeData.indent] is used. If that is
   /// also null, then this defaults to 0.0.
   /// {@endtemplate}
@@ -113,13 +113,13 @@ class Divider extends StatelessWidget {
 
   /// The amount of empty space to the trailing edge of the divider.
   ///
-  /// {@template flutter.material.Divider.endIndent}
+  /// {@template material_ui.Divider.endIndent}
   /// If this is null, then the [DividerThemeData.endIndent] is used. If that is
   /// also null, then this defaults to 0.0.
   /// {@endtemplate}
   final double? endIndent;
 
-  /// {@template flutter.material.Divider.radius}
+  /// {@template material_ui.Divider.radius}
   /// The amount of radius for the border of the divider.
   ///
   /// If this is null, then [DividerThemeData.radius] is used. If that is
@@ -127,7 +127,7 @@ class Divider extends StatelessWidget {
   /// {@endtemplate}
   final BorderRadiusGeometry? radius;
 
-  /// {@template flutter.material.Divider.color}
+  /// {@template material_ui.Divider.color}
   /// The color to use when painting the line.
   ///
   /// If this is null, then the [DividerThemeData.color] is used. If that is

--- a/packages/material_ui/lib/src/drawer.dart
+++ b/packages/material_ui/lib/src/drawer.dart
@@ -250,7 +250,7 @@ class Drawer extends StatelessWidget {
   ///    value is used.
   final String? semanticLabel;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// The [clipBehavior] argument specifies how to clip the drawer's [shape].
   ///
@@ -372,7 +372,7 @@ class DrawerController extends StatefulWidget {
   /// If false, tapping the barrier will not dismiss the drawer.
   final bool drawerBarrierDismissible;
 
-  /// {@template flutter.material.DrawerController.dragStartBehavior}
+  /// {@template material_ui.DrawerController.dragStartBehavior}
   /// Determines the way that drag start behavior is handled.
   ///
   /// If set to [DragStartBehavior.start], the drag behavior used for opening

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1134,7 +1134,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// this widget is displayed as a placeholder for the dropdown button's value.
   final Widget? disabledHint;
 
-  /// {@template flutter.material.dropdownButton.onChanged}
+  /// {@template material_ui.dropdownButton.onChanged}
   /// Called when the user selects an item.
   ///
   /// If the [onChanged] callback is null or the list of [DropdownButton.items]
@@ -1349,7 +1349,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// The cursor for a mouse pointer when it enters or is hovering over this
   /// button.
   ///
-  /// {@macro flutter.material.InkWell.mouseCursor}
+  /// {@macro material_ui.InkWell.mouseCursor}
   ///
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? mouseCursor;
@@ -1357,7 +1357,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// this button's [items].
   ///
-  /// {@macro flutter.material.InkWell.mouseCursor}
+  /// {@macro material_ui.InkWell.mouseCursor}
   ///
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? dropdownMenuItemMouseCursor;
@@ -1970,7 +1970,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
          },
        );
 
-  /// {@macro flutter.material.dropdownButton.onChanged}
+  /// {@macro material_ui.dropdownButton.onChanged}
   ///
   /// This callback is invoked after the parent [Form]'s [Form.onChanged] callback.
   /// The field's updated value is available in the [Form.onChanged] callback
@@ -1994,7 +1994,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// dropdown button and its [DropdownMenuItem]s.
   ///
-  /// {@macro flutter.material.InkWell.mouseCursor}
+  /// {@macro material_ui.InkWell.mouseCursor}
   ///
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? mouseCursor;
@@ -2002,7 +2002,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// this button's [DropdownMenuItem]s.
   ///
-  /// {@macro flutter.material.InkWell.mouseCursor}
+  /// {@macro material_ui.InkWell.mouseCursor}
   ///
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? dropdownMenuItemMouseCursor;

--- a/packages/material_ui/lib/src/dropdown_menu.dart
+++ b/packages/material_ui/lib/src/dropdown_menu.dart
@@ -670,7 +670,7 @@ class DropdownMenu<T> extends StatefulWidget {
   ///    and notifies its listeners on [TextEditingValue] changes.
   final List<TextInputFormatter>? inputFormatters;
 
-  /// {@macro flutter.material.MenuAnchor.alignmentOffset}
+  /// {@macro material_ui.MenuAnchor.alignmentOffset}
   final Offset? alignmentOffset;
 
   /// Defines the behavior for closing the dropdown menu when an item is selected.
@@ -712,7 +712,7 @@ class DropdownMenu<T> extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.cursorHeight}
   final double? cursorHeight;
 
-  /// {@macro flutter.cupertino.textfield.restorationId}
+  /// {@macro cupertino_ui.textfield.restorationId}
   final String? restorationId;
 
   /// An optional controller that allows opening and closing of the menu from

--- a/packages/material_ui/lib/src/elevated_button.dart
+++ b/packages/material_ui/lib/src/elevated_button.dart
@@ -97,7 +97,7 @@ class ElevatedButton extends ButtonStyleButton {
   /// If [icon] is null, this constructor will create an [ElevatedButton]
   /// that doesn't display an icon.
   ///
-  /// {@macro flutter.material.ButtonStyle.iconAlignment}
+  /// {@macro material_ui.ButtonStyle.iconAlignment}
   ///
   ElevatedButton.icon({
     super.key,
@@ -292,7 +292,7 @@ class ElevatedButton extends ButtonStyleButton {
   /// value for all states, otherwise the values are as specified for
   /// each state, and "others" means all other states.
   ///
-  /// {@template flutter.material.elevated_button.default_font_size}
+  /// {@template material_ui.elevated_button.default_font_size}
   /// The "default font size" below refers to the font size specified in the
   /// [defaultStyleOf] method (or 14.0 if unspecified), scaled by the
   /// `MediaQuery.textScalerOf(context).scale` method. The names of the

--- a/packages/material_ui/lib/src/expand_icon.dart
+++ b/packages/material_ui/lib/src/expand_icon.dart
@@ -69,7 +69,7 @@ class ExpandIcon extends StatefulWidget {
   /// Defaults to a padding of 8 on all sides.
   final EdgeInsetsGeometry padding;
 
-  /// {@template flutter.material.ExpandIcon.color}
+  /// {@template material_ui.ExpandIcon.color}
   /// The color of the icon.
   ///
   /// Defaults to [Colors.black54] when the theme's

--- a/packages/material_ui/lib/src/expansion_panel.dart
+++ b/packages/material_ui/lib/src/expansion_panel.dart
@@ -286,7 +286,7 @@ class ExpansionPanelList extends StatefulWidget {
   /// By default, the value of elevation is 2.
   final double elevation;
 
-  /// {@macro flutter.material.ExpandIcon.color}
+  /// {@macro material_ui.ExpandIcon.color}
   final Color? expandIconColor;
 
   /// Defines the [MaterialGap.size] of the [MaterialGap] which is placed

--- a/packages/material_ui/lib/src/expansion_tile.dart
+++ b/packages/material_ui/lib/src/expansion_tile.dart
@@ -400,7 +400,7 @@ class ExpansionTile extends StatefulWidget {
   ///   [ExpansionTileThemeData].
   final ShapeBorder? collapsedShape;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// If this is not null and a custom collapsed or expanded shape is provided,
   /// the value of [clipBehavior] will be used to clip the expansion tile.
@@ -427,7 +427,7 @@ class ExpansionTile extends StatefulWidget {
   /// more convenient than supplying a controller.
   final ExpansibleController? controller;
 
-  /// {@macro flutter.material.ListTile.dense}
+  /// {@macro material_ui.ListTile.dense}
   final bool? dense;
 
   /// The splash color of the ink response when the tile is tapped.
@@ -451,13 +451,13 @@ class ExpansionTile extends StatefulWidget {
 
   /// Defines how compact the expansion tile's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   final VisualDensity? visualDensity;
 
-  /// {@macro flutter.material.ListTile.minTileHeight}
+  /// {@macro material_ui.ListTile.minTileHeight}
   final double? minTileHeight;
 
-  /// {@macro flutter.material.ListTile.enableFeedback}
+  /// {@macro material_ui.ListTile.enableFeedback}
   final bool? enableFeedback;
 
   /// Whether this expansion tile is interactive.

--- a/packages/material_ui/lib/src/filled_button.dart
+++ b/packages/material_ui/lib/src/filled_button.dart
@@ -107,7 +107,7 @@ class FilledButton extends ButtonStyleButton {
   /// If [icon] is null, this constructor will create a [FilledButton]
   /// that doesn't display an icon.
   ///
-  /// {@macro flutter.material.ButtonStyle.iconAlignment}
+  /// {@macro material_ui.ButtonStyle.iconAlignment}
   ///
   FilledButton.icon({
     super.key,
@@ -339,7 +339,7 @@ class FilledButton extends ButtonStyleButton {
   /// value for all states, otherwise the values are as specified for
   /// each state, and "others" means all other states.
   ///
-  /// {@macro flutter.material.elevated_button.default_font_size}
+  /// {@macro material_ui.elevated_button.default_font_size}
   ///
   /// The color of the [ButtonStyle.textStyle] is not used, the
   /// [ButtonStyle.foregroundColor] color is used instead.

--- a/packages/material_ui/lib/src/floating_action_button.dart
+++ b/packages/material_ui/lib/src/floating_action_button.dart
@@ -339,7 +339,7 @@ class FloatingActionButton extends StatelessWidget {
   /// If this is set to null, the button will be disabled.
   final VoidCallback? onPressed;
 
-  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  /// {@macro material_ui.RawMaterialButton.mouseCursor}
   ///
   /// If this property is null, [FloatingActionButtonThemeData.mouseCursor] is used.
   /// If that is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
@@ -433,7 +433,7 @@ class FloatingActionButton extends StatelessWidget {
   /// shape as well.
   final ShapeBorder? shape;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/floating_action_button_theme.dart
+++ b/packages/material_ui/lib/src/floating_action_button_theme.dart
@@ -142,7 +142,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
   /// The text style for an extended [FloatingActionButton]'s label.
   final TextStyle? extendedTextStyle;
 
-  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  /// {@macro material_ui.RawMaterialButton.mouseCursor}
   ///
   /// If specified, overrides the default value of [FloatingActionButton.mouseCursor].
   final WidgetStateProperty<MouseCursor?>? mouseCursor;

--- a/packages/material_ui/lib/src/icon_button.dart
+++ b/packages/material_ui/lib/src/icon_button.dart
@@ -364,7 +364,7 @@ class IconButton extends StatelessWidget {
 
   /// Defines how compact the icon button's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// This property can be null. If null, it defaults to [VisualDensity.standard]
   /// in Material Design 3 to make sure the button will be circular on all platforms.
@@ -528,7 +528,7 @@ class IconButton extends StatelessWidget {
   /// If onPressed is set to null, the onLongPress callback is not called.
   final VoidCallback? onLongPress;
 
-  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  /// {@macro material_ui.RawMaterialButton.mouseCursor}
   ///
   /// If set to null, will default to [SystemMouseCursors.basic] if [onPressed]
   /// is null, otherwise [WidgetStateMouseCursor.adaptiveClickable].
@@ -621,7 +621,7 @@ class IconButton extends StatelessWidget {
   /// * [ImageIcon], for showing icons from [AssetImage]s or other [ImageProvider]s.
   final Widget? selectedIcon;
 
-  /// {@macro flutter.material.inkwell.statesController}
+  /// {@macro material_ui.inkwell.statesController}
   final MaterialStatesController? statesController;
 
   final _IconButtonVariant _variant;

--- a/packages/material_ui/lib/src/ink_well.dart
+++ b/packages/material_ui/lib/src/ink_well.dart
@@ -434,7 +434,7 @@ class InkResponse extends StatelessWidget {
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
-  /// {@template flutter.material.InkWell.mouseCursor}
+  /// {@template material_ui.InkWell.mouseCursor}
   /// If [mouseCursor] is a [WidgetStateMouseCursor],
   /// [WidgetStateProperty.resolve] is used for the following [WidgetState]s:
   ///
@@ -616,7 +616,7 @@ class InkResponse extends StatelessWidget {
   /// duplication of information.
   final bool excludeFromSemantics;
 
-  /// {@macro flutter.cupertino.inkwell.onFocusChange}
+  /// {@macro cupertino_ui.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@macro flutter.widgets.Focus.autofocus}
@@ -641,7 +641,7 @@ class InkResponse extends StatelessWidget {
   /// slightly more efficient).
   RectCallback? getRectCallback(RenderBox referenceBox) => null;
 
-  /// {@template flutter.material.inkwell.statesController}
+  /// {@template material_ui.inkwell.statesController}
   /// Represents the interactive "state" of this widget in terms of
   /// a set of [WidgetState]s, like [WidgetState.pressed] and
   /// [WidgetState.focused].

--- a/packages/material_ui/lib/src/input_date_picker_form_field.dart
+++ b/packages/material_ui/lib/src/input_date_picker_form_field.dart
@@ -147,7 +147,7 @@ class InputDatePickerFormField extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
 
-  /// {@macro flutter.material.calendar_date_picker.calendarDelegate}
+  /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
   @override

--- a/packages/material_ui/lib/src/input_decorator.dart
+++ b/packages/material_ui/lib/src/input_decorator.dart
@@ -1893,7 +1893,7 @@ class InputDecorator extends StatefulWidget {
   /// How the text in the decoration should be aligned horizontally.
   final TextAlign? textAlign;
 
-  /// {@macro flutter.cupertino.InputDecorator.textAlignVertical}
+  /// {@macro cupertino_ui.InputDecorator.textAlignVertical}
   final TextAlignVertical? textAlignVertical;
 
   /// Whether the input field has focus.
@@ -3006,7 +3006,7 @@ class InputDecoration {
 
   /// Optional widget that describes the input field.
   ///
-  /// {@template flutter.material.inputDecoration.label}
+  /// {@template material_ui.inputDecoration.label}
   /// When the input field is empty and unfocused, the label is displayed on
   /// top of the input field (i.e., at the same location on the screen where
   /// text may be entered in the input field). When the input field receives
@@ -3036,13 +3036,13 @@ class InputDecoration {
 
   /// Optional text that describes the input field.
   ///
-  /// {@macro flutter.material.inputDecoration.label}
+  /// {@macro material_ui.inputDecoration.label}
   ///
   /// If a more elaborate label is required, consider using [label] instead.
   /// Only one of [label] and [labelText] can be specified.
   final String? labelText;
 
-  /// {@template flutter.material.inputDecoration.labelStyle}
+  /// {@template material_ui.inputDecoration.labelStyle}
   /// The style to use for [InputDecoration.labelText] when the label is on top
   /// of the input field.
   ///
@@ -3079,7 +3079,7 @@ class InputDecoration {
   /// {@endtemplate}
   final TextStyle? labelStyle;
 
-  /// {@template flutter.material.inputDecoration.floatingLabelStyle}
+  /// {@template material_ui.inputDecoration.floatingLabelStyle}
   /// The style to use for [InputDecoration.labelText] when the label is
   /// above (i.e., vertically adjacent to) the input field.
   ///
@@ -3279,7 +3279,7 @@ class InputDecoration {
   /// Only one of [error] and [errorText] can be specified.
   final String? errorText;
 
-  /// {@template flutter.material.inputDecoration.errorStyle}
+  /// {@template material_ui.inputDecoration.errorStyle}
   /// The style to use for the [InputDecoration.errorText].
   ///
   /// If null, defaults of a value derived from the base [TextStyle] for the
@@ -3313,7 +3313,7 @@ class InputDecoration {
   ///  * [helperMaxLines], the equivalent but for the [helperText].
   final int? errorMaxLines;
 
-  /// {@template flutter.material.inputDecoration.floatingLabelBehavior}
+  /// {@template material_ui.inputDecoration.floatingLabelBehavior}
   /// Defines **how** the floating label should behave.
   ///
   /// When [FloatingLabelBehavior.auto] the label will float to the top only when
@@ -3335,7 +3335,7 @@ class InputDecoration {
   ///    should be displayed.
   final FloatingLabelBehavior? floatingLabelBehavior;
 
-  /// {@template flutter.material.inputDecoration.floatingLabelAlignment}
+  /// {@template material_ui.inputDecoration.floatingLabelAlignment}
   /// Defines **where** the floating label should be displayed.
   ///
   /// [FloatingLabelAlignment.start] aligns the floating label to the leftmost
@@ -3363,7 +3363,7 @@ class InputDecoration {
 
   /// The padding for the input decoration's container.
   ///
-  /// {@macro flutter.material.input_decorator.container_description}
+  /// {@macro material_ui.input_decorator.container_description}
   ///
   /// By default the [contentPadding] reflects [isDense] and the type of the
   /// [border].
@@ -3428,7 +3428,7 @@ class InputDecoration {
   /// )
   /// ```
   ///
-  /// {@macro flutter.material.input_decorator.container_description}
+  /// {@macro material_ui.input_decorator.container_description}
   ///
   /// The prefix icon alignment can be changed using [Align] with a fixed `widthFactor` and
   /// `heightFactor`.
@@ -3708,7 +3708,7 @@ class InputDecoration {
   ///
   /// Typically this field set to true if [border] is an [UnderlineInputBorder].
   ///
-  /// {@template flutter.material.input_decorator.container_description}
+  /// {@template material_ui.input_decorator.container_description}
   /// The decoration's container is the area which is filled if [filled] is true
   /// and bordered per the [border]. It's the area adjacent to [icon] and above
   /// the widgets that contain [helperText], [errorText], and [counterText].
@@ -3725,7 +3725,7 @@ class InputDecoration {
   /// By default the [fillColor] is based on the current
   /// [InputDecorationThemeData.fillColor].
   ///
-  /// {@macro flutter.material.input_decorator.container_description}
+  /// {@macro material_ui.input_decorator.container_description}
   final Color? fillColor;
 
   /// The fill color of the decoration's container when it has the input focus.
@@ -3738,7 +3738,7 @@ class InputDecoration {
   /// container color, they respond by changing their border to the
   /// [focusedBorder], which you can change the color of.
   ///
-  /// {@macro flutter.material.input_decorator.container_description}
+  /// {@macro material_ui.input_decorator.container_description}
   final Color? focusColor;
 
   /// The color of the highlight for the decoration shown if the container
@@ -3752,7 +3752,7 @@ class InputDecoration {
   ///
   /// By default the [hoverColor] is based on the current [Theme].
   ///
-  /// {@macro flutter.material.input_decorator.container_description}
+  /// {@macro material_ui.input_decorator.container_description}
   final Color? hoverColor;
 
   /// The border to display when the [InputDecorator] does not have the focus and
@@ -5012,10 +5012,10 @@ class InputDecorationThemeData with Diagnosticable {
     this.visualDensity,
   });
 
-  /// {@macro flutter.material.inputDecoration.labelStyle}
+  /// {@macro material_ui.inputDecoration.labelStyle}
   final TextStyle? labelStyle;
 
-  /// {@macro flutter.material.inputDecoration.floatingLabelStyle}
+  /// {@macro material_ui.inputDecoration.floatingLabelStyle}
   final TextStyle? floatingLabelStyle;
 
   /// The style to use for [InputDecoration.helperText].
@@ -5065,7 +5065,7 @@ class InputDecorationThemeData with Diagnosticable {
   /// of the [Text] widget used to display the hint text.
   final int? hintMaxLines;
 
-  /// {@macro flutter.material.inputDecoration.errorStyle}
+  /// {@macro material_ui.inputDecoration.errorStyle}
   final TextStyle? errorStyle;
 
   /// The maximum number of lines the [InputDecoration.errorText] can occupy.
@@ -5081,12 +5081,12 @@ class InputDecorationThemeData with Diagnosticable {
   ///  * [helperMaxLines], the equivalent but for the [InputDecoration.helperText].
   final int? errorMaxLines;
 
-  /// {@macro flutter.material.inputDecoration.floatingLabelBehavior}
+  /// {@macro material_ui.inputDecoration.floatingLabelBehavior}
   ///
   /// Defaults to [FloatingLabelBehavior.auto].
   final FloatingLabelBehavior floatingLabelBehavior;
 
-  /// {@macro flutter.material.inputDecoration.floatingLabelAlignment}
+  /// {@macro material_ui.inputDecoration.floatingLabelAlignment}
   ///
   /// Defaults to [FloatingLabelAlignment.start].
   final FloatingLabelAlignment floatingLabelAlignment;

--- a/packages/material_ui/lib/src/list_tile.dart
+++ b/packages/material_ui/lib/src/list_tile.dart
@@ -552,7 +552,7 @@ class ListTile extends StatelessWidget {
   ///   [ListTileThemeData].
   final bool? isThreeLine;
 
-  /// {@template flutter.material.ListTile.dense}
+  /// {@template material_ui.ListTile.dense}
   /// Whether this list tile is part of a vertically dense list.
   ///
   /// If this property is null then its value is based on [ListTileTheme.dense].
@@ -565,7 +565,7 @@ class ListTile extends StatelessWidget {
 
   /// Defines how compact the list tile's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// See also:
   ///
@@ -573,7 +573,7 @@ class ListTile extends StatelessWidget {
   ///    widgets within a [Theme].
   final VisualDensity? visualDensity;
 
-  /// {@template flutter.material.ListTile.shape}
+  /// {@template material_ui.ListTile.shape}
   /// Defines the tile's [InkWell.customBorder] and [Ink.decoration] shape.
   /// {@endtemplate}
   ///
@@ -698,10 +698,10 @@ class ListTile extends StatelessWidget {
   /// Inoperative if [enabled] is false.
   final GestureLongPressCallback? onLongPress;
 
-  /// {@macro flutter.cupertino.inkwell.onFocusChange}
+  /// {@macro cupertino_ui.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
-  /// {@template flutter.material.ListTile.mouseCursor}
+  /// {@template material_ui.ListTile.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
@@ -751,7 +751,7 @@ class ListTile extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@template flutter.material.ListTile.tileColor}
+  /// {@template material_ui.ListTile.tileColor}
   /// Defines the background color of `ListTile` when [selected] is false.
   ///
   /// If this property is null and [selected] is false then [ListTileThemeData.tileColor]
@@ -768,7 +768,7 @@ class ListTile extends StatelessWidget {
   /// if it's not null and to [Colors.transparent] if it's null.
   final Color? selectedTileColor;
 
-  /// {@template flutter.material.ListTile.enableFeedback}
+  /// {@template material_ui.ListTile.enableFeedback}
   /// Whether detected gestures should provide acoustic and/or haptic feedback.
   ///
   /// For example, on Android a tap will produce a clicking sound and a
@@ -782,7 +782,7 @@ class ListTile extends StatelessWidget {
   ///  * [Feedback] for providing platform-specific feedback to certain actions.
   final bool? enableFeedback;
 
-  /// {@template flutter.material.ListTile.horizontalTitleGap}
+  /// {@template material_ui.ListTile.horizontalTitleGap}
   /// The horizontal gap between the titles and the leading/trailing widgets.
   ///
   /// If null, then the value of [ListTileTheme.horizontalTitleGap] is used. If
@@ -790,7 +790,7 @@ class ListTile extends StatelessWidget {
   /// {@endtemplate}
   final double? horizontalTitleGap;
 
-  /// {@template flutter.material.ListTile.minVerticalPadding}
+  /// {@template material_ui.ListTile.minVerticalPadding}
   /// The minimum padding on the top and bottom of the title and subtitle widgets.
   ///
   /// If null, then the value of [ListTileTheme.minVerticalPadding] is used. If
@@ -798,7 +798,7 @@ class ListTile extends StatelessWidget {
   /// {@endtemplate}
   final double? minVerticalPadding;
 
-  /// {@template flutter.material.ListTile.minLeadingWidth}
+  /// {@template material_ui.ListTile.minLeadingWidth}
   /// The minimum width allocated for the [ListTile.leading] widget.
   ///
   /// If null, then the value of [ListTileTheme.minLeadingWidth] is used. If
@@ -806,7 +806,7 @@ class ListTile extends StatelessWidget {
   /// {@endtemplate}
   final double? minLeadingWidth;
 
-  /// {@template flutter.material.ListTile.minTileHeight}
+  /// {@template material_ui.ListTile.minTileHeight}
   /// The minimum height allocated for the [ListTile] widget.
   ///
   /// If this is null, default tile heights are 56.0, 72.0, and 88.0 for one,
@@ -837,7 +837,7 @@ class ListTile extends StatelessWidget {
   // the default value to true.
   final bool internalAddSemanticForOnTap;
 
-  /// {@macro flutter.material.inkwell.statesController}
+  /// {@macro material_ui.inkwell.statesController}
   final MaterialStatesController? statesController;
 
   /// Add a one pixel border in between each tile. If color isn't specified the

--- a/packages/material_ui/lib/src/material.dart
+++ b/packages/material_ui/lib/src/material.dart
@@ -222,7 +222,7 @@ class Material extends StatefulWidget {
   /// Whether the color should be animated.
   final bool animateColor;
 
-  /// {@template flutter.material.material.elevation}
+  /// {@template material_ui.material.elevation}
   /// The z-coordinate at which to place this material relative to its parent.
   ///
   /// This controls the size of the shadow below the material and the opacity
@@ -268,7 +268,7 @@ class Material extends StatefulWidget {
 
   /// The color to paint the shadow below the material.
   ///
-  /// {@template flutter.material.material.shadowColor}
+  /// {@template material_ui.material.shadowColor}
   /// If null and [ThemeData.useMaterial3] is true then [ThemeData]'s
   /// [ColorScheme.shadow] will be used. If [ThemeData.useMaterial3] is false
   /// then [ThemeData.shadowColor] will be used.
@@ -287,7 +287,7 @@ class Material extends StatefulWidget {
   /// The color of the surface tint overlay applied to the material color
   /// to indicate elevation.
   ///
-  /// {@template flutter.material.material.surfaceTintColor}
+  /// {@template material_ui.material.surfaceTintColor}
   /// Material Design 3 introduced a new way for some components to indicate
   /// their elevation by using a surface tint color overlay on top of the
   /// base material [color]. This overlay is painted with an opacity that is
@@ -316,7 +316,7 @@ class Material extends StatefulWidget {
 
   /// Defines the material's shape as well its shadow.
   ///
-  /// {@template flutter.material.material.shape}
+  /// {@template material_ui.material.shape}
   /// If shape is non null, the [borderRadius] is ignored and the material's
   /// clip boundary and shadow are defined by the shape.
   ///
@@ -331,7 +331,7 @@ class Material extends StatefulWidget {
   /// If false, the border will be painted behind the [child].
   final bool borderOnForeground;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -834,7 +834,7 @@ class _MaterialInterior extends ImplicitlyAnimatedWidget {
   /// If false, the border will be painted behind the child.
   final bool borderOnForeground;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/material_button.dart
+++ b/packages/material_ui/lib/src/material_button.dart
@@ -121,7 +121,7 @@ class MaterialButton extends StatelessWidget {
   /// [State.setState] is not allowed).
   final ValueChanged<bool>? onHighlightChanged;
 
-  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  /// {@macro material_ui.RawMaterialButton.mouseCursor}
   ///
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? mouseCursor;
@@ -325,7 +325,7 @@ class MaterialButton extends StatelessWidget {
 
   /// Defines how compact the button's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// See also:
   ///
@@ -343,7 +343,7 @@ class MaterialButton extends StatelessWidget {
   /// [ButtonThemeData.shape].
   final ShapeBorder? shape;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/material_state.dart
+++ b/packages/material_ui/lib/src/material_state.dart
@@ -37,7 +37,7 @@ import 'input_border.dart';
 ///    except [WidgetState] can be used outside of Material.
 ///  * [MaterialStateProperty], an interface for objects that "resolve" to
 ///    different values depending on a widget's material state.
-/// {@template flutter.material.MaterialStateProperty.implementations}
+/// {@template material_ui.MaterialStateProperty.implementations}
 ///  * [MaterialStateColor], a [Color] that implements `MaterialStateProperty`
 ///    which is used in APIs that need to accept either a [Color] or a
 ///    `MaterialStateProperty<Color>`.
@@ -568,7 +568,7 @@ class _WidgetInputBorderMapper extends WidgetStateMapper<InputBorder>
 ///
 ///  * [WidgetStateProperty], the non-Material version that can be used
 ///    interchangeably with `MaterialStateProperty`.
-/// {@macro flutter.material.MaterialStateProperty.implementations}
+/// {@macro material_ui.MaterialStateProperty.implementations}
 @Deprecated(
   'Use WidgetStateProperty instead. '
   'Moved to the Widgets layer to make code available outside of Material. '

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -307,7 +307,7 @@ class MenuAnchor extends StatefulWidget {
   /// Defaults to the ambient [MenuThemeData.style].
   final MenuStyle? style;
 
-  /// {@template flutter.material.MenuAnchor.alignmentOffset}
+  /// {@template material_ui.MenuAnchor.alignmentOffset}
   /// The offset of the menu relative to the alignment origin determined by
   /// [MenuStyle.alignment] on the [style] attribute and the ambient
   /// [Directionality].
@@ -338,7 +338,7 @@ class MenuAnchor extends StatefulWidget {
   /// surrounds if it moves because of view insets changes.
   final LayerLink? layerLink;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -460,7 +460,7 @@ class MenuAnchor extends StatefulWidget {
   /// A list of children containing the menu items that are the contents of the
   /// menu surrounded by this [MenuAnchor].
   ///
-  /// {@macro flutter.material.MenuBar.shortcuts_note}
+  /// {@macro material_ui.MenuBar.shortcuts_note}
   final List<Widget> menuChildren;
 
   /// The widget that this [MenuAnchor] surrounds.
@@ -819,7 +819,7 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
 /// [SubmenuButton.onOpen], and [SubmenuButton.onClose] are called on the
 /// corresponding [SubmenuButton] child of the menu bar.
 ///
-/// {@template flutter.material.MenuBar.shortcuts_note}
+/// {@template material_ui.MenuBar.shortcuts_note}
 /// Menus using [MenuItemButton] can have a [SingleActivator] or
 /// [CharacterActivator] assigned to them as their [MenuItemButton.shortcut],
 /// which will display an appropriate shortcut hint. Even though the shortcut
@@ -850,7 +850,7 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
 /// </callout-box>
 /// {@endtemplate}
 ///
-/// {@macro flutter.material.MenuAcceleratorLabel.accelerator_sample}
+/// {@macro material_ui.MenuAcceleratorLabel.accelerator_sample}
 ///
 /// See also:
 ///
@@ -886,7 +886,7 @@ class MenuBar extends StatelessWidget {
   /// Defaults to the ambient [MenuThemeData.style].
   final MenuStyle? style;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -901,7 +901,7 @@ class MenuBar extends StatelessWidget {
   /// incorrect behaviors. Whenever the menus list is modified, a new list
   /// object must be provided.
   ///
-  /// {@macro flutter.material.MenuBar.shortcuts_note}
+  /// {@macro material_ui.MenuBar.shortcuts_note}
   final List<Widget> children;
 
   @override
@@ -937,7 +937,7 @@ class MenuBar extends StatelessWidget {
 /// part of a [MenuBar], but may be used independently, or as part of a menu
 /// created with a [MenuAnchor].
 ///
-/// {@macro flutter.material.MenuBar.shortcuts_note}
+/// {@macro material_ui.MenuBar.shortcuts_note}
 ///
 /// See also:
 ///
@@ -1012,7 +1012,7 @@ class MenuItemButton extends StatefulWidget {
 
   /// The optional shortcut that selects this [MenuItemButton].
   ///
-  /// {@macro flutter.material.MenuBar.shortcuts_note}
+  /// {@macro material_ui.MenuBar.shortcuts_note}
   final MenuSerializableShortcut? shortcut;
 
   /// An optional Semantics label, applied to the entire [MenuItemButton].
@@ -1040,10 +1040,10 @@ class MenuItemButton extends StatefulWidget {
   /// Null by default.
   final ButtonStyle? style;
 
-  /// {@macro flutter.material.inkwell.statesController}
+  /// {@macro material_ui.inkwell.statesController}
   final MaterialStatesController? statesController;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1054,7 +1054,7 @@ class MenuItemButton extends StatefulWidget {
   /// An optional icon to display after the [child] label.
   final Widget? trailingIcon;
 
-  /// {@template flutter.material.menu_anchor.closeOnActivate}
+  /// {@template material_ui.menu_anchor.closeOnActivate}
   /// Determines if the menu will be closed when a [MenuItemButton]
   /// is pressed.
   ///
@@ -1091,9 +1091,9 @@ class MenuItemButton extends StatefulWidget {
 
   /// Defines the button's default appearance.
   ///
-  /// {@macro flutter.material.text_button.default_style_of}
+  /// {@macro material_ui.text_button.default_style_of}
   ///
-  /// {@macro flutter.material.text_button.material3_defaults}
+  /// {@macro material_ui.text_button.material3_defaults}
   ButtonStyle defaultStyleOf(BuildContext context) {
     return _MenuButtonDefaultsM3(context);
   }
@@ -1474,7 +1474,7 @@ class CheckboxMenuButton extends StatelessWidget {
 
   /// The optional shortcut that selects this [MenuItemButton].
   ///
-  /// {@macro flutter.material.MenuBar.shortcuts_note}
+  /// {@macro material_ui.MenuBar.shortcuts_note}
   final MenuSerializableShortcut? shortcut;
 
   /// Customizes this button's appearance.
@@ -1488,10 +1488,10 @@ class CheckboxMenuButton extends StatelessWidget {
   /// Null by default.
   final ButtonStyle? style;
 
-  /// {@macro flutter.material.inkwell.statesController}
+  /// {@macro material_ui.inkwell.statesController}
   final MaterialStatesController? statesController;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1499,7 +1499,7 @@ class CheckboxMenuButton extends StatelessWidget {
   /// An optional icon to display after the [child] label.
   final Widget? trailingIcon;
 
-  /// {@macro flutter.material.menu_anchor.closeOnActivate}
+  /// {@macro material_ui.menu_anchor.closeOnActivate}
   final bool closeOnActivate;
 
   /// The widget displayed in the center of this button.
@@ -1678,7 +1678,7 @@ class RadioMenuButton<T> extends StatelessWidget {
 
   /// The optional shortcut that selects this [MenuItemButton].
   ///
-  /// {@macro flutter.material.MenuBar.shortcuts_note}
+  /// {@macro material_ui.MenuBar.shortcuts_note}
   final MenuSerializableShortcut? shortcut;
 
   /// Customizes this button's appearance.
@@ -1692,10 +1692,10 @@ class RadioMenuButton<T> extends StatelessWidget {
   /// Null by default.
   final ButtonStyle? style;
 
-  /// {@macro flutter.material.inkwell.statesController}
+  /// {@macro material_ui.inkwell.statesController}
   final MaterialStatesController? statesController;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1703,7 +1703,7 @@ class RadioMenuButton<T> extends StatelessWidget {
   /// An optional icon to display after the [child] label.
   final Widget? trailingIcon;
 
-  /// {@macro flutter.material.menu_anchor.closeOnActivate}
+  /// {@macro material_ui.menu_anchor.closeOnActivate}
   final bool closeOnActivate;
 
   /// The widget displayed in the center of this button.
@@ -1860,7 +1860,7 @@ class SubmenuButton extends StatefulWidget {
   /// top of the [MenuAnchor] region.
   final Offset? alignmentOffset;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -1868,7 +1868,7 @@ class SubmenuButton extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
 
-  /// {@macro flutter.material.inkwell.statesController}
+  /// {@macro material_ui.inkwell.statesController}
   final MaterialStatesController? statesController;
 
   /// An optional icon to display before the [child].
@@ -1947,9 +1947,9 @@ class SubmenuButton extends StatefulWidget {
 
   /// Defines the button's default appearance.
   ///
-  /// {@macro flutter.material.text_button.default_style_of}
+  /// {@macro material_ui.text_button.default_style_of}
   ///
-  /// {@macro flutter.material.text_button.material3_defaults}
+  /// {@macro material_ui.text_button.material3_defaults}
   ButtonStyle defaultStyleOf(BuildContext context) {
     return _MenuButtonDefaultsM3(context);
   }
@@ -2910,7 +2910,7 @@ class MenuAcceleratorCallbackBinding extends InheritedWidget {
 /// The type of builder function used for building a [MenuAcceleratorLabel]'s
 /// [MenuAcceleratorLabel.builder] function.
 ///
-/// {@template flutter.material.menu_anchor.menu_accelerator_child_builder.args}
+/// {@template material_ui.menu_anchor.menu_accelerator_child_builder.args}
 /// The arguments to the function are as follows:
 ///
 /// * The `context` supplies the [BuildContext] to use.
@@ -2959,7 +2959,7 @@ typedef MenuAcceleratorChildBuilder =
 /// your own custom menu item type that takes a [MenuAcceleratorLabel], it is
 /// not necessary to provide one.
 ///
-/// {@template flutter.material.MenuAcceleratorLabel.accelerator_sample}
+/// {@template material_ui.MenuAcceleratorLabel.accelerator_sample}
 /// <callout-box>
 ///
 /// This example shows a [MenuBar] that handles keyboard
@@ -2988,7 +2988,7 @@ class MenuAcceleratorLabel extends StatefulWidget {
   /// The label string provides the label text, as well as the possible
   /// characters which could be used as accelerators in the menu system.
   ///
-  /// {@template flutter.material.menu_anchor.menu_accelerator_label.label}
+  /// {@template material_ui.menu_anchor.menu_accelerator_label.label}
   /// To indicate which letters in the label are to be used as accelerators, add
   /// an "&" character before the character in the string. If more than one
   /// character has an "&" in front of it, then the characters appearing earlier
@@ -3021,7 +3021,7 @@ class MenuAcceleratorLabel extends StatefulWidget {
   /// [TextSpan]s for rendering the label with an underscore under the selected
   /// accelerator for the label when accelerators have been activated.
   ///
-  /// {@macro flutter.material.menu_anchor.menu_accelerator_child_builder.args}
+  /// {@macro material_ui.menu_anchor.menu_accelerator_child_builder.args}
   ///
   /// When writing the builder function, it's not necessary to take the current
   /// platform into account. On platforms which don't support accelerators (e.g.
@@ -3031,7 +3031,7 @@ class MenuAcceleratorLabel extends StatefulWidget {
 
   /// Whether [label] contains an accelerator definition.
   ///
-  /// {@macro flutter.material.menu_anchor.menu_accelerator_label.label}
+  /// {@macro material_ui.menu_anchor.menu_accelerator_label.label}
   bool get hasAccelerator => RegExp(r'&(?!([&\s]|$))').hasMatch(label);
 
   /// Serves as the default value for [builder], rendering the label as a
@@ -3039,7 +3039,7 @@ class MenuAcceleratorLabel extends StatefulWidget {
   /// with an underscore under the selected accelerator for the label when the
   /// [index] is non-negative, and a [Text] widget when the [index] is negative.
   ///
-  /// {@macro flutter.material.menu_anchor.menu_accelerator_child_builder.args}
+  /// {@macro material_ui.menu_anchor.menu_accelerator_child_builder.args}
   static Widget defaultLabelBuilder(BuildContext context, String label, int index) {
     if (index < 0) {
       return Text(label);
@@ -3068,7 +3068,7 @@ class MenuAcceleratorLabel extends StatefulWidget {
   /// If [setIndex] is supplied, it will be called before this function returns
   /// with the index in the returned string of the accelerator character.
   ///
-  /// {@macro flutter.material.menu_anchor.menu_accelerator_label.label}
+  /// {@macro material_ui.menu_anchor.menu_accelerator_label.label}
   static String stripAcceleratorMarkers(String label, {void Function(int index)? setIndex}) {
     var quotedAmpersands = 0;
     final displayLabel = StringBuffer();
@@ -3627,7 +3627,7 @@ class _MenuPanel extends StatefulWidget {
   /// The menu style that has all the attributes for this menu panel.
   final MenuStyle? menuStyle;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/menu_style.dart
+++ b/packages/material_ui/lib/src/menu_style.dart
@@ -183,7 +183,7 @@ class MenuStyle with Diagnosticable {
 
   /// Defines how compact the menu's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// See also:
   ///

--- a/packages/material_ui/lib/src/outlined_button.dart
+++ b/packages/material_ui/lib/src/outlined_button.dart
@@ -101,7 +101,7 @@ class OutlinedButton extends ButtonStyleButton {
   /// If [icon] is null, this constructor will create an outlined button
   /// that doesn't display an icon.
   ///
-  /// {@macro flutter.material.ButtonStyle.iconAlignment}
+  /// {@macro material_ui.ButtonStyle.iconAlignment}
   ///
   OutlinedButton.icon({
     super.key,

--- a/packages/material_ui/lib/src/page.dart
+++ b/packages/material_ui/lib/src/page.dart
@@ -10,7 +10,7 @@ import 'theme.dart';
 /// A modal route that replaces the entire screen with a platform-adaptive
 /// transition.
 ///
-/// {@macro flutter.material.materialRouteTransitionMixin}
+/// {@macro material_ui.materialRouteTransitionMixin}
 ///
 /// By default, when a modal route is replaced by another, the previous route
 /// remains in memory. To free all the resources when this is not necessary, set
@@ -63,7 +63,7 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
 
 /// A mixin that provides platform-adaptive transitions for a [PageRoute].
 ///
-/// {@template flutter.material.materialRouteTransitionMixin}
+/// {@template material_ui.materialRouteTransitionMixin}
 /// For Android, the entrance transition for the page zooms in and fades in
 /// while the exiting page zooms out and fades out. The exit transition is similar,
 /// but in reverse.
@@ -208,7 +208,7 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
 
 /// A page that creates a material style [PageRoute].
 ///
-/// {@macro flutter.material.materialRouteTransitionMixin}
+/// {@macro material_ui.materialRouteTransitionMixin}
 ///
 /// By default, when the created route is replaced by another, the previous
 /// route remains in memory. To free all the resources when this is not

--- a/packages/material_ui/lib/src/paginated_data_table.dart
+++ b/packages/material_ui/lib/src/paginated_data_table.dart
@@ -257,7 +257,7 @@ class PaginatedDataTable extends StatefulWidget {
   /// This value defaults to 56.0 to adhere to the Material Design specifications.
   final double columnSpacing;
 
-  /// {@macro flutter.material.dataTable.showCheckboxColumn}
+  /// {@macro material_ui.dataTable.showCheckboxColumn}
   final bool showCheckboxColumn;
 
   /// Flag to display the pagination buttons to go to the first and last pages.
@@ -266,7 +266,7 @@ class PaginatedDataTable extends StatefulWidget {
   /// The index of the first row to display when the widget is first created.
   final int? initialFirstRowIndex;
 
-  /// {@macro flutter.material.dataTable.dividerThickness}
+  /// {@macro material_ui.dataTable.dividerThickness}
   ///
   /// If null, [DataTableThemeData.dividerThickness] is used. This value
   /// defaults to 1.0.
@@ -330,7 +330,7 @@ class PaginatedDataTable extends StatefulWidget {
   /// {@macro flutter.widgets.scroll_view.primary}
   final bool? primary;
 
-  /// {@macro flutter.material.dataTable.headingRowColor}
+  /// {@macro material_ui.dataTable.headingRowColor}
   final WidgetStateProperty<Color?>? headingRowColor;
 
   /// Controls the visibility of empty rows on the last page of a

--- a/packages/material_ui/lib/src/popup_menu.dart
+++ b/packages/material_ui/lib/src/popup_menu.dart
@@ -128,25 +128,25 @@ class PopupMenuDivider extends PopupMenuEntry<Never> {
 
   /// The thickness of the line drawn within the [PopupMenuDivider].
   ///
-  /// {@macro flutter.material.Divider.thickness}
+  /// {@macro material_ui.Divider.thickness}
   final double? thickness;
 
   /// The amount of empty space to the leading edge of the [PopupMenuDivider].
   ///
-  /// {@macro flutter.material.Divider.indent}
+  /// {@macro material_ui.Divider.indent}
   final double? indent;
 
   /// The amount of empty space to the trailing edge of the [PopupMenuDivider].
   ///
-  /// {@macro flutter.material.Divider.endIndent}
+  /// {@macro material_ui.Divider.endIndent}
   final double? endIndent;
 
   /// The amount of radius for the border of the [PopupMenuDivider].
   ///
-  /// {@macro flutter.material.Divider.radius}
+  /// {@macro material_ui.Divider.radius}
   final BorderRadiusGeometry? radius;
 
-  /// {@macro flutter.material.Divider.color}
+  /// {@macro material_ui.Divider.color}
   ///
   /// <callout-box>
   ///
@@ -340,7 +340,7 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
   /// the [ColorScheme.onSurface] color with 0.38 opacity when the popup menu item is disabled.
   final WidgetStateProperty<TextStyle?>? labelTextStyle;
 
-  /// {@template flutter.material.popupmenu.mouseCursor}
+  /// {@template material_ui.popupmenu.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
@@ -1567,7 +1567,7 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// over the button that was used to create it.
   final PopupMenuPosition? position;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// The [clipBehavior] argument is used the clip shape of the menu.
   ///

--- a/packages/material_ui/lib/src/popup_menu_theme.dart
+++ b/packages/material_ui/lib/src/popup_menu_theme.dart
@@ -94,7 +94,7 @@ class PopupMenuThemeData with Diagnosticable {
   /// If [PopupMenuButton.enableFeedback] is provided, [enableFeedback] is ignored.
   final bool? enableFeedback;
 
-  /// {@macro flutter.material.popupmenu.mouseCursor}
+  /// {@macro material_ui.popupmenu.mouseCursor}
   ///
   /// If specified, overrides the default value of [PopupMenuItem.mouseCursor].
   final WidgetStateProperty<MouseCursor?>? mouseCursor;

--- a/packages/material_ui/lib/src/progress_indicator.dart
+++ b/packages/material_ui/lib/src/progress_indicator.dart
@@ -49,7 +49,7 @@ const String _kValueControllerAssertion =
 abstract class ProgressIndicator extends StatefulWidget {
   /// Creates a progress indicator.
   ///
-  /// {@template flutter.material.ProgressIndicator.ProgressIndicator}
+  /// {@template material_ui.ProgressIndicator.ProgressIndicator}
   /// The [value] argument can either be null for an indeterminate
   /// progress indicator, or a non-null value between 0.0 and 1.0 for a
   /// determinate progress indicator.
@@ -412,7 +412,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 ///
 /// </callout-box>
 ///
-/// {@macro flutter.material.ProgressIndicator.AnimationSynchronization}
+/// {@macro material_ui.ProgressIndicator.AnimationSynchronization}
 ///
 /// See the documentation of [CircularProgressIndicator] for an example on this
 /// topic.
@@ -426,7 +426,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 class LinearProgressIndicator extends ProgressIndicator {
   /// Creates a linear progress indicator.
   ///
-  /// {@macro flutter.material.ProgressIndicator.ProgressIndicator}
+  /// {@macro material_ui.ProgressIndicator.ProgressIndicator}
   const LinearProgressIndicator({
     super.key,
     super.value,
@@ -450,7 +450,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   }) : assert(minHeight == null || minHeight > 0),
        assert(value == null || controller == null, _kValueControllerAssertion);
 
-  /// {@template flutter.material.LinearProgressIndicator.trackColor}
+  /// {@template material_ui.LinearProgressIndicator.trackColor}
   /// Color of the track being filled by the linear indicator.
   ///
   /// If [LinearProgressIndicator.backgroundColor] is null then the
@@ -461,7 +461,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   @override
   Color? get backgroundColor => super.backgroundColor;
 
-  /// {@template flutter.material.LinearProgressIndicator.minHeight}
+  /// {@template material_ui.LinearProgressIndicator.minHeight}
   /// The minimum height of the line used to draw the linear indicator.
   ///
   /// If [LinearProgressIndicator.minHeight] is null then it will use the
@@ -527,7 +527,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   )
   final bool? year2023;
 
-  /// {@template flutter.material.ProgressIndicator.controller}
+  /// {@template material_ui.ProgressIndicator.controller}
   /// An optional [AnimationController] that controls the animation of this
   /// indeterminate progress indicator.
   ///
@@ -843,7 +843,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 ///
 /// </callout-box>
 ///
-/// {@template flutter.material.ProgressIndicator.AnimationSynchronization}
+/// {@template material_ui.ProgressIndicator.AnimationSynchronization}
 /// ## Animation synchronization
 ///
 /// When multiple [CircularProgressIndicator]s or [LinearProgressIndicator]s are
@@ -893,7 +893,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 class CircularProgressIndicator extends ProgressIndicator {
   /// Creates a circular progress indicator.
   ///
-  /// {@macro flutter.material.ProgressIndicator.ProgressIndicator}
+  /// {@macro material_ui.ProgressIndicator.ProgressIndicator}
   const CircularProgressIndicator({
     super.key,
     super.value,
@@ -927,7 +927,7 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// [semanticsLabel], [semanticsValue], [trackGap], [year2023] will be
   /// ignored on iOS & macOS.
   ///
-  /// {@macro flutter.material.ProgressIndicator.ProgressIndicator}
+  /// {@macro material_ui.ProgressIndicator.ProgressIndicator}
   const CircularProgressIndicator.adaptive({
     super.key,
     super.value,
@@ -953,7 +953,7 @@ class CircularProgressIndicator extends ProgressIndicator {
 
   final _ActivityIndicatorType _indicatorType;
 
-  /// {@template flutter.material.CircularProgressIndicator.trackColor}
+  /// {@template material_ui.CircularProgressIndicator.trackColor}
   /// Color of the circular track being filled by the circular indicator.
   ///
   /// If [CircularProgressIndicator.backgroundColor] is null then the
@@ -1040,7 +1040,7 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// padding. Otherwise, defaults to zero padding.
   final EdgeInsetsGeometry? padding;
 
-  /// {@macro flutter.material.ProgressIndicator.controller}
+  /// {@macro material_ui.ProgressIndicator.controller}
   ///
   /// See also:
   ///
@@ -1335,7 +1335,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
   /// Rather than creating a refresh progress indicator directly, consider using
   /// a [RefreshIndicator] together with a [Scrollable] widget.
   ///
-  /// {@macro flutter.material.ProgressIndicator.ProgressIndicator}
+  /// {@macro material_ui.ProgressIndicator.ProgressIndicator}
   const RefreshProgressIndicator({
     super.key,
     super.value,
@@ -1352,7 +1352,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
     this.indicatorPadding = const EdgeInsets.all(12.0),
   });
 
-  /// {@macro flutter.material.material.elevation}
+  /// {@macro material_ui.material.elevation}
   final double elevation;
 
   /// The amount of space by which to inset the whole indicator.
@@ -1365,7 +1365,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
   /// Default stroke width.
   static const double defaultStrokeWidth = 2.5;
 
-  /// {@template flutter.material.RefreshProgressIndicator.backgroundColor}
+  /// {@template material_ui.RefreshProgressIndicator.backgroundColor}
   /// Background color of that fills the circle under the refresh indicator.
   ///
   /// If [RefreshIndicator.backgroundColor] is null then the

--- a/packages/material_ui/lib/src/progress_indicator_theme.dart
+++ b/packages/material_ui/lib/src/progress_indicator_theme.dart
@@ -72,16 +72,16 @@ class ProgressIndicatorThemeData with Diagnosticable {
   ///    a an animated color.
   final Color? color;
 
-  /// {@macro flutter.material.LinearProgressIndicator.trackColor}
+  /// {@macro material_ui.LinearProgressIndicator.trackColor}
   final Color? linearTrackColor;
 
-  /// {@macro flutter.material.LinearProgressIndicator.minHeight}
+  /// {@macro material_ui.LinearProgressIndicator.minHeight}
   final double? linearMinHeight;
 
-  /// {@macro flutter.material.CircularProgressIndicator.trackColor}
+  /// {@macro material_ui.CircularProgressIndicator.trackColor}
   final Color? circularTrackColor;
 
-  /// {@macro flutter.material.RefreshProgressIndicator.backgroundColor}
+  /// {@macro material_ui.RefreshProgressIndicator.backgroundColor}
   final Color? refreshBackgroundColor;
 
   /// Overrides the border radius of the [ProgressIndicator].

--- a/packages/material_ui/lib/src/radio.dart
+++ b/packages/material_ui/lib/src/radio.dart
@@ -189,14 +189,14 @@ class Radio<T> extends StatefulWidget {
   /// {@macro flutter.widget.RawRadio.value}
   final T value;
 
-  /// {@macro flutter.cupertino.Radio.groupValue}
+  /// {@macro cupertino_ui.Radio.groupValue}
   @Deprecated(
     'Use a RadioGroup ancestor to manage group value instead. '
     'This feature was deprecated after v3.32.0-0.0.pre.',
   )
   final T? groupValue;
 
-  /// {@macro flutter.cupertino.Radio.onChanged}
+  /// {@macro cupertino_ui.Radio.onChanged}
   ///
   /// For example:
   ///
@@ -251,7 +251,7 @@ class Radio<T> extends StatefulWidget {
   /// state, it will be used instead of this color.
   final Color? activeColor;
 
-  /// {@template flutter.material.radio.fillColor}
+  /// {@template material_ui.radio.fillColor}
   /// The color that fills the radio button, in all [WidgetState]s.
   ///
   /// Resolves in the following states:
@@ -294,7 +294,7 @@ class Radio<T> extends StatefulWidget {
   /// selected state and [ColorScheme.onSurfaceVariant] is used in the default state.
   final WidgetStateProperty<Color?>? fillColor;
 
-  /// {@template flutter.material.radio.materialTapTargetSize}
+  /// {@template material_ui.radio.materialTapTargetSize}
   /// Configures the minimum size of the tap target.
   /// {@endtemplate}
   ///
@@ -307,11 +307,11 @@ class Radio<T> extends StatefulWidget {
   ///  * [MaterialTapTargetSize], for a description of how this affects tap targets.
   final MaterialTapTargetSize? materialTapTargetSize;
 
-  /// {@template flutter.material.radio.visualDensity}
+  /// {@template material_ui.radio.visualDensity}
   /// Defines how compact the radio's layout will be.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   ///
   /// If null, then the value of [RadioThemeData.visualDensity] is used. If that
   /// is also null, then the value of [ThemeData.visualDensity] is used.
@@ -332,7 +332,7 @@ class Radio<T> extends StatefulWidget {
   /// [ThemeData.focusColor] is used.
   final Color? focusColor;
 
-  /// {@template flutter.material.radio.hoverColor}
+  /// {@template material_ui.radio.hoverColor}
   /// The color for the radio's [Material] when a pointer is hovering over it.
   ///
   /// If [overlayColor] returns a non-null color in the [WidgetState.hovered]
@@ -344,7 +344,7 @@ class Radio<T> extends StatefulWidget {
   /// [ThemeData.hoverColor] is used.
   final Color? hoverColor;
 
-  /// {@template flutter.material.radio.overlayColor}
+  /// {@template material_ui.radio.overlayColor}
   /// The color for the radio's [Material].
   ///
   /// Resolves in the following states:
@@ -371,7 +371,7 @@ class Radio<T> extends StatefulWidget {
   ///   * focused - Theme.colorScheme.onSurface(0.1)
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@template flutter.material.radio.splashRadius}
+  /// {@template material_ui.radio.splashRadius}
   /// The splash radius of the circular [Material] ink response.
   /// {@endtemplate}
   ///
@@ -402,10 +402,10 @@ class Radio<T> extends StatefulWidget {
 
   final _RadioType _radioType;
 
-  /// {@macro flutter.cupertino.Radio.enabled}
+  /// {@macro cupertino_ui.Radio.enabled}
   final bool? enabled;
 
-  /// {@template flutter.material.Radio.backgroundColor}
+  /// {@template material_ui.Radio.backgroundColor}
   /// The color of the background of the radio button, in all [WidgetState]s.
   ///
   /// Resolves in the following states:
@@ -419,7 +419,7 @@ class Radio<T> extends StatefulWidget {
   /// If that is also null the default value is transparent in all states.
   final WidgetStateProperty<Color?>? backgroundColor;
 
-  /// {@template flutter.material.Radio.side}
+  /// {@template material_ui.Radio.side}
   /// The side for the circular border of the radio button, in all
   /// [WidgetState]s.
   ///
@@ -437,7 +437,7 @@ class Radio<T> extends StatefulWidget {
   /// also null, the default value is a border using the fill color.
   final BorderSide? side;
 
-  /// {@template flutter.material.Radio.innerRadius}
+  /// {@template material_ui.Radio.innerRadius}
   /// The radius of the inner circle of the radio button, in all [WidgetState]s.
   ///
   /// Resolves in the following states:

--- a/packages/material_ui/lib/src/radio_list_tile.dart
+++ b/packages/material_ui/lib/src/radio_list_tile.dart
@@ -411,12 +411,12 @@ class RadioListTile<T> extends StatefulWidget {
   /// If that is also null, then the default value is used.
   final WidgetStateProperty<Color?>? fillColor;
 
-  /// {@macro flutter.material.radio.materialTapTargetSize}
+  /// {@macro material_ui.radio.materialTapTargetSize}
   ///
   /// Defaults to [MaterialTapTargetSize.shrinkWrap].
   final MaterialTapTargetSize? materialTapTargetSize;
 
-  /// {@macro flutter.material.radio.hoverColor}
+  /// {@macro material_ui.radio.hoverColor}
   final Color? hoverColor;
 
   /// The color for the radio's [Material].
@@ -432,7 +432,7 @@ class RadioListTile<T> extends StatefulWidget {
   /// also null, then the default value is used in the pressed and hovered state.
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@macro flutter.material.radio.splashRadius}
+  /// {@macro material_ui.radio.splashRadius}
   ///
   /// If null, then the value of [RadioThemeData.splashRadius] is used. If that
   /// is also null, then [kRadialReactionRadius] is used.
@@ -501,7 +501,7 @@ class RadioListTile<T> extends StatefulWidget {
 
   /// Defines how compact the list tile's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   final VisualDensity? visualDensity;
 
   /// {@macro flutter.widgets.Focus.focusNode}
@@ -510,26 +510,26 @@ class RadioListTile<T> extends StatefulWidget {
   /// Controls the interactive states of the backing [ListTile].
   final WidgetStatesController? statesController;
 
-  /// {@macro flutter.cupertino.inkwell.onFocusChange}
+  /// {@macro cupertino_ui.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
-  /// {@macro flutter.material.ListTile.enableFeedback}
+  /// {@macro material_ui.ListTile.enableFeedback}
   ///
   /// See also:
   ///
   ///  * [Feedback] for providing platform-specific feedback to certain actions.
   final bool? enableFeedback;
 
-  /// {@macro flutter.material.ListTile.horizontalTitleGap}
+  /// {@macro material_ui.ListTile.horizontalTitleGap}
   final double? horizontalTitleGap;
 
-  /// {@macro flutter.material.ListTile.minVerticalPadding}
+  /// {@macro material_ui.ListTile.minVerticalPadding}
   final double? minVerticalPadding;
 
-  /// {@macro flutter.material.ListTile.minLeadingWidth}
+  /// {@macro material_ui.ListTile.minLeadingWidth}
   final double? minLeadingWidth;
 
-  /// {@macro flutter.material.ListTile.minTileHeight}
+  /// {@macro material_ui.ListTile.minTileHeight}
   final double? minTileHeight;
 
   final _RadioType _radioType;

--- a/packages/material_ui/lib/src/radio_theme.dart
+++ b/packages/material_ui/lib/src/radio_theme.dart
@@ -59,48 +59,48 @@ class RadioThemeData with Diagnosticable {
   /// default value is [WidgetStateMouseCursor.clickable].
   final WidgetStateProperty<MouseCursor?>? mouseCursor;
 
-  /// {@macro flutter.material.radio.fillColor}
+  /// {@macro material_ui.radio.fillColor}
   ///
   /// If specified, overrides the default value of [Radio.fillColor].
   final WidgetStateProperty<Color?>? fillColor;
 
-  /// {@macro flutter.material.radio.overlayColor}
+  /// {@macro material_ui.radio.overlayColor}
   ///
   /// If specified, overrides the default value of [Radio.overlayColor].
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@macro flutter.material.radio.splashRadius}
+  /// {@macro material_ui.radio.splashRadius}
   ///
   /// If specified, overrides the default value of [Radio.splashRadius]. The
   /// default value is [kRadialReactionRadius].
   final double? splashRadius;
 
-  /// {@macro flutter.material.radio.materialTapTargetSize}
+  /// {@macro material_ui.radio.materialTapTargetSize}
   ///
   /// If specified, overrides the default value of
   /// [Radio.materialTapTargetSize]. The default value is the value of
   /// [ThemeData.materialTapTargetSize].
   final MaterialTapTargetSize? materialTapTargetSize;
 
-  /// {@macro flutter.material.radio.visualDensity}
+  /// {@macro material_ui.radio.visualDensity}
   ///
   /// If specified, overrides the default value of [Radio.visualDensity]. The
   /// default value is the value of [ThemeData.visualDensity].
   final VisualDensity? visualDensity;
 
-  /// {@macro flutter.material.Radio.backgroundColor}
+  /// {@macro material_ui.Radio.backgroundColor}
   ///
   /// If specified, overrides the default value of [Radio.backgroundColor]. The
   /// default value is transparent in all states.
   final WidgetStateProperty<Color?>? backgroundColor;
 
-  /// {@macro flutter.material.Radio.side}
+  /// {@macro material_ui.Radio.side}
   ///
   /// If specified, overrides the default value of [Radio.side]. The default
   /// value is a border using the fill color.
   final BorderSide? side;
 
-  /// {@macro flutter.material.Radio.innerRadius}
+  /// {@macro material_ui.Radio.innerRadius}
   ///
   /// If specified, overrides the default value of [Radio.innerRadius]. The
   /// default value is `4.5` in all states.

--- a/packages/material_ui/lib/src/range_slider_parts.dart
+++ b/packages/material_ui/lib/src/range_slider_parts.dart
@@ -40,12 +40,12 @@ abstract class RangeSliderThumbShape {
 
   /// Returns the preferred size of the shape, based on the given conditions.
   ///
-  /// {@template flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
+  /// {@template material_ui.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   /// The `isDiscrete` argument is true if [RangeSlider.divisions] is non-null.
   /// When true, the slider will render tick marks on top of the track.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
+  /// {@template material_ui.RangeSliderThumbShape.getPreferredSize.isEnabled}
   /// The `isEnabled` argument is false when [RangeSlider.onChanged] is null and
   /// true otherwise. When true, the slider will respond to input.
   /// {@endtemplate}
@@ -53,19 +53,19 @@ abstract class RangeSliderThumbShape {
 
   /// Paints the thumb shape based on the state passed to it.
   ///
-  /// {@template flutter.material.RangeSliderThumbShape.paint.context}
+  /// {@template material_ui.RangeSliderThumbShape.paint.context}
   /// The `context` argument represents the [RangeSlider]'s render box.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.center}
+  /// {@macro material_ui.SliderComponentShape.paint.center}
   ///
-  /// {@template flutter.material.RangeSliderThumbShape.paint.activationAnimation}
+  /// {@template material_ui.RangeSliderThumbShape.paint.activationAnimation}
   /// The `activationAnimation` argument is an animation triggered when the user
   /// begins to interact with the [RangeSlider]. It reverses when the user stops
   /// interacting with the slider.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.RangeSliderThumbShape.paint.enableAnimation}
+  /// {@template material_ui.RangeSliderThumbShape.paint.enableAnimation}
   /// The `enableAnimation` argument is an animation triggered when the
   /// [RangeSlider] is enabled, and it reverses when the slider is disabled. The
   /// [RangeSlider] is enabled when [RangeSlider.onChanged] is not null. Use
@@ -73,15 +73,15 @@ abstract class RangeSliderThumbShape {
   /// enabled state.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
   /// If the `isOnTop` argument is true, this thumb is painted on top of the
   /// other slider thumb because this thumb is the one that was most recently
   /// selected.
   ///
-  /// {@template flutter.material.RangeSliderThumbShape.paint.sliderTheme}
+  /// {@template material_ui.RangeSliderThumbShape.paint.sliderTheme}
   /// The `sliderTheme` argument is the theme assigned to the [RangeSlider] that
   /// this shape belongs to.
   /// {@endtemplate}
@@ -90,7 +90,7 @@ abstract class RangeSliderThumbShape {
   /// of either slider thumb should be changed, such as drawing different
   /// shapes for the left and right thumb.
   ///
-  /// {@template flutter.material.RangeSliderThumbShape.paint.thumb}
+  /// {@template material_ui.RangeSliderThumbShape.paint.thumb}
   /// The `thumb` argument is the specifier for which of the two thumbs this
   /// method should paint (start or end).
   /// {@endtemplate}
@@ -135,14 +135,14 @@ abstract class RangeSliderValueIndicatorShape {
 
   /// Returns the preferred size of the shape, based on the given conditions.
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   ///
   /// The `labelPainter` argument helps determine the width of the shape. It is
   /// variable width because it is derived from a formatted string.
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.textScaleFactor}
+  /// {@macro material_ui.SliderComponentShape.paint.textScaleFactor}
   Size getPreferredSize(
     bool isEnabled,
     bool isDiscrete, {
@@ -167,31 +167,31 @@ abstract class RangeSliderValueIndicatorShape {
 
   /// Paints the value indicator shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.context}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.context}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.center}
+  /// {@macro material_ui.SliderComponentShape.paint.center}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.activationAnimation}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.activationAnimation}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.enableAnimation}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.enableAnimation}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   ///
   /// The `isOnTop` argument is the top-most value indicator between the two value
   /// indicators, which is always the indicator for the most recently selected thumb. In
   /// the default case, this is used to paint a stroke around the top indicator
   /// for better visibility between the two indicators.
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.textScaleFactor}
+  /// {@macro material_ui.SliderComponentShape.paint.textScaleFactor}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.sizeWithOverflow}
+  /// {@macro material_ui.SliderComponentShape.paint.sizeWithOverflow}
   ///
-  /// {@template flutter.material.RangeSliderValueIndicatorShape.paint.parentBox}
+  /// {@template material_ui.RangeSliderValueIndicatorShape.paint.parentBox}
   /// The `parentBox` argument is the [RenderBox] of the [RangeSlider]. Its
   /// attributes, such as size, can be used to assist in painting this shape.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.sliderTheme}
   ///
   /// The `textDirection` argument can be used to determine how any extra text
   /// or graphics, besides the text painted by the [labelPainter] should be
@@ -201,7 +201,7 @@ abstract class RangeSliderValueIndicatorShape {
   /// The `value` argument is the current parametric value (from 0.0 to 1.0) of
   /// the slider.
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.thumb}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.thumb}
   void paint(
     PaintingContext context,
     Offset center, {
@@ -247,29 +247,29 @@ abstract class RangeSliderTickMarkShape {
   ///
   /// It is used to help position the tick marks within the slider.
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isEnabled}
   Size getPreferredSize({required SliderThemeData sliderTheme, bool isEnabled});
 
   /// Paints the slider track.
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.context}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.context}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.center}
+  /// {@macro material_ui.SliderComponentShape.paint.center}
   ///
-  /// {@macro flutter.material.RangeSliderValueIndicatorShape.paint.parentBox}
+  /// {@macro material_ui.RangeSliderValueIndicatorShape.paint.parentBox}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.enableAnimation}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.enableAnimation}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
   /// The `textDirection` argument can be used to determine how the tick marks
   /// are painted depending on whether they are on an active track segment or not.
   ///
-  /// {@template flutter.material.RangeSliderTickMarkShape.paint.trackSegment}
+  /// {@template material_ui.RangeSliderTickMarkShape.paint.trackSegment}
   /// The track segment between the two thumbs is the active track segment. The
   /// track segments between the thumb and each end of the slider are the inactive
   /// track segments. In [TextDirection.ltr], the start of the slider is on the
@@ -329,11 +329,11 @@ abstract class RangeSliderTrackShape {
   /// used to convert gesture coordinates from global to slider-relative
   /// coordinates.
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   Rect getPreferredRect({
     required RenderBox parentBox,
     Offset offset = Offset.zero,
@@ -344,17 +344,17 @@ abstract class RangeSliderTrackShape {
 
   /// Paints the track shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.context}
+  /// {@macro material_ui.SliderComponentShape.paint.context}
   ///
   /// The `offset` argument is the offset of the origin of the `parentBox` to
   /// the origin of its `context` canvas. This shape must be painted relative
   /// to this offset. See [PaintingContextCallback].
   ///
-  /// {@macro flutter.material.RangeSliderValueIndicatorShape.paint.parentBox}
+  /// {@macro material_ui.RangeSliderValueIndicatorShape.paint.parentBox}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.paint.enableAnimation}
+  /// {@macro material_ui.RangeSliderThumbShape.paint.enableAnimation}
   ///
   /// The `startThumbCenter` argument is the offset of the center of the start
   /// thumb relative to the origin of the [PaintingContext.canvas]. It can be
@@ -364,15 +364,15 @@ abstract class RangeSliderTrackShape {
   /// thumb relative to the origin of the [PaintingContext.canvas]. It can be
   /// used as one point that divides the track between inactive and active.
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
+  /// {@macro material_ui.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   ///
   /// The `textDirection` argument can be used to determine how the track
   /// segments are painted depending on whether they are on an active track
   /// segment or not.
   ///
-  /// {@macro flutter.material.RangeSliderTickMarkShape.paint.trackSegment}
+  /// {@macro material_ui.RangeSliderTickMarkShape.paint.trackSegment}
   void paint(
     PaintingContext context,
     Offset offset, {
@@ -470,7 +470,7 @@ mixin BaseRangeSliderTrackShape {
 ///   [SliderThemeData.disabledActiveTrackColor],
 ///   [SliderThemeData.disabledInactiveTrackColor].
 ///
-/// {@macro flutter.material.RangeSliderTickMarkShape.paint.trackSegment}
+/// {@macro material_ui.RangeSliderTickMarkShape.paint.trackSegment}
 ///
 /// ![A range slider widget, consisting of 5 divisions and showing the rectangular range slider track shape.](https://flutter.github.io/assets-for-api-docs/assets/material/rectangular_range_slider_track_shape.png)
 ///
@@ -579,7 +579,7 @@ class RectangularRangeSliderTrackShape extends RangeSliderTrackShape
 ///   [SliderThemeData.disabledActiveTrackColor],
 ///   [SliderThemeData.disabledInactiveTrackColor].
 ///
-/// {@macro flutter.material.RangeSliderTickMarkShape.paint.trackSegment}
+/// {@macro material_ui.RangeSliderTickMarkShape.paint.trackSegment}
 ///
 /// ![A range slider widget, consisting of 5 divisions and showing the rounded rect range slider track shape.](https://flutter.github.io/assets-for-api-docs/assets/material/rounded_rect_range_slider_track_shape.png)
 ///

--- a/packages/material_ui/lib/src/reorderable_list.dart
+++ b/packages/material_ui/lib/src/reorderable_list.dart
@@ -358,7 +358,7 @@ class ReorderableListView extends StatefulWidget {
   /// {@macro flutter.widgets.scrollable.restorationId}
   final String? restorationId;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/scaffold.dart
+++ b/packages/material_ui/lib/src/scaffold.dart
@@ -2041,7 +2041,7 @@ class Scaffold extends StatefulWidget {
   /// [AppBar.primary], is true.
   final bool primary;
 
-  /// {@macro flutter.material.DrawerController.dragStartBehavior}
+  /// {@macro material_ui.DrawerController.dragStartBehavior}
   final DragStartBehavior drawerDragStartBehavior;
 
   /// The width of the area within which a horizontal swipe will open the

--- a/packages/material_ui/lib/src/search.dart
+++ b/packages/material_ui/lib/src/search.dart
@@ -209,10 +209,10 @@ abstract class SearchDelegate<T> {
   ///  * [AppBar.leading], the intended use for the return value of this method.
   Widget? buildLeading(BuildContext context);
 
-  /// {@macro flutter.material.appbar.automaticallyImplyLeading}
+  /// {@macro material_ui.appbar.automaticallyImplyLeading}
   bool? automaticallyImplyLeading;
 
-  /// {@macro flutter.material.appbar.leadingWidth}
+  /// {@macro material_ui.appbar.leadingWidth}
   double? leadingWidth;
 
   /// Widgets to display after the search query in the [AppBar].

--- a/packages/material_ui/lib/src/selectable_text.dart
+++ b/packages/material_ui/lib/src/selectable_text.dart
@@ -93,7 +93,7 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
 /// behavior is useful, for example, to make the text bold while using the
 /// default font family and size.
 ///
-/// {@macro flutter.cupertino.textfield.wantKeepAlive}
+/// {@macro cupertino_ui.textfield.wantKeepAlive}
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/slider.dart
+++ b/packages/material_ui/lib/src/slider.dart
@@ -521,7 +521,7 @@ class Slider extends StatefulWidget {
   /// to [ColorScheme.primary] with an opacity of 0.12.
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@template flutter.material.slider.mouseCursor}
+  /// {@template material_ui.slider.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///

--- a/packages/material_ui/lib/src/slider_parts.dart
+++ b/packages/material_ui/lib/src/slider_parts.dart
@@ -43,9 +43,9 @@ abstract class SliderTickMarkShape {
   ///
   /// It is used to help position the tick marks within the slider.
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.sliderTheme}
+  /// {@macro material_ui.SliderComponentShape.paint.sliderTheme}
   ///
-  /// {@template flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
+  /// {@template material_ui.SliderTickMarkShape.getPreferredSize.isEnabled}
   /// The `isEnabled` argument is false when [Slider.onChanged] is null and true
   /// otherwise. When true, the slider will respond to input.
   /// {@endtemplate}
@@ -53,17 +53,17 @@ abstract class SliderTickMarkShape {
 
   /// Paints the slider track.
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.context}
+  /// {@macro material_ui.SliderComponentShape.paint.context}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.center}
+  /// {@macro material_ui.SliderComponentShape.paint.center}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.parentBox}
+  /// {@macro material_ui.SliderComponentShape.paint.parentBox}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.sliderTheme}
+  /// {@macro material_ui.SliderComponentShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.enableAnimation}
+  /// {@macro material_ui.SliderComponentShape.paint.enableAnimation}
   ///
-  /// {@macro flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.SliderTickMarkShape.getPreferredSize.isEnabled}
   ///
   /// The `textDirection` argument can be used to determine how the tick marks
   /// are painting depending on whether they are on an active track segment or
@@ -126,11 +126,11 @@ abstract class SliderTrackShape {
   /// The `offset` argument is relative to the caller's bounding box. It can be used to
   /// convert gesture coordinates from global to slider-relative coordinates.
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.sliderTheme}
+  /// {@macro material_ui.SliderComponentShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.SliderTickMarkShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.isDiscrete}
+  /// {@macro material_ui.SliderComponentShape.paint.isDiscrete}
   Rect getPreferredRect({
     required RenderBox parentBox,
     Offset offset = Offset.zero,
@@ -141,17 +141,17 @@ abstract class SliderTrackShape {
 
   /// Paints the track shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.context}
+  /// {@macro material_ui.SliderComponentShape.paint.context}
   ///
   /// The `offset` argument the offset of the origin of the `parentBox` to the
   /// origin of its `context` canvas. This shape must be painted relative to
   /// this offset. See [PaintingContextCallback].
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.parentBox}
+  /// {@macro material_ui.SliderComponentShape.paint.parentBox}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.sliderTheme}
+  /// {@macro material_ui.SliderComponentShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.enableAnimation}
+  /// {@macro material_ui.SliderComponentShape.paint.enableAnimation}
   ///
   /// The `thumbCenter` argument is the offset of the center of the thumb
   /// relative to the origin of the [PaintingContext.canvas]. It can be used as
@@ -162,14 +162,14 @@ abstract class SliderTrackShape {
   ///
   /// If not null, the track is divided into 3 segments.
   ///
-  /// {@macro flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
+  /// {@macro material_ui.SliderTickMarkShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.SliderComponentShape.paint.isDiscrete}
+  /// {@macro material_ui.SliderComponentShape.paint.isDiscrete}
   ///
   /// The `textDirection` argument can be used to determine how the track
   /// segments are painted depending on whether they are active or not.
   ///
-  /// {@template flutter.material.SliderTrackShape.paint.trackSegment}
+  /// {@template material_ui.SliderTrackShape.paint.trackSegment}
   /// The track segment between the start of the slider and the thumb is the
   /// active track segment. The track segment between the thumb and the end of the
   /// slider is the inactive track segment. In [TextDirection.ltr], the start of
@@ -275,7 +275,7 @@ mixin BaseSliderTrackShape {
 ///   [SliderThemeData.disabledActiveTrackColor],
 ///   [SliderThemeData.disabledInactiveTrackColor].
 ///
-/// {@macro flutter.material.SliderTrackShape.paint.trackSegment}
+/// {@macro material_ui.SliderTrackShape.paint.trackSegment}
 ///
 /// ![A slider widget, consisting of 5 divisions and showing the rectangular slider track shape.](https://flutter.github.io/assets-for-api-docs/assets/material/rectangular_slider_track_shape.png)
 ///
@@ -408,7 +408,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 ///   [SliderThemeData.disabledActiveTrackColor],
 ///   [SliderThemeData.disabledInactiveTrackColor].
 ///
-/// {@macro flutter.material.SliderTrackShape.paint.trackSegment}
+/// {@macro material_ui.SliderTrackShape.paint.trackSegment}
 ///
 /// ![A slider widget, consisting of 5 divisions and showing the rounded rect slider track shape.](https://flutter.github.io/assets-for-api-docs/assets/material/rounded_rect_slider_track_shape.png)
 ///

--- a/packages/material_ui/lib/src/slider_theme.dart
+++ b/packages/material_ui/lib/src/slider_theme.dart
@@ -609,7 +609,7 @@ class SliderThemeData with Diagnosticable {
   /// Override this for custom thumb selection.
   final RangeThumbSelector? thumbSelector;
 
-  /// {@macro flutter.material.slider.mouseCursor}
+  /// {@macro material_ui.slider.mouseCursor}
   ///
   /// If specified, overrides the default value of [Slider.mouseCursor].
   final WidgetStateProperty<MouseCursor?>? mouseCursor;

--- a/packages/material_ui/lib/src/slider_value_indicator_shape.dart
+++ b/packages/material_ui/lib/src/slider_value_indicator_shape.dart
@@ -42,12 +42,12 @@ abstract class SliderComponentShape {
 
   /// Paints the shape, taking into account the state passed to it.
   ///
-  /// {@template flutter.material.SliderComponentShape.paint.context}
+  /// {@template material_ui.SliderComponentShape.paint.context}
   /// The `context` argument is the same as the one that includes the [Slider]'s
   /// render box.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.SliderComponentShape.paint.center}
+  /// {@template material_ui.SliderComponentShape.paint.center}
   /// The `center` argument is the offset for where this shape's center should be
   /// painted. This offset is relative to the origin of the [context] canvas.
   /// {@endtemplate}
@@ -56,14 +56,14 @@ abstract class SliderComponentShape {
   /// begins to interact with the slider. It reverses when the user stops interacting
   /// with the slider.
   ///
-  /// {@template flutter.material.SliderComponentShape.paint.enableAnimation}
+  /// {@template material_ui.SliderComponentShape.paint.enableAnimation}
   /// The `enableAnimation` argument is an animation triggered when the [Slider]
   /// is enabled, and it reverses when the slider is disabled. The [Slider] is
   /// enabled when [Slider.onChanged] is not null. Use this to paint
   /// intermediate frames for this shape when the slider changes enabled state.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.SliderComponentShape.paint.isDiscrete}
+  /// {@template material_ui.SliderComponentShape.paint.isDiscrete}
   /// The `isDiscrete` argument is true if [Slider.divisions] is non-null. When
   /// true, the slider will render tick marks on top of the track.
   /// {@endtemplate}
@@ -73,12 +73,12 @@ abstract class SliderComponentShape {
   /// should appear. If the `labelPainter` argument is null, then no label was
   /// supplied to the [Slider].
   ///
-  /// {@template flutter.material.SliderComponentShape.paint.parentBox}
+  /// {@template material_ui.SliderComponentShape.paint.parentBox}
   /// The `parentBox` argument is the [RenderBox] of the [Slider]. Its attributes,
   /// such as size, can be used to assist in painting this shape.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.SliderComponentShape.paint.sliderTheme}
+  /// {@template material_ui.SliderComponentShape.paint.sliderTheme}
   /// the `sliderTheme` argument is the theme assigned to the [Slider] that this
   /// shape belongs to.
   /// {@endtemplate}
@@ -90,14 +90,14 @@ abstract class SliderComponentShape {
   /// The `value` argument is the current parametric value (from 0.0 to 1.0) of
   /// the slider.
   ///
-  /// {@template flutter.material.SliderComponentShape.paint.textScaleFactor}
+  /// {@template material_ui.SliderComponentShape.paint.textScaleFactor}
   /// The `textScaleFactor` argument can be used to determine whether the
   /// component should paint larger or smaller, depending on whether
   /// [textScaleFactor] is greater than 1 for larger, and between 0 and 1 for
   /// smaller. It's usually computed from [MediaQueryData.textScaler].
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.SliderComponentShape.paint.sizeWithOverflow}
+  /// {@template material_ui.SliderComponentShape.paint.sizeWithOverflow}
   /// The `sizeWithOverflow` argument can be used to determine the bounds the
   /// drawing of the components that are outside of the regular slider bounds.
   /// It's the size of the box, whose center is aligned with the slider's

--- a/packages/material_ui/lib/src/snack_bar.dart
+++ b/packages/material_ui/lib/src/snack_bar.dart
@@ -506,7 +506,7 @@ class SnackBar extends StatefulWidget {
   /// is used. If that is null, then the default is [DismissDirection.down].
   final DismissDirection? dismissDirection;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/spell_check_suggestions_toolbar.dart
+++ b/packages/material_ui/lib/src/spell_check_suggestions_toolbar.dart
@@ -49,7 +49,7 @@ class SpellCheckSuggestionsToolbar extends StatelessWidget {
   }) : buttonItems = buildButtonItems(editableTextState) ?? <ContextMenuButtonItem>[],
        anchor = getToolbarAnchor(editableTextState.contextMenuAnchors);
 
-  /// {@template flutter.material.SpellCheckSuggestionsToolbar.anchor}
+  /// {@template material_ui.SpellCheckSuggestionsToolbar.anchor}
   /// The focal point below which the toolbar attempts to position itself.
   /// {@endtemplate}
   final Offset anchor;

--- a/packages/material_ui/lib/src/spell_check_suggestions_toolbar_layout_delegate.dart
+++ b/packages/material_ui/lib/src/spell_check_suggestions_toolbar_layout_delegate.dart
@@ -18,7 +18,7 @@ class SpellCheckSuggestionsToolbarLayoutDelegate extends SingleChildLayoutDelega
   /// Creates an instance of [SpellCheckSuggestionsToolbarLayoutDelegate].
   SpellCheckSuggestionsToolbarLayoutDelegate({required this.anchor});
 
-  /// {@macro flutter.material.SpellCheckSuggestionsToolbar.anchor}
+  /// {@macro material_ui.SpellCheckSuggestionsToolbar.anchor}
   ///
   /// Should be provided in local coordinates.
   final Offset anchor;

--- a/packages/material_ui/lib/src/switch.dart
+++ b/packages/material_ui/lib/src/switch.dart
@@ -257,7 +257,7 @@ class Switch extends StatelessWidget {
   /// ```
   final ValueChanged<bool>? onChanged;
 
-  /// {@template flutter.material.switch.activeColor}
+  /// {@template material_ui.switch.activeColor}
   /// The color to use when this switch is on.
   /// {@endtemplate}
   ///
@@ -271,7 +271,7 @@ class Switch extends StatelessWidget {
   )
   final Color? activeColor;
 
-  /// {@template flutter.material.switch.activeThumbColor}
+  /// {@template material_ui.switch.activeThumbColor}
   /// The color to use when this switch is on.
   /// {@endtemplate}
   ///
@@ -281,7 +281,7 @@ class Switch extends StatelessWidget {
   /// state, it will be used instead of this color.
   final Color? activeThumbColor;
 
-  /// {@template flutter.material.switch.activeTrackColor}
+  /// {@template material_ui.switch.activeTrackColor}
   /// The color to use on the track when this switch is on.
   /// {@endtemplate}
   ///
@@ -291,7 +291,7 @@ class Switch extends StatelessWidget {
   /// state, it will be used instead of this color.
   final Color? activeTrackColor;
 
-  /// {@template flutter.material.switch.inactiveThumbColor}
+  /// {@template material_ui.switch.inactiveThumbColor}
   /// The color to use on the thumb when this switch is off.
   /// {@endtemplate}
   ///
@@ -301,7 +301,7 @@ class Switch extends StatelessWidget {
   /// used instead of this color.
   final Color? inactiveThumbColor;
 
-  /// {@template flutter.material.switch.inactiveTrackColor}
+  /// {@template material_ui.switch.inactiveTrackColor}
   /// The color to use on the track when this switch is off.
   /// {@endtemplate}
   ///
@@ -311,19 +311,19 @@ class Switch extends StatelessWidget {
   /// used instead of this color.
   final Color? inactiveTrackColor;
 
-  /// {@macro flutter.cupertino.switch.activeThumbImage}
+  /// {@macro cupertino_ui.switch.activeThumbImage}
   final ImageProvider? activeThumbImage;
 
-  /// {@macro flutter.cupertino.switch.onActiveThumbImageError}
+  /// {@macro cupertino_ui.switch.onActiveThumbImageError}
   final ImageErrorListener? onActiveThumbImageError;
 
-  /// {@macro flutter.cupertino.switch.inactiveThumbImage}
+  /// {@macro cupertino_ui.switch.inactiveThumbImage}
   final ImageProvider? inactiveThumbImage;
 
-  /// {@macro flutter.cupertino.switch.onInactiveThumbImageError}
+  /// {@macro cupertino_ui.switch.onInactiveThumbImageError}
   final ImageErrorListener? onInactiveThumbImageError;
 
-  /// {@template flutter.material.switch.thumbColor}
+  /// {@template material_ui.switch.thumbColor}
   /// The color of this [Switch]'s thumb.
   ///
   /// Resolved in the following states:
@@ -369,7 +369,7 @@ class Switch extends StatelessWidget {
   /// | Disabled | `Colors.grey.shade400`            | `Colors.grey.shade800`            |
   final WidgetStateProperty<Color?>? thumbColor;
 
-  /// {@template flutter.material.switch.trackColor}
+  /// {@template material_ui.switch.trackColor}
   /// The color of this [Switch]'s track.
   ///
   /// Resolved in the following states:
@@ -415,7 +415,7 @@ class Switch extends StatelessWidget {
   /// | Disabled | `Colors.black12`                | `Colors.white10`                |
   final WidgetStateProperty<Color?>? trackColor;
 
-  /// {@template flutter.material.switch.trackOutlineColor}
+  /// {@template material_ui.switch.trackOutlineColor}
   /// The outline color of this [Switch]'s track.
   ///
   /// Resolved in the following states:
@@ -454,7 +454,7 @@ class Switch extends StatelessWidget {
   /// the [Switch] track has no outline by default.
   final WidgetStateProperty<Color?>? trackOutlineColor;
 
-  /// {@template flutter.material.switch.trackOutlineWidth}
+  /// {@template material_ui.switch.trackOutlineWidth}
   /// The outline width of this [Switch]'s track.
   ///
   /// Resolved in the following states:
@@ -491,7 +491,7 @@ class Switch extends StatelessWidget {
   /// Defaults to 2.0.
   final WidgetStateProperty<double?>? trackOutlineWidth;
 
-  /// {@template flutter.material.switch.thumbIcon}
+  /// {@template material_ui.switch.thumbIcon}
   /// The icon to use on the thumb of this switch
   ///
   /// Resolved in the following states:
@@ -529,7 +529,7 @@ class Switch extends StatelessWidget {
   /// then the [Switch] does not have any icons on the thumb.
   final WidgetStateProperty<Icon?>? thumbIcon;
 
-  /// {@template flutter.material.switch.materialTapTargetSize}
+  /// {@template material_ui.switch.materialTapTargetSize}
   /// Configures the minimum size of the tap target.
   /// {@endtemplate}
   ///
@@ -544,13 +544,13 @@ class Switch extends StatelessWidget {
 
   final _SwitchType _switchType;
 
-  /// {@macro flutter.cupertino.CupertinoSwitch.applyTheme}
+  /// {@macro cupertino_ui.CupertinoSwitch.applyTheme}
   final bool? applyCupertinoTheme;
 
-  /// {@macro flutter.cupertino.CupertinoSwitch.dragStartBehavior}
+  /// {@macro cupertino_ui.CupertinoSwitch.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
 
-  /// {@template flutter.material.switch.mouseCursor}
+  /// {@template material_ui.switch.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
@@ -587,7 +587,7 @@ class Switch extends StatelessWidget {
   /// [ThemeData.hoverColor] is used.
   final Color? hoverColor;
 
-  /// {@template flutter.material.switch.overlayColor}
+  /// {@template material_ui.switch.overlayColor}
   /// The color for the switch's [Material].
   ///
   /// Resolves in the following states:
@@ -606,7 +606,7 @@ class Switch extends StatelessWidget {
   /// is used in the pressed, focused and hovered state.
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@template flutter.material.switch.splashRadius}
+  /// {@template material_ui.switch.splashRadius}
   /// The splash radius of the circular [Material] ink response.
   /// {@endtemplate}
   ///
@@ -617,7 +617,7 @@ class Switch extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
 
-  /// {@macro flutter.cupertino.inkwell.onFocusChange}
+  /// {@macro cupertino_ui.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@macro flutter.widgets.Focus.autofocus}

--- a/packages/material_ui/lib/src/switch_list_tile.dart
+++ b/packages/material_ui/lib/src/switch_list_tile.dart
@@ -356,7 +356,7 @@ class SwitchListTile extends StatelessWidget {
   /// </callout-box>
   final ValueChanged<bool>? onChanged;
 
-  /// {@macro flutter.material.switch.activeColor}
+  /// {@macro material_ui.switch.activeColor}
   ///
   /// Defaults to [ColorScheme.secondary] of the current [Theme].
   @Deprecated(
@@ -365,44 +365,44 @@ class SwitchListTile extends StatelessWidget {
   )
   final Color? activeColor;
 
-  /// {@macro flutter.material.switch.activeThumbColor}
+  /// {@macro material_ui.switch.activeThumbColor}
   ///
   /// Defaults to [ColorScheme.secondary] of the current [Theme].
   final Color? activeThumbColor;
 
-  /// {@macro flutter.material.switch.activeTrackColor}
+  /// {@macro material_ui.switch.activeTrackColor}
   ///
   /// Defaults to [ColorScheme.secondary] with the opacity set at 50%.
   ///
   /// Ignored if created with [SwitchListTile.adaptive].
   final Color? activeTrackColor;
 
-  /// {@macro flutter.material.switch.inactiveThumbColor}
+  /// {@macro material_ui.switch.inactiveThumbColor}
   ///
   /// Defaults to the colors described in the Material design specification.
   ///
   /// Ignored if created with [SwitchListTile.adaptive].
   final Color? inactiveThumbColor;
 
-  /// {@macro flutter.material.switch.inactiveTrackColor}
+  /// {@macro material_ui.switch.inactiveTrackColor}
   ///
   /// Defaults to the colors described in the Material design specification.
   ///
   /// Ignored if created with [SwitchListTile.adaptive].
   final Color? inactiveTrackColor;
 
-  /// {@macro flutter.cupertino.switch.activeThumbImage}
+  /// {@macro cupertino_ui.switch.activeThumbImage}
   final ImageProvider? activeThumbImage;
 
-  /// {@macro flutter.cupertino.switch.onActiveThumbImageError}
+  /// {@macro cupertino_ui.switch.onActiveThumbImageError}
   final ImageErrorListener? onActiveThumbImageError;
 
-  /// {@macro flutter.cupertino.switch.inactiveThumbImage}
+  /// {@macro cupertino_ui.switch.inactiveThumbImage}
   ///
   /// Ignored if created with [SwitchListTile.adaptive].
   final ImageProvider? inactiveThumbImage;
 
-  /// {@macro flutter.cupertino.switch.onInactiveThumbImageError}
+  /// {@macro cupertino_ui.switch.onInactiveThumbImageError}
   final ImageErrorListener? onInactiveThumbImageError;
 
   /// The color of this switch's thumb.
@@ -431,7 +431,7 @@ class SwitchListTile extends StatelessWidget {
   /// null, then the default value is used.
   final WidgetStateProperty<Color?>? trackColor;
 
-  /// {@macro flutter.material.switch.trackOutlineColor}
+  /// {@macro material_ui.switch.trackOutlineColor}
   ///
   /// The [ListTile] will be focused when this [SwitchListTile] requests focus,
   /// so the focused outline color of the switch will be ignored.
@@ -452,12 +452,12 @@ class SwitchListTile extends StatelessWidget {
   /// also null, then the [Switch] does not have any icons on the thumb.
   final WidgetStateProperty<Icon?>? thumbIcon;
 
-  /// {@macro flutter.material.switch.materialTapTargetSize}
+  /// {@macro material_ui.switch.materialTapTargetSize}
   ///
   /// defaults to [MaterialTapTargetSize.shrinkWrap].
   final MaterialTapTargetSize? materialTapTargetSize;
 
-  /// {@macro flutter.cupertino.CupertinoSwitch.dragStartBehavior}
+  /// {@macro cupertino_ui.CupertinoSwitch.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
 
   /// The cursor for a mouse pointer when it enters or is hovering over the
@@ -487,7 +487,7 @@ class SwitchListTile extends StatelessWidget {
   /// also null, then the default value is used in the pressed and hovered state.
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@macro flutter.material.switch.splashRadius}
+  /// {@macro material_ui.switch.splashRadius}
   ///
   /// If null, then the value of [SwitchThemeData.splashRadius] is used. If that
   /// is also null, then [kRadialReactionRadius] is used.
@@ -499,13 +499,13 @@ class SwitchListTile extends StatelessWidget {
   /// Controls the interactive states of the backing [ListTile].
   final WidgetStatesController? statesController;
 
-  /// {@macro flutter.cupertino.inkwell.onFocusChange}
+  /// {@macro cupertino_ui.inkwell.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.material.ListTile.tileColor}
+  /// {@macro material_ui.ListTile.tileColor}
   final Color? tileColor;
 
   /// The primary content of the list tile.
@@ -561,7 +561,7 @@ class SwitchListTile extends StatelessWidget {
   /// By default, the value of [controlAffinity] is [ListTileControlAffinity.platform].
   final ListTileControlAffinity? controlAffinity;
 
-  /// {@macro flutter.material.ListTile.shape}
+  /// {@macro material_ui.ListTile.shape}
   final ShapeBorder? shape;
 
   /// If non-null, defines the background color when [SwitchListTile.selected] is true.
@@ -569,32 +569,32 @@ class SwitchListTile extends StatelessWidget {
 
   /// Defines how compact the list tile's layout will be.
   ///
-  /// {@macro flutter.material.themedata.visualDensity}
+  /// {@macro material_ui.themedata.visualDensity}
   final VisualDensity? visualDensity;
 
-  /// {@macro flutter.material.ListTile.enableFeedback}
+  /// {@macro material_ui.ListTile.enableFeedback}
   ///
   /// See also:
   ///
   ///  * [Feedback] for providing platform-specific feedback to certain actions.
   final bool? enableFeedback;
 
-  /// {@macro flutter.material.ListTile.horizontalTitleGap}
+  /// {@macro material_ui.ListTile.horizontalTitleGap}
   final double? horizontalTitleGap;
 
-  /// {@macro flutter.material.ListTile.minVerticalPadding}
+  /// {@macro material_ui.ListTile.minVerticalPadding}
   final double? minVerticalPadding;
 
-  /// {@macro flutter.material.ListTile.minLeadingWidth}
+  /// {@macro material_ui.ListTile.minLeadingWidth}
   final double? minLeadingWidth;
 
-  /// {@macro flutter.material.ListTile.minTileHeight}
+  /// {@macro material_ui.ListTile.minTileHeight}
   final double? minTileHeight;
 
   /// The color for the tile's [Material] when a pointer is hovering over it.
   final Color? hoverColor;
 
-  /// {@macro flutter.cupertino.CupertinoSwitch.applyTheme}
+  /// {@macro cupertino_ui.CupertinoSwitch.applyTheme}
   final bool? applyCupertinoTheme;
 
   /// Whether to add button:true to the semantics if onTap is provided.

--- a/packages/material_ui/lib/src/switch_theme.dart
+++ b/packages/material_ui/lib/src/switch_theme.dart
@@ -50,48 +50,48 @@ class SwitchThemeData with Diagnosticable {
     this.padding,
   });
 
-  /// {@macro flutter.material.switch.thumbColor}
+  /// {@macro material_ui.switch.thumbColor}
   ///
   /// If specified, overrides the default value of [Switch.thumbColor].
   final WidgetStateProperty<Color?>? thumbColor;
 
-  /// {@macro flutter.material.switch.trackColor}
+  /// {@macro material_ui.switch.trackColor}
   ///
   /// If specified, overrides the default value of [Switch.trackColor].
   final WidgetStateProperty<Color?>? trackColor;
 
-  /// {@macro flutter.material.switch.trackOutlineColor}
+  /// {@macro material_ui.switch.trackOutlineColor}
   ///
   /// If specified, overrides the default value of [Switch.trackOutlineColor].
   final WidgetStateProperty<Color?>? trackOutlineColor;
 
-  /// {@macro flutter.material.switch.trackOutlineWidth}
+  /// {@macro material_ui.switch.trackOutlineWidth}
   ///
   /// If specified, overrides the default value of [Switch.trackOutlineWidth].
   final WidgetStateProperty<double?>? trackOutlineWidth;
 
-  /// {@macro flutter.material.switch.materialTapTargetSize}
+  /// {@macro material_ui.switch.materialTapTargetSize}
   ///
   /// If specified, overrides the default value of
   /// [Switch.materialTapTargetSize].
   final MaterialTapTargetSize? materialTapTargetSize;
 
-  /// {@macro flutter.material.switch.mouseCursor}
+  /// {@macro material_ui.switch.mouseCursor}
   ///
   /// If specified, overrides the default value of [Switch.mouseCursor].
   final WidgetStateProperty<MouseCursor?>? mouseCursor;
 
-  /// {@macro flutter.material.switch.overlayColor}
+  /// {@macro material_ui.switch.overlayColor}
   ///
   /// If specified, overrides the default value of [Switch.overlayColor].
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// {@macro flutter.material.switch.splashRadius}
+  /// {@macro material_ui.switch.splashRadius}
   ///
   /// If specified, overrides the default value of [Switch.splashRadius].
   final double? splashRadius;
 
-  /// {@macro flutter.material.switch.thumbIcon}
+  /// {@macro material_ui.switch.thumbIcon}
   ///
   /// It is overridden by [Switch.thumbIcon].
   final WidgetStateProperty<Icon?>? thumbIcon;

--- a/packages/material_ui/lib/src/tab_bar_theme.dart
+++ b/packages/material_ui/lib/src/tab_bar_theme.dart
@@ -411,7 +411,7 @@ class TabBarThemeData with Diagnosticable {
   /// Overrides the default value for [TabBar.splashFactory].
   final InteractiveInkFeatureFactory? splashFactory;
 
-  /// {@macro flutter.material.tabs.mouseCursor}
+  /// {@macro material_ui.tabs.mouseCursor}
   ///
   /// If specified, overrides the default value of [TabBar.mouseCursor].
   final WidgetStateProperty<MouseCursor?>? mouseCursor;

--- a/packages/material_ui/lib/src/tabs.dart
+++ b/packages/material_ui/lib/src/tabs.dart
@@ -1362,7 +1362,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
 
-  /// {@template flutter.material.tabs.mouseCursor}
+  /// {@template material_ui.tabs.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// individual tab widgets.
   ///
@@ -2305,7 +2305,7 @@ class TabBarView extends StatefulWidget {
   /// {@macro flutter.widgets.pageview.viewportFraction}
   final double viewportFraction;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/material_ui/lib/src/text_button.dart
+++ b/packages/material_ui/lib/src/text_button.dart
@@ -116,7 +116,7 @@ class TextButton extends ButtonStyleButton {
   /// If [icon] is null, this constructor will create a [TextButton]
   /// that doesn't display an icon.
   ///
-  /// {@macro flutter.material.ButtonStyle.iconAlignment}
+  /// {@macro material_ui.ButtonStyle.iconAlignment}
   ///
   TextButton.icon({
     super.key,
@@ -279,7 +279,7 @@ class TextButton extends ButtonStyleButton {
 
   /// Defines the button's default appearance.
   ///
-  /// {@template flutter.material.text_button.default_style_of}
+  /// {@template material_ui.text_button.default_style_of}
   /// The button [child]'s [Text] and [Icon] widgets are rendered with
   /// the [ButtonStyle]'s foreground color. The button's [InkWell] adds
   /// the style's overlay color when the button is focused, hovered
@@ -353,7 +353,7 @@ class TextButton extends ButtonStyleButton {
   /// If [ThemeData.useMaterial3] is set to true the following defaults will
   /// be used:
   ///
-  /// {@template flutter.material.text_button.material3_defaults}
+  /// {@template material_ui.text_button.material3_defaults}
   /// * `textStyle` - Theme.textTheme.labelLarge
   /// * `backgroundColor` - transparent
   /// * `foregroundColor`

--- a/packages/material_ui/lib/src/text_field.dart
+++ b/packages/material_ui/lib/src/text_field.dart
@@ -99,7 +99,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
 ///
-/// {@macro flutter.cupertino.textfield.wantKeepAlive}
+/// {@macro cupertino_ui.textfield.wantKeepAlive}
 ///
 /// Remember to call [TextEditingController.dispose] on the [TextEditingController]
 /// when it is no longer needed. This will ensure we discard any resources used
@@ -485,7 +485,7 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.textAlign}
   final TextAlign textAlign;
 
-  /// {@macro flutter.cupertino.InputDecorator.textAlignVertical}
+  /// {@macro cupertino_ui.InputDecorator.textAlignVertical}
   final TextAlignVertical? textAlignVertical;
 
   /// {@macro flutter.widgets.editableText.textDirection}
@@ -734,7 +734,7 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.selectionEnabled}
   bool get selectionEnabled => enableInteractiveSelection;
 
-  /// {@macro flutter.cupertino.textfield.onTap}
+  /// {@macro cupertino_ui.textfield.onTap}
   ///
   /// If [onTapAlwaysCalled] is enabled, this will also be called for consecutive
   /// taps.
@@ -839,12 +839,12 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
-  /// {@macro flutter.cupertino.Material.clipBehavior}
+  /// {@macro cupertino_ui.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
-  /// {@macro flutter.cupertino.textfield.restorationId}
+  /// {@macro cupertino_ui.textfield.restorationId}
   final String? restorationId;
 
   /// {@macro flutter.widgets.editableText.scribbleEnabled}

--- a/packages/material_ui/lib/src/text_form_field.dart
+++ b/packages/material_ui/lib/src/text_form_field.dart
@@ -35,7 +35,7 @@ export 'package:flutter/services.dart' show SmartDashesType, SmartQuotesType;
 /// If a [controller] is not specified, [initialValue] can be used to give
 /// the automatically generated controller an initial value.
 ///
-/// {@macro flutter.cupertino.textfield.wantKeepAlive}
+/// {@macro cupertino_ui.textfield.wantKeepAlive}
 ///
 /// Remember to call [TextEditingController.dispose] of the [TextEditingController]
 /// when it is no longer needed. This will ensure any resources used by the object
@@ -339,7 +339,7 @@ class TextFormField extends FormField<String> {
   /// {@macro flutter.widgets.editableText.groupId}
   final Object groupId;
 
-  /// {@macro flutter.cupertino.TextFormField.onChanged}
+  /// {@macro cupertino_ui.TextFormField.onChanged}
   final ValueChanged<String>? onChanged;
 
   static Widget _defaultContextMenuBuilder(

--- a/packages/material_ui/lib/src/text_selection_toolbar.dart
+++ b/packages/material_ui/lib/src/text_selection_toolbar.dart
@@ -48,20 +48,20 @@ class TextSelectionToolbar extends StatelessWidget {
     required this.children,
   }) : assert(children.length > 0);
 
-  /// {@macro flutter.cupertino.TextSelectionToolbar.anchorAbove}
+  /// {@macro cupertino_ui.TextSelectionToolbar.anchorAbove}
   final Offset anchorAbove;
 
-  /// {@macro flutter.cupertino.TextSelectionToolbar.anchorBelow}
+  /// {@macro cupertino_ui.TextSelectionToolbar.anchorBelow}
   final Offset anchorBelow;
 
-  /// {@macro flutter.cupertino.TextSelectionToolbar.children}
+  /// {@macro cupertino_ui.TextSelectionToolbar.children}
   ///
   /// See also:
   ///   * [TextSelectionToolbarTextButton], which builds a default Material-
   ///     style text selection toolbar text button.
   final List<Widget> children;
 
-  /// {@macro flutter.cupertino.TextSelectionToolbar.toolbarBuilder}
+  /// {@macro cupertino_ui.TextSelectionToolbar.toolbarBuilder}
   final ToolbarBuilder toolbarBuilder;
 
   /// The size of the text selection handles.

--- a/packages/material_ui/lib/src/text_selection_toolbar_text_button.dart
+++ b/packages/material_ui/lib/src/text_selection_toolbar_text_button.dart
@@ -43,14 +43,14 @@ class TextSelectionToolbarTextButton extends StatelessWidget {
   static const double _kMiddlePadding = 9.5;
   static const double _kEndPadding = 14.5;
 
-  /// {@template flutter.material.TextSelectionToolbarTextButton.child}
+  /// {@template material_ui.TextSelectionToolbarTextButton.child}
   /// The child of this button.
   ///
   /// Usually a [Text].
   /// {@endtemplate}
   final Widget child;
 
-  /// {@template flutter.material.TextSelectionToolbarTextButton.onPressed}
+  /// {@template material_ui.TextSelectionToolbarTextButton.onPressed}
   /// Called when this button is pressed.
   /// {@endtemplate}
   final VoidCallback? onPressed;

--- a/packages/material_ui/lib/src/theme_data.dart
+++ b/packages/material_ui/lib/src/theme_data.dart
@@ -1176,7 +1176,7 @@ class ThemeData with Diagnosticable {
 
   /// The density value for specifying the compactness of various UI components.
   ///
-  /// {@template flutter.material.themedata.visualDensity}
+  /// {@template material_ui.themedata.visualDensity}
   /// Density, in the context of a UI, is the vertical and horizontal
   /// "compactness" of the elements in the UI. It is unitless, since it means
   /// different things to different UI elements. For buttons, it affects the
@@ -1220,7 +1220,7 @@ class ThemeData with Diagnosticable {
   /// The color of [Material] when it is used as a [Card].
   final Color cardColor;
 
-  /// {@macro flutter.material.color_scheme.ColorScheme}
+  /// {@macro material_ui.color_scheme.ColorScheme}
   ///
   /// This property was added much later than the theme's set of highly specific
   /// colors, like [cardColor], [canvasColor] etc. New components can be defined

--- a/packages/material_ui/lib/src/time_picker.dart
+++ b/packages/material_ui/lib/src/time_picker.dart
@@ -2374,10 +2374,10 @@ class TimePickerDialog extends StatefulWidget {
   /// Callback called when the selected entry mode is changed.
   final EntryModeChangeCallback? onEntryModeChanged;
 
-  /// {@macro flutter.material.time_picker.switchToInputEntryModeIcon}
+  /// {@macro material_ui.time_picker.switchToInputEntryModeIcon}
   final Icon? switchToInputEntryModeIcon;
 
-  /// {@macro flutter.material.time_picker.switchToTimerEntryModeIcon}
+  /// {@macro material_ui.time_picker.switchToTimerEntryModeIcon}
   final Icon? switchToTimerEntryModeIcon;
 
   /// If true and entry mode is [TimePickerEntryMode.input], the hour and minute
@@ -2838,10 +2838,10 @@ class _TimePicker extends StatefulWidget {
   /// Callback called when the selected entry mode is changed.
   final EntryModeChangeCallback? onEntryModeChanged;
 
-  /// {@macro flutter.material.time_picker.switchToInputEntryModeIcon}
+  /// {@macro material_ui.time_picker.switchToInputEntryModeIcon}
   final Icon? switchToInputEntryModeIcon;
 
-  /// {@macro flutter.material.time_picker.switchToTimerEntryModeIcon}
+  /// {@macro material_ui.time_picker.switchToTimerEntryModeIcon}
   final Icon? switchToTimerEntryModeIcon;
 
   /// If true, input fields start empty in input mode.
@@ -3179,7 +3179,7 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
 /// parameter to override the default and force the dialog to appear in either
 /// portrait or landscape mode.
 ///
-/// {@template flutter.material.time_picker.switchToInputEntryModeIcon}
+/// {@template material_ui.time_picker.switchToInputEntryModeIcon}
 /// The optional [switchToInputEntryModeIcon] argument can be used to customize
 /// the input method icon that is shown when the [TimePickerEntryMode]
 /// is [TimePickerEntryMode.dial].
@@ -3187,7 +3187,7 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
 /// Defaults to an [Icon] widget with [Icons.keyboard_outlined] as icon.
 /// {@endtemplate}
 ///
-/// {@template flutter.material.time_picker.switchToTimerEntryModeIcon}
+/// {@template material_ui.time_picker.switchToTimerEntryModeIcon}
 /// The optional [switchToTimerEntryModeIcon] argument can be used to customize
 /// the input method icon that is shown when the [TimePickerEntryMode]
 /// is [TimePickerEntryMode.input].

--- a/packages/material_ui/lib/src/toggle_buttons.dart
+++ b/packages/material_ui/lib/src/toggle_buttons.dart
@@ -281,7 +281,7 @@ class ToggleButtons extends StatelessWidget {
   /// When the callback is null, all toggle buttons will be disabled.
   final void Function(int index)? onPressed;
 
-  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  /// {@macro material_ui.RawMaterialButton.mouseCursor}
   ///
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] is used.
   final MouseCursor? mouseCursor;


### PR DESCRIPTION
This PR rename macro names from `flutter.material.*` to `material_ui.*`, and `flutter.cupertino.*` to `cupertino_ui.*`.

These changes are not only aesthetic, but also functionally necessary, because the current macro names are also present in the Flutter framework. Since the `dartdoc` also read the framework, it will treat all macros/templates of the same name as duplicate entries, and will always display the macro content from the Flutter framework.

For example, the following screenshot shows the page of `cupertino_ui.CupertinoCheckbox.fillColor` as of 745da2e91d112c280123bacf5435ab18a6240005 .
<img width="863" height="846" alt="image" src="https://github.com/user-attachments/assets/1fd790b5-18d7-4138-afab-2876003df1f8" />

 Despite that we have long migrated it away from `@tool snippet`, 

https://github.com/flutter/packages/blob/745da2e91d112c280123bacf5435ab18a6240005/packages/cupertino_ui/lib/src/checkbox.dart#L211-L230

they still show `@tool snippet` because `dartdoc` replaces the `cupertino_ui` doc with the content from `flutter/cupertino` ([link](https://github.com/flutter/flutter/blob/6c66df7aeb64b834098441835f74fa24e2371a6e/packages/flutter/lib/src/cupertino/checkbox.dart#L205)). 

This issue is fixed after this PR.


## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
