### PR TITLE
[ci] Remove manual SwiftPM enabling step

### DIFF
--- a/.ci/scripts/enable_swift_package_manager.sh
+++ b/.ci/scripts/enable_swift_package_manager.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Copyright 2013 The Flutter Authors
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-set -e
-
-flutter config --enable-swift-package-manager

--- a/.ci/targets/ios_platform_tests.yaml
+++ b/.ci/targets/ios_platform_tests.yaml
@@ -2,10 +2,6 @@ tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
-  - name: enable Swift Package Manager
-    # For consistency between stable and master channels, enable SwiftPM.
-    # TODO(stuartmorgan): Remove this step once it's the default on stable.
-    script: .ci/scripts/enable_swift_package_manager.sh
   - name: create simulator
     script: .ci/scripts/create_simulator.sh
     infra_step: true # Note infra steps failing prevents "always" from running.

--- a/.ci/targets/macos_platform_tests.yaml
+++ b/.ci/targets/macos_platform_tests.yaml
@@ -2,10 +2,6 @@ tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
     infra_step: true # Note infra steps failing prevents "always" from running.
-  - name: enable Swift Package Manager
-    # For consistency between stable and master channels, enable SwiftPM.
-    # TODO(stuartmorgan): Remove this step once it's the default on stable.
-    script: .ci/scripts/enable_swift_package_manager.sh
   - name: download Dart and macOS deps
     script: .ci/scripts/tool_runner.sh
     args: ["fetch-deps", "--macos", "--supporting-target-platforms-only", "--swift-package-manager"]


### PR DESCRIPTION
Now that Swift Package Manager support is on by default for both master and stable, we don't need to manually enable it in CI.