### PR TITLE
[vector_graphics_compiler] Ignore unrecognized font-weight values

### DIFF
--- a/packages/vector_graphics_compiler/CHANGELOG.md
+++ b/packages/vector_graphics_compiler/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.0
+
+* An unrecognized `font-weight` value now falls back to normal weight with a
+  warning (and still throws when `warningsAsErrors` is set) instead of always
+  throwing, following the CSS behavior of ignoring an invalid `font-weight`.
+  This lets the compiler tolerate non-standard values such as `regular` emitted
+  by some SVG generators.
+
 ## 1.2.6
 
 * Fixes `linux-arm64` host support by selecting the Flutter engine

--- a/packages/vector_graphics_compiler/CHANGELOG.md
+++ b/packages/vector_graphics_compiler/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 1.3.0
 
-* An unrecognized `font-weight` value now falls back to normal weight with a
-  warning (and still throws when `warningsAsErrors` is set) instead of always
-  throwing, following the CSS behavior of ignoring an invalid `font-weight`.
-  This lets the compiler tolerate non-standard values such as `regular` emitted
-  by some SVG generators.
+* An unrecognized `font-weight` value is now ignored with a warning (and still
+  throws when `warningsAsErrors` is set) instead of always throwing. This
+  preserves an inherited weight, or the initial normal weight at the root, and
+  lets the compiler tolerate non-standard values such as `regular` emitted by
+  some SVG generators.
 
 ## 1.2.6
 

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -1296,9 +1296,9 @@ class SvgParser {
 
   /// Parse the raw font weight string.
   ///
-  /// An unrecognized value falls back to [normalFontWeight] with a warning,
-  /// following the CSS behavior of ignoring an invalid `font-weight`, or throws
-  /// a [StateError] when warnings are treated as errors.
+  /// An unrecognized value is ignored with a warning so that inheritance can
+  /// determine the effective weight, or throws a [StateError] when warnings are
+  /// treated as errors.
   FontWeight? parseFontWeight(String? fontWeight) {
     if (fontWeight == null) {
       return null;
@@ -1333,8 +1333,8 @@ class SvgParser {
     if (_warningsAsErrors) {
       throw StateError(errorMessage);
     }
-    print('Warning: $errorMessage. Defaulting to normal.');
-    return normalFontWeight;
+    print('Warning: $errorMessage. Ignoring invalid value.');
+    return null;
   }
 
   /// Converts a SVG Color String (either a # prefixed color string or a named color) to a [Color].

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -1295,6 +1295,10 @@ class SvgParser {
   }
 
   /// Parse the raw font weight string.
+  ///
+  /// An unrecognized value falls back to [normalFontWeight] with a warning,
+  /// following the CSS behavior of ignoring an invalid `font-weight`, or throws
+  /// a [StateError] when warnings are treated as errors.
   FontWeight? parseFontWeight(String? fontWeight) {
     if (fontWeight == null) {
       return null;
@@ -1325,7 +1329,12 @@ class SvgParser {
         return FontWeight.w900;
     }
 
-    throw StateError('Invalid "font-weight": $fontWeight');
+    final errorMessage = 'Invalid "font-weight": $fontWeight';
+    if (_warningsAsErrors) {
+      throw StateError(errorMessage);
+    }
+    print('Warning: $errorMessage. Defaulting to normal.');
+    return normalFontWeight;
   }
 
   /// Converts a SVG Color String (either a # prefixed color string or a named color) to a [Color].

--- a/packages/vector_graphics_compiler/pubspec.yaml
+++ b/packages/vector_graphics_compiler/pubspec.yaml
@@ -2,7 +2,7 @@ name: vector_graphics_compiler
 description: A compiler to convert SVGs to the binary format used by `package:vector_graphics`.
 repository: https://github.com/flutter/packages/tree/main/packages/vector_graphics_compiler
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_graphics%22
-version: 1.2.6
+version: 1.3.0
 
 executables:
   vector_graphics_compiler:

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -414,7 +414,7 @@ ${[for (var i = 2; i <= 30; i++) '    <pattern id="lvl$i" width="10" height="10"
     ]);
   });
 
-  test('Non-standard font-weight="regular" falls back to normal', () {
+  test('Non-standard root font-weight="regular" uses initial weight', () {
     final VectorInstructions instructions = parseWithoutOptimizers('''
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <text x="10" y="20" font-size="12" font-weight="regular">Regular text</text>
@@ -423,13 +423,24 @@ ${[for (var i = 2; i <= 30; i++) '    <pattern id="lvl$i" width="10" height="10"
     expect(instructions.text.single.fontWeight, FontWeight.w400);
   });
 
-  test('Unrecognized font-weight falls back to normal', () {
+  test('Unrecognized root font-weight uses initial weight', () {
     final VectorInstructions instructions = parseWithoutOptimizers('''
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <text x="10" y="20" font-size="12" font-weight="wobbly">Some text</text>
 </svg>''');
 
     expect(instructions.text.single.fontWeight, FontWeight.w400);
+  });
+
+  test('Unrecognized font-weight preserves inherited weight', () {
+    final VectorInstructions instructions = parseWithoutOptimizers('''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <g font-weight="bold">
+    <text x="10" y="20" font-size="12" font-weight="wobbly">Some text</text>
+  </g>
+</svg>''');
+
+    expect(instructions.text.single.fontWeight, FontWeight.w700);
   });
 
   test('Unrecognized font-weight throws when warnings are errors', () {

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -414,6 +414,34 @@ ${[for (var i = 2; i <= 30; i++) '    <pattern id="lvl$i" width="10" height="10"
     ]);
   });
 
+  test('Non-standard font-weight="regular" falls back to normal', () {
+    final VectorInstructions instructions = parseWithoutOptimizers('''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <text x="10" y="20" font-size="12" font-weight="regular">Regular text</text>
+</svg>''');
+
+    expect(instructions.text.single.fontWeight, FontWeight.w400);
+  });
+
+  test('Unrecognized font-weight falls back to normal', () {
+    final VectorInstructions instructions = parseWithoutOptimizers('''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <text x="10" y="20" font-size="12" font-weight="wobbly">Some text</text>
+</svg>''');
+
+    expect(instructions.text.single.fontWeight, FontWeight.w400);
+  });
+
+  test('Unrecognized font-weight throws when warnings are errors', () {
+    expect(
+      () => parseWithoutOptimizers('''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <text x="10" y="20" font-size="12" font-weight="wobbly">Some text</text>
+</svg>''', warningsAsErrors: true),
+      throwsStateError,
+    );
+  });
+
   test('Fill rule inheritence', () {
     final VectorInstructions instructions = parseWithoutOptimizers(inheritFillRule);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/186933

`SvgParser.parseFontWeight` throws on any value outside the recognized CSS
keywords and numeric weights. That makes the whole SVG fail to compile for
non-standard values such as `font-weight="regular"`.

This change treats an unrecognized value as an invalid declaration: it emits a
warning and returns no parsed value, so normal style inheritance still applies.
An unstyled root therefore keeps the initial normal weight, while an invalid
child declaration no longer overrides a bold parent. Strict
`warningsAsErrors` builds continue to throw.

Tests cover an unrecognized root value, inheritance from a bold parent, and the
warnings-as-errors path. `flutter analyze` and the full 333-test
`vector_graphics_compiler` suite pass locally.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
