### PR TITLE
[material_ui] Fix upstream localization test

### DIFF
--- a/packages/material_ui/test/l10n/date_picker_test.dart
+++ b/packages/material_ui/test/l10n/date_picker_test.dart
@@ -25,27 +25,27 @@ void main() {
         'textDirection': TextDirection.ltr,
         'expectedDaysOfWeek': <String>['S', 'M', 'T', 'W', 'T', 'F', 'S'],
         'expectedDaysOfMonth': List<String>.generate(30, (int i) => '${i + 1}'),
-        'expectedMonthYearHeader': 'September 2017',
+        'expectedMonthYearHeader': <String>['September 2017'],
       },
       // Tests a different first day of week.
       const Locale('ru', 'RU'): <String, dynamic>{
         'textDirection': TextDirection.ltr,
         'expectedDaysOfWeek': <String>['В', 'П', 'В', 'С', 'Ч', 'П', 'С'],
         'expectedDaysOfMonth': List<String>.generate(30, (int i) => '${i + 1}'),
-        'expectedMonthYearHeader': 'сентябрь 2017\u202fг.',
+        'expectedMonthYearHeader': <String>['сентябрь 2017\u202fг.'],
       },
       const Locale('ro', 'RO'): <String, dynamic>{
         'textDirection': TextDirection.ltr,
         'expectedDaysOfWeek': <String>['D', 'L', 'M', 'M', 'J', 'V', 'S'],
         'expectedDaysOfMonth': List<String>.generate(30, (int i) => '${i + 1}'),
-        'expectedMonthYearHeader': 'septembrie 2017',
+        'expectedMonthYearHeader': <String>['septembrie 2017'],
       },
       // Tests RTL.
       const Locale('ar', 'AR'): <String, dynamic>{
         'textDirection': TextDirection.rtl,
         'expectedDaysOfWeek': <String>['ح', 'ن', 'ث', 'ر', 'خ', 'ج', 'س'],
         'expectedDaysOfMonth': List<String>.generate(30, (int i) => arabicNumbers.format(i + 1)),
-        'expectedMonthYearHeader': 'سبتمبر 2017',
+        'expectedMonthYearHeader': <String>['سبتمبر ٢٠١٧', 'سبتمبر 2017'],
       },
     };
 
@@ -53,7 +53,9 @@ void main() {
       testWidgets('shows dates for $locale', (WidgetTester tester) async {
         final expectedDaysOfWeek = testLocales[locale]!['expectedDaysOfWeek'] as List<String>;
         final expectedDaysOfMonth = testLocales[locale]!['expectedDaysOfMonth'] as List<String>;
-        final expectedMonthYearHeader = testLocales[locale]!['expectedMonthYearHeader'] as String;
+        // TODO(Piinks): Clean up this workaround after https://github.com/flutter/flutter/pull/188473 reaches stable
+        final expectedMonthYearHeaders =
+            testLocales[locale]!['expectedMonthYearHeader'] as List<String>;
         final textDirection = testLocales[locale]!['textDirection'] as TextDirection;
         final baseDate = DateTime(2017, 9, 27);
 
@@ -68,7 +70,14 @@ void main() {
           locale: locale,
           textDirection: textDirection,
         );
-        expect(find.text(expectedMonthYearHeader), findsOneWidget);
+
+        // TODO(Piinks): Clean up this workaround after https://github.com/flutter/flutter/pull/188473 reaches stable
+        expect(
+          find.byWidgetPredicate(
+            (Widget widget) => widget is Text && expectedMonthYearHeaders.contains(widget.data),
+          ),
+          findsOneWidget,
+        );
 
         for (final dayOfWeek in expectedDaysOfWeek) {
           expect(find.text(dayOfWeek), findsWidgets);

--- a/packages/material_ui/test/l10n/date_picker_test.dart
+++ b/packages/material_ui/test/l10n/date_picker_test.dart
@@ -53,7 +53,7 @@ void main() {
       testWidgets('shows dates for $locale', (WidgetTester tester) async {
         final expectedDaysOfWeek = testLocales[locale]!['expectedDaysOfWeek'] as List<String>;
         final expectedDaysOfMonth = testLocales[locale]!['expectedDaysOfMonth'] as List<String>;
-        // TODO(Piinks): Clean up this workaround after https://github.com/flutter/flutter/pull/188473 reaches stable
+        // TODO(Piinks): Clean up this workaround after https://github.com/flutter/flutter/pull/188473 reaches stable, https://github.com/flutter/flutter/issues/189528
         final expectedMonthYearHeaders =
             testLocales[locale]!['expectedMonthYearHeader'] as List<String>;
         final textDirection = testLocales[locale]!['textDirection'] as TextDirection;
@@ -71,7 +71,7 @@ void main() {
           textDirection: textDirection,
         );
 
-        // TODO(Piinks): Clean up this workaround after https://github.com/flutter/flutter/pull/188473 reaches stable
+        // TODO(Piinks): Clean up this workaround after https://github.com/flutter/flutter/pull/188473 reaches stable, https://github.com/flutter/flutter/issues/189528
         expect(
           find.byWidgetPredicate(
             (Widget widget) => widget is Text && expectedMonthYearHeaders.contains(widget.data),


### PR DESCRIPTION
Fixes the tree. `flutter_localizations` contains a patch from https://github.com/flutter/flutter/pull/188473 that has not reached stable yet. This means this test needs to accommodate a different result when tested on stable versus master. Refactored to green the tree. 
@justinmc is filing a follow up issue and looking into extending the code freeze that did not originally apply to localizations.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
