### PR TITLE
[material_ui, cupertino_ui] Rename l10n macros

### DIFF
--- a/packages/cupertino_ui/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/cupertino_ui/lib/src/l10n/generated_cupertino_localizations.dart
@@ -17471,7 +17471,7 @@ final Set<String> kCupertinoSupportedLanguages = HashSet<String>.from(const <Str
 ///
 /// The following locales are supported by this package:
 ///
-/// {@template flutter.localizations.cupertino.languages}
+/// {@template cupertino_ui.localizations.languages}
 ///  * `af` - Afrikaans
 ///  * `am` - Amharic
 ///  * `ar` - Arabic

--- a/packages/material_ui/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/material_ui/lib/src/l10n/generated_material_localizations.dart
@@ -46611,7 +46611,7 @@ final Set<String> kMaterialSupportedLanguages = HashSet<String>.from(const <Stri
 ///
 /// The following locales are supported by this package:
 ///
-/// {@template flutter.localizations.material.languages}
+/// {@template material_ui.localizations.languages}
 ///  * `af` - Afrikaans
 ///  * `am` - Amharic
 ///  * `ar` - Arabic

--- a/script/l10n/lib/gen_cupertino_localizations.dart
+++ b/script/l10n/lib/gen_cupertino_localizations.dart
@@ -75,4 +75,4 @@ const String cupertinoFactoryArguments =
 
 const String cupertinoSupportedLanguagesConstant = 'kCupertinoSupportedLanguages';
 
-const String cupertinoSupportedLanguagesDocMacro = 'flutter.localizations.cupertino.languages';
+const String cupertinoSupportedLanguagesDocMacro = 'cupertino_ui.localizations.languages';

--- a/script/l10n/lib/gen_material_localizations.dart
+++ b/script/l10n/lib/gen_material_localizations.dart
@@ -77,4 +77,4 @@ const String materialFactoryArguments =
 
 const String materialSupportedLanguagesConstant = 'kMaterialSupportedLanguages';
 
-const String materialSupportedLanguagesDocMacro = 'flutter.localizations.material.languages';
+const String materialSupportedLanguagesDocMacro = 'material_ui.localizations.languages';


### PR DESCRIPTION
This PR renames macros used by l10n.

For why the rename is needed, see https://github.com/flutter/packages/pull/12198.

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
