### PR TITLE
[google_fonts] Extract the config class to its own file

### DIFF
--- a/packages/google_fonts/CHANGELOG.md
+++ b/packages/google_fonts/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 8.2.0
 
-* Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+- Extract the class `Config` to its own file and rename it `GoogleFontsConfig`. The `Config` class is now deprecated.
+- Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 8.1.0
 

--- a/packages/google_fonts/generator/google_fonts.tmpl
+++ b/packages/google_fonts/generator/google_fonts.tmpl
@@ -9,27 +9,12 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 
 import 'google_fonts_base.dart';
+import 'google_fonts_config.dart';
 {{#allParts}}
 import '{{partFilePath}}';
 {{/allParts}}
-
-/// A collection of properties used to specify custom behavior of the
-/// GoogleFonts library.
-class Config {
-  /// Whether or not the GoogleFonts library can make requests to
-  /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
-  bool allowRuntimeFetching = true;
-
-  /// The HTTP client used to fetch fonts.
-  ///
-  /// If this is null, a shared default [http.Client] will be used.
-  ///
-  /// If you supply a client, you are responsible for closing it.
-  http.Client? httpClient;
-}
 
 /// Provides configuration, and static methods to obtain [TextStyle]s and [TextTheme]s.
 ///
@@ -49,7 +34,7 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
-  static final Config config = Config();
+  static final GoogleFontsConfig config = GoogleFontsConfig();
 
   /// Returns a [Future] which resolves when requested fonts have finished
   /// loading and are ready to be rendered on screen.

--- a/packages/google_fonts/lib/google_fonts.dart
+++ b/packages/google_fonts/lib/google_fonts.dart
@@ -3,3 +3,4 @@
 // found in the LICENSE file.
 
 export 'src/google_fonts_all_parts.dart';
+export 'src/google_fonts_config.dart';

--- a/packages/google_fonts/lib/src/google_fonts_all_parts.dart
+++ b/packages/google_fonts/lib/src/google_fonts_all_parts.dart
@@ -9,9 +9,9 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 
 import 'google_fonts_base.dart';
+import 'google_fonts_config.dart';
 import 'google_fonts_parts/part_a.dart';
 import 'google_fonts_parts/part_b.dart';
 import 'google_fonts_parts/part_c.dart';
@@ -39,21 +39,6 @@ import 'google_fonts_parts/part_x.dart';
 import 'google_fonts_parts/part_y.dart';
 import 'google_fonts_parts/part_z.dart';
 
-/// A collection of properties used to specify custom behavior of the
-/// GoogleFonts library.
-class Config {
-  /// Whether or not the GoogleFonts library can make requests to
-  /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
-  bool allowRuntimeFetching = true;
-
-  /// The HTTP client used to fetch fonts.
-  ///
-  /// If this is null, a shared default [http.Client] will be used.
-  ///
-  /// If you supply a client, you are responsible for closing it.
-  http.Client? httpClient;
-}
-
 /// Provides configuration, and static methods to obtain [TextStyle]s and [TextTheme]s.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=8Vzv2CdbEY0}
@@ -72,7 +57,7 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
-  static final Config config = Config();
+  static final GoogleFontsConfig config = GoogleFontsConfig();
 
   /// Returns a [Future] which resolves when requested fonts have finished
   /// loading and are ready to be rendered on screen.

--- a/packages/google_fonts/lib/src/google_fonts_config.dart
+++ b/packages/google_fonts/lib/src/google_fonts_config.dart
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:http/http.dart' as http;
+
+/// A collection of properties used to specify custom behavior of the
+/// GoogleFonts library.
+class GoogleFontsConfig {
+  /// Whether or not the GoogleFonts library can make requests to
+  /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
+  bool allowRuntimeFetching = true;
+
+  /// The HTTP client used to fetch fonts.
+  ///
+  /// If this is null, a shared default [http.Client] will be used.
+  ///
+  /// If you supply a client, you are responsible for closing it.
+  http.Client? httpClient;
+}
+
+/// Deprecated. Use [GoogleFontsConfig] instead.
+@Deprecated('Use GoogleFontsConfig instead')
+typedef Config = GoogleFontsConfig;

--- a/packages/google_fonts/pubspec.yaml
+++ b/packages/google_fonts/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_fonts
 description: A Flutter package to use fonts from fonts.google.com. Supports HTTP fetching, caching, and asset bundling.
 repository: https://github.com/flutter/packages/tree/main/packages/google_fonts
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_fonts%22
-version: 8.1.0
+version: 8.2.0
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Extract Config from google_fonts_all_parts.dart to google_fonts_config.dart. Rename Config to GoogleFontsConfig to avoid namespace clutter. Add a deprecated Config typedef for backward compatibility. Export GoogleFontsConfig and the deprecated Config in lib/google_fonts.dart. Bump package version to 8.2.0.

Unblocks https://github.com/flutter/packages/pull/11433

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
