### PR TITLE
[material_ui] Rename the remaining templates

### DIFF
--- a/packages/material_ui/lib/src/dropdown_menu.dart
+++ b/packages/material_ui/lib/src/dropdown_menu.dart
@@ -706,7 +706,7 @@ class DropdownMenu<T> extends StatefulWidget {
   ///    the [TextField] can display.
   final int? maxLines;
 
-  /// {@macro flutter.widgets.TextField.textInputAction}
+  /// {@macro material_ui.TextField.textInputAction}
   final TextInputAction? textInputAction;
 
   /// {@macro flutter.widgets.editableText.cursorHeight}

--- a/packages/material_ui/lib/src/progress_indicator.dart
+++ b/packages/material_ui/lib/src/progress_indicator.dart
@@ -88,7 +88,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// for the given use case. See the subclass documentation for details.
   final Color? backgroundColor;
 
-  /// {@template flutter.progress_indicator.ProgressIndicator.color}
+  /// {@template material_ui.progress_indicator.ProgressIndicator.color}
   /// The progress indicator's color.
   ///
   /// This is only used if [ProgressIndicator.valueColor] is null.
@@ -106,7 +106,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// is also null then it defaults to the current theme's [ColorScheme.primary].
   final Animation<Color?>? valueColor;
 
-  /// {@template flutter.progress_indicator.ProgressIndicator.semanticsLabel}
+  /// {@template material_ui.progress_indicator.ProgressIndicator.semanticsLabel}
   /// The [SemanticsProperties.label] for this progress indicator.
   ///
   /// This value indicates the purpose of the progress bar, and will be
@@ -115,7 +115,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// {@endtemplate}
   final String? semanticsLabel;
 
-  /// {@template flutter.progress_indicator.ProgressIndicator.semanticsValue}
+  /// {@template material_ui.progress_indicator.ProgressIndicator.semanticsValue}
   /// The [SemanticsProperties.value] for this progress indicator.
   ///
   /// This will be used in conjunction with the [semanticsLabel] by

--- a/packages/material_ui/lib/src/refresh_indicator.dart
+++ b/packages/material_ui/lib/src/refresh_indicator.dart
@@ -298,13 +298,13 @@ class RefreshIndicator extends StatefulWidget {
   /// else for more complicated layouts.
   final ScrollNotificationPredicate notificationPredicate;
 
-  /// {@macro flutter.progress_indicator.ProgressIndicator.semanticsLabel}
+  /// {@macro material_ui.progress_indicator.ProgressIndicator.semanticsLabel}
   ///
   /// This will be defaulted to [MaterialLocalizations.refreshIndicatorSemanticLabel]
   /// if it is null.
   final String? semanticsLabel;
 
-  /// {@macro flutter.progress_indicator.ProgressIndicator.semanticsValue}
+  /// {@macro material_ui.progress_indicator.ProgressIndicator.semanticsValue}
   final String? semanticsValue;
 
   /// Defines [strokeWidth] for `RefreshIndicator`.

--- a/packages/material_ui/lib/src/search_anchor.dart
+++ b/packages/material_ui/lib/src/search_anchor.dart
@@ -429,7 +429,7 @@ class SearchAnchor extends StatefulWidget {
   /// To get a different layout, use [viewBuilder] to override.
   final SuggestionsBuilder suggestionsBuilder;
 
-  /// {@macro flutter.widgets.TextField.textInputAction}
+  /// {@macro material_ui.TextField.textInputAction}
   final TextInputAction? textInputAction;
 
   /// The type of action button to use for the keyboard.
@@ -1608,7 +1608,7 @@ class SearchBar extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autoFocus;
 
-  /// {@macro flutter.widgets.TextField.textInputAction}
+  /// {@macro material_ui.TextField.textInputAction}
   final TextInputAction? textInputAction;
 
   /// The type of action button to use for the keyboard.

--- a/packages/material_ui/lib/src/text_field.dart
+++ b/packages/material_ui/lib/src/text_field.dart
@@ -456,7 +456,7 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.keyboardType}
   final TextInputType keyboardType;
 
-  /// {@template flutter.widgets.TextField.textInputAction}
+  /// {@template material_ui.TextField.textInputAction}
   /// The type of action button to use for the keyboard.
   ///
   /// Defaults to [TextInputAction.newline] if [keyboardType] is


### PR DESCRIPTION
This PR follows up the comment under https://github.com/flutter/packages/pull/12198, and renames all remaining `@template`s so that no templates conflict with the framework.

Note: The templates in `generated_cupertino_localizations.dart` and `generated_material_localizations.dart` have been left as-is for now, as these files are auto-generated. A separate migration of the generation script will be required to address those specific instances.

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
